### PR TITLE
Seed the namespace picker from --namespaces for auth-enabled sessions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ If your account can list resources inside several namespaces but cannot list nam
 kubectl radar --namespaces ns1,ns2,ns3
 ```
 
-Radar probes each listed namespace for access and watches every namespace where access is granted — resource views then cover all of them, not just the first. When Radar opens the browser itself, the list is also applied as the initial namespace selection. The picker can then switch between those namespaces or keep several selected at once.
+Radar probes each listed namespace for access and watches every namespace where access is granted — resource views then cover all of them, not just the first. The list is also each user's initial picker selection: locally via the launch URL, and in shared (auth-enabled) deployments as a per-session default seeded on first read. Clearing the picker back to **All namespaces** sticks for the rest of the session. The picker can switch between those namespaces or keep several selected at once.
 
 This currently applies to built-in resource types. Custom resources (CRDs — GitOps, Gateway API, etc.) still fall back to the first granted namespace when cluster-wide listing is denied; full multi-namespace CRD coverage is tracked separately. The list is capped by `--max-scope-candidates` (default 20) — startup fails with a clear error rather than silently probing a subset.
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -60,6 +60,10 @@ var (
 	contextNamespace   string   // Default namespace from kubeconfig context
 	fallbackNamespace  string   // Explicit namespace from --namespace flag
 	fallbackNamespaces []string // Explicit namespace candidates from --namespaces flag
+	// fallbackNamespacesExplicit distinguishes SetFallbackNamespaces (the
+	// plural --namespaces flag, which also seeds the per-user picker) from
+	// SetFallbackNamespace (--namespace, which only steers RBAC probing).
+	fallbackNamespacesExplicit bool
 	// fallbackNamespaceContext is the context that was active when --namespace was
 	// set at startup. --namespace is an *initial* value, so it only pins the cache
 	// scope for that context — after switching clusters, the scope target comes
@@ -678,6 +682,7 @@ func SetFallbackNamespace(ns string) {
 	defer clientMu.Unlock()
 	fallbackNamespace = ns
 	fallbackNamespaces = dedupeNamespacesLocked([]string{ns})
+	fallbackNamespacesExplicit = false
 	// Record the context this --namespace applies to, so it only pins the cache
 	// scope while we're on that context (see GetNamespaceScopeTarget).
 	fallbackNamespaceContext = contextName
@@ -691,12 +696,26 @@ func SetFallbackNamespaces(namespaces []string) {
 	clientMu.Lock()
 	defer clientMu.Unlock()
 	fallbackNamespaces = dedupeNamespacesLocked(namespaces)
+	fallbackNamespacesExplicit = len(fallbackNamespaces) > 0
 	if len(fallbackNamespaces) > 0 {
 		fallbackNamespace = fallbackNamespaces[0]
 	} else {
 		fallbackNamespace = ""
 	}
 	fallbackNamespaceContext = contextName
+}
+
+// ConfiguredNamespacesForCurrentContext returns the --namespaces list when
+// the current kubeconfig context is still the one the flag was configured
+// against. --namespaces is an *initial* value: after a context switch the
+// list references the previous cluster's namespaces and must not seed picks.
+func ConfiguredNamespacesForCurrentContext() []string {
+	clientMu.RLock()
+	defer clientMu.RUnlock()
+	if !fallbackNamespacesExplicit || fallbackNamespaceContext != contextName || len(fallbackNamespaces) == 0 {
+		return nil
+	}
+	return append([]string(nil), fallbackNamespaces...)
 }
 
 func dedupeNamespacesLocked(namespaces []string) []string {

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -129,16 +128,10 @@ func (s *Server) setActiveNamespaceForUser(r *http.Request, namespaces []string)
 func (s *Server) clearAllNamespacePreferences() {
 	// Under nsPickMu so an in-flight seed can't land between the two map
 	// wipes (a seeded preference without its marker would let a later clear
-	// re-seed). The --namespace-scope rescope inside handleSetActiveNamespace
-	// already holds nsPickMu — it must use the Locked variant instead.
+	// re-seed). No caller holds nsPickMu: handleSetActiveNamespace releases
+	// it before any k8s operation whose callbacks reach this function.
 	s.nsPickMu.Lock()
 	defer s.nsPickMu.Unlock()
-	s.clearAllNamespacePreferencesLocked()
-}
-
-// clearAllNamespacePreferencesLocked is the body of
-// clearAllNamespacePreferences; caller must hold nsPickMu.
-func (s *Server) clearAllNamespacePreferencesLocked() {
 	s.nsPreferences.Range(func(k, _ any) bool {
 		s.nsPreferences.Delete(k)
 		return true
@@ -162,15 +155,6 @@ func (s *Server) finalizePostContextSwitch() {
 	s.clearAllNamespacePreferences()
 	// AI investigations are cancelled + staled by the BEFORE-switch hook (see
 	// OnBeforeContextSwitch in New) so they can't touch the new cluster.
-}
-
-// finalizePostContextSwitchNsPickHeld is finalizePostContextSwitch for the
-// one caller that already holds nsPickMu (the --namespace-scope rescope in
-// handleSetActiveNamespace) — nsPickMu is not reentrant, so going through
-// clearAllNamespacePreferences there would self-deadlock.
-func (s *Server) finalizePostContextSwitchNsPickHeld() {
-	s.invalidatePostContextSwitchCaches()
-	s.clearAllNamespacePreferencesLocked()
 }
 
 func (s *Server) invalidatePostContextSwitchCaches() {
@@ -212,35 +196,32 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 		saved := settings.Load()
 		if saved.ActiveNamespaces != nil {
 			if picks := saved.ActiveNamespaces[ctxName]; len(picks) > 0 {
-				// A pick from disk is user intent too — burn configured-seed
-				// eligibility first, so if the deleted-namespace prune later
-				// evicts this pick (and its settings entry), reads fall back
-				// to All namespaces per the prune's recovery contract instead
-				// of re-applying --namespaces.
-				s.seededPicks.Store(key, true)
-				// Seed only while the pick is still empty. The Load check
-				// above is racy on its own — a concurrent POST could install
-				// a pick between it and this store — so re-check under the
-				// lock and skip if one landed.
-				s.commitPickMutation(r, ctxName, nil, picks, false)
+				// A settings snapshot read outside the lock can be stale
+				// against a concurrent POST set+clear; the atomic seed
+				// protocol (marker + absent-preference recheck under the
+				// lock) rejects it in that case, the same way it guards the
+				// configured list. Seeding from disk also burns configured-
+				// seed eligibility, so a later prune eviction falls back to
+				// All namespaces instead of resurfacing --namespaces.
+				s.seedPick(ctxName, key, picks)
 				return
 			}
 		}
 	}
 	if configured := k8s.ConfiguredNamespacesForCurrentContext(); len(configured) > 0 {
-		s.seedConfiguredPick(ctxName, key, configured)
+		s.seedPick(ctxName, key, configured)
 	}
 }
 
-// seedConfiguredPick installs the --namespaces startup list as key's pick.
-// The whole decision runs under nsPickMu so it cannot interleave with an
-// explicit POST (which burns the seed marker, including on clears) or a
-// context switch (which clears both maps under the same lock): context,
-// marker, and preference are all rechecked inside the critical section. A
-// bare preference CAS is NOT enough here — an absent key means both "never
-// picked" (seed) and "explicitly cleared" (don't); the marker is what tells
-// them apart.
-func (s *Server) seedConfiguredPick(ctxName, key string, configured []string) {
+// seedPick installs picks (from settings.json or the --namespaces startup
+// list) as key's initial pick. The whole decision runs under nsPickMu so it
+// cannot interleave with an explicit POST (which burns the seed marker,
+// including on clears) or a context switch (which clears both maps under the
+// same lock): context, marker, and preference are all rechecked inside the
+// critical section. A bare preference CAS is NOT enough here — an absent key
+// means both "never picked" (seed) and "explicitly cleared" (don't); the
+// marker is what tells them apart.
+func (s *Server) seedPick(ctxName, key string, picks []string) {
 	s.nsPickMu.Lock()
 	defer s.nsPickMu.Unlock()
 	if k8s.GetContextName() != ctxName {
@@ -252,7 +233,7 @@ func (s *Server) seedConfiguredPick(ctxName, key string, configured []string) {
 	if _, ok := s.nsPreferences.Load(key); ok {
 		return
 	}
-	s.nsPreferences.Store(key, append([]string(nil), configured...))
+	s.nsPreferences.Store(key, append([]string(nil), picks...))
 }
 
 // pruneToExistingNamespaces returns picks minus namespaces absent from
@@ -578,12 +559,26 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 	// so it can't revert a pick set here from a stale snapshot. Lock order is
 	// scopeMutationMu → nsPickMu; the prune takes only nsPickMu.
 	//
+	// nsPickMu MUST NOT be held across k8s operations: PerformNamespaceRescope
+	// waits on the k8s operation lock, and a concurrent context switch holding
+	// that lock fires callbacks that take nsPickMu (finalizePostContextSwitch)
+	// — holding it there closes an AB/BA deadlock. The rescope branch releases
+	// and re-acquires around the k8s call; commitPickMutation's CAS keeps the
+	// unlocked window safe against read-path mutations.
+	//
 	// Released explicitly before the closing handleGetNamespaceScope render:
 	// that path runs the prune, which takes nsPickMu itself — holding it
 	// across the render would self-deadlock (the mutex is not reentrant).
-	// OnceFunc keeps every early error return covered by the defer.
+	// The held-flag closure keeps every early error return covered by the
+	// defer across the release/re-acquire cycle.
 	s.nsPickMu.Lock()
-	unlockNsPick := sync.OnceFunc(s.nsPickMu.Unlock)
+	nsPickHeld := true
+	unlockNsPick := func() {
+		if nsPickHeld {
+			nsPickHeld = false
+			s.nsPickMu.Unlock()
+		}
+	}
 	defer unlockNsPick()
 
 	// Persist the no-auth (single-user) pick across restarts before acting on it.
@@ -618,6 +613,7 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 			// namespace. PerformNamespaceRescope stops active sessions itself, but
 			// only once it commits to the teardown (after its connectivity check),
 			// so a failed rescope doesn't kill port-forwards / exec for nothing.
+			unlockNsPick()
 			if err := k8s.PerformNamespaceRescope(cleaned[0]); err != nil {
 				// We persisted the requested pick above, but the rescope didn't take
 				// (rolled back to the previous namespace, or superseded by a newer op).
@@ -638,7 +634,9 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 				s.writeError(w, http.StatusServiceUnavailable, "failed to rescope namespace cache: "+err.Error())
 				return
 			}
-			s.finalizePostContextSwitchNsPickHeld()
+			s.finalizePostContextSwitch()
+			s.nsPickMu.Lock()
+			nsPickHeld = true
 		}
 	}
 

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -127,6 +127,12 @@ func (s *Server) clearAllNamespacePreferences() {
 		s.nsPreferences.Delete(k)
 		return true
 	})
+	// Seed marks reference the previous cluster's keys; dropping them lets a
+	// switch back to the startup context re-apply the configured initial view.
+	s.seededPicks.Range(func(k, _ any) bool {
+		s.seededPicks.Delete(k)
+		return true
+	})
 }
 
 // finalizePostContextSwitch clears all per-user state that referenced the
@@ -151,30 +157,53 @@ func (s *Server) finalizePostContextSwitch() {
 	// OnBeforeContextSwitch in New) so they can't touch the new cluster.
 }
 
-// loadSavedNamespacePreference seeds the per-user map from settings.json on
-// first reach. Only relevant for the no-auth (local single-user) path —
-// auth-enabled deploys don't persist picks across pod restarts.
+// loadSavedNamespacePreference seeds the per-user map on first reach.
+// Sources, in priority order:
+//   - a settings.json pick (no-auth local single-user only) — a remembered
+//     narrower choice survives restarts;
+//   - the --namespaces startup list (any user, auth included) — each user's
+//     session starts on the configured view. Seeded at most once per
+//     (user, context) key, so clearing back to "All namespaces" sticks for
+//     the rest of the session instead of being re-applied on the next read.
 func (s *Server) loadSavedNamespacePreference(r *http.Request) {
-	if auth.UserFromContext(r.Context()) != nil {
-		return // multi-user: no shared persisted pref
-	}
 	ctxName := k8s.GetContextName()
 	if ctxName == "" {
 		return
 	}
-	key := nsPreferenceKey("", ctxName)
+	username := ""
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		username = u.Username
+	}
+	key := nsPreferenceKey(username, ctxName)
 	if _, ok := s.nsPreferences.Load(key); ok {
 		return
 	}
-	saved := settings.Load()
-	if saved.ActiveNamespaces == nil {
-		return
+
+	// Configured-seed eligibility is decided (and burned) before any seeding:
+	// whichever source wins, the configured list must not re-apply after the
+	// user later clears their pick.
+	seedConfigured := false
+	configured := k8s.ConfiguredNamespacesForCurrentContext()
+	if len(configured) > 0 {
+		_, alreadyConsidered := s.seededPicks.LoadOrStore(key, true)
+		seedConfigured = !alreadyConsidered
 	}
-	if picks := saved.ActiveNamespaces[ctxName]; len(picks) > 0 {
-		// Seed only while the pick is still empty. The Load check above is
-		// racy on its own — a concurrent POST could install a pick between it
-		// and this store — so re-check under the lock and skip if one landed.
-		s.commitPickMutation(r, ctxName, nil, picks, false)
+
+	if username == "" {
+		saved := settings.Load()
+		if saved.ActiveNamespaces != nil {
+			if picks := saved.ActiveNamespaces[ctxName]; len(picks) > 0 {
+				// Seed only while the pick is still empty. The Load check
+				// above is racy on its own — a concurrent POST could install
+				// a pick between it and this store — so re-check under the
+				// lock and skip if one landed.
+				s.commitPickMutation(r, ctxName, nil, picks, false)
+				return
+			}
+		}
+	}
+	if seedConfigured {
+		s.commitPickMutation(r, ctxName, nil, configured, false)
 	}
 }
 

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -129,9 +129,16 @@ func (s *Server) setActiveNamespaceForUser(r *http.Request, namespaces []string)
 func (s *Server) clearAllNamespacePreferences() {
 	// Under nsPickMu so an in-flight seed can't land between the two map
 	// wipes (a seeded preference without its marker would let a later clear
-	// re-seed). Callers never hold nsPickMu here.
+	// re-seed). The --namespace-scope rescope inside handleSetActiveNamespace
+	// already holds nsPickMu — it must use the Locked variant instead.
 	s.nsPickMu.Lock()
 	defer s.nsPickMu.Unlock()
+	s.clearAllNamespacePreferencesLocked()
+}
+
+// clearAllNamespacePreferencesLocked is the body of
+// clearAllNamespacePreferences; caller must hold nsPickMu.
+func (s *Server) clearAllNamespacePreferencesLocked() {
 	s.nsPreferences.Range(func(k, _ any) bool {
 		s.nsPreferences.Delete(k)
 		return true
@@ -151,6 +158,22 @@ func (s *Server) clearAllNamespacePreferences() {
 // SAR results, and those entries (TTL 2m) then authorize NEW cluster
 // requests.
 func (s *Server) finalizePostContextSwitch() {
+	s.invalidatePostContextSwitchCaches()
+	s.clearAllNamespacePreferences()
+	// AI investigations are cancelled + staled by the BEFORE-switch hook (see
+	// OnBeforeContextSwitch in New) so they can't touch the new cluster.
+}
+
+// finalizePostContextSwitchNsPickHeld is finalizePostContextSwitch for the
+// one caller that already holds nsPickMu (the --namespace-scope rescope in
+// handleSetActiveNamespace) — nsPickMu is not reentrant, so going through
+// clearAllNamespacePreferences there would self-deadlock.
+func (s *Server) finalizePostContextSwitchNsPickHeld() {
+	s.invalidatePostContextSwitchCaches()
+	s.clearAllNamespacePreferencesLocked()
+}
+
+func (s *Server) invalidatePostContextSwitchCaches() {
 	if s.permCache != nil {
 		s.permCache.Invalidate()
 	}
@@ -161,9 +184,6 @@ func (s *Server) finalizePostContextSwitch() {
 	clearPackagesCache()
 	clearApplicationsCache()
 	s.vitalsMetrics.clear()
-	s.clearAllNamespacePreferences()
-	// AI investigations are cancelled + staled by the BEFORE-switch hook (see
-	// OnBeforeContextSwitch in New) so they can't touch the new cluster.
 }
 
 // loadSavedNamespacePreference seeds the per-user map on first reach.
@@ -192,6 +212,12 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 		saved := settings.Load()
 		if saved.ActiveNamespaces != nil {
 			if picks := saved.ActiveNamespaces[ctxName]; len(picks) > 0 {
+				// A pick from disk is user intent too — burn configured-seed
+				// eligibility first, so if the deleted-namespace prune later
+				// evicts this pick (and its settings entry), reads fall back
+				// to All namespaces per the prune's recovery contract instead
+				// of re-applying --namespaces.
+				s.seededPicks.Store(key, true)
 				// Seed only while the pick is still empty. The Load check
 				// above is racy on its own — a concurrent POST could install
 				// a pick between it and this store — so re-check under the
@@ -612,7 +638,7 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 				s.writeError(w, http.StatusServiceUnavailable, "failed to rescope namespace cache: "+err.Error())
 				return
 			}
-			s.finalizePostContextSwitch()
+			s.finalizePostContextSwitchNsPickHeld()
 		}
 	}
 

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -111,6 +111,10 @@ func (s *Server) setActiveNamespaceForUser(r *http.Request, namespaces []string)
 		return
 	}
 	key := nsPreferenceKey(username, ctxName)
+	// An explicit set — including a clear — expresses user intent; burn the
+	// configured-seed eligibility so the --namespaces startup list can't
+	// override it on a later read.
+	s.seededPicks.Store(key, true)
 	if len(namespaces) == 0 {
 		s.nsPreferences.Delete(key)
 		return
@@ -123,6 +127,11 @@ func (s *Server) setActiveNamespaceForUser(r *http.Request, namespaces []string)
 // clearAllNamespacePreferences drops every saved pick. Called on context
 // switch — picks against the previous cluster's namespaces are meaningless.
 func (s *Server) clearAllNamespacePreferences() {
+	// Under nsPickMu so an in-flight seed can't land between the two map
+	// wipes (a seeded preference without its marker would let a later clear
+	// re-seed). Callers never hold nsPickMu here.
+	s.nsPickMu.Lock()
+	defer s.nsPickMu.Unlock()
 	s.nsPreferences.Range(func(k, _ any) bool {
 		s.nsPreferences.Delete(k)
 		return true
@@ -179,16 +188,6 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 		return
 	}
 
-	// Configured-seed eligibility is decided (and burned) before any seeding:
-	// whichever source wins, the configured list must not re-apply after the
-	// user later clears their pick.
-	seedConfigured := false
-	configured := k8s.ConfiguredNamespacesForCurrentContext()
-	if len(configured) > 0 {
-		_, alreadyConsidered := s.seededPicks.LoadOrStore(key, true)
-		seedConfigured = !alreadyConsidered
-	}
-
 	if username == "" {
 		saved := settings.Load()
 		if saved.ActiveNamespaces != nil {
@@ -202,9 +201,32 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 			}
 		}
 	}
-	if seedConfigured {
-		s.commitPickMutation(r, ctxName, nil, configured, false)
+	if configured := k8s.ConfiguredNamespacesForCurrentContext(); len(configured) > 0 {
+		s.seedConfiguredPick(ctxName, key, configured)
 	}
+}
+
+// seedConfiguredPick installs the --namespaces startup list as key's pick.
+// The whole decision runs under nsPickMu so it cannot interleave with an
+// explicit POST (which burns the seed marker, including on clears) or a
+// context switch (which clears both maps under the same lock): context,
+// marker, and preference are all rechecked inside the critical section. A
+// bare preference CAS is NOT enough here — an absent key means both "never
+// picked" (seed) and "explicitly cleared" (don't); the marker is what tells
+// them apart.
+func (s *Server) seedConfiguredPick(ctxName, key string, configured []string) {
+	s.nsPickMu.Lock()
+	defer s.nsPickMu.Unlock()
+	if k8s.GetContextName() != ctxName {
+		return
+	}
+	if _, considered := s.seededPicks.LoadOrStore(key, true); considered {
+		return
+	}
+	if _, ok := s.nsPreferences.Load(key); ok {
+		return
+	}
+	s.nsPreferences.Store(key, append([]string(nil), configured...))
 }
 
 // pruneToExistingNamespaces returns picks minus namespaces absent from

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -755,27 +755,52 @@ func TestLoadSavedNamespacePreference_PostBeforeFirstLoadBurnsSeed(t *testing.T)
 	}
 }
 
-// The --namespace-scope rescope calls finalize while handleSetActiveNamespace
-// holds nsPickMu; the NsPickHeld variant must complete without trying to
-// re-acquire the non-reentrant lock.
-func TestFinalizePostContextSwitchNsPickHeld_NoDeadlock(t *testing.T) {
+// finalizePostContextSwitch takes nsPickMu itself; no caller may hold it.
+// This pins the lock discipline: it must complete promptly when nothing
+// holds the lock, and the rescope path in handleSetActiveNamespace releases
+// the lock before any k8s operation whose callbacks reach finalize.
+func TestFinalizePostContextSwitch_TakesNsPickMuItself(t *testing.T) {
 	s := newTestServer(t)
 	s.setActiveNamespaceForUser(reqAs("alice"), []string{"alpha"})
 
 	done := make(chan struct{})
 	go func() {
-		s.nsPickMu.Lock()
-		defer s.nsPickMu.Unlock()
-		s.finalizePostContextSwitchNsPickHeld()
+		s.finalizePostContextSwitch()
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("finalizePostContextSwitchNsPickHeld deadlocked under held nsPickMu")
+		t.Fatal("finalizePostContextSwitch blocked with no lock holders")
 	}
 	if got := s.getActiveNamespaceForUser(reqAs("alice")); len(got) != 0 {
 		t.Fatalf("picks survived finalize: %v", got)
+	}
+}
+
+// A stale settings snapshot must not resurrect a pick the user explicitly
+// cleared: the settings seed goes through the same marker-gated protocol as
+// the configured seed, and an explicit set/clear burns the marker.
+func TestLoadSavedNamespacePreference_StaleSettingsCannotOverrideClear(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	s := newTestServer(t)
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"stale-ns"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+	req := reqAs("")
+
+	// User expressed intent (set then clear) before/while a load's settings
+	// snapshot was in flight; the disk entry still says stale-ns.
+	s.setActiveNamespaceForUser(req, []string{"fresh-ns"})
+	s.setActiveNamespaceForUser(req, nil)
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); len(got) != 0 {
+		t.Fatalf("stale settings snapshot overrode explicit clear: %v", got)
 	}
 }
 

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -754,3 +754,63 @@ func TestLoadSavedNamespacePreference_PostBeforeFirstLoadBurnsSeed(t *testing.T)
 		t.Fatalf("explicit clear before first load was overridden by seed: %v", got)
 	}
 }
+
+// The --namespace-scope rescope calls finalize while handleSetActiveNamespace
+// holds nsPickMu; the NsPickHeld variant must complete without trying to
+// re-acquire the non-reentrant lock.
+func TestFinalizePostContextSwitchNsPickHeld_NoDeadlock(t *testing.T) {
+	s := newTestServer(t)
+	s.setActiveNamespaceForUser(reqAs("alice"), []string{"alpha"})
+
+	done := make(chan struct{})
+	go func() {
+		s.nsPickMu.Lock()
+		defer s.nsPickMu.Unlock()
+		s.finalizePostContextSwitchNsPickHeld()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("finalizePostContextSwitchNsPickHeld deadlocked under held nsPickMu")
+	}
+	if got := s.getActiveNamespaceForUser(reqAs("alice")); len(got) != 0 {
+		t.Fatalf("picks survived finalize: %v", got)
+	}
+}
+
+// A settings.json pick burns configured-seed eligibility: once the pick is
+// later evicted (deleted-namespace prune, explicit clear), reads fall back to
+// All namespaces — the configured list must not resurface.
+func TestLoadSavedNamespacePreference_SettingsSeedBurnsConfigured(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	s := newTestServer(t)
+	k8s.SetFallbackNamespaces([]string{"team-a", "team-b"})
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"team-b"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+	req := reqAs("")
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); !slices.Equal(got, []string{"team-b"}) {
+		t.Fatalf("saved pick = %v, want [team-b]", got)
+	}
+
+	// Evict the pick the way the prune does: in-memory + settings entry.
+	s.setActiveNamespaceForUser(req, nil)
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); len(got) != 0 {
+		t.Fatalf("configured list resurfaced after settings pick eviction: %v", got)
+	}
+}

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -643,3 +643,96 @@ func TestPruneDeletedNamespacePicks_SkipsAcrossContextSwitch(t *testing.T) {
 		t.Errorf("old-context pick mutated across switch: %v, want %v", picks, snapshot)
 	}
 }
+
+// --namespaces seeds each user's picker once per session; a clear back to
+// "All namespaces" must stick instead of being re-applied on the next read.
+func TestLoadSavedNamespacePreference_SeedsConfiguredNamespacesOnce(t *testing.T) {
+	s := newTestServer(t)
+	k8s.SetFallbackNamespaces([]string{"team-a", "team-b"})
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	req := reqAs("alice")
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); !slices.Equal(got, []string{"team-a", "team-b"}) {
+		t.Fatalf("configured seed = %v, want [team-a team-b]", got)
+	}
+
+	s.setActiveNamespaceForUser(req, nil) // user clears to All
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); len(got) != 0 {
+		t.Fatalf("configured list re-seeded after clear: %v", got)
+	}
+
+	// A different user gets their own seed.
+	bob := reqAs("bob")
+	s.loadSavedNamespacePreference(bob)
+	if got := s.getActiveNamespaceForUser(bob); !slices.Equal(got, []string{"team-a", "team-b"}) {
+		t.Fatalf("second user seed = %v, want [team-a team-b]", got)
+	}
+}
+
+// A locally persisted pick outranks the configured startup list, and the
+// seed eligibility burned in that pass keeps the configured list from
+// re-applying after the user clears.
+func TestLoadSavedNamespacePreference_LocalSavedPickBeatsConfigured(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	s := newTestServer(t)
+	k8s.SetFallbackNamespaces([]string{"team-a", "team-b"})
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"team-b"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	req := reqAs("")
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); !slices.Equal(got, []string{"team-b"}) {
+		t.Fatalf("saved pick = %v, want [team-b]", got)
+	}
+}
+
+// --namespace (singular) steers RBAC probing but must NOT seed the picker;
+// and after a context switch the configured list references the previous
+// cluster, so it must not seed either.
+func TestLoadSavedNamespacePreference_ConfiguredSeedGates(t *testing.T) {
+	s := newTestServer(t)
+	k8s.SetFallbackNamespace("solo-ns")
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	req := reqAs("alice")
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); len(got) != 0 {
+		t.Fatalf("--namespace must not seed the picker, got %v", got)
+	}
+
+	// Plural flag set, but context switched afterwards → stale list, no seed.
+	k8s.SetFallbackNamespaces([]string{"team-a"})
+	prev := k8s.SetTestContextName("other-ctx")
+	t.Cleanup(func() { k8s.SetTestContextName(prev) })
+	req2 := reqAs("bob")
+	s.loadSavedNamespacePreference(req2)
+	if got := s.getActiveNamespaceForUser(req2); len(got) != 0 {
+		t.Fatalf("stale-context configured list must not seed, got %v", got)
+	}
+}
+
+// Context switch drops seed marks: returning to the startup context
+// re-applies the configured initial view to a fresh session.
+func TestClearAllNamespacePreferences_ResetsSeedMarks(t *testing.T) {
+	s := newTestServer(t)
+	k8s.SetFallbackNamespaces([]string{"team-a"})
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	req := reqAs("alice")
+
+	s.loadSavedNamespacePreference(req)
+	s.setActiveNamespaceForUser(req, nil) // clear → seed mark burned
+
+	s.clearAllNamespacePreferences() // context switch
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); !slices.Equal(got, []string{"team-a"}) {
+		t.Fatalf("seed after context-switch reset = %v, want [team-a]", got)
+	}
+}

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -736,3 +736,21 @@ func TestClearAllNamespacePreferences_ResetsSeedMarks(t *testing.T) {
 		t.Fatalf("seed after context-switch reset = %v, want [team-a]", got)
 	}
 }
+
+// The deterministic seed-override case: a user who picked and then cleared
+// BEFORE the first load must not receive the configured list — the explicit
+// set burned seed eligibility even though no load had run yet.
+func TestLoadSavedNamespacePreference_PostBeforeFirstLoadBurnsSeed(t *testing.T) {
+	s := newTestServer(t)
+	k8s.SetFallbackNamespaces([]string{"team-a", "team-b"})
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+	req := reqAs("alice")
+
+	s.setActiveNamespaceForUser(req, []string{"team-b"}) // pick before any load
+	s.setActiveNamespaceForUser(req, nil)                // then clear
+
+	s.loadSavedNamespacePreference(req)
+	if got := s.getActiveNamespaceForUser(req); len(got) != 0 {
+		t.Fatalf("explicit clear before first load was overridden by seed: %v", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,12 @@ type Server struct {
 	// pick and silently revert it.
 	nsPickMu sync.Mutex
 
+	// seededPicks marks (user, context) keys whose picker was already seeded
+	// from --namespaces, so the configured list applies once per session and
+	// a user's clear back to "All namespaces" is not overridden on later
+	// reads. Cleared alongside nsPreferences on context switch.
+	seededPicks sync.Map
+
 	// Short-TTL cache for topology builds. The Topology graph is a
 	// deterministic projection of the informer cache; rebuilding it walks
 	// every resource of every kind. A 5s TTL absorbs the typical bursts


### PR DESCRIPTION
## Problem

`--namespaces` (#1082) pre-selects the picker only through the launch URL's `?namespaces=` query — which auth-enabled (shared) deployments never see, because users arrive via their own logins rather than the startup redirect. Their pickers started on "All namespaces" even when the operator configured an explicit list.

## What this does

Each user's picker is seeded from the configured `--namespaces` list on first read, built on the pick-mutation primitives from #1115:

- **Seed-once per (user, context) key.** The whole decision runs under `nsPickMu` — context, seed marker, and stored preference are rechecked inside the critical section. Every explicit set (including a clear) burns seed eligibility for its key, so clearing back to **All namespaces** sticks for the rest of the session; a bare preference CAS could not distinguish never-picked from explicitly-cleared.
- **A locally persisted pick outranks the configured list** (no-auth restarts keep the user's narrower choice).
- **Gated to the startup context** via `k8s.ConfiguredNamespacesForCurrentContext()`: `--namespace` (singular) does not seed, and after a kubeconfig context switch the list references the previous cluster so it stays inert. Seed marks reset together with the pick map on switch (under the same lock), so switching back re-applies the configured initial view to the fresh session.
- Seeded picks flow through the existing per-user RBAC intersection on reads and the #1115 deleted-namespace prune, like any other pick.

## Testing

Unit: auth-user seed + clear-sticks + second-user isolation, pick-then-clear before first load (the deterministic override case), local saved pick precedence, singular-flag and stale-context gates, context-switch seed-mark reset. `internal/server` green under `-race`; `internal/k8s` + `internal/app` suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared per-user session state and namespace-scope handler locking around cache rescope; mistakes could wrong-foot picker defaults or deadlock, but behavior is heavily unit-tested.
> 
> **Overview**
> Shared (**auth-enabled**) deployments no longer start every user on **All namespaces** when the operator passes **`--namespaces`**: each **(user, context)** picker is seeded from that list on the first scope read, not only via the local launch URL.
> 
> Seeding is **once per session** per key: a **`seededPicks`** marker plus **`nsPickMu`**-guarded **`seedPick`** distinguish “never picked” from an explicit clear; any POST (including clear) burns eligibility so **All namespaces** sticks. **Local `settings.json`** still wins for no-auth; **`ConfiguredNamespacesForCurrentContext()`** limits the list to the startup kubeconfig context and **only the plural `--namespaces` flag** (singular **`--namespace`** does not seed). Context switch clears picks and seed marks together; switching back can re-apply the configured default.
> 
> **`handleSetActiveNamespace`** releases **`nsPickMu`** before **`PerformNamespaceRescope`** to avoid deadlock with context-switch callbacks. Docs in **`configuration.md`** describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ffe050501adcc1b416f857df7ef474260d70c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Deployment note

Seed-once state (`seededPicks`) is per-process memory: on a multi-replica Radar behind a non-sticky load balancer, "clear sticks for the session" holds per pod, not per user. Single-replica (the Helm default and the norm) is unaffected; a shared store would be needed before scaling replicas.