### PR TITLE
Stop logging routine topology broadcasts

### DIFF
--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -594,8 +594,6 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		return
 	}
 
-	log.Printf("Broadcasting topology update to %d clients", len(clients))
-
 	// One broadcast cycle = one debounce fire that reaches clients. Counted
 	// here (not in the per-group loop below) so the metric reflects cycles,
 	// not the number of distinct namespace/view/policy groups.


### PR DESCRIPTION
## Summary

Avoid flooding Radar server logs with a success message on every debounced topology update. Topology broadcasts continue unchanged and remain observable through the existing SSE broadcast performance counter.

## Testing

- `make test`
- `make build`
- Visual test skipped: no UI delta

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no behavior change to SSE delivery or topology build logic.
> 
> **Overview**
> Removes the **`log.Printf`** that ran on every successful debounced topology broadcast in **`broadcastTopologyUpdate`**, which was flooding Radar server logs during normal operation.
> 
> **SSE topology broadcasts are unchanged** — clients still receive updates on the same debounce schedule. **`perfstats.IncSSEBroadcast()`** remains so broadcast volume stays visible via diagnostics/performance counters instead of log lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7e476051ef630f5f7514d759ecb3b972aa91d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->