### PR TITLE
Keep workload pane loader centered when host height chain collapses

### DIFF
--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -778,7 +778,7 @@ export function WorkloadView({
           {!resource ? (
             // Fill the drawer body so the loading logo centers in it, not in a
             // 128px box pinned to the top (matches the splash/PaneLoader centering).
-            <FetchResult loading={resourceLoading} error={resourceError} className="h-full" />
+            <FetchResult loading={resourceLoading} error={resourceError} className={FULL_PANE_FETCH_STATE} />
           ) : showYaml ? (
             <EditableYamlView
               resource={selectedResource}
@@ -993,7 +993,7 @@ export function WorkloadView({
             />
         )}
         {effectiveTab === 'topology' && (
-          <div className="relative h-full min-h-0 w-full">
+          <div className="relative h-full min-h-[60dvh] w-full">
             {topology ? (
               <TopologyGraph
                 topology={neighborhood}
@@ -1066,7 +1066,7 @@ export function WorkloadView({
               {yamlObject && !yamlObject.primary && renderRelatedYaml ? (
                 renderRelatedYaml(yamlObject)
               ) : !resource ? (
-                <FetchResult loading={resourceLoading} error={resourceError} className="h-full" />
+                <FetchResult loading={resourceLoading} error={resourceError} className={FULL_PANE_FETCH_STATE} />
               ) : (
                 <EditableYamlView
                   resource={selectedResource}
@@ -1461,7 +1461,7 @@ function InfoTab({
   leadContent?: ReactNode
 }) {
   if (!resource) {
-    return <FetchResult loading={isLoading} error={error} className="h-full" />
+    return <FetchResult loading={isLoading} error={error} className={FULL_PANE_FETCH_STATE} />
   }
 
   if (!isRuntimeWorkloadOverviewKind(selectedResource.kind)) {
@@ -1548,6 +1548,13 @@ function InfoTab({
     />
   )
 }
+
+// Full-pane fetch states (loader / error / not-found). `h-full` centers in the
+// pane when the ancestor height chain resolves to the viewport; the dvh floor
+// keeps the state vertically centered when an embedding host lets the page
+// scroll (auto-height ancestors collapse h-full to content height, pinning the
+// loader to the top — seen on mobile hosts).
+const FULL_PANE_FETCH_STATE = 'h-full min-h-[60dvh]'
 
 const POD_VISIBLE_LIMIT = 5
 const EVENT_VISIBLE_LIMIT = 5


### PR DESCRIPTION
## Description

On the hosted app-detail workload view (mobile), the Overview tab's loading radar sat pinned to the top of the pane instead of centering.

Root cause: the full-pane fetch states in `WorkloadView` (Overview `InfoTab`, YAML pane, drawer body — loader / error / not-found via `FetchResult`) and the Topology pane wrapper all rely on bare `h-full`. That centers correctly when the ancestor height chain terminates in a viewport-bound frame (standalone Radar's `h-screen`), but embedded hosts use `h-full min-h-0` all the way up — if the host page scrolls (auto-height ancestors, as on mobile), `h-full` collapses to content height and the loader hugs the top. The Topology pane's `absolute inset-0` loader collapses to zero height in the same scenario.

Fix: introduce a shared `FULL_PANE_FETCH_STATE` class (`h-full min-h-[60dvh]`) for the three `FetchResult` call sites and give the Topology pane wrapper the same `min-h-[60dvh]` floor. The floor is a no-op when the pane resolves to a real height (any pane ≥ 60dvh), and gives the loader a viewport-relative band to center in when the chain collapses.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- `make tsc` passes.
- No unit tests cover this component; the change is a pure CSS min-height floor. The collapsed-chain scenario can't reproduce in standalone Radar (its `h-screen` frame keeps the chain intact), so behavior there is unchanged by construction; verification of the embedded-host mobile case needs a Radar Hub deploy consuming this `@skyhook-io/k8s-ui` change.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

N/A — reported via mobile screenshot of the hosted app detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS93k2c3jsTwuyyQZ62L9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01CS93k2c3jsTwuyyQZ62L9L)_