### PR TITLE
timeline: SeqPaging - full backfill in resumable seq-ascending pages

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2951,6 +2951,12 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		opts.SinceSeq = n
+		// An explicit since_seq — including 0 — selects seq paging (ascending
+		// arrival order). since_seq=0 is the full-backfill page one: "every
+		// row, oldest arrival first", resumable via the returned max seq.
+		// Callers that want the newest-first full fetch omit the parameter
+		// (the shipped web client only sends since_seq when its cursor > 0).
+		opts.SeqPaging = true
 	}
 	if kind != "" {
 		opts.Kinds = []string{kind}

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -532,17 +532,18 @@ func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 		args = append(args, opts.ClusterContext)
 	}
 
-	if opts.SinceSeq > 0 {
+	seqPaging := opts.SeqPaging || opts.SinceSeq > 0
+	if seqPaging {
 		query.WriteString(" AND seq > ?")
 		args = append(args, opts.SinceSeq)
 	}
 
-	// Delta reads (SinceSeq>0) page by ascending arrival order: the server
+	// Delta reads (seq paging) page by ascending arrival order: the server
 	// advances the client cursor by the max seq in the page, so a burst larger
 	// than the limit must resume from the lowest unseen seq — timestamp DESC
 	// would return the newest matches and silently drop the mid-seq ones. The
 	// client merges by id, so ascending is fine. Non-delta reads page newest-first.
-	if opts.SinceSeq > 0 {
+	if seqPaging {
 		query.WriteString(" ORDER BY seq ASC")
 	} else {
 		query.WriteString(" ORDER BY timestamp DESC")

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -166,7 +166,7 @@ func (m *MemoryStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 	// seq. Ring position tracks arrival order (each writeAtHead takes the next
 	// seq), so oldest-first iteration yields ascending seq. Non-delta reads page
 	// newest-first.
-	deltaAscending := opts.SinceSeq > 0
+	deltaAscending := opts.SeqPaging || opts.SinceSeq > 0
 
 	for i := 0; i < m.count && len(results) < limit; i++ {
 		var idx int
@@ -381,7 +381,7 @@ func (m *MemoryStore) matchesFilters(event *TimelineEvent, opts QueryOptions, cf
 		return false
 	}
 
-	if opts.SinceSeq > 0 && event.Seq <= opts.SinceSeq {
+	if (opts.SeqPaging || opts.SinceSeq > 0) && event.Seq <= opts.SinceSeq {
 		return false
 	}
 

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -76,6 +76,17 @@ type QueryOptions struct {
 	// delta-mode behavior is unspecified.
 	SinceSeq int64
 
+	// SeqPaging forces the delta-read shape (seq > SinceSeq, ascending seq)
+	// even when SinceSeq is 0 — i.e. "every row the query's OTHER filters
+	// admit, in arrival order" (content filters like FilterPreset and
+	// IncludeManaged still apply; a full backfill pairs this with the
+	// everything-visible options). A plain
+	// SinceSeq of 0 keeps its historical meaning (no cursor, newest-first),
+	// which existing full-fetch callers rely on; this flag is how a consumer
+	// that needs a FULL backfill in resumable pages asks for page one. Same
+	// combination caveats as SinceSeq.
+	SeqPaging bool
+
 	// Filter preset (overrides individual filters if set)
 	FilterPreset string
 

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -288,4 +288,44 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 			t.Fatalf("enriched bump did not fill Owner: %+v", row.Owner)
 		}
 	})
+
+	t.Run("seq paging from zero backfills every row in arrival order", func(t *testing.T) {
+		store := newStore(t)
+		for i := range 7 {
+			mustAppend(t, store, informer(fmt.Sprintf("bf-%d", i), time.Duration(i)*time.Second))
+		}
+		// A full backfill pages with SeqPaging from cursor 0 — every row,
+		// oldest arrival first, resumable by max seq. Plain SinceSeq=0 keeps
+		// its historical newest-first meaning (asserted implicitly by every
+		// queryAll above); this flag is the ONLY way to page from the floor.
+		cursor := int64(0)
+		var order []string
+		for range 10 { // bounded; must terminate long before this
+			page, err := store.Query(ctx, timeline.QueryOptions{
+				Limit: 3, SinceSeq: cursor, SeqPaging: true,
+				IncludeManaged: true, IncludeK8sEvents: true,
+			})
+			if err != nil {
+				t.Fatalf("Query(seqPaging, cursor=%d): %v", cursor, err)
+			}
+			if len(page) == 0 {
+				break
+			}
+			for _, e := range page {
+				if e.Seq <= cursor {
+					t.Fatalf("page returned seq %d not after cursor %d", e.Seq, cursor)
+				}
+				order = append(order, e.ID)
+				cursor = e.Seq
+			}
+		}
+		if len(order) != 7 {
+			t.Fatalf("backfill returned %d rows, want 7: %v", len(order), order)
+		}
+		for i, id := range order {
+			if id != fmt.Sprintf("bf-%d", i) {
+				t.Fatalf("backfill out of arrival order at %d: %v", i, order)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Adds a `SeqPaging` option to `timeline.QueryOptions`: the delta-read shape (seq > cursor, ascending) explicitly selected even at `since_seq=0`, so a consumer can backfill the entire store in resumable arrival-order pages. A plain `SinceSeq: 0` keeps its historical newest-first meaning — existing full-fetch callers are unaffected; the server sets the flag only when the `since_seq` query param is present (including `0`).

Motivation: radar-hub's timeline-retention feature pulls the full timeline (then deltas) through `/api/changes`; "start from the beginning, in order, resumable" was the one shape the API couldn't express.

Pinned by a new conformance case (`seq paging from zero backfills every row in arrival order`) so both the memory and sqlite stores stay in contract. Full suites green.

https://claude.ai/code/session_01MMmGgbwNpFBcPvi5GXmzne

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible extension: omitting since_seq is unchanged; only explicit since_seq (including 0) selects the new paging mode on timeline query paths.
> 
> **Overview**
> Adds **`SeqPaging`** on `timeline.QueryOptions` so consumers can request the delta-read shape (`seq > cursor`, **ascending** arrival order) even when the cursor is **0**—enabling a **full store backfill** in resumable pages instead of only newest-first snapshots.
> 
> **`/api/changes`:** when the `since_seq` query parameter is **present** (including `0`), the handler sets `SeqPaging`; omitting `since_seq` keeps the existing newest-first full fetch. The shipped web client only sends `since_seq` when its cursor is &gt; 0, so default UI behavior is unchanged.
> 
> **Stores:** memory and SQLite query paths now treat seq paging as `SeqPaging || SinceSeq > 0` for filtering, sort order, and iteration. A conformance test asserts paging with `SeqPaging: true` and `SinceSeq: 0` returns every row in arrival order across pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0440a3c3ad95d6e4efbf29999f7b2a6c713e0631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->