### PR TITLE
traffic: stop auto-connect retry loop on failed traffic source

### DIFF
--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -958,7 +958,11 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
     }
   }, [sourcesData, sourcesLoading])
 
-  // Shared connection handler — used by auto-connect and retry buttons
+  // Shared connection handler — used by auto-connect and retry buttons.
+  // Deliberately does NOT reset hasAutoConnectedRef on failure: that ref gates
+  // the auto-connect effect, and re-arming it would re-fire auto-connect on
+  // every failed attempt (unbounded loop). Retries come from the explicit
+  // Retry button, which calls handleConnect directly.
   const handleConnect = useCallback(() => {
     setIsConnecting(true)
     setConnectionError(null)
@@ -969,18 +973,18 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
         setIsConnecting(false)
         if (!data.connected && data.error) {
           setConnectionError(data.error)
-          hasAutoConnectedRef.current = false // allow retry
         }
       },
       onError: (error) => {
         setIsConnecting(false)
         setConnectionError(error.message)
-        hasAutoConnectedRef.current = false // allow retry
       },
     })
   }, [connectMutation, queryClient])
 
-  // Auto-connect when source is detected
+  // Auto-connect once when a source is first detected. Strictly one-shot per
+  // mount / cluster (the ref resets on cluster change); failures surface a
+  // manual Retry rather than re-arming this effect.
   useEffect(() => {
     if (wizardState === 'ready' && !hasAutoConnectedRef.current && !isConnecting) {
       hasAutoConnectedRef.current = true


### PR DESCRIPTION
Fixes #1151.

## Problem

In `TrafficView`, when a cluster's traffic source is *detected* as `available` but the actual connect **fails**, the auto-connect effect re-fired indefinitely — hammering the traffic-connect mutation (→ hub → CAC → connector → cluster) for as long as the view stayed mounted, with no backoff and no cap.

The `hasAutoConnectedRef` guard was reset to `false` on every failed connect ("allow retry"). But that same ref gates the auto-connect effect, which depends on `isConnecting`. So each failure re-armed the guard right as `isConnecting` flipped `true → false`, and the effect immediately re-fired. `connectionError` doesn't gate the effect, so surfacing the error never stopped the loop.

## Fix

Keep auto-connect strictly one-shot per mount/cluster: don't reset `hasAutoConnectedRef` on failure. The ref still resets on cluster change, so a new cluster re-arms auto-connect once. Manual retry is unaffected — the Retry button calls `handleConnect` directly, independent of the ref, so a failed auto-connect leaves the user with a working manual Retry instead of a silent loop.

## Test plan

- `npm run tsc` — clean
- `make test` — pass
- Behavioral: with a detectable-but-broken source, auto-connect now attempts once, surfaces the error + Retry pill, and stops calling the connect endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in traffic connect orchestration; reduces load on the connect path and does not alter auth or data handling.
> 
> **Overview**
> Fixes an **unbounded auto-connect loop** in `TrafficView` when a traffic source is detected as available but the connect call fails.
> 
> **`handleConnect`** no longer clears `hasAutoConnectedRef` on connect error or on a successful response with `connected: false`. That ref only gates the auto-connect `useEffect`, so resetting it on failure re-armed auto-connect as `isConnecting` dropped and the effect ran again indefinitely.
> 
> Auto-connect is now **one attempt per mount/cluster** (the ref still resets on cluster change). Failed connects show the existing error UI and **retry** / **Retry Connection**, which call `handleConnect` directly without touching the ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056a54339e41c1c3420a2d3a6890587a7ad8a76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->