### PR TITLE
Enable per-resource Argo CD sync

### DIFF
--- a/internal/server/argo_handlers.go
+++ b/internal/server/argo_handlers.go
@@ -35,6 +35,7 @@ func (s *Server) handleArgoSync(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	opts = enforceArgoSelectiveSyncSafety(opts)
 	result, err := gitops.SyncArgoApp(r.Context(), client, namespace, name, opts)
 	if err != nil {
 		s.writeGitOpsError(w, err, "argo", "sync", namespace, name)
@@ -42,6 +43,17 @@ func (s *Server) handleArgoSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, toGitOpsResponse(result))
+}
+
+func enforceArgoSelectiveSyncSafety(opts gitops.ArgoSyncOptions) gitops.ArgoSyncOptions {
+	if len(opts.Resources) == 0 {
+		return opts
+	}
+	falseValue := false
+	opts.Revision = ""
+	opts.Prune = &falseValue
+	opts.ApplyOnly = &falseValue
+	return opts
 }
 
 func (s *Server) handleArgoValidateResource(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/argo_handlers.go
+++ b/internal/server/argo_handlers.go
@@ -265,6 +265,8 @@ func (s *Server) writeGitOpsError(w http.ResponseWriter, err error, module, acti
 		status = http.StatusConflict
 	case errors.Is(err, gitops.ErrNoOperationInProgress):
 		status = http.StatusBadRequest
+	case errors.Is(err, gitops.ErrInvalidResourceSelection):
+		status = http.StatusBadRequest
 	default:
 		status = http.StatusInternalServerError
 	}

--- a/internal/server/argo_handlers.go
+++ b/internal/server/argo_handlers.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +42,41 @@ func (s *Server) handleArgoSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, toGitOpsResponse(result))
+}
+
+func (s *Server) handleArgoValidateResource(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	auth.AuditLog(r, namespace, name)
+	client := s.getDynamicClientForRequest(r)
+	if client == nil {
+		log.Printf("[argo] Dynamic client unavailable for validating Application %s/%s", sanitizeForLog(namespace), sanitizeForLog(name))
+		s.writeError(w, http.StatusServiceUnavailable, "dynamic client not available")
+		return
+	}
+	var opts gitops.ArgoSyncOptions
+	if r.Body == nil || r.ContentLength == 0 {
+		s.writeError(w, http.StatusBadRequest, "validation request requires exactly one resource")
+		return
+	}
+	if err := json.NewDecoder(r.Body).Decode(&opts); err != nil {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid validation request: %v", err))
+		return
+	}
+	if len(opts.Resources) != 1 || opts.Resources[0].Kind == "" || opts.Resources[0].Name == "" {
+		s.writeError(w, http.StatusBadRequest, "validation request requires exactly one resource with kind and name")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	result, err := gitops.ValidateArgoResource(ctx, client, namespace, name, opts.Resources[0], opts)
+	if err != nil {
+		s.writeGitOpsError(w, err, "argo", "validate resource", namespace, name)
+		return
+	}
+	s.writeJSON(w, result)
 }
 
 // handleArgoRefresh triggers a refresh (re-read from git) on an ArgoCD Application
@@ -198,6 +235,8 @@ func (s *Server) writeGitOpsError(w http.ResponseWriter, err error, module, acti
 	msg := err.Error()
 	var status int
 	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		status = http.StatusGatewayTimeout
 	case apierrors.IsNotFound(err):
 		status = http.StatusNotFound
 	case apierrors.IsForbidden(err):

--- a/internal/server/argo_handlers_test.go
+++ b/internal/server/argo_handlers_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/gitops"
+)
+
+func TestEnforceArgoSelectiveSyncSafety(t *testing.T) {
+	trueValue := true
+	resource := gitops.ArgoSyncResource{Group: "apps", Kind: "Deployment", Namespace: "default", Name: "api"}
+	opts := enforceArgoSelectiveSyncSafety(gitops.ArgoSyncOptions{
+		Resources: []gitops.ArgoSyncResource{resource},
+		Revision:  "unsafe-revision",
+		Prune:     &trueValue,
+		DryRun:    &trueValue,
+		Force:     &trueValue,
+		ApplyOnly: &trueValue,
+	})
+	if opts.Revision != "" || opts.Prune == nil || *opts.Prune || opts.ApplyOnly == nil || *opts.ApplyOnly {
+		t.Fatalf("selective sync safety not enforced: %#v", opts)
+	}
+	if opts.DryRun == nil || !*opts.DryRun || opts.Force == nil || !*opts.Force || len(opts.Resources) != 1 {
+		t.Fatalf("allowed selective sync options changed: %#v", opts)
+	}
+}
+
+func TestEnforceArgoSelectiveSyncSafetyLeavesFullSyncUnchanged(t *testing.T) {
+	trueValue := true
+	original := gitops.ArgoSyncOptions{Revision: "release", Prune: &trueValue, ApplyOnly: &trueValue}
+	opts := enforceArgoSelectiveSyncSafety(original)
+	if opts.Revision != "release" || opts.Prune != original.Prune || opts.ApplyOnly != original.ApplyOnly {
+		t.Fatalf("full sync options changed: %#v", opts)
+	}
+}

--- a/internal/server/gitops_handlers_test.go
+++ b/internal/server/gitops_handlers_test.go
@@ -149,6 +149,11 @@ func TestWriteGitOpsErrorStatusMapping(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "ErrInvalidResourceSelection → 400",
+			err:        gitops.ErrInvalidResourceSelection,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "unrecognized error → 500",
 			err:        errors.New("something else"),
 			wantStatus: http.StatusInternalServerError,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -532,6 +532,7 @@ func (s *Server) setupRoutes() {
 			// ArgoCD routes
 			r.Get("/argo/destinations", s.handleArgoDestinations)
 			r.Post("/argo/applications/{namespace}/{name}/sync", s.handleArgoSync)
+			r.Post("/argo/applications/{namespace}/{name}/validate-resource", s.handleArgoValidateResource)
 			r.Post("/argo/applications/{namespace}/{name}/refresh", s.handleArgoRefresh)
 			r.Post("/argo/applications/{namespace}/{name}/rollback", s.handleArgoRollback)
 			r.Post("/argo/applications/{namespace}/{name}/terminate", s.handleArgoTerminate)

--- a/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
@@ -77,6 +77,7 @@ export interface ArgoActionHandlers {
   autoSyncEnabled: boolean
   // isRunning: caller derives from status.operationState.phase === 'Running'.
   isRunning: boolean
+  operationInProgress?: boolean
 }
 
 export interface FluxActionHandlers {
@@ -252,6 +253,7 @@ export function GitOpsDetailLayout(props: GitOpsDetailLayoutProps) {
   }, [identity.name, manageDocumentTitle, documentTitleSuffix])
 
   const effectiveSuspended = status?.suspended ?? false
+  const argoOperationInProgress = argo?.operationInProgress ?? argo?.isRunning ?? false
   // graphFullscreen hides everything chrome-side; the body region expands.
   // Mirrors the OSS GitOpsDetailView shell behavior so the visual chrome
   // class set carries through.
@@ -344,8 +346,12 @@ export function GitOpsDetailLayout(props: GitOpsDetailLayoutProps) {
                     icon={ArrowDownUp}
                     loading={argo.syncing}
                     onClick={argo.onSyncRequested}
-                    disabled={effectiveSuspended || terminating}
-                    disabledReason={terminating ? terminatingActionTooltip : undefined}
+                    disabled={effectiveSuspended || terminating || argoOperationInProgress}
+                    disabledReason={terminating
+                      ? terminatingActionTooltip
+                      : argoOperationInProgress
+                        ? 'Wait for the current Argo operation to finish.'
+                        : undefined}
                     primary
                   />
                   <ActionButton

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -35,7 +35,7 @@ import { DistributionBar } from '../ui/DistributionBar'
 import { RowActionMenu, type RowActionItem } from '../ui/RowActionMenu'
 import { BoardTableSkeleton, BoardRailSkeleton } from '../ui/BoardSkeleton'
 import { getGitOpsResourceStatus } from './detail-helpers'
-import { isArgoSuspendedByRadar } from '../resources/resource-utils-argo'
+import { isArgoOperationInProgress, isArgoSuspendedByRadar } from '../resources/resource-utils-argo'
 import { toggleSet } from './GitOpsGraphFilterRail'
 import { useFilterState, defineFilterSchema } from '../../filter-state'
 import { parseContextName } from '../../utils/context-name'
@@ -1358,13 +1358,20 @@ function buildRowActionItems(
   const items: RowActionItem[] = []
 
   if (row.tool === 'argo') {
+    const operationInProgress = isArgoOperationInProgress(row.raw)
     items.push({
       key: 'sync',
       label: 'Sync...',
       icon: ArrowDownUp,
       onClick: () => onAction(row, 'sync'),
-      disabled: suspended || terminating,
-      disabledReason: terminating ? terminatingReason : suspended ? suspendedReason : undefined,
+      disabled: suspended || terminating || operationInProgress,
+      disabledReason: terminating
+        ? terminatingReason
+        : suspended
+          ? suspendedReason
+          : operationInProgress
+            ? 'Wait for the current Argo operation to finish.'
+            : undefined,
       pending: isPending('sync'),
     })
     // Refresh / Hard refresh are read-style verbs — they re-read Git and

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.test.ts
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildArgoSyncOpts } from './SyncOptionsDialog'
+
+describe('buildArgoSyncOpts', () => {
+  it('keeps full application sync controls', () => {
+    expect(
+      buildArgoSyncOpts({
+        resourceMode: false,
+        revision: ' main ',
+        prune: true,
+        dryRun: true,
+        force: false,
+        applyOnly: true,
+        replace: true,
+        serverSideApply: false,
+      }),
+    ).toEqual({
+      revision: 'main',
+      prune: true,
+      dryRun: true,
+      force: false,
+      applyOnly: true,
+      syncOptions: ['Replace=true'],
+    })
+  })
+
+  it('removes revision, prune, and apply-only semantics from resource sync', () => {
+    expect(
+      buildArgoSyncOpts({
+        resourceMode: true,
+        revision: 'unsafe-revision',
+        prune: true,
+        dryRun: false,
+        force: true,
+        applyOnly: true,
+        replace: false,
+        serverSideApply: true,
+      }),
+    ).toEqual({
+      revision: undefined,
+      prune: false,
+      dryRun: false,
+      force: true,
+      applyOnly: false,
+      syncOptions: ['ServerSideApply=true'],
+    })
+  })
+})

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, type ComponentType } from 'react'
-import { Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 
 import { DialogPortal } from '../ui/DialogPortal'
 import { Input } from '../ui/Input'
+import type { GitOpsInsightRef } from '../../types/gitops-insights'
 
 // =============================================================================
 // SyncOptionsDialog — Argo CD Sync drawer, shared between per-cluster
@@ -11,9 +12,9 @@ import { Input } from '../ui/Input'
 // the onConfirm callback (POST to /api/argo/applications/{ns}/{name}/sync
 // or the hub-proxied equivalent /c/{ctrl}/api/argo/...).
 //
-// Defaults match Argo's most-common path (prune true, no dry-run, no
-// force) so the two-click sync stays cheap. Revision is optional — empty
-// falls through to the Application's targetRevision.
+// Full sync defaults match Argo's most-common path (prune true, no dry-run,
+// no force). Resource sync fixes prune off and omits revision/apply-only so
+// selecting one object cannot opt into deletion behavior.
 // =============================================================================
 
 // ArgoSyncOpts is the payload shape the dialog passes to its onConfirm
@@ -33,12 +34,13 @@ export interface ArgoSyncOpts {
 export interface SyncOptionsDialogProps {
   open: boolean
   appLabel: string
+  resource?: GitOpsInsightRef
   pending?: boolean
   onCancel: () => void
   onConfirm: (opts: ArgoSyncOpts) => void
 }
 
-export function SyncOptionsDialog({ open, appLabel, pending, onCancel, onConfirm }: SyncOptionsDialogProps) {
+export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel, onConfirm }: SyncOptionsDialogProps) {
   const [revision, setRevision] = useState('')
   const [prune, setPrune] = useState(true)
   const [dryRun, setDryRun] = useState(false)
@@ -52,61 +54,68 @@ export function SyncOptionsDialog({ open, appLabel, pending, onCancel, onConfirm
   useEffect(() => {
     if (open) {
       setRevision('')
-      setPrune(true)
+      setPrune(!resource)
       setDryRun(false)
       setForce(false)
       setApplyOnly(false)
       setReplace(false)
       setServerSideApply(false)
     }
-  }, [open])
+  }, [open, resource])
 
   function submit() {
-    const syncOptions: string[] = []
-    if (replace) syncOptions.push('Replace=true')
-    if (serverSideApply) syncOptions.push('ServerSideApply=true')
-    onConfirm({
-      revision: revision.trim() || undefined,
-      prune,
-      dryRun,
-      force,
-      applyOnly,
-      syncOptions,
-    })
+    onConfirm(buildArgoSyncOpts({ resourceMode: !!resource, revision, prune, dryRun, force, applyOnly, replace, serverSideApply }))
   }
 
   return (
     <DialogPortal open={open} onClose={pending ? () => {} : onCancel} className="w-[480px]" closable={!pending}>
       <div className="border-b border-theme-border px-4 py-3">
-        <h2 className="text-sm font-semibold text-theme-text-primary">Sync application</h2>
+        <h2 className="text-sm font-semibold text-theme-text-primary">{resource ? 'Sync resource' : 'Sync application'}</h2>
         <p className="mt-0.5 text-xs text-theme-text-tertiary">{appLabel}</p>
       </div>
       <div className="space-y-4 px-4 py-4 text-sm">
-        <label className="block">
-          <span className="text-xs font-medium text-theme-text-secondary">Revision (optional)</span>
-          <Input
-            value={revision}
-            onChange={(e) => setRevision(e.target.value)}
-            placeholder="HEAD"
-            disabled={pending}
-            className="mt-1 w-full rounded-md border border-theme-border bg-theme-base px-2 py-1.5 font-mono text-xs text-theme-text-primary outline-none placeholder:text-theme-text-tertiary focus:border-sky-500"
-          />
-          <span className="mt-0.5 block text-[11px] text-theme-text-tertiary">
-            Branch, tag, or commit SHA. Leave empty to use the Application's targetRevision.
-          </span>
-        </label>
+        {resource && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div>
+                <div className="text-xs font-medium text-theme-text-primary">
+                  {resource.kind} / {resource.namespace ? `${resource.namespace}/` : ''}{resource.name}
+                </div>
+                <p className="mt-1 text-[11px] leading-relaxed text-theme-text-secondary">
+                  Only this resource will be applied. Selective sync bypasses hooks and normal sync-wave ordering; use a full application sync when this resource depends on them.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+        {!resource && (
+          <label className="block">
+            <span className="text-xs font-medium text-theme-text-secondary">Revision (optional)</span>
+            <Input
+              value={revision}
+              onChange={(e) => setRevision(e.target.value)}
+              placeholder="HEAD"
+              disabled={pending}
+              className="mt-1 w-full rounded-md border border-theme-border bg-theme-base px-2 py-1.5 font-mono text-xs text-theme-text-primary outline-none placeholder:text-theme-text-tertiary focus:border-sky-500"
+            />
+            <span className="mt-0.5 block text-[11px] text-theme-text-tertiary">
+              Branch, tag, or commit SHA. Leave empty to use the Application's targetRevision.
+            </span>
+          </label>
+        )}
 
         {/* Common (Prune / Dry run) sit above a divider; Advanced toggles
             stay accessible but visually subordinate so the common-case user
             can scan past them without parsing every helper line. */}
         <fieldset className="space-y-2">
           <legend className="mb-1 text-xs font-medium text-theme-text-secondary">Sync options</legend>
-          <Toggle label="Prune" checked={prune} onChange={setPrune} disabled={pending} hint="Delete resources that are no longer in Git." />
+          {!resource && <Toggle label="Prune" checked={prune} onChange={setPrune} disabled={pending} hint="Delete resources that are no longer in Git." />}
           <Toggle label="Dry run" checked={dryRun} onChange={setDryRun} disabled={pending} hint="Preview only — Argo computes the diff but applies nothing." />
         </fieldset>
         <fieldset className="space-y-2 border-t border-theme-border pt-3">
           <legend className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">Advanced</legend>
-          <Toggle label="Apply only" checked={applyOnly} onChange={setApplyOnly} disabled={pending} hint="Skip PreSync / PostSync / SyncFail hooks." />
+          {!resource && <Toggle label="Apply only" checked={applyOnly} onChange={setApplyOnly} disabled={pending} hint="Skip PreSync / PostSync / SyncFail hooks." />}
           <Toggle label="Force" checked={force} onChange={setForce} disabled={pending} hint="Use kubectl --force; required for some immutable-field changes." />
           <Toggle label="Replace" checked={replace} onChange={setReplace} disabled={pending} hint="kubectl replace instead of apply (drops fields not in source)." />
           <Toggle label="Server-side apply" checked={serverSideApply} onChange={setServerSideApply} disabled={pending} hint="Use the K8s server-side apply mechanism for ownership tracking." />
@@ -121,10 +130,33 @@ export function SyncOptionsDialog({ open, appLabel, pending, onCancel, onConfirm
         >
           Cancel
         </button>
-        <PrimaryButton onClick={submit} disabled={pending} icon={pending ? Loader2 : RefreshCw} loading={pending} label={dryRun ? 'Run dry-run' : 'Sync now'} />
+        <PrimaryButton onClick={submit} disabled={pending} icon={pending ? Loader2 : RefreshCw} loading={pending} label={dryRun ? 'Run dry-run' : resource ? 'Sync resource' : 'Sync now'} />
       </div>
     </DialogPortal>
   )
+}
+
+export function buildArgoSyncOpts({ resourceMode, revision, prune, dryRun, force, applyOnly, replace, serverSideApply }: {
+  resourceMode: boolean
+  revision: string
+  prune: boolean
+  dryRun: boolean
+  force: boolean
+  applyOnly: boolean
+  replace: boolean
+  serverSideApply: boolean
+}): ArgoSyncOpts {
+  const syncOptions: string[] = []
+  if (replace) syncOptions.push('Replace=true')
+  if (serverSideApply) syncOptions.push('ServerSideApply=true')
+  return {
+    revision: resourceMode ? undefined : revision.trim() || undefined,
+    prune: resourceMode ? false : prune,
+    dryRun,
+    force,
+    applyOnly: resourceMode ? false : applyOnly,
+    syncOptions,
+  }
 }
 
 function Toggle({ label, checked, onChange, disabled, hint }: { label: string; checked: boolean; onChange: (v: boolean) => void; disabled?: boolean; hint?: string }) {

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
@@ -39,6 +39,7 @@ export interface SyncOptionsDialogProps {
   pending?: boolean
   autoSyncEnabled?: boolean
   validationPending?: boolean
+  operationInProgress?: boolean
   validationResult?: ResourceValidationResult | null
   validationError?: string | null
   onCancel: () => void
@@ -56,7 +57,7 @@ export interface ResourceValidationResult {
   }
 }
 
-export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncEnabled, validationPending, validationResult, validationError, onCancel, onConfirm, onValidate, onValidationReset }: SyncOptionsDialogProps) {
+export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncEnabled, validationPending, operationInProgress, validationResult, validationError, onCancel, onConfirm, onValidate, onValidationReset }: SyncOptionsDialogProps) {
   const [revision, setRevision] = useState('')
   const [prune, setPrune] = useState(true)
   const [dryRun, setDryRun] = useState(false)
@@ -65,7 +66,8 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
   const [replace, setReplace] = useState(false)
   const [serverSideApply, setServerSideApply] = useState(false)
   const richResourceValidation = !!resource && !!onValidate
-  const optionsDisabled = !!pending || !!validationPending
+  const busy = !!pending || !!validationPending
+  const optionsDisabled = busy || !!operationInProgress
 
   // Reset on each open so a previous attempt's flags don't leak into the
   // next sync — easy footgun in modal-heavy flows.
@@ -95,7 +97,7 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
   }
 
   return (
-    <DialogPortal open={open} onClose={pending ? () => {} : onCancel} className="w-[480px]" closable={!pending}>
+    <DialogPortal open={open} onClose={busy ? () => {} : onCancel} className="w-[480px]" closable={!busy}>
       <div className="border-b border-theme-border px-4 py-3">
         <h2 className="text-sm font-semibold text-theme-text-primary">{resource ? 'Sync resource' : 'Sync application'}</h2>
         <p className="mt-0.5 break-all text-xs text-theme-text-tertiary">{appLabel}</p>
@@ -114,7 +116,7 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
                 </p>
                 {autoSyncEnabled && (
                   <p className="mt-2 border-t border-amber-500/20 pt-2 text-[11px] leading-relaxed text-theme-text-secondary">
-                    Auto-sync is enabled. Argo can reconcile this Application independently while validation runs; Validate does not pause automation.
+                    Auto-sync is enabled. Argo can reconcile this Application independently while the dry-run runs; a dry-run does not pause automation.
                   </p>
                 )}
               </div>
@@ -157,12 +159,17 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
         {richResourceValidation && (validationPending || validationResult || validationError) && (
           <ValidationResult pending={!!validationPending} result={validationResult} error={validationError} />
         )}
+        {richResourceValidation && !validationPending && operationInProgress && (
+          <p className="text-[11px] leading-relaxed text-theme-text-secondary">
+            Argo is finishing the current operation. Sync becomes available when it releases the operation slot.
+          </p>
+        )}
       </div>
       <div className="flex items-center justify-end gap-2 border-t border-theme-border bg-theme-base px-4 py-3">
         <button
           type="button"
           onClick={onCancel}
-          disabled={pending}
+          disabled={busy}
           className="rounded-md border border-theme-border bg-theme-surface px-3 py-1.5 text-xs text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           Cancel
@@ -176,7 +183,7 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
               className="inline-flex items-center gap-1.5 rounded-md border border-theme-border bg-theme-surface px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
               {validationPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
-              {validationPending ? 'Validating…' : 'Validate'}
+              {validationPending ? 'Running dry-run…' : 'Dry-run'}
             </button>
           </Tooltip>
         )}
@@ -192,7 +199,7 @@ function ValidationResult({ pending, result, error }: { pending: boolean; result
       <div className="card-inner flex items-start gap-2 px-3 py-2.5">
         <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-theme-text-secondary" />
         <div>
-          <div className="text-xs font-medium text-theme-text-primary">Validating with Argo</div>
+          <div className="text-xs font-medium text-theme-text-primary">Running selective dry-run</div>
           <p className="mt-0.5 text-[11px] text-theme-text-secondary">Waiting for the selective dry-run result. No resource changes will be applied.</p>
         </div>
       </div>
@@ -204,8 +211,8 @@ function ValidationResult({ pending, result, error }: { pending: boolean; result
         <div className="flex items-start gap-2">
           <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
           <div>
-            <div className="text-xs font-medium text-theme-text-primary">Validation could not start or complete</div>
-            <p className="mt-0.5 break-words text-[11px] text-theme-text-secondary">{error}</p>
+            <div className="text-xs font-medium text-theme-text-primary">Dry-run could not start or complete</div>
+            <p className="mt-0.5 max-h-20 overflow-auto break-words text-[11px] text-theme-text-secondary">{error}</p>
           </div>
         </div>
       </div>
@@ -229,9 +236,9 @@ function ValidationResult({ pending, result, error }: { pending: boolean; result
         <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${iconTone}`} />
         <div className="min-w-0">
           <div className="text-xs font-medium text-theme-text-primary">{title}</div>
-          <p className="mt-0.5 text-[11px] text-theme-text-secondary">{result.message}</p>
+          <p className="mt-0.5 max-h-20 overflow-auto break-words text-[11px] text-theme-text-secondary">{result.message}</p>
           {(result.resource?.status || result.resource?.message) && (
-            <div className="mt-2 break-all font-mono text-[10px] text-theme-text-secondary">
+            <div className="mt-2 max-h-28 overflow-auto break-all font-mono text-[10px] text-theme-text-secondary">
               {result.resource.status}{result.resource.status && result.resource.message ? ' — ' : ''}{result.resource.message}
             </div>
           )}

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
@@ -98,15 +98,15 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
     <DialogPortal open={open} onClose={pending ? () => {} : onCancel} className="w-[480px]" closable={!pending}>
       <div className="border-b border-theme-border px-4 py-3">
         <h2 className="text-sm font-semibold text-theme-text-primary">{resource ? 'Sync resource' : 'Sync application'}</h2>
-        <p className="mt-0.5 text-xs text-theme-text-tertiary">{appLabel}</p>
+        <p className="mt-0.5 break-all text-xs text-theme-text-tertiary">{appLabel}</p>
       </div>
       <div className="space-y-4 px-4 py-4 text-sm">
         {resource && (
           <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
             <div className="flex items-start gap-2">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-              <div>
-                <div className="text-xs font-medium text-theme-text-primary">
+              <div className="min-w-0">
+                <div className="break-all text-xs font-medium text-theme-text-primary">
                   {resource.kind} / {resource.namespace ? `${resource.namespace}/` : ''}{resource.name}
                 </div>
                 <p className="mt-1 text-[11px] leading-relaxed text-theme-text-secondary">
@@ -168,7 +168,7 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
           Cancel
         </button>
         {richResourceValidation && (
-          <Tooltip content="Runs an Argo selective dry-run for this resource. Applies nothing." wrapperClassName="inline-flex">
+          <Tooltip content="Runs an Argo selective dry-run. Applies nothing; API admission can still reject the real sync." wrapperClassName="inline-flex">
             <button
               type="button"
               onClick={validate}
@@ -216,7 +216,7 @@ function ValidationResult({ pending, result, error }: { pending: boolean; result
   const succeeded = result.outcome === 'succeeded'
   const inconclusive = result.outcome === 'inconclusive'
   const Icon = succeeded ? CheckCircle2 : inconclusive ? CircleAlert : XCircle
-  const title = succeeded ? 'Validation passed' : inconclusive ? 'Validation was inconclusive' : 'Validation failed'
+  const title = succeeded ? 'Dry-run passed' : inconclusive ? 'Dry-run was inconclusive' : 'Dry-run failed'
   const surface = succeeded
     ? 'border-emerald-500/30 bg-emerald-500/5'
     : inconclusive
@@ -231,7 +231,7 @@ function ValidationResult({ pending, result, error }: { pending: boolean; result
           <div className="text-xs font-medium text-theme-text-primary">{title}</div>
           <p className="mt-0.5 text-[11px] text-theme-text-secondary">{result.message}</p>
           {(result.resource?.status || result.resource?.message) && (
-            <div className="mt-2 font-mono text-[10px] text-theme-text-secondary">
+            <div className="mt-2 break-all font-mono text-[10px] text-theme-text-secondary">
               {result.resource.status}{result.resource.status && result.resource.message ? ' — ' : ''}{result.resource.message}
             </div>
           )}

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, CheckCircle2, CircleAlert, Loader2, RefreshCw, ShieldChe
 
 import { DialogPortal } from '../ui/DialogPortal'
 import { Input } from '../ui/Input'
+import { Tooltip } from '../ui/Tooltip'
 import type { GitOpsInsightRef } from '../../types/gitops-insights'
 
 // =============================================================================
@@ -167,15 +168,17 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncE
           Cancel
         </button>
         {richResourceValidation && (
-          <button
-            type="button"
-            onClick={validate}
-            disabled={optionsDisabled}
-            className="inline-flex items-center gap-1.5 rounded-md border border-theme-border bg-theme-surface px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {validationPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
-            {validationPending ? 'Validating…' : 'Validate'}
-          </button>
+          <Tooltip content="Runs an Argo selective dry-run for this resource. Applies nothing." wrapperClassName="inline-flex">
+            <button
+              type="button"
+              onClick={validate}
+              disabled={optionsDisabled}
+              className="inline-flex items-center gap-1.5 rounded-md border border-theme-border bg-theme-surface px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {validationPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
+              {validationPending ? 'Validating…' : 'Validate'}
+            </button>
+          </Tooltip>
         )}
         <PrimaryButton onClick={submit} disabled={optionsDisabled} icon={pending ? Loader2 : RefreshCw} loading={pending} label={dryRun && !richResourceValidation ? 'Run dry-run' : resource ? 'Sync resource' : 'Sync now'} />
       </div>

--- a/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
+++ b/packages/k8s-ui/src/components/gitops/SyncOptionsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type ComponentType } from 'react'
-import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, CircleAlert, Loader2, RefreshCw, ShieldCheck, XCircle } from 'lucide-react'
 
 import { DialogPortal } from '../ui/DialogPortal'
 import { Input } from '../ui/Input'
@@ -36,11 +36,26 @@ export interface SyncOptionsDialogProps {
   appLabel: string
   resource?: GitOpsInsightRef
   pending?: boolean
+  autoSyncEnabled?: boolean
+  validationPending?: boolean
+  validationResult?: ResourceValidationResult | null
+  validationError?: string | null
   onCancel: () => void
   onConfirm: (opts: ArgoSyncOpts) => void
+  onValidate?: (opts: ArgoSyncOpts) => void
+  onValidationReset?: () => void
 }
 
-export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel, onConfirm }: SyncOptionsDialogProps) {
+export interface ResourceValidationResult {
+  outcome: 'succeeded' | 'failed' | 'inconclusive'
+  message: string
+  resource?: {
+    status?: string
+    message?: string
+  }
+}
+
+export function SyncOptionsDialog({ open, appLabel, resource, pending, autoSyncEnabled, validationPending, validationResult, validationError, onCancel, onConfirm, onValidate, onValidationReset }: SyncOptionsDialogProps) {
   const [revision, setRevision] = useState('')
   const [prune, setPrune] = useState(true)
   const [dryRun, setDryRun] = useState(false)
@@ -48,6 +63,8 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
   const [applyOnly, setApplyOnly] = useState(false)
   const [replace, setReplace] = useState(false)
   const [serverSideApply, setServerSideApply] = useState(false)
+  const richResourceValidation = !!resource && !!onValidate
+  const optionsDisabled = !!pending || !!validationPending
 
   // Reset on each open so a previous attempt's flags don't leak into the
   // next sync — easy footgun in modal-heavy flows.
@@ -64,7 +81,16 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
   }, [open, resource])
 
   function submit() {
-    onConfirm(buildArgoSyncOpts({ resourceMode: !!resource, revision, prune, dryRun, force, applyOnly, replace, serverSideApply }))
+    onConfirm(buildArgoSyncOpts({ resourceMode: !!resource, revision, prune, dryRun: richResourceValidation ? false : dryRun, force, applyOnly, replace, serverSideApply }))
+  }
+
+  function validate() {
+    onValidate?.(buildArgoSyncOpts({ resourceMode: true, revision, prune, dryRun: true, force, applyOnly, replace, serverSideApply }))
+  }
+
+  function updateValidationOption(setter: (value: boolean) => void, value: boolean) {
+    setter(value)
+    onValidationReset?.()
   }
 
   return (
@@ -85,6 +111,11 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
                 <p className="mt-1 text-[11px] leading-relaxed text-theme-text-secondary">
                   Only this resource will be applied. Selective sync bypasses hooks and normal sync-wave ordering; use a full application sync when this resource depends on them.
                 </p>
+                {autoSyncEnabled && (
+                  <p className="mt-2 border-t border-amber-500/20 pt-2 text-[11px] leading-relaxed text-theme-text-secondary">
+                    Auto-sync is enabled. Argo can reconcile this Application independently while validation runs; Validate does not pause automation.
+                  </p>
+                )}
               </div>
             </div>
           </div>
@@ -96,7 +127,7 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
               value={revision}
               onChange={(e) => setRevision(e.target.value)}
               placeholder="HEAD"
-              disabled={pending}
+              disabled={optionsDisabled}
               className="mt-1 w-full rounded-md border border-theme-border bg-theme-base px-2 py-1.5 font-mono text-xs text-theme-text-primary outline-none placeholder:text-theme-text-tertiary focus:border-sky-500"
             />
             <span className="mt-0.5 block text-[11px] text-theme-text-tertiary">
@@ -108,18 +139,23 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
         {/* Common (Prune / Dry run) sit above a divider; Advanced toggles
             stay accessible but visually subordinate so the common-case user
             can scan past them without parsing every helper line. */}
-        <fieldset className="space-y-2">
-          <legend className="mb-1 text-xs font-medium text-theme-text-secondary">Sync options</legend>
-          {!resource && <Toggle label="Prune" checked={prune} onChange={setPrune} disabled={pending} hint="Delete resources that are no longer in Git." />}
-          <Toggle label="Dry run" checked={dryRun} onChange={setDryRun} disabled={pending} hint="Preview only — Argo computes the diff but applies nothing." />
-        </fieldset>
+        {!richResourceValidation && (
+          <fieldset className="space-y-2">
+            <legend className="mb-1 text-xs font-medium text-theme-text-secondary">Sync options</legend>
+            {!resource && <Toggle label="Prune" checked={prune} onChange={setPrune} disabled={optionsDisabled} hint="Delete resources that are no longer in Git." />}
+            <Toggle label="Dry run" checked={dryRun} onChange={setDryRun} disabled={optionsDisabled} hint="Preview only — Argo computes the diff but applies nothing." />
+          </fieldset>
+        )}
         <fieldset className="space-y-2 border-t border-theme-border pt-3">
           <legend className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">Advanced</legend>
-          {!resource && <Toggle label="Apply only" checked={applyOnly} onChange={setApplyOnly} disabled={pending} hint="Skip PreSync / PostSync / SyncFail hooks." />}
-          <Toggle label="Force" checked={force} onChange={setForce} disabled={pending} hint="Use kubectl --force; required for some immutable-field changes." />
-          <Toggle label="Replace" checked={replace} onChange={setReplace} disabled={pending} hint="kubectl replace instead of apply (drops fields not in source)." />
-          <Toggle label="Server-side apply" checked={serverSideApply} onChange={setServerSideApply} disabled={pending} hint="Use the K8s server-side apply mechanism for ownership tracking." />
+          {!resource && <Toggle label="Apply only" checked={applyOnly} onChange={setApplyOnly} disabled={optionsDisabled} hint="Skip PreSync / PostSync / SyncFail hooks." />}
+          <Toggle label="Force" checked={force} onChange={(value) => updateValidationOption(setForce, value)} disabled={optionsDisabled} hint="Use kubectl --force; required for some immutable-field changes." />
+          <Toggle label="Replace" checked={replace} onChange={(value) => updateValidationOption(setReplace, value)} disabled={optionsDisabled} hint="kubectl replace instead of apply (drops fields not in source)." />
+          <Toggle label="Server-side apply" checked={serverSideApply} onChange={(value) => updateValidationOption(setServerSideApply, value)} disabled={optionsDisabled} hint="Use the K8s server-side apply mechanism for ownership tracking." />
         </fieldset>
+        {richResourceValidation && (validationPending || validationResult || validationError) && (
+          <ValidationResult pending={!!validationPending} result={validationResult} error={validationError} />
+        )}
       </div>
       <div className="flex items-center justify-end gap-2 border-t border-theme-border bg-theme-base px-4 py-3">
         <button
@@ -130,9 +166,75 @@ export function SyncOptionsDialog({ open, appLabel, resource, pending, onCancel,
         >
           Cancel
         </button>
-        <PrimaryButton onClick={submit} disabled={pending} icon={pending ? Loader2 : RefreshCw} loading={pending} label={dryRun ? 'Run dry-run' : resource ? 'Sync resource' : 'Sync now'} />
+        {richResourceValidation && (
+          <button
+            type="button"
+            onClick={validate}
+            disabled={optionsDisabled}
+            className="inline-flex items-center gap-1.5 rounded-md border border-theme-border bg-theme-surface px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {validationPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
+            {validationPending ? 'Validating…' : 'Validate'}
+          </button>
+        )}
+        <PrimaryButton onClick={submit} disabled={optionsDisabled} icon={pending ? Loader2 : RefreshCw} loading={pending} label={dryRun && !richResourceValidation ? 'Run dry-run' : resource ? 'Sync resource' : 'Sync now'} />
       </div>
     </DialogPortal>
+  )
+}
+
+function ValidationResult({ pending, result, error }: { pending: boolean; result?: ResourceValidationResult | null; error?: string | null }) {
+  if (pending) {
+    return (
+      <div className="card-inner flex items-start gap-2 px-3 py-2.5">
+        <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-theme-text-secondary" />
+        <div>
+          <div className="text-xs font-medium text-theme-text-primary">Validating with Argo</div>
+          <p className="mt-0.5 text-[11px] text-theme-text-secondary">Waiting for the selective dry-run result. No resource changes will be applied.</p>
+        </div>
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2.5">
+        <div className="flex items-start gap-2">
+          <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+          <div>
+            <div className="text-xs font-medium text-theme-text-primary">Validation could not start or complete</div>
+            <p className="mt-0.5 break-words text-[11px] text-theme-text-secondary">{error}</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  if (!result) return null
+
+  const succeeded = result.outcome === 'succeeded'
+  const inconclusive = result.outcome === 'inconclusive'
+  const Icon = succeeded ? CheckCircle2 : inconclusive ? CircleAlert : XCircle
+  const title = succeeded ? 'Validation passed' : inconclusive ? 'Validation was inconclusive' : 'Validation failed'
+  const surface = succeeded
+    ? 'border-emerald-500/30 bg-emerald-500/5'
+    : inconclusive
+      ? 'border-amber-500/30 bg-amber-500/5'
+      : 'border-red-500/30 bg-red-500/5'
+  const iconTone = succeeded ? 'text-emerald-500' : inconclusive ? 'text-amber-500' : 'text-red-500'
+  return (
+    <div className={`rounded-md border px-3 py-2.5 ${surface}`}>
+      <div className="flex items-start gap-2">
+        <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${iconTone}`} />
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-theme-text-primary">{title}</div>
+          <p className="mt-0.5 text-[11px] text-theme-text-secondary">{result.message}</p>
+          {(result.resource?.status || result.resource?.message) && (
+            <div className="mt-2 font-mono text-[10px] text-theme-text-secondary">
+              {result.resource.status}{result.resource.status && result.resource.message ? ' — ' : ''}{result.resource.message}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ArrowUpDown, ChevronDown, ChevronRight, ChevronUp, CircleAlert, Clock3, GitBranch, GitCommit, Info, Loader2, Plus, Trash2 } from 'lucide-react'
+import { AlertTriangle, ArrowUpDown, ChevronDown, ChevronRight, ChevronUp, CircleAlert, Clock3, GitBranch, GitCommit, Info, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { PaneLoader } from '../../ui/PaneLoader'
 import { clsx } from 'clsx'
 import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
@@ -20,6 +20,7 @@ import {
   entryTone,
   gitopsToSeverity,
   healthStatusRank,
+  isArgoResourceSyncEligible,
   messageToPhase,
   normalizeHealthStatus,
   normalizeSyncStatus,
@@ -703,6 +704,8 @@ interface GitOpsChangesViewProps {
   insight?: GitOpsInsight | null
   error?: Error | null
   onOpenResource?: (ref: GitOpsChange['ref']) => void
+  onSyncResource?: (ref: GitOpsChange['ref']) => void
+  syncResourceDisabledReason?: string
   // When set, the matching change row scrolls into view and gets a transient
   // highlight ring. Used when the user clicks "View →" on an issue alert in
   // the band above. Key shape: `${kind}/${namespace||''}/${name}` (group is
@@ -724,7 +727,7 @@ const STATUS_FACETS: { key: ResourceStatusFacet; label: string; tone: FilterPill
   { key: 'missing', label: 'Missing', tone: 'danger' },
 ]
 
-export function GitOpsChangesView({ insight, error, onOpenResource, focusKey, tree }: GitOpsChangesViewProps) {
+export function GitOpsChangesView({ insight, error, onOpenResource, onSyncResource, syncResourceDisabledReason, focusKey, tree }: GitOpsChangesViewProps) {
   // "All resources" toggle: when on, render generated descendants alongside
   // the controller's declared inventory. Argo's UI defaults to "all" — we
   // default to "declared" because the diagnostic data (drift, events) lives
@@ -741,6 +744,9 @@ export function GitOpsChangesView({ insight, error, onOpenResource, focusKey, tr
   const [statusFilters, setStatusFilters] = useState<Set<ResourceStatusFacet>>(new Set())
   const [sort, setSort] = useState<{ key: ResourceSortKey; dir: SortDir }>({ key: 'order', dir: 'asc' })
   const changes = insight?.changes ?? []
+  // Keep object identity here: tree extras are newly allocated, while ordered
+  // controller changes retain their original references.
+  const declaredChanges = new Set(changes)
   const plan = insight?.plan ?? []
   // Synthesize Change rows for generated tree nodes that aren't already in
   // the declared inventory. These rows carry less diagnostic data — no
@@ -1006,6 +1012,9 @@ export function GitOpsChangesView({ insight, error, onOpenResource, focusKey, tr
                       autoExpand={focused}
                       hasInlineDetail={hasInlineDetail}
                       onOpenResource={onOpenResource}
+                      onSyncResource={onSyncResource}
+                      syncResourceDisabledReason={syncResourceDisabledReason}
+                      declared={declaredChanges.has(change)}
                       sourceTreeURL={sourceTreeURL}
                       registerRef={(el) => {
                         if (el) {
@@ -1178,6 +1187,9 @@ function ChangeRow({
   autoExpand,
   hasInlineDetail,
   onOpenResource,
+  onSyncResource,
+  syncResourceDisabledReason,
+  declared,
   sourceTreeURL,
   registerRef,
 }: {
@@ -1191,6 +1203,9 @@ function ChangeRow({
   autoExpand: boolean
   hasInlineDetail: boolean
   onOpenResource?: (ref: GitOpsChange['ref']) => void
+  onSyncResource?: (ref: GitOpsChange['ref']) => void
+  syncResourceDisabledReason?: string
+  declared: boolean
   // Constructed URL pointing at the source directory in the remote Git
   // host (github / gitlab / bitbucket). Used as the "where this would be
   // declared" affordance on Missing rows, since opening the drawer for a
@@ -1224,6 +1239,18 @@ function ChangeRow({
   // intentionally non-interactive — there's nowhere useful to go.
   const rowInteractive = hasInlineDetail || (!isAbsent && !!onOpenResource)
   const hookLabel = change.hookPhase || hook
+  const canSyncResource = !!onSyncResource && isArgoResourceSyncEligible(change, declared, hookLabel)
+  const syncResourceButton = canSyncResource ? (
+    <button
+      type="button"
+      onClick={() => onSyncResource(change.ref)}
+      disabled={!!syncResourceDisabledReason}
+      className="inline-flex w-full items-center justify-center gap-1.5 rounded border border-theme-border bg-theme-base px-2 py-1 text-[11px] font-medium text-theme-text-secondary transition-colors hover:bg-theme-hover hover:text-theme-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <RefreshCw className="h-3 w-3" />
+      Sync resource
+    </button>
+  ) : null
   return (
     <div
       ref={registerRef}
@@ -1299,7 +1326,12 @@ function ChangeRow({
         </button>
         <div className="self-start"><SyncStatusBadge sync={normalizeSyncStatus(change.sync ?? change.category)} /></div>
         <div className="self-start"><HealthStatusBadge health={normalizeHealthStatus(change.health)} /></div>
-        <div className="self-start">
+        <div className="self-start space-y-1.5">
+          {syncResourceButton && syncResourceDisabledReason ? (
+            <Tooltip content={syncResourceDisabledReason} delay={200} wrapperClassName="block">
+              {syncResourceButton}
+            </Tooltip>
+          ) : syncResourceButton}
           {/* Three affordance states:
               - Live resource (not Missing): "Open <kind> <name> →" opens the
                 K8s drawer.

--- a/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
@@ -284,7 +284,7 @@ function TerminatingStatusStrip({ summary }: { summary: NonNullable<GitOpsInsigh
 
 function isInFlightPhase(phase: string): boolean {
   const p = phase.toLowerCase()
-  return p.includes('running') || p.includes('progress') || p.includes('reconcil')
+  return p.includes('running') || p.includes('terminat') || p.includes('progress') || p.includes('reconcil')
 }
 
 // Show the operation chip only for phases the operator needs to *act on*.

--- a/packages/k8s-ui/src/components/gitops/insights/insights-helpers.test.ts
+++ b/packages/k8s-ui/src/components/gitops/insights/insights-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   entryTone,
   gitopsToSeverity,
   healthStatusRank,
+  isArgoResourceSyncEligible,
   messageToPhase,
   phaseToTone,
   resourceStatusCounts,
@@ -168,6 +169,21 @@ describe('resourceStatusCounts', () => {
       change({ ref: { kind: 'ConfigMap', name: 'd' }, sync: 'Synced', health: 'Healthy' }),
     ])
     expect(counts).toEqual({ outOfSync: 2, degraded: 1, missing: 1 })
+  })
+})
+
+describe('isArgoResourceSyncEligible', () => {
+  const outOfSync = change({ ref: { group: 'apps', kind: 'Deployment', namespace: 'demo', name: 'web' }, sync: 'OutOfSync' })
+
+  it('allows declared OutOfSync and Missing resources', () => {
+    expect(isArgoResourceSyncEligible(outOfSync, true)).toBe(true)
+    expect(isArgoResourceSyncEligible(change({ ref: { kind: 'Service', name: 'missing' }, health: 'Missing' }), true)).toBe(true)
+  })
+
+  it('excludes generated, hook, and already-synced resources', () => {
+    expect(isArgoResourceSyncEligible(outOfSync, false)).toBe(false)
+    expect(isArgoResourceSyncEligible(outOfSync, true, 'PreSync')).toBe(false)
+    expect(isArgoResourceSyncEligible(change({ ref: { kind: 'Service', name: 'ready' }, sync: 'Synced', health: 'Healthy' }), true)).toBe(false)
   })
 })
 

--- a/packages/k8s-ui/src/components/gitops/insights/insights-helpers.ts
+++ b/packages/k8s-ui/src/components/gitops/insights/insights-helpers.ts
@@ -46,6 +46,11 @@ export function changeHealth(change: GitOpsChange): GitOpsHealthStatus {
   return normalizeHealthStatus(change.health)
 }
 
+export function isArgoResourceSyncEligible(change: GitOpsChange, declared: boolean, hook?: string): boolean {
+  if (!declared || hook || change.hookPhase) return false
+  return changeSync(change) === 'OutOfSync' || changeHealth(change) === 'Missing' || change.category === 'Missing'
+}
+
 // Rank sync/health so an ascending sort surfaces the states an operator cares
 // about first (drift, then failures). Mirrors the GitOps application table's
 // syncRank/healthRank so the two tables order status the same way.

--- a/packages/k8s-ui/src/components/resources/resource-utils-argo.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-argo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getArgoApplicationStatus } from './resource-utils-argo'
+import { getArgoApplicationStatus, isArgoOperationInProgress } from './resource-utils-argo'
 
 describe('getArgoApplicationStatus', () => {
   // A Suspended Argo app is intentionally paused — neutral (sky), matching the
@@ -19,5 +19,22 @@ describe('getArgoApplicationStatus', () => {
   it('still maps a degraded app to unhealthy', () => {
     const badge = getArgoApplicationStatus({ status: { health: { status: 'Degraded' }, sync: { status: 'Synced' } } })
     expect(badge.level).toBe('unhealthy')
+  })
+
+  it('surfaces an operation being terminated', () => {
+    const badge = getArgoApplicationStatus({ status: { operationState: { phase: 'Terminating' } } })
+    expect(badge.level).toBe('degraded')
+    expect(badge.text).toBe('Terminating')
+  })
+})
+
+describe('isArgoOperationInProgress', () => {
+  it.each([
+    [{ status: { operationState: { phase: 'Running' } } }, true],
+    [{ status: { operationState: { phase: 'Terminating' } } }, true],
+    [{ operation: { sync: {} }, status: { operationState: { phase: 'Succeeded' } } }, true],
+    [{ status: { operationState: { phase: 'Succeeded' } } }, false],
+  ])('maps %o to %s', (app, expected) => {
+    expect(isArgoOperationInProgress(app)).toBe(expected)
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-argo.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-argo.ts
@@ -33,6 +33,9 @@ export function getArgoApplicationStatus(app: any): StatusBadge {
   if (opPhase === 'Running') {
     return { text: 'Syncing', color: healthColors.degraded, level: 'degraded' }
   }
+  if (opPhase === 'Terminating') {
+    return { text: 'Terminating', color: healthColors.degraded, level: 'degraded' }
+  }
 
   // Failed operation
   if (opPhase === 'Failed' || opPhase === 'Error') {
@@ -59,6 +62,11 @@ export function getArgoApplicationStatus(app: any): StatusBadge {
   }
 
   return { text: health || sync || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function isArgoOperationInProgress(app: any): boolean {
+  const phase = app?.status?.operationState?.phase
+  return app?.operation != null || phase === 'Running' || phase === 'Terminating'
 }
 
 // Radar suspends an Argo Application by clearing spec.syncPolicy.automated and

--- a/packages/k8s-ui/src/types/gitops.ts
+++ b/packages/k8s-ui/src/types/gitops.ts
@@ -254,7 +254,7 @@ export interface ArgoAppStatus {
  * ArgoCD status patterns:
  * - sync.status: Synced, OutOfSync, Unknown
  * - health.status: Healthy, Progressing, Degraded, Suspended, Missing, Unknown
- * - operationState.phase: Running, Succeeded, Failed, Error
+ * - operationState.phase: Running, Terminating, Succeeded, Failed, Error
  */
 export function argoStatusToGitOpsStatus(status: ArgoAppStatus): GitOpsStatus {
   const syncStatus = status.sync?.status
@@ -267,7 +267,7 @@ export function argoStatusToGitOpsStatus(status: ArgoAppStatus): GitOpsStatus {
     sync = 'Synced'
   } else if (syncStatus === 'OutOfSync') {
     sync = 'OutOfSync'
-  } else if (opPhase === 'Running') {
+  } else if (opPhase === 'Running' || opPhase === 'Terminating') {
     sync = 'Reconciling'
   }
 
@@ -288,7 +288,7 @@ export function argoStatusToGitOpsStatus(status: ArgoAppStatus): GitOpsStatus {
   }
 
   // Override with operation state if active
-  if (opPhase === 'Running') {
+  if (opPhase === 'Running' || opPhase === 'Terminating') {
     health = 'Progressing'
   } else if (opPhase === 'Failed' || opPhase === 'Error') {
     health = 'Degraded'

--- a/pkg/gitops/operations.go
+++ b/pkg/gitops/operations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -172,6 +173,21 @@ type ArgoSyncOptions struct {
 	SyncOptions []string           `json:"syncOptions,omitempty"`
 }
 
+type ArgoResourceValidationResult struct {
+	Outcome  string                        `json:"outcome"`
+	Message  string                        `json:"message"`
+	Resource *ArgoResourceValidationTarget `json:"resource,omitempty"`
+}
+
+type ArgoResourceValidationTarget struct {
+	Group     string `json:"group,omitempty"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Status    string `json:"status,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
 // ArgoRollbackOptions controls an ArgoCD rollback operation. ID is the
 // history entry to roll back to (matches HistoryItem.ID surfaced by the
 // insights builder). Argo's rollback uses the same operation slot as sync
@@ -186,6 +202,10 @@ type ArgoRollbackOptions struct {
 
 // SyncArgoApp triggers a sync operation on an ArgoCD Application.
 func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions) (OperationResult, error) {
+	return syncArgoApp(ctx, dynClient, namespace, name, opts, "", false)
+}
+
+func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions, validationID string, rejectQueued bool) (OperationResult, error) {
 	app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -201,6 +221,11 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
 	if found && phase == "Running" {
 		return OperationResult{}, fmt.Errorf("sync operation already in progress for %s/%s: %w", namespace, name, ErrOperationInProgress)
+	}
+	if rejectQueued {
+		if operation, found, _ := unstructured.NestedFieldNoCopy(app.Object, "operation"); found && operation != nil {
+			return OperationResult{}, fmt.Errorf("sync operation already queued for %s/%s: %w", namespace, name, ErrOperationInProgress)
+		}
 	}
 
 	timestamp := time.Now().Format(time.RFC3339Nano)
@@ -258,18 +283,28 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 			sync["resources"] = resources
 		}
 	}
+	operation := map[string]any{
+		"initiatedBy": map[string]any{
+			"username": "radar",
+		},
+		"sync": sync,
+	}
+	if validationID != "" {
+		operation["info"] = []any{map[string]any{
+			"name":  "radar-validation-id",
+			"value": validationID,
+		}}
+	}
 	patch := map[string]any{
-		"metadata": map[string]any{
+		"operation": operation,
+	}
+	dryRun := opts.DryRun != nil && *opts.DryRun
+	if !dryRun {
+		patch["metadata"] = map[string]any{
 			"annotations": map[string]string{
 				"argocd.argoproj.io/refresh": "hard",
 			},
-		},
-		"operation": map[string]any{
-			"initiatedBy": map[string]any{
-				"username": "radar",
-			},
-			"sync": sync,
-		},
+		}
 	}
 
 	if err := mergePatch(ctx, dynClient, argoAppGVR, namespace, name, patch); err != nil {
@@ -285,6 +320,115 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 		Name:        name,
 		RequestedAt: timestamp,
 	}, nil
+}
+
+func ValidateArgoResource(ctx context.Context, dynClient dynamic.Interface, namespace, name string, resource ArgoSyncResource, opts ArgoSyncOptions) (ArgoResourceValidationResult, error) {
+	if resource.Kind == "" || resource.Name == "" {
+		return ArgoResourceValidationResult{}, errors.New("validation requires a resource kind and name")
+	}
+	validationID := uuid.NewString()
+	falseValue := false
+	trueValue := true
+	opts.Resources = []ArgoSyncResource{resource}
+	opts.Revision = ""
+	opts.Prune = &falseValue
+	opts.DryRun = &trueValue
+	opts.ApplyOnly = &falseValue
+	if _, err := syncArgoApp(ctx, dynClient, namespace, name, opts, validationID, true); err != nil {
+		return ArgoResourceValidationResult{}, err
+	}
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return ArgoResourceValidationResult{}, fmt.Errorf("ArgoCD Application %s/%s not found while validating: %w", namespace, name, err)
+			}
+			return ArgoResourceValidationResult{}, fmt.Errorf("failed to read Application validation result: %w", err)
+		}
+		if err := assertNotTerminating(app, "ArgoCD Application", namespace, name); err != nil {
+			return ArgoResourceValidationResult{}, err
+		}
+		if result, done := argoResourceValidationResult(app, validationID, resource); done {
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ArgoResourceValidationResult{}, fmt.Errorf("timed out waiting for ArgoCD validation result: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func argoResourceValidationResult(app *unstructured.Unstructured, validationID string, target ArgoSyncResource) (ArgoResourceValidationResult, bool) {
+	operation, found, _ := unstructured.NestedMap(app.Object, "status", "operationState", "operation")
+	if !found || !argoOperationHasInfo(operation, "radar-validation-id", validationID) {
+		return ArgoResourceValidationResult{}, false
+	}
+	phase, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+	if phase == "" || phase == "Running" {
+		return ArgoResourceValidationResult{}, false
+	}
+
+	message, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "message")
+	resources, _, _ := unstructured.NestedSlice(app.Object, "status", "operationState", "syncResult", "resources")
+	for _, item := range resources {
+		entry, ok := item.(map[string]any)
+		if !ok || !argoResourceResultMatches(entry, target) {
+			continue
+		}
+		resource := &ArgoResourceValidationTarget{
+			Group:     stringValue(entry["group"]),
+			Kind:      stringValue(entry["kind"]),
+			Namespace: stringValue(entry["namespace"]),
+			Name:      stringValue(entry["name"]),
+			Status:    stringValue(entry["status"]),
+			Message:   stringValue(entry["message"]),
+		}
+		if phase == "Succeeded" {
+			return ArgoResourceValidationResult{Outcome: "succeeded", Message: "Argo validated the resource without applying changes.", Resource: resource}, true
+		}
+		if message == "" {
+			message = resource.Message
+		}
+		return ArgoResourceValidationResult{Outcome: "failed", Message: message, Resource: resource}, true
+	}
+	if phase == "Succeeded" {
+		return ArgoResourceValidationResult{Outcome: "inconclusive", Message: "Argo completed the dry-run but did not report a result for the selected resource."}, true
+	}
+	if message == "" {
+		message = fmt.Sprintf("Argo validation finished with phase %s.", phase)
+	}
+	return ArgoResourceValidationResult{Outcome: "failed", Message: message}, true
+}
+
+func argoOperationHasInfo(operation map[string]any, name, value string) bool {
+	info, ok := operation["info"].([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range info {
+		entry, ok := item.(map[string]any)
+		if ok && entry["name"] == name && entry["value"] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func argoResourceResultMatches(entry map[string]any, target ArgoSyncResource) bool {
+	return stringValue(entry["group"]) == target.Group &&
+		stringValue(entry["kind"]) == target.Kind &&
+		stringValue(entry["namespace"]) == target.Namespace &&
+		stringValue(entry["name"]) == target.Name
+}
+
+func stringValue(value any) string {
+	result, _ := value.(string)
+	return result
 }
 
 // SetArgoAutoSync enables or disables automated sync on an ArgoCD Application.

--- a/pkg/gitops/operations.go
+++ b/pkg/gitops/operations.go
@@ -420,10 +420,12 @@ func argoOperationHasInfo(operation map[string]any, name, value string) bool {
 }
 
 func argoResourceResultMatches(entry map[string]any, target ArgoSyncResource) bool {
-	return stringValue(entry["group"]) == target.Group &&
-		stringValue(entry["kind"]) == target.Kind &&
-		stringValue(entry["namespace"]) == target.Namespace &&
-		stringValue(entry["name"]) == target.Name
+	if stringValue(entry["group"]) != target.Group ||
+		stringValue(entry["kind"]) != target.Kind ||
+		stringValue(entry["name"]) != target.Name {
+		return false
+	}
+	return target.Namespace == "" || stringValue(entry["namespace"]) == target.Namespace
 }
 
 func stringValue(value any) string {

--- a/pkg/gitops/operations.go
+++ b/pkg/gitops/operations.go
@@ -43,6 +43,9 @@ var (
 	// ErrNoOperationInProgress: a terminate couldn't fire because there
 	// was no active operation. HTTP 400.
 	ErrNoOperationInProgress = errors.New("no operation in progress")
+	// ErrInvalidResourceSelection: a requested selective sync contains an
+	// incomplete resource identity. HTTP 400.
+	ErrInvalidResourceSelection = errors.New("invalid resource selection")
 	// ErrHistoryEntryNotFound: the requested rollback target id isn't in
 	// status.history. HTTP 404.
 	ErrHistoryEntryNotFound = errors.New("history entry not found")
@@ -215,6 +218,12 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 }
 
 func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions, validationID string) (OperationResult, error) {
+	for i, resource := range opts.Resources {
+		if resource.Kind == "" || resource.Name == "" {
+			return OperationResult{}, fmt.Errorf("sync resource %d requires kind and name: %w", i+1, ErrInvalidResourceSelection)
+		}
+	}
+
 	app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -272,9 +281,6 @@ func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 	if len(opts.Resources) > 0 {
 		resources := make([]map[string]any, 0, len(opts.Resources))
 		for _, res := range opts.Resources {
-			if res.Kind == "" || res.Name == "" {
-				continue
-			}
 			resources = append(resources, map[string]any{
 				"group":     res.Group,
 				"kind":      res.Kind,
@@ -282,9 +288,7 @@ func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 				"name":      res.Name,
 			})
 		}
-		if len(resources) > 0 {
-			sync["resources"] = resources
-		}
+		sync["resources"] = resources
 	}
 	operation := map[string]any{
 		"initiatedBy": map[string]any{
@@ -300,10 +304,14 @@ func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 	}
 	patch := map[string]any{
 		"operation": operation,
+		"metadata": map[string]any{
+			"resourceVersion": app.GetResourceVersion(),
+		},
 	}
 	dryRun := opts.DryRun != nil && *opts.DryRun
 	if !dryRun {
 		patch["metadata"] = map[string]any{
+			"resourceVersion": app.GetResourceVersion(),
 			"annotations": map[string]string{
 				"argocd.argoproj.io/refresh": "hard",
 			},
@@ -311,6 +319,9 @@ func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 	}
 
 	if err := mergePatch(ctx, dynClient, argoAppGVR, namespace, name, patch); err != nil {
+		if apierrors.IsConflict(err) {
+			return OperationResult{}, fmt.Errorf("Application changed before sync could start for %s/%s: %w", namespace, name, ErrOperationInProgress)
+		}
 		return OperationResult{}, fmt.Errorf("failed to sync Application %s/%s: %w", namespace, name, err)
 	}
 
@@ -595,9 +606,6 @@ func TerminateArgoSync(ctx context.Context, dynClient dynamic.Interface, namespa
 	timestamp := time.Now().Format(time.RFC3339Nano)
 	message := "Termination requested"
 	patch := make([]map[string]any, 0, 4)
-	if resourceVersion := app.GetResourceVersion(); resourceVersion != "" {
-		patch = append(patch, map[string]any{"op": "test", "path": "/metadata/resourceVersion", "value": resourceVersion})
-	}
 	patch = append(patch, map[string]any{"op": "test", "path": "/status/operationState/phase", "value": "Running"})
 	if operationFound && operation != nil {
 		patch = append(patch,
@@ -695,6 +703,7 @@ func RollbackArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace
 		rollback["dryRun"] = *opts.DryRun
 	}
 	patch := map[string]any{
+		"metadata": map[string]any{"resourceVersion": app.GetResourceVersion()},
 		"operation": map[string]any{
 			"initiatedBy": map[string]any{"username": "radar"},
 			"rollback":    rollback,
@@ -702,6 +711,9 @@ func RollbackArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace
 	}
 
 	if err := mergePatch(ctx, dynClient, argoAppGVR, namespace, name, patch); err != nil {
+		if apierrors.IsConflict(err) {
+			return OperationResult{}, fmt.Errorf("Application changed before rollback could start for %s/%s: %w", namespace, name, ErrOperationInProgress)
+		}
 		return OperationResult{}, fmt.Errorf("failed to rollback Application %s/%s: %w", namespace, name, err)
 	}
 

--- a/pkg/gitops/operations.go
+++ b/pkg/gitops/operations.go
@@ -41,7 +41,7 @@ var (
 	// Application already has an in-flight operation. HTTP 409.
 	ErrOperationInProgress = errors.New("operation already in progress")
 	// ErrNoOperationInProgress: a terminate couldn't fire because there
-	// was no operation to remove. HTTP 400.
+	// was no active operation. HTTP 400.
 	ErrNoOperationInProgress = errors.New("no operation in progress")
 	// ErrHistoryEntryNotFound: the requested rollback target id isn't in
 	// status.history. HTTP 404.
@@ -53,8 +53,8 @@ var (
 	// frontend can show a tailored "resource is pending deletion" toast
 	// instead of bubbling up a generic K8s error message. Read-only verbs
 	// (Argo Refresh) and op-cancel (Argo Terminate) are *not* gated by this
-	// check — refresh just re-reads from Git, terminate just clears an
-	// in-flight op record; both are harmless on a Terminating resource.
+	// check — refresh just re-reads from Git, while terminate asks Argo to
+	// stop its in-flight operation; both are harmless on a Terminating resource.
 	ErrResourceTerminating = errors.New("resource is pending deletion")
 )
 
@@ -82,6 +82,15 @@ func assertNotTerminating(obj *unstructured.Unstructured, kind, namespace, name 
 		suffix = fmt.Sprintf(" (finalizers: %s)", strings.Join(finalizers, ", "))
 	}
 	return fmt.Errorf("%s %s/%s is being deleted%s: %w", kind, namespace, name, suffix, ErrResourceTerminating)
+}
+
+func argoOperationInProgress(app *unstructured.Unstructured) bool {
+	operation, found, _ := unstructured.NestedFieldNoCopy(app.Object, "operation")
+	if found && operation != nil {
+		return true
+	}
+	phase, _, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+	return phase == "Running" || phase == "Terminating"
 }
 
 // argoAppGVR is the GVR for ArgoCD Application resources.
@@ -202,10 +211,10 @@ type ArgoRollbackOptions struct {
 
 // SyncArgoApp triggers a sync operation on an ArgoCD Application.
 func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions) (OperationResult, error) {
-	return syncArgoApp(ctx, dynClient, namespace, name, opts, "", false)
+	return syncArgoApp(ctx, dynClient, namespace, name, opts, "")
 }
 
-func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions, validationID string, rejectQueued bool) (OperationResult, error) {
+func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string, opts ArgoSyncOptions, validationID string) (OperationResult, error) {
 	app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -218,14 +227,8 @@ func syncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, na
 		return OperationResult{}, err
 	}
 
-	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
-	if found && phase == "Running" {
+	if argoOperationInProgress(app) {
 		return OperationResult{}, fmt.Errorf("sync operation already in progress for %s/%s: %w", namespace, name, ErrOperationInProgress)
-	}
-	if rejectQueued {
-		if operation, found, _ := unstructured.NestedFieldNoCopy(app.Object, "operation"); found && operation != nil {
-			return OperationResult{}, fmt.Errorf("sync operation already queued for %s/%s: %w", namespace, name, ErrOperationInProgress)
-		}
 	}
 
 	timestamp := time.Now().Format(time.RFC3339Nano)
@@ -334,7 +337,7 @@ func ValidateArgoResource(ctx context.Context, dynClient dynamic.Interface, name
 	opts.Prune = &falseValue
 	opts.DryRun = &trueValue
 	opts.ApplyOnly = &falseValue
-	if _, err := syncArgoApp(ctx, dynClient, namespace, name, opts, validationID, true); err != nil {
+	if _, err := syncArgoApp(ctx, dynClient, namespace, name, opts, validationID); err != nil {
 		return ArgoResourceValidationResult{}, err
 	}
 
@@ -389,7 +392,7 @@ func argoResourceValidationResult(app *unstructured.Unstructured, validationID s
 			Message:   stringValue(entry["message"]),
 		}
 		if phase == "Succeeded" {
-			return ArgoResourceValidationResult{Outcome: "succeeded", Message: "Argo validated the resource without applying changes.", Resource: resource}, true
+			return ArgoResourceValidationResult{Outcome: "succeeded", Message: "Argo's dry-run completed without applying changes. API admission can still reject the real sync.", Resource: resource}, true
 		}
 		if message == "" {
 			message = resource.Message
@@ -574,20 +577,49 @@ func TerminateArgoSync(ctx context.Context, dynClient dynamic.Interface, namespa
 	}
 
 	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+	operation, operationFound, _ := unstructured.NestedFieldNoCopy(app.Object, "operation")
+	if found && phase == "Terminating" && operationFound && operation != nil {
+		return OperationResult{
+			Message:   "Termination already in progress",
+			Operation: "terminate",
+			Tool:      "argocd",
+			Kind:      "Application",
+			Namespace: namespace,
+			Name:      name,
+		}, nil
+	}
 	if !found || phase != "Running" {
 		return OperationResult{}, fmt.Errorf("no sync operation in progress for %s/%s: %w", namespace, name, ErrNoOperationInProgress)
 	}
 
-	patchBytes := []byte(`[{"op": "remove", "path": "/operation"}]`)
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	message := "Termination requested"
+	patch := make([]map[string]any, 0, 4)
+	if resourceVersion := app.GetResourceVersion(); resourceVersion != "" {
+		patch = append(patch, map[string]any{"op": "test", "path": "/metadata/resourceVersion", "value": resourceVersion})
+	}
+	patch = append(patch, map[string]any{"op": "test", "path": "/status/operationState/phase", "value": "Running"})
+	if operationFound && operation != nil {
+		patch = append(patch,
+			map[string]any{"op": "test", "path": "/operation", "value": operation},
+			map[string]any{"op": "replace", "path": "/status/operationState/phase", "value": "Terminating"},
+		)
+	} else {
+		message = "Stale operation status cleared"
+		patch = append(patch,
+			map[string]any{"op": "replace", "path": "/status/operationState/phase", "value": "Error"},
+			map[string]any{"op": "add", "path": "/status/operationState/message", "value": "The operation was cleared before termination completed."},
+			map[string]any{"op": "add", "path": "/status/operationState/finishedAt", "value": timestamp},
+		)
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return OperationResult{}, fmt.Errorf("failed to marshal terminate patch: %w", err)
+	}
 	_, err = dynClient.Resource(argoAppGVR).Namespace(namespace).Patch(
 		ctx, name, types.JSONPatchType, patchBytes, metav1.PatchOptions{},
 	)
 	if err != nil {
-		// Race: the operation completed (and was removed) between the GET
-		// above and this PATCH. K8s rejects the JSON-Patch with Invalid
-		// because the /operation path is gone — surface the same sentinel
-		// as the pre-flight check so the handler reports "nothing to
-		// terminate" honestly instead of a fake "Sync terminated".
 		if apierrors.IsInvalid(err) {
 			return OperationResult{}, fmt.Errorf("no sync operation in progress for %s/%s (completed before terminate could fire): %w", namespace, name, ErrNoOperationInProgress)
 		}
@@ -595,12 +627,13 @@ func TerminateArgoSync(ctx context.Context, dynClient dynamic.Interface, namespa
 	}
 
 	return OperationResult{
-		Message:   fmt.Sprintf("Sync operation terminated for ArgoCD Application %s/%s", namespace, name),
-		Operation: "terminate",
-		Tool:      "argocd",
-		Kind:      "Application",
-		Namespace: namespace,
-		Name:      name,
+		Message:     message,
+		Operation:   "terminate",
+		Tool:        "argocd",
+		Kind:        "Application",
+		Namespace:   namespace,
+		Name:        name,
+		RequestedAt: timestamp,
 	}, nil
 }
 
@@ -623,8 +656,7 @@ func RollbackArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace
 		return OperationResult{}, err
 	}
 
-	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
-	if found && phase == "Running" {
+	if argoOperationInProgress(app) {
 		return OperationResult{}, fmt.Errorf("cannot rollback while another operation is in progress for %s/%s: %w", namespace, name, ErrOperationInProgress)
 	}
 

--- a/pkg/gitops/operations_test.go
+++ b/pkg/gitops/operations_test.go
@@ -440,10 +440,7 @@ func TestOperationsPreserveNotFoundChain(t *testing.T) {
 	}
 }
 
-// TestSyncArgoAppSelectiveResources covers the selective-sync code path: a
-// non-empty Resources slice should produce sync.resources, an all-blank
-// slice should be filtered out and produce no sync.resources field, and
-// mixed entries should drop only the empty rows.
+// TestSyncArgoAppSelectiveResources covers the selective-sync wire shape.
 func TestSyncArgoAppSelectiveResources(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -456,29 +453,9 @@ func TestSyncArgoAppSelectiveResources(t *testing.T) {
 			want:      nil,
 		},
 		{
-			name: "all entries blank → resources field omitted",
-			resources: []ArgoSyncResource{
-				{Kind: "", Name: ""},
-				{Kind: "Deployment", Name: ""}, // missing name
-				{Kind: "", Name: "x"},          // missing kind
-			},
-			want: nil,
-		},
-		{
 			name: "single valid entry survives",
 			resources: []ArgoSyncResource{
 				{Group: "apps", Kind: "Deployment", Namespace: "demo", Name: "web"},
-			},
-			want: []map[string]any{
-				{"group": "apps", "kind": "Deployment", "namespace": "demo", "name": "web"},
-			},
-		},
-		{
-			name: "mixed valid + invalid drops only the invalid",
-			resources: []ArgoSyncResource{
-				{Kind: "Deployment", Name: ""},
-				{Group: "apps", Kind: "Deployment", Namespace: "demo", Name: "web"},
-				{Kind: "", Name: "ghost"},
 			},
 			want: []map[string]any{
 				{"group": "apps", "kind": "Deployment", "namespace": "demo", "name": "web"},
@@ -516,6 +493,23 @@ func TestSyncArgoAppSelectiveResources(t *testing.T) {
 	}
 }
 
+func TestSyncArgoAppRejectsIncompleteSelectiveResource(t *testing.T) {
+	resources := []ArgoSyncResource{
+		{Group: "apps", Kind: "Deployment", Namespace: "demo", Name: "web"},
+		{Kind: "Service"},
+	}
+	client := newFakeArgo(argoAppForTest("argocd", "demo", nil))
+	_, err := SyncArgoApp(context.Background(), client, "argocd", "demo", ArgoSyncOptions{Resources: resources})
+	if !errors.Is(err, ErrInvalidResourceSelection) {
+		t.Fatalf("SyncArgoApp error = %v, want ErrInvalidResourceSelection", err)
+	}
+	for _, action := range client.Actions() {
+		if _, ok := action.(clienttesting.PatchAction); ok {
+			t.Fatalf("invalid selective sync issued a patch; actions=%v", client.Actions())
+		}
+	}
+}
+
 func TestSyncArgoAppDryRunDoesNotRequestHardRefresh(t *testing.T) {
 	dryRun := true
 	client := newFakeArgo(argoAppForTest("argocd", "demo", nil))
@@ -523,8 +517,70 @@ func TestSyncArgoAppDryRunDoesNotRequestHardRefresh(t *testing.T) {
 		t.Fatalf("SyncArgoApp: %v", err)
 	}
 	body := captureLastPatch(t, client)
-	if metadata := nestedMap(body, "metadata"); metadata != nil {
-		t.Fatalf("dry-run patch must not request a refresh, got metadata %#v", metadata)
+	if annotations := nestedMap(body, "metadata", "annotations"); annotations != nil {
+		t.Fatalf("dry-run patch must not request a refresh, got annotations %#v", annotations)
+	}
+}
+
+func TestArgoOperationPatchesUseResourceVersion(t *testing.T) {
+	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		metadata, _ := obj["metadata"].(map[string]any)
+		metadata["resourceVersion"] = "17"
+		status, _ := obj["status"].(map[string]any)
+		status["history"] = []any{map[string]any{"id": int64(1)}}
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		client := newFakeArgo(app.DeepCopy())
+		if _, err := SyncArgoApp(context.Background(), client, "argocd", "demo", ArgoSyncOptions{}); err != nil {
+			t.Fatalf("SyncArgoApp: %v", err)
+		}
+		metadata := nestedMap(captureLastPatch(t, client), "metadata")
+		if metadata["resourceVersion"] != "17" {
+			t.Fatalf("sync resourceVersion = %#v, want 17", metadata["resourceVersion"])
+		}
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		client := newFakeArgo(app.DeepCopy())
+		if _, err := RollbackArgoApp(context.Background(), client, "argocd", "demo", ArgoRollbackOptions{ID: 1}); err != nil {
+			t.Fatalf("RollbackArgoApp: %v", err)
+		}
+		metadata := nestedMap(captureLastPatch(t, client), "metadata")
+		if metadata["resourceVersion"] != "17" {
+			t.Fatalf("rollback resourceVersion = %#v, want 17", metadata["resourceVersion"])
+		}
+	})
+}
+
+func TestArgoOperationPatchConflictMapsToOperationInProgress(t *testing.T) {
+	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		status, _ := obj["status"].(map[string]any)
+		status["history"] = []any{map[string]any{"id": int64(1)}}
+	})
+	cases := []struct {
+		name string
+		run  func(*fake.FakeDynamicClient) error
+	}{
+		{name: "sync", run: func(client *fake.FakeDynamicClient) error {
+			_, err := SyncArgoApp(context.Background(), client, "argocd", "demo", ArgoSyncOptions{})
+			return err
+		}},
+		{name: "rollback", run: func(client *fake.FakeDynamicClient) error {
+			_, err := RollbackArgoApp(context.Background(), client, "argocd", "demo", ArgoRollbackOptions{ID: 1})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newFakeArgo(app.DeepCopy())
+			client.PrependReactor("patch", "applications", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewConflict(argoAppGVR.GroupResource(), "demo", errors.New("changed"))
+			})
+			if err := tc.run(client); !errors.Is(err, ErrOperationInProgress) {
+				t.Fatalf("error = %v, want ErrOperationInProgress", err)
+			}
+		})
 	}
 }
 
@@ -554,8 +610,8 @@ func TestValidateArgoResourceStartsSafeSelectiveDryRun(t *testing.T) {
 		t.Fatalf("ValidateArgoResource error = %v, want context deadline", err)
 	}
 	body := captureLastPatch(t, client)
-	if metadata := nestedMap(body, "metadata"); metadata != nil {
-		t.Fatalf("validation patch must not request a refresh, got metadata %#v", metadata)
+	if annotations := nestedMap(body, "metadata", "annotations"); annotations != nil {
+		t.Fatalf("validation patch must not request a refresh, got annotations %#v", annotations)
 	}
 	sync := nestedMap(body, "operation", "sync")
 	if sync["dryRun"] != true || sync["prune"] != false {
@@ -983,6 +1039,8 @@ func TestTerminateArgoSyncJSONPatchRaceMapsToSentinel(t *testing.T) {
 
 func TestTerminateArgoSyncRequestsControllerTermination(t *testing.T) {
 	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		metadata, _ := obj["metadata"].(map[string]any)
+		metadata["resourceVersion"] = "23"
 		obj["operation"] = map[string]any{"sync": map[string]any{"revision": "abc123"}}
 		status, _ := obj["status"].(map[string]any)
 		status["operationState"] = map[string]any{"phase": "Running"}
@@ -1006,6 +1064,21 @@ func TestTerminateArgoSyncRequestsControllerTermination(t *testing.T) {
 	}
 	if operation, found, _ := unstructured.NestedFieldNoCopy(updated.Object, "operation"); !found || operation == nil {
 		t.Fatal("terminate removed spec.operation instead of leaving it for the Argo controller")
+	}
+	for _, action := range client.Actions() {
+		patchAction, ok := action.(clienttesting.PatchAction)
+		if !ok {
+			continue
+		}
+		var operations []map[string]any
+		if err := json.Unmarshal(patchAction.GetPatch(), &operations); err != nil {
+			t.Fatalf("decode terminate patch: %v", err)
+		}
+		for _, operation := range operations {
+			if operation["path"] == "/metadata/resourceVersion" {
+				t.Fatal("terminate must not reject a live operation because unrelated status updates changed resourceVersion")
+			}
+		}
 	}
 }
 

--- a/pkg/gitops/operations_test.go
+++ b/pkg/gitops/operations_test.go
@@ -605,6 +605,17 @@ func TestArgoResourceValidationResultCorrelatesAndReturnsTarget(t *testing.T) {
 	if result.Resource.Status != "Synced" || !strings.Contains(result.Resource.Message, "dry run") {
 		t.Fatalf("resource result = %#v, want exact Argo status and message", result.Resource)
 	}
+	targetWithoutNamespace := target
+	targetWithoutNamespace.Namespace = ""
+	result, done = argoResourceValidationResult(makeApp("current", "Succeeded", []any{matchingResource}), "current", targetWithoutNamespace)
+	if !done || result.Outcome != "succeeded" {
+		t.Fatalf("namespace-omitted selector result = %#v, done=%v; want succeeded", result, done)
+	}
+	targetInAnotherNamespace := target
+	targetInAnotherNamespace.Namespace = "other"
+	if argoResourceResultMatches(matchingResource, targetInAnotherNamespace) {
+		t.Fatal("an explicit selector namespace must match the result namespace")
+	}
 	result, done = argoResourceValidationResult(makeApp("current", "Succeeded", nil), "current", target)
 	if !done || result.Outcome != "inconclusive" {
 		t.Fatalf("missing target result = %#v, done=%v; want inconclusive", result, done)

--- a/pkg/gitops/operations_test.go
+++ b/pkg/gitops/operations_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -513,6 +514,100 @@ func TestSyncArgoAppSelectiveResources(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSyncArgoAppDryRunDoesNotRequestHardRefresh(t *testing.T) {
+	dryRun := true
+	client := newFakeArgo(argoAppForTest("argocd", "demo", nil))
+	if _, err := SyncArgoApp(context.Background(), client, "argocd", "demo", ArgoSyncOptions{DryRun: &dryRun}); err != nil {
+		t.Fatalf("SyncArgoApp: %v", err)
+	}
+	body := captureLastPatch(t, client)
+	if metadata := nestedMap(body, "metadata"); metadata != nil {
+		t.Fatalf("dry-run patch must not request a refresh, got metadata %#v", metadata)
+	}
+}
+
+func TestValidateArgoResourceRejectsQueuedOperation(t *testing.T) {
+	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		obj["operation"] = map[string]any{"sync": map[string]any{}}
+	})
+	client := newFakeArgo(app)
+	_, err := ValidateArgoResource(context.Background(), client, "argocd", "demo", ArgoSyncResource{Kind: "Service", Name: "api"}, ArgoSyncOptions{})
+	if !errors.Is(err, ErrOperationInProgress) {
+		t.Fatalf("ValidateArgoResource error = %v, want ErrOperationInProgress", err)
+	}
+	for _, action := range client.Actions() {
+		if _, ok := action.(clienttesting.PatchAction); ok {
+			t.Fatalf("validation overwrote a queued operation; actions=%v", client.Actions())
+		}
+	}
+}
+
+func TestValidateArgoResourceStartsSafeSelectiveDryRun(t *testing.T) {
+	client := newFakeArgo(argoAppForTest("argocd", "demo", nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	target := ArgoSyncResource{Group: "apps", Kind: "Deployment", Namespace: "demo", Name: "api"}
+	_, err := ValidateArgoResource(ctx, client, "argocd", "demo", target, ArgoSyncOptions{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ValidateArgoResource error = %v, want context deadline", err)
+	}
+	body := captureLastPatch(t, client)
+	if metadata := nestedMap(body, "metadata"); metadata != nil {
+		t.Fatalf("validation patch must not request a refresh, got metadata %#v", metadata)
+	}
+	sync := nestedMap(body, "operation", "sync")
+	if sync["dryRun"] != true || sync["prune"] != false {
+		t.Fatalf("validation flags = dryRun:%#v prune:%#v", sync["dryRun"], sync["prune"])
+	}
+	resources, ok := sync["resources"].([]any)
+	if !ok || len(resources) != 1 {
+		t.Fatalf("validation resources = %#v, want one exact selector", sync["resources"])
+	}
+	info, ok := nestedMap(body, "operation")["info"].([]any)
+	if !ok || len(info) != 1 {
+		t.Fatalf("validation info = %#v, want one correlation entry", nestedMap(body, "operation")["info"])
+	}
+}
+
+func TestArgoResourceValidationResultCorrelatesAndReturnsTarget(t *testing.T) {
+	target := ArgoSyncResource{Group: "karpenter.sh", Kind: "NodePool", Namespace: "default", Name: "default"}
+	makeApp := func(id, phase string, resources []any) *unstructured.Unstructured {
+		return argoAppForTest("argocd", "demo", func(obj map[string]any) {
+			obj["status"] = map[string]any{
+				"operationState": map[string]any{
+					"phase": phase,
+					"operation": map[string]any{
+						"info": []any{map[string]any{"name": "radar-validation-id", "value": id}},
+					},
+					"syncResult": map[string]any{"resources": resources},
+				},
+			}
+		})
+	}
+	matchingResource := map[string]any{
+		"group": "karpenter.sh", "kind": "NodePool", "namespace": "default", "name": "default",
+		"status": "Synced", "message": "nodepool.karpenter.sh/default configured (dry run)",
+	}
+
+	if _, done := argoResourceValidationResult(makeApp("old", "Succeeded", []any{matchingResource}), "current", target); done {
+		t.Fatal("a terminal result from a previous request must not complete the current validation")
+	}
+	if _, done := argoResourceValidationResult(makeApp("current", "Running", []any{matchingResource}), "current", target); done {
+		t.Fatal("a matching operation that is still running must keep waiting")
+	}
+	result, done := argoResourceValidationResult(makeApp("current", "Succeeded", []any{matchingResource}), "current", target)
+	if !done || result.Outcome != "succeeded" || result.Resource == nil {
+		t.Fatalf("result = %#v, done=%v; want succeeded target result", result, done)
+	}
+	if result.Resource.Status != "Synced" || !strings.Contains(result.Resource.Message, "dry run") {
+		t.Fatalf("resource result = %#v, want exact Argo status and message", result.Resource)
+	}
+	result, done = argoResourceValidationResult(makeApp("current", "Succeeded", nil), "current", target)
+	if !done || result.Outcome != "inconclusive" {
+		t.Fatalf("missing target result = %#v, done=%v; want inconclusive", result, done)
 	}
 }
 

--- a/pkg/gitops/operations_test.go
+++ b/pkg/gitops/operations_test.go
@@ -293,9 +293,8 @@ func TestSentinelErrorsAreDistinct(t *testing.T) {
 
 // TestOperationsRefuseTerminatingResource pins that mutating ops refuse a
 // resource with metadata.deletionTimestamp set, returning ErrResourceTerminating.
-// Refresh and Terminate are intentionally excluded: Refresh re-reads from
-// Git (read-only against the cluster) and Terminate clears an in-flight
-// op record — both useful when an operation is what's blocking deletion.
+// Refresh and Terminate are intentionally excluded because both remain useful
+// when an in-flight operation is blocking deletion.
 func TestOperationsRefuseTerminatingResource(t *testing.T) {
 	ctx := context.Background()
 	terminatingApp := func() *unstructured.Unstructured {
@@ -601,6 +600,9 @@ func TestArgoResourceValidationResultCorrelatesAndReturnsTarget(t *testing.T) {
 	result, done := argoResourceValidationResult(makeApp("current", "Succeeded", []any{matchingResource}), "current", target)
 	if !done || result.Outcome != "succeeded" || result.Resource == nil {
 		t.Fatalf("result = %#v, done=%v; want succeeded target result", result, done)
+	}
+	if !strings.Contains(result.Message, "API admission can still reject") {
+		t.Fatalf("success message = %q, want dry-run limitation", result.Message)
 	}
 	if result.Resource.Status != "Synced" || !strings.Contains(result.Resource.Message, "dry run") {
 		t.Fatalf("resource result = %#v, want exact Argo status and message", result.Resource)
@@ -955,12 +957,6 @@ func patchActionsByResource(client *fake.FakeDynamicClient) map[string]int {
 	return out
 }
 
-// TestTerminateArgoSyncJSONPatchRace pins the IsInvalid mapping in
-// TerminateArgoSync. When the operation removes itself between the GET
-// and the JSON-Patch (the documented race), K8s returns
-// StatusReasonInvalid because the JSON-Patch path no longer exists. The
-// handler must recognize that as ErrNoOperationInProgress (mapped to 400)
-// rather than letting it surface as a generic 500.
 func TestTerminateArgoSyncJSONPatchRaceMapsToSentinel(t *testing.T) {
 	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
 		status, _ := obj["status"].(map[string]any)
@@ -982,6 +978,62 @@ func TestTerminateArgoSyncJSONPatchRaceMapsToSentinel(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNoOperationInProgress) {
 		t.Fatalf("expected ErrNoOperationInProgress, got %v", err)
+	}
+}
+
+func TestTerminateArgoSyncRequestsControllerTermination(t *testing.T) {
+	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		obj["operation"] = map[string]any{"sync": map[string]any{"revision": "abc123"}}
+		status, _ := obj["status"].(map[string]any)
+		status["operationState"] = map[string]any{"phase": "Running"}
+	})
+	client := newFakeArgo(app)
+
+	result, err := TerminateArgoSync(context.Background(), client, "argocd", "demo")
+	if err != nil {
+		t.Fatalf("TerminateArgoSync: %v", err)
+	}
+	if result.Message != "Termination requested" {
+		t.Fatalf("message = %q, want termination request", result.Message)
+	}
+	updated, err := client.Resource(argoAppGVR).Namespace("argocd").Get(context.Background(), "demo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated Application: %v", err)
+	}
+	phase, _, _ := unstructured.NestedString(updated.Object, "status", "operationState", "phase")
+	if phase != "Terminating" {
+		t.Fatalf("operation phase = %q, want Terminating", phase)
+	}
+	if operation, found, _ := unstructured.NestedFieldNoCopy(updated.Object, "operation"); !found || operation == nil {
+		t.Fatal("terminate removed spec.operation instead of leaving it for the Argo controller")
+	}
+}
+
+func TestTerminateArgoSyncRepairsStaleRunningStatus(t *testing.T) {
+	app := argoAppForTest("argocd", "demo", func(obj map[string]any) {
+		status, _ := obj["status"].(map[string]any)
+		status["operationState"] = map[string]any{"phase": "Running", "message": "waiting for hook"}
+	})
+	client := newFakeArgo(app)
+
+	result, err := TerminateArgoSync(context.Background(), client, "argocd", "demo")
+	if err != nil {
+		t.Fatalf("TerminateArgoSync: %v", err)
+	}
+	if result.Message != "Stale operation status cleared" {
+		t.Fatalf("message = %q, want stale-status recovery", result.Message)
+	}
+	updated, err := client.Resource(argoAppGVR).Namespace("argocd").Get(context.Background(), "demo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated Application: %v", err)
+	}
+	phase, _, _ := unstructured.NestedString(updated.Object, "status", "operationState", "phase")
+	if phase != "Error" {
+		t.Fatalf("operation phase = %q, want Error", phase)
+	}
+	finishedAt, _, _ := unstructured.NestedString(updated.Object, "status", "operationState", "finishedAt")
+	if _, err := time.Parse(time.RFC3339Nano, finishedAt); err != nil {
+		t.Fatalf("finishedAt = %q, want RFC3339 timestamp: %v", finishedAt, err)
 	}
 }
 

--- a/web/src/api/client.argoResourceSync.test.ts
+++ b/web/src/api/client.argoResourceSync.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { buildArgoResourceSyncVars } from './client'
+
+const options = {
+  revision: 'should-not-survive',
+  prune: true,
+  dryRun: false,
+  force: true,
+  applyOnly: true,
+  syncOptions: ['ServerSideApply=true'],
+}
+
+describe('buildArgoResourceSyncVars', () => {
+  it('preserves the complete Argo status ref and forces resource-safe options', () => {
+    expect(
+      buildArgoResourceSyncVars(
+        'argocd',
+        'guestbook',
+        {
+          group: 'apps',
+          kind: 'Deployment',
+          namespace: 'guestbook',
+          name: 'guestbook-ui',
+        },
+        options,
+      ),
+    ).toEqual({
+      namespace: 'argocd',
+      name: 'guestbook',
+      resources: [
+        {
+          group: 'apps',
+          kind: 'Deployment',
+          namespace: 'guestbook',
+          name: 'guestbook-ui',
+        },
+      ],
+      revision: undefined,
+      prune: false,
+      dryRun: false,
+      force: true,
+      applyOnly: false,
+      syncOptions: ['ServerSideApply=true'],
+    })
+  })
+
+  it('preserves an empty core API group', () => {
+    const variables = buildArgoResourceSyncVars(
+      'argocd',
+      'guestbook',
+      {
+        group: '',
+        kind: 'Service',
+        namespace: 'guestbook',
+        name: 'guestbook-ui',
+      },
+      options,
+    )
+
+    expect(variables.resources).toEqual([
+      {
+        group: '',
+        kind: 'Service',
+        namespace: 'guestbook',
+        name: 'guestbook-ui',
+      },
+    ])
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import type { AppHistory, AppRow } from '@skyhook-io/k8s-ui'
+import type { AppHistory, AppRow, ArgoSyncOpts, GitOpsInsightRef } from '@skyhook-io/k8s-ui'
 import { useQuery, useMutation, useQueryClient, skipToken } from '@tanstack/react-query'
 import { showApiError, showApiSuccess } from '../components/ui/Toast'
 import { useCanHelmWrite } from '../contexts/CapabilitiesContext'
@@ -3283,7 +3283,7 @@ type ArgoAppVars = { namespace: string; name: string }
 // ArgoSyncVars extends ArgoAppVars with the sync request body fields. Only
 // useArgoSync sends these — splitting the type prevents callers from passing
 // resources/revision/prune to mutations that would silently drop them.
-type ArgoSyncVars = ArgoAppVars & {
+export type ArgoSyncVars = ArgoAppVars & {
   resources?: Array<{ group?: string; kind: string; namespace?: string; name: string }>
   revision?: string
   prune?: boolean
@@ -3294,6 +3294,18 @@ type ArgoSyncVars = ArgoAppVars & {
   // "ServerSideApply=true", "PruneLast=true". Caller is responsible for
   // spelling.
   syncOptions?: string[]
+}
+
+export function buildArgoResourceSyncVars(namespace: string, name: string, resource: GitOpsInsightRef, opts: ArgoSyncOpts): ArgoSyncVars {
+  return {
+    namespace,
+    name,
+    ...opts,
+    resources: [{ group: resource.group, kind: resource.kind, namespace: resource.namespace, name: resource.name }],
+    revision: undefined,
+    prune: false,
+    applyOnly: false,
+  }
 }
 
 // ArgoRollbackVars targets a specific Argo history entry by ID. Prune and

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1047,7 +1047,7 @@ export function useGitOpsTree(kind: string, namespace: string, name: string, gro
 
 // Poll fast (2s) while a sync/rollback is in flight so the user sees the
 // outcome quickly; otherwise rely on staleTime + manual refetch. Argo flips
-// operationState.phase from "Running" -> Succeeded/Failed when done, so this
+// operationState.phase from Running/Terminating to a terminal phase, so this
 // auto-quiesces on completion.
 const INSIGHTS_RUNNING_POLL_MS = 2000
 
@@ -1065,7 +1065,7 @@ export function useGitOpsInsights(kind: string, namespace: string, name: string,
     staleTime: 5000,
     refetchInterval: (query) => {
       const phase = query.state.data?.summary?.operationPhase
-      return phase === 'Running' ? INSIGHTS_RUNNING_POLL_MS : false
+      return phase === 'Running' || phase === 'Terminating' ? INSIGHTS_RUNNING_POLL_MS : false
     },
   })
 }
@@ -3238,7 +3238,8 @@ interface GitOpsMutationConfig<TVariables> {
   getPath: (variables: TVariables) => string
   getBody?: (variables: TVariables) => unknown
   errorMessage: string
-  successMessage: string
+  successMessage?: string
+  getSuccessMessage?: (data: GitOpsOperationResponse) => string
   getInvalidateKeys: (variables: TVariables) => (string | undefined)[][]
 }
 
@@ -3266,7 +3267,8 @@ function createGitOpsMutation<TVariables>(config: GitOpsMutationConfig<TVariable
         errorMessage: config.errorMessage,
         successMessage: config.successMessage,
       },
-      onSuccess: (_, variables) => {
+      onSuccess: (data, variables) => {
+        if (config.getSuccessMessage) showApiSuccess(config.getSuccessMessage(data))
         config.getInvalidateKeys(variables).forEach(key =>
           queryClient.invalidateQueries({ queryKey: key })
         )
@@ -3438,7 +3440,7 @@ export const useArgoRollback = createGitOpsMutation<ArgoRollbackVars>({
 export const useArgoTerminate = createGitOpsMutation<ArgoAppVars>({
   getPath: (v) => `/argo/applications/${v.namespace}/${v.name}/terminate`,
   errorMessage: 'Failed to terminate sync',
-  successMessage: 'Sync terminated',
+  getSuccessMessage: (data) => data.message,
   getInvalidateKeys: argoInvalidateKeys,
 })
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3296,6 +3296,19 @@ export type ArgoSyncVars = ArgoAppVars & {
   syncOptions?: string[]
 }
 
+export interface ArgoResourceValidationResult {
+  outcome: 'succeeded' | 'failed' | 'inconclusive'
+  message: string
+  resource?: {
+    group?: string
+    kind: string
+    namespace?: string
+    name: string
+    status?: string
+    message?: string
+  }
+}
+
 export function buildArgoResourceSyncVars(namespace: string, name: string, resource: GitOpsInsightRef, opts: ArgoSyncOpts): ArgoSyncVars {
   return {
     namespace,
@@ -3388,6 +3401,31 @@ export const useArgoSync = createGitOpsMutation<ArgoSyncVars>({
   successMessage: 'Sync initiated',
   getInvalidateKeys: argoInvalidateKeys,
 })
+
+export function useArgoResourceValidation() {
+  const queryClient = useQueryClient()
+  return useMutation<ArgoResourceValidationResult, Error, ArgoSyncVars>({
+    mutationFn: async (variables) => {
+      const response = await apiFetch(`${getApiBase()}/argo/applications/${variables.namespace}/${variables.name}/validate-resource`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          resources: variables.resources,
+          force: variables.force,
+          syncOptions: variables.syncOptions,
+        }),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unknown error' }))
+        throw new Error(error.error || `HTTP ${response.status}`)
+      }
+      return response.json() as Promise<ArgoResourceValidationResult>
+    },
+    onSettled: (_, __, variables) => {
+      argoInvalidateKeys(variables).forEach(key => queryClient.invalidateQueries({ queryKey: key }))
+    },
+  })
+}
 
 export const useArgoRollback = createGitOpsMutation<ArgoRollbackVars>({
   getPath: (v) => `/argo/applications/${v.namespace}/${v.name}/rollback`,

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -46,6 +46,7 @@ import { useToast } from '../ui/Toast'
 
 import {
   fetchJSON,
+  buildArgoResourceSyncVars,
   useApplyResource,
   useArgoRefresh,
   useArgoResume,
@@ -79,6 +80,10 @@ const GITOPS_KINDS: APIResource[] = [
   { name: 'helmrepositories', kind: 'HelmRepository', group: 'source.toolkit.fluxcd.io', version: 'v1', namespaced: true, verbs: ['list', 'get'], isCrd: true },
   { name: 'alerts', kind: 'Alert', group: 'notification.toolkit.fluxcd.io', version: 'v1beta3', namespaced: true, verbs: ['list', 'get'], isCrd: true },
 ]
+
+type ArgoSyncDialogTarget =
+  | { scope: 'application' }
+  | { scope: 'resource'; resource: GitOpsInsightRef }
 
 const KIND_BY_NAME = new Map(GITOPS_KINDS.map((k) => [k.name, k]))
 
@@ -414,7 +419,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   const fluxSuspend = useFluxSuspend()
   const fluxResume = useFluxResume()
 
-  const [syncDialogOpen, setSyncDialogOpen] = useState(false)
+  const [syncDialogTarget, setSyncDialogTarget] = useState<ArgoSyncDialogTarget | null>(null)
   // Doubles as the "open" flag (truthy = dialog open) and the data carrier
   // for which history entry to roll back to.
   const [rollbackTarget, setRollbackTarget] = useState<GitOpsHistoryItem | null>(null)
@@ -463,7 +468,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
 
   // Detail-page shortcuts. Skip when a modal is already open so a stray "s"
   // in an input field doesn't pop another sync dialog.
-  const shortcutsEnabled = !syncDialogOpen && !rollbackTarget
+  const shortcutsEnabled = !syncDialogTarget && !rollbackTarget
   useRegisterShortcut({
     id: 'gitops-detail-sync',
     keys: 's',
@@ -472,7 +477,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
     scope: 'gitops',
     handler: () => {
       if (effectiveSuspended || terminating) return
-      if (isArgoApp) setSyncDialogOpen(true)
+      if (isArgoApp) setSyncDialogTarget({ scope: 'application' })
       else if (isFlux) fluxReconcile.mutate({ kind, namespace, name })
     },
     enabled: shortcutsEnabled && (isArgoApp || isFlux) && !effectiveSuspended && !terminating,
@@ -529,7 +534,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   }
 
   const argoHandlers: ArgoActionHandlers | undefined = isArgoApp ? {
-    onSyncRequested: () => setSyncDialogOpen(true),
+    onSyncRequested: () => setSyncDialogTarget({ scope: 'application' }),
     onRefresh: (refreshType) => {
       setRefreshKind(refreshType)
       argoRefresh.mutate({ namespace, name, hard: refreshType === 'hard' })
@@ -692,6 +697,16 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
               insight={insightsQ.data}
               error={insightsQ.error as Error | null}
               onOpenResource={openResourceFromTree}
+              onSyncResource={isArgoApp ? (resource) => setSyncDialogTarget({ scope: 'resource', resource }) : undefined}
+              syncResourceDisabledReason={isArgoApp ? (
+                terminating
+                  ? terminatingActionTooltip
+                  : effectiveSuspended
+                    ? 'Resume the Application before syncing a resource.'
+                    : isRunning || argoSync.isPending
+                      ? 'Wait for the current sync operation to finish.'
+                      : undefined
+              ) : undefined}
               focusKey={changesFocusKey}
               tree={tree}
             />
@@ -739,13 +754,18 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
       {isArgoApp && (
         <>
           <SyncOptionsDialog
-            open={syncDialogOpen}
+            open={!!syncDialogTarget}
             appLabel={`${namespace}/${name}`}
+            resource={syncDialogTarget?.scope === 'resource' ? syncDialogTarget.resource : undefined}
             pending={argoSync.isPending}
-            onCancel={() => setSyncDialogOpen(false)}
+            onCancel={() => setSyncDialogTarget(null)}
             onConfirm={(opts) => {
-              argoSync.mutate({ namespace, name, ...opts }, {
-                onSettled: () => setSyncDialogOpen(false),
+              if (!syncDialogTarget) return
+              const variables = syncDialogTarget.scope === 'resource'
+                ? buildArgoResourceSyncVars(namespace, name, syncDialogTarget.resource, opts)
+                : { namespace, name, ...opts }
+              argoSync.mutate(variables, {
+                onSettled: () => setSyncDialogTarget(null),
               })
             }}
           />

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -19,6 +19,7 @@ import {
   formatGitOpsSourceUrl,
   getGitOpsResourceStatus,
   getGitOpsTool,
+  isArgoOperationInProgress,
   isArgoSuspendedByRadar,
   gitOpsInsightChangeKey,
   initNavigationMap,
@@ -474,6 +475,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   }
 
   const isRunning = resourceQ.data?.status?.operationState?.phase === 'Running'
+  const operationInProgress = isArgoOperationInProgress(resourceQ.data)
   const isFluxWorkload = kind === 'kustomizations' || kind === 'helmreleases'
   const isFlux = tool === 'flux'
   const isArgoApp = kind === 'applications'
@@ -488,11 +490,11 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
     category: 'GitOps',
     scope: 'gitops',
     handler: () => {
-      if (effectiveSuspended || terminating) return
+      if (effectiveSuspended || terminating || operationInProgress) return
       if (isArgoApp) openArgoSyncDialog({ scope: 'application' })
       else if (isFlux) fluxReconcile.mutate({ kind, namespace, name })
     },
-    enabled: shortcutsEnabled && (isArgoApp || isFlux) && !effectiveSuspended && !terminating,
+    enabled: shortcutsEnabled && (isArgoApp || isFlux) && !effectiveSuspended && !terminating && !(isArgoApp && operationInProgress),
   })
   useRegisterShortcut({
     id: 'gitops-detail-refresh',
@@ -562,6 +564,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
     resuming: argoResume.isPending,
     autoSyncEnabled: argoAutoSyncEnabled,
     isRunning,
+    operationInProgress,
   } : undefined
 
   const fluxHandlers: FluxActionHandlers | undefined = isFlux ? {
@@ -696,7 +699,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
             <GitOpsActivityInsightView
               insight={insightsQ.data}
               error={insightsQ.error as Error | null}
-              onRollback={isArgoApp ? (item) => {
+              onRollback={isArgoApp && !operationInProgress ? (item) => {
                 if (parseArgoRollbackID(item.id) == null) return
                 setRollbackTarget(item)
               } : undefined}
@@ -715,7 +718,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
                   ? terminatingActionTooltip
                   : effectiveSuspended
                     ? 'Resume the Application before syncing a resource.'
-                    : isRunning || argoSync.isPending
+                    : operationInProgress || argoSync.isPending
                       ? 'Wait for the current sync operation to finish.'
                       : undefined
               ) : undefined}

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -49,6 +49,7 @@ import {
   buildArgoResourceSyncVars,
   useApplyResource,
   useArgoRefresh,
+  useArgoResourceValidation,
   useArgoResume,
   useArgoRollback,
   useArgoSuspend,
@@ -408,6 +409,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   const [helmValuesOpen, setHelmValuesOpen] = useState(false)
 
   const argoSync = useArgoSync()
+  const argoResourceValidation = useArgoResourceValidation()
   const argoRefresh = useArgoRefresh()
   const argoTerminate = useArgoTerminate()
   const argoSuspend = useArgoSuspend()
@@ -425,6 +427,16 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   const [rollbackTarget, setRollbackTarget] = useState<GitOpsHistoryItem | null>(null)
   // Disambiguates which refresh button is in flight (both share argoRefresh).
   const [refreshKind, setRefreshKind] = useState<'normal' | 'hard'>('normal')
+
+  function openArgoSyncDialog(target: ArgoSyncDialogTarget) {
+    argoResourceValidation.reset()
+    setSyncDialogTarget(target)
+  }
+
+  function closeArgoSyncDialog() {
+    argoResourceValidation.reset()
+    setSyncDialogTarget(null)
+  }
 
   const detailRow = resourceQ.data ? normalizeDetailResource(kind, group, resourceQ.data) : null
   const tree = treeQ.data ?? null
@@ -477,7 +489,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
     scope: 'gitops',
     handler: () => {
       if (effectiveSuspended || terminating) return
-      if (isArgoApp) setSyncDialogTarget({ scope: 'application' })
+      if (isArgoApp) openArgoSyncDialog({ scope: 'application' })
       else if (isFlux) fluxReconcile.mutate({ kind, namespace, name })
     },
     enabled: shortcutsEnabled && (isArgoApp || isFlux) && !effectiveSuspended && !terminating,
@@ -534,7 +546,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   }
 
   const argoHandlers: ArgoActionHandlers | undefined = isArgoApp ? {
-    onSyncRequested: () => setSyncDialogTarget({ scope: 'application' }),
+    onSyncRequested: () => openArgoSyncDialog({ scope: 'application' }),
     onRefresh: (refreshType) => {
       setRefreshKind(refreshType)
       argoRefresh.mutate({ namespace, name, hard: refreshType === 'hard' })
@@ -697,7 +709,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
               insight={insightsQ.data}
               error={insightsQ.error as Error | null}
               onOpenResource={openResourceFromTree}
-              onSyncResource={isArgoApp ? (resource) => setSyncDialogTarget({ scope: 'resource', resource }) : undefined}
+              onSyncResource={isArgoApp ? (resource) => openArgoSyncDialog({ scope: 'resource', resource }) : undefined}
               syncResourceDisabledReason={isArgoApp ? (
                 terminating
                   ? terminatingActionTooltip
@@ -758,14 +770,22 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
             appLabel={`${namespace}/${name}`}
             resource={syncDialogTarget?.scope === 'resource' ? syncDialogTarget.resource : undefined}
             pending={argoSync.isPending}
-            onCancel={() => setSyncDialogTarget(null)}
+            autoSyncEnabled={argoAutoSyncEnabled}
+            validationPending={argoResourceValidation.isPending}
+            validationResult={argoResourceValidation.data}
+            validationError={argoResourceValidation.error?.message}
+            onCancel={closeArgoSyncDialog}
+            onValidationReset={() => argoResourceValidation.reset()}
+            onValidate={syncDialogTarget?.scope === 'resource' ? (opts) => {
+              argoResourceValidation.mutate(buildArgoResourceSyncVars(namespace, name, syncDialogTarget.resource, opts))
+            } : undefined}
             onConfirm={(opts) => {
               if (!syncDialogTarget) return
               const variables = syncDialogTarget.scope === 'resource'
                 ? buildArgoResourceSyncVars(namespace, name, syncDialogTarget.resource, opts)
                 : { namespace, name, ...opts }
               argoSync.mutate(variables, {
-                onSettled: () => setSyncDialogTarget(null),
+                onSettled: closeArgoSyncDialog,
               })
             }}
           />

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -775,6 +775,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
             pending={argoSync.isPending}
             autoSyncEnabled={argoAutoSyncEnabled}
             validationPending={argoResourceValidation.isPending}
+            operationInProgress={operationInProgress}
             validationResult={argoResourceValidation.data}
             validationError={argoResourceValidation.error?.message}
             onCancel={closeArgoSyncDialog}


### PR DESCRIPTION
## Summary

- add a **Sync resource** action for declared Argo CD resources that are `OutOfSync` or `Missing`, while excluding hooks, generated descendants, and already-synced resources
- add an optional selective **Dry-run** preflight with correlated per-resource results, explicit admission caveats, operation-slot feedback, and bounded long-message rendering
- enforce selective-sync safety on the server: no revision override, pruning, apply-only mode, incomplete selectors, or queued/running operation replacement
- protect sync, dry-run, and rollback operation writes with Kubernetes resource-version concurrency, while terminating active syncs using Argo's controller-compatible `Terminating` phase
- keep the shared dialog compatible with consumers that only provide the original dry-run checkbox

## Safety

- resource operations always target one exact group/kind/namespace/name selector
- malformed resource selectors return `400` instead of falling through to a full application sync
- operation write races return `409` instead of overwriting another Argo operation
- resource dry-runs do not request a hard refresh and never apply changes
- auto-sync remains independent and is called out in the dialog

## Testing

- `make tsc`
- `make test`
- `make build`
- `npm --prefix packages/k8s-ui test` — 82 files, 1,187 tests
- focused GitOps package, server-handler, and web API tests
- live Argo dry-run result verified against a real Application, including the distinction between dry-run success and a later admission rejection during apply
- read-only Playwright verification at 1920×1080 and 1280×800: resource dialog layout, Dry-run tooltip/copy, and zero console errors

Visual captures:

- `.playwright-mcp/visual-test/20260713-152830/argo-resource-sync-dialog-tooltip.png`
- `.playwright-mcp/visual-test/20260713-152830/argo-resource-sync-dialog-1280.png`
