### PR TITLE
Stop visual-test scripts leaving empty folders and popping Finder

### DIFF
--- a/scripts/visual-test-start.sh
+++ b/scripts/visual-test-start.sh
@@ -18,6 +18,24 @@ SSDIR=".playwright-mcp/visual-test/$TIMESTAMP"
 LOGFILE="/tmp/radar-visual-test-$PORT.log"
 STATEFILE=".playwright-mcp/visual-test-state.env"
 
+active_screenshot_dir=""
+if [[ -f "$STATEFILE" ]]; then
+  source "$STATEFILE"
+  if [[ -n "${RADAR_PID:-}" && -n "${SCREENSHOT_DIR:-}" ]] && kill -0 "$RADAR_PID" 2>/dev/null; then
+    active_screenshot_dir="$SCREENSHOT_DIR"
+  fi
+fi
+
+# Prune empty screenshot dirs left by prior runs that captured nothing.
+if [[ -d .playwright-mcp/visual-test ]]; then
+  while IFS= read -r -d '' dir; do
+    if [[ -n "$active_screenshot_dir" && "$dir" == "$active_screenshot_dir" ]]; then
+      continue
+    fi
+    rmdir "$dir" 2>/dev/null || true
+  done < <(find .playwright-mcp/visual-test -mindepth 1 -maxdepth 1 -type d -empty -print0 2>/dev/null)
+fi
+
 mkdir -p "$SSDIR"
 
 # Build unless skipped

--- a/scripts/visual-test-stop.sh
+++ b/scripts/visual-test-stop.sh
@@ -20,10 +20,16 @@ else
   echo "Radar (PID $RADAR_PID) was already stopped."
 fi
 
-# Open screenshot folder
+# Open the screenshot folder only if something was actually captured.
+# start.sh pre-creates the dir, so an unconditional `open` would pop a Finder
+# window on an empty folder for every run that took no screenshots.
 if [[ -d "$SCREENSHOT_DIR" ]]; then
-  echo "Screenshots: $SCREENSHOT_DIR"
-  open "$SCREENSHOT_DIR" 2>/dev/null || true
+  if [[ -n "$(ls -A "$SCREENSHOT_DIR" 2>/dev/null)" ]]; then
+    echo "Screenshots: $SCREENSHOT_DIR"
+    open "$SCREENSHOT_DIR" 2>/dev/null || true
+  else
+    rmdir "$SCREENSHOT_DIR" 2>/dev/null || true
+  fi
 fi
 
 echo "Logs: $RADAR_LOG"


### PR DESCRIPTION
## Summary

Visual-test runs that capture no screenshots no longer leave empty timestamped folders behind or open Finder on an empty directory. This keeps repeated local visual-test runs quiet while preserving screenshot folders when captures actually exist.

## What changed

- `visual-test-stop.sh` opens the screenshot folder only when it contains captured files.
- Empty run directories are removed during stop instead of being left under `.playwright-mcp/visual-test/`.
- `visual-test-start.sh` prunes leftover empty timestamped directories before a new run starts.
- The startup prune preserves the screenshot directory for the currently active run recorded in `.playwright-mcp/visual-test-state.env` when that Radar process is still alive, so relaunching with `--skip-build` cannot delete the active capture target.

## Testing

- `bash -n scripts/visual-test-start.sh`
- `bash -n scripts/visual-test-stop.sh`
- `git diff --check`
- visual-test: skipped (script-only cleanup; no UI delta)