### PR TITLE
Fix resource count coverage for direct-read built-ins

### DIFF
--- a/internal/k8s/builtin_group_test.go
+++ b/internal/k8s/builtin_group_test.go
@@ -42,6 +42,13 @@ func TestTypedKindOwnsGroup(t *testing.T) {
 		// Built-in, but intentionally served through the dynamic cache
 		// rather than a baseline typed informer.
 		{"endpointslices", "discovery.k8s.io", false},
+		{"endpoints", "", false},
+		{"leases", "coordination.k8s.io", false},
+		{"priorityclasses", "scheduling.k8s.io", false},
+		{"runtimeclasses", "node.k8s.io", false},
+		{"mutatingwebhookconfigurations", "admissionregistration.k8s.io", false},
+		{"validatingwebhookconfigurations", "admissionregistration.k8s.io", false},
+		{"volumeattachments", "storage.k8s.io", false},
 
 		// Core kinds: own group is "" — typed, with or without an explicit "".
 		{"pods", "", true},
@@ -91,11 +98,19 @@ func TestBuiltinGVR(t *testing.T) {
 		{"pods", "", schema.GroupVersionResource{Version: "v1", Resource: "pods"}, true},
 		{"svc", "", schema.GroupVersionResource{Version: "v1", Resource: "services"}, true},
 		{"cm", "", schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}, true},
+		{"endpoints", "", schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}, true},
+		{"ep", "", schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}, true},
 		{"ns", "", schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, true},
 		{"no", "", schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, true},
 		{"sa", "", schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, true},
 		{"netpols", "networking.k8s.io", schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}, true},
 		{"endpointslice", "discovery.k8s.io", schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}, true},
+		{"lease", "coordination.k8s.io", schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"}, true},
+		{"priorityclass", "scheduling.k8s.io", schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}, true},
+		{"runtimeclass", "node.k8s.io", schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"}, true},
+		{"mutatingwebhookconfigurations", "admissionregistration.k8s.io", schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"}, true},
+		{"validatingwebhookconfiguration", "admissionregistration.k8s.io", schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}, true},
+		{"volumeattachments", "storage.k8s.io", schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattachments"}, true},
 		{"services", "serving.knative.dev", schema.GroupVersionResource{}, false}, // CRD collision
 		{"widgets", "example.com", schema.GroupVersionResource{}, false},          // genuine CRD
 	}
@@ -114,6 +129,7 @@ func TestCanonicalBuiltinKind(t *testing.T) {
 		"deploy":   "deployments",
 		"deploys":  "deployments",
 		"cm":       "configmaps",
+		"ep":       "endpoints",
 		"ns":       "namespaces",
 		"no":       "nodes",
 		"sts":      "statefulsets",
@@ -139,6 +155,7 @@ func TestBuiltinGVRAnyGroup(t *testing.T) {
 		{"deploy", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, true},
 		{"sts", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, true},
 		{"svc", schema.GroupVersionResource{Version: "v1", Resource: "services"}, true},
+		{"pc", schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}, true},
 		{"widgets", schema.GroupVersionResource{}, false},
 	}
 	for _, tc := range cases {

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -903,14 +903,14 @@ func (c *ResourceCache) getDynamicWithGroup(ctx context.Context, kind string, na
 	// cluster-wide just to power a per-page-load drift diff.
 	var u *unstructured.Unstructured
 	var err error
-	if shouldBypassDynamicInformer(gvr) {
+	if preserveLastApplied {
+		u, err = dynamicCache.GetDirectPreserveLastApplied(ctx, gvr, namespace, name)
+	} else if shouldBypassDynamicInformer(gvr) {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
 	} else if gvr.Group == "apiextensions.k8s.io" && gvr.Resource == "customresourcedefinitions" {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
 	} else if gvr.Group == "apiregistration.k8s.io" && gvr.Resource == "apiservices" {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
-	} else if preserveLastApplied {
-		u, err = dynamicCache.GetDirectPreserveLastApplied(ctx, gvr, namespace, name)
 	} else {
 		u, err = dynamicCache.Get(gvr, namespace, name)
 	}

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -812,7 +812,7 @@ func (c *ResourceCache) ListDynamicWithGroup(ctx context.Context, kind string, n
 		return nil, fmt.Errorf("dynamic resource cache not initialized")
 	}
 
-	if gvr.Group == "discovery.k8s.io" && gvr.Resource == "endpointslices" {
+	if shouldBypassDynamicInformer(gvr) {
 		return dynamicCache.ListDirect(ctx, gvr, namespace)
 	}
 
@@ -828,6 +828,12 @@ func (c *ResourceCache) ListDynamicWithGroup(ctx context.Context, kind string, n
 // when discovery is incomplete.
 func builtinGVRFallback(kind, group string) (schema.GroupVersionResource, bool) {
 	return BuiltinGVR(kind, group)
+}
+
+func shouldBypassDynamicInformer(gvr schema.GroupVersionResource) bool {
+	return (gvr.Group == "discovery.k8s.io" && gvr.Resource == "endpointslices") ||
+		(gvr.Group == "coordination.k8s.io" && gvr.Resource == "leases") ||
+		(gvr.Group == "" && gvr.Resource == "endpoints")
 }
 
 // ErrUnknownDynamicKind is returned by ListDynamic / GetDynamicWithGroup when
@@ -897,7 +903,7 @@ func (c *ResourceCache) getDynamicWithGroup(ctx context.Context, kind string, na
 	// cluster-wide just to power a per-page-load drift diff.
 	var u *unstructured.Unstructured
 	var err error
-	if gvr.Group == "discovery.k8s.io" && gvr.Resource == "endpointslices" {
+	if shouldBypassDynamicInformer(gvr) {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
 	} else if gvr.Group == "apiextensions.k8s.io" && gvr.Resource == "customresourcedefinitions" {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)

--- a/internal/k8s/cache_dynamic_test.go
+++ b/internal/k8s/cache_dynamic_test.go
@@ -96,12 +96,16 @@ func TestHighChurnDynamicBuiltinsBypassInformer(t *testing.T) {
 			defer ResetTestDynamicState()
 
 			gvr := schema.GroupVersionResource{Group: tc.group, Version: tc.version, Resource: tc.resource}
+			lastApplied := `{"kind":"` + tc.kind + `"}`
 			obj := &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": tc.apiVersion,
 				"kind":       tc.kind,
 				"metadata": map[string]any{
 					"name":      "sample",
 					"namespace": tc.namespace,
+					"annotations": map[string]any{
+						"kubectl.kubernetes.io/last-applied-configuration": lastApplied,
+					},
 				},
 			}}
 			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
@@ -134,6 +138,16 @@ func TestHighChurnDynamicBuiltinsBypassInformer(t *testing.T) {
 			}
 			if got.GetName() != "sample" {
 				t.Fatalf("GetDynamicWithGroup name = %q", got.GetName())
+			}
+			if _, ok := got.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+				t.Fatalf("GetDynamicWithGroup should strip last-applied")
+			}
+			preserved, err := cache.GetDynamicWithGroupPreserveLastApplied(context.Background(), tc.kind, tc.namespace, "sample", tc.group)
+			if err != nil {
+				t.Fatalf("GetDynamicWithGroupPreserveLastApplied: %v", err)
+			}
+			if preserved.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"] != lastApplied {
+				t.Fatalf("GetDynamicWithGroupPreserveLastApplied did not preserve last-applied: %v", preserved.GetAnnotations())
 			}
 			if count := GetDynamicResourceCache().GetInformerCount(); count != 0 {
 				t.Fatalf("%s started %d dynamic informer(s), want direct reads", tc.kind, count)

--- a/internal/k8s/cache_dynamic_test.go
+++ b/internal/k8s/cache_dynamic_test.go
@@ -47,3 +47,97 @@ func TestGetDynamicWithGroupDirectFetchesAPIService(t *testing.T) {
 		t.Fatalf("GetDynamicWithGroup(APIService) started %d dynamic informer(s), want direct GET", count)
 	}
 }
+
+func TestHighChurnDynamicBuiltinsBypassInformer(t *testing.T) {
+	cases := []struct {
+		name       string
+		group      string
+		version    string
+		kind       string
+		resource   string
+		listKind   string
+		namespace  string
+		apiVersion string
+	}{
+		{
+			name:       "EndpointSlice",
+			group:      "discovery.k8s.io",
+			version:    "v1",
+			kind:       "EndpointSlice",
+			resource:   "endpointslices",
+			listKind:   "EndpointSliceList",
+			namespace:  "default",
+			apiVersion: "discovery.k8s.io/v1",
+		},
+		{
+			name:       "Lease",
+			group:      "coordination.k8s.io",
+			version:    "v1",
+			kind:       "Lease",
+			resource:   "leases",
+			listKind:   "LeaseList",
+			namespace:  "kube-node-lease",
+			apiVersion: "coordination.k8s.io/v1",
+		},
+		{
+			name:       "Endpoints",
+			group:      "",
+			version:    "v1",
+			kind:       "Endpoints",
+			resource:   "endpoints",
+			listKind:   "EndpointsList",
+			namespace:  "default",
+			apiVersion: "v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer ResetTestDynamicState()
+
+			gvr := schema.GroupVersionResource{Group: tc.group, Version: tc.version, Resource: tc.resource}
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": tc.apiVersion,
+				"kind":       tc.kind,
+				"metadata": map[string]any{
+					"name":      "sample",
+					"namespace": tc.namespace,
+				},
+			}}
+			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{gvr: tc.listKind},
+				obj,
+			)
+			if err := InitTestDynamicResourceCache(dyn, []APIResource{{
+				Group:      tc.group,
+				Version:    tc.version,
+				Kind:       tc.kind,
+				Name:       tc.resource,
+				Namespaced: true,
+				Verbs:      []string{"get", "list", "watch"},
+			}}); err != nil {
+				t.Fatalf("InitTestDynamicResourceCache: %v", err)
+			}
+
+			cache := &ResourceCache{}
+			items, err := cache.ListDynamicWithGroup(context.Background(), tc.kind, tc.namespace, tc.group)
+			if err != nil {
+				t.Fatalf("ListDynamicWithGroup: %v", err)
+			}
+			if len(items) != 1 || items[0].GetName() != "sample" {
+				t.Fatalf("ListDynamicWithGroup returned %#v", items)
+			}
+			got, err := cache.GetDynamicWithGroup(context.Background(), tc.kind, tc.namespace, "sample", tc.group)
+			if err != nil {
+				t.Fatalf("GetDynamicWithGroup: %v", err)
+			}
+			if got.GetName() != "sample" {
+				t.Fatalf("GetDynamicWithGroup name = %q", got.GetName())
+			}
+			if count := GetDynamicResourceCache().GetInformerCount(); count != 0 {
+				t.Fatalf("%s started %d dynamic informer(s), want direct reads", tc.kind, count)
+			}
+		})
+	}
+}

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -29,6 +29,7 @@ type ResourcePermissions struct {
 	StatefulSets             bool `json:"statefulSets"`
 	ReplicaSets              bool `json:"replicaSets"`
 	Ingresses                bool `json:"ingresses"`
+	IngressClasses           bool `json:"ingressClasses"`
 	ConfigMaps               bool `json:"configMaps"`
 	Secrets                  bool `json:"secrets"`
 	Events                   bool `json:"events"`
@@ -717,6 +718,7 @@ func resourceProbeTargets(perms *ResourcePermissions) []resourceProbe {
 		{key: k8score.StatefulSets, gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, field: &perms.StatefulSets},
 		{key: k8score.ReplicaSets, gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, field: &perms.ReplicaSets},
 		{key: k8score.Ingresses, gvr: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}, field: &perms.Ingresses},
+		{key: k8score.IngressClasses, gvr: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"}, clusterOnly: true, field: &perms.IngressClasses},
 		{key: k8score.NetworkPolicies, gvr: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}, field: &perms.NetworkPolicies},
 		{key: k8score.Jobs, gvr: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}, field: &perms.Jobs},
 		{key: k8score.CronJobs, gvr: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}, field: &perms.CronJobs},

--- a/internal/k8s/capabilities_alignment_test.go
+++ b/internal/k8s/capabilities_alignment_test.go
@@ -113,6 +113,24 @@ func TestCapabilitiesAlignment_TypedVsDynamic(t *testing.T) {
 	}
 }
 
+// TestCapabilitiesAlignment_AllTypedInformersProbed asserts every typed
+// informer key is represented in resourceProbeTargets. Without this,
+// ResourceScopes disables the omitted informer even when the apiserver would
+// allow it.
+func TestCapabilitiesAlignment_AllTypedInformersProbed(t *testing.T) {
+	probeKeys := make(map[string]bool)
+	for _, p := range resourceProbeTargets(&ResourcePermissions{}) {
+		probeKeys[p.key] = true
+	}
+
+	for _, key := range k8score.InformerResourceKeys() {
+		if !probeKeys[key] {
+			t.Errorf("typed informer %q has no probe in resourceProbeTargets — "+
+				"ResourceScopes will disable it even when list access is allowed.", key)
+		}
+	}
+}
+
 // TestCapabilitiesAlignment_JSONTagMatchesProbeKey asserts the JSON tag,
 // lowercased, equals the probe key. This is the actual contract — a future
 // field that breaks it (e.g. tag "snake_case") will fail this test.

--- a/internal/k8s/fetch.go
+++ b/internal/k8s/fetch.go
@@ -21,16 +21,13 @@ import (
 // is not a built-in typed resource. The caller should fall through to the dynamic cache.
 var ErrUnknownKind = fmt.Errorf("unknown typed kind")
 
-// builtinGVRs maps every lowercase kind form the typed informer cache serves
-// (plural, singular, and abbreviations — the union of what
-// FetchResource/FetchResourceList and the REST switch in internal/server
-// accept) to its canonical GroupVersionResource. Versions are the GA
-// group/versions every supported cluster serves.
+// builtinGVRs maps lowercase built-in kind forms to their canonical
+// GroupVersionResource. Versions are the GA group/versions every supported
+// cluster serves.
 //
 // One table, two jobs:
 //   - TypedKindOwnsGroup decides typed-vs-dynamic routing for the resource
-//     GET/LIST handlers (a built-in addressed by its own group must use the
-//     typed cache, not the dynamic/CRD cache).
+//     GET/LIST handlers. Only kinds with typed cache listers participate there.
 //   - BuiltinGVR is a static fallback for live/dynamic fetches when API
 //     discovery can't resolve a built-in's GVR (partial discovery under
 //     restricted RBAC, or a transient refresh miss). The drift/insights live
@@ -38,52 +35,64 @@ var ErrUnknownKind = fmt.Errorf("unknown typed kind")
 //     it needs last-applied, which the typed cache strips — so without this it
 //     would silently return nil and drop drift for built-in managed resources.
 //
-// Keep in sync with the typed switches in this file and internal/server.
-var builtinGVRs = func() map[string]schema.GroupVersionResource {
+// Keep typed=true in sync with the typed switches in this file and internal/server.
+var builtinGVRs, typedBuiltinGVRs = func() (map[string]schema.GroupVersionResource, map[string]schema.GroupVersionResource) {
 	defs := []struct {
 		forms    []string
 		group    string
 		version  string
 		resource string
+		typed    bool
 	}{
-		{[]string{"pod", "pods", "po"}, "", "v1", "pods"},
-		{[]string{"service", "services", "svc"}, "", "v1", "services"},
-		{[]string{"configmap", "configmaps", "cm"}, "", "v1", "configmaps"},
-		{[]string{"secret", "secrets"}, "", "v1", "secrets"},
-		{[]string{"event", "events"}, "", "v1", "events"},
-		{[]string{"persistentvolumeclaim", "persistentvolumeclaims", "pvc", "pvcs"}, "", "v1", "persistentvolumeclaims"},
-		{[]string{"node", "nodes", "no"}, "", "v1", "nodes"},
-		{[]string{"namespace", "namespaces", "ns"}, "", "v1", "namespaces"},
-		{[]string{"persistentvolume", "persistentvolumes", "pv", "pvs"}, "", "v1", "persistentvolumes"},
-		{[]string{"serviceaccount", "serviceaccounts", "sa"}, "", "v1", "serviceaccounts"},
-		{[]string{"limitrange", "limitranges"}, "", "v1", "limitranges"},
-		{[]string{"resourcequota", "resourcequotas"}, "", "v1", "resourcequotas"},
-		{[]string{"deployment", "deployments", "deploy", "deploys"}, "apps", "v1", "deployments"},
-		{[]string{"daemonset", "daemonsets", "ds"}, "apps", "v1", "daemonsets"},
-		{[]string{"statefulset", "statefulsets", "sts"}, "apps", "v1", "statefulsets"},
-		{[]string{"replicaset", "replicasets", "rs"}, "apps", "v1", "replicasets"},
-		{[]string{"job", "jobs"}, "batch", "v1", "jobs"},
-		{[]string{"cronjob", "cronjobs", "cj"}, "batch", "v1", "cronjobs"},
-		{[]string{"hpa", "hpas", "horizontalpodautoscaler", "horizontalpodautoscalers"}, "autoscaling", "v2", "horizontalpodautoscalers"},
-		{[]string{"ingress", "ingresses"}, "networking.k8s.io", "v1", "ingresses"},
-		{[]string{"networkpolicy", "networkpolicies", "netpol", "netpols"}, "networking.k8s.io", "v1", "networkpolicies"},
-		{[]string{"ingressclass", "ingressclasses"}, "networking.k8s.io", "v1", "ingressclasses"},
-		{[]string{"endpointslice", "endpointslices"}, "discovery.k8s.io", "v1", "endpointslices"},
-		{[]string{"poddisruptionbudget", "poddisruptionbudgets", "pdb", "pdbs"}, "policy", "v1", "poddisruptionbudgets"},
-		{[]string{"storageclass", "storageclasses", "sc"}, "storage.k8s.io", "v1", "storageclasses"},
-		{[]string{"role", "roles"}, "rbac.authorization.k8s.io", "v1", "roles"},
-		{[]string{"clusterrole", "clusterroles"}, "rbac.authorization.k8s.io", "v1", "clusterroles"},
-		{[]string{"rolebinding", "rolebindings"}, "rbac.authorization.k8s.io", "v1", "rolebindings"},
-		{[]string{"clusterrolebinding", "clusterrolebindings"}, "rbac.authorization.k8s.io", "v1", "clusterrolebindings"},
+		{[]string{"pod", "pods", "po"}, "", "v1", "pods", true},
+		{[]string{"service", "services", "svc"}, "", "v1", "services", true},
+		{[]string{"configmap", "configmaps", "cm"}, "", "v1", "configmaps", true},
+		{[]string{"secret", "secrets"}, "", "v1", "secrets", true},
+		{[]string{"event", "events"}, "", "v1", "events", true},
+		{[]string{"endpoint", "endpoints", "ep"}, "", "v1", "endpoints", false},
+		{[]string{"persistentvolumeclaim", "persistentvolumeclaims", "pvc", "pvcs"}, "", "v1", "persistentvolumeclaims", true},
+		{[]string{"node", "nodes", "no"}, "", "v1", "nodes", true},
+		{[]string{"namespace", "namespaces", "ns"}, "", "v1", "namespaces", true},
+		{[]string{"persistentvolume", "persistentvolumes", "pv", "pvs"}, "", "v1", "persistentvolumes", true},
+		{[]string{"serviceaccount", "serviceaccounts", "sa"}, "", "v1", "serviceaccounts", true},
+		{[]string{"limitrange", "limitranges"}, "", "v1", "limitranges", true},
+		{[]string{"resourcequota", "resourcequotas"}, "", "v1", "resourcequotas", true},
+		{[]string{"deployment", "deployments", "deploy", "deploys"}, "apps", "v1", "deployments", true},
+		{[]string{"daemonset", "daemonsets", "ds"}, "apps", "v1", "daemonsets", true},
+		{[]string{"statefulset", "statefulsets", "sts"}, "apps", "v1", "statefulsets", true},
+		{[]string{"replicaset", "replicasets", "rs"}, "apps", "v1", "replicasets", true},
+		{[]string{"job", "jobs"}, "batch", "v1", "jobs", true},
+		{[]string{"cronjob", "cronjobs", "cj"}, "batch", "v1", "cronjobs", true},
+		{[]string{"hpa", "hpas", "horizontalpodautoscaler", "horizontalpodautoscalers"}, "autoscaling", "v2", "horizontalpodautoscalers", true},
+		{[]string{"ingress", "ingresses"}, "networking.k8s.io", "v1", "ingresses", true},
+		{[]string{"networkpolicy", "networkpolicies", "netpol", "netpols"}, "networking.k8s.io", "v1", "networkpolicies", true},
+		{[]string{"ingressclass", "ingressclasses"}, "networking.k8s.io", "v1", "ingressclasses", true},
+		{[]string{"endpointslice", "endpointslices"}, "discovery.k8s.io", "v1", "endpointslices", false},
+		{[]string{"lease", "leases"}, "coordination.k8s.io", "v1", "leases", false},
+		{[]string{"priorityclass", "priorityclasses", "pc"}, "scheduling.k8s.io", "v1", "priorityclasses", false},
+		{[]string{"runtimeclass", "runtimeclasses"}, "node.k8s.io", "v1", "runtimeclasses", false},
+		{[]string{"mutatingwebhookconfiguration", "mutatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "mutatingwebhookconfigurations", false},
+		{[]string{"validatingwebhookconfiguration", "validatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "validatingwebhookconfigurations", false},
+		{[]string{"volumeattachment", "volumeattachments"}, "storage.k8s.io", "v1", "volumeattachments", false},
+		{[]string{"poddisruptionbudget", "poddisruptionbudgets", "pdb", "pdbs"}, "policy", "v1", "poddisruptionbudgets", true},
+		{[]string{"storageclass", "storageclasses", "sc"}, "storage.k8s.io", "v1", "storageclasses", true},
+		{[]string{"role", "roles"}, "rbac.authorization.k8s.io", "v1", "roles", true},
+		{[]string{"clusterrole", "clusterroles"}, "rbac.authorization.k8s.io", "v1", "clusterroles", true},
+		{[]string{"rolebinding", "rolebindings"}, "rbac.authorization.k8s.io", "v1", "rolebindings", true},
+		{[]string{"clusterrolebinding", "clusterrolebindings"}, "rbac.authorization.k8s.io", "v1", "clusterrolebindings", true},
 	}
 	m := make(map[string]schema.GroupVersionResource)
+	typed := make(map[string]schema.GroupVersionResource)
 	for _, d := range defs {
 		gvr := schema.GroupVersionResource{Group: d.group, Version: d.version, Resource: d.resource}
 		for _, f := range d.forms {
 			m[f] = gvr
+			if d.typed {
+				typed[f] = gvr
+			}
 		}
 	}
-	return m
+	return m, typed
 }()
 
 // TypedKindOwnsGroup reports whether (kind, group) names a built-in kind
@@ -94,10 +103,7 @@ var builtinGVRs = func() map[string]schema.GroupVersionResource {
 // dynamic cache" dispatch so built-in workloads addressed with their real group
 // don't fall through to the dynamic cache (which has no informer for them).
 func TypedKindOwnsGroup(kind, group string) bool {
-	gvr, ok := builtinGVRs[strings.ToLower(kind)]
-	if ok && gvr.Group == "discovery.k8s.io" && gvr.Resource == "endpointslices" {
-		return false
-	}
+	gvr, ok := typedBuiltinGVRs[strings.ToLower(kind)]
 	return ok && gvr.Group == group
 }
 

--- a/internal/k8s/kinds.go
+++ b/internal/k8s/kinds.go
@@ -30,6 +30,8 @@ var clusterOnlyKinds = map[string]ClusterOnlyKindInfo{
 	"storageclasses":                  {"storage.k8s.io", "storageclasses"},
 	"storageclass":                    {"storage.k8s.io", "storageclasses"},
 	"sc":                              {"storage.k8s.io", "storageclasses"},
+	"volumeattachments":               {"storage.k8s.io", "volumeattachments"},
+	"volumeattachment":                {"storage.k8s.io", "volumeattachments"},
 	"ingressclasses":                  {"networking.k8s.io", "ingressclasses"},
 	"ingressclass":                    {"networking.k8s.io", "ingressclasses"},
 	"clusterroles":                    {"rbac.authorization.k8s.io", "clusterroles"},

--- a/internal/k8s/kinds_test.go
+++ b/internal/k8s/kinds_test.go
@@ -7,6 +7,7 @@ func TestIsClusterOnlyKind(t *testing.T) {
 		"nodes", "node", "Node",
 		"persistentvolumes", "persistentvolume", "pv", "PV",
 		"storageclasses", "storageclass", "sc",
+		"volumeattachments", "volumeattachment",
 		"ingressclasses", "ingressclass",
 		"clusterroles", "clusterrole",
 		"clusterrolebindings", "clusterrolebinding",
@@ -51,6 +52,7 @@ func TestClusterOnlyKindGVR(t *testing.T) {
 		{"namespaces", "", "namespaces", true}, // GVR exists even though IsClusterOnlyKind=false
 		{"ns", "", "namespaces", true},
 		{"clusterroles", "rbac.authorization.k8s.io", "clusterroles", true},
+		{"volumeattachments", "storage.k8s.io", "volumeattachments", true},
 		{"crd", "apiextensions.k8s.io", "customresourcedefinitions", true},
 		{"NODES", "", "nodes", true}, // case-insensitive
 		{"pods", "", "", false},

--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -30,9 +30,9 @@ const (
 )
 
 const (
-	endpointSliceCountKey          = "discovery.k8s.io/EndpointSlice"
-	endpointSliceCountNamespaceCap = 50
-	endpointSliceCountConcurrency  = 8
+	endpointSliceCountKey       = "discovery.k8s.io/EndpointSlice"
+	directCountNamespaceCap     = 50
+	directCountProbeConcurrency = 8
 )
 
 func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
@@ -56,27 +56,56 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 	var forbidden []string
 	var unavailable []string
 	reasons := map[string]string{}
+	covered := map[string]bool{}
+	forbiddenSeen := map[string]bool{}
+	unavailableSeen := map[string]bool{}
 
-	countEndpointSlices := func() {
+	countKey := func(group, kind string) string {
+		if group != "" {
+			return group + "/" + kind
+		}
+		return kind
+	}
+	markCounted := func(key string, count int) {
+		counts[key] = count
+		covered[key] = true
+	}
+	markForbidden := func(key, reason string) {
+		if covered[key] {
+			return
+		}
+		if !forbiddenSeen[key] {
+			forbidden = append(forbidden, key)
+			forbiddenSeen[key] = true
+		}
+		reasons[key] = reason
+		covered[key] = true
+	}
+	markUnavailable := func(key string) {
+		if covered[key] {
+			return
+		}
+		if !unavailableSeen[key] {
+			unavailable = append(unavailable, key)
+			unavailableSeen[key] = true
+		}
+		covered[key] = true
+	}
+	countDirectProbe := func(key string, gvr schema.GroupVersionResource, namespaces []string) {
 		dynamicCache := k8s.GetDynamicResourceCache()
 		if dynamicCache == nil {
-			unavailable = append(unavailable, endpointSliceCountKey)
+			markUnavailable(key)
 			return
 		}
-		gvr, ok := k8s.BuiltinGVR("endpointslices", "discovery.k8s.io")
-		if !ok {
-			unavailable = append(unavailable, endpointSliceCountKey)
-			return
-		}
-		total, err := dynamicCache.CountDirectProbe(r.Context(), gvr, namespaces, endpointSliceCountNamespaceCap, endpointSliceCountConcurrency)
+		total, err := dynamicCache.CountDirectProbe(r.Context(), gvr, namespaces, directCountNamespaceCap, directCountProbeConcurrency)
 		if err != nil {
-			unavailable = append(unavailable, endpointSliceCountKey)
+			markUnavailable(key)
 			if !errors.Is(err, k8score.ErrResourceCountUnavailable) {
-				log.Printf("[resource-counts] Failed to count EndpointSlice: %v", err)
+				log.Printf("[resource-counts] Failed to count %s: %v", key, err)
 			}
 			return
 		}
-		counts[endpointSliceCountKey] = total
+		markCounted(key, total)
 	}
 
 	for _, kl := range k8score.AllKindListers() {
@@ -84,8 +113,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		if l == nil {
 			// No informer: Radar's SA can't read this kind (not installed, SA
 			// RBAC, or feature off) — a user-level grant won't surface it.
-			forbidden = append(forbidden, kl.CountKey())
-			reasons[kl.CountKey()] = reasonUnavailable
+			markForbidden(kl.CountKey(), reasonUnavailable)
 			continue
 		}
 		// Cluster-scoped kinds: ListCountNamespaced ignores the namespace
@@ -100,8 +128,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 			// surfaced as forbidden rather than silently omitted — otherwise the
 			// UI shows "0 / No X found", indistinguishable from an empty cluster.
 			if !s.canRead(r, group, resource, "", "list") {
-				forbidden = append(forbidden, kl.CountKey())
-				reasons[kl.CountKey()] = reasonRBACDenied
+				markForbidden(kl.CountKey(), reasonRBACDenied)
 				continue
 			}
 		}
@@ -113,10 +140,13 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		if kl.Kind() == "Namespace" && len(namespaces) > 0 {
 			n = len(namespaces)
 		}
-		counts[kl.CountKey()] = n
+		markCounted(kl.CountKey(), n)
 	}
 
-	// 2. Dynamic resources (CRDs) — report counts only for already-watched informers.
+	// 2. Dynamic resources:
+	//   - CRDs are counted only from already-watched informers.
+	//   - Built-ins that do not have typed listers are counted with bounded
+	//     direct probes, restricted to the existing built-in GVR catalogue.
 	discovery := k8s.GetResourceDiscovery()
 	dynamicCache := k8s.GetDynamicResourceCache()
 	if discovery != nil && dynamicCache != nil {
@@ -125,7 +155,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[resource-counts] Failed to discover API resources for CRD counts: %v", err)
 		} else {
 			// Deduplicate CRDs by group+kind, keeping the most stable served version.
-			type crdInfo struct {
+			type discoveredInfo struct {
 				kind       string
 				group      string
 				resource   string
@@ -133,40 +163,55 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 				namespaced bool
 				gvr        schema.GroupVersionResource
 			}
-			seen := make(map[string]bool)
-			crds := make(map[string]crdInfo)
-			var order []string
+			crdSeen := make(map[string]bool)
+			crds := make(map[string]discoveredInfo)
+			var crdOrder []string
+			builtinSeen := make(map[string]bool)
+			builtins := make(map[string]discoveredInfo)
+			var builtinOrder []string
 			for _, res := range resources {
-				if !res.IsCRD {
+				if !slices.Contains(res.Verbs, "list") {
 					continue
 				}
-				// Informer-backed counts only work for listable+watchable kinds.
-				// Create-only review resources (LocalSubjectAccessReview, etc.)
-				// never sync an informer and would log a permanent count error.
-				if !slices.Contains(res.Verbs, "list") || !slices.Contains(res.Verbs, "watch") {
+				key := countKey(res.Group, res.Kind)
+				info := discoveredInfo{
+					kind:       res.Kind,
+					group:      res.Group,
+					resource:   res.Name,
+					version:    res.Version,
+					namespaced: res.Namespaced,
+					gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
+				}
+				if res.IsCRD {
+					// Informer-backed counts only work for listable+watchable kinds.
+					// Create-only review resources (LocalSubjectAccessReview, etc.)
+					// never sync an informer and would log a permanent count error.
+					if !slices.Contains(res.Verbs, "watch") {
+						continue
+					}
+					if !crdSeen[key] {
+						crdSeen[key] = true
+						crdOrder = append(crdOrder, key)
+						crds[key] = info
+					} else if k8score.IsMoreStableVersion(res.Version, crds[key].version) {
+						crds[key] = info
+					}
 					continue
 				}
-				key := res.Group + "/" + res.Kind
-				if !seen[key] {
-					seen[key] = true
-					order = append(order, key)
-					crds[key] = crdInfo{
-						kind:       res.Kind,
-						group:      res.Group,
-						resource:   res.Name,
-						version:    res.Version,
-						namespaced: res.Namespaced,
-						gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
+				if covered[key] {
+					continue
+				}
+				if _, ok := k8s.BuiltinGVR(res.Name, res.Group); !ok {
+					if _, ok := k8s.BuiltinGVR(res.Kind, res.Group); !ok {
+						continue
 					}
-				} else if k8score.IsMoreStableVersion(res.Version, crds[key].version) {
-					crds[key] = crdInfo{
-						kind:       res.Kind,
-						group:      res.Group,
-						resource:   res.Name,
-						version:    res.Version,
-						namespaced: res.Namespaced,
-						gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
-					}
+				}
+				if !builtinSeen[key] {
+					builtinSeen[key] = true
+					builtinOrder = append(builtinOrder, key)
+					builtins[key] = info
+				} else if k8score.IsMoreStableVersion(res.Version, builtins[key].version) {
+					builtins[key] = info
 				}
 			}
 
@@ -175,7 +220,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 			if len(namespaces) > 0 {
 				clusterScopedWatchedCounts = dynamicCache.CountWatched(nil)
 			}
-			for _, key := range order {
+			for _, key := range crdOrder {
 				crd := crds[key]
 				countSource := watchedCounts
 				if !crd.namespaced {
@@ -185,14 +230,32 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 					countSource = clusterScopedWatchedCounts
 				}
 				if n, ok := countSource[crd.gvr]; ok {
-					counts[key] = n
+					markCounted(key, n)
 					continue
 				}
-				unavailable = append(unavailable, key)
+				markUnavailable(key)
+			}
+			for _, key := range builtinOrder {
+				builtin := builtins[key]
+				probeNamespaces := namespaces
+				if !builtin.namespaced {
+					if !s.canRead(r, builtin.group, builtin.resource, "", "list") {
+						markForbidden(key, reasonRBACDenied)
+						continue
+					}
+					probeNamespaces = nil
+				}
+				countDirectProbe(key, builtin.gvr, probeNamespaces)
 			}
 		}
 	}
-	countEndpointSlices()
+	if !covered[endpointSliceCountKey] {
+		if gvr, ok := k8s.BuiltinGVR("endpointslices", "discovery.k8s.io"); ok {
+			countDirectProbe(endpointSliceCountKey, gvr, namespaces)
+		} else {
+			markUnavailable(endpointSliceCountKey)
+		}
+	}
 
 	s.writeJSON(w, ResourceCountsResponse{
 		Counts:      counts,

--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -30,9 +30,9 @@ const (
 )
 
 const (
-	endpointSliceCountKey       = "discovery.k8s.io/EndpointSlice"
-	directCountNamespaceCap     = 50
-	directCountProbeConcurrency = 8
+	endpointSliceCountKey          = "discovery.k8s.io/EndpointSlice"
+	endpointSliceCountNamespaceCap = 50
+	endpointSliceCountConcurrency  = 8
 )
 
 func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +67,9 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		return kind
 	}
 	markCounted := func(key string, count int) {
+		if covered[key] {
+			return
+		}
 		counts[key] = count
 		covered[key] = true
 	}
@@ -91,21 +94,29 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		}
 		covered[key] = true
 	}
-	countDirectProbe := func(key string, gvr schema.GroupVersionResource, namespaces []string) {
-		dynamicCache := k8s.GetDynamicResourceCache()
-		if dynamicCache == nil {
-			markUnavailable(key)
+	countEndpointSlices := func() {
+		if covered[endpointSliceCountKey] {
 			return
 		}
-		total, err := dynamicCache.CountDirectProbe(r.Context(), gvr, namespaces, directCountNamespaceCap, directCountProbeConcurrency)
+		dynamicCache := k8s.GetDynamicResourceCache()
+		if dynamicCache == nil {
+			markUnavailable(endpointSliceCountKey)
+			return
+		}
+		gvr, ok := k8s.BuiltinGVR("endpointslices", "discovery.k8s.io")
+		if !ok {
+			markUnavailable(endpointSliceCountKey)
+			return
+		}
+		total, err := dynamicCache.CountDirectProbe(r.Context(), gvr, namespaces, endpointSliceCountNamespaceCap, endpointSliceCountConcurrency)
 		if err != nil {
-			markUnavailable(key)
+			markUnavailable(endpointSliceCountKey)
 			if !errors.Is(err, k8score.ErrResourceCountUnavailable) {
-				log.Printf("[resource-counts] Failed to count %s: %v", key, err)
+				log.Printf("[resource-counts] Failed to count EndpointSlice: %v", err)
 			}
 			return
 		}
-		markCounted(key, total)
+		markCounted(endpointSliceCountKey, total)
 	}
 
 	for _, kl := range k8score.AllKindListers() {
@@ -143,10 +154,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		markCounted(kl.CountKey(), n)
 	}
 
-	// 2. Dynamic resources:
-	//   - CRDs are counted only from already-watched informers.
-	//   - Built-ins that do not have typed listers are counted with bounded
-	//     direct probes, restricted to the existing built-in GVR catalogue.
+	// 2. Dynamic resources (CRDs) — report counts only for already-watched informers.
 	discovery := k8s.GetResourceDiscovery()
 	dynamicCache := k8s.GetDynamicResourceCache()
 	if discovery != nil && dynamicCache != nil {
@@ -155,7 +163,7 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[resource-counts] Failed to discover API resources for CRD counts: %v", err)
 		} else {
 			// Deduplicate CRDs by group+kind, keeping the most stable served version.
-			type discoveredInfo struct {
+			type crdInfo struct {
 				kind       string
 				group      string
 				resource   string
@@ -164,17 +172,20 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 				gvr        schema.GroupVersionResource
 			}
 			crdSeen := make(map[string]bool)
-			crds := make(map[string]discoveredInfo)
+			crds := make(map[string]crdInfo)
 			var crdOrder []string
-			builtinSeen := make(map[string]bool)
-			builtins := make(map[string]discoveredInfo)
-			var builtinOrder []string
 			for _, res := range resources {
-				if !slices.Contains(res.Verbs, "list") {
+				if !res.IsCRD {
+					continue
+				}
+				// Informer-backed counts only work for listable+watchable kinds.
+				// Create-only review resources (LocalSubjectAccessReview, etc.)
+				// never sync an informer and would log a permanent count error.
+				if !slices.Contains(res.Verbs, "list") || !slices.Contains(res.Verbs, "watch") {
 					continue
 				}
 				key := countKey(res.Group, res.Kind)
-				info := discoveredInfo{
+				info := crdInfo{
 					kind:       res.Kind,
 					group:      res.Group,
 					resource:   res.Name,
@@ -182,36 +193,12 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 					namespaced: res.Namespaced,
 					gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
 				}
-				if res.IsCRD {
-					// Informer-backed counts only work for listable+watchable kinds.
-					// Create-only review resources (LocalSubjectAccessReview, etc.)
-					// never sync an informer and would log a permanent count error.
-					if !slices.Contains(res.Verbs, "watch") {
-						continue
-					}
-					if !crdSeen[key] {
-						crdSeen[key] = true
-						crdOrder = append(crdOrder, key)
-						crds[key] = info
-					} else if k8score.IsMoreStableVersion(res.Version, crds[key].version) {
-						crds[key] = info
-					}
-					continue
-				}
-				if covered[key] {
-					continue
-				}
-				if _, ok := k8s.BuiltinGVR(res.Name, res.Group); !ok {
-					if _, ok := k8s.BuiltinGVR(res.Kind, res.Group); !ok {
-						continue
-					}
-				}
-				if !builtinSeen[key] {
-					builtinSeen[key] = true
-					builtinOrder = append(builtinOrder, key)
-					builtins[key] = info
-				} else if k8score.IsMoreStableVersion(res.Version, builtins[key].version) {
-					builtins[key] = info
+				if !crdSeen[key] {
+					crdSeen[key] = true
+					crdOrder = append(crdOrder, key)
+					crds[key] = info
+				} else if k8score.IsMoreStableVersion(res.Version, crds[key].version) {
+					crds[key] = info
 				}
 			}
 
@@ -235,27 +222,9 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 				}
 				markUnavailable(key)
 			}
-			for _, key := range builtinOrder {
-				builtin := builtins[key]
-				probeNamespaces := namespaces
-				if !builtin.namespaced {
-					if !s.canRead(r, builtin.group, builtin.resource, "", "list") {
-						markForbidden(key, reasonRBACDenied)
-						continue
-					}
-					probeNamespaces = nil
-				}
-				countDirectProbe(key, builtin.gvr, probeNamespaces)
-			}
 		}
 	}
-	if !covered[endpointSliceCountKey] {
-		if gvr, ok := k8s.BuiltinGVR("endpointslices", "discovery.k8s.io"); ok {
-			countDirectProbe(endpointSliceCountKey, gvr, namespaces)
-		} else {
-			markUnavailable(endpointSliceCountKey)
-		}
-	}
+	countEndpointSlices()
 
 	s.writeJSON(w, ResourceCountsResponse{
 		Counts:      counts,

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -78,7 +78,7 @@ func TestResourceCountsCountsWatchedCRDsAndMarksUnwatchedUnavailable(t *testing.
 	}
 }
 
-func TestResourceCountsCountsDiscoveredBuiltinResourcesWithoutTypedListers(t *testing.T) {
+func TestResourceCountsLeavesDiscoveredBuiltinsWithoutTypedListersUnprobed(t *testing.T) {
 	priorityClassGVR := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
 	leaseGVR := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"}
 	endpointsGVR := schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}
@@ -122,6 +122,14 @@ func TestResourceCountsCountsDiscoveredBuiltinResourcesWithoutTypedListers(t *te
 			"metadata":   map[string]any{"name": "api", "namespace": "other"},
 		}},
 	)
+	listProbes := map[string]int{}
+	for _, resource := range []string{"priorityclasses", "leases", "endpoints"} {
+		resource := resource
+		dyn.PrependReactor("list", resource, func(action k8stesting.Action) (bool, runtime.Object, error) {
+			listProbes[resource]++
+			return true, &unstructured.UnstructuredList{}, nil
+		})
+	}
 	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
 		{Group: "scheduling.k8s.io", Version: "v1", Kind: "PriorityClass", Name: "priorityclasses", Namespaced: false, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
 		{Group: "coordination.k8s.io", Version: "v1", Kind: "Lease", Name: "leases", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
@@ -141,22 +149,22 @@ func TestResourceCountsCountsDiscoveredBuiltinResourcesWithoutTypedListers(t *te
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if got := body.Counts["scheduling.k8s.io/PriorityClass"]; got != 2 {
-		t.Fatalf("PriorityClass count = %d, want 2", got)
-	}
-	if got := body.Counts["coordination.k8s.io/Lease"]; got != 1 {
-		t.Fatalf("Lease count = %d, want 1", got)
-	}
-	if got := body.Counts["Endpoints"]; got != 1 {
-		t.Fatalf("Endpoints count = %d, want 1", got)
+	if got := body.Counts[endpointSliceCountKey]; got != 0 {
+		t.Fatalf("EndpointSlice count = %d, want 0", got)
 	}
 	for _, key := range []string{"scheduling.k8s.io/PriorityClass", "coordination.k8s.io/Lease", "Endpoints"} {
+		if _, ok := body.Counts[key]; ok {
+			t.Fatalf("%s unexpectedly had a count: %v", key, body.Counts[key])
+		}
 		if containsString(body.Unavailable, key) {
-			t.Fatalf("%s counted but marked unavailable: %v", key, body.Unavailable)
+			t.Fatalf("%s should be omitted rather than marked unavailable: %v", key, body.Unavailable)
 		}
 		if containsString(body.Forbidden, key) {
-			t.Fatalf("%s counted but marked forbidden: %v", key, body.Forbidden)
+			t.Fatalf("%s should be omitted rather than marked forbidden: %v", key, body.Forbidden)
 		}
+	}
+	if len(listProbes) > 0 {
+		t.Fatalf("unexpected direct probes for low-value built-ins: %v", listProbes)
 	}
 }
 
@@ -213,59 +221,6 @@ func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	}
 	if containsString(body.Unavailable, "karpenter.sh/NodePool") {
 		t.Fatalf("denied NodePool should not be advertised as unavailable: %v", body.Unavailable)
-	}
-}
-
-func TestResourceCountsSurfacesDeniedDiscoveredClusterScopedBuiltinAsForbidden(t *testing.T) {
-	priorityClassGVR := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
-	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
-	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-		runtime.NewScheme(),
-		map[schema.GroupVersionResource]string{
-			priorityClassGVR: "PriorityClassList",
-			endpointSliceGVR: "EndpointSliceList",
-		},
-		&unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "scheduling.k8s.io/v1",
-			"kind":       "PriorityClass",
-			"metadata":   map[string]any{"name": "high"},
-		}},
-	)
-	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
-		{Group: "scheduling.k8s.io", Version: "v1", Kind: "PriorityClass", Name: "priorityclasses", Namespaced: false, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
-		{Group: "discovery.k8s.io", Version: "v1", Kind: "EndpointSlice", Name: "endpointslices", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
-	}); err != nil {
-		t.Fatalf("InitTestDynamicResourceCache: %v", err)
-	}
-	t.Cleanup(k8s.ResetTestDynamicState)
-
-	s := newAuthServer(auth.Config{Mode: "proxy"})
-	user := &auth.User{Username: "alice"}
-	perms := &auth.UserPermissions{AllowedNamespaces: nil}
-	perms.SetCanI("list", "scheduling.k8s.io", "priorityclasses", "", false)
-	s.permCache.Set(user.Username, perms)
-	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
-
-	rec := httptest.NewRecorder()
-	s.handleResourceCounts(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
-	}
-	var body ResourceCountsResponse
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if _, ok := body.Counts["scheduling.k8s.io/PriorityClass"]; ok {
-		t.Fatalf("denied PriorityClass leaked a count: %v", body.Counts["scheduling.k8s.io/PriorityClass"])
-	}
-	if !containsString(body.Forbidden, "scheduling.k8s.io/PriorityClass") {
-		t.Fatalf("denied PriorityClass should be in forbidden, got: %v", body.Forbidden)
-	}
-	if body.Reasons["scheduling.k8s.io/PriorityClass"] != "rbac_denied" {
-		t.Fatalf("PriorityClass reason = %q, want rbac_denied", body.Reasons["scheduling.k8s.io/PriorityClass"])
-	}
-	if containsString(body.Unavailable, "scheduling.k8s.io/PriorityClass") {
-		t.Fatalf("denied PriorityClass should not be advertised as unavailable: %v", body.Unavailable)
 	}
 }
 

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -78,6 +78,88 @@ func TestResourceCountsCountsWatchedCRDsAndMarksUnwatchedUnavailable(t *testing.
 	}
 }
 
+func TestResourceCountsCountsDiscoveredBuiltinResourcesWithoutTypedListers(t *testing.T) {
+	priorityClassGVR := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
+	leaseGVR := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"}
+	endpointsGVR := schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}
+	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			priorityClassGVR: "PriorityClassList",
+			leaseGVR:         "LeaseList",
+			endpointsGVR:     "EndpointsList",
+			endpointSliceGVR: "EndpointSliceList",
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "scheduling.k8s.io/v1",
+			"kind":       "PriorityClass",
+			"metadata":   map[string]any{"name": "high"},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "scheduling.k8s.io/v1",
+			"kind":       "PriorityClass",
+			"metadata":   map[string]any{"name": "low"},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "coordination.k8s.io/v1",
+			"kind":       "Lease",
+			"metadata":   map[string]any{"name": "default-lease", "namespace": "default"},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "coordination.k8s.io/v1",
+			"kind":       "Lease",
+			"metadata":   map[string]any{"name": "other-lease", "namespace": "other"},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Endpoints",
+			"metadata":   map[string]any{"name": "api", "namespace": "default"},
+		}},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Endpoints",
+			"metadata":   map[string]any{"name": "api", "namespace": "other"},
+		}},
+	)
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
+		{Group: "scheduling.k8s.io", Version: "v1", Kind: "PriorityClass", Name: "priorityclasses", Namespaced: false, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+		{Group: "coordination.k8s.io", Version: "v1", Kind: "Lease", Name: "leases", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+		{Group: "", Version: "v1", Kind: "Endpoints", Name: "endpoints", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+		{Group: "discovery.k8s.io", Version: "v1", Kind: "EndpointSlice", Name: "endpointslices", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+
+	rec := httptest.NewRecorder()
+	testServerSrv.handleResourceCounts(rec, httptest.NewRequest(http.MethodGet, "/api/resource-counts?namespace=default", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body.Counts["scheduling.k8s.io/PriorityClass"]; got != 2 {
+		t.Fatalf("PriorityClass count = %d, want 2", got)
+	}
+	if got := body.Counts["coordination.k8s.io/Lease"]; got != 1 {
+		t.Fatalf("Lease count = %d, want 1", got)
+	}
+	if got := body.Counts["Endpoints"]; got != 1 {
+		t.Fatalf("Endpoints count = %d, want 1", got)
+	}
+	for _, key := range []string{"scheduling.k8s.io/PriorityClass", "coordination.k8s.io/Lease", "Endpoints"} {
+		if containsString(body.Unavailable, key) {
+			t.Fatalf("%s counted but marked unavailable: %v", key, body.Unavailable)
+		}
+		if containsString(body.Forbidden, key) {
+			t.Fatalf("%s counted but marked forbidden: %v", key, body.Forbidden)
+		}
+	}
+}
+
 func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	nodePoolGVR := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
 	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
@@ -131,6 +213,59 @@ func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	}
 	if containsString(body.Unavailable, "karpenter.sh/NodePool") {
 		t.Fatalf("denied NodePool should not be advertised as unavailable: %v", body.Unavailable)
+	}
+}
+
+func TestResourceCountsSurfacesDeniedDiscoveredClusterScopedBuiltinAsForbidden(t *testing.T) {
+	priorityClassGVR := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
+	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			priorityClassGVR: "PriorityClassList",
+			endpointSliceGVR: "EndpointSliceList",
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "scheduling.k8s.io/v1",
+			"kind":       "PriorityClass",
+			"metadata":   map[string]any{"name": "high"},
+		}},
+	)
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
+		{Group: "scheduling.k8s.io", Version: "v1", Kind: "PriorityClass", Name: "priorityclasses", Namespaced: false, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+		{Group: "discovery.k8s.io", Version: "v1", Kind: "EndpointSlice", Name: "endpointslices", Namespaced: true, IsCRD: false, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "alice"}
+	perms := &auth.UserPermissions{AllowedNamespaces: nil}
+	perms.SetCanI("list", "scheduling.k8s.io", "priorityclasses", "", false)
+	s.permCache.Set(user.Username, perms)
+	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
+
+	rec := httptest.NewRecorder()
+	s.handleResourceCounts(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body.Counts["scheduling.k8s.io/PriorityClass"]; ok {
+		t.Fatalf("denied PriorityClass leaked a count: %v", body.Counts["scheduling.k8s.io/PriorityClass"])
+	}
+	if !containsString(body.Forbidden, "scheduling.k8s.io/PriorityClass") {
+		t.Fatalf("denied PriorityClass should be in forbidden, got: %v", body.Forbidden)
+	}
+	if body.Reasons["scheduling.k8s.io/PriorityClass"] != "rbac_denied" {
+		t.Fatalf("PriorityClass reason = %q, want rbac_denied", body.Reasons["scheduling.k8s.io/PriorityClass"])
+	}
+	if containsString(body.Unavailable, "scheduling.k8s.io/PriorityClass") {
+		t.Fatalf("denied PriorityClass should not be advertised as unavailable: %v", body.Unavailable)
 	}
 }
 

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
@@ -75,6 +75,20 @@ describe('ResourcesSidebar count visibility', () => {
     expect(html).toContain('Show')
   })
 
+  it('keeps the selected confirmed-empty resource visible', () => {
+    const html = renderToString(
+      <ResourcesSidebar
+        selectedKind={{ name: 'horizontalpodautoscalers', kind: 'HorizontalPodAutoscaler', group: 'autoscaling' }}
+        onSelectedKindChange={() => {}}
+        apiResources={[horizontalPodAutoscaler]}
+        resourceCounts={{ 'autoscaling/HorizontalPodAutoscaler': 0 }}
+      />
+    )
+
+    expect(html).toContain('HorizontalPodAutoscaler')
+    expect(html).toContain('>0</')
+  })
+
   it('keeps pinned confirmed-empty resources visible in Favorites', () => {
     const html = renderToString(
       <ResourcesSidebar

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
@@ -58,6 +58,7 @@ describe('ResourcesSidebar count visibility', () => {
 
     expect(html).toContain('HorizontalPodAutoscaler')
     expect(html).toContain('–')
+    expect(html).toContain('aria-label="Count unavailable. Open to view resources."')
   })
 
   it('hides confirmed-empty resources by default', () => {

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
@@ -13,6 +13,16 @@ const sqlInstance: APIResource = {
   verbs: ['list'],
 }
 
+const horizontalPodAutoscaler: APIResource = {
+  group: 'autoscaling',
+  version: 'v2',
+  kind: 'HorizontalPodAutoscaler',
+  name: 'horizontalpodautoscalers',
+  namespaced: true,
+  isCrd: false,
+  verbs: ['list'],
+}
+
 describe('ResourcesSidebar CRD group labels', () => {
   it('keeps raw API groups available for filtering and hover recovery', () => {
     expect(resourceMatchesSidebarFilter(sqlInstance, 'cnrm')).toBe(true)
@@ -32,5 +42,51 @@ describe('ResourcesSidebar CRD group labels', () => {
 
     expect(html).toContain('Config Connector')
     expect(html).toContain('title="API group: sql.cnrm.cloud.google.com"')
+  })
+})
+
+describe('ResourcesSidebar count visibility', () => {
+  it('keeps resources visible when their count is unknown', () => {
+    const html = renderToString(
+      <ResourcesSidebar
+        selectedKind={null}
+        onSelectedKindChange={() => {}}
+        apiResources={[horizontalPodAutoscaler]}
+        resourceCounts={{}}
+      />
+    )
+
+    expect(html).toContain('HorizontalPodAutoscaler')
+    expect(html).toContain('–')
+  })
+
+  it('hides confirmed-empty resources by default', () => {
+    const html = renderToString(
+      <ResourcesSidebar
+        selectedKind={null}
+        onSelectedKindChange={() => {}}
+        apiResources={[horizontalPodAutoscaler]}
+        resourceCounts={{ 'autoscaling/HorizontalPodAutoscaler': 0 }}
+      />
+    )
+
+    expect(html).not.toContain('HorizontalPodAutoscaler')
+    expect(html).toContain('Show')
+  })
+
+  it('keeps pinned confirmed-empty resources visible in Favorites', () => {
+    const html = renderToString(
+      <ResourcesSidebar
+        selectedKind={null}
+        onSelectedKindChange={() => {}}
+        apiResources={[horizontalPodAutoscaler]}
+        resourceCounts={{ 'autoscaling/HorizontalPodAutoscaler': 0 }}
+        pinned={[{ name: 'horizontalpodautoscalers', kind: 'HorizontalPodAutoscaler', group: 'autoscaling' }]}
+        isPinned={(name, group) => name === 'horizontalpodautoscalers' && group === 'autoscaling'}
+      />
+    )
+
+    expect(html).toContain('Favorites')
+    expect(html).toContain('HorizontalPodAutoscaler')
   })
 })

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -318,7 +318,10 @@ export function ResourcesSidebar({
       // visible as a dash so count coverage gaps do not masquerade as emptiness.
       const visibleResources = category.resources.filter(resource => {
         const count = counts[resource.group ? `${resource.group}/${resource.kind}` : resource.kind]
-        const shouldShow = count === null || (count ?? 0) > 0 || showEmptyKinds
+        const isSelectedResource =
+          (effectiveSelectedKind.name === resource.name && effectiveSelectedKind.group === resource.group) ||
+          (effectiveSelectedKind.kind.toLowerCase() === resource.kind.toLowerCase() && effectiveSelectedKind.group === resource.group)
+        const shouldShow = isSelectedResource || count === null || (count ?? 0) > 0 || showEmptyKinds
         if (!shouldShow) totalHiddenKinds++
         return shouldShow
       })
@@ -341,7 +344,7 @@ export function ResourcesSidebar({
     })
 
     return { sortedCategories: visibleCategories, hiddenKindsCount: totalHiddenKinds, hiddenGroupsCount: totalHiddenGroups }
-  }, [categories, counts, showEmptyKinds])
+  }, [categories, counts, showEmptyKinds, effectiveSelectedKind.name, effectiveSelectedKind.kind, effectiveSelectedKind.group])
 
   // Filter sidebar categories/kinds by the kind search term
   const filteredCategories = useMemo(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -52,6 +52,7 @@ export interface ResourcesSidebarProps {
 
 // Persisted across remounts so collapsed categories survive tab switches
 let persistedExpandedCategories: Set<string> | null = null
+const COUNT_UNAVAILABLE_MESSAGE = 'Count unavailable. Open to view resources.'
 
 // Fallback resource types when API resources aren't loaded yet
 const CORE_RESOURCE_TYPES = [
@@ -150,15 +151,25 @@ const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps
             <Tooltip content="Insufficient permissions" position="left">
               <Shield className="w-3.5 h-3.5 text-amber-400/60" />
             </Tooltip>
+          ) : count === null ? (
+            <Tooltip content={COUNT_UNAVAILABLE_MESSAGE} position="left">
+              <span
+                className={clsx(
+                  'text-xs py-0.5 rounded text-center font-mono w-8 text-theme-text-disabled',
+                  isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
+                )}
+                aria-label={COUNT_UNAVAILABLE_MESSAGE}
+              >
+                –
+              </span>
+            </Tooltip>
           ) : (
             <span className={clsx(
               'text-xs py-0.5 rounded text-center font-mono',
               isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
-              count === null
-                ? 'w-8 text-theme-text-disabled'
-                : count < 1000 ? 'w-8' : 'w-9',
+              count < 1000 ? 'w-8' : 'w-9',
             )}>
-              {count === null ? '–' : count}
+              {count}
             </span>
           )}
         </div>
@@ -620,13 +631,26 @@ export function ResourcesSidebar({
               >
                 <Icon className="w-4 h-4 shrink-0" />
                 <span className="flex-1 text-left">{type.label}</span>
-                <span className={clsx(
-                  'badge font-mono',
-                  isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
-                  count === null && 'text-theme-text-disabled',
-                )}>
-                  {count === null ? '–' : count}
-                </span>
+                {count === null ? (
+                  <Tooltip content={COUNT_UNAVAILABLE_MESSAGE} position="left">
+                    <span
+                      className={clsx(
+                        'badge font-mono text-theme-text-disabled',
+                        isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
+                      )}
+                      aria-label={COUNT_UNAVAILABLE_MESSAGE}
+                    >
+                      –
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <span className={clsx(
+                    'badge font-mono',
+                    isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
+                  )}>
+                    {count}
+                  </span>
+                )}
               </button>
             )
           })

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -53,29 +53,6 @@ export interface ResourcesSidebarProps {
 // Persisted across remounts so collapsed categories survive tab switches
 let persistedExpandedCategories: Set<string> | null = null
 
-// Core kinds that are always shown even with 0 instances
-// These are the most commonly used Kubernetes resources (using Kind names, not plural names)
-const ALWAYS_SHOWN_KINDS = new Set([
-  'Pod',
-  'Deployment',
-  'DaemonSet',
-  'StatefulSet',
-  'ReplicaSet',
-  'Service',
-  'Ingress',
-  'ConfigMap',
-  'Secret',
-  'Job',
-  'CronJob',
-  'HorizontalPodAutoscaler',
-  'PersistentVolumeClaim',
-  'Node',
-  'Namespace',
-  'ServiceAccount',
-  'NetworkPolicy',
-  'Event',
-])
-
 // Fallback resource types when API resources aren't loaded yet
 const CORE_RESOURCE_TYPES = [
   { kind: 'pods', label: 'Pods' },
@@ -299,7 +276,7 @@ export function ResourcesSidebar({
       } else if (key in resourceCounts) {
         results[key] = resourceCounts[key] ?? null
       } else {
-        results[key] = 0
+        results[key] = null
       }
     }
     return results
@@ -326,14 +303,11 @@ export function ResourcesSidebar({
         0
       )
 
-      // Filter resources: show if has instances, is core kind, has an
-      // unknown count (loading — don't pre-emptively hide), or
-      // showEmptyKinds is true.
+      // Filter resources: hide only confirmed-empty kinds. Unknown counts stay
+      // visible as a dash so count coverage gaps do not masquerade as emptiness.
       const visibleResources = category.resources.filter(resource => {
         const count = counts[resource.group ? `${resource.group}/${resource.kind}` : resource.kind]
-        const isCore = ALWAYS_SHOWN_KINDS.has(resource.kind)
-        const isLoading = count === null
-        const shouldShow = (count ?? 0) > 0 || isCore || isLoading || showEmptyKinds
+        const shouldShow = count === null || (count ?? 0) > 0 || showEmptyKinds
         if (!shouldShow) totalHiddenKinds++
         return shouldShow
       })
@@ -348,9 +322,8 @@ export function ResourcesSidebar({
       return 0
     })
 
-    // Filter out empty groups unless they have visible resources (core kinds) or showEmptyKinds is true
+    // Filter out empty groups unless they have visible resources or showEmptyKinds is true.
     const visibleCategories = sorted.filter(category => {
-      // Show if: has resources with instances, OR has visible resources (core kinds), OR showEmptyKinds
       const shouldShow = category.total > 0 || category.visibleResources.length > 0 || showEmptyKinds
       if (!shouldShow) totalHiddenGroups++
       return shouldShow

--- a/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { APIResource } from '../../types'
-import { canonicalizeSelectedKind } from './ResourcesView'
+import { canonicalizeSelectedKind, deriveSidebarResourceCounts, LOADED_RESOURCE_COUNT_TTL_MS } from './ResourcesView'
 
 const endpoints: APIResource = {
   group: '',
@@ -51,5 +51,63 @@ describe('canonicalizeSelectedKind', () => {
         [httpRoute]
       )
     ).toEqual({ name: 'httproutes', kind: 'HTTPRoute', group: 'gateway.networking.k8s.io' })
+  })
+})
+
+describe('deriveSidebarResourceCounts', () => {
+  it('keeps recently loaded counts for resources omitted from resource-counts', () => {
+    const now = 10_000
+
+    expect(
+      deriveSidebarResourceCounts(
+        [endpoints],
+        {},
+        undefined,
+        { Endpoints: { count: 132, expiresAt: now + LOADED_RESOURCE_COUNT_TTL_MS } },
+        now
+      )
+    ).toEqual({ Endpoints: 132 })
+  })
+
+  it('expires loaded counts after the TTL', () => {
+    const now = 10_000
+
+    expect(
+      deriveSidebarResourceCounts(
+        [endpoints],
+        {},
+        undefined,
+        { Endpoints: { count: 132, expiresAt: now } },
+        now
+      )
+    ).toEqual({ Endpoints: null })
+  })
+
+  it('prefers authoritative resource-counts over cached loaded counts', () => {
+    const now = 10_000
+
+    expect(
+      deriveSidebarResourceCounts(
+        [endpoints],
+        { Endpoints: 7 },
+        undefined,
+        { Endpoints: { count: 132, expiresAt: now + LOADED_RESOURCE_COUNT_TTL_MS } },
+        now
+      )
+    ).toEqual({ Endpoints: 7 })
+  })
+
+  it('lets a fresh loaded count override an unavailable count marker', () => {
+    const now = 10_000
+
+    expect(
+      deriveSidebarResourceCounts(
+        [endpoints],
+        {},
+        ['Endpoints'],
+        { Endpoints: { count: 132, expiresAt: now + LOADED_RESOURCE_COUNT_TTL_MS } },
+        now
+      )
+    ).toEqual({ Endpoints: 132 })
   })
 })

--- a/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { APIResource } from '../../types'
+import { canonicalizeSelectedKind } from './ResourcesView'
+
+const endpoints: APIResource = {
+  group: '',
+  version: 'v1',
+  kind: 'Endpoints',
+  name: 'endpoints',
+  namespaced: true,
+  isCrd: false,
+  verbs: ['list', 'get', 'watch'],
+}
+
+const httpRoute: APIResource = {
+  group: 'gateway.networking.k8s.io',
+  version: 'v1',
+  kind: 'HTTPRoute',
+  name: 'httproutes',
+  namespaced: true,
+  isCrd: true,
+  verbs: ['list', 'get', 'watch'],
+}
+
+describe('canonicalizeSelectedKind', () => {
+  it('restores the canonical Kind when URL hydration only has the plural resource name', () => {
+    expect(
+      canonicalizeSelectedKind(
+        { name: 'endpoints', kind: 'endpoints', group: '' },
+        [endpoints],
+        [endpoints]
+      )
+    ).toEqual({ name: 'endpoints', kind: 'Endpoints', group: '' })
+  })
+
+  it('leaves an already canonical selection alone', () => {
+    expect(
+      canonicalizeSelectedKind(
+        { name: 'endpoints', kind: 'Endpoints', group: '' },
+        [endpoints],
+        [endpoints]
+      )
+    ).toBeNull()
+  })
+
+  it('resolves CRD deep links from Kind to plural resource name', () => {
+    expect(
+      canonicalizeSelectedKind(
+        { name: 'HTTPRoute', kind: 'HTTPRoute', group: 'gateway.networking.k8s.io' },
+        [],
+        [httpRoute]
+      )
+    ).toEqual({ name: 'httproutes', kind: 'HTTPRoute', group: 'gateway.networking.k8s.io' })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.selected-kind.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { APIResource } from '../../types'
-import { canonicalizeSelectedKind, deriveSidebarResourceCounts, LOADED_RESOURCE_COUNT_TTL_MS } from './ResourcesView'
+import {
+  canonicalizeSelectedKind,
+  deriveSidebarResourceCounts,
+  LOADED_RESOURCE_COUNT_TTL_MS,
+  resourceQueryMatchesSelectedKind,
+} from './ResourcesView'
 
 const endpoints: APIResource = {
   group: '',
@@ -109,5 +114,30 @@ describe('deriveSidebarResourceCounts', () => {
         now
       )
     ).toEqual({ Endpoints: 132 })
+  })
+})
+
+describe('resourceQueryMatchesSelectedKind', () => {
+  it('accepts untagged legacy query results', () => {
+    expect(resourceQueryMatchesSelectedKind(undefined, { name: 'endpoints', kind: 'Endpoints', group: '' })).toBe(true)
+    expect(resourceQueryMatchesSelectedKind({}, { name: 'endpoints', kind: 'Endpoints', group: '' })).toBe(true)
+  })
+
+  it('rejects stale selected-kind query results from the previous kind', () => {
+    expect(
+      resourceQueryMatchesSelectedKind(
+        { resourceName: 'pods', group: '' },
+        { name: 'endpoints', kind: 'Endpoints', group: '' }
+      )
+    ).toBe(false)
+  })
+
+  it('matches grouped built-in resources by plural name and group', () => {
+    expect(
+      resourceQueryMatchesSelectedKind(
+        { resourceName: 'endpointslices', group: 'discovery.k8s.io' },
+        { name: 'endpointslices', kind: 'EndpointSlice', group: 'discovery.k8s.io' }
+      )
+    ).toBe(true)
   })
 })

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2007,6 +2007,26 @@ function getInitialKindFromURL(
   return defaultKind
 }
 
+export function canonicalizeSelectedKind(
+  selectedKind: SelectedKindInfo,
+  resourcesToCount: Array<Pick<APIResource, 'name' | 'kind' | 'group'>>,
+  apiResources?: APIResource[],
+): SelectedKindInfo | null {
+  const nameMatch = resourcesToCount.find(r =>
+    r.name === selectedKind.name && r.group === selectedKind.group
+  )
+  if (nameMatch) {
+    return selectedKind.kind === nameMatch.kind
+      ? null
+      : { name: nameMatch.name, kind: nameMatch.kind, group: nameMatch.group }
+  }
+
+  const match = apiResources?.find(r =>
+    r.kind === selectedKind.kind && r.group === selectedKind.group
+  )
+  return match ? { name: match.name, kind: match.kind, group: match.group } : null
+}
+
 // Get initial filters from URL
 function getInitialFiltersFromURL() {
   const params = new URLSearchParams(window.location.search)
@@ -3144,18 +3164,9 @@ export function ResourcesView({
   // getInitialKindFromURL can't look up CRDs, so name may be wrong (e.g., 'HTTPRoute' instead of 'httproutes')
   useEffect(() => {
     if (!apiResources) return
-    // Check if current selectedKind already matches a discovered resource
-    const alreadyResolved = resourcesToCount.some(r =>
-      r.name === selectedKind.name && r.group === selectedKind.group
-    )
-    if (alreadyResolved) return
-
-    // Try to match by kind name (URL stores kind=HTTPRoute, API has name=httproutes)
-    const match = apiResources.find(r =>
-      r.kind === selectedKind.kind && r.group === selectedKind.group
-    )
-    if (match) {
-      setSelectedKind({ name: match.name, kind: match.kind, group: match.group })
+    const canonicalKind = canonicalizeSelectedKind(selectedKind, resourcesToCount, apiResources)
+    if (canonicalKind) {
+      setSelectedKind(canonicalKind)
     }
   }, [apiResources, resourcesToCount, selectedKind.name, selectedKind.kind, selectedKind.group])
 

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1850,7 +1850,7 @@ interface ResourcesViewProps {
   /** @deprecated Use resourceCounts + resourceForbidden + selectedKindQuery instead */
   resourceQueries?: ResourceQueryResult[]
   // Lightweight counts for sidebar badges (from /api/resource-counts)
-  resourceCounts?: Record<string, number>
+  resourceCounts?: Record<string, number | null>
   resourceForbidden?: string[]
   /** Per-kind reason a forbidden kind is hidden ("rbac_denied" | "unavailable"),
    *  keyed by the same count key as resourceForbidden. Drives RestrictedState copy. */
@@ -3226,9 +3226,9 @@ export function ResourcesView({
         if (unavailableKinds.has(key)) {
           results[key] = null
         } else if (key in resourceCountsProp!) {
-          results[key] = resourceCountsProp![key]
+          results[key] = resourceCountsProp![key] ?? null
         } else {
-          results[key] = 0
+          results[key] = null
         }
       }
       return results

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1958,6 +1958,18 @@ interface ResourcesViewProps {
 
 // Default selected kind
 const DEFAULT_KIND_INFO: SelectedKindInfo = { name: 'pods', kind: 'Pod', group: '' }
+export const LOADED_RESOURCE_COUNT_TTL_MS = 5 * 60 * 1000
+
+interface LoadedResourceCount {
+  count: number
+  expiresAt: number
+}
+
+type LoadedResourceCountCache = Record<string, LoadedResourceCount>
+
+function resourceCountKey(resource: Pick<APIResource, 'group' | 'kind'>): string {
+  return resource.group ? `${resource.group}/${resource.kind}` : resource.kind
+}
 
 // Read initial state from URL — kind is in the path: {basePath}/{kind}
 //
@@ -2025,6 +2037,33 @@ export function canonicalizeSelectedKind(
     r.kind === selectedKind.kind && r.group === selectedKind.group
   )
   return match ? { name: match.name, kind: match.kind, group: match.group } : null
+}
+
+export function deriveSidebarResourceCounts(
+  resourcesToCount: Array<Pick<APIResource, 'kind' | 'group'>>,
+  resourceCounts: Record<string, number | null> | undefined,
+  resourceUnavailable: string[] | undefined,
+  loadedCountCache: LoadedResourceCountCache,
+  now: number = Date.now(),
+): Record<string, number | null> {
+  const unavailableKinds = new Set(resourceUnavailable ?? [])
+  const results: Record<string, number | null> = {}
+
+  for (const resource of resourcesToCount) {
+    const key = resourceCountKey(resource)
+    const cached = loadedCountCache[key]
+    if (resourceCounts && key in resourceCounts) {
+      results[key] = resourceCounts[key] ?? null
+    } else if (cached && cached.expiresAt > now) {
+      results[key] = cached.count
+    } else if (unavailableKinds.has(key)) {
+      results[key] = null
+    } else {
+      results[key] = null
+    }
+  }
+
+  return results
 }
 
 // Get initial filters from URL
@@ -3229,25 +3268,46 @@ export function ResourcesView({
     ? `${selectedKind.group}/${selectedKind.kind}`
     : selectedKind.kind
   const selectedQueryHasLoadedCount = Array.isArray(resources) && !isLoading && !selectedQueryError && !largeListGuard
+  const selectedLoadedResourceCount = Array.isArray(resources) ? resources.length : undefined
+  const [loadedCountCache, setLoadedCountCache] = useState<LoadedResourceCountCache>({})
+
+  useEffect(() => {
+    if (!selectedQueryHasLoadedCount || selectedLoadedResourceCount == null) return
+    const now = Date.now()
+    const loadedAt = selectedQuery?.dataUpdatedAt && selectedQuery.dataUpdatedAt > 0
+      ? selectedQuery.dataUpdatedAt
+      : now
+    const expiresAt = loadedAt + LOADED_RESOURCE_COUNT_TTL_MS
+
+    setLoadedCountCache(prev => {
+      const next: LoadedResourceCountCache = {}
+      let changed = false
+      for (const [key, cached] of Object.entries(prev)) {
+        if (cached.expiresAt > now || key === selectedKindCountKey) {
+          next[key] = cached
+        } else {
+          changed = true
+        }
+      }
+
+      const existing = next[selectedKindCountKey]
+      if (existing?.count === selectedLoadedResourceCount && existing.expiresAt === expiresAt) {
+        return changed ? next : prev
+      }
+
+      return {
+        ...next,
+        [selectedKindCountKey]: { count: selectedLoadedResourceCount, expiresAt },
+      }
+    })
+  }, [selectedQueryHasLoadedCount, selectedLoadedResourceCount, selectedKindCountKey, selectedQuery?.dataUpdatedAt])
 
   // Derive counts — prefer lightweight resourceCounts prop over full query data
   const counts = useMemo(() => {
     if (useNewCountsMode) {
-      // resourceCountsProp uses "group/Kind" keys for CRDs, "Kind" for core — same format as sidebar
-      const unavailableKinds = new Set(resourceUnavailableProp ?? [])
-      const results: Record<string, number | null> = {}
-      for (const resource of resourcesToCount) {
-        const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
-        if (unavailableKinds.has(key)) {
-          results[key] = null
-        } else if (resourceCountsProp && key in resourceCountsProp) {
-          results[key] = resourceCountsProp[key] ?? null
-        } else {
-          results[key] = null
-        }
-      }
-      if (selectedQueryHasLoadedCount) {
-        results[selectedKindCountKey] = resources.length
+      const results = deriveSidebarResourceCounts(resourcesToCount, resourceCountsProp, resourceUnavailableProp, loadedCountCache)
+      if (selectedQueryHasLoadedCount && selectedLoadedResourceCount != null) {
+        results[selectedKindCountKey] = selectedLoadedResourceCount
       }
       return results
     }
@@ -3259,14 +3319,14 @@ export function ResourcesView({
       results[key] = Array.isArray(data) ? data.length : 0
     })
     return results
-  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceUnavailableProp, resources, selectedQueryHasLoadedCount, selectedKindCountKey, resourceQueries])
+  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceUnavailableProp, loadedCountCache, selectedQueryHasLoadedCount, selectedLoadedResourceCount, selectedKindCountKey, resourceQueries])
 
   const sidebarResourceUnavailable = useMemo(() => {
-    if (!selectedQueryHasLoadedCount || !resourceUnavailableProp?.includes(selectedKindCountKey)) {
+    if (!resourceUnavailableProp?.length) {
       return resourceUnavailableProp
     }
-    return resourceUnavailableProp.filter(key => key !== selectedKindCountKey)
-  }, [resourceUnavailableProp, selectedKindCountKey, selectedQueryHasLoadedCount])
+    return resourceUnavailableProp.filter(key => counts[key] == null)
+  }, [resourceUnavailableProp, counts])
 
   // Track which resource kinds returned 403 Forbidden
   const forbiddenKinds = useMemo(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1818,6 +1818,8 @@ interface ResourcesViewData {
 export const ResourcesViewDataContext = React.createContext<ResourcesViewData>({})
 
 export interface ResourceQueryResult {
+  resourceName?: string
+  group?: string
   data?: any[]
   isLoading: boolean
   error?: any
@@ -1969,6 +1971,14 @@ type LoadedResourceCountCache = Record<string, LoadedResourceCount>
 
 function resourceCountKey(resource: Pick<APIResource, 'group' | 'kind'>): string {
   return resource.group ? `${resource.group}/${resource.kind}` : resource.kind
+}
+
+export function resourceQueryMatchesSelectedKind(
+  query: Pick<ResourceQueryResult, 'resourceName' | 'group'> | undefined,
+  selectedKind: SelectedKindInfo,
+): boolean {
+  if (!query?.resourceName) return true
+  return query.resourceName === selectedKind.name && (query.group ?? '') === selectedKind.group
 }
 
 // Read initial state from URL — kind is in the path: {basePath}/{kind}
@@ -3221,7 +3231,8 @@ export function ResourcesView({
   }, [resourcesToCount, selectedKind.name, selectedKind.group])
 
   const selectedQuery = selectedKindQueryProp ?? resourceQueries[selectedQueryIndex]
-  const resources = selectedQuery?.data
+  const selectedQueryMatchesKind = resourceQueryMatchesSelectedKind(selectedQuery, selectedKind)
+  const resources = selectedQueryMatchesKind ? selectedQuery?.data : undefined
 
   // Auto-surface the GPU column the first time GPU-bearing rows load for a kind
   // the user has never customized — a static default can't know whether the
@@ -3262,14 +3273,25 @@ export function ResourcesView({
       annotation: Array.from(annotations).sort(),
     }
   }, [resources])
-  const isLoading = selectedQuery?.isLoading ?? true
-  const selectedQueryError = selectedQuery?.error
+  const isLoading = selectedQueryMatchesKind ? (selectedQuery?.isLoading ?? true) : true
+  const selectedQueryError = selectedQueryMatchesKind ? selectedQuery?.error : undefined
   const selectedKindCountKey = selectedKind.group
     ? `${selectedKind.group}/${selectedKind.kind}`
     : selectedKind.kind
   const selectedQueryHasLoadedCount = Array.isArray(resources) && !isLoading && !selectedQueryError && !largeListGuard
   const selectedLoadedResourceCount = Array.isArray(resources) ? resources.length : undefined
   const [loadedCountCache, setLoadedCountCache] = useState<LoadedResourceCountCache>({})
+  const namespaceScopeKey = useMemo(
+    () => namespaces.length === 0 ? '' : [...namespaces].sort().join('\0'),
+    [namespaces],
+  )
+  const loadedCountScopeRef = useRef(namespaceScopeKey)
+
+  useEffect(() => {
+    if (loadedCountScopeRef.current === namespaceScopeKey) return
+    loadedCountScopeRef.current = namespaceScopeKey
+    setLoadedCountCache({})
+  }, [namespaceScopeKey])
 
   useEffect(() => {
     if (!selectedQueryHasLoadedCount || selectedLoadedResourceCount == null) return

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3214,6 +3214,10 @@ export function ResourcesView({
   }, [resources])
   const isLoading = selectedQuery?.isLoading ?? true
   const selectedQueryError = selectedQuery?.error
+  const selectedKindCountKey = selectedKind.group
+    ? `${selectedKind.group}/${selectedKind.kind}`
+    : selectedKind.kind
+  const selectedQueryHasLoadedCount = Array.isArray(resources) && !isLoading && !selectedQueryError && !largeListGuard
 
   // Derive counts — prefer lightweight resourceCounts prop over full query data
   const counts = useMemo(() => {
@@ -3231,6 +3235,9 @@ export function ResourcesView({
           results[key] = null
         }
       }
+      if (selectedQueryHasLoadedCount) {
+        results[selectedKindCountKey] = resources.length
+      }
       return results
     }
     // Legacy: derive counts from full query data
@@ -3241,7 +3248,14 @@ export function ResourcesView({
       results[key] = Array.isArray(data) ? data.length : 0
     })
     return results
-  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceUnavailableProp, resourceQueries])
+  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceUnavailableProp, resources, selectedQueryHasLoadedCount, selectedKindCountKey, resourceQueries])
+
+  const sidebarResourceUnavailable = useMemo(() => {
+    if (!selectedQueryHasLoadedCount || !resourceUnavailableProp?.includes(selectedKindCountKey)) {
+      return resourceUnavailableProp
+    }
+    return resourceUnavailableProp.filter(key => key !== selectedKindCountKey)
+  }, [resourceUnavailableProp, selectedKindCountKey, selectedQueryHasLoadedCount])
 
   // Track which resource kinds returned 403 Forbidden
   const forbiddenKinds = useMemo(() => {
@@ -3262,9 +3276,6 @@ export function ResourcesView({
   // denials) OR the selected kind is in the counts `forbidden` set. Denied
   // cluster-scoped kinds return 200 with `[]` from the list endpoint, so the
   // 403 signal alone misses them — they'd fall through to "No <kind> found".
-  const selectedKindCountKey = selectedKind.group
-    ? `${selectedKind.group}/${selectedKind.kind}`
-    : selectedKind.kind
   // Actual rows win over a stale counts `forbidden` entry: a kind can be marked
   // forbidden/unavailable in counts (e.g. an informer not yet synced at counts
   // time) while the list query has since returned data — show the table, not
@@ -3994,7 +4005,7 @@ export function ResourcesView({
           apiResources={apiResourcesProp}
           resourceCounts={counts}
           resourceForbidden={Array.from(forbiddenKinds)}
-          resourceUnavailable={resourceUnavailableProp}
+          resourceUnavailable={sidebarResourceUnavailable}
           pinned={pinned}
           togglePin={togglePin}
           isPinned={isPinned}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3161,7 +3161,7 @@ export function ResourcesView({
 
   // Resource data — prefer new lightweight props over legacy resourceQueries array
   const resourceQueries = resourceQueriesProp ?? []
-  const useNewCountsMode = !!resourceCountsProp
+  const useNewCountsMode = resourceCountsProp !== undefined || selectedKindQueryProp !== undefined
 
   // Find the selected kind's query
   const selectedQueryIndex = useMemo(() => {
@@ -3229,8 +3229,8 @@ export function ResourcesView({
         const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
         if (unavailableKinds.has(key)) {
           results[key] = null
-        } else if (key in resourceCountsProp!) {
-          results[key] = resourceCountsProp![key] ?? null
+        } else if (resourceCountsProp && key in resourceCountsProp) {
+          results[key] = resourceCountsProp[key] ?? null
         } else {
           results[key] = null
         }

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -11,6 +11,7 @@ export interface ResourcePermissions {
   statefulSets: boolean
   replicaSets: boolean
   ingresses: boolean
+  ingressClasses: boolean
   configMaps: boolean
   secrets: boolean
   events: boolean

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -41,6 +41,7 @@ interface ResourcesViewProps {
 
 type SelectedKindInfo = { name: string; kind: string; group: string } | null
 
+const EMPTY_RESOURCE_COUNTS: Record<string, number> = {}
 const LARGE_RESOURCE_LIST_LIMIT = 25000
 const LARGE_RESOURCE_LIST_GUARD_KEYS = new Set([
   'Pod',
@@ -332,7 +333,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       // Injected data
       apiResources={apiResources}
       // Lightweight counts for sidebar (replaces 233 parallel queries)
-      resourceCounts={countsData?.counts}
+      resourceCounts={countsData?.counts ?? EMPTY_RESOURCE_COUNTS}
       resourceForbidden={countsData?.forbidden}
       resourceReasons={countsData?.reasons}
       resourceUnavailable={countsData?.unavailable}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -60,6 +60,10 @@ function resourceCountKey(kind: NonNullable<SelectedKindInfo>): string {
   return kind.group ? `${kind.group}/${kind.kind}` : kind.kind
 }
 
+function hasResourceCount(counts: Record<string, number> | undefined, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(counts ?? {}, key)
+}
+
 export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces }: ResourcesViewProps) {
   const location = useLocation()
   const navigate = useNavigate()
@@ -181,22 +185,25 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
 
   const selectedCountKey = selectedKind ? resourceCountKey(selectedKind) : ''
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined
+  const selectedCountKnown = selectedCountKey ? hasResourceCount(countsData?.counts, selectedCountKey) : false
   const selectedCountUnavailable = selectedCountKey ? countsData?.unavailable?.includes(selectedCountKey) ?? false : false
+  const selectedCountUnknown = selectedCountKey !== '' && countsData != null && !selectedCountKnown
   const isSelectedKindGuarded = selectedCountKey !== '' && LARGE_RESOURCE_LIST_GUARD_KEYS.has(selectedCountKey)
   const waitingForGuardCount = isSelectedKindGuarded && !countsData && !countsIsError
-  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT)
+  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || selectedCountUnknown || (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT)
   const selectedKindQueryBlocked = waitingForGuardCount || largeListBlocked
   const podCount = countsData?.counts.Pod
+  const podCountKnown = hasResourceCount(countsData?.counts, 'Pod')
   const podCountUnavailable = countsData?.unavailable?.includes('Pod') ?? false
-  const podCountAllowsBulkMetrics = countsData != null && !podCountUnavailable && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
+  const podCountAllowsBulkMetrics = countsData != null && podCountKnown && !podCountUnavailable && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
   const selectedKindName = selectedKind?.name.toLowerCase() ?? ''
   const topPodMetricsEnabled = selectedKindName === 'pods' && podCountAllowsBulkMetrics
   const topNodeMetricsEnabled = selectedKindName === 'nodes' && namespaces.length === 0 && podCountAllowsBulkMetrics
   const largeListGuard = selectedKind && largeListBlocked
     ? {
         kind: selectedKind.name,
-        count: selectedCountUnavailable ? undefined : selectedCount,
-        reason: selectedCountUnavailable ? 'count-unavailable' as const : 'too-many' as const,
+        count: selectedCountUnavailable || selectedCountUnknown ? undefined : selectedCount,
+        reason: selectedCountUnavailable || selectedCountUnknown ? 'count-unavailable' as const : 'too-many' as const,
         limit: LARGE_RESOURCE_LIST_LIMIT,
         namespaces,
       }

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -188,10 +188,9 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined
   const selectedCountKnown = selectedCountKey ? hasResourceCount(countsData?.counts, selectedCountKey) : false
   const selectedCountUnavailable = selectedCountKey ? countsData?.unavailable?.includes(selectedCountKey) ?? false : false
-  const selectedCountUnknown = selectedCountKey !== '' && countsData != null && !selectedCountKnown
   const isSelectedKindGuarded = selectedCountKey !== '' && LARGE_RESOURCE_LIST_GUARD_KEYS.has(selectedCountKey)
   const waitingForGuardCount = isSelectedKindGuarded && !countsData && !countsIsError
-  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || selectedCountUnknown || (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT)
+  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCountKnown && (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT))
   const selectedKindQueryBlocked = waitingForGuardCount || largeListBlocked
   const podCount = countsData?.counts.Pod
   const podCountKnown = hasResourceCount(countsData?.counts, 'Pod')
@@ -203,8 +202,8 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const largeListGuard = selectedKind && largeListBlocked
     ? {
         kind: selectedKind.name,
-        count: selectedCountUnavailable || selectedCountUnknown ? undefined : selectedCount,
-        reason: selectedCountUnavailable || selectedCountUnknown ? 'count-unavailable' as const : 'too-many' as const,
+        count: selectedCountUnavailable ? undefined : selectedCount,
+        reason: selectedCountUnavailable ? 'count-unavailable' as const : 'too-many' as const,
         limit: LARGE_RESOURCE_LIST_LIMIT,
         namespaces,
       }

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -255,6 +255,8 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const selectedKindQueryResult: ResourceQueryResult | undefined = useMemo(() => {
     if (!selectedKind) return undefined
     return {
+      resourceName: selectedKind.name,
+      group: selectedKind.group,
       data: selectedKindQueryBlocked ? [] : selectedKindQuery.data as any[] | undefined,
       isLoading: waitingForGuardCount || selectedKindQuery.isLoading,
       error: selectedKindQueryBlocked ? undefined : selectedKindQuery.error,
@@ -322,7 +324,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   return (
     <>
     <BaseResourcesView
-      key={location.pathname}
+      key={connection.context || 'default'}
       namespaces={namespaces}
       selectedResource={selectedResource}
       onResourceClick={onResourceClick}


### PR DESCRIPTION
## Summary

Radar now distinguishes between built-in resources that are cheap to count from typed caches and built-in resources that should stay on direct list/get paths. Operators no longer see missing or misleading sidebar counts for resources like `Endpoints` and `Lease`: unknown counts render explicitly as unknown, loaded lists can contribute a stable sidebar badge, and low-value/high-churn kinds do not get counted by expensive probes or dynamic informers.

## What Changed

The backend resource model now separates typed built-ins from dynamic/direct-read built-ins. Typed resources continue to use existing listers for `/api/resource-counts`, while selected built-ins that lack typed listers remain available through direct list/get without being promoted into cluster-wide dynamic informer coverage. High-churn or low-value resources are intentionally omitted from count probes rather than marked empty, which keeps count collection bounded and avoids doing extra work for kinds that are rarely useful in the sidebar.

Resource counting now deduplicates covered kinds, preserves forbidden and unavailable markers, and includes `IngressClass` in the same visibility probe path as other typed informer resources. Direct drift reads also preserve kubectl last-applied annotations so the drift path can inspect fields that the cached/resource-list path strips for normal UI use.

The resources sidebar now treats missing counts as unknown instead of zero. Unknown counts show a dash with a short tooltip, confirmed-empty kinds can still be hidden, and selected or pinned kinds stay visible even when their count is unavailable. When a user opens a direct-read kind, the loaded list length feeds a short-lived sidebar count cache so switching to another kind does not make that count disappear.

The selected-kind query result is tagged with the resource name and group, so stale rows from the previous kind cannot update the new kind badge during navigation. The view no longer remounts on every `/resources/<kind>` pathname change, which lets the count cache survive normal kind switches while still clearing when the namespace scope changes.

## Testing

- `go test ./internal/k8s ./internal/server -run Test\(BuiltinGVR\|CanonicalBuiltinKind\|BuiltinGVRAnyGroup\|TypedKindOwnsGroup\|IsClusterOnlyKind\|ClusterOnlyKindGVR\|ClassifyKindScope\|ResourceCounts\)`
- `go test ./internal/k8s -run TestHighChurnDynamicBuiltinsBypassInformer`
- `npm test --workspace @skyhook-io/k8s-ui -- ResourcesView.selected-kind ResourcesSidebar`
- `make test`
- `make tsc`
- `make build`
- Manual smoke: rebuilt and ran `./radar -port 9383 -no-browser`; verified the app starts against the test cluster
- Playwright smoke: opened `/resources/endpoints`, verified `Endpoints 134`, opened `Lease` and verified `Lease 61`, switched to `Pods`, and verified both cached count badges stayed visible
- Visual-test skipped: this is a badge/count-state adjustment, and the meaningful behavior was exercised through the running app/API rather than screenshot comparison

Closes #1141
Closes #1142