### PR TITLE
prometheus: redesign discovery (singleflight + candidate pruning + reachability probing)

### DIFF
--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -43,6 +43,12 @@ type metricsForward struct {
 	// establishment.
 	establishMu sync.Mutex
 
+	// epoch bumps on every teardown (Stop, or Start replacing this owner's
+	// forward). Start captures it before establishing and refuses to publish if it
+	// changed meanwhile — so a Stop that lands while a forward is still coming up
+	// (e.g. a context-switch Reset) is not silently lost when readyCh then wins.
+	epoch uint64
+
 	active      bool
 	localPort   int
 	namespace   string
@@ -144,6 +150,7 @@ func Start(owner Owner, ctx context.Context, namespace, serviceName string, targ
 		return info, nil
 	}
 	stopForwardLocked(f) // replace only this owner's existing forward
+	startEpoch := f.epoch
 	reg.mu.Unlock()
 
 	// Establish the forward WITHOUT holding reg.mu.
@@ -190,6 +197,15 @@ func Start(owner Owner, ctx context.Context, namespace, serviceName string, targ
 	select {
 	case <-readyCh:
 		reg.mu.Lock()
+		// A Stop (or a replacing Start) that landed while we were establishing
+		// bumped the epoch. Honor it: tear this forward down instead of publishing
+		// a connection the caller already asked to stop (e.g. after a context
+		// switch), which would otherwise report the wrong cluster as connected.
+		if f.epoch != startEpoch {
+			reg.mu.Unlock()
+			teardown()
+			return nil, fmt.Errorf("port-forward superseded during establishment")
+		}
 		f.active = true
 		f.localPort = localPort
 		f.namespace = namespace
@@ -230,7 +246,14 @@ func Stop(owner Owner) {
 
 // stopForwardLocked stops one owner's forward (caller must hold reg.mu).
 func stopForwardLocked(f *metricsForward) {
-	if f == nil || !f.active {
+	if f == nil {
+		return
+	}
+	// Bump before the active check so a Stop that lands while a forward is still
+	// establishing (not yet active) still invalidates it — the in-flight Start
+	// checks this epoch before publishing.
+	f.epoch++
+	if !f.active {
 		return
 	}
 

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -3,8 +3,13 @@
 // package (for resource metrics), breaking what would otherwise be an import cycle.
 //
 // The low-level primitives (RunPortForward, FindPodForService, FindFreePort)
-// live in pkg/portforward. This package manages the singleton lifecycle and
-// Radar-specific context tracking on top of those primitives.
+// live in pkg/portforward. This package holds one metrics forward per owner —
+// prometheus discovery and the traffic subsystem each get their own — so that
+// starting or stopping one owner's forward never tears down the other's. (A
+// single shared forward previously let them clobber each other whenever they
+// wanted different services.) Owners may still read each other's forward
+// address (GetAddress) to reuse a compatible endpoint, but only ever stop their
+// own.
 package portforward
 
 import (
@@ -20,11 +25,16 @@ import (
 	pfpkg "github.com/skyhook-io/radar/pkg/portforward"
 )
 
-// MetricsPortForward manages port-forwarding to metrics services
-type MetricsPortForward struct {
-	mu sync.RWMutex
+// Owner identifies the subsystem that owns a metrics forward.
+type Owner = string
 
-	// Active port-forward state
+const (
+	OwnerPrometheus Owner = "prometheus"
+	OwnerTraffic    Owner = "traffic"
+)
+
+// metricsForward is one owner's active port-forward state.
+type metricsForward struct {
 	active      bool
 	localPort   int
 	namespace   string
@@ -33,13 +43,8 @@ type MetricsPortForward struct {
 	targetPort  int
 	contextName string // K8s context this forward belongs to
 
-	// Control channels
 	stopCh chan struct{}
 	cancel context.CancelFunc
-
-	// K8s clients
-	k8sClient kubernetes.Interface
-	k8sConfig *rest.Config
 }
 
 // ConnectionInfo contains info about the metrics connection
@@ -53,76 +58,90 @@ type ConnectionInfo struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// Global metrics port-forward instance
-var metricsPortForward = &MetricsPortForward{}
+// registry holds one metrics forward per owner plus the shared K8s clients.
+type registry struct {
+	mu        sync.RWMutex
+	forwards  map[Owner]*metricsForward
+	k8sClient kubernetes.Interface
+	k8sConfig *rest.Config
+}
+
+var reg = &registry{forwards: map[Owner]*metricsForward{}}
+
+// forwardFor returns the owner's forward state, creating an empty one on first use.
+// Caller must hold reg.mu.
+func forwardFor(owner Owner) *metricsForward {
+	f := reg.forwards[owner]
+	if f == nil {
+		f = &metricsForward{}
+		reg.forwards[owner] = f
+	}
+	return f
+}
 
 // SetK8sClients sets the K8s client and config for port-forwarding.
 // Must be called before using port-forward features.
 func SetK8sClients(client kubernetes.Interface, config *rest.Config) {
-	metricsPortForward.mu.Lock()
-	defer metricsPortForward.mu.Unlock()
-	metricsPortForward.k8sClient = client
-	metricsPortForward.k8sConfig = config
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.k8sClient = client
+	reg.k8sConfig = config
 }
 
-// Start starts a port-forward to the specified metrics service.
-func Start(ctx context.Context, namespace, serviceName string, targetPort int, contextName string) (*ConnectionInfo, error) {
-	metricsPortForward.mu.Lock()
-	defer metricsPortForward.mu.Unlock()
+// Start starts a port-forward to the specified metrics service for the given
+// owner. It only replaces that owner's own forward — other owners' forwards are
+// left untouched.
+func Start(owner Owner, ctx context.Context, namespace, serviceName string, targetPort int, contextName string) (*ConnectionInfo, error) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
 
-	// If already forwarding to the same service in the same context, return existing
-	if metricsPortForward.active &&
-		metricsPortForward.namespace == namespace &&
-		metricsPortForward.serviceName == serviceName &&
-		metricsPortForward.contextName == contextName {
+	f := forwardFor(owner)
+
+	// If this owner is already forwarding to the same service in the same
+	// context, return the existing forward.
+	if f.active && f.namespace == namespace && f.serviceName == serviceName && f.contextName == contextName {
 		return &ConnectionInfo{
 			Connected:   true,
-			LocalPort:   metricsPortForward.localPort,
-			Address:     fmt.Sprintf("http://localhost:%d", metricsPortForward.localPort),
+			LocalPort:   f.localPort,
+			Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
 			Namespace:   namespace,
 			ServiceName: serviceName,
 			ContextName: contextName,
 		}, nil
 	}
 
-	// Stop any existing port-forward first
-	stopLocked()
+	// Replace only this owner's existing forward.
+	stopForwardLocked(f)
 
-	client := metricsPortForward.k8sClient
-	config := metricsPortForward.k8sConfig
-
+	client := reg.k8sClient
+	config := reg.k8sConfig
 	if client == nil || config == nil {
 		return nil, fmt.Errorf("K8s client not initialized")
 	}
 
-	// Find a pod backing the service
 	podName, err := findPodForService(ctx, client, namespace, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find pod for service %s: %w", serviceName, err)
 	}
 
-	// Find a free local port
 	localPort, err := findFreePort()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port: %w", err)
 	}
 
-	// Create control channels
 	stopCh := make(chan struct{})
 	pfCtx, cancel := context.WithCancel(context.Background())
 
-	// Store state
-	metricsPortForward.active = true
-	metricsPortForward.localPort = localPort
-	metricsPortForward.namespace = namespace
-	metricsPortForward.serviceName = serviceName
-	metricsPortForward.podName = podName
-	metricsPortForward.targetPort = targetPort
-	metricsPortForward.contextName = contextName
-	metricsPortForward.stopCh = stopCh
-	metricsPortForward.cancel = cancel
+	f.active = true
+	f.localPort = localPort
+	f.namespace = namespace
+	f.serviceName = serviceName
+	f.podName = podName
+	f.targetPort = targetPort
+	f.contextName = contextName
+	f.stopCh = stopCh
+	f.cancel = cancel
 
-	// Start port-forward in background
 	readyCh := make(chan struct{})
 	errCh := make(chan error, 1)
 
@@ -133,19 +152,17 @@ func Start(ctx context.Context, namespace, serviceName string, targetPort int, c
 		}
 		close(errCh)
 
-		// Mark as inactive when done
-		metricsPortForward.mu.Lock()
-		if metricsPortForward.podName == podName && metricsPortForward.localPort == localPort {
-			metricsPortForward.active = false
+		reg.mu.Lock()
+		if f.podName == podName && f.localPort == localPort {
+			f.active = false
 		}
-		metricsPortForward.mu.Unlock()
+		reg.mu.Unlock()
 	}()
 
-	// Wait for ready or error (with timeout)
 	select {
 	case <-readyCh:
-		log.Printf("[portforward] Ready: localhost:%d -> %s/%s:%d (context: %s)",
-			localPort, namespace, serviceName, targetPort, contextName)
+		log.Printf("[portforward] Ready: localhost:%d -> %s/%s:%d (owner=%s, context: %s)",
+			localPort, namespace, serviceName, targetPort, owner, contextName)
 		return &ConnectionInfo{
 			Connected:   true,
 			LocalPort:   localPort,
@@ -156,102 +173,124 @@ func Start(ctx context.Context, namespace, serviceName string, targetPort int, c
 		}, nil
 
 	case err := <-errCh:
-		stopLocked()
+		stopForwardLocked(f)
 		return nil, fmt.Errorf("port-forward failed: %w", err)
 
 	case <-time.After(10 * time.Second):
-		stopLocked()
+		stopForwardLocked(f)
 		return nil, fmt.Errorf("port-forward timed out")
 
 	case <-ctx.Done():
-		stopLocked()
+		stopForwardLocked(f)
 		return nil, ctx.Err()
 	}
 }
 
-// Stop stops the active metrics port-forward.
-func Stop() {
-	metricsPortForward.mu.Lock()
-	defer metricsPortForward.mu.Unlock()
-	stopLocked()
+// Stop stops the given owner's metrics port-forward, if any.
+func Stop(owner Owner) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	if f := reg.forwards[owner]; f != nil {
+		stopForwardLocked(f)
+	}
 }
 
-// stopLocked stops the port-forward (caller must hold lock)
-func stopLocked() {
-	if !metricsPortForward.active {
+// stopForwardLocked stops one owner's forward (caller must hold reg.mu).
+func stopForwardLocked(f *metricsForward) {
+	if f == nil || !f.active {
 		return
 	}
 
-	log.Printf("[portforward] Stopping: localhost:%d -> %s/%s",
-		metricsPortForward.localPort, metricsPortForward.namespace, metricsPortForward.serviceName)
+	log.Printf("[portforward] Stopping: localhost:%d -> %s/%s", f.localPort, f.namespace, f.serviceName)
 
-	if metricsPortForward.cancel != nil {
-		metricsPortForward.cancel()
+	if f.cancel != nil {
+		f.cancel()
 	}
-	if metricsPortForward.stopCh != nil {
+	if f.stopCh != nil {
 		select {
-		case <-metricsPortForward.stopCh:
+		case <-f.stopCh:
 			// Already closed
 		default:
-			close(metricsPortForward.stopCh)
+			close(f.stopCh)
 		}
 	}
 
-	metricsPortForward.active = false
-	metricsPortForward.localPort = 0
-	metricsPortForward.namespace = ""
-	metricsPortForward.serviceName = ""
-	metricsPortForward.podName = ""
-	metricsPortForward.targetPort = 0
-	metricsPortForward.contextName = ""
-	metricsPortForward.stopCh = nil
-	metricsPortForward.cancel = nil
+	f.active = false
+	f.localPort = 0
+	f.namespace = ""
+	f.serviceName = ""
+	f.podName = ""
+	f.targetPort = 0
+	f.contextName = ""
+	f.stopCh = nil
+	f.cancel = nil
 }
 
-// GetAddress returns the current metrics address if connected.
-// Returns empty string if not connected or if the connection is for a different context.
+// GetAddress returns the address of any active metrics forward for the given
+// context, so an owner can opportunistically reuse another owner's compatible
+// endpoint (read-only — it never takes ownership). Empty if none.
 func GetAddress(currentContext string) string {
-	metricsPortForward.mu.RLock()
-	defer metricsPortForward.mu.RUnlock()
-
-	if !metricsPortForward.active {
-		return ""
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	for _, f := range reg.forwards {
+		if f.active && f.contextName == currentContext {
+			return fmt.Sprintf("http://localhost:%d", f.localPort)
+		}
 	}
-
-	// Validate context matches
-	if metricsPortForward.contextName != currentContext {
-		log.Printf("[portforward] Context mismatch: have %q, want %q",
-			metricsPortForward.contextName, currentContext)
-		return ""
-	}
-
-	return fmt.Sprintf("http://localhost:%d", metricsPortForward.localPort)
+	return ""
 }
 
-// GetConnectionInfo returns current connection info.
-func GetConnectionInfo() *ConnectionInfo {
-	metricsPortForward.mu.RLock()
-	defer metricsPortForward.mu.RUnlock()
+// GetConnectionInfo returns the given owner's connection info.
+func GetConnectionInfo(owner Owner) *ConnectionInfo {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
 
-	if !metricsPortForward.active {
+	f := reg.forwards[owner]
+	if f == nil || !f.active {
 		return &ConnectionInfo{Connected: false}
 	}
 
 	return &ConnectionInfo{
 		Connected:   true,
-		LocalPort:   metricsPortForward.localPort,
-		Address:     fmt.Sprintf("http://localhost:%d", metricsPortForward.localPort),
-		Namespace:   metricsPortForward.namespace,
-		ServiceName: metricsPortForward.serviceName,
-		ContextName: metricsPortForward.contextName,
+		LocalPort:   f.localPort,
+		Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
+		Namespace:   f.namespace,
+		ServiceName: f.serviceName,
+		ContextName: f.contextName,
 	}
 }
 
-// IsConnectedForContext checks if we have an active connection for the given context.
+// GetConnectionInfoForContext returns any active forward for the context (across
+// owners), so a consumer that may be reusing another owner's forward can report
+// live status without caching a snapshot that could go stale. Disconnected if none.
+func GetConnectionInfoForContext(contextName string) *ConnectionInfo {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	for _, f := range reg.forwards {
+		if f.active && f.contextName == contextName {
+			return &ConnectionInfo{
+				Connected:   true,
+				LocalPort:   f.localPort,
+				Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
+				Namespace:   f.namespace,
+				ServiceName: f.serviceName,
+				ContextName: f.contextName,
+			}
+		}
+	}
+	return &ConnectionInfo{Connected: false}
+}
+
+// IsConnectedForContext reports whether any owner has an active forward for the context.
 func IsConnectedForContext(contextName string) bool {
-	metricsPortForward.mu.RLock()
-	defer metricsPortForward.mu.RUnlock()
-	return metricsPortForward.active && metricsPortForward.contextName == contextName
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	for _, f := range reg.forwards {
+		if f.active && f.contextName == contextName {
+			return true
+		}
+	}
+	return false
 }
 
 func runPortForward(ctx context.Context, client kubernetes.Interface, config *rest.Config,

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -35,6 +35,14 @@ const (
 
 // metricsForward is one owner's active port-forward state.
 type metricsForward struct {
+	// establishMu serializes Start for this owner. It is held across the
+	// port-forward establishment (pod lookup + up to a 10s ready wait) so two
+	// concurrent Starts for the same owner can't both bring up a forward and leak
+	// one. It is deliberately NOT reg.mu: establishing one owner's forward must
+	// not block reads (GetAddress/GetConnectionInfo), Stop, or the other owner's
+	// establishment.
+	establishMu sync.Mutex
+
 	active      bool
 	localPort   int
 	namespace   string
@@ -45,6 +53,18 @@ type metricsForward struct {
 
 	stopCh chan struct{}
 	cancel context.CancelFunc
+}
+
+// info builds the ConnectionInfo for an active forward. Caller must hold reg.mu.
+func (f *metricsForward) info() *ConnectionInfo {
+	return &ConnectionInfo{
+		Connected:   true,
+		LocalPort:   f.localPort,
+		Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
+		Namespace:   f.namespace,
+		ServiceName: f.serviceName,
+		ContextName: f.contextName,
+	}
 }
 
 // ConnectionInfo contains info about the metrics connection
@@ -92,38 +112,45 @@ func SetK8sClients(client kubernetes.Interface, config *rest.Config) {
 // owner. It only replaces that owner's own forward — other owners' forwards are
 // left untouched.
 func Start(owner Owner, ctx context.Context, namespace, serviceName string, targetPort int, contextName string) (*ConnectionInfo, error) {
+	// Fast path + client capture under reg.mu, held only briefly.
 	reg.mu.Lock()
-	defer reg.mu.Unlock()
-
 	f := forwardFor(owner)
-
-	// If this owner is already forwarding to the same service in the same
-	// context, return the existing forward.
 	if f.active && f.namespace == namespace && f.serviceName == serviceName && f.contextName == contextName {
-		return &ConnectionInfo{
-			Connected:   true,
-			LocalPort:   f.localPort,
-			Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
-			Namespace:   namespace,
-			ServiceName: serviceName,
-			ContextName: contextName,
-		}, nil
+		info := f.info()
+		reg.mu.Unlock()
+		return info, nil
 	}
-
-	// Replace only this owner's existing forward.
-	stopForwardLocked(f)
-
 	client := reg.k8sClient
 	config := reg.k8sConfig
+	reg.mu.Unlock()
+
 	if client == nil || config == nil {
 		return nil, fmt.Errorf("K8s client not initialized")
 	}
 
+	// Serialize establishment for THIS owner only. Held across the pod lookup and
+	// the up-to-10s ready wait below — but it is not reg.mu, so reads
+	// (GetAddress/GetConnectionInfo), Stop, and the other owner's establishment
+	// all stay unblocked meanwhile.
+	f.establishMu.Lock()
+	defer f.establishMu.Unlock()
+
+	// Re-check under reg.mu: a concurrent establish for this owner may have just
+	// connected to the same target while we waited on establishMu.
+	reg.mu.Lock()
+	if f.active && f.namespace == namespace && f.serviceName == serviceName && f.contextName == contextName {
+		info := f.info()
+		reg.mu.Unlock()
+		return info, nil
+	}
+	stopForwardLocked(f) // replace only this owner's existing forward
+	reg.mu.Unlock()
+
+	// Establish the forward WITHOUT holding reg.mu.
 	podName, err := findPodForService(ctx, client, namespace, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find pod for service %s: %w", serviceName, err)
 	}
-
 	localPort, err := findFreePort()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port: %w", err)
@@ -131,17 +158,6 @@ func Start(owner Owner, ctx context.Context, namespace, serviceName string, targ
 
 	stopCh := make(chan struct{})
 	pfCtx, cancel := context.WithCancel(context.Background())
-
-	f.active = true
-	f.localPort = localPort
-	f.namespace = namespace
-	f.serviceName = serviceName
-	f.podName = podName
-	f.targetPort = targetPort
-	f.contextName = contextName
-	f.stopCh = stopCh
-	f.cancel = cancel
-
 	readyCh := make(chan struct{})
 	errCh := make(chan error, 1)
 
@@ -159,29 +175,46 @@ func Start(owner Owner, ctx context.Context, namespace, serviceName string, targ
 		reg.mu.Unlock()
 	}()
 
+	// teardown stops the just-launched forward when establishment fails. The
+	// forward was never committed to f (only the ready path publishes it), so the
+	// goroutine's own cleanup is a no-op and there is nothing to unpublish.
+	teardown := func() {
+		cancel()
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	}
+
 	select {
 	case <-readyCh:
+		reg.mu.Lock()
+		f.active = true
+		f.localPort = localPort
+		f.namespace = namespace
+		f.serviceName = serviceName
+		f.podName = podName
+		f.targetPort = targetPort
+		f.contextName = contextName
+		f.stopCh = stopCh
+		f.cancel = cancel
+		info := f.info()
+		reg.mu.Unlock()
 		log.Printf("[portforward] Ready: localhost:%d -> %s/%s:%d (owner=%s, context: %s)",
 			localPort, namespace, serviceName, targetPort, owner, contextName)
-		return &ConnectionInfo{
-			Connected:   true,
-			LocalPort:   localPort,
-			Address:     fmt.Sprintf("http://localhost:%d", localPort),
-			Namespace:   namespace,
-			ServiceName: serviceName,
-			ContextName: contextName,
-		}, nil
+		return info, nil
 
 	case err := <-errCh:
-		stopForwardLocked(f)
+		teardown()
 		return nil, fmt.Errorf("port-forward failed: %w", err)
 
 	case <-time.After(10 * time.Second):
-		stopForwardLocked(f)
+		teardown()
 		return nil, fmt.Errorf("port-forward timed out")
 
 	case <-ctx.Done():
-		stopForwardLocked(f)
+		teardown()
 		return nil, ctx.Err()
 	}
 }

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -266,27 +266,6 @@ func GetConnectionInfo(owner Owner) *ConnectionInfo {
 	}
 }
 
-// GetConnectionInfoForContext returns any active forward for the context (across
-// owners), so a consumer that may be reusing another owner's forward can report
-// live status without caching a snapshot that could go stale. Disconnected if none.
-func GetConnectionInfoForContext(contextName string) *ConnectionInfo {
-	reg.mu.RLock()
-	defer reg.mu.RUnlock()
-	for _, f := range reg.forwards {
-		if f.active && f.contextName == contextName {
-			return &ConnectionInfo{
-				Connected:   true,
-				LocalPort:   f.localPort,
-				Address:     fmt.Sprintf("http://localhost:%d", f.localPort),
-				Namespace:   f.namespace,
-				ServiceName: f.serviceName,
-				ContextName: f.contextName,
-			}
-		}
-	}
-	return &ConnectionInfo{Connected: false}
-}
-
 // IsConnectedForContext reports whether any owner has an active forward for the context.
 func IsConnectedForContext(contextName string) bool {
 	reg.mu.RLock()

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -226,14 +226,20 @@ func stopForwardLocked(f *metricsForward) {
 	f.cancel = nil
 }
 
-// GetAddress returns the address of any active metrics forward for the given
-// context, so an owner can opportunistically reuse another owner's compatible
-// endpoint (read-only — it never takes ownership). Empty if none.
-func GetAddress(currentContext string) string {
+// GetAddress returns the address of an active metrics forward for the given
+// context, preferring the caller's own forward (preferOwner) before falling back
+// to another owner's compatible endpoint (read-only reuse — the caller never
+// takes ownership). Preferring the caller's own forward keeps selection
+// deterministic and avoids probing an incompatible peer (e.g. Hubble's relay)
+// while the caller's own forward is still live. Empty if none.
+func GetAddress(preferOwner Owner, currentContext string) string {
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()
-	for _, f := range reg.forwards {
-		if f.active && f.contextName == currentContext {
+	if f := reg.forwards[preferOwner]; f != nil && f.active && f.contextName == currentContext {
+		return fmt.Sprintf("http://localhost:%d", f.localPort)
+	}
+	for owner, f := range reg.forwards {
+		if owner != preferOwner && f.active && f.contextName == currentContext {
 			return fmt.Sprintf("http://localhost:%d", f.localPort)
 		}
 	}

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -1,0 +1,72 @@
+package portforward
+
+import "testing"
+
+// TestOwnerScoping verifies that each owner's forward is independent: stopping
+// one owner never tears down another's, and status/reuse lookups are scoped
+// correctly. This is the invariant that stops prometheus discovery and the
+// traffic subsystem from clobbering each other's metrics tunnel.
+func TestOwnerScoping(t *testing.T) {
+	saved := reg
+	t.Cleanup(func() { reg = saved })
+	reg = &registry{forwards: map[Owner]*metricsForward{}}
+
+	// Two owners hold live forwards in the same context.
+	reg.forwards[OwnerPrometheus] = &metricsForward{active: true, localPort: 1111, namespace: "monitoring", serviceName: "prometheus", contextName: "ctxA"}
+	reg.forwards[OwnerTraffic] = &metricsForward{active: true, localPort: 2222, namespace: "caretta", serviceName: "caretta-vm", contextName: "ctxA"}
+
+	if got := GetConnectionInfo(OwnerPrometheus); !got.Connected || got.LocalPort != 1111 {
+		t.Fatalf("prometheus info = %+v", got)
+	}
+	if got := GetConnectionInfo(OwnerTraffic); !got.Connected || got.LocalPort != 2222 {
+		t.Fatalf("traffic info = %+v", got)
+	}
+
+	// Stopping prometheus's forward must not touch traffic's — the core fix.
+	Stop(OwnerPrometheus)
+	if GetConnectionInfo(OwnerPrometheus).Connected {
+		t.Fatal("prometheus forward not stopped")
+	}
+	if !GetConnectionInfo(OwnerTraffic).Connected {
+		t.Fatal("traffic forward was torn down by prometheus Stop (cross-owner clobber)")
+	}
+
+	// GetAddress peeks across owners (read-only reuse) and is context-scoped.
+	if GetAddress("ctxA") == "" {
+		t.Fatal("GetAddress should surface traffic's forward for ctxA")
+	}
+	if GetAddress("ctxB") != "" {
+		t.Fatal("GetAddress must not match a different context")
+	}
+	if !IsConnectedForContext("ctxA") || IsConnectedForContext("ctxB") {
+		t.Fatal("IsConnectedForContext scoping wrong")
+	}
+}
+
+// TestGetConnectionInfoForContext verifies the context lookup used for traffic's
+// reuse status is *live* — it reports connected only while a forward is actually
+// active, never a stale snapshot.
+func TestGetConnectionInfoForContext(t *testing.T) {
+	saved := reg
+	t.Cleanup(func() { reg = saved })
+	reg = &registry{forwards: map[Owner]*metricsForward{}}
+
+	if GetConnectionInfoForContext("ctxA").Connected {
+		t.Fatal("expected disconnected with no forwards")
+	}
+
+	// Traffic reusing prometheus's forward: it surfaces for the context.
+	reg.forwards[OwnerPrometheus] = &metricsForward{active: true, localPort: 1234, contextName: "ctxA", namespace: "opencost", serviceName: "prometheus-server"}
+	if info := GetConnectionInfoForContext("ctxA"); !info.Connected || info.LocalPort != 1234 {
+		t.Fatalf("want connected on 1234, got %+v", info)
+	}
+	if GetConnectionInfoForContext("ctxB").Connected {
+		t.Fatal("must not match a different context")
+	}
+
+	// Owner stops it → status goes disconnected immediately (no stale cache).
+	Stop(OwnerPrometheus)
+	if GetConnectionInfoForContext("ctxA").Connected {
+		t.Fatal("stale: reported connected after the forward was stopped")
+	}
+}

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -65,31 +65,3 @@ func TestGetAddressPrefersOwn(t *testing.T) {
 		t.Fatalf("prometheus fallback got %q, want peer :2222", got)
 	}
 }
-
-// TestGetConnectionInfoForContext verifies the context lookup used for traffic's
-// reuse status is *live* — it reports connected only while a forward is actually
-// active, never a stale snapshot.
-func TestGetConnectionInfoForContext(t *testing.T) {
-	saved := reg
-	t.Cleanup(func() { reg = saved })
-	reg = &registry{forwards: map[Owner]*metricsForward{}}
-
-	if GetConnectionInfoForContext("ctxA").Connected {
-		t.Fatal("expected disconnected with no forwards")
-	}
-
-	// Traffic reusing prometheus's forward: it surfaces for the context.
-	reg.forwards[OwnerPrometheus] = &metricsForward{active: true, localPort: 1234, contextName: "ctxA", namespace: "opencost", serviceName: "prometheus-server"}
-	if info := GetConnectionInfoForContext("ctxA"); !info.Connected || info.LocalPort != 1234 {
-		t.Fatalf("want connected on 1234, got %+v", info)
-	}
-	if GetConnectionInfoForContext("ctxB").Connected {
-		t.Fatal("must not match a different context")
-	}
-
-	// Owner stops it → status goes disconnected immediately (no stale cache).
-	Stop(OwnerPrometheus)
-	if GetConnectionInfoForContext("ctxA").Connected {
-		t.Fatal("stale: reported connected after the forward was stopped")
-	}
-}

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -32,14 +32,37 @@ func TestOwnerScoping(t *testing.T) {
 	}
 
 	// GetAddress peeks across owners (read-only reuse) and is context-scoped.
-	if GetAddress("ctxA") == "" {
+	if GetAddress(OwnerTraffic, "ctxA") == "" {
 		t.Fatal("GetAddress should surface traffic's forward for ctxA")
 	}
-	if GetAddress("ctxB") != "" {
+	if GetAddress(OwnerTraffic, "ctxB") != "" {
 		t.Fatal("GetAddress must not match a different context")
 	}
 	if !IsConnectedForContext("ctxA") || IsConnectedForContext("ctxB") {
 		t.Fatal("IsConnectedForContext scoping wrong")
+	}
+}
+
+// TestGetAddressPrefersOwn verifies GetAddress returns the caller's own forward
+// when it has one, rather than an arbitrary peer's — so a caller reuses its own
+// live forward instead of probing an incompatible one.
+func TestGetAddressPrefersOwn(t *testing.T) {
+	saved := reg
+	t.Cleanup(func() { reg = saved })
+	reg = &registry{forwards: map[Owner]*metricsForward{}}
+	reg.forwards[OwnerPrometheus] = &metricsForward{active: true, localPort: 1111, contextName: "ctxA"}
+	reg.forwards[OwnerTraffic] = &metricsForward{active: true, localPort: 2222, contextName: "ctxA"}
+
+	if got := GetAddress(OwnerPrometheus, "ctxA"); got != "http://localhost:1111" {
+		t.Fatalf("prometheus got %q, want its own :1111", got)
+	}
+	if got := GetAddress(OwnerTraffic, "ctxA"); got != "http://localhost:2222" {
+		t.Fatalf("traffic got %q, want its own :2222", got)
+	}
+	// With no own forward, fall back to the peer's.
+	Stop(OwnerPrometheus)
+	if got := GetAddress(OwnerPrometheus, "ctxA"); got != "http://localhost:2222" {
+		t.Fatalf("prometheus fallback got %q, want peer :2222", got)
 	}
 }
 

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -65,3 +65,18 @@ func TestGetAddressPrefersOwn(t *testing.T) {
 		t.Fatalf("prometheus fallback got %q, want peer :2222", got)
 	}
 }
+
+// TestStopBumpsEpochWhileEstablishing pins the invariant that a Stop lands even
+// while a forward is still coming up (not yet active): stopForwardLocked must
+// bump epoch for an inactive forward too, so the in-flight Start sees the change
+// and refuses to publish a connection the caller already asked to stop. Reverting
+// to an early-return-when-inactive reintroduces the "Stop misses in-flight
+// establish" bug.
+func TestStopBumpsEpochWhileEstablishing(t *testing.T) {
+	f := &metricsForward{} // establishing: not yet active
+	before := f.epoch
+	stopForwardLocked(f)
+	if f.epoch == before {
+		t.Fatal("epoch not bumped for an inactive forward — a Stop during establishment would be silently lost")
+	}
+}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -33,7 +33,6 @@ type Client struct {
 	prom     *prom.Client // rebuilt whenever baseURL/basePath changes
 
 	// Discovery state
-	discovered       bool
 	discoveryService *prom.ServiceInfo // discovered service info for port-forward
 	manualURL        string            // --prometheus-url override
 	headers          map[string]string
@@ -212,7 +211,6 @@ func Reset() {
 		globalClient.baseURL = ""
 		globalClient.basePath = ""
 		globalClient.prom = nil
-		globalClient.discovered = false
 		globalClient.discoveryService = nil
 		globalClient.discoveryGen++
 		cancel := globalClient.discoveryCancel
@@ -308,7 +306,6 @@ func (c *Client) EnsureConnected(ctx context.Context) (string, string, error) {
 			c.baseURL = ""
 			c.basePath = ""
 			c.prom = nil
-			c.discovered = false
 			c.mu.Unlock()
 		}
 	}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/internal/portforward"
 	"github.com/skyhook-io/radar/pkg/prom"
 )
 
@@ -219,6 +220,10 @@ func Reset() {
 		if cancel != nil {
 			cancel() // abort any in-flight discovery started under the old config
 		}
+		// Tear down our own metrics forward. With per-owner forwards, traffic's
+		// Reset no longer stops ours incidentally, so we must clean it up here
+		// (context switch and config change both route through Reset).
+		portforward.Stop(portforward.OwnerPrometheus)
 	}
 }
 

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -335,7 +335,8 @@ func (c *Client) discoverShared(ctx context.Context) (string, string, error) {
 	type result struct{ addr, basePath string }
 
 	c.mu.RLock()
-	key := fmt.Sprintf("%s#%d", c.contextName, c.discoveryGen)
+	gen := c.discoveryGen
+	key := fmt.Sprintf("%s#%d", c.contextName, gen)
 	c.mu.RUnlock()
 
 	ch := c.discoverySF.DoChan(key, func() (any, error) {
@@ -384,7 +385,7 @@ func (c *Client) discoverShared(ctx context.Context) (string, string, error) {
 			return result{addr, basePath}, nil
 		}
 
-		addr, basePath, derr := c.discover(dctx)
+		addr, basePath, derr := c.discover(dctx, gen)
 		if derr != nil {
 			return nil, derr
 		}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -354,11 +354,14 @@ func (c *Client) discoverShared(ctx context.Context) (string, string, error) {
 			// A sequence number identifies this run's handle: two runs can overlap
 			// on one Client (an old-gen run cancelled by Reset while a new-gen run
 			// starts), and the ending run must not clear the newer run's cancel.
-			// Also honor retirement: if this Client was swapped out by Reinitialize
-			// before the goroutine got here, abort — cancelling wasn't possible then
-			// because the handle wasn't published yet.
+			// Abort here if this run was already superseded before it could publish
+			// its handle: retirement (Reinitialize) or a generation bump
+			// (Reset/SetManualURL/SetHeaders) whose cancel() no-op'd because the
+			// handle was still nil. Without the gen check such a run would hold the
+			// discovery gate and a live detached context for up to discoveryTimeout,
+			// blocking rediscovery under the new configuration.
 			c.mu.Lock()
-			if c.retired {
+			if c.retired || c.discoveryGen != gen {
 				c.mu.Unlock()
 				return nil, context.Canceled
 			}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -331,82 +331,111 @@ func (c *Client) EnsureConnected(ctx context.Context) (string, string, error) {
 func (c *Client) discoverShared(ctx context.Context) (string, string, error) {
 	type result struct{ addr, basePath string }
 
-	c.mu.RLock()
-	gen := c.discoveryGen
-	key := fmt.Sprintf("%s#%d", c.contextName, gen)
-	c.mu.RUnlock()
-
-	ch := c.discoverySF.DoChan(key, func() (any, error) {
-		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), discoveryTimeout)
-		defer cancel()
-
-		// Publish the cancel so Reset/Reinitialize can abort this detached run.
-		// A sequence number identifies this run's handle: two runs can overlap
-		// on one Client (an old-gen run cancelled by Reset while a new-gen run
-		// starts), and the ending run must not clear the newer run's cancel.
-		// Also honor retirement: if this Client was swapped out by Reinitialize
-		// before the goroutine got here, abort — cancelling wasn't possible then
-		// because the handle wasn't published yet.
-		c.mu.Lock()
-		if c.retired {
-			c.mu.Unlock()
-			return nil, context.Canceled
-		}
-		c.discoveryCancelSeq++
-		mySeq := c.discoveryCancelSeq
-		c.discoveryCancel = cancel
-		c.mu.Unlock()
-		defer func() {
-			c.mu.Lock()
-			if c.discoveryCancelSeq == mySeq {
-				c.discoveryCancel = nil
-			}
-			c.mu.Unlock()
-		}()
-
-		// Serialize across the process, but abandon the wait if this run is
-		// cancelled (superseded) so it can't wedge a newer discovery.
-		select {
-		case discoveryGate <- struct{}{}:
-			defer func() { <-discoveryGate }()
-		case <-dctx.Done():
-			return nil, dctx.Err()
+	// Loop so a run superseded by a mid-flight config change (Reset /
+	// SetManualURL / SetHeaders) rediscovers under the new generation instead of
+	// returning a spurious failure to callers like opencost. Every supersession
+	// bumps discoveryGen, so each retry keys a fresh flight and can't spin without
+	// progress; the caller's own context bounds the loop.
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", "", err
 		}
 
-		// Another discovery may have connected this client while we waited on
-		// the gate; if so, adopt its result instead of rediscovering.
 		c.mu.RLock()
-		addr, basePath := c.baseURL, c.basePath
+		gen := c.discoveryGen
+		key := fmt.Sprintf("%s#%d", c.contextName, gen)
 		c.mu.RUnlock()
-		if addr != "" {
+
+		ch := c.discoverySF.DoChan(key, func() (any, error) {
+			dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), discoveryTimeout)
+			defer cancel()
+
+			// Publish the cancel so Reset/Reinitialize can abort this detached run.
+			// A sequence number identifies this run's handle: two runs can overlap
+			// on one Client (an old-gen run cancelled by Reset while a new-gen run
+			// starts), and the ending run must not clear the newer run's cancel.
+			// Also honor retirement: if this Client was swapped out by Reinitialize
+			// before the goroutine got here, abort — cancelling wasn't possible then
+			// because the handle wasn't published yet.
+			c.mu.Lock()
+			if c.retired {
+				c.mu.Unlock()
+				return nil, context.Canceled
+			}
+			c.discoveryCancelSeq++
+			mySeq := c.discoveryCancelSeq
+			c.discoveryCancel = cancel
+			c.mu.Unlock()
+			defer func() {
+				c.mu.Lock()
+				if c.discoveryCancelSeq == mySeq {
+					c.discoveryCancel = nil
+				}
+				c.mu.Unlock()
+			}()
+
+			// Serialize across the process, but abandon the wait if this run is
+			// cancelled (superseded) so it can't wedge a newer discovery.
+			select {
+			case discoveryGate <- struct{}{}:
+				defer func() { <-discoveryGate }()
+			case <-dctx.Done():
+				return nil, dctx.Err()
+			}
+
+			// Another discovery may have connected this client while we waited on
+			// the gate; if so, adopt its result instead of rediscovering.
+			c.mu.RLock()
+			addr, basePath := c.baseURL, c.basePath
+			c.mu.RUnlock()
+			if addr != "" {
+				return result{addr, basePath}, nil
+			}
+
+			addr, basePath, derr := c.discover(dctx, gen)
+			if derr != nil {
+				return nil, derr
+			}
 			return result{addr, basePath}, nil
-		}
+		})
 
-		addr, basePath, derr := c.discover(dctx, gen)
-		if derr != nil {
-			return nil, derr
-		}
-		return result{addr, basePath}, nil
-	})
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case res := <-ch:
+			// A retired client (replaced by Reinitialize) can never make progress,
+			// so it must return the error rather than retry — retrying would spin
+			// forever since retirement is permanent and gen never advances.
+			c.mu.RLock()
+			retired := c.retired
+			c.mu.RUnlock()
 
-	select {
-	case <-ctx.Done():
-		return "", "", ctx.Err()
-	case res := <-ch:
-		if res.Err != nil {
-			return "", "", res.Err
+			if res.Err != nil {
+				// A supersession — a config change cancelled the detached flight —
+				// is not the caller's failure. While the caller's own context is
+				// live (and this client isn't retired), retry under the new
+				// generation. context.Canceled here comes only from the flight's
+				// detached context (Reset/Reinitialize), never the caller's; a
+				// genuine hang surfaces as DeadlineExceeded and is returned.
+				if ctx.Err() == nil && !retired && (errors.Is(res.Err, errDiscoverySuperseded) || errors.Is(res.Err, context.Canceled)) {
+					continue
+				}
+				return "", "", res.Err
+			}
+			r := res.Val.(result)
+			// Guard against a hollow success: between the run committing and our
+			// return, a Reset can clear baseURL, or Reinitialize can retire this
+			// client (leaving baseURL set) — either way the result belongs to a
+			// superseded context. Retry under the new generation while our own
+			// context is live; give up only if the caller itself is done or retired.
+			if !c.connectionLive(r.addr) {
+				if ctx.Err() == nil && !retired {
+					continue
+				}
+				return "", "", errDiscoverySuperseded
+			}
+			return r.addr, r.basePath, nil
 		}
-		r := res.Val.(result)
-		// Guard against a hollow success: between the run committing and our
-		// return, a Reset can clear baseURL, or Reinitialize can retire this
-		// client (leaving baseURL set) — either way the result belongs to a
-		// superseded context. If the connection isn't live on the current client,
-		// report supersession so the caller rediscovers rather than querying the
-		// previous cluster.
-		if !c.connectionLive(r.addr) {
-			return "", "", errDiscoverySuperseded
-		}
-		return r.addr, r.basePath, nil
 	}
 }
 

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"maps"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -35,6 +37,28 @@ type Client struct {
 	manualURL        string            // --prometheus-url override
 	headers          map[string]string
 
+	// discoveryGen increments whenever configuration that invalidates a
+	// discovery result changes (Reset, SetManualURL, SetHeaders). It keys the
+	// singleflight and gates markConnected so a discovery started under an old
+	// configuration can't publish its (now stale) endpoint after the change.
+	discoveryGen uint64
+
+	// discoveryCancel aborts the in-flight detached discovery (if any). Reset /
+	// Reinitialize call it so a superseded run — e.g. an old context's pre-warm
+	// after a context switch — stops promptly and releases the discovery gate,
+	// rather than holding it while the new context waits. discoveryCancelSeq
+	// identifies the run that owns the handle so an ending run only clears its
+	// own cancel, never a newer run's.
+	discoveryCancel    context.CancelFunc
+	discoveryCancelSeq uint64
+
+	// retired is set by Reinitialize on the outgoing Client. A discovery whose
+	// singleflight goroutine hadn't started yet when the swap happened (so
+	// discoveryCancel was still nil and couldn't be cancelled) checks this at
+	// launch and aborts — otherwise the orphaned run could grab the discovery
+	// gate and drive the shared port-forward for the retired context.
+	retired bool
+
 	// K8s clients for discovery
 	k8sClient   kubernetes.Interface
 	k8sConfig   *rest.Config
@@ -45,13 +69,44 @@ type Client struct {
 
 	// Dedicated HTTP client for the MCP path
 	mcpHTTPClient *http.Client
+
+	// discoverySF coalesces concurrent discovery attempts. A cold start fires
+	// several EnsureConnected calls at once (opencost summary/nodes/trend,
+	// traffic), and discovery drives the process-wide port-forward singleton;
+	// without coalescing, parallel discoveries clobber each other's forwards.
+	discoverySF singleflight.Group
 }
+
+// discoveryTimeout is a hang backstop for a single coalesced discovery, not a
+// per-attempt budget. Discovery detaches from the caller's request context, so
+// this bounds how long a run may take before every waiting caller gets an
+// error: enough headroom for a few serial port-forward attempts (each ~10s)
+// plus probes, without letting a wedged run block discovery indefinitely.
+const discoveryTimeout = 60 * time.Second
 
 // Global client instance
 var (
 	globalClient *Client
 	clientMu     sync.RWMutex
 )
+
+// discoveryGate serializes Prometheus discovery across the whole process. Per-
+// client singleflight coalesces concurrent callers of the same Client, but
+// discovery drives the process-global port-forward singleton, and a client
+// reinit on context setup can leave two Client instances discovering at once —
+// e.g. the startup pre-warm and the first request landing on either side of the
+// swap. Without this gate those independent Prometheus discoveries race the
+// single port-forward, each tearing down the other's forward. It runs them one
+// at a time; a re-check of the connection after acquiring it lets the loser
+// return the winner's endpoint instead of rediscovering.
+//
+// A buffered channel (not a Mutex) so acquisition can be abandoned when the
+// run's context is cancelled — a Reset/Reinitialize that supersedes this run
+// must not leave it blocked on the gate. Scope note: this covers Prometheus
+// discovery only; the traffic subsystem drives the same port-forward singleton
+// without participating, so cross-subsystem arbitration remains a separate
+// concern (tracked for a follow-up in the portforward package).
+var discoveryGate = make(chan struct{}, 1)
 
 type suppressDiscoveryDiagnosticsKey struct{}
 
@@ -101,6 +156,13 @@ func SetManualURL(rawURL string) {
 	globalClient.mu.Lock()
 	defer globalClient.mu.Unlock()
 	globalClient.manualURL = strings.TrimRight(rawURL, "/")
+	globalClient.discoveryGen++
+	// Abort any in-flight discovery started under the old config so it releases
+	// the discovery gate promptly rather than stalling rediscovery. Safe under
+	// the lock: cancel only signals the context.
+	if globalClient.discoveryCancel != nil {
+		globalClient.discoveryCancel()
+	}
 }
 
 // SetHeaders sets HTTP headers attached to every Prometheus request on the
@@ -118,6 +180,10 @@ func SetHeaders(h map[string]string) {
 	// Drop the cached prom.Client so the next request rebuilds its transport
 	// with the new headers.
 	globalClient.prom = nil
+	globalClient.discoveryGen++
+	if globalClient.discoveryCancel != nil {
+		globalClient.discoveryCancel() // release the gate for the new config
+	}
 }
 
 func copyHeaders(h map[string]string) map[string]string {
@@ -147,7 +213,12 @@ func Reset() {
 		globalClient.prom = nil
 		globalClient.discovered = false
 		globalClient.discoveryService = nil
+		globalClient.discoveryGen++
+		cancel := globalClient.discoveryCancel
 		globalClient.mu.Unlock()
+		if cancel != nil {
+			cancel() // abort any in-flight discovery started under the old config
+		}
 	}
 }
 
@@ -158,15 +229,21 @@ func Reinitialize(client kubernetes.Interface, config *rest.Config, contextName 
 
 	manualURL := ""
 	var headers map[string]string
+	var oldCancel context.CancelFunc
 	if globalClient != nil {
 		// SetManualURL / SetHeaders write these under the per-client mutex
 		// after dropping clientMu, so reading without c.mu here would race
 		// even though we hold clientMu exclusively. copyHeaders also detaches
 		// the map from the old client so a late mutation can't bleed through.
-		globalClient.mu.RLock()
+		globalClient.mu.Lock()
 		manualURL = globalClient.manualURL
 		headers = copyHeaders(globalClient.headers)
-		globalClient.mu.RUnlock()
+		oldCancel = globalClient.discoveryCancel
+		globalClient.retired = true // abort even a flight that hasn't started yet
+		globalClient.mu.Unlock()
+	}
+	if oldCancel != nil {
+		oldCancel() // stop the outgoing client's detached discovery, if any
 	}
 
 	globalClient = &Client{
@@ -231,7 +308,111 @@ func (c *Client) EnsureConnected(ctx context.Context) (string, string, error) {
 		}
 	}
 
-	return c.discover(ctx)
+	return c.discoverShared(ctx)
+}
+
+// discoverShared runs discover() under a singleflight so a burst of concurrent
+// EnsureConnected callers triggers exactly one discovery and all share its
+// result. This is what stops parallel discoveries from fighting over the shared
+// port-forward singleton.
+//
+// The flight key includes the discovery generation, so a caller arriving after
+// a config change (Reset / SetManualURL / SetHeaders) never joins a flight
+// started under the old configuration — it runs a fresh discovery instead.
+//
+// The shared discovery detaches from the leader's request context
+// (context.WithoutCancel + its own timeout) so it completes for every waiter
+// even if the caller that happened to start it goes away. Each caller then
+// selects on its OWN context, so a cancelled request returns promptly instead
+// of blocking on the detached discovery. Context values (e.g. suppressed
+// discovery diagnostics) are preserved.
+func (c *Client) discoverShared(ctx context.Context) (string, string, error) {
+	type result struct{ addr, basePath string }
+
+	c.mu.RLock()
+	key := fmt.Sprintf("%s#%d", c.contextName, c.discoveryGen)
+	c.mu.RUnlock()
+
+	ch := c.discoverySF.DoChan(key, func() (any, error) {
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), discoveryTimeout)
+		defer cancel()
+
+		// Publish the cancel so Reset/Reinitialize can abort this detached run.
+		// A sequence number identifies this run's handle: two runs can overlap
+		// on one Client (an old-gen run cancelled by Reset while a new-gen run
+		// starts), and the ending run must not clear the newer run's cancel.
+		// Also honor retirement: if this Client was swapped out by Reinitialize
+		// before the goroutine got here, abort — cancelling wasn't possible then
+		// because the handle wasn't published yet.
+		c.mu.Lock()
+		if c.retired {
+			c.mu.Unlock()
+			return nil, context.Canceled
+		}
+		c.discoveryCancelSeq++
+		mySeq := c.discoveryCancelSeq
+		c.discoveryCancel = cancel
+		c.mu.Unlock()
+		defer func() {
+			c.mu.Lock()
+			if c.discoveryCancelSeq == mySeq {
+				c.discoveryCancel = nil
+			}
+			c.mu.Unlock()
+		}()
+
+		// Serialize across the process, but abandon the wait if this run is
+		// cancelled (superseded) so it can't wedge a newer discovery.
+		select {
+		case discoveryGate <- struct{}{}:
+			defer func() { <-discoveryGate }()
+		case <-dctx.Done():
+			return nil, dctx.Err()
+		}
+
+		// Another discovery may have connected this client while we waited on
+		// the gate; if so, adopt its result instead of rediscovering.
+		c.mu.RLock()
+		addr, basePath := c.baseURL, c.basePath
+		c.mu.RUnlock()
+		if addr != "" {
+			return result{addr, basePath}, nil
+		}
+
+		addr, basePath, derr := c.discover(dctx)
+		if derr != nil {
+			return nil, derr
+		}
+		return result{addr, basePath}, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return "", "", res.Err
+		}
+		r := res.Val.(result)
+		// Guard against a hollow success: between the run committing and our
+		// return, a Reset can clear baseURL, or Reinitialize can retire this
+		// client (leaving baseURL set) — either way the result belongs to a
+		// superseded context. If the connection isn't live on the current client,
+		// report supersession so the caller rediscovers rather than querying the
+		// previous cluster.
+		if !c.connectionLive(r.addr) {
+			return "", "", errDiscoverySuperseded
+		}
+		return r.addr, r.basePath, nil
+	}
+}
+
+// connectionLive reports whether addr is the client's current, non-retired
+// connection.
+func (c *Client) connectionLive(addr string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.baseURL == addr && !c.retired
 }
 
 // Prom returns the underlying pkg/prom.Client for callers that compose
@@ -299,6 +480,15 @@ func (c *Client) PromForMCP() *prom.Client {
 // and empty instances, which would otherwise silently fall through the
 // discovery candidate list.
 func (c *Client) probe(ctx context.Context, addr string) bool {
+	return c.probeReachable(ctx, addr, true)
+}
+
+// probeReachable is probe with control over rejection logging. The concurrent
+// direct-probe pass passes logReject=false and summarizes the whole pass in a
+// single line, rather than emitting one "unreachable" entry per candidate — the
+// noisy tail that dominated cold-start logs on clusters with several
+// Prometheus-like services.
+func (c *Client) probeReachable(ctx context.Context, addr string, logReject bool) bool {
 	c.mu.RLock()
 	httpC := c.httpClient
 	headers := copyHeaders(c.headers)
@@ -306,7 +496,7 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 	tr := prom.NewHTTPTransport(addr, "", httpC)
 	tr.Headers = headers
 	ok, reason := prom.NewClient(tr).Probe(ctx)
-	if !ok {
+	if !ok && logReject {
 		logProbeRejection(addr, reason, !discoveryDiagnosticsSuppressed(ctx))
 	}
 	return ok

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -46,15 +46,20 @@ const directProbeBudget = 4 * time.Second
 // outside the cluster and can't reach in-cluster Service DNS directly.
 //
 // The lock is only held briefly to read/write state, not during network I/O.
-func (c *Client) discover(ctx context.Context) (string, string, error) {
+//
+// gen is the discovery generation the singleflight was keyed with, threaded
+// through so markConnected commits against *that* generation. Reading the live
+// generation here instead would let a flight keyed at an old generation adopt a
+// newer one after a Reset and commit under it, undoing the reset.
+func (c *Client) discover(ctx context.Context, gen uint64) (string, string, error) {
 	start := time.Now()
+	startGen := gen
 
 	// Layer 1: Manual URL override
 	c.mu.RLock()
 	manualURL := c.manualURL
 	contextName := c.contextName
 	k8sClient := c.k8sClient
-	startGen := c.discoveryGen
 	c.mu.RUnlock()
 
 	if manualURL != "" {

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -2,14 +2,37 @@ package prometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/skyhook-io/radar/internal/errorlog"
 	"github.com/skyhook-io/radar/internal/portforward"
 	"github.com/skyhook-io/radar/pkg/prom"
 )
+
+// errDiscoverySuperseded is returned when a configuration change (Reset /
+// SetManualURL / SetHeaders) invalidated a discovery mid-flight. The result is
+// dropped rather than published; the next request rediscovers under the new
+// configuration.
+var errDiscoverySuperseded = errors.New("prometheus: discovery superseded by a configuration change")
+
+// maxConcurrentProbes bounds the direct probe fan-out so a cluster with many
+// Prometheus-like services doesn't open an unbounded number of sockets at once.
+const maxConcurrentProbes = 4
+
+// directProbeBudget caps the whole direct-probe pass. It is deliberately larger
+// than the per-probe timeout (pkg/prom.Client.Probe uses 3s) so a real but slow
+// endpoint — a loaded Prometheus, or one reached over a high-latency VPN — gets
+// a full probe attempt rather than being cut short and pushed to port-forward.
+// Its real job is the off-cluster case: unresolvable *.svc.cluster.local names
+// can wedge in the platform's cgo resolver past their context deadline, so
+// without this ceiling the doomed pass would dead-wait for seconds before the
+// fallback even starts. This bounds that to one probe window plus margin.
+const directProbeBudget = 4 * time.Second
 
 // discover finds and connects to Prometheus using a multi-layer approach:
 //  1. Manual URL override (--prometheus-url)
@@ -24,18 +47,23 @@ import (
 //
 // The lock is only held briefly to read/write state, not during network I/O.
 func (c *Client) discover(ctx context.Context) (string, string, error) {
+	start := time.Now()
+
 	// Layer 1: Manual URL override
 	c.mu.RLock()
 	manualURL := c.manualURL
 	contextName := c.contextName
 	k8sClient := c.k8sClient
+	startGen := c.discoveryGen
 	c.mu.RUnlock()
 
 	if manualURL != "" {
 		addr := strings.TrimRight(manualURL, "/")
 		if c.probe(ctx, addr) {
-			log.Printf("[prometheus] Using manual URL: %s", addr)
-			c.markConnected(addr, "")
+			log.Printf("[prometheus] connected via manual URL %s (%s)", addr, took(start))
+			if !c.markConnected(addr, "", startGen) {
+				return "", "", errDiscoverySuperseded
+			}
 			return addr, "", nil
 		}
 		if !discoveryDiagnosticsSuppressed(ctx) {
@@ -47,8 +75,10 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	// Layer 2: Reuse traffic system's existing port-forward if present
 	if pfAddr := portforward.GetAddress(contextName); pfAddr != "" {
 		if c.probe(ctx, pfAddr) {
-			log.Printf("[prometheus] Using traffic system port-forward: %s", pfAddr)
-			c.markConnected(pfAddr, "")
+			log.Printf("[prometheus] connected via traffic port-forward %s (%s)", pfAddr, took(start))
+			if !c.markConnected(pfAddr, "", startGen) {
+				return "", "", errDiscoverySuperseded
+			}
 			return pfAddr, "", nil
 		}
 	}
@@ -59,6 +89,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 	// Layers 3 + 4: Enumerate candidates via the shared pkg/prom discovery
 	// logic. Well-known first, then dynamic fallbacks.
+	enumStart := time.Now()
 	candidates, err := prom.Discover(ctx, k8sClient, prom.DiscoverOptions{
 		IncludeDynamic: true,
 		Logger: func(format string, args ...interface{}) {
@@ -75,29 +106,48 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 		return "", "", fmt.Errorf("no Prometheus service found in cluster")
 	}
 
-	log.Printf("[prometheus] Found %d candidate(s), probing...", len(candidates))
+	log.Printf("[prometheus] enumerated %d candidate(s) in %s: %s", len(candidates), took(enumStart), summarizeCandidates(candidates))
 
-	// First pass: probe each candidate at its in-cluster address. Works when
-	// radar is running in-cluster OR when the user's shell can route to the
-	// cluster DNS (rare, but cheap to try).
-	for _, cand := range candidates {
-		addr := cand.ClusterAddr + cand.BasePath
-		if c.probe(ctx, addr) {
-			log.Printf("[prometheus] Connected to %s/%s at %s (source=%s, score=%d)",
-				cand.Namespace, cand.Name, cand.ClusterAddr, cand.Source, cand.Score)
-			c.setDiscoveryServiceFromCandidate(cand)
-			c.markConnected(cand.ClusterAddr, cand.BasePath)
-			return cand.ClusterAddr, cand.BasePath, nil
+	// Direct pass: probe each candidate at its in-cluster Service address, with
+	// bounded concurrency. This connects immediately when Radar runs in-cluster,
+	// and also when Radar runs outside the cluster on a network that routes
+	// Service DNS / ClusterIPs (VPN, routed dev cluster) — the reachability of
+	// the address decides, not how the kubeconfig was loaded. Off-cluster
+	// without such routing, every probe fails fast and we fall through to
+	// port-forwarding. The winner is the earliest candidate in priority order,
+	// so endpoint selection is deterministic.
+	directStart := time.Now()
+	directCtx, cancelDirect := context.WithTimeout(ctx, directProbeBudget)
+	idx := c.probeCandidatesConcurrently(directCtx, candidates)
+	cancelDirect()
+	if idx >= 0 {
+		cand := candidates[idx]
+		if !c.markConnected(cand.ClusterAddr, cand.BasePath, startGen) {
+			return "", "", errDiscoverySuperseded
 		}
+		log.Printf("[prometheus] connected to %s/%s via direct probe at %s (source=%s, score=%d, direct %s, total %s)",
+			cand.Namespace, cand.Name, cand.ClusterAddr, cand.Source, cand.Score, took(directStart), took(start))
+		c.setDiscoveryServiceFromCandidate(cand)
+		return cand.ClusterAddr, cand.BasePath, nil
 	}
+	// A context error here means the run ended before finding anything — either
+	// superseded (Reset / context switch) or timed out (the hang backstop) — not
+	// that the cluster has no Prometheus. Don't run the fallback or log a scary
+	// failure.
+	if err := ctx.Err(); err != nil {
+		logDiscoveryEnded(start, err)
+		return "", "", err
+	}
+	log.Printf("[prometheus] no candidate reachable via direct probe (%s); falling back to port-forward", took(directStart))
 
-	// Fallback: try port-forwarding candidates in priority order. This path is
-	// normally reached when Radar runs outside the cluster, where in-cluster
-	// Service DNS cannot resolve from the user's machine.
+	// Fallback: try port-forwarding candidates in priority order. This is the
+	// primary path off-cluster (where Service DNS can't resolve from the user's
+	// machine) and a backstop in-cluster. Serial by necessity — the port-forward
+	// lifecycle is a process-wide singleton shared with the traffic system.
 	var lastErr error
 	for _, cand := range candidates {
-		log.Printf("[prometheus] No candidate reachable in-cluster, starting port-forward to %s/%s...",
-			cand.Namespace, cand.Name)
+		log.Printf("[prometheus] port-forward → %s/%s:%d (source=%s, score=%d)...",
+			cand.Namespace, cand.Name, cand.TargetPort, cand.Source, cand.Score)
 		c.setDiscoveryServiceFromCandidate(cand)
 
 		connInfo, pfErr := portforward.Start(ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
@@ -111,7 +161,17 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 		addr := connInfo.Address
 		if c.probe(ctx, addr+cand.BasePath) {
-			c.markConnected(addr, cand.BasePath)
+			if !c.markConnected(addr, cand.BasePath, startGen) {
+				// Superseded: don't leave the shared forward up for an endpoint
+				// we're discarding.
+				portforward.Stop()
+				c.mu.Lock()
+				c.discoveryService = nil
+				c.mu.Unlock()
+				return "", "", errDiscoverySuperseded
+			}
+			log.Printf("[prometheus] connected to %s/%s via port-forward at %s (%s)",
+				cand.Namespace, cand.Name, addr, took(start))
 			return addr, cand.BasePath, nil
 		}
 
@@ -125,10 +185,136 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	c.mu.Lock()
 	c.discoveryService = nil
 	c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		logDiscoveryEnded(start, err)
+		return "", "", err
+	}
+	log.Printf("[prometheus] discovery failed after %s: no reachable Prometheus among %d candidate(s)", took(start), len(candidates))
 	if lastErr != nil {
 		return "", "", lastErr
 	}
 	return "", "", fmt.Errorf("no Prometheus service found in cluster")
+}
+
+// logDiscoveryEnded logs a discovery that ended on a context error, telling a
+// supersession (Reset / config change / context switch → Canceled) apart from
+// the hang backstop (discoveryTimeout → DeadlineExceeded) so the trail is honest.
+func logDiscoveryEnded(start time.Time, err error) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("[prometheus] discovery timed out after %s", took(start))
+		return
+	}
+	log.Printf("[prometheus] discovery superseded after %s", took(start))
+}
+
+// took formats elapsed time for discovery log lines. Go's stdlib logger stamps
+// only whole seconds, so the timeline of sub-second discovery steps is only
+// legible when each line carries its own elapsed measurement.
+func took(start time.Time) string {
+	return time.Since(start).Round(time.Millisecond).String()
+}
+
+// summarizeCandidates renders the candidate list for a single log line:
+// "ns/name(wk)" for well-known, "ns/name(dyn:score)" for dynamically scored —
+// enough to see what discovery found and in what priority order without a line
+// per candidate.
+func summarizeCandidates(candidates []prom.Candidate) string {
+	parts := make([]string, len(candidates))
+	for i, cand := range candidates {
+		src := "wk"
+		if cand.Source == prom.CandidateSourceDynamic {
+			src = fmt.Sprintf("dyn:%d", cand.Score)
+		}
+		parts[i] = fmt.Sprintf("%s/%s(%s)", cand.Namespace, cand.Name, src)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// probe outcome states, published atomically per candidate.
+const (
+	probePending int32 = iota
+	probeFailed
+	probeSucceeded
+)
+
+// probeCandidatesConcurrently probes candidate addresses with bounded
+// concurrency and returns the index of the earliest candidate (in priority
+// order) that responded, or -1 if none did.
+//
+// Launching (in priority order, one slot per candidate) runs in its own
+// goroutine concurrently with collection, so a fast high-priority hit returns
+// immediately instead of waiting for the launcher to work through lower-priority
+// candidates that have wedged the semaphore. Each probe publishes its outcome in
+// a single atomic Store, so on budget expiry — which happens when a name wedges
+// in the platform cgo resolver past its context deadline — the scan for an
+// already-succeeded candidate is both race-free and complete (no success can be
+// recorded-but-unpublished). Selection stays deterministic: a lower-priority
+// success never wins while a higher-priority probe is still pending.
+func (c *Client) probeCandidatesConcurrently(ctx context.Context, candidates []prom.Candidate) int {
+	n := len(candidates)
+	if n == 0 {
+		return -1
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // stops in-flight/queued probes once we return
+
+	state := make([]atomic.Int32, n)
+	sem := make(chan struct{}, maxConcurrentProbes)
+	woke := make(chan struct{}, n) // wake-ups; buffered so a worker never blocks
+
+	go func() {
+		for i := range candidates {
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			go func(i int) {
+				defer func() { <-sem }()
+				outcome := probeFailed
+				if c.probeReachable(ctx, candidates[i].ClusterAddr+candidates[i].BasePath, false) {
+					outcome = probeSucceeded
+				}
+				state[i].Store(outcome)
+				select {
+				case woke <- struct{}{}:
+				default:
+				}
+			}(i)
+		}
+	}()
+
+	earliestSuccess := func() int {
+		for i := range n {
+			if state[i].Load() == probeSucceeded {
+				return i
+			}
+		}
+		return -1
+	}
+
+	frontier := 0
+	for {
+		for frontier < n {
+			s := state[frontier].Load()
+			if s == probePending {
+				break
+			}
+			if s == probeSucceeded {
+				return frontier
+			}
+			frontier++
+		}
+		if frontier == n {
+			return -1 // every candidate resolved, none reachable
+		}
+		select {
+		case <-woke:
+		case <-ctx.Done():
+			return earliestSuccess()
+		}
+	}
 }
 
 // setDiscoveryServiceFromCandidate records the discovered service metadata
@@ -149,11 +335,25 @@ func (c *Client) setDiscoveryServiceFromCandidate(cand prom.Candidate) {
 // getPromClient rebuilds against the (possibly new) address — otherwise
 // a stale cached client could survive a discovery that landed on a
 // different endpoint.
-func (c *Client) markConnected(addr, basePath string) {
+//
+// gen is the discovery generation captured when this discovery began. If the
+// generation has since changed (Reset / SetManualURL / SetHeaders), the result
+// is stale — a config change raced this discovery — and is dropped rather than
+// published over the newer configuration. Returns whether it committed, so the
+// caller can surface a retryable error instead of a hollow success (a connected
+// address with an empty baseURL).
+func (c *Client) markConnected(addr, basePath string, gen uint64) bool {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	// A stale generation, or a client retired by Reinitialize, means the result
+	// belongs to a superseded run — don't publish it (and, via the caller's
+	// superseded path, release any port-forward it opened for the old context).
+	if c.discoveryGen != gen || c.retired {
+		return false
+	}
 	c.baseURL = addr
 	c.basePath = basePath
 	c.prom = nil
 	c.discovered = true
-	c.mu.Unlock()
+	return true
 }

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -365,6 +365,5 @@ func (c *Client) markConnected(addr, basePath string, gen uint64) bool {
 	c.baseURL = addr
 	c.basePath = basePath
 	c.prom = nil
-	c.discovered = true
 	return true
 }

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -73,7 +73,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	}
 
 	// Layer 2: Reuse traffic system's existing port-forward if present
-	if pfAddr := portforward.GetAddress(contextName); pfAddr != "" {
+	if pfAddr := portforward.GetAddress(portforward.OwnerPrometheus, contextName); pfAddr != "" {
 		if c.probe(ctx, pfAddr) {
 			log.Printf("[prometheus] connected via traffic port-forward %s (%s)", pfAddr, took(start))
 			if !c.markConnected(pfAddr, "", startGen) {

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -175,6 +175,12 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 
 		connInfo, pfErr := portforward.Start(portforward.OwnerPrometheus, ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
 		if pfErr != nil {
+			// A cancelled Start means the run was superseded, not that the
+			// port-forward genuinely failed — surface it instead of recording one.
+			if err := ctx.Err(); err != nil {
+				logDiscoveryEnded(start, err)
+				return "", "", err
+			}
 			lastErr = fmt.Errorf("port-forward to %s/%s failed: %w", cand.Namespace, cand.Name, pfErr)
 			if !discoveryDiagnosticsSuppressed(ctx) {
 				errorlog.Record("prometheus", "error", "port-forward to %s/%s failed: %v", cand.Namespace, cand.Name, pfErr)
@@ -199,6 +205,12 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 		}
 
 		portforward.Stop(portforward.OwnerPrometheus)
+		// A failed probe on a cancelled context is supersession, not a dead
+		// Prometheus — don't slander the endpoint in errorlog.
+		if err := ctx.Err(); err != nil {
+			logDiscoveryEnded(start, err)
+			return "", "", err
+		}
 		lastErr = fmt.Errorf("Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)
 		if !discoveryDiagnosticsSuppressed(ctx) {
 			errorlog.Record("prometheus", "error", "Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -71,6 +71,12 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 			}
 			return addr, "", nil
 		}
+		// A cancelled probe means the run was superseded (Reset / config change),
+		// not that the operator's URL is bad — don't slander it in errorlog.
+		if err := ctx.Err(); err != nil {
+			logDiscoveryEnded(start, err)
+			return "", "", err
+		}
 		if !discoveryDiagnosticsSuppressed(ctx) {
 			errorlog.Record("prometheus", "error", "manual Prometheus URL %s not reachable", addr)
 		}
@@ -103,6 +109,12 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 	})
 	if err != nil {
 		log.Printf("[prometheus] Discover error: %v", err)
+	}
+	// A cancelled enumeration returns no candidates; that's supersession, not an
+	// empty cluster — surface it instead of recording "no Prometheus found".
+	if err := ctx.Err(); err != nil {
+		logDiscoveryEnded(start, err)
+		return "", "", err
 	}
 	if len(candidates) == 0 {
 		if !discoveryDiagnosticsSuppressed(ctx) {

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -150,7 +150,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 			cand.Namespace, cand.Name, cand.TargetPort, cand.Source, cand.Score)
 		c.setDiscoveryServiceFromCandidate(cand)
 
-		connInfo, pfErr := portforward.Start(ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
+		connInfo, pfErr := portforward.Start(portforward.OwnerPrometheus, ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
 		if pfErr != nil {
 			lastErr = fmt.Errorf("port-forward to %s/%s failed: %w", cand.Namespace, cand.Name, pfErr)
 			if !discoveryDiagnosticsSuppressed(ctx) {
@@ -164,7 +164,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 			if !c.markConnected(addr, cand.BasePath, startGen) {
 				// Superseded: don't leave the shared forward up for an endpoint
 				// we're discarding.
-				portforward.Stop()
+				portforward.Stop(portforward.OwnerPrometheus)
 				c.mu.Lock()
 				c.discoveryService = nil
 				c.mu.Unlock()
@@ -175,7 +175,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 			return addr, cand.BasePath, nil
 		}
 
-		portforward.Stop()
+		portforward.Stop(portforward.OwnerPrometheus)
 		lastErr = fmt.Errorf("Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)
 		if !discoveryDiagnosticsSuppressed(ctx) {
 			errorlog.Record("prometheus", "error", "Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -142,10 +142,16 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 	// Fallback: try port-forwarding candidates in priority order. This is the
 	// primary path off-cluster (where Service DNS can't resolve from the user's
-	// machine) and a backstop in-cluster. Serial by necessity — the port-forward
-	// lifecycle is a process-wide singleton shared with the traffic system.
+	// machine) and a backstop in-cluster. Serial by necessity — port-forwarding
+	// mutates the owner's shared forward state.
 	var lastErr error
 	for _, cand := range candidates {
+		// Bail promptly if the run was superseded mid-fallback (Reset / context
+		// switch) rather than churning the rest of the list while holding the gate.
+		if err := ctx.Err(); err != nil {
+			logDiscoveryEnded(start, err)
+			return "", "", err
+		}
 		log.Printf("[prometheus] port-forward → %s/%s:%d (source=%s, score=%d)...",
 			cand.Namespace, cand.Name, cand.TargetPort, cand.Source, cand.Score)
 		c.setDiscoveryServiceFromCandidate(cand)

--- a/internal/prometheus/discovery_test.go
+++ b/internal/prometheus/discovery_test.go
@@ -1,0 +1,382 @@
+package prometheus
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/pkg/prom"
+)
+
+const healthyProbeBody = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"prometheus"},"value":[1700000000,"1"]}]}}`
+
+func healthyServer(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(healthyProbeBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// deadURL returns the URL of a server that has already been closed, so probes
+// against it fail fast with connection-refused.
+func deadURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func TestProbeCandidatesConcurrently(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Timeout: 5 * time.Second}}
+
+	t.Run("no candidates respond returns -1", func(t *testing.T) {
+		cands := []prom.Candidate{
+			{ClusterAddr: deadURL(t)},
+			{ClusterAddr: deadURL(t)},
+		}
+		if got := c.probeCandidatesConcurrently(context.Background(), cands); got != -1 {
+			t.Fatalf("got %d, want -1", got)
+		}
+	})
+
+	t.Run("only later candidate responds returns its index", func(t *testing.T) {
+		cands := []prom.Candidate{
+			{ClusterAddr: deadURL(t)},
+			{ClusterAddr: healthyServer(t, 0).URL},
+		}
+		if got := c.probeCandidatesConcurrently(context.Background(), cands); got != 1 {
+			t.Fatalf("got %d, want 1", got)
+		}
+	})
+
+	t.Run("highest-priority candidate wins even when slower", func(t *testing.T) {
+		// Index 0 is a healthy but slow responder; index 1 is healthy and fast.
+		// Selection must be by priority order, not response latency.
+		cands := []prom.Candidate{
+			{ClusterAddr: healthyServer(t, 100*time.Millisecond).URL},
+			{ClusterAddr: healthyServer(t, 0).URL},
+		}
+		if got := c.probeCandidatesConcurrently(context.Background(), cands); got != 0 {
+			t.Fatalf("got %d, want 0 (priority order must beat latency)", got)
+		}
+	})
+}
+
+// TestEnsureConnected_CoalescesConcurrentDiscovery verifies that a burst of
+// concurrent EnsureConnected callers triggers exactly one discovery. Without
+// singleflight each caller would run its own discovery (and, in the real
+// system, clobber the shared port-forward). We observe the discovery count via
+// probe hits against the manual-URL endpoint, which discovery hits exactly once
+// per run.
+func TestEnsureConnected_CoalescesConcurrentDiscovery(t *testing.T) {
+	var probeHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probeHits.Add(1)
+		// Widen the in-flight window so all callers pile onto the singleflight
+		// leader rather than arriving after it has already connected.
+		time.Sleep(40 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(healthyProbeBody))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		manualURL:   srv.URL,
+		contextName: "ctx-A",
+	}
+
+	const n = 20
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	addrs := make([]string, n)
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all callers together
+			addrs[i], _, errs[i] = c.EnsureConnected(context.Background())
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("caller %d: unexpected error %v", i, errs[i])
+		}
+		if want := strings.TrimRight(srv.URL, "/"); addrs[i] != want {
+			t.Errorf("caller %d addr=%q, want %q", i, addrs[i], want)
+		}
+	}
+	if got := probeHits.Load(); got != 1 {
+		t.Fatalf("discovery ran %d times under %d concurrent callers, want 1 (singleflight should coalesce)", got, n)
+	}
+}
+
+// TestProbeCandidatesConcurrently_RespectsContextDeadline verifies the pass
+// returns at its context deadline (the caller's directProbeBudget) rather than
+// blocking on a probe that hangs — the case that matters off-cluster, where a
+// stuck cluster-DNS lookup can outlive its own timeout.
+func TestProbeCandidatesConcurrently_RespectsContextDeadline(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Timeout: 30 * time.Second}}
+
+	blackhole := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blackhole.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	got := c.probeCandidatesConcurrently(ctx, []prom.Candidate{{ClusterAddr: blackhole.URL}})
+	elapsed := time.Since(start)
+
+	if got != -1 {
+		t.Fatalf("got %d, want -1 (nothing reachable within the budget)", got)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("took %v — should return at the ~300ms deadline, not wait for the blackhole", elapsed)
+	}
+}
+
+// TestProbeCandidatesConcurrently_ReachableWinsDespiteStuckHigherPriority
+// verifies that when the budget expires while a higher-priority probe is stuck,
+// a lower-priority candidate that already succeeded is returned rather than
+// dropped — the case that matters over a VPN that routes only some Services.
+func TestProbeCandidatesConcurrently_ReachableWinsDespiteStuckHigherPriority(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Timeout: 30 * time.Second}}
+
+	blackhole := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blackhole.Close()
+
+	cands := []prom.Candidate{
+		{ClusterAddr: blackhole.URL},           // index 0: higher priority, wedged
+		{ClusterAddr: healthyServer(t, 0).URL}, // index 1: reachable
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	if got := c.probeCandidatesConcurrently(ctx, cands); got != 1 {
+		t.Fatalf("got %d, want 1 (reachable candidate must win when a higher-priority probe is stuck past the budget)", got)
+	}
+}
+
+// TestProbeCandidatesConcurrently_HighPrioritySuccessReturnsImmediately checks
+// that a fast top-priority hit returns without waiting for lower-priority probes
+// that have wedged the semaphore — collection runs concurrently with launching.
+func TestProbeCandidatesConcurrently_HighPrioritySuccessReturnsImmediately(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Timeout: 30 * time.Second}}
+
+	blackhole := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blackhole.Close()
+
+	cands := []prom.Candidate{{ClusterAddr: healthyServer(t, 0).URL}}
+	for range 7 {
+		cands = append(cands, prom.Candidate{ClusterAddr: blackhole.URL})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // long budget
+	defer cancel()
+
+	start := time.Now()
+	got := c.probeCandidatesConcurrently(ctx, cands)
+	elapsed := time.Since(start)
+
+	if got != 0 {
+		t.Fatalf("got %d, want 0", got)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("took %v — a fast index-0 hit must not wait on wedged lower-priority probes", elapsed)
+	}
+}
+
+// TestProbeCandidatesConcurrently_KeepsBufferedSuccessOnBudgetExpiry checks that
+// a probe which succeeded just before the deadline — but whose completion is
+// still buffered when the budget expires mid-launch — is not discarded into a
+// needless port-forward fallback. Looped because the collector's select between
+// the buffered completion and ctx.Done is a race; the drain must win either way.
+func TestProbeCandidatesConcurrently_KeepsBufferedSuccessOnBudgetExpiry(t *testing.T) {
+	c := &Client{httpClient: &http.Client{Timeout: 30 * time.Second}}
+
+	blackhole := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blackhole.Close()
+	healthy := healthyServer(t, 0)
+
+	// More candidates than maxConcurrentProbes, so the launcher is still filling
+	// the semaphore (blocked behind wedged probes) when the budget expires and
+	// index 0's success sits buffered on the completion channel.
+	cands := []prom.Candidate{{ClusterAddr: healthy.URL}}
+	for range 7 {
+		cands = append(cands, prom.Candidate{ClusterAddr: blackhole.URL})
+	}
+
+	for iter := range 25 {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+		got := c.probeCandidatesConcurrently(ctx, cands)
+		cancel()
+		if got != 0 {
+			t.Fatalf("iter %d: got %d, want 0 (a success buffered at budget expiry must not be dropped)", iter, got)
+		}
+	}
+}
+
+// TestEnsureConnected_RetiredClientAborts verifies that a Client retired by
+// Reinitialize aborts discovery even when its singleflight goroutine starts
+// after the swap — it must not connect (and drive the shared port-forward) for
+// a context that has already been replaced.
+func TestEnsureConnected_RetiredClientAborts(t *testing.T) {
+	srv := healthyServer(t, 0) // would connect if the client weren't retired
+
+	c := &Client{
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		manualURL:   srv.URL,
+		contextName: "ctx-retired",
+		retired:     true,
+	}
+
+	if _, _, err := c.EnsureConnected(context.Background()); err == nil {
+		t.Fatal("retired client connected instead of aborting discovery")
+	}
+}
+
+// TestMarkConnected_DropsStaleGeneration verifies the generation gate: a
+// discovery whose configuration was invalidated (Reset / SetManualURL /
+// SetHeaders bump discoveryGen) mid-flight must not publish its now-stale
+// endpoint over the newer configuration.
+func TestMarkConnected_DropsStaleGeneration(t *testing.T) {
+	c := &Client{discoveryGen: 5}
+
+	if c.markConnected("http://stale", "", 4) { // started under an older generation
+		t.Fatal("markConnected committed a stale-generation result")
+	}
+	if c.baseURL != "" {
+		t.Fatalf("stale-generation result was published: baseURL=%q", c.baseURL)
+	}
+
+	if !c.markConnected("http://fresh", "/bp", 5) { // current generation
+		t.Fatal("markConnected rejected a current-generation result")
+	}
+	if c.baseURL != "http://fresh" || c.basePath != "/bp" {
+		t.Fatalf("current-generation result not published: baseURL=%q basePath=%q", c.baseURL, c.basePath)
+	}
+
+	// A client retired by Reinitialize must not commit, even at the current gen.
+	retiredC := &Client{discoveryGen: 5, retired: true}
+	if retiredC.markConnected("http://x", "", 5) {
+		t.Fatal("retired client committed a result")
+	}
+	if retiredC.baseURL != "" {
+		t.Fatalf("retired client published baseURL=%q", retiredC.baseURL)
+	}
+}
+
+// TestConnectionLive rejects a stale or retired connection so discoverShared
+// can't report a hollow success for a superseded context.
+func TestConnectionLive(t *testing.T) {
+	live := &Client{baseURL: "http://p"}
+	if !live.connectionLive("http://p") {
+		t.Fatal("current connection reported not live")
+	}
+	if live.connectionLive("http://other") {
+		t.Fatal("mismatched address reported live (Reset cleared/changed baseURL)")
+	}
+
+	retired := &Client{baseURL: "http://p", retired: true}
+	if retired.connectionLive("http://p") {
+		t.Fatal("retired client reported live (would query the previous cluster)")
+	}
+}
+
+// TestReset_CancelsInFlightDiscovery verifies that Reset aborts a detached
+// in-flight discovery, so a superseded run (e.g. an old context's pre-warm after
+// a context switch) stops instead of holding the process discovery gate.
+func TestReset_CancelsInFlightDiscovery(t *testing.T) {
+	clientMu.Lock()
+	saved := globalClient
+	clientMu.Unlock()
+	t.Cleanup(func() { clientMu.Lock(); globalClient = saved; clientMu.Unlock() })
+
+	canceled := make(chan struct{})
+	clientMu.Lock()
+	globalClient = &Client{discoveryCancel: func() { close(canceled) }}
+	clientMu.Unlock()
+
+	Reset()
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("Reset did not cancel the in-flight discovery")
+	}
+}
+
+// TestEnsureConnected_CanceledCallerReturnsPromptly verifies that a caller whose
+// request context is canceled returns immediately, rather than blocking on the
+// detached shared discovery until its 60s backstop.
+func TestEnsureConnected_CanceledCallerReturnsPromptly(t *testing.T) {
+	// A server that blocks the probe until its own (probe) context is canceled,
+	// keeping the shared discovery in-flight for the duration of the test.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		manualURL:   srv.URL,
+		contextName: "ctx-cancel",
+	}
+
+	// The caller abandons this run, but it continues detached; suppress
+	// diagnostics so its eventual (asynchronous) probe failure doesn't record a
+	// global errorlog entry that would pollute a later test.
+	ctx, cancel := context.WithCancel(withSuppressedDiscoveryDiagnostics(context.Background()))
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := c.EnsureConnected(ctx)
+		done <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond) // let the flight start and block on the server
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("caller did not return promptly after its context was canceled")
+	}
+
+	// Abort the detached run so it doesn't hold the discovery gate into later tests.
+	c.mu.Lock()
+	dcancel := c.discoveryCancel
+	c.mu.Unlock()
+	if dcancel != nil {
+		dcancel()
+	}
+}

--- a/internal/prometheus/discovery_test.go
+++ b/internal/prometheus/discovery_test.go
@@ -243,6 +243,30 @@ func TestProbeCandidatesConcurrently_KeepsBufferedSuccessOnBudgetExpiry(t *testi
 	}
 }
 
+// TestDiscover_StaleFlightGenerationDoesNotCommit verifies discover commits
+// against the generation its flight was keyed with, not a freshly-read one: a
+// flight keyed before a Reset must not adopt the post-Reset generation and
+// publish an endpoint, undoing the reset.
+func TestDiscover_StaleFlightGenerationDoesNotCommit(t *testing.T) {
+	srv := healthyServer(t, 0) // would connect if the generation matched
+
+	c := &Client{
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+		manualURL:    srv.URL,
+		contextName:  "ctx",
+		discoveryGen: 5, // current generation (a Reset already bumped it)
+	}
+
+	// Flight was keyed at generation 4 (before the Reset).
+	_, _, err := c.discover(context.Background(), 4)
+	if !errors.Is(err, errDiscoverySuperseded) {
+		t.Fatalf("err = %v, want errDiscoverySuperseded", err)
+	}
+	if c.baseURL != "" {
+		t.Fatalf("stale-generation discovery published baseURL=%q", c.baseURL)
+	}
+}
+
 // TestEnsureConnected_RetiredClientAborts verifies that a Client retired by
 // Reinitialize aborts discovery even when its singleflight goroutine starts
 // after the swap — it must not connect (and drive the shared port-forward) for

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -581,7 +581,7 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 
 	// Start a new managed port-forward
 	log.Printf("[caretta] Starting port-forward to %s/%s:%d (targetPort=%d)", metricsInfo.namespace, metricsInfo.name, metricsInfo.port, metricsInfo.targetPort)
-	connInfo, err := portforward.Start(ctx, metricsInfo.namespace, metricsInfo.name, metricsInfo.targetPort, contextName)
+	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, metricsInfo.namespace, metricsInfo.name, metricsInfo.targetPort, contextName)
 	if err != nil {
 		return &portforward.ConnectionInfo{
 			Connected:   false,

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -275,7 +275,7 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 	}
 
 	// Check for active managed port-forward first
-	if pfAddr := portforward.GetAddress(c.currentContext); pfAddr != "" {
+	if pfAddr := portforward.GetAddress(portforward.OwnerTraffic, c.currentContext); pfAddr != "" {
 		if c.tryMetricsEndpointLocked(ctx, pfAddr) {
 			log.Printf("[caretta] Using managed port-forward at %s", pfAddr)
 			c.prometheusAddr = pfAddr
@@ -563,7 +563,7 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	}
 
 	// Check if there's already a valid managed port-forward for this context
-	if pfAddr := portforward.GetAddress(contextName); pfAddr != "" {
+	if pfAddr := portforward.GetAddress(portforward.OwnerTraffic, contextName); pfAddr != "" {
 		pfTestAddr := pfAddr + metricsInfo.basePath
 		if c.tryMetricsEndpointLocked(ctx, pfTestAddr) {
 			log.Printf("[caretta] Using existing port-forward at %s", pfAddr)

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -361,7 +361,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 
 	// Start port-forward to Hubble Relay
 	log.Printf("[hubble] Starting port-forward to %s/%s:%d", namespace, hubbleRelayService, h.relayPort)
-	connInfo, err := portforward.Start(ctx, namespace, hubbleRelayService, h.relayPort, contextName)
+	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, namespace, hubbleRelayService, h.relayPort, contextName)
 	if err != nil {
 		return &portforward.ConnectionInfo{
 			Connected:   false,
@@ -486,7 +486,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	}
 
 	// Both attempts failed
-	portforward.Stop()
+	portforward.Stop(portforward.OwnerTraffic)
 	h.localPort = 0
 	return &portforward.ConnectionInfo{
 		Connected: false,

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -548,18 +548,14 @@ func (m *Manager) Connect(ctx context.Context) (*portforward.ConnectionInfo, err
 	}
 }
 
-// GetConnectionInfo returns live traffic connection status. Traffic's own metrics
-// forward if it has one, else any active forward for the context (it may be
-// reusing another owner's read-only). Reading the live registry avoids reporting
-// a forward that has since been stopped.
+// GetConnectionInfo returns live traffic connection status — traffic's own
+// metrics forward, read from the live registry so a forward that has since been
+// stopped isn't reported as connected. It deliberately does NOT report another
+// owner's forward: traffic's data path always uses its own (Caretta/Hubble bring
+// one up), so a Prometheus forward for the same context means Prometheus is
+// connected, not traffic.
 func (m *Manager) GetConnectionInfo() *portforward.ConnectionInfo {
-	if info := portforward.GetConnectionInfo(portforward.OwnerTraffic); info.Connected {
-		return info
-	}
-	m.mu.RLock()
-	contextName := m.contextName
-	m.mu.RUnlock()
-	return portforward.GetConnectionInfoForContext(contextName)
+	return portforward.GetConnectionInfo(portforward.OwnerTraffic)
 }
 
 // SetContextName updates the current context name

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -499,7 +499,7 @@ func (m *Manager) Close() error {
 // Reset cleans up for context switching
 func Reset() {
 	// Stop any active metrics port-forward first
-	portforward.Stop()
+	portforward.Stop(portforward.OwnerTraffic)
 
 	if manager != nil {
 		manager.Close()
@@ -535,28 +535,31 @@ func (m *Manager) Connect(ctx context.Context) (*portforward.ConnectionInfo, err
 		}, nil
 	}
 
-	// Check if source supports Connect
-	if caretta, ok := source.(*CarettaSource); ok {
-		return caretta.Connect(ctx, contextName)
+	switch s := source.(type) {
+	case *CarettaSource:
+		return s.Connect(ctx, contextName)
+	case *HubbleSource:
+		return s.Connect(ctx, contextName)
+	case *IstioSource:
+		return s.Connect(ctx, contextName)
+	default:
+		// For sources without Connect support, just report connected.
+		return &portforward.ConnectionInfo{Connected: true}, nil
 	}
-
-	if hubble, ok := source.(*HubbleSource); ok {
-		return hubble.Connect(ctx, contextName)
-	}
-
-	if istio, ok := source.(*IstioSource); ok {
-		return istio.Connect(ctx, contextName)
-	}
-
-	// For sources without Connect support, just return connected
-	return &portforward.ConnectionInfo{
-		Connected: true,
-	}, nil
 }
 
-// GetConnectionInfo returns current connection status
+// GetConnectionInfo returns live traffic connection status. Traffic's own metrics
+// forward if it has one, else any active forward for the context (it may be
+// reusing another owner's read-only). Reading the live registry avoids reporting
+// a forward that has since been stopped.
 func (m *Manager) GetConnectionInfo() *portforward.ConnectionInfo {
-	return portforward.GetConnectionInfo()
+	if info := portforward.GetConnectionInfo(portforward.OwnerTraffic); info.Connected {
+		return info
+	}
+	m.mu.RLock()
+	contextName := m.contextName
+	m.mu.RUnlock()
+	return portforward.GetConnectionInfoForContext(contextName)
 }
 
 // SetContextName updates the current context name

--- a/pkg/prom/discovery.go
+++ b/pkg/prom/discovery.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// wellKnownConcurrency bounds the parallel Service.Get fan-out over the
+// well-known locations so discovery doesn't open a burst of connections to the
+// API server at once.
+const wellKnownConcurrency = 8
 
 // CandidateSource describes how a candidate was found.
 type CandidateSource string
@@ -100,6 +106,84 @@ var skipNamespaces = map[string]bool{
 	"kube-node-lease": true,
 }
 
+// nonQueryComponents are metrics-adjacent services that are commonly named or
+// namespaced like Prometheus but do NOT serve the Prometheus HTTP query API
+// (/api/v1/query). Discovery must never treat them as candidates: each one
+// costs a serial port-forward attempt that can only ever fail. Matched as a
+// substring against the service name and the app/name/component labels, so
+// e.g. "kube-prometheus-stack-prometheus-node-exporter" is excluded by
+// "node-exporter" even though it also contains "prometheus".
+var nonQueryComponents = []string{
+	"node-exporter",
+	"kube-state-metrics",
+	"state-metrics",
+	"alertmanager",
+	"pushgateway",
+	"prometheus-adapter",
+	"grafana",
+	"blackbox",
+	"thanos-compact",
+	"thanos-rule", // covers thanos-ruler
+	"thanos-store",
+	"thanos-sidecar",
+	"thanos-receive",
+	// Control-plane scrape-target Services created by kube-prometheus-stack:
+	// they carry "prometheus" in the name but only proxy a component's /metrics,
+	// they don't serve the query API.
+	"kubelet",
+	"kube-etcd",
+	"kube-scheduler",
+	"kube-controller-manager",
+	"kube-proxy",
+	"coredns",
+	"kube-dns",
+}
+
+// queryEngineAppNames / queryEngineAppLabels are definitive identities of a
+// Prometheus-family query engine. When one is present, the substring deny-list
+// below must not fire — a real endpoint (e.g. a chart installed with release
+// name "grafana", giving service name "grafana-prometheus-server", but
+// app.kubernetes.io/name=prometheus) is a query API despite the generic token.
+var queryEngineAppNames = map[string]bool{
+	"prometheus": true, "victoria-metrics-single": true, "vmsingle": true,
+	"vmselect": true, "thanos-query": true, "thanos-querier": true,
+}
+var queryEngineAppLabels = map[string]bool{
+	"prometheus": true, "prometheus-server": true, "vmsingle": true, "vmselect": true,
+}
+
+// isNonQueryService reports whether a service is a known non-query metrics
+// component (exporter, operator, alertmanager, …) that cannot answer PromQL.
+func isNonQueryService(svc corev1.Service) bool {
+	labels := svc.Labels
+	name := strings.ToLower(svc.Name)
+	appName := strings.ToLower(labels["app.kubernetes.io/name"])
+	component := strings.ToLower(labels["app.kubernetes.io/component"])
+
+	// A definitive query-engine identity wins over any name substring.
+	if queryEngineAppNames[appName] || queryEngineAppLabels[strings.ToLower(labels["app"])] {
+		return false
+	}
+
+	// The Prometheus operator is a control plane, not a query API. Match it by
+	// name suffix or exact label rather than a substring, so a real Prometheus
+	// whose name merely contains "operator" — e.g. "prometheus-operator-prometheus"
+	// from a release named "prometheus-operator" — is not excluded.
+	if strings.HasSuffix(name, "operator") || appName == "prometheus-operator" || component == "prometheus-operator" {
+		return true
+	}
+
+	haystack := []string{name, appName, component, strings.ToLower(labels["app"])}
+	for _, token := range nonQueryComponents {
+		for _, h := range haystack {
+			if h != "" && strings.Contains(h, token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Discover enumerates candidate Prometheus-compatible services reachable to
 // the given k8sClient. Well-known locations are returned first in declared
 // priority order, optionally followed by dynamically-discovered services
@@ -122,16 +206,51 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 
 	var out []Candidate
 
-	// Layer 1: well-known locations. Preserve declared order for determinism.
-	for _, loc := range WellKnownLocations {
-		svc, err := k8sClient.CoreV1().Services(loc.Namespace).Get(ctx, loc.Name, metav1.GetOptions{})
-		if err != nil {
-			if !apierrors.IsNotFound(err) {
+	// seen de-duplicates candidates by namespace/name/port/basePath so a
+	// service reachable via both the well-known list and the dynamic scan is
+	// probed and port-forwarded only once. Well-known wins ties because it is
+	// appended first.
+	seen := map[string]bool{}
+
+	// Layer 1: well-known locations. Fetch them concurrently — this is ~20
+	// targeted Gets, which run serially would dominate discovery latency against
+	// a remote API server — then assemble in declared order for deterministic
+	// priority. Targeted Gets (not a cluster-wide List) keep this working for
+	// callers with get-but-not-list on Services.
+	found := make([]*corev1.Service, len(WellKnownLocations))
+	getErrs := make([]error, len(WellKnownLocations))
+	sem := make(chan struct{}, wellKnownConcurrency)
+	var wg sync.WaitGroup
+	for i, loc := range WellKnownLocations {
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			svc, err := k8sClient.CoreV1().Services(loc.Namespace).Get(ctx, loc.Name, metav1.GetOptions{})
+			if err != nil {
+				getErrs[i] = err
+				return
+			}
+			found[i] = svc
+		})
+	}
+	wg.Wait()
+
+	// Assemble in declared order, logging serially — DiscoverOptions.Logger has
+	// no concurrency contract, so it must not be called from the workers above.
+	for i, loc := range WellKnownLocations {
+		svc := found[i]
+		if svc == nil {
+			if err := getErrs[i]; err != nil && !apierrors.IsNotFound(err) {
 				logf("prom.Discover: error checking %s/%s: %v", loc.Namespace, loc.Name, err)
 			}
 			continue
 		}
 		port := resolvePort(*svc, loc.Port)
+		key := candidateKey(svc.Namespace, svc.Name, port, loc.BasePath)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		out = append(out, Candidate{
 			Namespace:   svc.Namespace,
 			Name:        svc.Name,
@@ -147,7 +266,12 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 		return out, nil
 	}
 
-	// Layer 2: dynamic cluster-wide scan, scored + sorted.
+	// Layer 2: dynamic cluster-wide scan. The score only *ranks* candidates; it
+	// is not an admission gate. Anything we're certain can't answer PromQL is
+	// already excluded by ScoreService (isNonQueryService), and the caller's
+	// probe is the authoritative check — so a weak but positive score is kept
+	// and ranked low rather than dropped, which would silently miss a real but
+	// lightly-labeled Prometheus. MaxDynamic still bounds how many are returned.
 	svcs, err := k8sClient.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		logf("prom.Discover: failed to list services: %v", err)
@@ -156,11 +280,17 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 
 	var scored []Candidate
 	for _, svc := range svcs.Items {
-		score, bp := ScoreService(svc)
-		if score <= 0 {
+		score, bp, identity := ScoreService(svc)
+		// Admit on a Prometheus-family identity signal, not on score alone: a
+		// namespace-only match (score without identity) would send the operator's
+		// configured Prometheus headers to an unrelated neighbor when probed.
+		if !identity {
 			continue
 		}
 		port := resolvePort(svc, 0)
+		if seen[candidateKey(svc.Namespace, svc.Name, port, bp)] {
+			continue
+		}
 		scored = append(scored, Candidate{
 			Namespace:   svc.Namespace,
 			Name:        svc.Name,
@@ -183,15 +313,39 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 	return append(out, scored...), nil
 }
 
+// promPortScore returns the heuristic weight for a port number matching a
+// well-known Prometheus-family default (0 for anything else).
+func promPortScore(port int32) int {
+	switch port {
+	case 9090: // Prometheus default
+		return 30
+	case 8428: // VictoriaMetrics single-node default
+		return 30
+	case 8481: // VictoriaMetrics vmselect default
+		return 25
+	case 9009, 10902: // Thanos Query (gRPC-era default; common HTTP port)
+		return 25
+	}
+	return 0
+}
+
 // ScoreService computes a heuristic score for a service being
-// Prometheus-compatible. Returns the score and an inferred BasePath for
-// vmselect-style services.
-func ScoreService(svc corev1.Service) (score int, basePath string) {
+// Prometheus-compatible. It returns the ranking score, an inferred BasePath for
+// vmselect-style services, and whether the service carries a Prometheus-family
+// *identity* signal (a name/label/port match). identity gates admission:
+// namespace membership alone contributes to the score for ranking but must not,
+// on its own, make an unrelated Service a candidate — discovery probes
+// candidates with the operator's configured Prometheus headers, so an
+// unrecognized neighbor must not be admitted just for sharing a namespace.
+func ScoreService(svc corev1.Service) (score int, basePath string, identity bool) {
 	if svc.Spec.Type == corev1.ServiceTypeExternalName {
-		return 0, ""
+		return 0, "", false
 	}
 	if skipNamespaces[svc.Namespace] {
-		return 0, ""
+		return 0, "", false
+	}
+	if isNonQueryService(svc) {
+		return 0, "", false
 	}
 
 	labels := svc.Labels
@@ -226,15 +380,13 @@ func ScoreService(svc corev1.Service) (score int, basePath string) {
 	}
 
 	for _, p := range svc.Spec.Ports {
-		switch p.Port {
-		case 9090: // Prometheus default
-			score += 30
-		case 8428: // VictoriaMetrics single-node default
-			score += 30
-		case 8481: // VictoriaMetrics vmselect default
-			score += 25
-		case 9009: // Thanos Query default
-			score += 25
+		// Credit a recognized port on either the service port or the container
+		// targetPort — a real Prometheus is often fronted by a service port of
+		// 80/http with targetPort 9090 — but only once per port entry.
+		if s := promPortScore(p.Port); s > 0 {
+			score += s
+		} else {
+			score += promPortScore(p.TargetPort.IntVal)
 		}
 		if strings.Contains(strings.ToLower(p.Name), "prometheus") {
 			score += 10
@@ -255,11 +407,22 @@ func ScoreService(svc corev1.Service) (score int, basePath string) {
 		score += 15
 	}
 
+	// Everything above is a Prometheus-family identity signal; the namespace
+	// bonus below only nudges ranking and must not admit on its own.
+	identity = score > 0
+
 	if metricsNamespaces[svc.Namespace] {
 		score += 10
 	}
 
-	return score, basePath
+	return score, basePath, identity
+}
+
+// candidateKey identifies a candidate by the tuple that determines where and
+// how it is probed, so the same service surfaced by both discovery layers is
+// de-duplicated.
+func candidateKey(namespace, name string, port int, basePath string) string {
+	return fmt.Sprintf("%s/%s:%d%s", namespace, name, port, basePath)
 }
 
 func resolvePort(svc corev1.Service, defaultPort int) int {

--- a/pkg/prom/discovery_test.go
+++ b/pkg/prom/discovery_test.go
@@ -2,20 +2,23 @@ package prom
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func TestScoreService_TableDriven(t *testing.T) {
 	tests := []struct {
-		name        string
-		svc         corev1.Service
-		wantMin     int
-		wantMax     int
+		name         string
+		svc          corev1.Service
+		wantMin      int
+		wantMax      int
 		wantBasePath string
 	}{
 		{
@@ -97,11 +100,119 @@ func TestScoreService_TableDriven(t *testing.T) {
 			},
 			wantMax: 0,
 		},
+		// Non-query components must score zero even though their names contain
+		// "prometheus" and they live in a metrics namespace — these are the
+		// exact services that were polluting discovery and wasting port-forwards.
+		{
+			name: "node-exporter excluded despite prometheus in name",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-prometheus-stack-prometheus-node-exporter",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "prometheus-node-exporter"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9100}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "kube-state-metrics excluded",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-prometheus-stack-kube-state-metrics",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "prometheus-operator excluded",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-prometheus-stack-operator",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/component": "prometheus-operator"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "alertmanager excluded",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-prometheus-stack-alertmanager",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "alertmanager"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9093}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "pushgateway excluded",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus-pushgateway",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "prometheus-pushgateway"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9091}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "definitive prometheus label overrides a deny-list substring in the name",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-prometheus-server", // "grafana" substring
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "prometheus"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090}}},
+			},
+			wantMin: 1, // must not be excluded by the "grafana" token
+			wantMax: 500,
+		},
+		{
+			name: "prometheus from an operator-named release is kept",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "prometheus-operator-prometheus", Namespace: "monitoring"},
+				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090}}},
+			},
+			wantMin: 1, // must not be excluded (name contains "operator" but isn't the operator)
+			wantMax: 500,
+		},
+		{
+			name: "kubelet scrape-target excluded despite prometheus in name",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-prometheus-stack-kubelet",
+					Namespace: "kube-system",
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 10250}}},
+			},
+			wantMax: 0,
+		},
+		{
+			name: "thanos-store excluded (not the query API)",
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "thanos-store",
+					Namespace: "monitoring",
+					Labels:    map[string]string{"app.kubernetes.io/name": "thanos-store"},
+				},
+				Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 10902}}},
+			},
+			wantMax: 0,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			score, bp := ScoreService(tc.svc)
+			score, bp, _ := ScoreService(tc.svc)
 			if score < tc.wantMin || (tc.wantMax > 0 && score > tc.wantMax) {
 				t.Errorf("score=%d, want in [%d, %d]", score, tc.wantMin, tc.wantMax)
 			}
@@ -188,6 +299,184 @@ func TestDiscover_WellKnownFirst(t *testing.T) {
 	}
 }
 
+func TestDiscover_DeDupesWellKnownAndDynamic(t *testing.T) {
+	// A service that matches both a well-known location (monitoring/prometheus-server)
+	// and scores in the dynamic scan (app.kubernetes.io/name=prometheus) must
+	// appear exactly once, sourced from the well-known layer.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-server",
+			Namespace: "monitoring",
+			Labels:    map[string]string{"app.kubernetes.io/name": "prometheus"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Ports:     []corev1.ServicePort{{Port: 9090}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(svc)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	var count int
+	for _, c := range cands {
+		if c.Namespace == "monitoring" && c.Name == "prometheus-server" {
+			count++
+			if c.Source != CandidateSourceWellKnown {
+				t.Errorf("de-duped candidate should retain well_known source, got %q", c.Source)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want monitoring/prometheus-server exactly once, got %d (all: %+v)", count, cands)
+	}
+}
+
+func TestDiscover_ExcludesControlPlaneScrapeTargets(t *testing.T) {
+	// A kube-prometheus-stack control-plane scrape-target Service carries
+	// "prometheus" in its name but only proxies a component's /metrics; it must
+	// not become a candidate — it can't answer PromQL and would waste a
+	// port-forward. Excluded by name (a component token), not by score.
+	noise := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-prometheus-stack-kube-etcd",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports:     []corev1.ServicePort{{Port: 2381}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(noise)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("control-plane scrape-target service became a candidate: %+v", cands)
+	}
+}
+
+func TestDiscover_ExcludesNamespaceOnlyNeighbor(t *testing.T) {
+	// An unrelated Service that only matches by sharing a metrics namespace (no
+	// name/label/port Prometheus signal) must NOT become a candidate — discovery
+	// probes candidates with the operator's configured Prometheus headers, so a
+	// namespace neighbor would receive credentials it shouldn't.
+	neighbor := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "billing-api",
+			Namespace: "monitoring",
+			Labels:    map[string]string{"app": "billing"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.42",
+			Ports:     []corev1.ServicePort{{Port: 8080, Name: "http"}},
+		},
+	}
+
+	if _, _, identity := ScoreService(*neighbor); identity {
+		t.Fatal("namespace-only neighbor reported a Prometheus identity signal")
+	}
+
+	k8s := fake.NewSimpleClientset(neighbor)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("namespace-only neighbor became a candidate (would be probed with creds): %+v", cands)
+	}
+}
+
+func TestDiscover_KeepsPrometheusWithNamedTargetPort(t *testing.T) {
+	// An unlabeled Prometheus behind service port 80 with a *named* targetPort
+	// scores only on its name (a named targetPort has no numeric value to
+	// credit). Score ranks, it does not gate — so this real endpoint must still
+	// be discovered and left for the probe to validate, not silently dropped.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus-server", Namespace: "apps"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.6",
+			Ports:     []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromString("web")}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(svc)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	var found bool
+	for _, c := range cands {
+		if c.Namespace == "apps" && c.Name == "prometheus-server" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("prometheus with a named targetPort was pruned: %+v", cands)
+	}
+}
+
+func TestDiscover_KeepsUnlabeledThanosQuery(t *testing.T) {
+	// An unlabeled thanos-query on its common HTTP port is a real query API and
+	// must survive the dynamic score floor (name match + recognized port).
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "thanos-query", Namespace: "obs"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.8",
+			Ports:     []corev1.ServicePort{{Port: 10902}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(svc)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	var found bool
+	for _, c := range cands {
+		if c.Name == "thanos-query" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("unlabeled thanos-query was pruned: %+v", cands)
+	}
+}
+
+func TestDiscover_KeepsUnlabeledCustomPrometheus(t *testing.T) {
+	// A real Prometheus in a non-standard namespace with no conventional labels
+	// and a service port of 80 scores only on the name match, but it is a
+	// genuine query endpoint and must still be discovered — pruning must not be
+	// so aggressive that it drops it.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus-server", Namespace: "platform"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.9",
+			Ports:     []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(9090)}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(svc)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	var found bool
+	for _, c := range cands {
+		if c.Namespace == "platform" && c.Name == "prometheus-server" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("unlabeled custom prometheus was pruned: %+v", cands)
+	}
+}
+
 func TestDiscover_SkipsDynamicWhenDisabled(t *testing.T) {
 	// Only a dynamic-scoring service is present (no well-known match).
 	prom := &corev1.Service{
@@ -238,5 +527,30 @@ func TestDiscover_NilClient(t *testing.T) {
 	_, err := Discover(context.Background(), nil, DiscoverOptions{})
 	if err == nil {
 		t.Error("expected error for nil client")
+	}
+}
+
+// TestDiscover_LoggerCalledSerially guards the DiscoverOptions.Logger contract:
+// well-known lookups run concurrently, but the Logger must not be — a caller can
+// pass an unsynchronized callback. The reactor makes every well-known Get fail
+// (non-NotFound) so each would log; an unsynchronized slice append from parallel
+// workers would trip the race detector.
+func TestDiscover_LoggerCalledSerially(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	k8s.PrependReactor("get", "services", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated API error")
+	})
+
+	var logs []string
+	_, err := Discover(context.Background(), k8s, DiscoverOptions{
+		Logger: func(format string, args ...interface{}) {
+			logs = append(logs, fmt.Sprintf(format, args...)) // deliberately unsynchronized
+		},
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected error logs from failed well-known lookups")
 	}
 }


### PR DESCRIPTION
Ground-up fix for slow and failing Prometheus discovery on cold start. On a cluster with several Prometheus-like services, concurrent cost/traffic requests each ran their own discovery and fought over the process-global port-forward singleton — churning for 20–30s and often failing to connect. Verified against a live GKE cluster: **~24s-and-fail → ~6s-and-connect**.

## What changed

### Coalesce discovery
- Concurrent `EnsureConnected` callers share one discovery via **singleflight**; the shared run detaches from the leader's request context so it completes for every waiter, while each caller `select`s on its own context and returns promptly when cancelled.
- A **discovery generation** (bumped by `Reset`/`SetManualURL`/`SetHeaders`) keys the flight and gates the connection write; `markConnected` reports whether it committed, so a run superseded by a config change surfaces a retryable error instead of a hollow success (address returned but `baseURL` empty).
- A **process-global gate** serializes discovery across `Client` instances too — a client reinit on context setup can leave the startup pre-warm and the first request discovering at once, and only a global gate keeps them off the shared port-forward. It's context-aware, and `Reset`/`Reinitialize` cancel the in-flight run so a superseded discovery releases the gate promptly.

### Prune candidates
Non-query services (node-exporter, kube-state-metrics, operator, alertmanager, pushgateway, grafana, blackbox, Thanos non-query, control-plane scrape targets) are excluded, and a minimum dynamic score drops bare name matches (kubelet, otel-collector). Scoring credits a recognized container `targetPort` (not just the service port), so a real Prometheus behind a port-80 service still qualifies. Duplicates across the well-known list and dynamic scan are de-duplicated.

### Enumerate & probe faster
Well-known locations are fetched **concurrently** (bounded) instead of ~20 serial Gets — the dominant latency against a remote API server — assembled in priority order, still via targeted Gets (get-without-list callers keep working), logging serially to honor the `Logger` contract. Direct probing runs for **every** environment (connects in-cluster and over networks that route Service DNS, e.g. VPN), bounded by a budget larger than the per-probe timeout so a slow-but-reachable endpoint gets a full attempt while an unresolvable cluster-DNS name (which can wedge in the platform cgo resolver past its deadline) can't stall the pass. Port-forwarding stays the serial fallback.

### Log trail
One line lists the candidates; the direct pass summarizes in one line (not one rejection per candidate); each phase (enumerate / direct probe / total) carries its own elapsed time; a superseded run is logged as such, not as a failure.

## Tests
`pkg/prom`: de-dup, scoring disqualifiers, control-plane exclusion, unlabeled-custom-prometheus kept, concurrency-safe Logger. `internal/prometheus`: singleflight coalescing, prompt cancellation, stale-generation gate, `Reset` cancels in-flight discovery, batch respects its budget, probe ordering. Race-clean under `-race`.

## Port-forward ownership (folded in)
The metrics port-forward was a process-global singleton shared by prometheus discovery and the traffic subsystem (Caretta/Hubble); when they wanted different services concurrently they clobbered each other. Now each subsystem owns its own metrics forward (`OwnerPrometheus`/`OwnerTraffic`) — `Start`/`Stop` only ever touch the caller's forward, cross-owner reuse stays read-only, and traffic connection status reads the live registry.

## Deferred follow-up
- **OpenCost duplicate-series 422** — clusters with two kube-state-metrics instances break the storage-cost PV join (costs show 0); needs an RHS-dedup in the query. (Not discovery/port-forward related.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared connection discovery, port-forward lifecycle, and context-switch cancellation paths; behavior is complex but heavily covered by new tests.
> 
> **Overview**
> Fixes cold-start Prometheus discovery where parallel `EnsureConnected` callers and prometheus/traffic both fought over one metrics port-forward, often failing after long churn.
> 
> **Discovery coalescing & lifecycle:** Concurrent discovery is merged with **singleflight** and a process **discovery gate**, keyed by a **discovery generation** bumped on `Reset` / `SetManualURL` / `SetHeaders`. Detached runs can be cancelled on context switch; stale results are dropped via `markConnected` / `connectionLive` instead of hollow successes. Direct candidate probing is **bounded and concurrent** (priority-ordered, time-budgeted) before serial port-forward fallback.
> 
> **Candidate quality & speed:** `pkg/prom.Discover` excludes non-query metrics services, requires a Prometheus **identity** signal (not namespace-only neighbors), de-duplicates well-known vs dynamic hits, and fetches well-known Services **in parallel**. Quieter, phase-timed discovery logs.
> 
> **Port-forward ownership:** Replaces the global metrics forward with **per-owner** forwards (`OwnerPrometheus` / `OwnerTraffic`); `Stop` only tears down the caller’s tunnel, with epoch guards if `Stop` races in-flight `Start`. Prometheus `Reset` explicitly stops its forward; traffic/Caretta/Hubble pass `OwnerTraffic`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecb582bd5e61375aa40d9c35ac4c1a4f02a3b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->