### PR TITLE
Fix Operational Issues layout in the resource drawer

### DIFF
--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -132,6 +132,10 @@ export interface IssueRowProps {
   as?: 'li' | 'div';
   className?: string;
   dimmed?: boolean;
+  /** Suppress the "Subject" deep-link in the expanded body — set by hosts that
+   *  embed the row under the very resource that IS the subject (the drawer header
+   *  already names it), so it doesn't echo back redundantly. */
+  hideSubject?: boolean;
   renderBadges?: (ctx: IssueRowSlotContext) => ReactNode;
   renderMeta?: (ctx: IssueRowSlotContext) => ReactNode;
   renderActions?: (ctx: IssueRowSlotContext) => ReactNode;
@@ -148,6 +152,7 @@ export function IssueRow({
   as = 'li',
   className,
   dimmed,
+  hideSubject,
   renderBadges,
   renderMeta,
   renderActions,
@@ -162,6 +167,36 @@ export function IssueRow({
   const SeverityIcon = ISSUE_SEVERITY_ICON[severity];
   const slotCtx = { issue, open };
   const timing = issueTiming(issue);
+
+  // Severity pill + age + timing chip. Rendered in two positions the container
+  // query toggles: inline at the row's right edge on a wide container, and on a
+  // line of its own below the resource line once the row is too narrow to hold
+  // it beside the title — so the title never has to truncate to make room.
+  const metaChips = (wrapperClass: string) => (
+    <div className={`items-center gap-3 ${wrapperClass}`}>
+      <span className={`badge-sm shrink-0 px-2.5 py-0.5 text-xs font-semibold ${open ? ISSUE_SEVERITY_SOLID_CLASS[severity] : ISSUE_SEVERITY_BADGE_CLASS[severity]}`}>
+        {ISSUE_SEVERITY_LABEL[severity]}
+      </span>
+      {issue.first_seen ? (
+        <>
+          <Tooltip content={ageTitle(issue)} delay={200} wrapperClassName="shrink-0">
+            <time
+              dateTime={issue.first_seen}
+              className="flex items-center gap-1 text-xs tabular-nums text-theme-text-tertiary"
+            >
+              <Clock className="h-3 w-3" aria-hidden />
+              {formatCompactAge(issue.first_seen)}
+            </time>
+          </Tooltip>
+          {timing ? (
+            <Tooltip content={timing.tooltip} delay={200}>
+              <span className="badge-sm text-[10px] text-theme-text-secondary">{timing.chip}</span>
+            </Tooltip>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
 
   useEffect(() => {
     if (open) {
@@ -206,13 +241,13 @@ export function IssueRow({
             onToggle();
           }
         }}
-        className={`group flex cursor-pointer items-center gap-3 border-l-[3px] py-3 pl-3 pr-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40 ${open ? ISSUE_SEVERITY_HEADER_BAND_CLASS[severity] : ISSUE_SEVERITY_RAIL_CLASS[severity]}`}
+        className={`group @container/issue flex cursor-pointer items-center gap-3 border-l-[3px] py-3 pl-3 pr-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40 ${open ? ISSUE_SEVERITY_HEADER_BAND_CLASS[severity] : ISSUE_SEVERITY_RAIL_CLASS[severity]}`}
       >
         <SeverityIcon className={`h-[18px] w-[18px] shrink-0 ${ISSUE_SEVERITY_TEXT_CLASS[severity]}`} aria-hidden />
 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex min-w-0 items-baseline gap-2">
-            <span className="shrink-0 text-sm font-medium text-theme-text-primary">{categoryLabel(issue.category)}</span>
+            <span className="min-w-0 truncate text-sm font-medium text-theme-text-primary">{categoryLabel(issue.category)}</span>
             <span className={`shrink-0 self-center ${groupBadgeClass(issue.category_group)}`}>{groupLabel(issue.category_group)}</span>
             {renderBadges?.(slotCtx)}
             {/* The detector reason rides the title row while COLLAPSED so the
@@ -265,32 +300,16 @@ export function IssueRow({
             ) : null}
             {renderMeta?.(slotCtx)}
           </div>
+          {/* Narrow container: the meta chips drop to their own line here rather
+              than stealing width from the title on the row above. Hidden once the
+              row is wide enough to hold them inline in the right cluster. */}
+          {metaChips('flex @2xl/issue:hidden')}
         </div>
 
-        {/* Right cluster — severity pill THEN age, vertically centered as a group. */}
+        {/* Right cluster — the always-visible affordances (per-row action +
+            chevron) plus, on a wide container, the inline meta chips. */}
         <div className="flex shrink-0 items-center gap-3">
-          <span className={`badge-sm shrink-0 px-2.5 py-0.5 text-xs font-semibold ${open ? ISSUE_SEVERITY_SOLID_CLASS[severity] : ISSUE_SEVERITY_BADGE_CLASS[severity]}`}>
-            {ISSUE_SEVERITY_LABEL[severity]}
-          </span>
-          {/* Age chip: keep recency visible; the deployment-start signal rides as a secondary tag. */}
-          {issue.first_seen ? (
-            <>
-              <Tooltip content={ageTitle(issue)} delay={200} wrapperClassName="shrink-0">
-                <time
-                  dateTime={issue.first_seen}
-                  className="flex items-center gap-1 text-xs tabular-nums text-theme-text-tertiary"
-                >
-                  <Clock className="h-3 w-3" aria-hidden />
-                  {formatCompactAge(issue.first_seen)}
-                </time>
-              </Tooltip>
-              {timing ? (
-                <Tooltip content={timing.tooltip} delay={200}>
-                  <span className="badge-sm text-[10px] text-theme-text-secondary">{timing.chip}</span>
-                </Tooltip>
-              ) : null}
-            </>
-          ) : null}
+          {metaChips('hidden @2xl/issue:flex')}
           {renderActions?.(slotCtx)}
           <ChevronRight className={`h-4 w-4 shrink-0 text-theme-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`} />
         </div>
@@ -329,7 +348,7 @@ export function IssueRow({
                   </section>
                 ) : null}
                 <DiagnosticContext issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
-                <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
+                <AffectedResources issue={issue} hideSubject={hideSubject} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
               </div>
             </div>
           </div>
@@ -519,11 +538,13 @@ function ageTitle(issue: Issue): string {
 
 function AffectedResources({
   issue,
+  hideSubject,
   resourceHref,
   onResourceClick,
   ResourceLinkIcon,
 }: {
   issue: Issue;
+  hideSubject?: boolean;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
   ResourceLinkIcon: ComponentType<{ className?: string }>;
@@ -532,14 +553,19 @@ function AffectedResources({
   // count is the backend fan-out size (members, subject excluded — see
   // grouping.go); fall back to the inline member count, not +1.
   const total = issue.count ?? members.length;
+  // With the subject suppressed and no fanned-out members, this section has
+  // nothing to show — return null so the divider row above it doesn't render empty.
+  if (hideSubject && members.length === 0) return null;
   return (
     <section className="flex flex-col gap-3">
       {/* The subject (the grouped thing — e.g. the Deployment) is always the
           first deep-link; members (the folded pods) follow. ResourceLine emits
           an <li>, so it needs a list parent of its own. */}
-      <ul className="flex flex-col gap-px">
-        <ResourceLine label="Subject" compact refForLink={subjectRef(issue)} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
-      </ul>
+      {!hideSubject && (
+        <ul className="flex flex-col gap-px">
+          <ResourceLine label="Subject" compact refForLink={subjectRef(issue)} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
+        </ul>
+      )}
       {members.length > 0 && (
         <CardSection icon={Layers} label="Affected resources" labelExtra={`· ${total}`}>
           <ul className="flex flex-col gap-px">

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.test.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { renderToString } from 'react-dom/server'
-import { ResourceIssuesSection } from './ResourceIssuesSection'
+import { ResourceIssuesSection, sameResource } from './ResourceIssuesSection'
+import { IssueRow } from './IssuesView'
 import type { Issue } from './types'
 
 const issue: Issue = {
@@ -36,5 +37,36 @@ describe('ResourceIssuesSection', () => {
     expect(html).not.toContain('What&#x27;s wrong')
     expect(html).not.toContain('Context')
     expect(html).not.toContain('Blocked pods')
+  })
+
+  it('shows the Subject deep-link by default', () => {
+    const html = renderToString(<IssueRow issue={issue} open onToggle={() => {}} onResourceClick={() => {}} />)
+    expect(html).toContain('Subject')
+  })
+
+  it('suppresses the Subject deep-link when the issue subject is the embedding resource', () => {
+    // apiKind (plural) must still resolve to the same identity as the wire kind.
+    const html = renderToString(<IssueRow issue={issue} open onToggle={() => {}} onResourceClick={() => {}} hideSubject />)
+    expect(html).not.toContain('Subject')
+  })
+})
+
+describe('sameResource', () => {
+  const subject = { kind: 'PersistentVolumeClaim', namespace: 'demo', name: 'data' }
+
+  it('matches across singular kind vs plural API name', () => {
+    expect(sameResource(subject, { kind: 'persistentvolumeclaims', namespace: 'demo', name: 'data' })).toBe(true)
+  })
+
+  it('treats a missing namespace as empty', () => {
+    expect(sameResource({ kind: 'Node', name: 'n1' }, { kind: 'nodes', namespace: '', name: 'n1' })).toBe(true)
+  })
+
+  it('does not match a different name', () => {
+    expect(sameResource(subject, { kind: 'persistentvolumeclaims', namespace: 'demo', name: 'other' })).toBe(false)
+  })
+
+  it('does not match a different kind', () => {
+    expect(sameResource(subject, { kind: 'configmaps', namespace: 'demo', name: 'data' })).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -1,15 +1,22 @@
 import { useMemo, useState } from 'react'
 import { AlertTriangle } from 'lucide-react'
+import { kindToPlural } from '../../utils/navigation'
 import { IssueRow } from './IssuesView'
-import { compareIssues, type Issue, type IssueResourceRef } from './types'
+import { compareIssues, subjectRef, type Issue, type IssueResourceRef } from './types'
 
 export function ResourceIssuesSection({
   issues,
   onResourceClick,
+  subjectResource,
 }: {
   issues: Issue[] | undefined
   /** When provided, related resources in a causal link become clickable. */
   onResourceClick?: (ref: IssueResourceRef) => void
+  /** The resource this section is embedded under. When an issue's subject IS
+   *  this resource, its redundant "Subject" deep-link is suppressed — the drawer
+   *  header already names it. Omit (e.g. the standalone fleet queue) to always
+   *  show the subject. */
+  subjectResource?: IssueResourceRef
 }) {
   const sorted = useMemo(() => [...(issues ?? [])].sort(compareIssues), [issues])
   const [openId, setOpenId] = useState<string | null>(null)
@@ -32,11 +39,24 @@ export function ResourceIssuesSection({
               open={openId === key}
               onToggle={() => setOpenId((cur) => (cur === key ? null : key))}
               onResourceClick={onResourceClick}
+              hideSubject={subjectResource ? sameResource(subjectRef(issue), subjectResource) : false}
             />
           )
         })}
       </ol>
     </section>
+  )
+}
+
+// Identity match tolerant of singular/plural + casing on kind (the subject ref
+// carries the wire kind, the host typically passes the plural API name) — group
+// is deliberately ignored: a per-resource issue feed is already scoped to one
+// resource, and kind+namespace+name uniquely identifies it there.
+export function sameResource(a: IssueResourceRef, b: IssueResourceRef): boolean {
+  return (
+    a.name === b.name &&
+    (a.namespace ?? '') === (b.namespace ?? '') &&
+    kindToPlural(a.kind).toLowerCase() === kindToPlural(b.kind).toLowerCase()
   )
 }
 

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -410,7 +410,7 @@ export function AlertBanner({ variant, icon, title, message, items, children }: 
         {hasBody ? (
           <div className="flex-1 min-w-0">
             <div className={clsx('text-sm font-medium', colors.title, items && 'mb-1')}>{title}</div>
-            {message && <div className={clsx('text-xs mt-1 break-all', colors.message)}>{message}</div>}
+            {message && <div className={clsx('text-xs mt-1 break-words', colors.message)}>{message}</div>}
             {items && items.length > 0 && (
               <ul className={clsx('text-xs space-y-1', colors.list)}>
                 {items.map((item, i) => (

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -968,6 +968,7 @@ export function WorkloadView({
         renderOverviewLead={() => (
           <ResourceIssuesSection
             issues={liveIssues}
+            subjectResource={{ kind: apiKind, namespace, name, group: rest.group }}
             onResourceClick={
               rest.onNavigateToResource
                 ? (ref) =>


### PR DESCRIPTION
## Summary

Three layout/readability fixes to the **Operational Issues** panel shown in the resource detail drawer. In the narrow drawer the issue title collided with the severity pill, long error messages broke in the middle of words, and each issue echoed a "Subject" deep-link back to the very resource the drawer was already showing.

## What changed

- **The issue row reflows responsively.** The header is a container query (`@container/issue`): on a wide row (the full-page fleet/issues queue) the meta chips — severity pill, age, "since creation" — sit inline on the right, exactly as before. Once the row is narrow (the in-drawer embed), those chips drop to their own line beneath the `kind · namespace/name` line, so the title gets the full width and is never truncated to make room. Only the chevron (and any per-row action) stay pinned top-right. The chips render from a single helper shown in one of two slots (`hidden @2xl/issue:flex` / `flex @2xl/issue:hidden`) so the two layouts can't drift apart.
- **Alert-banner messages wrap on word boundaries.** `AlertBanner` (used by the Gateway API route/gateway renderers, `ProblemAlerts`, and other condition surfaces) wrapped its message with `break-all`, splitting words mid-character. It now uses `break-words`, so text wraps on spaces and only breaks a token when it genuinely can't fit on its own line.
- **Redundant Subject line suppressed in the drawer.** When an issue's subject is the resource the drawer is already displaying, the "Subject" deep-link is dropped (the header names it). `ResourceIssuesSection` takes an optional `subjectResource`; each row hides its Subject line when that ref matches the issue's subject (kind compared plural/singular- and case-insensitively, namespace/name exact). The affected-resources section renders nothing — no empty divider — when the subject is hidden and there are no fanned-out members. Omitting `subjectResource` (e.g. the standalone fleet queue) preserves the always-show behavior.

Reviewer focus: the `@2xl/issue` breakpoint that flips the meta chips between inline and stacked; `sameResource()` kind normalization in `ResourceIssuesSection.tsx`; and the `hideSubject` null-render branch in `AffectedResources`.

## Testing

- `make tsc` — clean.
- `packages/k8s-ui` vitest — pass, including new coverage for `IssueRow` with/without `hideSubject` and `sameResource` normalization (singular↔plural, missing namespace, mismatched name/kind).
- Visually checked the drawer at in-drawer width (title full, chips stacked) and the full-width queue (single-line, unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and conditional rendering in the issues panel and AlertBanner; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Improves **Operational Issues** readability in narrow resource drawers and related alert surfaces.
> 
> **Issue rows** use container queries so severity, age, and timing chips sit inline on wide rows but move to their own line when space is tight; the category title **truncates** instead of overlapping the severity pill. **`hideSubject`** on `IssueRow` / `AffectedResources` drops the redundant “Subject” deep-link when the drawer already shows that resource; **`ResourceIssuesSection`** accepts optional **`subjectResource`** and uses **`sameResource()`** (plural/singular kind via `kindToPlural`, namespace/name match) to set `hideSubject` per row. If the subject is hidden and there are no member resources, the affected block renders nothing (no empty divider). **`WorkloadView`** passes the current resource as `subjectResource`.
> 
> **`AlertBanner`** message text switches from **`break-all`** to **`break-words`** so long messages wrap on word boundaries.
> 
> Tests cover default vs suppressed Subject and `sameResource` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938a277db84dcd0603a368ea66bc5e93c2c0db26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->