### PR TITLE
CRD multi-namespace parity for namespace-restricted identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ radar
 | `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
 | `--kubeconfig-dir` | | Comma-separated directories containing kubeconfig files |
 | `--namespace` | (all) | Initial namespace filter (supports multi-select in the UI; also used as RBAC fallback for namespace-scoped users) |
-| `--namespaces` | (all) | Initial namespace filters as a comma-separated list, e.g. `--namespaces ns1,ns2,ns3`. Use this when your identity can list resources in specific namespaces but cannot list namespaces cluster-wide. Applies to built-in resource types; CRD views currently use the first granted namespace. |
+| `--namespaces` | (all) | Initial namespace filters as a comma-separated list, e.g. `--namespaces ns1,ns2,ns3`. Use this when your identity can list resources in specific namespaces but cannot list namespaces cluster-wide. |
 | `--namespace-scope` | `false` | Pin namespaced informer caches to a **single** namespace for large clusters (scoping to multiple namespaces is not supported yet). Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
 | `--no-browser` | `false` | Don't auto-open browser |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,7 @@ kubectl radar --namespaces ns1,ns2,ns3
 
 Radar probes each listed namespace for access and watches every namespace where access is granted — resource views then cover all of them, not just the first. When Radar opens the browser itself, the list is also applied as the initial namespace selection. The picker can then switch between those namespaces or keep several selected at once.
 
-This currently applies to built-in resource types. Custom resources (CRDs — GitOps, Gateway API, etc.) still fall back to the first granted namespace when cluster-wide listing is denied; full multi-namespace CRD coverage is tracked separately. The list is capped by `--max-scope-candidates` (default 20) — startup fails with a clear error rather than silently probing a subset.
+This covers built-in resource types and custom resources alike: CRDs (GitOps, Gateway API, etc.) are probed per-kind across the same list and watched in every granted namespace. The list is capped by `--max-scope-candidates` (default 20) — startup fails with a clear error rather than silently probing a subset.
 
 When Radar starts with `--namespace-scope`, the picker controls the process-wide cache scope instead of just a view filter. Namespaced informer caches are pinned to one namespace while cluster-scoped resources remain cluster-wide. Local/no-auth sessions can switch the scoped namespace, which rebuilds the cache in place. Auth-enabled and Radar Cloud sessions lock the picker to the startup namespace so one user cannot reshape the shared backend cache for everyone.
 

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -72,6 +72,7 @@ type PermissionCheckResult struct {
 	Namespace       string // The fallback namespace used for namespace-scoped probes
 	Scopes          map[string]k8score.ResourceScope
 	ScopeNamespaces map[string][]string // Per-kind namespace-scoped informer fanout; nil/empty means use Scopes[key].Namespace
+	ScopeCandidates []string            // The candidate namespaces the probe walked — the dynamic CRD cache probes these per-GVR as its namespace fallbacks
 }
 
 // Capabilities represents the features available based on RBAC permissions
@@ -901,6 +902,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 			Namespace:       cachedPermResult.Namespace,
 			Scopes:          scopesCopy,
 			ScopeNamespaces: scopeNamespacesCopy,
+			ScopeCandidates: append([]string(nil), cachedPermResult.ScopeCandidates...),
 		}
 		resourcePermsMu.RUnlock()
 		return result
@@ -1038,13 +1040,14 @@ func mergeScopeCandidateLists(ctxNs string, flagNamespaces []string, accessible 
 }
 
 // pickPrimaryNs picks the namespace that PermissionCheckResult.Namespace
-// reports. The dynamic CRD cache reads it as NamespaceFallback (single
-// anchor for all CRD informers); it has to be a namespace where the user
-// actually has reads, otherwise CRD informers get pinned where they 403.
-// Walk candidates in order and pick the first one any typed kind landed
-// in. Fall back to scopeNamespaces[0] when nothing was granted — the
-// dynamic cache short-circuits on NamespaceScoped=false in that case, so
-// the value is only used by the diagnostics page (preserves prior shape).
+// reports — the stable primary for single-namespace consumers (legacy
+// diagnostics, the dynamic cache's last-resort single fallback). The dynamic
+// CRD cache fans out across ScopeCandidates per-GVR, so this is no longer
+// the only namespace CRDs can watch. Walk candidates in order and pick the
+// first one any typed kind landed in. Fall back to scopeNamespaces[0] when
+// nothing was granted — the dynamic cache short-circuits on
+// NamespaceScoped=false in that case, so the value is only used by the
+// diagnostics page (preserves prior shape).
 func pickPrimaryNs(scopeNamespaces []string, scopes map[string]k8score.ResourceScope) string {
 	granted := map[string]bool{}
 	for _, s := range scopes {
@@ -1054,12 +1057,6 @@ func pickPrimaryNs(scopeNamespaces []string, scopes map[string]k8score.ResourceS
 	}
 	for _, ns := range scopeNamespaces {
 		if granted[ns] {
-			// CRDs the user reads in the OTHER granted namespaces will
-			// silently 403 — proper fix needs multi-ns scope per kind in
-			// pkg/k8score; warn so the operator can see the asymmetry.
-			if len(granted) > 1 {
-				log.Printf("RBAC: typed kinds granted in %d distinct namespaces; CRD informer fallback pinned to %q — CRDs in the others will be marked denied", len(granted), SanitizeForLog(ns))
-			}
 			return ns
 		}
 	}
@@ -1301,6 +1298,7 @@ func probeResourceAccess(ctx context.Context, dyn dynamic.Interface, scopeNamesp
 		Namespace:       primaryNs,
 		Scopes:          scopes,
 		ScopeNamespaces: scopeNamespacesByKind,
+		ScopeCandidates: append([]string(nil), scopeNamespaces...),
 	}, hadErrors.Load()
 }
 
@@ -1329,6 +1327,7 @@ func GetCachedPermissionResult() *PermissionCheckResult {
 		Namespace:       cachedPermResult.Namespace,
 		Scopes:          scopesCopy,
 		ScopeNamespaces: scopeNamespacesCopy,
+		ScopeCandidates: append([]string(nil), cachedPermResult.ScopeCandidates...),
 	}
 }
 

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -43,8 +43,10 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 		// cluster-wide is denied); per-user namespace filtering happens at
 		// the HTTP layer (see internal/server/namespace_scope.go).
 		var nsFallback string
+		var nsFallbacks []string
 		if permResult := GetCachedPermissionResult(); permResult != nil && permResult.NamespaceScoped && permResult.Namespace != "" {
 			nsFallback = permResult.Namespace
+			nsFallbacks = permResult.ScopeCandidates
 		}
 
 		// --namespace-scope pins namespaced CRD informers to the target namespace
@@ -70,13 +72,14 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 		recordClusterContext := ActiveClusterContext()
 
 		core, err := k8score.NewDynamicResourceCache(k8score.DynamicCacheConfig{
-			DynamicClient:     client,
-			Discovery:         sharedDiscovery,
-			Changes:           changeCh,
-			NamespaceFallback: nsFallback,
-			NamespaceScoped:   nsScoped,
-			Namespace:         nsTarget,
-			DebugEvents:       DebugEvents,
+			DynamicClient:      client,
+			Discovery:          sharedDiscovery,
+			Changes:            changeCh,
+			NamespaceFallback:  nsFallback,
+			NamespaceFallbacks: nsFallbacks,
+			NamespaceScoped:    nsScoped,
+			Namespace:          nsTarget,
+			DebugEvents:        DebugEvents,
 			OnReceived: func(kind string) {
 				timeline.IncrementReceived(kind)
 			},
@@ -344,9 +347,12 @@ func RegisterSupportedCRDFallbacks() {
 		return
 	}
 
-	nsFallback := ""
+	var nsFallbacks []string
 	if permResult := GetCachedPermissionResult(); permResult != nil && permResult.NamespaceScoped && permResult.Namespace != "" {
-		nsFallback = permResult.Namespace
+		nsFallbacks = permResult.ScopeCandidates
+		if len(nsFallbacks) == 0 {
+			nsFallbacks = []string{permResult.Namespace}
+		}
 	}
 
 	const maxConcurrentProbes = 12
@@ -371,7 +377,7 @@ func RegisterSupportedCRDFallbacks() {
 
 			for _, version := range c.Versions {
 				gvr := schema.GroupVersionResource{Group: c.Group, Version: version, Resource: c.Resource}
-				namespace, ok := fallbackListProbe(client, gvr, c.Namespaced, nsFallback)
+				namespace, ok := fallbackListProbe(client, gvr, c.Namespaced, nsFallbacks)
 				if !ok {
 					continue
 				}
@@ -402,7 +408,7 @@ func RegisterSupportedCRDFallbacks() {
 	}
 }
 
-func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespaced bool, nsFallback string) (string, bool) {
+func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespaced bool, nsFallbacks []string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -410,18 +416,26 @@ func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource
 	if err == nil {
 		return "", true
 	}
-	if namespaced && nsFallback != "" {
+	if namespaced && len(nsFallbacks) > 0 {
 		if !isExpectedFallbackProbeDenial(err) {
 			log.Printf("[crd-fallback] Cluster-wide list probe failed for %s.%s/%s: %v", gvr.Resource, gvr.Group, gvr.Version, err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err = client.Resource(gvr).Namespace(nsFallback).List(ctx, metav1.ListOptions{Limit: 1})
-		if err == nil {
-			return nsFallback, true
-		}
-		if !isExpectedFallbackProbeDenial(err) {
-			log.Printf("[crd-fallback] Namespace list probe failed for %s.%s/%s in ns=%q: %v", gvr.Resource, gvr.Group, gvr.Version, nsFallback, err)
+		// Registration probe only — the dynamic cache re-probes every
+		// candidate per-GVR when it starts watching, so first grant is
+		// enough to prove the CRD exists and is readable somewhere.
+		for _, ns := range nsFallbacks {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			nsErr := func() error {
+				defer cancel()
+				_, e := client.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1})
+				return e
+			}()
+			if nsErr == nil {
+				return ns, true
+			}
+			if !isExpectedFallbackProbeDenial(nsErr) {
+				log.Printf("[crd-fallback] Namespace list probe failed for %s.%s/%s in ns=%q: %v", gvr.Resource, gvr.Group, gvr.Version, ns, nsErr)
+			}
 		}
 		return "", false
 	}

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -436,13 +436,21 @@ func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource
 		// candidate per-GVR when it starts watching. Return every
 		// list-granted candidate so the caller can find one that also
 		// grants watch (list-only in the first namespace must not hide a
-		// CRD that is fully readable in a later one).
+		// CRD that is fully readable in a later one). One shared budget for
+		// the whole walk plus a per-candidate sub-deadline: a fresh 5s per
+		// candidate would let a degraded apiserver stall discovery for
+		// minutes at the 20-candidate cap.
+		walkCtx, walkCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer walkCancel()
 		var granted []string
 		for _, ns := range nsFallbacks {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if walkCtx.Err() != nil {
+				break
+			}
+			nsCtx, nsCancel := context.WithTimeout(walkCtx, 2*time.Second)
 			nsErr := func() error {
-				defer cancel()
-				_, e := client.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1})
+				defer nsCancel()
+				_, e := client.Resource(gvr).Namespace(ns).List(nsCtx, metav1.ListOptions{Limit: 1})
 				return e
 			}()
 			if nsErr == nil {

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -44,8 +44,13 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 		// the HTTP layer (see internal/server/namespace_scope.go).
 		var nsFallback string
 		var nsFallbacks []string
-		if permResult := GetCachedPermissionResult(); permResult != nil && permResult.NamespaceScoped && permResult.Namespace != "" {
-			nsFallback = permResult.Namespace
+		if permResult := GetCachedPermissionResult(); permResult != nil {
+			if permResult.NamespaceScoped && permResult.Namespace != "" {
+				nsFallback = permResult.Namespace
+			}
+			// Candidates apply regardless of the typed outcome: an identity
+			// can hold cluster-wide built-in access but namespace-only CRD
+			// access (or the reverse) — the per-GVR probe decides.
 			nsFallbacks = permResult.ScopeCandidates
 		}
 
@@ -348,9 +353,9 @@ func RegisterSupportedCRDFallbacks() {
 	}
 
 	var nsFallbacks []string
-	if permResult := GetCachedPermissionResult(); permResult != nil && permResult.NamespaceScoped && permResult.Namespace != "" {
+	if permResult := GetCachedPermissionResult(); permResult != nil {
 		nsFallbacks = permResult.ScopeCandidates
-		if len(nsFallbacks) == 0 {
+		if len(nsFallbacks) == 0 && permResult.NamespaceScoped && permResult.Namespace != "" {
 			nsFallbacks = []string{permResult.Namespace}
 		}
 	}
@@ -377,11 +382,18 @@ func RegisterSupportedCRDFallbacks() {
 
 			for _, version := range c.Versions {
 				gvr := schema.GroupVersionResource{Group: c.Group, Version: version, Resource: c.Resource}
-				namespace, ok := fallbackListProbe(client, gvr, c.Namespaced, nsFallbacks)
+				namespaces, ok := fallbackListProbe(client, gvr, c.Namespaced, nsFallbacks)
 				if !ok {
 					continue
 				}
-				if !fallbackWatchProbe(client, gvr, namespace) {
+				watchable := false
+				for _, namespace := range namespaces {
+					if fallbackWatchProbe(client, gvr, namespace) {
+						watchable = true
+						break
+					}
+				}
+				if !watchable {
 					continue
 				}
 				discovery.AddAPIResource(k8score.APIResource{
@@ -408,21 +420,24 @@ func RegisterSupportedCRDFallbacks() {
 	}
 }
 
-func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespaced bool, nsFallbacks []string) (string, bool) {
+func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespaced bool, nsFallbacks []string) ([]string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	_, err := client.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
 	if err == nil {
-		return "", true
+		return []string{""}, true
 	}
 	if namespaced && len(nsFallbacks) > 0 {
 		if !isExpectedFallbackProbeDenial(err) {
 			log.Printf("[crd-fallback] Cluster-wide list probe failed for %s.%s/%s: %v", gvr.Resource, gvr.Group, gvr.Version, err)
 		}
 		// Registration probe only — the dynamic cache re-probes every
-		// candidate per-GVR when it starts watching, so first grant is
-		// enough to prove the CRD exists and is readable somewhere.
+		// candidate per-GVR when it starts watching. Return every
+		// list-granted candidate so the caller can find one that also
+		// grants watch (list-only in the first namespace must not hide a
+		// CRD that is fully readable in a later one).
+		var granted []string
 		for _, ns := range nsFallbacks {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			nsErr := func() error {
@@ -431,18 +446,19 @@ func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource
 				return e
 			}()
 			if nsErr == nil {
-				return ns, true
+				granted = append(granted, ns)
+				continue
 			}
 			if !isExpectedFallbackProbeDenial(nsErr) {
 				log.Printf("[crd-fallback] Namespace list probe failed for %s.%s/%s in ns=%q: %v", gvr.Resource, gvr.Group, gvr.Version, ns, nsErr)
 			}
 		}
-		return "", false
+		return granted, len(granted) > 0
 	}
 	if !isExpectedFallbackProbeDenial(err) {
 		log.Printf("[crd-fallback] List probe failed for %s.%s/%s: %v", gvr.Resource, gvr.Group, gvr.Version, err)
 	}
-	return "", false
+	return nil, false
 }
 
 func fallbackWatchProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string) bool {

--- a/internal/k8s/dynamic_cache_fallback_test.go
+++ b/internal/k8s/dynamic_cache_fallback_test.go
@@ -33,12 +33,12 @@ func TestFallbackListProbeUsesNamespaceFallback(t *testing.T) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
 	})
 
-	namespace, ok := fallbackListProbe(client, gvr, true, []string{"team-a"})
+	namespaces, ok := fallbackListProbe(client, gvr, true, []string{"team-a"})
 	if !ok {
 		t.Fatal("expected namespace fallback probe to succeed")
 	}
-	if namespace != "team-a" {
-		t.Fatalf("namespace = %q, want team-a", namespace)
+	if len(namespaces) != 1 || namespaces[0] != "team-a" {
+		t.Fatalf("namespaces = %v, want [team-a]", namespaces)
 	}
 }
 
@@ -56,12 +56,12 @@ func TestFallbackListProbeWalksCandidatesToLaterGrant(t *testing.T) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
 	})
 
-	namespace, ok := fallbackListProbe(client, gvr, true, []string{"team-a", "team-b"})
+	namespaces, ok := fallbackListProbe(client, gvr, true, []string{"team-a", "team-b"})
 	if !ok {
 		t.Fatal("expected probe to find the later candidate grant")
 	}
-	if namespace != "team-b" {
-		t.Fatalf("namespace = %q, want team-b", namespace)
+	if len(namespaces) != 1 || namespaces[0] != "team-b" {
+		t.Fatalf("namespaces = %v, want [team-b]", namespaces)
 	}
 }
 

--- a/internal/k8s/dynamic_cache_fallback_test.go
+++ b/internal/k8s/dynamic_cache_fallback_test.go
@@ -33,12 +33,35 @@ func TestFallbackListProbeUsesNamespaceFallback(t *testing.T) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
 	})
 
-	namespace, ok := fallbackListProbe(client, gvr, true, "team-a")
+	namespace, ok := fallbackListProbe(client, gvr, true, []string{"team-a"})
 	if !ok {
 		t.Fatal("expected namespace fallback probe to succeed")
 	}
 	if namespace != "team-a" {
 		t.Fatalf("namespace = %q, want team-a", namespace)
+	}
+}
+
+func TestFallbackListProbeWalksCandidatesToLaterGrant(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "virtualservices"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VirtualServiceList"},
+	)
+	client.PrependReactor("list", "virtualservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction := action.(k8stesting.ListAction)
+		if listAction.GetNamespace() == "team-b" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+	})
+
+	namespace, ok := fallbackListProbe(client, gvr, true, []string{"team-a", "team-b"})
+	if !ok {
+		t.Fatal("expected probe to find the later candidate grant")
+	}
+	if namespace != "team-b" {
+		t.Fatalf("namespace = %q, want team-b", namespace)
 	}
 }
 
@@ -56,7 +79,7 @@ func TestFallbackListProbeDoesNotNamespaceFallbackClusterScoped(t *testing.T) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
 	})
 
-	if _, ok := fallbackListProbe(client, gvr, false, "team-a"); ok {
+	if _, ok := fallbackListProbe(client, gvr, false, []string{"team-a"}); ok {
 		t.Fatal("expected cluster-scoped fallback probe to fail after cluster-wide denial")
 	}
 }

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1216,7 +1216,7 @@ func TestDynamicResourceCache_NamespaceFallbackIsPerGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	clusterScopes, err := d.probeScopes(clusterGVR, "")
+	clusterScopes, _, err := d.probeScopes(clusterGVR, "")
 	if err != nil {
 		t.Fatalf("cluster GVR probe failed: %v", err)
 	}
@@ -1224,7 +1224,7 @@ func TestDynamicResourceCache_NamespaceFallbackIsPerGVR(t *testing.T) {
 		t.Errorf("cluster GVR scopes = %q, want cluster-wide", clusterScopes)
 	}
 
-	nsScopes, err := d.probeScopes(namespacedGVR, "")
+	nsScopes, _, err := d.probeScopes(namespacedGVR, "")
 	if err != nil {
 		t.Fatalf("namespaced GVR probe failed: %v", err)
 	}
@@ -1251,7 +1251,7 @@ func TestDynamicResourceCache_ForcedNamespaceScopesEveryGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	scopes, err := d.probeScopes(gvr, "")
+	scopes, _, err := d.probeScopes(gvr, "")
 	if err != nil {
 		t.Fatalf("forced namespace probe failed: %v", err)
 	}
@@ -1282,7 +1282,7 @@ func TestDynamicResourceCache_ProbeScope_HonorsRequestedNamespace(t *testing.T) 
 	}
 
 	// Requesting the namespace the user can list scopes the informer there.
-	scopes, err := d.probeScopes(gvr, wantedNs)
+	scopes, _, err := d.probeScopes(gvr, wantedNs)
 	if err != nil {
 		t.Fatalf("probeScopes(%q) failed: %v", wantedNs, err)
 	}
@@ -1292,7 +1292,7 @@ func TestDynamicResourceCache_ProbeScope_HonorsRequestedNamespace(t *testing.T) 
 
 	// With no requested namespace, it falls back to the configured fallback,
 	// which the user cannot list — so the probe is forbidden.
-	if _, err := d.probeScopes(gvr, ""); !apierrors.IsForbidden(err) {
+	if _, _, err := d.probeScopes(gvr, ""); !apierrors.IsForbidden(err) {
 		t.Errorf("probeScopes(\"\") err = %v, want forbidden", err)
 	}
 }
@@ -1694,12 +1694,15 @@ func TestDynamicResourceCache_ProbeScopesFansOutAcrossFallbacks(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	scopes, err := d.probeScopes(gvr, "")
+	scopes, complete, err := d.probeScopes(gvr, "")
 	if err != nil {
 		t.Fatalf("probeScopes failed: %v", err)
 	}
 	if !reflect.DeepEqual(scopes, []string{nsA, nsB}) {
 		t.Fatalf("scopes = %v, want [%s %s]", scopes, nsA, nsB)
+	}
+	if !complete {
+		t.Fatal("healthy fanout walk must report complete")
 	}
 }
 

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1751,3 +1751,87 @@ func TestDynamicResourceCache_EnsureWatchingFansOutAndUnions(t *testing.T) {
 		t.Fatalf("Count = %d, %v; want 2", n, err)
 	}
 }
+
+// Pins the unavailable-over-partial contract: a fanout GVR whose informers
+// exist only from namespace-specific reads (all-namespaces walk never
+// settled) must refuse an all-namespace count rather than sum the subset —
+// and must start counting once an all-namespaces read settles the walk.
+func TestDynamicResourceCache_CountRefusesUnsettledFanout(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB
+	})
+	for _, ns := range []string{nsA, nsB} {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w-" + ns, "namespace": ns},
+		}}
+		if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed %s: %v", ns, err)
+		}
+	}
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:      dyn,
+		NamespaceFallbacks: []string{nsA, nsB},
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	// Namespace-specific read only — informer for nsA exists, walk unsettled.
+	if _, err := d.ListBlocking(gvr, nsA, 3*time.Second); err != nil {
+		t.Fatalf("ListBlocking(%s): %v", nsA, err)
+	}
+	if n, err := d.Count(gvr, nil); err == nil {
+		t.Fatalf("all-namespace count on unsettled fanout returned %d, want error", n)
+	}
+
+	// All-namespaces read settles the walk; the count becomes authoritative.
+	if _, err := d.ListBlocking(gvr, "", 3*time.Second); err != nil {
+		t.Fatalf("ListBlocking(all): %v", err)
+	}
+	if n, err := d.Count(gvr, nil); err != nil || n != 2 {
+		t.Fatalf("settled count = %d, %v; want 2", n, err)
+	}
+}
+
+// Legacy single-fallback regression: with exactly one configured fallback
+// namespace, an informer created by an explicit-namespace read fully covers
+// the configured scope — Count(gvr, nil) must work without ever seeing an
+// all-namespaces read.
+func TestDynamicResourceCache_SingleFallbackCountsWithoutAllNamespacesRead(t *testing.T) {
+	const ns = "team-a"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == ns
+	})
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w-1", "namespace": ns},
+	}}
+	if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:     dyn,
+		NamespaceFallback: ns,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	// Explicit-namespace read only — never an all-namespaces read.
+	if _, err := d.ListBlocking(gvr, ns, 3*time.Second); err != nil {
+		t.Fatalf("ListBlocking(%s): %v", ns, err)
+	}
+	if n, err := d.Count(gvr, nil); err != nil || n != 1 {
+		t.Fatalf("single-fallback Count = %d, %v; want 1", n, err)
+	}
+}

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1215,20 +1216,20 @@ func TestDynamicResourceCache_NamespaceFallbackIsPerGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	clusterScope, err := d.probeScope(clusterGVR, "")
+	clusterScopes, err := d.probeScopes(clusterGVR, "")
 	if err != nil {
 		t.Fatalf("cluster GVR probe failed: %v", err)
 	}
-	if clusterScope != "" {
-		t.Errorf("cluster GVR scope = %q, want cluster-wide", clusterScope)
+	if !reflect.DeepEqual(clusterScopes, []string{""}) {
+		t.Errorf("cluster GVR scopes = %q, want cluster-wide", clusterScopes)
 	}
 
-	nsScope, err := d.probeScope(namespacedGVR, "")
+	nsScopes, err := d.probeScopes(namespacedGVR, "")
 	if err != nil {
 		t.Fatalf("namespaced GVR probe failed: %v", err)
 	}
-	if nsScope != ns {
-		t.Errorf("namespaced GVR scope = %q, want %q", nsScope, ns)
+	if !reflect.DeepEqual(nsScopes, []string{ns}) {
+		t.Errorf("namespaced GVR scopes = %q, want [%q]", nsScopes, ns)
 	}
 }
 
@@ -1250,12 +1251,12 @@ func TestDynamicResourceCache_ForcedNamespaceScopesEveryGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	scope, err := d.probeScope(gvr, "")
+	scopes, err := d.probeScopes(gvr, "")
 	if err != nil {
 		t.Fatalf("forced namespace probe failed: %v", err)
 	}
-	if scope != ns {
-		t.Errorf("GVR scope = %q, want %q", scope, ns)
+	if !reflect.DeepEqual(scopes, []string{ns}) {
+		t.Errorf("GVR scopes = %q, want [%q]", scopes, ns)
 	}
 }
 
@@ -1281,18 +1282,18 @@ func TestDynamicResourceCache_ProbeScope_HonorsRequestedNamespace(t *testing.T) 
 	}
 
 	// Requesting the namespace the user can list scopes the informer there.
-	scope, err := d.probeScope(gvr, wantedNs)
+	scopes, err := d.probeScopes(gvr, wantedNs)
 	if err != nil {
-		t.Fatalf("probeScope(%q) failed: %v", wantedNs, err)
+		t.Fatalf("probeScopes(%q) failed: %v", wantedNs, err)
 	}
-	if scope != wantedNs {
-		t.Errorf("scope = %q, want %q", scope, wantedNs)
+	if !reflect.DeepEqual(scopes, []string{wantedNs}) {
+		t.Errorf("scopes = %q, want [%q]", scopes, wantedNs)
 	}
 
 	// With no requested namespace, it falls back to the configured fallback,
 	// which the user cannot list — so the probe is forbidden.
-	if _, err := d.probeScope(gvr, ""); !apierrors.IsForbidden(err) {
-		t.Errorf("probeScope(\"\") err = %v, want forbidden", err)
+	if _, err := d.probeScopes(gvr, ""); !apierrors.IsForbidden(err) {
+		t.Errorf("probeScopes(\"\") err = %v, want forbidden", err)
 	}
 }
 
@@ -1672,4 +1673,78 @@ func fakeDynamicForListAccess(
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
 	})
 	return dyn
+}
+
+// The PR core for CRDs: cluster-wide denied but several fallback namespaces
+// granted → one scope per granted namespace, denied candidates skipped.
+func TestDynamicResourceCache_ProbeScopesFansOutAcrossFallbacks(t *testing.T) {
+	const nsA, nsB, nsDenied = "team-a", "team-b", "team-c"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:      dyn,
+		NamespaceFallbacks: []string{nsA, nsB, nsDenied},
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	scopes, err := d.probeScopes(gvr, "")
+	if err != nil {
+		t.Fatalf("probeScopes failed: %v", err)
+	}
+	if !reflect.DeepEqual(scopes, []string{nsA, nsB}) {
+		t.Fatalf("scopes = %v, want [%s %s]", scopes, nsA, nsB)
+	}
+}
+
+// End-to-end: an all-namespaces read of a fallback-scoped GVR starts one
+// informer per granted namespace, unions their contents, and does not
+// re-probe on subsequent reads.
+func TestDynamicResourceCache_EnsureWatchingFansOutAndUnions(t *testing.T) {
+	const nsA, nsB, nsDenied = "team-a", "team-b", "team-c"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB
+	})
+	for _, ns := range []string{nsA, nsB} {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w-" + ns, "namespace": ns},
+		}}
+		if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed %s: %v", ns, err)
+		}
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:      dyn,
+		NamespaceFallbacks: []string{nsA, nsB, nsDenied},
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	items, err := d.ListBlocking(gvr, "", 3*time.Second)
+	if err != nil {
+		t.Fatalf("ListBlocking failed: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("union read = %d items, want 2 (one per granted namespace)", len(items))
+	}
+
+	if !d.hasCoveringInformer(gvr, "") {
+		t.Fatal("all-namespaces scope not marked resolved — every read would re-probe cluster + candidates")
+	}
+	if n, err := d.Count(gvr, nil); err != nil || n != 2 {
+		t.Fatalf("Count = %d, %v; want 2", n, err)
+	}
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -724,7 +724,15 @@ func (d *DynamicResourceCache) readEntries(gvr schema.GroupVersionResource, ns s
 	// connects with a namespace-restricted identity (fallbacks configured),
 	// cluster-wide list was denied so the only informers for this GVR are
 	// per-namespace — union them, otherwise an all-namespaces read returns
-	// nothing even though the per-namespace informers are synced. A cluster-wide
+	// nothing even though the per-namespace informers are synced.
+	//
+	// Deliberately NOT gated on fallbackResolved: list surfaces are
+	// best-effort and self-healing (every read re-runs ensureWatching until
+	// the candidate walk settles), matching the typed probe's keep-partial
+	// philosophy. Cardinality/absence assertions are the strict surfaces —
+	// Count(gvr, nil), CountWatched, and IsClusterWideSynced all refuse an
+	// unsettled fanout, because a partial number masquerades as a smaller
+	// truth while a partial list is just an incomplete view. A cluster-wide
 	// cache (no fallbacks configured) stays empty here, preserving the
 	// deterministic cluster-wide-only contract that keeps incidental
 	// per-namespace informers from leaking across users.
@@ -1652,7 +1660,10 @@ func (d *DynamicResourceCache) WaitForSync(gvr schema.GroupVersionResource, time
 	return cache.WaitForCacheSync(ctx.Done(), syncFuncs...)
 }
 
-// IsSynced checks if a resource's cache(s) are synced (non-blocking).
+// IsSynced checks if a resource's cache(s) are synced (non-blocking). It
+// reports on the informers that EXIST — an unsettled fallback fanout can be
+// synced-but-partial. Callers asserting completeness or absence must use
+// IsClusterWideSynced (or Count, which refuses unsettled fanouts) instead.
 func (d *DynamicResourceCache) IsSynced(gvr schema.GroupVersionResource) bool {
 	return entriesSynced(d.entriesForGVR(gvr))
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -170,7 +170,7 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 
 	// Probe access (cluster-wide first, then fallback namespaces) BEFORE
 	// acquiring the write lock; the result tells us which scopes to watch.
-	scopes, err := d.probeScopes(gvr, preferredNS)
+	scopes, complete, err := d.probeScopes(gvr, preferredNS)
 	if err != nil {
 		return fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
 	}
@@ -180,10 +180,12 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 			return err
 		}
 	}
-	if preferredNS == "" {
-		// The all-namespaces scope for this GVR is now settled — informers
-		// exist for every granted scope. Mark it so the next all-namespaces
-		// read doesn't re-probe cluster-wide plus every candidate.
+	if preferredNS == "" && complete {
+		// The all-namespaces scope for this GVR is settled — informers exist
+		// for every granted scope. Mark it so the next all-namespaces read
+		// doesn't re-probe cluster-wide plus every candidate. An incomplete
+		// walk (deadline hit mid-fanout) is deliberately NOT marked, so the
+		// next read finishes the job.
 		d.mu.Lock()
 		d.fallbackResolved[gvr] = true
 		d.mu.Unlock()
@@ -332,7 +334,7 @@ func (d *DynamicResourceCache) fallbackNamespaces() []string {
 // preferredNS is the namespace the caller actually wants; when cluster-wide
 // is denied and the caller named none, every configured fallback namespace
 // is probed and each granted one becomes a scope.
-func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, preferredNS string) ([]string, error) {
+func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, preferredNS string) (scopes []string, complete bool, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -343,49 +345,63 @@ func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, pref
 	if d.config.NamespaceScoped && d.config.Namespace != "" && d.gvrIsNamespaced(gvr) {
 		ns, err := d.classifyScope(gvr, d.config.Namespace, d.listProbe(ctx, gvr, d.config.Namespace))
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
-		return []string{ns}, nil
+		return []string{ns}, true, nil
 	}
 
 	// Cluster-wide first — one informer then serves every namespace.
-	err := d.listProbe(ctx, gvr, "")
+	err = d.listProbe(ctx, gvr, "")
 	if err == nil {
-		return []string{""}, nil
+		return []string{""}, true, nil
 	}
 	if !isAuthProbeError(err) {
 		// Transient/NotFound on proxy-fronted clusters — fail open to a
 		// cluster-wide informer rather than disabling the kind; real
 		// problems surface when the informer lists.
 		log.Printf("[dynamic cache] Cluster-wide probe for %s.%s/%s returned non-auth error (allowing): %v", gvr.Resource, gvr.Group, gvr.Version, err)
-		return []string{""}, nil
+		return []string{""}, true, nil
 	}
 	if !d.gvrIsNamespaced(gvr) {
-		return nil, err // cluster-scoped resource, no namespace to fall back to
+		return nil, true, err // cluster-scoped resource, no namespace to fall back to
 	}
 
 	if preferredNS != "" {
 		ns, err := d.classifyScope(gvr, preferredNS, d.listProbe(ctx, gvr, preferredNS))
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
-		return []string{ns}, nil
+		return []string{ns}, true, nil
 	}
 
 	fallbacks := d.fallbackNamespaces()
 	if len(fallbacks) == 0 {
-		return nil, err
+		return nil, true, err
 	}
 	granted := make([]string, 0, len(fallbacks))
+	complete = true
 	for _, ns := range fallbacks {
-		if scoped, nsErr := d.classifyScope(gvr, ns, d.listProbe(ctx, gvr, ns)); nsErr == nil {
+		if ctx.Err() != nil {
+			complete = false
+			break
+		}
+		scoped, nsErr := d.classifyScope(gvr, ns, d.listProbe(ctx, gvr, ns))
+		if ctx.Err() != nil {
+			// The probe ran into the shared deadline — classifyScope's
+			// fail-open would turn the deadline error into a grant, starting
+			// informers in namespaces that were never verified. Treat the
+			// walk as incomplete instead so it retries on the next read.
+			complete = false
+			break
+		}
+		if nsErr == nil {
 			granted = append(granted, scoped)
 		}
 	}
 	if len(granted) == 0 {
-		return nil, err // original cluster-wide forbidden — no candidate granted either
+		return nil, complete, err // original cluster-wide forbidden — no candidate granted
 	}
-	return granted, nil
+	return granted, complete, nil
 }
 
 func (d *DynamicResourceCache) listProbe(ctx context.Context, gvr schema.GroupVersionResource, namespace string) error {
@@ -1302,18 +1318,19 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 
 	const maxConcurrentProbes = 50
 	type probeResult struct {
-		gvr    schema.GroupVersionResource
-		scopes []string
-		ok     bool
+		gvr      schema.GroupVersionResource
+		scopes   []string
+		complete bool
+		ok       bool
 	}
 	results := make(chan probeResult, len(gvrs))
 	sem := make(chan struct{}, maxConcurrentProbes)
 	for _, gvr := range gvrs {
 		go func(g schema.GroupVersionResource) {
 			sem <- struct{}{}
-			scopes, err := d.probeScopes(g, "")
+			scopes, complete, err := d.probeScopes(g, "")
 			<-sem
-			results <- probeResult{gvr: g, scopes: scopes, ok: err == nil}
+			results <- probeResult{gvr: g, scopes: scopes, complete: complete, ok: err == nil}
 		}(gvr)
 	}
 
@@ -1339,7 +1356,7 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 				allStarted = false
 			}
 		}
-		if allStarted {
+		if allStarted && r.complete {
 			d.mu.Lock()
 			d.fallbackResolved[r.gvr] = true
 			d.mu.Unlock()
@@ -1617,7 +1634,13 @@ func (d *DynamicResourceCache) IsClusterWideSynced(gvr schema.GroupVersionResour
 	if d == nil {
 		return false
 	}
-	return d.hasCoveringInformer(gvr, "") && d.IsSynced(gvr)
+	// Explicitly require the cluster-wide informer — hasCoveringInformer
+	// also reports true for a resolved namespace-fallback fanout, whose
+	// coverage is NOT cluster-wide (callers use this to assert absence).
+	d.mu.RLock()
+	_, clusterWide := d.informers[informerKey{gvr: gvr}]
+	d.mu.RUnlock()
+	return clusterWide && d.IsSynced(gvr)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -46,16 +46,21 @@ type informerEntry struct {
 // resources. It is safe for concurrent use. Application-specific callbacks
 // (timeline, metrics) are injected via DynamicCacheConfig.
 type DynamicResourceCache struct {
-	factory         dynamicinformer.DynamicSharedInformerFactory
-	nsFactories     map[string]dynamicinformer.DynamicSharedInformerFactory // one per watched namespace, lazily created
-	informers       map[informerKey]*informerEntry
-	stopCh          chan struct{} // global shutdown; parent of every per-informer context
-	stopOnce        sync.Once
-	mu              sync.RWMutex
-	config          DynamicCacheConfig
-	discoveryStatus CRDDiscoveryStatus
-	discoveryMu     sync.RWMutex
-	discoveryDone   chan struct{} // closed when DiscoverAllCRDs() completes
+	factory     dynamicinformer.DynamicSharedInformerFactory
+	nsFactories map[string]dynamicinformer.DynamicSharedInformerFactory // one per watched namespace, lazily created
+	informers   map[informerKey]*informerEntry
+	// fallbackResolved marks GVRs whose "all namespaces" scope was already
+	// probed and fanned out across the fallback namespaces. Without it every
+	// all-namespaces read of a fallback-scoped GVR would re-probe cluster-wide
+	// plus each candidate namespace. Guarded by mu.
+	fallbackResolved map[schema.GroupVersionResource]bool
+	stopCh           chan struct{} // global shutdown; parent of every per-informer context
+	stopOnce         sync.Once
+	mu               sync.RWMutex
+	config           DynamicCacheConfig
+	discoveryStatus  CRDDiscoveryStatus
+	discoveryMu      sync.RWMutex
+	discoveryDone    chan struct{} // closed when DiscoverAllCRDs() completes
 
 	// gvrHandlers holds change handlers registered via AddGVRChangeHandler,
 	// keyed by GVR. They are re-applied to every informer started for that GVR
@@ -83,19 +88,22 @@ func NewDynamicResourceCache(cfg DynamicCacheConfig) (*DynamicResourceCache, err
 	)
 	if cfg.NamespaceScoped && cfg.Namespace != "" {
 		log.Printf("Using namespace-scoped dynamic informers for namespace %q", cfg.Namespace)
+	} else if len(cfg.NamespaceFallbacks) > 0 {
+		log.Printf("Using namespace fallbacks for dynamic informers: %q", cfg.NamespaceFallbacks)
 	} else if cfg.NamespaceFallback != "" {
 		log.Printf("Using namespace fallback for dynamic informers: %q", cfg.NamespaceFallback)
 	}
 
 	d := &DynamicResourceCache{
-		factory:         factory,
-		nsFactories:     make(map[string]dynamicinformer.DynamicSharedInformerFactory),
-		informers:       make(map[informerKey]*informerEntry),
-		stopCh:          make(chan struct{}),
-		config:          cfg,
-		discoveryStatus: CRDDiscoveryIdle,
-		discoveryDone:   make(chan struct{}),
-		gvrHandlers:     make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
+		factory:          factory,
+		nsFactories:      make(map[string]dynamicinformer.DynamicSharedInformerFactory),
+		fallbackResolved: make(map[schema.GroupVersionResource]bool),
+		informers:        make(map[informerKey]*informerEntry),
+		stopCh:           make(chan struct{}),
+		config:           cfg,
+		discoveryStatus:  CRDDiscoveryIdle,
+		discoveryDone:    make(chan struct{}),
+		gvrHandlers:      make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
 	}
 
 	log.Println("Dynamic resource cache initialized")
@@ -160,14 +168,27 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 		}
 	}
 
-	// Probe access (cluster-wide first, then a specific namespace) BEFORE
-	// acquiring the write lock; the result tells us which scope to watch.
-	scopeNS, err := d.probeScope(gvr, preferredNS)
+	// Probe access (cluster-wide first, then fallback namespaces) BEFORE
+	// acquiring the write lock; the result tells us which scopes to watch.
+	scopes, err := d.probeScopes(gvr, preferredNS)
 	if err != nil {
 		return fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
 	}
 
-	return d.startWatching(gvr, scopeNS)
+	for _, scopeNS := range scopes {
+		if err := d.startWatching(gvr, scopeNS); err != nil {
+			return err
+		}
+	}
+	if preferredNS == "" {
+		// The all-namespaces scope for this GVR is now settled — informers
+		// exist for every granted scope. Mark it so the next all-namespaces
+		// read doesn't re-probe cluster-wide plus every candidate.
+		d.mu.Lock()
+		d.fallbackResolved[gvr] = true
+		d.mu.Unlock()
+	}
+	return nil
 }
 
 // hasCoveringInformer reports whether an existing informer already serves
@@ -186,7 +207,10 @@ func (d *DynamicResourceCache) hasCoveringInformer(gvr schema.GroupVersionResour
 		return true
 	}
 	if ns == "" {
-		return false
+		// Covered without a cluster-wide informer only when a previous
+		// all-namespaces ensureWatching already fanned out across the
+		// fallback namespaces; readEntries(gvr, "") unions those.
+		return d.fallbackResolved[gvr]
 	}
 	_, ok := d.informers[informerKey{gvr: gvr, ns: ns}]
 	return ok
@@ -289,13 +313,26 @@ func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, sc
 	return nil
 }
 
-// probeScope decides which namespace to watch for gvr via a limit=1 list
-// probe. It returns the scope ("" = cluster-wide) on success, or a forbidden
-// error when the identity can list the resource neither cluster-wide nor in
-// the candidate namespace. preferredNS is the namespace the caller actually
-// wants; when cluster-wide is denied it becomes the fallback target (falling
-// back to the configured NamespaceFallback only when the caller named none).
-func (d *DynamicResourceCache) probeScope(gvr schema.GroupVersionResource, preferredNS string) (string, error) {
+// fallbackNamespaces returns the configured namespace-fallback candidates,
+// preferring the multi-namespace form.
+func (d *DynamicResourceCache) fallbackNamespaces() []string {
+	if len(d.config.NamespaceFallbacks) > 0 {
+		return d.config.NamespaceFallbacks
+	}
+	if d.config.NamespaceFallback != "" {
+		return []string{d.config.NamespaceFallback}
+	}
+	return nil
+}
+
+// probeScopes decides which scopes to watch for gvr via limit=1 list probes.
+// It returns the scope namespaces to start informers for — [""] means one
+// cluster-wide informer — or a forbidden error when the identity can list
+// the resource neither cluster-wide nor in any candidate namespace.
+// preferredNS is the namespace the caller actually wants; when cluster-wide
+// is denied and the caller named none, every configured fallback namespace
+// is probed and each granted one becomes a scope.
+func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, preferredNS string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -304,33 +341,51 @@ func (d *DynamicResourceCache) probeScope(gvr schema.GroupVersionResource, prefe
 	// so they fall through to the cluster-wide path below — pinning them to a
 	// namespace would list nothing.
 	if d.config.NamespaceScoped && d.config.Namespace != "" && d.gvrIsNamespaced(gvr) {
-		return d.classifyScope(gvr, d.config.Namespace, d.listProbe(ctx, gvr, d.config.Namespace))
+		ns, err := d.classifyScope(gvr, d.config.Namespace, d.listProbe(ctx, gvr, d.config.Namespace))
+		if err != nil {
+			return nil, err
+		}
+		return []string{ns}, nil
 	}
 
 	// Cluster-wide first — one informer then serves every namespace.
 	err := d.listProbe(ctx, gvr, "")
 	if err == nil {
-		return "", nil
+		return []string{""}, nil
 	}
 	if !isAuthProbeError(err) {
 		// Transient/NotFound on proxy-fronted clusters — fail open to a
 		// cluster-wide informer rather than disabling the kind; real
 		// problems surface when the informer lists.
 		log.Printf("[dynamic cache] Cluster-wide probe for %s.%s/%s returned non-auth error (allowing): %v", gvr.Resource, gvr.Group, gvr.Version, err)
-		return "", nil
+		return []string{""}, nil
 	}
 	if !d.gvrIsNamespaced(gvr) {
-		return "", err // cluster-scoped resource, no namespace to fall back to
+		return nil, err // cluster-scoped resource, no namespace to fall back to
 	}
 
-	fallbackNS := preferredNS
-	if fallbackNS == "" {
-		fallbackNS = d.config.NamespaceFallback
+	if preferredNS != "" {
+		ns, err := d.classifyScope(gvr, preferredNS, d.listProbe(ctx, gvr, preferredNS))
+		if err != nil {
+			return nil, err
+		}
+		return []string{ns}, nil
 	}
-	if fallbackNS == "" {
-		return "", err
+
+	fallbacks := d.fallbackNamespaces()
+	if len(fallbacks) == 0 {
+		return nil, err
 	}
-	return d.classifyScope(gvr, fallbackNS, d.listProbe(ctx, gvr, fallbackNS))
+	granted := make([]string, 0, len(fallbacks))
+	for _, ns := range fallbacks {
+		if scoped, nsErr := d.classifyScope(gvr, ns, d.listProbe(ctx, gvr, ns)); nsErr == nil {
+			granted = append(granted, scoped)
+		}
+	}
+	if len(granted) == 0 {
+		return nil, err // original cluster-wide forbidden — no candidate granted either
+	}
+	return granted, nil
 }
 
 func (d *DynamicResourceCache) listProbe(ctx context.Context, gvr schema.GroupVersionResource, namespace string) error {
@@ -433,8 +488,14 @@ func (d *DynamicResourceCache) probeCountList(ctx context.Context, gvr schema.Gr
 	if err == nil {
 		return list, nil
 	}
-	if isAuthProbeError(err) && d.config.NamespaceFallback != "" && d.gvrIsNamespaced(gvr) {
-		return d.config.DynamicClient.Resource(gvr).Namespace(d.config.NamespaceFallback).List(ctx, metav1.ListOptions{Limit: 1})
+	if isAuthProbeError(err) && d.gvrIsNamespaced(gvr) {
+		// Size heuristic only — the first granted fallback namespace is a
+		// good-enough sample for the eager-warm decision.
+		for _, ns := range d.fallbackNamespaces() {
+			if nsList, nsErr := d.config.DynamicClient.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1}); nsErr == nil {
+				return nsList, nil
+			}
+		}
 	}
 	return list, err
 }
@@ -629,14 +690,14 @@ func (d *DynamicResourceCache) readEntries(gvr schema.GroupVersionResource, ns s
 		return nil
 	}
 	// ns == "" ("all namespaces") with no cluster-wide informer. When Radar
-	// connects with a namespace-restricted identity (NamespaceFallback set),
+	// connects with a namespace-restricted identity (fallbacks configured),
 	// cluster-wide list was denied so the only informers for this GVR are
 	// per-namespace — union them, otherwise an all-namespaces read returns
 	// nothing even though the per-namespace informers are synced. A cluster-wide
-	// cache (NamespaceFallback == "") stays empty here, preserving the
+	// cache (no fallbacks configured) stays empty here, preserving the
 	// deterministic cluster-wide-only contract that keeps incidental
 	// per-namespace informers from leaking across users.
-	if d.config.NamespaceFallback == "" {
+	if len(d.fallbackNamespaces()) == 0 {
 		return nil
 	}
 	var out []*informerEntry
@@ -735,11 +796,11 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 	}
 
 	if len(namespaces) == 0 {
-		// No cluster-wide informer. In namespace-scoped mode (NamespaceFallback
-		// set) union the per-namespace informers so Count agrees with
+		// No cluster-wide informer. In namespace-fallback mode union the
+		// per-namespace informers so Count agrees with
 		// readEntries on an all-namespaces read; a cluster-wide cache keeps the
 		// strict cluster-wide-only contract and errors.
-		if d.config.NamespaceFallback == "" {
+		if len(d.fallbackNamespaces()) == 0 {
 			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 		}
 		total := 0
@@ -813,7 +874,7 @@ func (d *DynamicResourceCache) CountWatched(namespaces []string) map[schema.Grou
 				counts[gvr] = len(set.clusterWide.informer.GetIndexer().List())
 				continue
 			}
-			if d.config.NamespaceFallback == "" {
+			if len(d.fallbackNamespaces()) == 0 {
 				continue
 			}
 			total := 0
@@ -1241,18 +1302,18 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 
 	const maxConcurrentProbes = 50
 	type probeResult struct {
-		gvr   schema.GroupVersionResource
-		scope string
-		ok    bool
+		gvr    schema.GroupVersionResource
+		scopes []string
+		ok     bool
 	}
 	results := make(chan probeResult, len(gvrs))
 	sem := make(chan struct{}, maxConcurrentProbes)
 	for _, gvr := range gvrs {
 		go func(g schema.GroupVersionResource) {
 			sem <- struct{}{}
-			scope, err := d.probeScope(g, "")
+			scopes, err := d.probeScopes(g, "")
 			<-sem
-			results <- probeResult{gvr: g, scope: scope, ok: err == nil}
+			results <- probeResult{gvr: g, scopes: scopes, ok: err == nil}
 		}(gvr)
 	}
 
@@ -1270,8 +1331,18 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 
 	var started []informerKey
 	for _, r := range accessible {
-		if err := d.startWatching(r.gvr, r.scope); err == nil {
-			started = append(started, informerKey{gvr: r.gvr, ns: r.scope})
+		allStarted := true
+		for _, scope := range r.scopes {
+			if err := d.startWatching(r.gvr, scope); err == nil {
+				started = append(started, informerKey{gvr: r.gvr, ns: scope})
+			} else {
+				allStarted = false
+			}
+		}
+		if allStarted {
+			d.mu.Lock()
+			d.fallbackResolved[r.gvr] = true
+			d.mu.Unlock()
 		}
 	}
 

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -56,6 +56,7 @@ type DynamicResourceCache struct {
 	fallbackResolved map[schema.GroupVersionResource]bool
 	stopCh           chan struct{} // global shutdown; parent of every per-informer context
 	stopOnce         sync.Once
+	stopped          bool // set under mu by Stop; startWatching refuses new informers after
 	mu               sync.RWMutex
 	config           DynamicCacheConfig
 	discoveryStatus  CRDDiscoveryStatus
@@ -227,6 +228,12 @@ func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, sc
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	if d.stopped {
+		// A warmup or read probe can race Stop (context switch); informers
+		// created now would never be shut down with the rest of the cache.
+		return fmt.Errorf("dynamic cache stopped")
+	}
+
 	key := informerKey{gvr: gvr, ns: scopeNS}
 	if _, exists := d.informers[key]; exists {
 		return nil
@@ -335,7 +342,15 @@ func (d *DynamicResourceCache) fallbackNamespaces() []string {
 // is denied and the caller named none, every configured fallback namespace
 // is probed and each granted one becomes a scope.
 func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, preferredNS string) (scopes []string, complete bool, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// The budget covers the cluster-wide probe plus the whole candidate walk;
+	// scale it with the candidate count so a 20-namespace fanout isn't judged
+	// by a budget sized for the single-fallback case, while staying bounded
+	// for the synchronous read paths that call ensureWatching.
+	budget := 5 * time.Second
+	if n := len(d.fallbackNamespaces()); n > 1 {
+		budget = min(5*time.Second+time.Duration(n)*500*time.Millisecond, 15*time.Second)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 
 	// Forced namespace mode (--namespace-scope): pin NAMESPACED resources to the
@@ -819,6 +834,11 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 		if len(d.fallbackNamespaces()) == 0 {
 			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 		}
+		// A truncated candidate walk leaves a partial namespace set whose sum
+		// would silently under-count; only a settled fanout is authoritative.
+		if !d.fallbackResolved[gvr] {
+			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+		}
 		total := 0
 		found := false
 		for k, e := range d.informers {
@@ -883,6 +903,16 @@ func (d *DynamicResourceCache) CountWatched(namespaces []string) map[schema.Grou
 		}
 	}
 
+	// Unsynced entries were dropped above, so re-scan for GVRs whose fanout
+	// still has an unsynced sibling — summing the synced subset would report
+	// a silently smaller count instead of "not ready yet".
+	partiallySynced := make(map[schema.GroupVersionResource]bool)
+	for k, e := range d.informers {
+		if !e.informer.HasSynced() {
+			partiallySynced[k.gvr] = true
+		}
+	}
+
 	counts := make(map[schema.GroupVersionResource]int)
 	for gvr, set := range byGVR {
 		if len(namespaces) == 0 {
@@ -891,6 +921,11 @@ func (d *DynamicResourceCache) CountWatched(namespaces []string) map[schema.Grou
 				continue
 			}
 			if len(d.fallbackNamespaces()) == 0 {
+				continue
+			}
+			// All-namespaces sums over a fanout are only authoritative once
+			// the candidate walk settled and every informer synced.
+			if !d.fallbackResolved[gvr] || partiallySynced[gvr] {
 				continue
 			}
 			total := 0
@@ -1745,6 +1780,10 @@ func (d *DynamicResourceCache) Stop() {
 
 	d.stopOnce.Do(func() {
 		log.Println("Stopping dynamic resource cache")
+
+		d.mu.Lock()
+		d.stopped = true
+		d.mu.Unlock()
 
 		d.discoveryMu.Lock()
 		if d.discoveryStatus != CRDDiscoveryComplete {

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -322,8 +322,33 @@ func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, sc
 	return nil
 }
 
+// nsCtxExpired reports whether a probe error is a context deadline/cancel —
+// the one non-auth error class that must NOT fail open into a grant during
+// the fanout walk.
+func nsCtxExpired(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}
+
 // fallbackNamespaces returns the configured namespace-fallback candidates,
 // preferring the multi-namespace form.
+// fanoutSettled reports whether the all-namespaces scope for gvr is fully
+// resolved. A multi-candidate walk settles via the fallbackResolved marker;
+// a SINGLE-candidate configuration is trivially settled the moment its one
+// informer exists — a legacy --namespace user reading through explicit
+// namespace requests must not have counts withheld waiting for an
+// all-namespaces read that their UI never issues. Caller must hold d.mu.
+func (d *DynamicResourceCache) fanoutSettledLocked(gvr schema.GroupVersionResource) bool {
+	if d.fallbackResolved[gvr] {
+		return true
+	}
+	fallbacks := d.fallbackNamespaces()
+	if len(fallbacks) != 1 {
+		return false
+	}
+	_, ok := d.informers[informerKey{gvr: gvr, ns: fallbacks[0]}]
+	return ok
+}
+
 func (d *DynamicResourceCache) fallbackNamespaces() []string {
 	if len(d.config.NamespaceFallbacks) > 0 {
 		return d.config.NamespaceFallbacks
@@ -400,7 +425,14 @@ func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, pref
 			complete = false
 			break
 		}
-		scoped, nsErr := d.classifyScope(gvr, ns, d.listProbe(ctx, gvr, ns))
+		// Per-candidate sub-deadline: without it a single consistently slow
+		// namespace eats the whole walk budget on every retry, and since
+		// retries restart from the first candidate, later namespaces would
+		// never be reached at all.
+		nsCtx, nsCancel := context.WithTimeout(ctx, 2*time.Second)
+		probeErr := d.listProbe(nsCtx, gvr, ns)
+		nsCancel()
+		scoped, nsErr := d.classifyScope(gvr, ns, probeErr)
 		if ctx.Err() != nil {
 			// The probe ran into the shared deadline — classifyScope's
 			// fail-open would turn the deadline error into a grant, starting
@@ -410,6 +442,13 @@ func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, pref
 			break
 		}
 		if nsErr == nil {
+			if probeErr != nil && nsCtxExpired(probeErr) {
+				// The candidate's own sub-deadline fired; classifyScope's
+				// fail-open would count that as a grant. Record the walk as
+				// incomplete instead so a later attempt re-tries it.
+				complete = false
+				continue
+			}
 			granted = append(granted, scoped)
 		}
 	}
@@ -844,7 +883,7 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 		}
 		// A truncated candidate walk leaves a partial namespace set whose sum
 		// would silently under-count; only a settled fanout is authoritative.
-		if !d.fallbackResolved[gvr] {
+		if !d.fanoutSettledLocked(gvr) {
 			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 		}
 		total := 0
@@ -933,7 +972,7 @@ func (d *DynamicResourceCache) CountWatched(namespaces []string) map[schema.Grou
 			}
 			// All-namespaces sums over a fanout are only authoritative once
 			// the candidate walk settled and every informer synced.
-			if !d.fallbackResolved[gvr] || partiallySynced[gvr] {
+			if !d.fanoutSettledLocked(gvr) || partiallySynced[gvr] {
 				continue
 			}
 			total := 0

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -294,7 +294,12 @@ type DynamicCacheConfig struct {
 	// NamespaceFallback is used when informers should prefer cluster-wide
 	// access but retry namespace-scoped after a cluster-wide 403/401.
 	// Ignored when NamespaceScoped is true.
-	NamespaceFallback string
+	// NamespaceFallbacks is the multi-namespace form: after a cluster-wide
+	// 403/401 every listed namespace is probed and each granted one gets its
+	// own informer, with reads unioning across them. When set it takes
+	// precedence over NamespaceFallback.
+	NamespaceFallback  string
+	NamespaceFallbacks []string
 
 	// DebugEvents enables verbose debug logging.
 	DebugEvents bool


### PR DESCRIPTION
## Problem

#1082 gave namespace-restricted identities (`--namespaces`) multi-namespace coverage for built-in resource types, but CRDs stayed pinned to the single primary namespace: a user granted Argo/Flux/Gateway-API reads in several namespaces saw those resources in only one.

## What this does

When a CRD's cluster-wide list is denied, the dynamic cache now probes every configured fallback namespace per-GVR and starts one informer per granted namespace. Reads and counts already unioned per-namespace informers; this closes the loop from probe to fanout.

- **`DynamicCacheConfig.NamespaceFallbacks`** (plural) supersedes the single `NamespaceFallback` when set. Candidates flow from the typed probe's candidate walk (`PermissionCheckResult.ScopeCandidates`) — independently of the typed outcome, so an identity with cluster-wide built-in access but namespace-only CRD access gets the fanout too.
- **Resolution marker:** once an all-namespaces scope is settled, subsequent reads stop re-probing cluster-wide plus every candidate (previously every such read re-probed even with a single fallback).
- **Deadline honesty:** a fanout walk that runs into the probe deadline reports incomplete — no grants are fabricated from deadline errors through the fail-open path, the GVR is not marked resolved, and the next read finishes the walk.
- **`IsClusterWideSynced` keeps its contract:** it requires an actual cluster-wide informer; a resolved namespace fanout does not satisfy it (cluster audit uses it to assert absence).
- **CRD registration probe** (partial-discovery fallback) walks all candidates and requires list+watch on the same namespace, so list-only access in the first namespace cannot hide a CRD fully readable in a later one.
- `pickPrimaryNs` no longer warns about CRDs being pinned to one namespace — they aren't.

## Testing

- Unit: probe fanout across granted/denied candidates, end-to-end union read + count against a fake dynamic client, no-reprobe after resolution, completeness flag on healthy walks, registration-probe candidate walk, `ScopeCandidates` deep copies. `pkg/k8score` green under `-race`; `internal/k8s` + `internal/audit` suites green.
- Live on EKS (`radar-test-nonprod`): ServiceAccount with kueue reads in two namespaces (denied in a third), `--namespaces` across all three — `/api/resources/localqueues` returns objects from both granted namespaces through the union, per-namespace dynamic informers visible in logs, namespace filter works, repeat reads start no new informers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dynamic informer wiring, RBAC probe fanout, and count/sync semantics for namespace-restricted users; well-tested but affects cache behavior on slow or partial clusters.
> 
> **Overview**
> Extends **`--namespaces`** parity from built-in types to **CRDs**: when cluster-wide list is denied, the dynamic cache probes each candidate namespace **per GVR**, starts one informer per granted namespace, and unions reads across them.
> 
> **`PermissionCheckResult.ScopeCandidates`** records the namespace walk and is passed into the dynamic cache as **`NamespaceFallbacks`** (independent of whether typed resources ended up cluster-wide or namespace-scoped). **`probeScope`** becomes **`probeScopes`** with multi-namespace fanout, scaled probe budgets, and a **`fallbackResolved`** marker so settled all-namespace scopes do not re-probe on every read. Incomplete walks (deadlines) are not marked resolved; **`Count`** / **`CountWatched`** refuse unsettled fanouts so partial sums are not reported as authoritative. **`IsClusterWideSynced`** still requires a real cluster-wide informer, not a resolved namespace fanout.
> 
> Partial-discovery **CRD registration** walks all list-granted candidates and requires **watch** on at least one. Docs drop the “CRDs use first namespace only” caveat; the old **`pickPrimaryNs`** CRD pinning warning is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aed27fae3daeacb83a59fb05a535300d490cc9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->