### PR TITLE
Configure OpenCost billable namespace forecasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 /radar-amd64
 /*.png
 /AGENTS.md
+.worktrees/
 
 # Local visual-test screenshot artifacts (never commit)
 vt-shots/

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ radar
 | `--prometheus-url` | (auto-discover) | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) |
 | `--prometheus-header` | | HTTP header sent with every Prometheus request, format `Key=Value` (repeatable). Required for auth-protected backends. |
 | `--prometheus-header-from-env` | | HTTP header sent with every Prometheus request, sourced from an environment variable, format `Key=ENV_VAR` (repeatable). |
+| `--opencost-excluded-namespaces` | | Comma-separated namespaces omitted from OpenCost summaries, totals, and trends. |
+| `--opencost-disable-node-cost-floor` | `false` | Keep OpenCost totals based on namespace allocations instead of promoting node capacity cost. |
 | `--auth-mode` | `none` | Authentication mode: `none`, `proxy`, or `oidc` ([details](docs/authentication.md)) |
 | `--no-mcp` | `false` | Disable MCP server for AI tool integration |
 | `--mcp-catalog-stdio` | `false` | Start only the MCP catalog over stdio for registry introspection |

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -89,6 +89,8 @@ func main() {
 	flag.Var(promHeaders, "prometheus-header", "HTTP header to send with Prometheus requests, e.g. 'Authorization=Bearer <token>' (repeatable). Required for auth-protected backends.")
 	promHeadersFromEnv := newHeaderFromEnvFlag(fileCfg.PrometheusHeadersFromEnv)
 	flag.Var(promHeadersFromEnv, "prometheus-header-from-env", "HTTP header to send with Prometheus requests, sourced from an env var, e.g. 'Authorization=PROMETHEUS_TOKEN' (repeatable).")
+	opencostExcludedNamespaces := flag.String("opencost-excluded-namespaces", "", "Comma-separated namespaces to exclude from OpenCost summaries and trends")
+	opencostDisableNodeCostFloor := flag.Bool("opencost-disable-node-cost-floor", false, "Do not promote node capacity cost above OpenCost namespace allocations")
 	// MCP server
 	noMCP := flag.Bool("no-mcp", !fileCfg.MCPEnabledOr(true), "Disable MCP (Model Context Protocol) server for AI tools")
 	mcpCatalogStdio := flag.Bool("mcp-catalog-stdio", false, "Start only the MCP catalog over stdio for registry/inspector introspection; skips Kubernetes initialization")
@@ -208,34 +210,36 @@ func main() {
 	}
 
 	cfg := app.AppConfig{
-		Kubeconfig:               *kubeconfig,
-		KubeconfigDirs:           app.ParseKubeconfigDirs(*kubeconfigDir),
-		Namespace:                *namespace,
-		Port:                     *port,
-		NoBrowser:                *noBrowser,
-		Browser:                  *browser,
-		DevMode:                  *devMode,
-		HistoryLimit:             *historyLimit,
-		DebugEvents:              *debugEvents,
-		FakeInCluster:            *fakeInCluster,
-		DisableHelmWrite:         *disableHelmWrite,
-		DisableExec:              *disableExec,
-		DisableLocalTerminal:     *disableLocalTerminal,
-		PodShellDefault:          *podShellDefault,
-		DebugImage:               *debugImage,
-		ListPageSize:             *listPageSize,
-		NamespaceScope:           *namespaceScope,
-		TimelineStorage:          *timelineStorage,
-		TimelineDBPath:           *timelineDBPath,
-		TimelineRetention:        *timelineRetention,
-		TimelineMaxSizeBytes:     timelineMaxSizeBytes,
-		PrometheusURL:            *prometheusURL,
-		PrometheusHeaders:        resolvedPrometheusHeaders,
-		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),
-		MCPEnabled:               mcpEnabled,
-		AIHistory:                *aiHistory,
-		AIHistoryDBPath:          fileCfg.AIHistoryDBPath,
-		Version:                  version,
+		Kubeconfig:                   *kubeconfig,
+		KubeconfigDirs:               app.ParseKubeconfigDirs(*kubeconfigDir),
+		Namespace:                    *namespace,
+		Port:                         *port,
+		NoBrowser:                    *noBrowser,
+		Browser:                      *browser,
+		DevMode:                      *devMode,
+		HistoryLimit:                 *historyLimit,
+		DebugEvents:                  *debugEvents,
+		FakeInCluster:                *fakeInCluster,
+		DisableHelmWrite:             *disableHelmWrite,
+		DisableExec:                  *disableExec,
+		DisableLocalTerminal:         *disableLocalTerminal,
+		PodShellDefault:              *podShellDefault,
+		DebugImage:                   *debugImage,
+		ListPageSize:                 *listPageSize,
+		NamespaceScope:               *namespaceScope,
+		TimelineStorage:              *timelineStorage,
+		TimelineDBPath:               *timelineDBPath,
+		TimelineRetention:            *timelineRetention,
+		TimelineMaxSizeBytes:         timelineMaxSizeBytes,
+		PrometheusURL:                *prometheusURL,
+		PrometheusHeaders:            resolvedPrometheusHeaders,
+		PrometheusHeadersFromEnv:     promHeadersFromEnv.value(),
+		OpenCostExcludedNamespaces:   parseCSV(*opencostExcludedNamespaces),
+		OpenCostDisableNodeCostFloor: *opencostDisableNodeCostFloor,
+		MCPEnabled:                   mcpEnabled,
+		AIHistory:                    *aiHistory,
+		AIHistoryDBPath:              fileCfg.AIHistoryDBPath,
+		Version:                      version,
 		AuthConfig: auth.Config{
 			Mode:                      *authMode,
 			Secret:                    *authSecret,

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -68,6 +68,12 @@ spec:
             {{- range $k, $v := .Values.traffic.prometheusHeadersFromEnv }}
             - {{ printf "--prometheus-header-from-env=%s=%s" $k $v | quote }}
             {{- end }}
+            {{- if .Values.opencost.excludedNamespaces }}
+            - {{ printf "--opencost-excluded-namespaces=%s" (join "," .Values.opencost.excludedNamespaces) | quote }}
+            {{- end }}
+            {{- if .Values.opencost.disableNodeCostFloor }}
+            - --opencost-disable-node-cost-floor
+            {{- end }}
             {{- if not .Values.mcp.enabled }}
             - --no-mcp
             {{- end }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -367,6 +367,13 @@ mcp:
   # Set to false to disable the MCP server (useful when deployed behind authentication)
   enabled: true
 
+# OpenCost forecast configuration
+opencost:
+  # Exact namespace names excluded from cost summaries, totals, and trends.
+  excludedNamespaces: []
+  # Disable the node-capacity floor when nodes are not the provider billing unit.
+  disableNodeCostFloor: false
+
 # Traffic source configuration
 traffic:
   # Manual Prometheus/VictoriaMetrics URL (bypasses auto-discovery)

--- a/docs/specs/2026-07-10-opencost-autopilot-forecast.md
+++ b/docs/specs/2026-07-10-opencost-autopilot-forecast.md
@@ -118,6 +118,28 @@ validation, then mark it ready. GitOps consumption waits for the first official
 Radar release containing the change. No private image release is used if the
 upstream release is delayed.
 
+## Execution Evidence
+
+Passed on 2026-07-10:
+
+```sh
+make test
+make test-chart
+helm lint deploy/helm/radar
+go test ./...
+go vet ./...
+(cd pkg && go test ./...)
+(cd pkg && go test -race ./opencost)
+(cd pkg && go vet ./...)
+git diff --check upstream/main...HEAD
+gitleaks protect --staged --redact --no-banner
+gitleaks detect --no-banner --redact --log-opts upstream/main..HEAD
+```
+
+Chart tests prove default values omit both arguments and configured values
+render exact namespace exclusions plus node-floor disablement. No frontend
+files changed, so visual browser validation was not required.
+
 ## Task Breakdown
 
 - [x] Commit this approved plan and open the Draft PR.
@@ -125,5 +147,5 @@ upstream release is delayed.
 - [x] Wire CLI flags and immutable handler configuration.
 - [x] Add Helm values, rendered arguments, and chart coverage.
 - [x] Update operator documentation.
-- [ ] Run focused and full validation.
+- [x] Run focused and full validation.
 - [ ] Push implementation and mark the upstream PR ready.

--- a/docs/specs/2026-07-10-opencost-autopilot-forecast.md
+++ b/docs/specs/2026-07-10-opencost-autopilot-forecast.md
@@ -91,7 +91,7 @@ queries and node cost responses continue to work.
 Run:
 
 ```sh
-go test ./pkg/opencost ./internal/opencost
+go test ./opencost
 make test-chart
 go test ./...
 go vet ./...
@@ -120,10 +120,10 @@ upstream release is delayed.
 
 ## Task Breakdown
 
-- [ ] Commit this approved plan and open the Draft PR.
-- [ ] Add pure OpenCost exclusion and node-floor options with tests.
-- [ ] Wire CLI flags and immutable handler configuration.
-- [ ] Add Helm values, rendered arguments, and chart coverage.
-- [ ] Update operator documentation.
+- [x] Commit this approved plan and open the Draft PR.
+- [x] Add pure OpenCost exclusion and node-floor options with tests.
+- [x] Wire CLI flags and immutable handler configuration.
+- [x] Add Helm values, rendered arguments, and chart coverage.
+- [x] Update operator documentation.
 - [ ] Run focused and full validation.
 - [ ] Push implementation and mark the upstream PR ready.

--- a/docs/specs/2026-07-10-opencost-autopilot-forecast.md
+++ b/docs/specs/2026-07-10-opencost-autopilot-forecast.md
@@ -1,0 +1,129 @@
+# OpenCost Autopilot Forecast Configuration
+
+## Goal
+
+Let operators exclude non-billable namespaces from Radar's OpenCost summary
+and trend, and optionally stop node capacity pricing from replacing the
+namespace allocation total.
+
+Success means:
+
+- configured namespaces are absent from summary and trend results
+- excluded namespaces do not contribute to totals or the trend `other` series
+- disabling the node-cost floor keeps the summary total equal to included
+  namespace allocations
+- OpenCost node details and raw Prometheus metrics remain unchanged
+- existing installations preserve current behavior by default
+
+The audience is operators running Radar against managed Kubernetes offerings
+whose billing unit differs from node capacity, including GKE Autopilot.
+
+## Scope And Interfaces
+
+In scope:
+
+- OpenCost summary and Prometheus trend computation
+- Radar startup configuration and Helm chart arguments
+- focused Go and chart rendering tests
+- CLI and Helm documentation
+
+Out of scope:
+
+- cloud billing export ingestion
+- currency conversion
+- provider-specific namespace defaults
+- Prometheus metric relabeling or deletion
+- frontend layout changes
+
+New CLI interfaces:
+
+```text
+--opencost-excluded-namespaces=<comma-separated namespace names>
+--opencost-disable-node-cost-floor
+```
+
+New Helm values:
+
+```yaml
+opencost:
+  excludedNamespaces: []
+  disableNodeCostFloor: false
+```
+
+Both defaults preserve existing behavior. Namespace matching is exact after
+trimming empty comma-separated values; Radar does not embed provider-specific
+regular expressions or default exclusions.
+
+## Data Flow And Behavior
+
+```text
+Helm values
+  -> Radar CLI arguments
+  -> immutable OpenCost handler configuration
+  -> summary/trend compute options
+  -> excluded namespace rows removed before totals and ranking
+  -> optional node_total_hourly_cost floor bypass
+  -> existing API response shapes
+```
+
+Exclusions apply to both REST-backed and Prometheus-backed summary computation.
+They apply to Prometheus trend ranking and aggregation so excluded rows cannot
+reappear under `other`. The workload endpoint remains queryable for an excluded
+namespace, and the node endpoint remains unchanged.
+
+When the node-cost floor is disabled, only the summary fallback that promotes
+`node_total_hourly_cost` above namespace allocations is skipped. Node pricing
+queries and node cost responses continue to work.
+
+## Risks, Failure Modes, And Rollback
+
+- A misspelled namespace remains included. The Helm render and live response
+  verification must check exact configured names.
+- Filtering after a Prometheus query could accidentally move excluded values
+  into `other`. Focused trend tests must prove this cannot happen.
+- A default change would alter every existing installation. Tests must prove
+  unset values keep namespace totals and the node floor unchanged.
+- Rollback is removal of the two Helm values or reversion to the previous Radar
+  release; no metric or stored data migration is involved.
+
+## Validation And Acceptance
+
+Run:
+
+```sh
+go test ./pkg/opencost ./internal/opencost
+make test-chart
+go test ./...
+go vet ./...
+git diff --check
+```
+
+Render the chart with configured exclusions and verify the Deployment contains
+the two expected arguments. Render defaults and verify neither argument is
+present.
+
+Acceptance cases:
+
+- default summary still includes all namespaces and applies the node floor
+- configured namespaces are absent from summary rows and total cost
+- disabled node floor does not replace the included namespace sum
+- excluded trend series are absent and do not contribute to `other`
+- REST summary filtering matches Prometheus summary filtering
+- node responses and raw metric collection are unaffected
+
+## Rollout
+
+Open a Draft PR against `skyhook-io/radar:main`, complete implementation and
+validation, then mark it ready. GitOps consumption waits for the first official
+Radar release containing the change. No private image release is used if the
+upstream release is delayed.
+
+## Task Breakdown
+
+- [ ] Commit this approved plan and open the Draft PR.
+- [ ] Add pure OpenCost exclusion and node-floor options with tests.
+- [ ] Wire CLI flags and immutable handler configuration.
+- [ ] Add Helm values, rendered arguments, and chart coverage.
+- [ ] Update operator documentation.
+- [ ] Run focused and full validation.
+- [ ] Push implementation and mark the upstream PR ready.

--- a/docs/specs/2026-07-10-opencost-autopilot-forecast.md
+++ b/docs/specs/2026-07-10-opencost-autopilot-forecast.md
@@ -148,4 +148,4 @@ files changed, so visual browser validation was not required.
 - [x] Add Helm values, rendered arguments, and chart coverage.
 - [x] Update operator documentation.
 - [x] Run focused and full validation.
-- [ ] Push implementation and mark the upstream PR ready.
+- [x] Push implementation and mark the upstream PR ready.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skyhook-io/radar/internal/helm"
 	"github.com/skyhook-io/radar/internal/k8s"
 	mcppkg "github.com/skyhook-io/radar/internal/mcp"
+	opencostpkg "github.com/skyhook-io/radar/internal/opencost"
 	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
 	"github.com/skyhook-io/radar/internal/server"
 	"github.com/skyhook-io/radar/internal/settings"
@@ -31,35 +32,37 @@ var clusterConnectionProbe = k8s.TestClusterConnection
 
 // AppConfig holds all parsed configuration for the Radar application.
 type AppConfig struct {
-	Kubeconfig               string
-	KubeconfigDirs           []string
-	Namespace                string
-	Port                     int
-	NoBrowser                bool
-	Browser                  string
-	DevMode                  bool
-	HistoryLimit             int
-	DebugEvents              bool
-	FakeInCluster            bool
-	DisableHelmWrite         bool
-	DisableExec              bool
-	DisableLocalTerminal     bool
-	PodShellDefault          string
-	DebugImage               string
-	ListPageSize             int64
-	NamespaceScope           bool
-	TimelineStorage          string
-	TimelineDBPath           string
-	TimelineRetention        time.Duration
-	TimelineMaxSizeBytes     int64
-	PrometheusURL            string
-	PrometheusHeaders        map[string]string
-	PrometheusHeadersFromEnv map[string]string
-	Version                  string
-	MCPEnabled               bool
-	AIHistory                bool   // persist AI investigations across restarts
-	AIHistoryDBPath          string // "" = ~/.radar/ai-runs.db
-	AuthConfig               auth.Config
+	Kubeconfig                   string
+	KubeconfigDirs               []string
+	Namespace                    string
+	Port                         int
+	NoBrowser                    bool
+	Browser                      string
+	DevMode                      bool
+	HistoryLimit                 int
+	DebugEvents                  bool
+	FakeInCluster                bool
+	DisableHelmWrite             bool
+	DisableExec                  bool
+	DisableLocalTerminal         bool
+	PodShellDefault              string
+	DebugImage                   string
+	ListPageSize                 int64
+	NamespaceScope               bool
+	TimelineStorage              string
+	TimelineDBPath               string
+	TimelineRetention            time.Duration
+	TimelineMaxSizeBytes         int64
+	PrometheusURL                string
+	PrometheusHeaders            map[string]string
+	PrometheusHeadersFromEnv     map[string]string
+	OpenCostExcludedNamespaces   []string
+	OpenCostDisableNodeCostFloor bool
+	Version                      string
+	MCPEnabled                   bool
+	AIHistory                    bool   // persist AI investigations across restarts
+	AIHistoryDBPath              string // "" = ~/.radar/ai-runs.db
+	AuthConfig                   auth.Config
 }
 
 // SetGlobals applies debug/test flags to global state.
@@ -229,6 +232,8 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 
 // CreateServer creates the HTTP server with the given configuration.
 func CreateServer(cfg AppConfig) *server.Server {
+	opencostpkg.Configure(cfg.OpenCostExcludedNamespaces, cfg.OpenCostDisableNodeCostFloor)
+
 	effectiveCfg := &config.Config{
 		Kubeconfig:               cfg.Kubeconfig,
 		KubeconfigDirs:           cfg.KubeconfigDirs,

--- a/internal/opencost/handlers.go
+++ b/internal/opencost/handlers.go
@@ -15,6 +15,16 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+var (
+	excludedNamespaces   []string
+	disableNodeCostFloor bool
+)
+
+func Configure(namespaces []string, disableFloor bool) {
+	excludedNamespaces = append([]string(nil), namespaces...)
+	disableNodeCostFloor = disableFloor
+}
+
 // RegisterRoutes registers OpenCost routes on the given router.
 func RegisterRoutes(r chi.Router) {
 	r.Get("/opencost/summary", handleSummary)
@@ -36,7 +46,10 @@ func handleSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, pkgopencost.ComputeCostSummaryFromProm(
-		r.Context(), client.Prom(), pkgopencost.SummaryOptions{}))
+		r.Context(), client.Prom(), pkgopencost.SummaryOptions{
+			ExcludedNamespaces:   excludedNamespaces,
+			DisableNodeCostFloor: disableNodeCostFloor,
+		}))
 }
 
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
@@ -128,7 +141,10 @@ func handleTrend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, pkgopencost.ComputeCostTrendFromProm(
-		r.Context(), client.Prom(), pkgopencost.TrendPromOptions{Range: r.URL.Query().Get("range")}))
+		r.Context(), client.Prom(), pkgopencost.TrendPromOptions{
+			Range:              r.URL.Query().Get("range"),
+			ExcludedNamespaces: excludedNamespaces,
+		}))
 }
 
 // handleNodes returns per-node cost breakdown.

--- a/pkg/opencost/compute.go
+++ b/pkg/opencost/compute.go
@@ -71,6 +71,13 @@ type SummaryOptions struct {
 	// filter rows by their Properties["namespace"] to actually honor the
 	// drill-down scope.
 	NamespaceFilter string
+
+	// ExcludedNamespaces removes exact namespace matches from rows and totals.
+	ExcludedNamespaces []string
+
+	// DisableNodeCostFloor keeps Prometheus summaries based on namespace
+	// allocations when node capacity is not the provider's billing unit.
+	DisableNodeCostFloor bool
 }
 
 // ComputeCostSummary is the default compute path: asks OpenCost's REST API
@@ -179,8 +186,16 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 	namespaces := make([]NamespaceCost, 0, len(combined))
 	var totalHourlyCost, totalStorageCost, totalNetworkCost, totalIdleCost float64
 	var totalAllocCost, totalUsageCost float64
+	excluded := namespaceSet(opts.ExcludedNamespaces)
 
 	for name, a := range combined {
+		ns := name
+		if propertyNamespace, ok := a.Properties["namespace"].(string); ok && propertyNamespace != "" {
+			ns = propertyNamespace
+		}
+		if namespaceExcluded(excluded, ns) {
+			continue
+		}
 		// OpenCost emits __idle__ as a synthetic row for unallocated node
 		// capacity. Surface it as a dedicated idle total, not a namespace.
 		//
@@ -407,7 +422,11 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 
 	var totalHourlyCost, totalStorageCost, totalUsageCost, totalAllocCost float64
 	namespaces := make([]NamespaceCost, 0, len(nsMap))
+	excluded := namespaceSet(opts.ExcludedNamespaces)
 	for _, nc := range nsMap {
+		if namespaceExcluded(excluded, nc.Name) {
+			continue
+		}
 		nc.HourlyCost = nc.CPUCost + nc.MemoryCost
 		nc.StorageCost = storageMap[nc.Name]
 		nc.HourlyCost += nc.StorageCost
@@ -425,9 +444,11 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 		namespaces = append(namespaces, *nc)
 	}
 
-	if nodeResult, err := client.Query(ctx, `sum(node_total_hourly_cost)`); err == nil && len(nodeResult.Series) > 0 && len(nodeResult.Series[0].DataPoints) > 0 {
-		if nodeCost := nodeResult.Series[0].DataPoints[0].Value; nodeCost > totalHourlyCost {
-			totalHourlyCost = nodeCost
+	if !opts.DisableNodeCostFloor {
+		if nodeResult, err := client.Query(ctx, `sum(node_total_hourly_cost)`); err == nil && len(nodeResult.Series) > 0 && len(nodeResult.Series[0].DataPoints) > 0 {
+			if nodeCost := nodeResult.Series[0].DataPoints[0].Value; nodeCost > totalHourlyCost {
+				totalHourlyCost = nodeCost
+			}
 		}
 	}
 
@@ -461,6 +482,24 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 		ClusterEfficiency: clusterEfficiency,
 		Namespaces:        namespaces,
 	}
+}
+
+func namespaceSet(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			set[name] = struct{}{}
+		}
+	}
+	return set
+}
+
+func namespaceExcluded(excluded map[string]struct{}, namespace string) bool {
+	_, ok := excluded[namespace]
+	return ok
 }
 
 func mergeSeriesIntoNamespaceField(result *prom.QueryResult, nsMap map[string]*NamespaceCost, set func(*NamespaceCost, float64)) {

--- a/pkg/opencost/compute_rest_test.go
+++ b/pkg/opencost/compute_rest_test.go
@@ -127,6 +127,27 @@ func TestComputeCostSummary_REST_HappyPath(t *testing.T) {
 	}
 }
 
+func TestComputeCostSummary_REST_ExcludesNamespaces(t *testing.T) {
+	body := buildAllocationResponse(t, map[string]float64{
+		"app":         3.00,
+		"kube-system": 15.00,
+	})
+	client := fakeOpenCost(t, body)
+
+	got := ComputeCostSummary(context.Background(), client, SummaryOptions{
+		ExcludedNamespaces: []string{"kube-system"},
+	})
+	if !got.Available {
+		t.Fatalf("expected Available=true; got %+v", got)
+	}
+	if got.TotalHourlyCost != 3.0 {
+		t.Errorf("TotalHourlyCost=%v, want included namespace sum 3.0", got.TotalHourlyCost)
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0].Name != "app" {
+		t.Errorf("unexpected namespaces: %+v", got.Namespaces)
+	}
+}
+
 func TestComputeCostSummary_REST_IdleRowSurfaced(t *testing.T) {
 	// OpenCost emits __idle__ for unallocated node capacity. We surface it
 	// as TotalIdleCost (not a namespace row), and do NOT roll it into

--- a/pkg/opencost/compute_test.go
+++ b/pkg/opencost/compute_test.go
@@ -135,6 +135,28 @@ func TestComputeCostSummary_HappyPath(t *testing.T) {
 	}
 }
 
+func TestComputeCostSummary_ExcludesNamespacesAndDisablesNodeCostFloor(t *testing.T) {
+	client := scriptedProm(t, []scriptedCase{
+		{contains: "container_cpu_allocation", body: vectorBody(map[string]float64{"app": 2.0, "kube-system": 10.0})},
+		{contains: "container_memory_allocation_bytes", body: vectorBody(map[string]float64{"app": 1.0, "kube-system": 5.0})},
+		{contains: "node_total_hourly_cost", body: scalarBody(20.0)},
+	})
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{
+		ExcludedNamespaces:   []string{"kube-system"},
+		DisableNodeCostFloor: true,
+	})
+	if !got.Available {
+		t.Fatalf("summary unavailable: %+v", got)
+	}
+	if got.TotalHourlyCost != 3.0 {
+		t.Errorf("TotalHourlyCost=%v, want included namespace sum 3.0", got.TotalHourlyCost)
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0].Name != "app" {
+		t.Errorf("unexpected namespaces: %+v", got.Namespaces)
+	}
+}
+
 func TestComputeCostSummary_NoMetricsReason(t *testing.T) {
 	client := scriptedProm(t, []scriptedCase{
 		// All queries return empty vector results.

--- a/pkg/opencost/trend_prom.go
+++ b/pkg/opencost/trend_prom.go
@@ -18,6 +18,10 @@ type TrendPromOptions struct {
 	// MaxSeries is the top-N namespaces kept; the rest are aggregated into
 	// a single "other" series. Defaults to 8 when zero.
 	MaxSeries int
+
+	// ExcludedNamespaces removes exact namespace matches before ranking and
+	// aggregation into the other series.
+	ExcludedNamespaces []string
 }
 
 // ComputeCostTrendFromProm returns a stacked per-namespace cost trend from
@@ -59,10 +63,11 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 		lastCost float64
 		idx      int
 	}
+	excluded := namespaceSet(opts.ExcludedNamespaces)
 	ranks := make([]nsRank, 0, len(result.Series))
 	for i, s := range result.Series {
 		ns := s.Labels["namespace"]
-		if ns == "" {
+		if ns == "" || namespaceExcluded(excluded, ns) {
 			continue
 		}
 		var last float64
@@ -92,6 +97,10 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 		otherMap := make(map[int64]float64)
 		for i, s := range result.Series {
 			if topSet[i] {
+				continue
+			}
+			ns := s.Labels["namespace"]
+			if ns == "" || namespaceExcluded(excluded, ns) {
 				continue
 			}
 			for _, dp := range s.DataPoints {

--- a/pkg/opencost/trend_prom_test.go
+++ b/pkg/opencost/trend_prom_test.go
@@ -113,6 +113,30 @@ func TestComputeCostTrendFromProm_TopNAndOther(t *testing.T) {
 	}
 }
 
+func TestComputeCostTrendFromProm_ExcludedNamespacesDoNotBecomeOther(t *testing.T) {
+	client := rangeProm(t, matrixBody([]namespaceSeries{
+		{"kube-system", []dpoint{{1700000000, 100}, {1700003600, 100}}},
+		{"app", []dpoint{{1700000000, 9}, {1700003600, 10}}},
+		{"jobs", []dpoint{{1700000000, 4}, {1700003600, 5}}},
+		{"monitoring", []dpoint{{1700000000, 1}, {1700003600, 2}}},
+	}))
+
+	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{
+		Range:              "24h",
+		MaxSeries:          1,
+		ExcludedNamespaces: []string{"kube-system"},
+	})
+	if !got.Available {
+		t.Fatalf("expected Available=true, got %+v", got)
+	}
+	if len(got.Series) != 2 || got.Series[0].Namespace != "app" || got.Series[1].Namespace != "other" {
+		t.Fatalf("unexpected series: %v", namesOf(got.Series))
+	}
+	if got.Series[1].DataPoints[1].Value != 7 {
+		t.Errorf("other latest value=%v, want jobs+monitoring=7", got.Series[1].DataPoints[1].Value)
+	}
+}
+
 func TestComputeCostTrendFromProm_AllUnderMaxSeriesNoOther(t *testing.T) {
 	// 2 namespaces, MaxSeries=8 → no "other" series.
 	client := rangeProm(t, matrixBody([]namespaceSeries{

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -54,6 +54,16 @@ assert_not_contains '^kind: RoleBinding$'           "no namespaced RoleBinding"
 assert_not_contains 'MY_POD_NAMESPACE'              "no downward-API env var"
 assert_not_contains 'MY_DEPLOYMENT_NAME'            "no deployment-name env var"
 assert_not_contains 'self-upgrade'                  "no self-upgrade references anywhere"
+assert_not_contains 'opencost-excluded-namespaces'     "no OpenCost namespace exclusions"
+assert_not_contains 'opencost-disable-node-cost-floor' "node cost floor stays enabled"
+echo
+
+render "OpenCost billable namespace forecast" \
+  --set 'opencost.excludedNamespaces[0]=kube-system' \
+  --set 'opencost.excludedNamespaces[1]=gke-gmp-system' \
+  --set opencost.disableNodeCostFloor=true
+assert_contains '"--opencost-excluded-namespaces=kube-system,gke-gmp-system"' "excluded namespaces rendered"
+assert_contains '--opencost-disable-node-cost-floor' "node cost floor disablement rendered"
 echo
 
 render "prometheusHeadersFromEnv — flag and secret env stay separate" \


### PR DESCRIPTION
## Summary
- Add operator controls for excluding non-billable namespaces from OpenCost forecasts.
- Allow managed-cluster users to disable the node-capacity floor without changing raw metrics.

## Changes
- Add `--opencost-excluded-namespaces` and `--opencost-disable-node-cost-floor`.
- Add backward-compatible Helm values and rendered Deployment arguments.
- Filter excluded namespaces from summary totals, trend ranking, and the `other` series.
- Cover Prometheus and REST summaries, trend aggregation, defaults, and chart rendering.

## Testing
- `make test`
- `make test-chart`
- `helm lint deploy/helm/radar`
- `go test ./...`
- `go vet ./...`
- `(cd pkg && go test ./...)`
- `(cd pkg && go test -race ./opencost)`
- `(cd pkg && go vet ./...)`
- `git diff --check upstream/main...HEAD`
- `gitleaks detect --no-banner --redact --log-opts upstream/main..HEAD`

## Risks/Notes
- Defaults preserve existing behavior.
- Namespace matching is exact; no provider-specific exclusions are hard-coded.
- Node detail endpoints and raw Prometheus metrics remain unchanged.
- No frontend files changed; visual browser testing was not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in configuration with backward-compatible defaults; changes are limited to OpenCost aggregation logic and deployment args, not auth or cluster mutation paths.
> 
> **Overview**
> Adds operator controls so OpenCost **summary** and **trend** can omit non-billable namespaces and optionally stop promoting `node_total_hourly_cost` above the sum of included namespace allocations—aimed at managed clusters (e.g. GKE Autopilot) where node capacity is not the billing unit.
> 
> **Configuration:** New CLI flags `--opencost-excluded-namespaces` (comma-separated, exact match) and `--opencost-disable-node-cost-floor`; Helm `opencost.excludedNamespaces` / `opencost.disableNodeCostFloor` render the same args on the Deployment. Startup wires flags into `AppConfig`, `opencost.Configure` at server creation, and handler options for summary/trend.
> 
> **Compute:** `SummaryOptions` / `TrendPromOptions` gain exclusion and floor flags; REST and Prometheus summaries drop excluded namespaces from rows and totals; Prometheus summary skips the node-cost ceiling when disabled; trend ranking and the `other` bucket ignore excluded series so costs do not leak into `other`. Workloads and nodes endpoints are unchanged.
> 
> Docs (README), a design spec, Go tests, and chart render assertions cover defaults (no new args) and configured values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69acf410a2c774d0a0fa94d33708a081a6cb281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->