### PR TITLE
issues: de-duplicate operational-issue surfaces (per-listener route collapse + renderer banner deferral)

### DIFF
--- a/internal/issues/source_conditions.go
+++ b/internal/issues/source_conditions.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -207,18 +208,41 @@ func detectObjectConditionIssues(gvr schema.GroupVersionResource, kind string, u
 	return []Issue{newConditionIssue(gvr, kind, u.GetNamespace(), u.GetName(), severity, condTypeReason(condType, reason), msg, since, "", u.GetCreationTimestamp().Time)}
 }
 
+// gwListenerCond is one listener's failing condition within a gateway group.
+type gwListenerCond struct {
+	section, msg string
+	since        time.Duration
+}
+
 func detectGatewayRouteParentIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
 	parents, found, _ := unstructured.NestedSlice(u.Object, "status", "parents")
 	if !found {
 		return nil
 	}
-	var out []Issue
+
+	// A route can attach to several listeners of one Gateway — an unscoped
+	// parentRef the controller expands per listener, or explicit per-listener
+	// parentRefs (sectionName). The Gateway API reports acceptance PER LISTENER, so
+	// a single fault (e.g. a hostname matching no listener) surfaces as the same
+	// condition on every listener. Collapse those into ONE gateway-level issue
+	// keyed on (condType, reason, gateway); listeners failing for genuinely
+	// different reasons still get their own row. The key deliberately omits the
+	// listener: the row's identity must not flip as listeners join or leave the
+	// same fault, or acknowledgement/history would be lost and duplicate alerts
+	// would fire.
+	type routeGroup struct {
+		condType, reason, gwLabel, gwKey string
+		members                          []gwListenerCond
+	}
+	groups := map[string]*routeGroup{}
+	var order []string
+
 	for _, parent := range parents {
 		pm, ok := parent.(map[string]any)
 		if !ok {
 			continue
 		}
-		parentLabel, parentKey := gatewayParentRefLabel(pm)
+		gwLabel, gwKey, section := gatewayParentRef(pm)
 		conds, _ := pm["conditions"].([]any)
 		for _, c := range conds {
 			cm, ok := c.(map[string]any)
@@ -237,19 +261,90 @@ func detectGatewayRouteParentIssues(gvr schema.GroupVersionResource, kind string
 				continue
 			}
 			msg, _ := cm["message"].(string)
-			if parentLabel != "" {
-				if msg != "" {
-					msg = parentLabel + ": " + msg
-				} else {
-					msg = parentLabel
-				}
+			gk := condType + "\x00" + reason + "\x00" + gwKey
+			g := groups[gk]
+			if g == nil {
+				g = &routeGroup{condType: condType, reason: reason, gwLabel: gwLabel, gwKey: gwKey}
+				groups[gk] = g
+				order = append(order, gk)
 			}
-			since := conditionSince(cm)
-			fp := condType + ":" + parentKey
-			out = append(out, newConditionIssue(gvr, kind, u.GetNamespace(), u.GetName(), SeverityWarning, condTypeReason(condType, reason), msg, since, fp, u.GetCreationTimestamp().Time))
+			g.members = append(g.members, gwListenerCond{section: section, msg: msg, since: conditionSince(cm)})
 		}
 	}
+
+	ns, name, createdAt := u.GetNamespace(), u.GetName(), u.GetCreationTimestamp().Time
+	var out []Issue
+	for _, gk := range order {
+		g := groups[gk]
+		// Stable output regardless of the order listeners appear in status.parents.
+		sort.SliceStable(g.members, func(i, j int) bool { return g.members[i].section < g.members[j].section })
+		// first_seen anchors on the OLDEST listener transition: the gateway
+		// attachment has been failing since the first listener broke; a later
+		// listener joining the same fault doesn't make it a new problem.
+		oldest := g.members[0].since
+		for _, m := range g.members[1:] {
+			if m.since > oldest {
+				oldest = m.since
+			}
+		}
+		fp := g.condType + ":" + g.gwKey + ":" + g.reason
+		message := gatewayRouteMessage(g.gwLabel, g.members)
+		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning, condTypeReason(g.condType, g.reason), message, oldest, fp, createdAt))
+	}
 	return out
+}
+
+// gatewayRouteMessage renders a collapsed gateway group's message. When every
+// listener carries the same detail it names the affected listeners once; when
+// they differ it lists each listener's detail so none is dropped.
+func gatewayRouteMessage(gwLabel string, members []gwListenerCond) string {
+	allSame := true
+	for _, m := range members[1:] {
+		if m.msg != members[0].msg {
+			allSame = false
+			break
+		}
+	}
+	var sections []string
+	for _, m := range members {
+		if m.section != "" {
+			sections = append(sections, m.section)
+		}
+	}
+	if allSame {
+		label := gwLabel
+		switch len(sections) {
+		case 0:
+		case 1:
+			label += " listener " + sections[0]
+		default:
+			label += " listeners " + strings.Join(sections, ", ")
+		}
+		return composeParentMessage(label, members[0].msg)
+	}
+	var parts []string
+	for _, m := range members {
+		switch {
+		case m.section != "" && m.msg != "":
+			parts = append(parts, m.section+" — "+m.msg)
+		case m.msg != "":
+			parts = append(parts, m.msg)
+		}
+	}
+	return composeParentMessage(gwLabel, strings.Join(parts, "; "))
+}
+
+// composeParentMessage prefixes the detector message with the parent (gateway or
+// listener) context, tolerating either side being empty.
+func composeParentMessage(label, msg string) string {
+	switch {
+	case label == "":
+		return msg
+	case msg == "":
+		return label
+	default:
+		return label + ": " + msg
+	}
 }
 
 func newConditionIssue(gvr schema.GroupVersionResource, kind, namespace, name string, severity Severity, reason, message string, since time.Duration, fingerprint string, createdAt time.Time) Issue {
@@ -294,19 +389,24 @@ func conditionSince(cond map[string]any) time.Duration {
 	return time.Since(t)
 }
 
-func gatewayParentRefLabel(parent map[string]any) (label, key string) {
+// gatewayParentRef returns the gateway-level display label and identity key
+// (without sectionName/port, so per-listener conditions collapse onto one gateway)
+// plus the listener descriptor — sectionName, or a "port N" fallback — used to
+// name the affected listeners in the collapsed message.
+func gatewayParentRef(parent map[string]any) (gwLabel, gwKey, section string) {
 	ref, _ := parent["parentRef"].(map[string]any)
 	if len(ref) == 0 {
-		return "", "unknown"
+		return "", "unknown", ""
 	}
 	group, _ := ref["group"].(string)
 	kind, _ := ref["kind"].(string)
 	namespace, _ := ref["namespace"].(string)
 	name, _ := ref["name"].(string)
-	sectionName, _ := ref["sectionName"].(string)
-	port := ""
-	if p, ok := ref["port"]; ok {
-		port = toString(p)
+	section, _ = ref["sectionName"].(string)
+	if section == "" {
+		if p, ok := ref["port"]; ok {
+			section = "port " + toString(p)
+		}
 	}
 	if group == "" {
 		group = "gateway.networking.k8s.io"
@@ -314,20 +414,13 @@ func gatewayParentRefLabel(parent map[string]any) (label, key string) {
 	if kind == "" {
 		kind = "Gateway"
 	}
-	parts := []string{group, kind, namespace, name, sectionName, port}
-	key = strings.Join(parts, "/")
+	gwKey = strings.Join([]string{group, kind, namespace, name}, "/")
 	displayName := name
 	if namespace != "" {
 		displayName = namespace + "/" + name
 	}
-	label = kind + " " + displayName
-	if sectionName != "" {
-		label += " listener " + sectionName
-	}
-	if port != "" {
-		label += " port " + port
-	}
-	return label, key
+	gwLabel = kind + " " + displayName
+	return gwLabel, gwKey, section
 }
 
 func toString(v any) string {

--- a/internal/issues/source_conditions_test.go
+++ b/internal/issues/source_conditions_test.go
@@ -1,6 +1,7 @@
 package issues
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -173,6 +174,128 @@ func TestDetectGenericCRDIssues_GatewayRouteParentConditions(t *testing.T) {
 	}
 	if got[0].Message == "" || got[0].Message == "Service prod/api does not exist" {
 		t.Fatalf("route issue should include parent context; got message %q", got[0].Message)
+	}
+}
+
+// routeWithParents builds an HTTPRoute whose status.parents each carry one
+// Accepted=False condition with the given (sectionName, reason, message).
+func routeWithParents(gw string, listeners []struct{ section, reason, message string }) *unstructured.Unstructured {
+	now := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	parents := make([]any, len(listeners))
+	for i, l := range listeners {
+		parents[i] = map[string]any{
+			"parentRef": map[string]any{"name": gw, "namespace": "infra", "sectionName": l.section},
+			"conditions": []any{
+				map[string]any{"type": "Accepted", "status": "False", "reason": l.reason, "message": l.message, "lastTransitionTime": now},
+			},
+		}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "web", "namespace": "prod"},
+		"status":   map[string]any{"parents": parents},
+	}}
+}
+
+// A single gateway fault reported on several listeners with the SAME reason and
+// message collapses to one gateway-level issue that NAMES the affected listeners
+// (so an explicit per-listener attachment isn't silently flattened) rather than
+// emitting one near-identical row per listener.
+func TestDetectGatewayRouteParentIssues_CollapsesPerListenerDupes(t *testing.T) {
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	route := routeWithParents("primary-gateway", []struct{ section, reason, message string }{
+		{"http", "NoMatchingListenerHostname", "no hostname intersections"},
+		{"https", "NoMatchingListenerHostname", "no hostname intersections"},
+	})
+	p := &fakeProvider{
+		dynamic:    map[schema.GroupVersionResource][]*unstructured.Unstructured{routeGVR: {route}},
+		kinds:      map[schema.GroupVersionResource]string{routeGVR: "HTTPRoute"},
+		namespaced: map[schema.GroupVersionResource]bool{routeGVR: true},
+	}
+
+	got := Compose(p, Filters{})
+	if len(got) != 1 {
+		t.Fatalf("per-listener dupes must collapse to 1 issue, got %d: %+v", len(got), got)
+	}
+	if got[0].Reason != "Accepted: NoMatchingListenerHostname" {
+		t.Fatalf("reason = %q, want Accepted: NoMatchingListenerHostname", got[0].Reason)
+	}
+	// Names the gateway and BOTH affected listeners, and the shared detail once.
+	for _, want := range []string{"Gateway infra/primary-gateway", "listeners http, https", "no hostname intersections"} {
+		if !strings.Contains(got[0].Message, want) {
+			t.Fatalf("collapsed message %q must contain %q", got[0].Message, want)
+		}
+	}
+}
+
+// When listeners fail with the same reason but DIFFERENT messages, the collapse
+// must keep all of them (attributed per listener) — never drop the others.
+func TestDetectGatewayRouteParentIssues_DifferentMessagesAggregated(t *testing.T) {
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	route := routeWithParents("primary-gateway", []struct{ section, reason, message string }{
+		{"http", "NoMatchingListenerHostname", "no host match for a.example.com"},
+		{"https", "NoMatchingListenerHostname", "no host match for b.example.com"},
+	})
+	p := &fakeProvider{
+		dynamic:    map[schema.GroupVersionResource][]*unstructured.Unstructured{routeGVR: {route}},
+		kinds:      map[schema.GroupVersionResource]string{routeGVR: "HTTPRoute"},
+		namespaced: map[schema.GroupVersionResource]bool{routeGVR: true},
+	}
+
+	got := Compose(p, Filters{})
+	if len(got) != 1 {
+		t.Fatalf("same-reason listeners collapse to 1 issue, got %d: %+v", len(got), got)
+	}
+	for _, want := range []string{"a.example.com", "b.example.com", "http", "https"} {
+		if !strings.Contains(got[0].Message, want) {
+			t.Fatalf("aggregated message %q must retain %q", got[0].Message, want)
+		}
+	}
+}
+
+// Listeners on the same gateway failing for DIFFERENT reasons are distinct
+// problems and must stay as separate rows.
+func TestDetectGatewayRouteParentIssues_DistinctReasonsStaySeparate(t *testing.T) {
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	route := routeWithParents("primary-gateway", []struct{ section, reason, message string }{
+		{"http", "NoMatchingListenerHostname", "no hostname intersections"},
+		{"https", "NoMatchingParent", "no matching parent"},
+	})
+	p := &fakeProvider{
+		dynamic:    map[schema.GroupVersionResource][]*unstructured.Unstructured{routeGVR: {route}},
+		kinds:      map[schema.GroupVersionResource]string{routeGVR: "HTTPRoute"},
+		namespaced: map[schema.GroupVersionResource]bool{routeGVR: true},
+	}
+
+	got := Compose(p, Filters{})
+	if len(got) != 2 {
+		t.Fatalf("distinct reasons must stay separate, got %d issues: %+v", len(got), got)
+	}
+}
+
+// The single-listener issue's identity must not change when a second listener
+// starts failing the same way — otherwise acknowledgement/history is lost. The
+// gateway-level fingerprint keeps the ID stable across the 1↔many boundary.
+func TestDetectGatewayRouteParentIssues_StableIdentityAcrossListenerCount(t *testing.T) {
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	mk := func(listeners []struct{ section, reason, message string }) Issue {
+		p := &fakeProvider{
+			dynamic:    map[schema.GroupVersionResource][]*unstructured.Unstructured{routeGVR: {routeWithParents("primary-gateway", listeners)}},
+			kinds:      map[schema.GroupVersionResource]string{routeGVR: "HTTPRoute"},
+			namespaced: map[schema.GroupVersionResource]bool{routeGVR: true},
+		}
+		got := Compose(p, Filters{})
+		if len(got) != 1 {
+			t.Fatalf("want 1 issue, got %d: %+v", len(got), got)
+		}
+		return got[0]
+	}
+	one := mk([]struct{ section, reason, message string }{{"http", "NoMatchingListenerHostname", "x"}})
+	two := mk([]struct{ section, reason, message string }{
+		{"http", "NoMatchingListenerHostname", "x"},
+		{"https", "NoMatchingListenerHostname", "x"},
+	})
+	if one.ID == "" || one.ID != two.ID {
+		t.Fatalf("issue ID must be stable as listeners join the same fault: one=%q two=%q", one.ID, two.ID)
 	}
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield, Clock, Globe, Key } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { pluralize } from '../../../utils/pluralize'
 
 interface CertificateRendererProps {
@@ -34,6 +34,7 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const isReady = readyCond?.status === 'True'
   const isNotReady = readyCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const notAfter = status.notAfter
   const notBefore = status.notBefore
@@ -69,7 +70,7 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
   return (
     <>
       {/* Problem detection alerts */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Certificate Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield, FileText, Info } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 
 interface CertificateRequestRendererProps {
   data: any
@@ -20,6 +20,7 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
 
   const isReady = readyCond?.status === 'True'
   const isNotReady = readyCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const isApproved = approvedCond?.status === 'True'
   const isDenied = deniedCond?.status === 'True'
 
@@ -28,7 +29,7 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
   return (
     <>
       {/* Problem detection alerts */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Certificate Request Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx'
 import { Layers, GitBranch, Box, ChevronRight, Pause } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { Tooltip } from '../../ui/Tooltip'
 import {
   getCrossplaneStatus,
@@ -78,6 +78,7 @@ export function CompositeRenderer({ data, onNavigate, composedRefStatuses }: Com
   const boundXR = claim ? getBoundXRRef(data) : null
   const paused = isCrossplanePaused(data)
   const alertVariant = status.level === 'unhealthy' || status.level === 'alert' ? status.level : null
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
@@ -90,7 +91,7 @@ export function CompositeRenderer({ data, onNavigate, composedRefStatuses }: Com
         />
       )}
 
-      {alertVariant && reason && (
+      {alertVariant && reason && !operationalIssuesShown && (
         <AlertBanner
           variant={alertVariant === 'unhealthy' ? 'error' : 'warning'}
           title={status.text}

--- a/packages/k8s-ui/src/components/resources/renderers/ExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ExternalSecretRenderer.tsx
@@ -1,5 +1,5 @@
 import { KeyRound, RefreshCw, CloudCog } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown } from '../../ui/drawer-components'
 import {
   getExternalSecretStatus,
   getExternalSecretStore,
@@ -30,11 +30,12 @@ export function ExternalSecretRenderer({ data, onNavigate }: ExternalSecretRende
   // Problem detection
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const isNotReady = readyCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
       {/* Alert if not synced */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="ExternalSecret Not Synced"

--- a/packages/k8s-ui/src/components/resources/renderers/GRPCRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GRPCRouteRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, ArrowRight, Network, Filter } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
@@ -23,6 +23,10 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
   const unresolvedRefsParents = parentStatuses.filter((p: any) =>
     (p.conditions || []).some((c: any) => c.type === 'ResolvedRefs' && c.status === 'False')
   )
+  // The Operational Issues section (when the host shows it) already reports these
+  // Accepted/ResolvedRefs failures with richer cause + next-step context, so drop
+  // the renderer's own banners to avoid showing the same failure twice.
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const firstParentConditions = parentStatuses.length > 0
     ? parentStatuses[0].conditions
@@ -47,7 +51,7 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
 
   return (
     <>
-      {notAcceptedParents.length > 0 && (
+      {notAcceptedParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Route Not Accepted"
@@ -61,7 +65,7 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
         />
       )}
 
-      {unresolvedRefsParents.length > 0 && (
+      {unresolvedRefsParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="warning"
           title="Unresolved References"

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cpu } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { Badge } from '../../ui/Badge'
 
 interface GatewayClassRendererProps {
@@ -14,11 +14,12 @@ export function GatewayClassRenderer({ data }: GatewayClassRendererProps) {
   const acceptedCond = conditions.find((c: any) => c.type === 'Accepted')
   const isAccepted = acceptedCond?.status === 'True'
   const isNotAccepted = acceptedCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
       {/* Problem detection alert */}
-      {isNotAccepted && (
+      {isNotAccepted && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="GatewayClass Not Accepted"

--- a/packages/k8s-ui/src/components/resources/renderers/HTTPRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/HTTPRouteRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, ArrowRight, Network, Filter } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
@@ -23,6 +23,10 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
   const unresolvedRefsParents = parentStatuses.filter((p: any) =>
     (p.conditions || []).some((c: any) => c.type === 'ResolvedRefs' && c.status === 'False')
   )
+  // The Operational Issues section (when the host shows it) already reports these
+  // Accepted/ResolvedRefs failures with richer cause + next-step context, so drop
+  // the renderer's own banners to avoid showing the same failure twice.
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const firstParentConditions = parentStatuses.length > 0
     ? parentStatuses[0].conditions
@@ -47,7 +51,7 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
 
   return (
     <>
-      {notAcceptedParents.length > 0 && (
+      {notAcceptedParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Route Not Accepted"
@@ -61,7 +65,7 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
         />
       )}
 
-      {unresolvedRefsParents.length > 0 && (
+      {unresolvedRefsParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="warning"
           title="Unresolved References"

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, HardDrive, Shield, Network, Tag, Image } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { getEC2NodeClassStatus } from '../resource-utils-karpenter'
 
 interface KarpenterEC2NodeClassRendererProps {
@@ -13,6 +13,7 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
 
   const nodeClassStatus = getEC2NodeClassStatus(data)
   const isNotReady = nodeClassStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const amiTerms = spec.amiSelectorTerms || []
@@ -28,7 +29,7 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
 
   return (
     <>
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="EC2NodeClass Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -1,6 +1,6 @@
 import { Server, Cpu, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { CAPACITY_TYPE_BADGE, BADGE_INACTIVE } from '../../../utils/badge-colors'
 import {
@@ -40,6 +40,7 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
 
   const claimStatus = getNodeClaimStatus(data)
   const isNotReady = claimStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const capacity = getNodeClaimCapacity(data)
   const requirements = getNodeClaimRequirements(data)
@@ -61,7 +62,7 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
   return (
     <>
       {/* Problem alert */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="NodeClaim Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Settings, Shield, Cpu, Tag, BarChart3 } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import {
   getNodePoolStatus,
@@ -31,6 +31,7 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
 
   const poolStatus = getNodePoolStatus(data)
   const isNotReady = poolStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const requirements = getNodePoolRequirements(data)
   const weight = getNodePoolWeight(data)
@@ -45,7 +46,7 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
   return (
     <>
       {/* Problem alert */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="NodePool Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/KedaScaledJobRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaScaledJobRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cpu } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown } from '../../ui/drawer-components'
 import {
   getScaledJobStatus,
   getScaledJobTarget,
@@ -18,13 +18,14 @@ export function KedaScaledJobRenderer({ data }: KedaScaledJobRendererProps) {
 
   const jobStatus = getScaledJobStatus(data)
   const isNotReady = jobStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const triggers = getScaledJobTriggers(data)
 
   return (
     <>
       {/* Problem alert */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="ScaledJob Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cpu, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import {
   getScaledObjectStatus,
@@ -39,6 +39,7 @@ export function KedaScaledObjectRenderer({ data, onNavigate }: KedaScaledObjectR
   const isPaused = soStatus.text === 'Paused'
   const isFallback = soStatus.text === 'Fallback'
   const isNotReady = soStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const fallbackCond = conditions.find((c: any) => c.type === 'Fallback')
@@ -53,7 +54,7 @@ export function KedaScaledObjectRenderer({ data, onNavigate }: KedaScaledObjectR
           message={fallbackCond?.message || 'KEDA is using fallback replicas because triggers are failing.'}
         />
       )}
-      {isNotReady && !isFallback && (
+      {isNotReady && !isFallback && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="ScaledObject Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/ManagedResourceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ManagedResourceRenderer.tsx
@@ -1,5 +1,5 @@
 import { Box, Settings, Cloud, ScrollText, Pause, Layers } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { CodeViewer } from '../../ui/CodeViewer'
 import {
   getCrossplaneStatus,
@@ -41,6 +41,7 @@ export function ManagedResourceRenderer({ data, onNavigate }: ManagedResourceRen
   const atProvider = data?.status?.atProvider
 
   const alertVariant = status.level === 'unhealthy' || status.level === 'alert' ? status.level : null
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
@@ -53,7 +54,7 @@ export function ManagedResourceRenderer({ data, onNavigate }: ManagedResourceRen
         />
       )}
 
-      {alertVariant && statusReason && (
+      {alertVariant && statusReason && !operationalIssuesShown && (
         <AlertBanner
           variant={alertVariant === 'unhealthy' ? 'error' : 'warning'}
           title={status.text}

--- a/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { HardDrive } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 
 interface PVCRendererProps {
   data: any
@@ -38,11 +38,12 @@ export function PVCRenderer({ data, onNavigate, extraSections }: PVCRendererProp
   const selectedNode = annotations['volume.kubernetes.io/selected-node']
   const bindCompleted = annotations['pv.kubernetes.io/bind-completed']
   const hasProvisionerInfo = provisioner || selectedNode || bindCompleted
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
       {/* Problem alerts */}
-      {isLost && (
+      {isLost && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Issues Detected"

--- a/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
@@ -1,6 +1,6 @@
 import { Lock, Key, FileText } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList, AlertBanner, ResourceLink, useOperationalIssuesShown } from '../../ui/drawer-components'
 
 interface SealedSecretRendererProps {
   data: any
@@ -32,6 +32,7 @@ export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererP
   const syncedCond = conditions.find((c: any) => c.type === 'Synced')
   const isSynced = syncedCond?.status === 'True'
   const isNotSynced = syncedCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const hasTemplateMetadata =
     (templateLabels && Object.keys(templateLabels).length > 0) ||
@@ -40,7 +41,7 @@ export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererP
   return (
     <>
       {/* Problem detection alert */}
-      {isNotSynced && (
+      {isNotSynced && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Secret is not synced"

--- a/packages/k8s-ui/src/components/resources/renderers/SecretStoreRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SecretStoreRenderer.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheck } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown } from '../../ui/drawer-components'
 import {
   getSecretStoreStatus,
   getSecretStoreProviderType,
@@ -41,11 +41,12 @@ export function SecretStoreRenderer({ data }: SecretStoreRendererProps) {
   // Problem detection
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const isNotReady = readyCond?.status === 'False'
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   return (
     <>
       {/* Alert if not ready */}
-      {isNotReady && (
+      {isNotReady && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Store Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/SimpleRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SimpleRouteRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, ArrowRight, Network } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge, useOperationalIssuesShown } from '../../ui/drawer-components'
 import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
@@ -26,6 +26,10 @@ export function SimpleRouteRenderer({ data, kind, onNavigate }: SimpleRouteRende
   const unresolvedRefsParents = parentStatuses.filter((p: any) =>
     (p.conditions || []).some((c: any) => c.type === 'ResolvedRefs' && c.status === 'False')
   )
+  // The Operational Issues section (when the host shows it) already reports these
+  // Accepted/ResolvedRefs failures with richer cause + next-step context, so drop
+  // the renderer's own banners to avoid showing the same failure twice.
+  const operationalIssuesShown = useOperationalIssuesShown()
 
   const firstParentConditions = parentStatuses.length > 0
     ? parentStatuses[0].conditions
@@ -50,7 +54,7 @@ export function SimpleRouteRenderer({ data, kind, onNavigate }: SimpleRouteRende
 
   return (
     <>
-      {notAcceptedParents.length > 0 && (
+      {notAcceptedParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Route Not Accepted"
@@ -64,7 +68,7 @@ export function SimpleRouteRenderer({ data, kind, onNavigate }: SimpleRouteRende
         />
       )}
 
-      {unresolvedRefsParents.length > 0 && (
+      {unresolvedRefsParents.length > 0 && !operationalIssuesShown && (
         <AlertBanner
           variant="warning"
           title="Unresolved References"

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -446,11 +446,14 @@ export interface Problem {
 }
 
 /** Displays a list of problem alerts (warnings and errors) */
-// True when the resource detail is already rendering a dedicated, authoritative
-// "Operational Issues" section (the Issues pipeline — richer cause/action). Only
-// renderers whose problems the pipeline COMPREHENSIVELY covers read this and drop
-// their own problem array so the same failure isn't shown twice — today that's
-// PodRenderer and WorkloadRenderer (workload + pod runtime). It is deliberately
+// True when the resource detail is rendering (or still fetching) a dedicated,
+// authoritative "Operational Issues" section (the Issues pipeline — richer
+// cause/action). Renderers whose problems the pipeline COMPREHENSIVELY covers read
+// this and drop their own condition banner so the same failure isn't shown twice.
+// It stays true WHILE the live-issues fetch is pending: a banner the pipeline will
+// cover would otherwise flash on first paint before the issues arrive and hide it;
+// once the fetch settles with no issues (e.g. a CRD the pipeline doesn't watch),
+// it flips false and the renderer's banner appears cleanly. It is deliberately
 // NOT wired into ProblemAlerts: that component is used only by GitOps renderers
 // (Argo/Flux), whose Degraded/OutOfSync/revision-mismatch banners the pipeline
 // does not fully emit (e.g. OutOfSync only for automated Argo apps) — suppressing

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -285,6 +285,10 @@ interface WorkloadViewProps {
    *  live issues for this resource). Avoids showing the same failure twice.
    *  Also gates the `renderOverviewLead` wrapper (see above). */
   hasOperationalIssues?: boolean
+  /** True while the live-issues fetch is still pending. Renderers suppress their
+   *  banners during this window too — a banner whose failure the pipeline covers
+   *  would otherwise flash on first paint before the issues arrive and hide it. */
+  operationalIssuesPending?: boolean
 
   // ── Duplicate ────────────────────────────────────────────────────────────
   /** Duplicate handler — opens create dialog with this resource's YAML */
@@ -374,6 +378,7 @@ export function WorkloadView({
   renderOverviewIntro,
   renderOverviewLead,
   hasOperationalIssues,
+  operationalIssuesPending,
   // Actions bar
   actionsBarProps,
   // Renderer overrides
@@ -805,7 +810,7 @@ export function WorkloadView({
               onDownload={onDownload}
             />
           ) : (
-            <OperationalIssuesShownContext.Provider value={!!hasOperationalIssues}>
+            <OperationalIssuesShownContext.Provider value={!!hasOperationalIssues || !!operationalIssuesPending}>
               {renderOverviewLead && hasOperationalIssues && (
                 <div className="px-4 pt-4">
                   {renderOverviewLead({ kind, namespace, name })}
@@ -842,7 +847,7 @@ export function WorkloadView({
 
   // ── Expanded (full) mode ─────────────────────────────────────────────────
   return (
-    <OperationalIssuesShownContext.Provider value={!!hasOperationalIssues}>
+    <OperationalIssuesShownContext.Provider value={!!hasOperationalIssues || !!operationalIssuesPending}>
     <DetailShell
       breadcrumb={breadcrumb}
       nav={

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -739,7 +739,7 @@ export function WorkloadView({
   // would flip the query key when the manifest arrives, drop liveIssues, and flash
   // the renderer banners. The backend canonicalizes a plural kind via discovery,
   // so using the normalized API kind resolves direct links and app navigation alike.
-  const { data: liveIssues } = useResourceIssues(apiKind, rest.group, namespace, name)
+  const { data: liveIssues, isPending: issuesPending } = useResourceIssues(apiKind, rest.group, namespace, name)
   const { data: auditFindings } = useResourceAudit(apiKind, namespace, name)
   const hasOperationalIssues = Boolean(liveIssues?.length)
   const {
@@ -983,6 +983,7 @@ export function WorkloadView({
           />
         )}
         hasOperationalIssues={hasOperationalIssues}
+        operationalIssuesPending={issuesPending}
         onOpenGitOpsResource={gitopsOwnerQuery.data ? handleOpenGitOpsResource : undefined}
         resolvedGitOpsOwner={gitopsOwner}
         gitOpsOwnerVerified={gitOpsOwnerVerified}


### PR DESCRIPTION
## Summary

De-duplicates how Radar surfaces resource problems, on two fronts that both stem from the same root: a problem being reported in more than one place.

1. **Within the Operational Issues list** — an HTTPRoute attached to several listeners of one Gateway produced one near-identical issue *per listener* (`listener http` / `listener https`). These now collapse into a single gateway-level issue.
2. **Across surfaces** — when the drawer shows the authoritative **Operational Issues** section, a renderer's own red/amber banner for the *same* status-condition failure is a redundant second copy. Renderers now defer that banner to the Operational Issues card (the pattern Pod/Workload already used).

## What changed

### Per-listener Gateway route collapse (backend — `internal/issues`)

`detectGatewayRouteParentIssues` groups a route's failing parent conditions by `(condType, reason, gateway)` — gateway identity without `sectionName`/`port` — and emits one issue per group:
- **Names the affected listeners** (`Gateway …/primary-gateway listeners http, https: …`), so an explicit per-listener attachment isn't silently flattened.
- **Aggregates, never drops** — differing per-listener messages are listed rather than keeping only the first.
- **Stable identity across the 1↔many boundary** — fingerprint is `condType:gwKey:reason` (not keyed on the listener), so a listener joining/leaving the same fault doesn't re-key the row.
- Distinct reasons stay separate; `first_seen` anchors on the oldest listener transition.

### Renderers defer condition-banners to Operational Issues (frontend — `packages/k8s-ui` renderers)

Extends the existing `useOperationalIssuesShown()` gate (already used by Pod/Workload) to every renderer whose condition-derived banner the issues pipeline covers comprehensively. Gated banners:
- Gateway API routes (HTTPRoute/GRPCRoute/SimpleRoute): Accepted + ResolvedRefs; GatewayClass: Accepted
- external-secrets (ExternalSecret/SecretStore), SealedSecret: Ready/Synced
- Karpenter (EC2NodeClass/NodeClaim/NodePool), KEDA (ScaledJob/ScaledObject): Ready
- cert-manager (Certificate/CertificateRequest): Ready
- Crossplane (Composite/ManagedResource): Synced/Ready
- PVC: lost-volume

The gate also stays active while the live-issues fetch is pending (threaded through `OperationalIssuesShownContext`), so a banner the pipeline will cover never flashes on first paint before the issues arrive to hide it.

**Only condition-derived banners are gated.** Heuristic banners (cert expiry, RBAC blast-radius, replica math, phase strings) are the renderer's unique value — the pipeline doesn't emit them — and are left. Left untouched by design: renderers with multiple *independent* conditions (Gateway Accepted+Programmed, XRD, CrossplanePackage) where the first-false pipeline detector isn't comprehensive; GitOps `ProblemAlerts` (Argo/Flux, whose problems the pipeline doesn't fully emit); and partially-covered kinds (Ingress/PersistentVolume/Node/Service).

Safety property: the gate hides a banner only when the pipeline emitted an issue for that resource, and for every gated kind the pipeline's *only possible* issue is the same condition the banner shows — so nothing is hidden that the richer card doesn't already show. The suppression is per-banner, so a renderer's heuristic banners keep showing alongside.

## Testing

- `go test ./internal/issues/... ./internal/k8s/` — pass (the `internal/k8s` per-listener timeline-diff tests are a separate concern, unaffected). `go vet` clean. `make tsc` clean; k8s-ui vitest — 266 renderer/issues/drawer tests pass.
- New Go coverage: per-listener dupes collapse to one listener-named issue; differing messages aggregated; distinct reasons stay separate; issue **ID stable** across the 1↔many boundary.
- **Verified live** against the nonprod cluster: the two `radar-hub` HTTPRoute rows became one (`listeners http, https`); the not-synced `SealedSecret` drawer now shows the Operational Issues card only — its redundant "Secret is not synced" banner is gone, while the Status/Conditions detail remains.

## Notes

A full renderer-by-renderer audit (all ~84 problem-banner renderers) backed the gated set; most banners are heuristic (not dupes) or GitOps (deliberately kept). CAPI renderers (Ready-condition banners) are a plausible follow-up once `DetectCAPIProblems` comprehensiveness is confirmed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes issue identity/fingerprints and UI suppression for operational alerts; incorrect grouping or pending gating could hide real problems or break ack history, but scope is issues detection and display with new tests.
> 
> **Overview**
> Reduces duplicate problem surfacing in the **Operational Issues** list and in resource drawers.
> 
> **Backend:** Gateway route parent-condition detection now **groups** failing `Accepted` / `ResolvedRefs` / `Programmed` conditions by `(condition type, reason, gateway)` instead of one issue per listener. Collapsed rows name affected listeners, merge differing per-listener messages, keep distinct reasons separate, use a **gateway-level fingerprint** so issue IDs stay stable when more listeners join the same fault, and anchor `first_seen` on the oldest listener transition.
> 
> **Frontend:** Many resource renderers hide **condition-derived** `AlertBanner`s when `useOperationalIssuesShown()` is true (Gateway routes/classes, cert-manager, ESO, SealedSecret, Karpenter, KEDA, Crossplane, PVC Lost, etc.); heuristic banners (expiry, paused, fallback) stay. `OperationalIssuesShownContext` is true while live issues are **loading** as well as when issues exist, via new `operationalIssuesPending`, so banners do not flash before the Operational Issues card appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34da67cc6cfd4156b820ba02b1d934cb6b0cd02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
