### PR TITLE
renderers: defer CAPI Not Ready banners to Operational Issues

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/AWSMachineRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSMachineRenderer.tsx
@@ -1,6 +1,6 @@
 import { Cpu, Network, Cloud } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAWSMachineStatus, getAWSMachineInstanceType, getAWSMachineInstanceState, getAWSMachineInstanceID } from '../resource-utils-aws-capi'
 
@@ -16,6 +16,7 @@ export function AWSMachineRenderer({ data }: Props) {
 
   const machineStatus = getAWSMachineStatus(data)
   const isFailed = machineStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const instanceState = getAWSMachineInstanceState(data)
@@ -23,7 +24,7 @@ export function AWSMachineRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="AWS Machine Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/AWSManagedClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSManagedClusterRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, Server } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAWSManagedClusterStatus, getAWSManagedClusterEndpoint, getAWSManagedClusterFailureDomains } from '../resource-utils-aws-capi'
 
@@ -11,13 +11,14 @@ export function AWSManagedClusterRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const clusterStatus = getAWSManagedClusterStatus(data)
   const isFailed = clusterStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const failureDomains = getAWSManagedClusterFailureDomains(data)
   const endpoint = getAWSManagedClusterEndpoint(data)
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Managed Cluster Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/AWSManagedControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSManagedControlPlaneRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, Network, Shield, Server, Package } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import {
   getAWSMCPStatus, getAWSMCPEKSClusterName, getAWSMCPRegion, getAWSMCPVersion,
@@ -18,6 +18,7 @@ export function AWSManagedControlPlaneRenderer({ data }: Props) {
 
   const mcpStatus = getAWSMCPStatus(data)
   const isFailed = mcpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const vpc = getAWSMCPVPC(data)
@@ -29,7 +30,7 @@ export function AWSManagedControlPlaneRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="EKS Control Plane Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/AWSManagedMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSManagedMachinePoolRenderer.tsx
@@ -1,6 +1,6 @@
 import { Server, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAWSMMPStatus, getAWSMMPInstanceType, getAWSMMPCapacityType, getAWSMMPAMIType, getAWSMMPNodegroupName, getAWSMMPScaling } from '../resource-utils-aws-capi'
 import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
@@ -17,6 +17,7 @@ export function AWSManagedMachinePoolRenderer({ data }: Props) {
 
   const mmpStatus = getAWSMMPStatus(data)
   const isFailed = mmpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const scaling = getAWSMMPScaling(data)
@@ -26,7 +27,7 @@ export function AWSManagedMachinePoolRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Managed Machine Pool Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/AzureMachineRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AzureMachineRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cloud } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAzureMachineStatus, getAzureMachineVMSize, getAzureMachineProviderID } from '../resource-utils-azure-capi'
 
@@ -13,12 +13,13 @@ export function AzureMachineRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const machineStatus = getAzureMachineStatus(data)
   const isFailed = machineStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const providerID = getAzureMachineProviderID(data)
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="Azure Machine Not Ready" message={readyCond?.message || 'AzureMachine is not ready.'} />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/AzureManagedControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AzureManagedControlPlaneRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, Shield, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAzureMCPStatus, getAzureMCPLocation, getAzureMCPVersion, getAzureMCPResourceGroup, getAzureMCPSKUTier, getAzureMCPNetworkPlugin, getAzureMCPNetworkPolicy, getAzureMCPDNSPrefix, getAzureMCPUpgradeChannel, getAzureMCPPrivateCluster } from '../resource-utils-azure-capi'
 
@@ -13,13 +13,14 @@ export function AzureManagedControlPlaneRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const mcpStatus = getAzureMCPStatus(data)
   const isFailed = mcpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const apiAccess = spec.apiServerAccessProfile || {}
   const authorizedRanges = apiAccess.authorizedIPRanges || []
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="AKS Control Plane Not Ready" message={readyCond?.message || 'AzureManagedControlPlane is not ready.'} />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/AzureManagedMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AzureManagedMachinePoolRenderer.tsx
@@ -1,6 +1,6 @@
 import { Server, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAzureMMPStatus, getAzureMMPSKU, getAzureMMPMode, getAzureMMPOSDiskInfo, getAzureMMPScaling, getAzureMMPScaleSetPriority, getAzureMMPOSType } from '../resource-utils-azure-capi'
 import { CAPACITY_TYPE_BADGE, NODEPOOL_MODE_BADGE } from '../../../utils/badge-colors'
@@ -16,6 +16,7 @@ export function AzureManagedMachinePoolRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const mmpStatus = getAzureMMPStatus(data)
   const isFailed = mmpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const scaling = getAzureMMPScaling(data)
   const mode = getAzureMMPMode(data)
@@ -26,7 +27,7 @@ export function AzureManagedMachinePoolRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="AKS Node Pool Not Ready" message={readyCond?.message || 'AzureManagedMachinePool is not ready.'} />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIClusterRenderer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Server, Globe, Network, Layers, Download, CheckCircle, AlertCircle } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getClusterStatus, getClusterClass, getClusterVersion, getClusterEndpoint, getProviderFromInfraKind, parseCAPIConditionMessage } from '../resource-utils-capi'
@@ -18,6 +18,7 @@ export function CAPIClusterRenderer({ data, onNavigate, apiBase = '' }: Props) {
 
   const clusterStatus = getClusterStatus(data)
   const isFailed = clusterStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready' || c.type === 'Available')
 
   const phase = status.phase || 'Unknown'
@@ -102,7 +103,7 @@ export function CAPIClusterRenderer({ data, onNavigate, apiBase = '' }: Props) {
         />
       )}
 
-      {isFailed && (() => {
+      {isFailed && !operationalIssuesShown && (() => {
         const msg = readyCond?.message || `Cluster is in ${phase} state.`
         const items = parseCAPIConditionMessage(msg)
         return <AlertBanner variant="error" title="Cluster Not Ready" items={items || undefined} message={items ? undefined : msg} />

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIKubeadmControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIKubeadmControlPlaneRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Shield, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getKCPStatus, getKCPVersion, getKCPInitialized, getMachineClusterName } from '../resource-utils-capi'
@@ -16,6 +16,7 @@ export function CAPIKubeadmControlPlaneRenderer({ data, onNavigate }: Props) {
 
   const kcpStatus = getKCPStatus(data)
   const isFailed = kcpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const clusterName = getMachineClusterName(data)
@@ -33,7 +34,7 @@ export function CAPIKubeadmControlPlaneRenderer({ data, onNavigate }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="Control Plane Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineDeploymentRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineDeploymentRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getMachineDeploymentStatus, getMachineDeploymentVersion, getMachineClusterName } from '../resource-utils-capi'
@@ -16,6 +16,7 @@ export function CAPIMachineDeploymentRenderer({ data, onNavigate }: Props) {
 
   const mdStatus = getMachineDeploymentStatus(data)
   const isFailed = mdStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const phase = status.phase || 'Unknown'
@@ -40,7 +41,7 @@ export function CAPIMachineDeploymentRenderer({ data, onNavigate }: Props) {
         />
       )}
 
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="MachineDeployment Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineHealthCheckRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineHealthCheckRenderer.tsx
@@ -1,5 +1,5 @@
 import { HeartPulse, Settings, Shield } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, LabelSelectorDisplay } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, LabelSelectorDisplay, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getMachineHealthCheckStatus, getMachineHealthCheckClusterName } from '../resource-utils-capi'
 
 interface Props {
@@ -14,6 +14,7 @@ export function CAPIMachineHealthCheckRenderer({ data }: Props) {
 
   const mhcStatus = getMachineHealthCheckStatus(data)
   const isFailed = mhcStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const clusterName = getMachineHealthCheckClusterName(data)
@@ -31,7 +32,7 @@ export function CAPIMachineHealthCheckRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="MachineHealthCheck Issue"

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachinePoolRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getMachinePoolStatus } from '../resource-utils-capi'
@@ -16,6 +16,7 @@ export function CAPIMachinePoolRenderer({ data, onNavigate }: Props) {
 
   const mpStatus = getMachinePoolStatus(data)
   const isFailed = mpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const clusterName = spec.clusterName || data.metadata?.labels?.['cluster.x-k8s.io/cluster-name'] || '-'
@@ -27,7 +28,7 @@ export function CAPIMachinePoolRenderer({ data, onNavigate }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="MachinePool Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cpu, Server, Network, Cloud } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getMachineStatus, getMachineRole, getMachineClusterName, getMachineNodeRef, getMachineVersion, getMachineProviderID, parseProviderID, getProviderFromInfraKind, parseCAPIConditionMessage } from '../resource-utils-capi'
@@ -16,6 +16,7 @@ export function CAPIMachineRenderer({ data, onNavigate }: Props) {
 
   const machineStatus = getMachineStatus(data)
   const isFailed = machineStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   // Find the most informative False condition for the alert message
   const falseCond = conditions.find((c: any) =>
@@ -38,7 +39,7 @@ export function CAPIMachineRenderer({ data, onNavigate }: Props) {
 
   return (
     <>
-      {isFailed && (() => {
+      {isFailed && !operationalIssuesShown && (() => {
         const msg = falseCond?.message || readyCond?.message || `Machine is in ${phase} state.`
         const items = parseCAPIConditionMessage(msg)
         return <AlertBanner variant="error" title="Machine Not Ready" items={items || undefined} message={items ? undefined : msg} />

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineSetRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineSetRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import { formatAge } from '../resource-utils'
 import { getMachineSetStatus, getMachineClusterName } from '../resource-utils-capi'
@@ -16,6 +16,7 @@ export function CAPIMachineSetRenderer({ data, onNavigate }: Props) {
 
   const msStatus = getMachineSetStatus(data)
   const isFailed = msStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   const clusterName = getMachineClusterName(data)
@@ -29,7 +30,7 @@ export function CAPIMachineSetRenderer({ data, onNavigate }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner
           variant="error"
           title="MachineSet Not Ready"

--- a/packages/k8s-ui/src/components/resources/renderers/GCPMachineRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GCPMachineRenderer.tsx
@@ -1,5 +1,5 @@
 import { Cpu, Cloud } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getGCPMachineStatus, getGCPMachineInstanceType, getGCPMachineZone, getGCPMachineInstanceID } from '../resource-utils-gcp-capi'
 
@@ -13,11 +13,12 @@ export function GCPMachineRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const machineStatus = getGCPMachineStatus(data)
   const isFailed = machineStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="GCP Machine Not Ready" message={readyCond?.message || 'GCPMachine is not ready.'} />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/GCPManagedControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GCPManagedControlPlaneRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, Shield, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getGCPMCPStatus, getGCPMCPClusterName, getGCPMCPProject, getGCPMCPLocation, getGCPMCPVersion, getGCPMCPReleaseChannel, getGCPMCPAutopilot, getGCPMCPEndpoint } from '../resource-utils-gcp-capi'
 
@@ -13,13 +13,14 @@ export function GCPManagedControlPlaneRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const mcpStatus = getGCPMCPStatus(data)
   const isFailed = mcpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const endpoint = getGCPMCPEndpoint(data)
   const masterAuth = spec.master_authorized_networks_config
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="GKE Control Plane Not Ready" message={readyCond?.message || 'GCPManagedControlPlane is not ready.'} />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/GCPManagedMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GCPManagedMachinePoolRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server, Settings } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, useOperationalIssuesShown} from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getGCPMMPStatus, getGCPMMPNodePoolName, getGCPMMPMachineType, getGCPMMPDiskInfo, getGCPMMPScaling, getGCPMMPImageType } from '../resource-utils-gcp-capi'
 
@@ -14,6 +14,7 @@ export function GCPManagedMachinePoolRenderer({ data }: Props) {
   const conditions = getCAPIConditions(data)
   const mmpStatus = getGCPMMPStatus(data)
   const isFailed = mmpStatus.level === 'unhealthy'
+  const operationalIssuesShown = useOperationalIssuesShown()
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const scaling = getGCPMMPScaling(data)
   const management = spec.management || {}
@@ -23,7 +24,7 @@ export function GCPManagedMachinePoolRenderer({ data }: Props) {
 
   return (
     <>
-      {isFailed && (
+      {isFailed && !operationalIssuesShown && (
         <AlertBanner variant="error" title="GKE Node Pool Not Ready" message={readyCond?.message || 'GCPManagedMachinePool is not ready.'} />
       )}
 


### PR DESCRIPTION
## Summary

Follows up [#1161](https://github.com/skyhook-io/radar/pull/1161) (which taught most resource renderers to defer their condition-derived problem banner to the authoritative **Operational Issues** section) by extending the same deferral to the Cluster API renderers. A failing CAPI resource opened in the drawer showed its failure twice — once in the Operational Issues card and again in the renderer's own red "… Not Ready" banner. Now it shows once.

## What changed

Each CAPI renderer (AWS/Azure/GCP infra machines, managed clusters, control planes, node pools; and CAPI-core Cluster, Machine, MachineSet, MachineDeployment, MachinePool, KubeadmControlPlane, MachineHealthCheck) renders a single `<kind> Not Ready` error banner guarded by `isFailed` — which is true on `status.phase == Failed` or a false `Ready` condition. That is exactly what the curated `DetectCAPIProblems` detector emits for the same resource (`internal/k8s/detect_capi.go`), so the banner is a duplicate of the card.

These banners are now gated on `useOperationalIssuesShown()`, the same mechanism Pod/Workload/Karpenter/external-secrets/etc. already use: the banner hides only when the pipeline emitted an issue for that resource, and whenever the banner would fire the pipeline does emit — so the failure is shown once, in the richer card, and nothing is hidden when the pipeline is silent (the banner reappears cleanly).

Left ungated by design:
- **`spec.paused` "… Paused" banners** — a heuristic the pipeline doesn't emit; it's the renderer's unique signal.
- **`CAPIMachineRenderer`'s secondary per-subcondition warning** (`BootstrapReady`/`NodeHealthy`/`InfrastructureReady`) — it selects the first false condition in `status.conditions` array order, whereas `DetectCAPIProblems` uses a priority order plus a staleness filter, so the two can surface *different* sub-conditions. Gating it could hide a different sub-condition than the card shows, so it stays.

## Testing

- `make tsc` clean; k8s-ui vitest — renderer suite passes.
- The gate is the identical, already-shipped `useOperationalIssuesShown()` pattern; the safety argument is the self-correcting property (banner hides only when the pipeline emitted for the resource).
- Not live-verified: this cluster has no Cluster API resources — the same as the Karpenter/KEDA renderers gated in #1161 (also healthy/absent there). The determination is from the detector's coverage in `detect_capi.go`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering in k8s-ui; no auth or cluster mutation paths, with fallback banners when the issues pipeline is silent.
> 
> **Overview**
> Extends the **Operational Issues** deferral pattern (from #1161) to all Cluster API resource drawer renderers so failures are not shown twice.
> 
> Each renderer’s red **“… Not Ready”** error `AlertBanner` (driven by unhealthy status / false `Ready`) now renders only when `useOperationalIssuesShown()` is false—i.e. when the backend pipeline has not already surfaced the same problem in the Operational Issues card. **Paused** warning banners and `CAPIMachineRenderer`’s per-subcondition warning banner stay ungated because they are not fully mirrored by the detector or can disagree on which sub-condition to highlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a89d5759432853834684f6139a383010597bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->