### PR TITLE
Preserve and clarify rightsizing scan results

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,6 +34,7 @@ Cool, professional, data-dense. A barely-blue-tinted neutral palette — not gen
 | `text-theme-text-secondary` | `--text-secondary` | `#555860` | `#D8DAE0` | Body text, descriptions |
 | `text-theme-text-tertiary` | `--text-tertiary` | `#6B7080` | `#B0B5C0` | Placeholders, metadata, timestamps |
 | `text-theme-text-disabled` | `--text-disabled` | `#A0A4AC` | `#6A7080` | Disabled states |
+| `text-warning-text` | `--warning-text` | `#92400E` | `#FBBF24` | Warning or attention text on a plain background |
 
 ### Borders
 | Token | CSS Variable | Light | Dark | Use for |

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -52,7 +52,7 @@ interface BadgeProps {
 // ---------------------------------------------------------------------------
 const SEVERITY: Record<BadgeSeverity, string> = {
   success: 'bg-emerald-100 text-emerald-700 border-emerald-300 dark:bg-emerald-950/50 dark:text-emerald-400 dark:border-emerald-700/40',
-  warning: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
+  warning: 'bg-amber-100 text-warning-text border-amber-300 dark:bg-amber-950/50 dark:border-amber-700/40',
   alert:   'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-700/40',
   error:   'bg-red-100 text-red-700 border-red-300 dark:bg-red-950/50 dark:text-red-400 dark:border-red-700/40',
   info:    'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',

--- a/packages/k8s-ui/src/theme/tailwind-theme.css
+++ b/packages/k8s-ui/src/theme/tailwind-theme.css
@@ -20,6 +20,7 @@
   --color-theme-text-secondary: var(--text-secondary);
   --color-theme-text-tertiary: var(--text-tertiary);
   --color-theme-text-disabled: var(--text-disabled);
+  --color-warning-text: var(--warning-text);
 
   /* Borders */
   --color-theme-border: var(--border-default);

--- a/packages/k8s-ui/src/theme/variables.css
+++ b/packages/k8s-ui/src/theme/variables.css
@@ -49,6 +49,7 @@
   --text-secondary: light-dark(#555860, #D8DAE0);
   --text-tertiary: light-dark(#6B7080, #B0B5C0);
   --text-disabled: light-dark(#A0A4AC, #6A7080);
+  --warning-text: light-dark(#92400E, #FBBF24);
 
   /* ── Borders (lightly blue-tinted in light mode) ── */
   --border-default: light-dark(#D8E0EE, #222840);

--- a/web/src/api/client.rightsizing.test.ts
+++ b/web/src/api/client.rightsizing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { skipToken } from '@tanstack/react-query'
+import { getRightsizingScanCacheConfig } from './client'
+
+describe('rightsizing scan cache config', () => {
+  it('is manual-only and retained briefly', () => {
+    const config = getRightsizingScanCacheConfig(['staging', 'default'], 'cluster-a')
+
+    expect(config.queryFn).toBe(skipToken)
+    expect(config.gcTime).toBe(5 * 60 * 1000)
+  })
+
+  it('normalizes namespace order and isolates cluster and namespace scopes', () => {
+    const config = getRightsizingScanCacheConfig(['staging', 'default'], 'cluster-a')
+
+    expect(config.namespaceKey).toBe('default,staging')
+    expect(config.queryKey).toEqual([
+      'prometheus-rightsizing-scan',
+      'cluster-a',
+      'default,staging',
+    ])
+    expect(getRightsizingScanCacheConfig(['default', 'staging'], 'cluster-a').queryKey).toEqual(
+      config.queryKey,
+    )
+    expect(getRightsizingScanCacheConfig(['default'], 'cluster-a').queryKey).not.toEqual(
+      config.queryKey,
+    )
+    expect(getRightsizingScanCacheConfig(['staging', 'default'], 'cluster-b').queryKey).not.toEqual(
+      config.queryKey,
+    )
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2389,14 +2389,37 @@ export function usePrometheusRightsizing(
   })
 }
 
+const RIGHTSIZING_SCAN_CACHE_TIME = 5 * 60 * 1000
+
+export function getRightsizingScanCacheConfig(
+  namespaces: string[],
+  context = '',
+): {
+  namespaceKey: string
+  queryKey: readonly ['prometheus-rightsizing-scan', string, string]
+  queryFn: typeof skipToken
+  gcTime: number
+} {
+  const namespaceKey = [...namespaces].sort().join(',')
+  return {
+    namespaceKey,
+    queryKey: ['prometheus-rightsizing-scan', context, namespaceKey] as const,
+    queryFn: skipToken,
+    gcTime: RIGHTSIZING_SCAN_CACHE_TIME,
+  }
+}
+
 // A fleet rightsizing scan is intentionally manual. It can query seven days of
 // Prometheus history for many containers, so navigation alone must never run it.
-export function useRightsizingScan(namespaces: string[]) {
-  const namespaceKey = [...namespaces].sort().join(',')
-  return useMutation({
-    mutationFn: async () => {
+export function useRightsizingScan(namespaces: string[], context = '') {
+  const queryClient = useQueryClient()
+  const { namespaceKey, ...snapshotOptions } = getRightsizingScanCacheConfig(namespaces, context)
+  const scanScope = { namespaceKey, queryKey: snapshotOptions.queryKey }
+  const snapshot = useQuery<RightsizingScanResponse>(snapshotOptions)
+  const mutation = useMutation({
+    mutationFn: async (startedScope: typeof scanScope) => {
       const params = new URLSearchParams()
-      if (namespaceKey) params.set('namespaces', namespaceKey)
+      if (startedScope.namespaceKey) params.set('namespaces', startedScope.namespaceKey)
       const query = params.toString()
       return fetchJSON<RightsizingScanResponse>(
         `/prometheus/rightsizing/scan${query ? `?${query}` : ''}`,
@@ -2405,7 +2428,14 @@ export function useRightsizingScan(namespaces: string[]) {
         },
       )
     },
+    onSuccess: (result, startedScope) => queryClient.setQueryData(startedScope.queryKey, result),
   })
+  return {
+    ...mutation,
+    data: snapshot.data,
+    mutate: () => mutation.mutate(scanScope),
+    mutateAsync: () => mutation.mutateAsync(scanScope),
+  }
 }
 
 // Raw PromQL query (range). Used by HPA charts for status_current_replicas etc.

--- a/web/src/components/rightsizing/RightsizingScanView.tsx
+++ b/web/src/components/rightsizing/RightsizingScanView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { AlertTriangle, DollarSign, ExternalLink, Gauge, Loader2, RefreshCw } from 'lucide-react'
 import {
@@ -27,6 +27,12 @@ import {
   type RightsizingScanRow,
   type ScanClass,
 } from './model'
+import {
+  getResourceRequestPresentation,
+  RIGHTSIZING_ACTION_SEVERITY,
+  type ResourceSignal,
+  type RightsizingActionTone,
+} from './presentation'
 
 export const RIGHTSIZING_SCAN_DESCRIPTION =
   'Find CPU and memory requests to increase, reduce, or review. Radar never changes them.'
@@ -74,17 +80,17 @@ const ACTION_META: Record<
 > = {
   reduction: {
     label: 'Reduce requests',
-    severity: 'info',
+    severity: RIGHTSIZING_ACTION_SEVERITY.reduction,
     helper: 'Reclaim meaningful capacity',
   },
   increase: {
     label: 'Increase or add',
-    severity: 'warning',
+    severity: RIGHTSIZING_ACTION_SEVERITY.increase,
     helper: 'Reduce reliability risk',
   },
   review: {
     label: 'Review first',
-    severity: 'neutral',
+    severity: RIGHTSIZING_ACTION_SEVERITY.review,
     helper: 'Check safety signals or workloads with no replicas',
   },
 }
@@ -99,26 +105,21 @@ export function RightsizingScanView({ namespaces }: RightsizingScanViewProps) {
     isLoading: statusLoading,
     refetch: retryPrometheus,
   } = usePrometheusStatus()
-  const scan = useRightsizingScan(namespaces)
-  const [result, setResult] = useState<Awaited<ReturnType<typeof scan.mutateAsync>>>()
+  const scan = useRightsizingScan(namespaces, clusterInfo?.context)
+  const result = scan.data
   const [openRow, setOpenRow] = useState<string | null>(null)
   const [visibleLimit, setVisibleLimit] = useState(ROW_PAGE_SIZE)
   const scopeKey = `${clusterInfo?.context ?? ''}\0${[...namespaces].sort().join(',')}`
-  const scopeKeyRef = useRef(scopeKey)
-  scopeKeyRef.current = scopeKey
 
-  useEffect(() => {
-    setResult(undefined)
+  useLayoutEffect(() => {
     setOpenRow(null)
     scan.reset()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scopeKey])
 
   const runScan = async () => {
-    const startedForScope = scopeKey
     try {
-      const next = await scan.mutateAsync()
-      if (scopeKeyRef.current === startedForScope) setResult(next)
+      await scan.mutateAsync()
     } catch {
       // A same-scope snapshot stays visible when refresh fails.
     }
@@ -364,10 +365,11 @@ export function RightsizingScanView({ namespaces }: RightsizingScanViewProps) {
                   />
                 ) : (
                   <div>
-                    <div className="grid grid-cols-[minmax(260px,1.1fr)_minmax(360px,1.6fr)_minmax(220px,.9fr)_28px] gap-4 border-b border-theme-border px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
+                    <div className="grid grid-cols-[minmax(230px,1.15fr)_minmax(190px,1fr)_minmax(200px,1fr)_minmax(220px,.9fr)_28px] gap-3 border-b border-theme-border px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
                       <span>Workload / container</span>
-                      <span>Suggested next step</span>
-                      <span>Across replicas</span>
+                      <span>CPU request</span>
+                      <span>Memory request</span>
+                      <span>Total request change</span>
                       <span />
                     </div>
                     <div className="table-divide-subtle">
@@ -559,13 +561,13 @@ function ScanFilters(props: {
         scope="global"
         shortcutId="rightsizing-search"
         placeholder="Search workloads…"
-        className="mr-auto w-72"
+        className="mr-auto w-60 2xl:w-72"
       />
       <SelectMenu
         ariaLabel="Filter by namespace"
         value={props.namespace}
         onChange={props.onNamespace}
-        className="w-48"
+        className="w-40 2xl:w-48"
         options={[
           { value: '', label: 'All namespaces' },
           ...props.namespaces.map((value) => ({ value, label: value })),
@@ -586,7 +588,7 @@ function ScanFilters(props: {
           ariaLabel="Choose workload scope"
           value={props.includeSystem ? 'all' : 'applications'}
           onChange={props.onScope}
-          className="w-48"
+          className="w-44 2xl:w-48"
           options={[
             { value: 'applications', label: 'Hide system workloads' },
             {
@@ -596,14 +598,14 @@ function ScanFilters(props: {
           ]}
         />
       )}
-      <span className="text-xs tabular-nums text-theme-text-tertiary">
+      <span className="shrink-0 text-xs tabular-nums text-theme-text-tertiary">
         {props.shown} of {props.total} containers
       </span>
       {props.active && (
         <button
           type="button"
           onClick={props.onClear}
-          className="text-xs text-accent-text hover:underline"
+          className="shrink-0 text-xs text-accent-text hover:underline"
         >
           Reset view
         </button>
@@ -629,7 +631,7 @@ function ScanResultRow({
         type="button"
         onClick={onToggle}
         aria-expanded={open}
-        className="grid w-full grid-cols-[minmax(260px,1.1fr)_minmax(360px,1.6fr)_minmax(220px,.9fr)_28px] items-center gap-4 px-4 py-3 text-left hover:bg-theme-hover/50"
+        className="grid w-full grid-cols-[minmax(230px,1.15fr)_minmax(190px,1fr)_minmax(200px,1fr)_minmax(220px,.9fr)_28px] items-center gap-3 px-4 py-3 text-left hover:bg-theme-hover/50"
       >
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -642,7 +644,8 @@ function ScanResultRow({
             {row.namespace} · {row.container}
           </div>
         </div>
-        <RecommendationCell row={row} />
+        <ResourceRequestCell row={row.cpu} scaledToZero={row.scaledToZero} />
+        <ResourceRequestCell row={row.memory} scaledToZero={row.scaledToZero} />
         <ImpactCell row={row} />
         <CollapseChevron open={open} className="h-4 w-4" />
       </button>
@@ -663,106 +666,37 @@ function ScanResultRow({
   )
 }
 
-function RecommendationCell({ row }: { row: RightsizingScanRow }) {
-  if (row.classification === 'in_range') {
-    return <span className="text-xs text-theme-text-tertiary">No meaningful request change</span>
-  }
+function ResourceRequestCell({
+  row,
+  scaledToZero,
+}: {
+  row?: RightsizingRow
+  scaledToZero: boolean
+}) {
+  const presentation = getResourceRequestPresentation(row, scaledToZero)
   return (
-    <div className="flex min-w-0 flex-col gap-1">
-      <ResourceAction
-        label="CPU"
-        row={row.cpu}
-        reviewWithNoCurrentReplicas={row.scaledToZero && row.classification === 'review'}
-      />
-      <ResourceAction
-        label="Memory"
-        row={row.memory}
-        reviewWithNoCurrentReplicas={row.scaledToZero && row.classification === 'review'}
-      />
+    <div className="min-w-0 text-xs">
+      <div className="truncate font-medium tabular-nums text-theme-text-primary">
+        {presentation.primary}
+      </div>
+      <div className={`mt-0.5 ${requestToneClass(presentation.tone)}`}>
+        {presentation.secondary}
+      </div>
+      {presentation.signals.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {presentation.signals.map((signal) => (
+            <SignalBadge key={signal} signal={signal} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
 
-function ResourceAction({
-  label,
-  row,
-  reviewWithNoCurrentReplicas = false,
-}: {
-  label: string
-  row?: RightsizingRow
-  reviewWithNoCurrentReplicas?: boolean
-}) {
-  if (!row) return <span className="text-xs text-theme-text-tertiary">{label}: no result</span>
-  const reason = row.recommendationReason
-  if (row.hpaManaged)
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Review {label} with the HPA
-      </span>
-    )
-  if (reason === 'hpa_evidence_unavailable')
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Review {label}; HPA status is unavailable
-      </span>
-    )
-  if (reason === 'oom_evidence')
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Keep {label}; an out-of-memory restart was seen
-      </span>
-    )
-  if (reason === 'oom_evidence_unavailable')
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Review {label}; restart history is incomplete
-      </span>
-    )
-  if (row.limitConflict)
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Raise the {label} limit before its request
-      </span>
-    )
-  if (row.queryError)
-    return <span className="text-xs text-theme-text-tertiary">{label}: metrics query failed</span>
-  if (row.fit === 'insufficient_history')
-    return <span className="text-xs text-theme-text-tertiary">{label}: not enough history</span>
-  if (reviewWithNoCurrentReplicas)
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Review {label} before the workload runs again
-      </span>
-    )
-  const isReduction =
-    row.recommendedRequestValue != null &&
-    row.currentRequestValue != null &&
-    row.recommendedRequestValue < row.currentRequestValue
-  if (row.resource === 'cpu' && isReduction && (row.bursty || (row.throttleRatio ?? 0) >= 0.1))
-    return (
-      <span className="text-xs font-medium text-theme-text-secondary">
-        Review {label} before reducing
-      </span>
-    )
-  if (row.recommendedRequest) {
-    if (!row.currentRequest || row.currentRequestValue === 0)
-      return (
-        <span className="text-xs font-medium text-theme-text-primary">
-          Add {label} request: {row.recommendedRequest}
-        </span>
-      )
-    const verb =
-      (row.recommendedRequestValue ?? 0) > (row.currentRequestValue ?? 0) ? 'Increase' : 'Reduce'
-    return (
-      <span className="text-xs font-medium text-theme-text-primary">
-        {verb} {label}:{' '}
-        <span className="tabular-nums">
-          {row.currentRequest} → {row.recommendedRequest}
-        </span>
-      </span>
-    )
-  }
-  return <span className="text-xs text-theme-text-tertiary">{label}: no meaningful change</span>
+function requestToneClass(tone: RightsizingActionTone): string {
+  if (tone === 'reduction') return 'text-accent-text'
+  if (tone === 'increase') return 'text-warning-text'
+  return 'text-theme-text-tertiary'
 }
 
 function ImpactCell({ row }: { row: RightsizingScanRow }) {
@@ -784,26 +718,26 @@ function ImpactCell({ row }: { row: RightsizingScanRow }) {
           </div>
         ))
       ) : (
-        <div className="mt-0.5 text-theme-text-tertiary">No calculated capacity change</div>
+        <div className="mt-0.5 text-theme-text-tertiary">No suggested change</div>
       )}
-      <div className="mt-1 flex flex-wrap gap-1">
-        {[...row.signals].map((signal) => (
-          <Badge
-            key={signal}
-            severity={
-              signal === 'oom' || signal === 'query_error'
-                ? 'error'
-                : signal === 'throttling'
-                  ? 'warning'
-                  : 'neutral'
-            }
-            size="sm"
-          >
-            {signalLabel(signal)}
-          </Badge>
-        ))}
-      </div>
     </div>
+  )
+}
+
+function SignalBadge({ signal }: { signal: ResourceSignal }) {
+  return (
+    <Badge
+      severity={
+        signal === 'oom' || signal === 'query_error'
+          ? 'error'
+          : signal === 'throttling'
+            ? 'warning'
+            : 'neutral'
+      }
+      size="sm"
+    >
+      {signalLabel(signal)}
+    </Badge>
   )
 }
 
@@ -957,16 +891,13 @@ function formatMemoryChange(value: number): string {
     : `${prefix}${Math.round(mib)}Mi memory requested`
 }
 
-function signalLabel(
-  signal: RightsizingScanRow['signals'] extends Set<infer T> ? T : never,
-): string {
+function signalLabel(signal: ResourceSignal): string {
   return {
     hpa: 'HPA',
-    oom: 'OOM',
+    oom: 'OOM restart',
     bursty: 'Bursty usage',
     throttling: 'Throttling',
-    query_error: 'Query error',
-    scaled_zero: 'No current replicas',
+    query_error: 'Metrics unavailable',
   }[signal]
 }
 

--- a/web/src/components/rightsizing/model.test.ts
+++ b/web/src/components/rightsizing/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { RightsizingScanResponse, RightsizingRow } from '../../api/client'
-import { classifyRows, flattenScanResults, scanClassCounts } from './model'
+import { calculateImpact, classifyRows, flattenScanResults, scanClassCounts } from './model'
 
 function metric(overrides: Partial<RightsizingRow> = {}): RightsizingRow {
   return {
@@ -125,6 +125,28 @@ describe('rightsizing scan model', () => {
     expect(classifyRows([meaningful], 1)).toBe('reduction')
   })
 
+  it('excludes recommendations that require manual review from aggregate impact', () => {
+    const cpu = metric({
+      fit: 'oversized',
+      currentRequestValue: 0.1,
+      recommendedRequestValue: 0.05,
+      recommendedRequest: '50m',
+      throttleRatio: 0.2,
+    })
+    const memory = metric({
+      resource: 'memory',
+      fit: 'oversized',
+      currentRequestValue: 128 * 1024 * 1024,
+      recommendedRequestValue: 64 * 1024 * 1024,
+      recommendedRequest: '64Mi',
+    })
+    expect(calculateImpact([cpu, memory], 3)).toEqual({
+      replicas: 3,
+      cpuChange: 0,
+      memoryChange: -192 * 1024 * 1024,
+    })
+  })
+
   it('keeps incomplete history out of no-change results', () => {
     expect(classifyRows([metric({ fit: 'insufficient_history' })])).toBe('need_data')
     expect(classifyRows([metric({ queryError: 'query failed' })])).toBe('need_data')
@@ -148,7 +170,6 @@ describe('rightsizing scan model', () => {
     )[0]
     expect(oversized.classification).toBe('review')
     expect(oversized.impact.cpuChange).toBe(0)
-    expect(oversized.signals).toContain('scaled_zero')
 
     expect(classifyRows([metric()], 0, true)).toBe('review')
     expect(classifyRows([metric({ fit: 'insufficient_history' })], 0, true)).toBe('need_data')
@@ -201,7 +222,6 @@ describe('rightsizing scan model', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0].impact.cpuChange).toBeCloseTo(0.3)
     expect(rows[0].system).toBe(true)
-    expect(rows[0].signals).toEqual(new Set(['oom', 'throttling']))
     expect(scanClassCounts(rows).increase).toBe(1)
   })
 })

--- a/web/src/components/rightsizing/model.ts
+++ b/web/src/components/rightsizing/model.ts
@@ -1,7 +1,6 @@
 import type { RightsizingScanResponse, RightsizingRow } from '../../api/client'
 
 export type ScanClass = 'increase' | 'reduction' | 'review' | 'in_range' | 'need_data'
-export type ScanSignal = 'hpa' | 'oom' | 'bursty' | 'throttling' | 'query_error' | 'scaled_zero'
 
 export interface RightsizingImpact {
   replicas: number
@@ -19,7 +18,6 @@ export interface RightsizingScanRow {
   cpu?: RightsizingRow
   memory?: RightsizingRow
   classification: ScanClass
-  signals: Set<ScanSignal>
   impact: RightsizingImpact
   system: boolean
   scaledToZero: boolean
@@ -82,7 +80,7 @@ export function calculateImpact(rows: RightsizingRow[], replicas: number): Right
   let cpuChange = 0
   let memoryChange = 0
   for (const row of rows) {
-    if (row.recommendedRequestValue == null) continue
+    if (row.recommendedRequestValue == null || needsManualReview(row)) continue
     const change = (row.recommendedRequestValue - (row.currentRequestValue ?? 0)) * count
     if (row.resource === 'cpu') cpuChange += change
     else memoryChange += change
@@ -100,13 +98,6 @@ export function flattenScanResults(scan: RightsizingScanResponse): RightsizingSc
       byContainer.set(row.container, rows)
     }
     for (const [container, rows] of byContainer) {
-      const signals = new Set<ScanSignal>()
-      if (rows.some((row) => row.hpaManaged)) signals.add('hpa')
-      if (rows.some((row) => row.currentPodOOM || row.windowOomEvidence)) signals.add('oom')
-      if (rows.some((row) => row.bursty)) signals.add('bursty')
-      if (rows.some((row) => (row.throttleRatio ?? 0) >= 0.1)) signals.add('throttling')
-      if (rows.some((row) => row.queryError)) signals.add('query_error')
-      if (workload.scaledToZero) signals.add('scaled_zero')
       const replicas = workload.replicas ?? 1
       result.push({
         id: `${workload.kind}/${workload.namespace}/${workload.name}/${container}`,
@@ -118,7 +109,6 @@ export function flattenScanResults(scan: RightsizingScanResponse): RightsizingSc
         cpu: rows.find((row) => row.resource === 'cpu'),
         memory: rows.find((row) => row.resource === 'memory'),
         classification: classifyRows(rows, replicas, workload.scaledToZero),
-        signals,
         impact: calculateImpact(rows, replicas),
         system: isSystemNamespace(workload.namespace),
         scaledToZero: workload.scaledToZero,

--- a/web/src/components/rightsizing/presentation.test.ts
+++ b/web/src/components/rightsizing/presentation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import type { RightsizingRow } from '../../api/client'
+import { getResourceRequestPresentation } from './presentation'
+
+function metric(overrides: Partial<RightsizingRow> = {}): RightsizingRow {
+  return {
+    container: 'app',
+    resource: 'cpu',
+    fit: 'balanced',
+    confidence: 'high',
+    sampleCount: 2017,
+    expectedSamples: 2017,
+    coverage: 1,
+    hpaManaged: false,
+    hpaEvidenceAvailable: true,
+    oomEvidenceAvailable: true,
+    ...overrides,
+  }
+}
+
+describe('rightsizing request presentation', () => {
+  it('shows configured and suggested values in a consistent comparison', () => {
+    expect(
+      getResourceRequestPresentation(
+        metric({
+          fit: 'oversized',
+          currentRequest: '1500m',
+          currentRequestValue: 1.5,
+          recommendedRequest: '750m',
+          recommendedRequestValue: 0.75,
+        }),
+      ),
+    ).toEqual({
+      primary: '1500m → 750m',
+      secondary: 'Reduce request',
+      signals: [],
+      tone: 'reduction',
+    })
+  })
+
+  it('makes missing requests explicit', () => {
+    expect(
+      getResourceRequestPresentation(
+        metric({
+          fit: 'missing_request',
+          recommendedRequest: '100m',
+          recommendedRequestValue: 0.1,
+        }),
+      ),
+    ).toEqual({
+      primary: 'Unset → 100m',
+      secondary: 'Add request',
+      signals: [],
+      tone: 'increase',
+    })
+  })
+
+  it('keeps the configured value visible when safety signals require review', () => {
+    expect(
+      getResourceRequestPresentation(
+        metric({
+          fit: 'oversized',
+          currentRequest: '200m',
+          currentRequestValue: 0.2,
+          recommendedRequest: '100m',
+          recommendedRequestValue: 0.1,
+          bursty: true,
+          throttleRatio: 0.2,
+        }),
+      ),
+    ).toEqual({
+      primary: '200m current',
+      secondary: 'Review before reducing',
+      signals: ['bursty', 'throttling'],
+      tone: 'review',
+    })
+  })
+
+  it('places resource-specific safety evidence with the request it qualifies', () => {
+    expect(
+      getResourceRequestPresentation(
+        metric({
+          resource: 'memory',
+          currentRequest: '128Mi',
+          currentRequestValue: 128 * 1024 * 1024,
+          recommendationReason: 'oom_evidence',
+          windowOomEvidence: true,
+        }),
+      ),
+    ).toEqual({
+      primary: '128Mi current',
+      secondary: 'Keep current request',
+      signals: ['oom'],
+      tone: 'review',
+    })
+  })
+
+  it('keeps no-change and unavailable data neutral', () => {
+    expect(getResourceRequestPresentation(metric()).tone).toBe('neutral')
+    expect(getResourceRequestPresentation(metric({ queryError: 'query failed' })).tone).toBe(
+      'neutral',
+    )
+  })
+})

--- a/web/src/components/rightsizing/presentation.ts
+++ b/web/src/components/rightsizing/presentation.ts
@@ -1,0 +1,94 @@
+import type { RightsizingRow } from '../../api/client'
+
+export type ResourceSignal = 'hpa' | 'oom' | 'bursty' | 'throttling' | 'query_error'
+export type RightsizingActionTone = 'reduction' | 'increase' | 'review' | 'neutral'
+
+export const RIGHTSIZING_ACTION_SEVERITY = {
+  reduction: 'info',
+  increase: 'warning',
+  review: 'neutral',
+} as const
+
+export interface ResourceRequestPresentation {
+  primary: string
+  secondary: string
+  signals: ResourceSignal[]
+  tone: RightsizingActionTone
+}
+
+export function getResourceRequestPresentation(
+  row?: RightsizingRow,
+  scaledToZero = false,
+): ResourceRequestPresentation {
+  if (!row) return { primary: '—', secondary: 'No result returned', signals: [], tone: 'neutral' }
+
+  const current = row.currentRequest && row.currentRequestValue !== 0 ? row.currentRequest : 'Unset'
+  const currentOnly = current === 'Unset' ? current : `${current} current`
+  const signals = resourceSignals(row)
+  const reason = row.recommendationReason
+
+  if (row.queryError)
+    return { primary: currentOnly, secondary: 'Metrics query failed', signals, tone: 'neutral' }
+  if (row.fit === 'insufficient_history')
+    return { primary: currentOnly, secondary: 'Not enough history', signals, tone: 'neutral' }
+  if (scaledToZero)
+    return { primary: currentOnly, secondary: 'Review before workload runs again', signals, tone: 'review' }
+  if (row.hpaManaged)
+    return { primary: currentOnly, secondary: 'Review with autoscaling', signals, tone: 'review' }
+  if (reason === 'hpa_evidence_unavailable')
+    return {
+      primary: currentOnly,
+      secondary: 'Review — autoscaling status unavailable',
+      signals,
+      tone: 'review',
+    }
+  if (reason === 'oom_evidence')
+    return { primary: currentOnly, secondary: 'Keep current request', signals, tone: 'review' }
+  if (reason === 'oom_evidence_unavailable')
+    return {
+      primary: currentOnly,
+      secondary: 'Review — restart history incomplete',
+      signals,
+      tone: 'review',
+    }
+
+  const isReduction =
+    row.recommendedRequestValue != null &&
+    row.currentRequestValue != null &&
+    row.recommendedRequestValue < row.currentRequestValue
+  const comparison = row.recommendedRequest
+    ? `${current} → ${row.recommendedRequest}`
+    : currentOnly
+
+  if (row.limitConflict)
+    return {
+      primary: comparison,
+      secondary: 'Raise the limit before changing',
+      signals,
+      tone: 'review',
+    }
+  if (row.resource === 'cpu' && isReduction && (row.bursty || (row.throttleRatio ?? 0) >= 0.1))
+    return { primary: currentOnly, secondary: 'Review before reducing', signals, tone: 'review' }
+  if (row.recommendedRequest) {
+    if (current === 'Unset')
+      return { primary: comparison, secondary: 'Add request', signals, tone: 'increase' }
+    const increase = (row.recommendedRequestValue ?? 0) > (row.currentRequestValue ?? 0)
+    return {
+      primary: comparison,
+      secondary: increase ? 'Increase request' : 'Reduce request',
+      signals,
+      tone: increase ? 'increase' : 'reduction',
+    }
+  }
+  return { primary: currentOnly, secondary: 'No meaningful change', signals, tone: 'neutral' }
+}
+
+function resourceSignals(row: RightsizingRow): ResourceSignal[] {
+  const signals: ResourceSignal[] = []
+  if (row.hpaManaged) signals.push('hpa')
+  if (row.resource === 'memory' && (row.currentPodOOM || row.windowOomEvidence)) signals.push('oom')
+  if (row.resource === 'cpu' && row.bursty) signals.push('bursty')
+  if (row.resource === 'cpu' && (row.throttleRatio ?? 0) >= 0.1) signals.push('throttling')
+  if (row.queryError) signals.push('query_error')
+  return signals
+}


### PR DESCRIPTION
## Summary
Rightsizing scans can take up to a minute and produce container-level decisions operators need to inspect across workload views. This keeps a completed scan available during short navigation and reorganizes each result around current and suggested CPU/memory requests so the next action is easier to understand.

## What changed
- Retains manual scan snapshots for five minutes, keyed by cluster context and normalized namespace scope. Navigation never starts a scan; changing scope selects a separate snapshot; refresh failures leave prior same-scope data visible.
- Presents CPU and memory independently with current → suggested values, action tone, and resource-specific safety evidence.
- Reports total requested-capacity change only for recommendations safe enough to act on; manual-review items remain visible without contributing to aggregate impact.
- Adds a central warning text token used consistently in light and dark themes and responsive table/filter sizing.

## Testing
- make tsc
- make test
- make build
- Real-cluster visual verification at 1280×800, 1920×1080, and 2560×1440 in light and dark themes.
- Verified scan → workload → browser Back restores the cached result without another scan request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how expensive scan results are retained and how capacity impact is calculated/displayed; mistakes could mislead operators about safe-to-apply recommendations, but scope is UI and client-side caching only.
> 
> **Overview**
> Manual rightsizing scan results are **cached for five minutes** in React Query, keyed by cluster context and sorted namespace list, so navigation (e.g. workload → Back) can restore the last scan without another POST. Scans still only run on explicit refresh; failed refreshes keep the prior snapshot for the same scope.
> 
> The scan table is reorganized around **separate CPU and memory request columns** (current → suggested, action tone, per-resource safety badges) plus a **total request change** column. Presentation logic moves into `presentation.ts`; aggregate **impact excludes rows that need manual review** (same rules as classification), while review items stay visible.
> 
> A **`text-warning-text`** theme token is added and wired through warning badges and increase-request styling; filter/table widths get minor responsive tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f995059cc96907a7a332fb96aefb1e75c8022e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->