### PR TITLE
feat: configurable Radar surfaces and GitOps managed-only views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ web/package.json.md5
 .env
 .env.local
 dist/
+.worktrees/
 
 # Visual-test + scratch artifacts
 .playwright-mcp/

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -70,6 +70,9 @@ func main() {
 	debugEvents := flag.Bool("debug-events", false, "Enable verbose event debugging (logs all event drops)")
 	fakeInCluster := flag.Bool("fake-in-cluster", false, "Simulate in-cluster mode for testing (shows kubectl copy buttons instead of port-forward)")
 	disableHelmWrite := flag.Bool("disable-helm-write", false, "Simulate restricted Helm permissions (disables install/upgrade/rollback/uninstall)")
+	disableCost := flag.Bool("disable-cost", false, "Disable cost, OpenCost, and rightsizing surfaces")
+	disableHelm := flag.Bool("disable-helm", false, "Disable native Helm surfaces and client initialization")
+	gitOpsManagedOnly := flag.Bool("gitops-managed-only", false, "Show only resources managed by GitOps controllers in topology and resource views")
 	disableExec := flag.Bool("disable-exec", false, "Simulate restricted exec permissions (disables terminal, debug shell)")
 	disableLocalTerminal := flag.Bool("disable-local-terminal", false, "Disable local terminal feature")
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
@@ -244,6 +247,9 @@ func main() {
 		DebugEvents:              *debugEvents,
 		FakeInCluster:            *fakeInCluster,
 		DisableHelmWrite:         *disableHelmWrite,
+		DisableCost:              *disableCost,
+		DisableHelm:              *disableHelm,
+		GitOpsManagedOnly:        *gitOpsManagedOnly,
 		DisableExec:              *disableExec,
 		DisableLocalTerminal:     *disableLocalTerminal,
 		PodShellDefault:          *podShellDefault,

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -77,6 +77,15 @@ spec:
             {{- if .Values.listPageSize }}
             - --list-page-size={{ .Values.listPageSize }}
             {{- end }}
+            {{- if not .Values.features.cost }}
+            - --disable-cost
+            {{- end }}
+            {{- if not .Values.features.helm }}
+            - --disable-helm
+            {{- end }}
+            {{- if .Values.features.gitOpsManagedOnly }}
+            - --gitops-managed-only
+            {{- end }}
             {{- if ne .Values.auth.mode "none" }}
             - {{ printf "--auth-mode=%s" .Values.auth.mode | quote }}
             - {{ printf "--auth-cookie-ttl=%s" .Values.auth.cookieTTL | quote }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -30,6 +30,15 @@
     },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
+    "features": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cost": { "type": "boolean" },
+        "helm": { "type": "boolean" },
+        "gitOpsManagedOnly": { "type": "boolean" }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -41,6 +41,14 @@ debug:
 # 0 = off (single LIST). Try 2000 if a large cluster fails to sync.
 listPageSize: 0
 
+# Optional Radar surfaces. Cost and native Helm are enabled by default for
+# backwards compatibility; GitOps managed-only scopes topology/resource views
+# to controller-managed resources when enabled.
+features:
+  cost: true
+  helm: true
+  gitOpsManagedOnly: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/docs/phases/phase-1-radar-surface-controls.md
+++ b/docs/phases/phase-1-radar-surface-controls.md
@@ -1,0 +1,266 @@
+# Phase 1: Radar Surface Controls
+
+## Objective and Success Criteria
+
+Add install-wide controls that let operators disable native Cost and Helm
+surfaces and restrict Resources and Topology to GitOps-managed objects.
+
+Success criteria:
+
+- Existing installs keep current behavior when no new values or flags are set.
+- Operators can disable Cost and native Helm through Helm values or CLI flags.
+- Disabled features are absent from navigation, routes, background clients,
+  dashboards, and MCP registration where applicable.
+- Resources and Topology can show only Argo CD- or Flux-managed objects plus
+  descendants generated through Kubernetes ownership.
+- Resource counts, REST topology, and SSE topology use the same managed-only
+  predicate.
+- Direct resource GET, Search, Issues, Applications, and Kubernetes RBAC
+  behavior remain unchanged.
+- Chart rendering, Go tests, frontend checks, and focused runtime smoke tests
+  pass.
+
+## Audience
+
+Radar operators running shared in-cluster deployments who need a smaller,
+GitOps-focused surface without maintaining a private Radar fork.
+
+## Scope
+
+In scope:
+
+- CLI, application, server, capabilities, and Helm chart configuration.
+- Cost/OpenCost and rightsizing route registration and frontend visibility.
+- Native Helm client, REST routes, MCP tools, dashboard data, and frontend
+  visibility.
+- Managed-only filtering for Resources lists/counts and Topology REST/SSE.
+- Documentation and tests for the new public configuration.
+
+Out of scope:
+
+- Kubernetes RBAC changes or per-object authorization.
+- Filtering Search, Issues, Applications, Packages, resource GET, or generic
+  MCP resource tools.
+- Removing Flux `HelmRelease` support from GitOps views.
+- Changing Prometheus-backed Traffic behavior.
+- Release publication or downstream GitOps adoption; those happen after the
+  upstream pull request is merged and released.
+
+## Public Interfaces and Defaults
+
+Add Helm values with backward-compatible defaults:
+
+```yaml
+features:
+  cost: true
+  helm: true
+  gitOpsManagedOnly: false
+```
+
+Add CLI flags:
+
+```text
+--disable-cost
+--disable-helm
+--gitops-managed-only
+```
+
+Add resolved feature state to `/api/capabilities`:
+
+```json
+{
+  "features": {
+    "cost": true,
+    "helm": true,
+    "gitOpsManagedOnly": false
+  }
+}
+```
+
+Older servers or missing `features` fields retain frontend defaults of Cost
+enabled, Helm enabled, and managed-only disabled.
+
+## Behavior and Data Flow
+
+### Cost
+
+`features.cost=false` renders `--disable-cost`. The server does not register
+OpenCost, application-cost, trend, or rightsizing routes. The frontend omits
+Cost navigation, shortcuts, home cards, rightsizing, and resource/workload cost
+tabs. Direct Cost URLs replace-navigate to Home. Prometheus Traffic remains
+enabled and unchanged.
+
+### Native Helm
+
+`features.helm=false` renders `--disable-helm`. Application bootstrap does not
+register Helm subsystem callbacks, so the native Helm client is not initialized
+or restarted on context switches. The server does not register native Helm or
+Helm-dashboard routes. MCP does not register native Helm tools. Combined
+surfaces omit Helm-client data without failing their non-Helm sources. The
+frontend omits Helm navigation, home summary, shortcuts, drawers, compare
+routes, and direct Helm routes. Flux `HelmRelease` remains available in GitOps.
+
+### GitOps-managed-only Resources and Topology
+
+Managed seeds are:
+
+- resources with `argocd.argoproj.io/tracking-id`
+- resources with `argocd.argoproj.io/instance`
+- resources with Flux Kustomization or HelmRelease ownership labels
+- Argo CD and Flux controller resources already modeled as GitOps nodes
+
+Legacy `app.kubernetes.io/instance` counts as Argo ownership only when it
+resolves to a live Argo Application, avoiding false positives from ordinary
+native Helm releases.
+
+From those seeds, recursively retain targets of topology `manages` edges. This
+keeps generated ReplicaSets, Pods, Jobs, and synthetic grouped descendants even
+when only their parent carries the GitOps marker. Plain native Helm metadata,
+untracked cluster resources, and GKE/Autopilot system objects are excluded.
+
+Use one shared predicate/index for:
+
+- `/api/resources/{kind}` list filtering
+- `/api/resource-counts`
+- `/api/topology`
+- topology payloads sent through SSE
+
+Keep existing namespace and per-user RBAC filtering first. Managed-only is an
+additional visibility filter, not an authorization boundary. Resource GET and
+all out-of-scope surfaces retain existing behavior.
+
+The frontend shows a small `GitOps-managed only` scope indicator in Resources
+and Topology and uses a specific empty state when no managed objects match.
+
+## Expected Change Areas
+
+- CLI and lifecycle: `cmd/explorer`, `internal/app`, and server configuration.
+- API and ownership projection: `internal/server`, `internal/k8s`, and
+  `pkg/topology` or the existing `pkg/gitops/tree` ownership helpers.
+- UI: capabilities context, primary navigation, Home, Cost/Helm route gates,
+  Resources, and Topology.
+- Distribution: `deploy/helm/radar`, README, and in-cluster documentation.
+
+No new dependency, generic feature registry, or pluggable policy abstraction
+will be introduced. Reuse existing capabilities, topology edges, GitOps
+ownership detectors, Helm lifecycle hooks, and conditional route registration.
+
+## Implementation Sequence
+
+1. Commit this approved phase plan as the first local branch commit. Do not
+   push or open an upstream pull request until the first validated
+   implementation slice is also committed.
+2. Add feature configuration types, CLI flags, Helm values/schema, deployment
+   arguments, and capabilities response with backward-compatible defaults.
+3. Gate native Helm initialization, REST/MCP registration, and combined-source
+   fallbacks; add focused backend and chart tests.
+4. Gate Cost/OpenCost and rightsizing routes; add focused backend tests.
+5. Add the shared GitOps ownership projection and apply it to Resources counts,
+   Resources lists, Topology REST, and Topology SSE; add table-driven tests for
+   ownership and filtering.
+6. Consume capabilities in the frontend to hide disabled surfaces, redirect
+   direct routes, and render managed-only scope/empty states; add focused UI
+   tests.
+7. Update public CLI/chart documentation, then run full build, test, render,
+   smoke, secret, and diff validation.
+8. Update the Draft PR description and mark Ready only after validation and
+   review of the complete diff.
+
+## Edge Cases and Failure Modes
+
+- Missing feature fields: preserve existing enabled behavior.
+- Helm disabled while Applications/Packages are open: omit Helm-client data and
+  retain label, CRD, Argo, and Flux sources.
+- Cost disabled while Prometheus is configured: keep Traffic and non-cost
+  metrics operating.
+- Workload cluster without Argo Application CRs: modern Argo tracking
+  annotations still seed managed resources.
+- Generated resources without tracking annotations: retain them through
+  recursive `manages` edges.
+- Native Helm-only workload: exclude it from managed-only Resources/Topology,
+  but do not remove its Kubernetes API accessibility.
+- Cyclic or broken ownership edges: use a visited set and terminate safely.
+- Namespace/RBAC restriction: intersect managed-only results with existing
+  caller permissions; never widen visibility.
+- SSE refresh: apply identical filtering on initial REST data and subsequent
+  topology events so unmanaged nodes cannot reappear.
+
+## Validation Checklist
+
+Focused automated checks:
+
+```sh
+go test ./cmd/explorer/... ./internal/app/... ./internal/server/... ./internal/mcp/... ./pkg/topology/... ./pkg/gitops/tree/...
+make tsc
+```
+
+Chart checks:
+
+```sh
+helm lint deploy/helm/radar
+helm template radar deploy/helm/radar >/tmp/radar-default.yaml
+helm template radar deploy/helm/radar \
+  --set features.cost=false \
+  --set features.helm=false \
+  --set features.gitOpsManagedOnly=true >/tmp/radar-focused.yaml
+```
+
+Assertions:
+
+- Default render contains none of the three new CLI flags.
+- Focused render contains all three flags.
+- Disabled Cost and Helm APIs return `404`.
+- Capabilities report resolved feature state.
+- Argo-tracked and Flux-managed resources remain visible.
+- Generated descendants remain visible.
+- Native Helm-only and untracked GKE/Autopilot resources are absent.
+- Counts match filtered lists.
+- REST and SSE topology contain the same managed set.
+- Direct resource GET and Traffic remain unchanged.
+
+Full validation:
+
+```sh
+make test
+make build
+git diff --check
+gitleaks detect --source . --no-git --redact --no-banner
+```
+
+Run the repository visual-test workflow for Home, Resources, Topology, direct
+Cost/Helm routes, and dark mode. If Playwright MCP remains unavailable, report
+that validation blocker explicitly and do not substitute an unsupported visual
+harness.
+
+## Rollback
+
+- Revert the upstream pull request. Defaults preserve existing installs, so no
+  migration or stored-state rollback is required.
+- If downstream adoption exposes a defect, set all feature values back to
+  defaults or pin the prior Radar release while the upstream fix is prepared.
+
+## PR Plan
+
+- Branch: `feat/radar-surface-controls`
+- Base: `skyhook-io/radar:main`
+- Commit 1: approved phase plan only, kept local until implementation exists.
+- Commit 2: public configuration and chart plumbing.
+- Commit 3: native Helm and Cost runtime gates.
+- Commit 4: managed-only backend projection.
+- Commit 5: frontend gates, scope indicator, and documentation.
+- PR description sections: `Summary`, `Changes`, `Testing`, `Risks/Notes`.
+- Never merge without explicit authorization for the exact upstream PR.
+
+## Task Breakdown
+
+- [ ] Commit approved phase plan locally.
+- [ ] Open Draft PR only after a validated implementation slice exists.
+- [ ] Add public configuration and chart plumbing.
+- [ ] Disable native Helm runtime and surfaces.
+- [ ] Disable Cost runtime and surfaces.
+- [ ] Add managed-only Resources and Topology projection.
+- [ ] Add frontend visibility gates and managed-only scope states.
+- [ ] Update documentation.
+- [ ] Run focused and full validation.
+- [ ] Run visual verification or report Playwright MCP blocker.
+- [ ] Update Draft PR and mark Ready for review.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -298,6 +298,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 			Cost:              !cfg.DisableCost,
 			Helm:              !cfg.DisableHelm,
 			GitOpsManagedOnly: cfg.GitOpsManagedOnly,
+			Configured:        true,
 		},
 	}
 

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -218,7 +218,9 @@ func BuildTimelineStoreConfig(cfg AppConfig) timeline.StoreConfig {
 // functions used for both initial cluster initialization and context switching.
 // Must be called before InitializeCluster.
 func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
-	k8s.RegisterHelmFuncs(helm.ResetClient, helm.ReinitClient)
+	if !cfg.DisableHelm {
+		k8s.RegisterHelmFuncs(helm.ResetClient, helm.ReinitClient)
+	}
 
 	k8s.RegisterTimelineFuncs(timeline.ResetStore, func() error {
 		return timeline.ReinitStore(timelineStoreCfg)

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -44,6 +44,9 @@ type AppConfig struct {
 	DebugEvents              bool
 	FakeInCluster            bool
 	DisableHelmWrite         bool
+	DisableCost              bool
+	DisableHelm              bool
+	GitOpsManagedOnly        bool
 	DisableExec              bool
 	DisableLocalTerminal     bool
 	PodShellDefault          string
@@ -289,6 +292,11 @@ func CreateServer(cfg AppConfig) *server.Server {
 			HasPrometheusHeaders: len(cfg.PrometheusHeaders) > 0,
 		},
 		AuthConfig: cfg.AuthConfig,
+		Features: server.FeaturesConfig{
+			Cost:              !cfg.DisableCost,
+			Helm:              !cfg.DisableHelm,
+			GitOpsManagedOnly: cfg.GitOpsManagedOnly,
+		},
 	}
 
 	// AI-history DB path: resolved here (like the timeline DB) so the server

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -76,6 +76,7 @@ type PermissionCheckResult struct {
 
 // Capabilities represents the features available based on RBAC permissions
 type Capabilities struct {
+	Features       FeatureCapabilities      `json:"features"`              // Server-configured optional surfaces
 	Exec           bool                     `json:"exec"`                  // Can create pods/exec (terminal feature)
 	LocalTerminal  bool                     `json:"localTerminal"`         // Local terminal available (not in-cluster, not disabled)
 	Logs           bool                     `json:"logs"`                  // Can get pods/log (log viewer)
@@ -91,6 +92,14 @@ type Capabilities struct {
 	Username       string                   `json:"username,omitempty"`    // Authenticated username (when auth enabled)
 	Resources      *ResourcePermissions     `json:"resources,omitempty"`   // Per-resource-type permissions
 	Visibility     *VisibilitySummary       `json:"visibility,omitempty"`  // Present when resource visibility is limited enough to make diagnostics incomplete
+}
+
+// FeatureCapabilities describes optional surfaces enabled for this Radar
+// instance. It is additive to RBAC capabilities and does not grant access.
+type FeatureCapabilities struct {
+	Cost              bool `json:"cost"`
+	Helm              bool `json:"helm"`
+	GitOpsManagedOnly bool `json:"gitOpsManagedOnly"`
 }
 
 // WorkloadWritePermissions indicates which workload resources the user can patch.

--- a/internal/server/managed_filter.go
+++ b/internal/server/managed_filter.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/skyhook-io/radar/pkg/topology"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func filterManagedResources(result any, kind string, topo *topology.Topology) any {
+	v := reflect.ValueOf(result)
+	if !v.IsValid() || v.Kind() != reflect.Slice {
+		return result
+	}
+	out := reflect.MakeSlice(v.Type(), 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		item := v.Index(i)
+		var obj metav1.Object
+		if item.Kind() == reflect.Interface && !item.IsNil() {
+			item = item.Elem()
+		}
+		if item.CanInterface() {
+			obj, _ = item.Interface().(metav1.Object)
+		}
+		if obj == nil || topology.IsManagedResource(topo, strings.TrimSuffix(kind, "s"), obj.GetNamespace(), obj.GetName(), obj.GetLabels(), obj.GetAnnotations()) {
+			out = reflect.Append(out, v.Index(i))
+		}
+	}
+	return out.Interface()
+}

--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -5,9 +5,11 @@ import (
 	"log"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/k8score"
+	"github.com/skyhook-io/radar/pkg/topology"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -225,6 +227,30 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	countEndpointSlices()
+	if r.URL.Query().Get("gitops-managed-only") == "true" {
+		if topo := s.broadcaster.GetCachedTopology(); topo != nil {
+			managed := topology.ManagedResourceSet(topo)
+			filtered := map[string]int{}
+			for _, n := range topo.Nodes {
+				if !managed[topology.ManagedResourceKey(string(n.Kind), topology.NodeNamespace(n), n.Name)] {
+					continue
+				}
+				group := ""
+				if apiVersion, ok := n.Data["apiVersion"].(string); ok {
+					if i := strings.IndexByte(apiVersion, '/'); i >= 0 {
+						group = apiVersion[:i]
+					}
+				}
+				key := n.Kind
+				if group != "" {
+					key = topology.NodeKind(group + "/" + string(n.Kind))
+				}
+				filtered[string(key)]++
+			}
+			counts = filtered
+			forbidden, unavailable, reasons = nil, nil, nil
+		}
+	}
 
 	s.writeJSON(w, ResourceCountsResponse{
 		Counts:      counts,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1340,6 +1340,9 @@ func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
 	if deny := s.deniedClusterScopedTopoKinds(r); len(deny) > 0 {
 		topo.StripNodeKinds(deny)
 	}
+	if r.URL.Query().Get("gitops-managed-only") == "true" {
+		topo.StripUnmanaged()
+	}
 
 	// Marshal once so we can record the exact wire size in perfstats.
 	// (writeJSON streams, which would force a counting-writer wrapper.)
@@ -1636,6 +1639,9 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if r.URL.Query().Get("gitops-managed-only") == "true" {
+			result = filterManagedResources(result, kind, s.broadcaster.GetCachedTopology())
+		}
 		if includeSummary {
 			result = applySummaryStrip(result)
 		}
@@ -1940,6 +1946,9 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Query().Get("gitops-managed-only") == "true" {
+		result = filterManagedResources(result, kind, s.broadcaster.GetCachedTopology())
+	}
 	if includeSummary {
 		result = applySummaryStrip(result)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1340,7 +1340,7 @@ func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
 	if deny := s.deniedClusterScopedTopoKinds(r); len(deny) > 0 {
 		topo.StripNodeKinds(deny)
 	}
-	if r.URL.Query().Get("gitops-managed-only") == "true" {
+	if s.features.GitOpsManagedOnly || r.URL.Query().Get("gitops-managed-only") == "true" {
 		topo.StripUnmanaged()
 	}
 
@@ -1639,7 +1639,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if r.URL.Query().Get("gitops-managed-only") == "true" {
+		if s.features.GitOpsManagedOnly || r.URL.Query().Get("gitops-managed-only") == "true" {
 			result = filterManagedResources(result, kind, s.broadcaster.GetCachedTopology())
 		}
 		if includeSummary {
@@ -1946,7 +1946,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Query().Get("gitops-managed-only") == "true" {
+	if s.features.GitOpsManagedOnly || r.URL.Query().Get("gitops-managed-only") == "true" {
 		result = filterManagedResources(result, kind, s.broadcaster.GetCachedTopology())
 	}
 	if includeSummary {
@@ -4179,6 +4179,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 	// Re-encode filtered namespaces back into query params for the broadcaster
 	q := r.URL.Query()
+	if s.features.GitOpsManagedOnly {
+		q.Set("gitops-managed-only", "true")
+	}
 	q.Del("namespace")
 	q.Del("namespaces")
 	if namespaces != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -388,7 +388,9 @@ func (s *Server) setupRoutes() {
 			r.Get("/dashboard", s.handleDashboard)
 			r.Get("/vitals", s.handleVitals)
 			r.Get("/dashboard/crds", s.handleDashboardCRDs)
-			r.Get("/dashboard/helm", s.handleDashboardHelm)
+			if s.features.Helm {
+				r.Get("/dashboard/helm", s.handleDashboardHelm)
+			}
 			r.Get("/cluster-info", s.handleClusterInfo)
 			r.Get("/capabilities", s.handleCapabilities)
 			r.Get("/topology", s.handleTopology)
@@ -507,8 +509,10 @@ func (s *Server) setupRoutes() {
 			r.Get("/workloads/{kind}/{namespace}/{name}/pods", s.handleWorkloadPods)
 
 			// Helm routes
-			helmHandlers := helm.NewHandlers(s.resolveHelmNamespaces)
-			helmHandlers.RegisterRoutes(r)
+			if s.features.Helm {
+				helmHandlers := helm.NewHandlers(s.resolveHelmNamespaces)
+				helmHandlers.RegisterRoutes(r)
+			}
 
 			// Image inspection routes
 			imageHandlers := images.NewHandlers()
@@ -536,15 +540,19 @@ func (s *Server) setupRoutes() {
 				}
 				return true
 			})
-			r.Post("/prometheus/rightsizing/scan", s.handleRightsizingScan)
-			prometheuspkg.RegisterRoutes(r)
+			if s.features.Cost {
+				r.Post("/prometheus/rightsizing/scan", s.handleRightsizingScan)
+				prometheuspkg.RegisterRoutes(r)
+			}
 
 			// OpenCost routes
-			r.Post("/opencost/application", s.handleOpenCostApplication)
-			r.Post("/opencost/application/trend", s.handleOpenCostApplicationTrend)
-			r.Get("/opencost/workload/{kind}/{namespace}/{name}", s.handleOpenCostWorkload)
-			r.Get("/opencost/workload/{kind}/{namespace}/{name}/trend", s.handleOpenCostWorkloadTrend)
-			opencost.RegisterRoutes(r)
+			if s.features.Cost {
+				r.Post("/opencost/application", s.handleOpenCostApplication)
+				r.Post("/opencost/application/trend", s.handleOpenCostApplicationTrend)
+				r.Get("/opencost/workload/{kind}/{namespace}/{name}", s.handleOpenCostWorkload)
+				r.Get("/opencost/workload/{kind}/{namespace}/{name}/trend", s.handleOpenCostWorkloadTrend)
+				opencost.RegisterRoutes(r)
+			}
 
 			// FluxCD routes
 			r.Post("/flux/{kind}/{namespace}/{name}/reconcile", s.handleFluxReconcile)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	diagConfig         *DiagConfig
 	effectiveConfig    *config.Config // running config for GET /api/config
 	authConfig         auth.Config
+	features           FeaturesConfig
 	permCache          *auth.PermissionCache
 	oidcHandler        *auth.OIDCHandler
 	saveFileFunc       func(defaultFilename string, data []byte) (string, error)
@@ -135,6 +136,16 @@ type Config struct {
 	EffectiveConfig    *config.Config // Running startup config for GET /api/config
 	AuthConfig         auth.Config    // Authentication configuration
 	AIHistoryDB        string         // AI run-history SQLite path ("" = memory-only runs)
+	Features           FeaturesConfig // Presentation and subsystem feature gates
+}
+
+// FeaturesConfig controls optional Radar surfaces exposed by this instance.
+// These flags are presentation/configuration controls; RBAC remains enforced
+// independently by the Kubernetes capability checks.
+type FeaturesConfig struct {
+	Cost              bool `json:"cost"`
+	Helm              bool `json:"helm"`
+	GitOpsManagedOnly bool `json:"gitOpsManagedOnly"`
 }
 
 // New creates a new server instance
@@ -152,6 +163,7 @@ func New(cfg Config) *Server {
 		diagConfig:         cfg.DiagConfig,
 		effectiveConfig:    cfg.EffectiveConfig,
 		authConfig:         cfg.AuthConfig,
+		features:           cfg.Features,
 		topoMemo:           topology.NewMemoizer(5 * time.Second),
 		rbacMemo:           rbac.NewMemoizer(5 * time.Second),
 	}
@@ -860,6 +872,11 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	}
 
 	caps.MCPEnabled = s.mcpHandler != nil
+	caps.Features = k8s.FeatureCapabilities{
+		Cost:              s.features.Cost,
+		Helm:              s.features.Helm,
+		GitOpsManagedOnly: s.features.GitOpsManagedOnly,
+	}
 	caps.Deployment = k8s.DeploymentInfo{Mode: deploymentMode()}
 	caps.AuthEnabled = s.authConfig.Enabled()
 	if user := auth.UserFromContext(r.Context()); user != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -146,11 +146,18 @@ type FeaturesConfig struct {
 	Cost              bool `json:"cost"`
 	Helm              bool `json:"helm"`
 	GitOpsManagedOnly bool `json:"gitOpsManagedOnly"`
+	Configured        bool `json:"-"`
 }
 
 // New creates a new server instance
 func New(cfg Config) *Server {
 	cfg.AuthConfig.Defaults()
+	if !cfg.Features.Configured {
+		// Preserve the historical server.New behavior for embedders and tests
+		// that do not provide feature configuration.
+		cfg.Features.Cost = true
+		cfg.Features.Helm = true
+	}
 
 	s := &Server{
 		router:             chi.NewRouter(),

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -64,6 +64,7 @@ type ClientInfo struct {
 	Namespaces       []string // Filter to specific namespaces (empty = all)
 	ViewMode         string   // "full" or "traffic"
 	ShowPolicyEffect bool     // Evaluate NetworkPolicies on edges
+	ManagedOnly      bool     // Restrict topology to Argo CD/Flux-managed resources
 	// DeniedKinds are cluster-scoped topology kinds (Nodes, PV, StorageClass,
 	// NodePool, …) this user can't list, stripped from every topology frame.
 	// Resolved once at subscribe time (the request is available there) so the
@@ -76,6 +77,7 @@ type clientRegistration struct {
 	namespaces       []string
 	viewMode         string
 	showPolicyEffect bool
+	managedOnly      bool
 	deniedKinds      map[topology.NodeKind]bool
 }
 
@@ -388,7 +390,7 @@ func (b *SSEBroadcaster) run() {
 				close(reg.ch) // Signal rejection by closing the channel
 				continue
 			}
-			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds}
+			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, ManagedOnly: reg.managedOnly, DeniedKinds: reg.deniedKinds}
 			b.mu.Unlock()
 			log.Printf("SSE client connected (namespaces=%v, view=%s), total clients: %d", reg.namespaces, reg.viewMode, len(b.clients))
 
@@ -624,10 +626,12 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		deniedKindsKey   string // comma-separated sorted denied cluster-scoped kinds
 		viewMode         string
 		showPolicyEffect bool
+		managedOnly      bool
 	}
 	type clientGroup struct {
 		namespaces       []string
 		showPolicyEffect bool
+		managedOnly      bool
 		deniedKinds      map[topology.NodeKind]bool
 		channels         []chan SSEEvent
 	}
@@ -637,9 +641,9 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		// Users with identical namespace + cluster-scoped RBAC share one frame;
 		// a user denied cluster-scoped kinds gets a distinct, stripped frame
 		// rather than the unfiltered bytes of a more-privileged peer.
-		key := clientKey{namespacesKey: nsKey, deniedKindsKey: deniedKindsKey(info.DeniedKinds), viewMode: info.ViewMode, showPolicyEffect: info.ShowPolicyEffect}
+		key := clientKey{namespacesKey: nsKey, deniedKindsKey: deniedKindsKey(info.DeniedKinds), viewMode: info.ViewMode, showPolicyEffect: info.ShowPolicyEffect, managedOnly: info.ManagedOnly}
 		if clientGroups[key] == nil {
-			clientGroups[key] = &clientGroup{namespaces: info.Namespaces, showPolicyEffect: info.ShowPolicyEffect, deniedKinds: info.DeniedKinds}
+			clientGroups[key] = &clientGroup{namespaces: info.Namespaces, showPolicyEffect: info.ShowPolicyEffect, deniedKinds: info.DeniedKinds, managedOnly: info.ManagedOnly}
 		}
 		clientGroups[key].channels = append(clientGroups[key].channels, ch)
 	}
@@ -665,6 +669,9 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			continue
 		}
 		topo.StripNodeKinds(group.deniedKinds)
+		if group.managedOnly {
+			topo.StripUnmanaged()
+		}
 
 		if int64(topo.EstimatedNodes) > maxEstimated {
 			maxEstimated = int64(topo.EstimatedNodes)
@@ -824,8 +831,9 @@ func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedK
 	}
 
 	policyEffect := len(showPolicyEffect) > 0 && showPolicyEffect[0]
+	managedOnly := len(showPolicyEffect) > 1 && showPolicyEffect[1]
 	ch := make(chan SSEEvent, 10)
-	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds}
+	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, managedOnly: managedOnly, deniedKinds: deniedKinds}
 	return ch
 }
 
@@ -959,6 +967,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 		viewMode = "full"
 	}
 	policyEffect := r.URL.Query().Get("policyEffect") == "true"
+	managedOnly := r.URL.Query().Get("gitops-managed-only") == "true"
 
 	// Ensure we can flush
 	flusher, ok := w.(http.Flusher)
@@ -968,7 +977,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 	}
 
 	// Subscribe to events
-	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, policyEffect)
+	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, policyEffect, managedOnly)
 	if eventCh == nil {
 		http.Error(w, "Too many SSE connections", http.StatusServiceUnavailable)
 		return

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -69,6 +69,13 @@ export interface Capabilities {
   nodeWrite: boolean      // Node write operations (cordon, uncordon, drain)
   workloadWrites?: WorkloadWritePermissions // Workload patch permissions (restart/scale controls)
   mcpEnabled: boolean     // MCP server is running
+  // Product surfaces enabled by server configuration. Optional for backwards
+  // compatibility with older Radar backends.
+  features?: {
+    cost?: boolean
+    helm?: boolean
+    gitOpsManagedOnly?: boolean
+  }
   // How / where this Radar binary is running. Optional on the wire so a
   // newer frontend (e.g. radar-hub-web bundling a fresher @skyhook-io/radar-app)
   // doesn't crash against an older backend that hasn't shipped the field yet —

--- a/pkg/topology/managed_filter.go
+++ b/pkg/topology/managed_filter.go
@@ -1,0 +1,132 @@
+package topology
+
+import "strings"
+
+// ManagedResourceSet returns GitOps-managed topology resources and their
+// descendants. It deliberately ignores native Helm metadata: Radar's
+// managed-only view is for Argo CD and Flux ownership, not every Helm install.
+func ManagedResourceSet(t *Topology) map[string]bool {
+	set := map[string]bool{}
+	if t == nil {
+		return set
+	}
+	seed := map[string]bool{}
+	for _, n := range t.Nodes {
+		if isGitOpsNode(n) {
+			seed[n.ID] = true
+			set[managedKey(string(n.Kind), nodeNamespace(n), n.Name)] = true
+		}
+	}
+	changed := true
+	for changed {
+		changed = false
+		for _, e := range t.Edges {
+			if e.Type != EdgeManages || !seed[e.Source] || seed[e.Target] {
+				continue
+			}
+			seed[e.Target] = true
+			changed = true
+		}
+	}
+	for _, n := range t.Nodes {
+		if seed[n.ID] {
+			set[managedKey(string(n.Kind), nodeNamespace(n), n.Name)] = true
+		}
+	}
+	return set
+}
+
+// StripUnmanaged removes resources outside the Argo/Flux ownership closure.
+func (t *Topology) StripUnmanaged() {
+	if t == nil {
+		return
+	}
+	managed := ManagedResourceSet(t)
+	dropped := map[string]bool{}
+	kept := t.Nodes[:0]
+	for _, n := range t.Nodes {
+		if managed[managedKey(string(n.Kind), nodeNamespace(n), n.Name)] {
+			kept = append(kept, n)
+		} else {
+			dropped[n.ID] = true
+		}
+	}
+	t.Nodes = kept
+	edges := t.Edges[:0]
+	for _, e := range t.Edges {
+		if !dropped[e.Source] && !dropped[e.Target] {
+			edges = append(edges, e)
+		}
+	}
+	t.Edges = edges
+}
+
+func managedKey(kind, namespace, name string) string {
+	return strings.ToLower(kind) + "\x00" + namespace + "\x00" + name
+}
+
+func ManagedResourceKey(kind, namespace, name string) string {
+	return managedKey(kind, namespace, name)
+}
+
+func nodeNamespace(n Node) string {
+	if n.Data == nil {
+		return ""
+	}
+	if ns, ok := n.Data["namespace"].(string); ok {
+		return ns
+	}
+	return ""
+}
+
+func NodeNamespace(n Node) string { return nodeNamespace(n) }
+
+func isGitOpsNode(n Node) bool {
+	if n.Kind == KindApplication || n.Kind == KindKustomization || n.Kind == KindHelmRelease {
+		return true
+	}
+	labels, _ := n.Data["labels"].(map[string]string)
+	annotations, _ := n.Data["annotations"].(map[string]string)
+	if labels == nil {
+		if raw, ok := n.Data["labels"].(map[string]any); ok {
+			labels = stringMap(raw)
+		}
+	}
+	if annotations == nil {
+		if raw, ok := n.Data["annotations"].(map[string]any); ok {
+			annotations = stringMap(raw)
+		}
+	}
+	if annotations["argocd.argoproj.io/tracking-id"] != "" {
+		return true
+	}
+	if labels["argocd.argoproj.io/instance"] != "" {
+		return true
+	}
+	return labels["kustomize.toolkit.fluxcd.io/name"] != "" && labels["kustomize.toolkit.fluxcd.io/namespace"] != "" ||
+		labels["helm.toolkit.fluxcd.io/name"] != "" && labels["helm.toolkit.fluxcd.io/namespace"] != ""
+}
+
+func stringMap(in map[string]any) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// IsManagedResource reports whether a resource belongs to a managed-only
+// topology projection. Direct GitOps markers win; descendants are matched by
+// the topology closure.
+func IsManagedResource(t *Topology, kind, namespace, name string, labels, annotations map[string]string) bool {
+	if annotations["argocd.argoproj.io/tracking-id"] != "" || labels["argocd.argoproj.io/instance"] != "" {
+		return true
+	}
+	if (labels["kustomize.toolkit.fluxcd.io/name"] != "" && labels["kustomize.toolkit.fluxcd.io/namespace"] != "") ||
+		(labels["helm.toolkit.fluxcd.io/name"] != "" && labels["helm.toolkit.fluxcd.io/namespace"] != "") {
+		return true
+	}
+	return ManagedResourceSet(t)[managedKey(kind, namespace, name)]
+}

--- a/pkg/topology/managed_filter_test.go
+++ b/pkg/topology/managed_filter_test.go
@@ -1,0 +1,24 @@
+package topology
+
+import "testing"
+
+func TestManagedResourceSetIncludesGitOpsDescendantsOnly(t *testing.T) {
+	topo := &Topology{Nodes: []Node{
+		{ID: "app", Kind: KindApplication, Name: "app", Data: map[string]any{"namespace": "argocd"}},
+		{ID: "deployment/default/web", Kind: KindDeployment, Name: "web", Data: map[string]any{"namespace": "default"}},
+		{ID: "deployment/default/unmanaged", Kind: KindDeployment, Name: "unmanaged", Data: map[string]any{"namespace": "default"}},
+	}, Edges: []Edge{{Source: "app", Target: "deployment/default/web", Type: EdgeManages}}}
+	set := ManagedResourceSet(topo)
+	if !set[managedKey("Deployment", "default", "web")] || set[managedKey("Deployment", "default", "unmanaged")] {
+		t.Fatalf("managed set = %#v", set)
+	}
+}
+
+func TestIsManagedResourceUsesGitOpsMarkers(t *testing.T) {
+	if !IsManagedResource(nil, "Deployment", "default", "web", map[string]string{"argocd.argoproj.io/instance": "app"}, nil) {
+		t.Fatal("expected Argo instance marker")
+	}
+	if IsManagedResource(nil, "Deployment", "default", "web", map[string]string{"app.kubernetes.io/managed-by": "Helm"}, map[string]string{"meta.helm.sh/release-name": "web"}) {
+		t.Fatal("native Helm metadata must not count as GitOps-managed")
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -416,6 +416,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
   // Set mainView by navigating to the path
   const setMainView = useCallback((view: ExtendedMainView, params?: Record<string, string>) => {
+    if ((view === 'cost' && capabilities.features?.cost === false) || (view === 'helm' && capabilities.features?.helm === false) || (view === 'helmCompare' && capabilities.features?.helm === false)) {
+      view = 'home'
+    }
     // Host takeover: fleet-shaped views (issues/gitops/checks) are owned by the
     // host's fleet pages. Hand straight to the host instead of navigating to
     // our own /<view> first — that intermediate hop mounts the view machinery
@@ -447,7 +450,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     }
 
     navigate({ pathname: path, search: newParams.toString() })
-  }, [navigate, searchParams, takeover, goHost])
+  }, [navigate, searchParams, takeover, goHost, capabilities.features?.cost, capabilities.features?.helm])
+
+  // Deep links must obey the same surface controls as in-app navigation.
+  useEffect(() => {
+    const view = getViewFromPath(location.pathname)
+    if ((view === 'cost' && capabilities.features?.cost === false) || ((view === 'helm' || view === 'helmCompare') && capabilities.features?.helm === false)) {
+      navigate('/', { replace: true })
+    }
+  }, [location.pathname, navigate, capabilities.features?.cost, capabilities.features?.helm])
 
   // Cloud (embedded) takes over the "fleet-shaped" per-cluster views with its
   // own fleet pages scoped to this cluster — owned by the host's left rail — so
@@ -681,6 +692,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   }, [searchParams, navigate])
 
   const navigateToHelmRelease = useCallback((namespace: string, name: string, storageNamespace?: string) => {
+    if (capabilities.features?.helm === false) return
     const newParams = new URLSearchParams()
     const globalNamespaces = searchParams.get('namespaces')
     if (globalNamespaces) {
@@ -696,7 +708,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       return
     }
     navigate({ pathname: '/helm', search: newParams.toString() })
-  }, [mainView, searchParams, navigate, setSearchParams])
+  }, [mainView, searchParams, navigate, setSearchParams, capabilities.features?.helm])
 
   // From the Issues queue: special controller/manager subjects route to their
   // rich detail pages, not the generic resource drawer that's a dead-end for
@@ -774,7 +786,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     workload: '', compare: '', helmCompare: '',
   }
   const views = Object.keys(VIEW_SHORTCUT_KEYS).filter(
-    (v): v is ExtendedMainView => VIEW_SHORTCUT_KEYS[v as ExtendedMainView] !== '',
+    (v): v is ExtendedMainView => VIEW_SHORTCUT_KEYS[v as ExtendedMainView] !== '' && !(v === 'cost' && capabilities.features?.cost === false) && !(v === 'helm' && capabilities.features?.helm === false),
   )
   useRegisterShortcuts([
     ...views.map((view) => ({
@@ -1598,6 +1610,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           showPinToggle={!railForcedSlim}
           onOpenSettings={() => setShowSettings(true)}
           accountSlot={<UserMenu variant="rail" pinned={navRailEffectivePinned} />}
+          enabledViews={new Set(['home', 'resources', 'issues', 'topology', 'applications', 'timeline', 'traffic', 'gitops', 'checks', ...(capabilities.features?.helm === false ? [] : ['helm']), ...(capabilities.features?.cost === false ? [] : ['cost'])])}
         />
       )}
       {/* `relative` makes this column the containing block for the absolute
@@ -1649,6 +1662,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
                   disabledTooltip={namespaceFilter.tooltip}
                 />
               </ScopePill>
+              {capabilities.features?.gitOpsManagedOnly && (mainView === 'topology' || mainView === 'resources') && (
+                <span className="text-[10px] text-skyhook-600 dark:text-skyhook-400 whitespace-nowrap" title="Showing resources managed by GitOps controllers">GitOps managed</span>
+              )}
             )}
             {/* Connection status — a fixed-size dot (state in the tooltip), an
                 optional reconnect button, and when the header is wide enough
@@ -1710,7 +1726,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             { view: 'topology' as const, icon: Network, label: 'Topology' },
             { view: 'resources' as const, icon: List, label: 'Resources' },
             { view: 'timeline' as const, icon: Clock, label: 'Timeline' },
-            { view: 'helm' as const, icon: Package, label: 'Helm' },
+            ...(capabilities.features?.helm === false ? [] : [{ view: 'helm' as const, icon: Package, label: 'Helm' }]),
             { view: 'gitops' as const, icon: GitBranch, label: 'GitOps' },
             // Applications is intentionally hidden from the pill bar for now —
             // the bar is full, and the view's primary home is Cloud's fleet
@@ -1729,7 +1745,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             // Drop any pill the host took over — cluster-scoped access stays
             // available via the Home cards (redirected by the takeover effect
             // above), ⌘K, and bookmarks. Standalone OSS keeps every pill.
-            .filter(({ view }) => !isViewTakenOver(view))
+            .filter(({ view }) => !isViewTakenOver(view) && !(view === 'cost' && capabilities.features?.cost === false))
             .map(({ view, icon: Icon, label }) => (
             <Tooltip key={view} content={label} delay={100} position="bottom">
               <button

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -570,13 +570,14 @@ export function useDashboardCRDs(namespaces: string[] = []) {
 }
 
 // Helm summary - loaded lazily after main dashboard (Helm SDK lists K8s secrets, ~2-3s)
-export function useDashboardHelm(namespaces: string[] = []) {
+export function useDashboardHelm(namespaces: string[] = [], options?: { enabled?: boolean }) {
   const params = namespaces.length > 0 ? `?namespaces=${namespaces.join(',')}` : ''
   return useQuery<DashboardHelmSummary>({
     queryKey: ['dashboard-helm', namespaces],
     queryFn: () => fetchJSON(`/dashboard/helm${params}`),
     staleTime: 30000,
     refetchInterval: 60000,
+    enabled: options?.enabled ?? true,
   })
 }
 

--- a/web/src/components/applications/ApplicationsView.tsx
+++ b/web/src/components/applications/ApplicationsView.tsx
@@ -37,6 +37,7 @@ import { buildWorkloadPath, kindToPlural } from '../../utils/navigation'
 import { WorkloadView } from '../workload/WorkloadView'
 import { ApplicationCostTab } from '../cost/ApplicationCostTab'
 import { isOpenCostWorkloadKind } from '../cost/kinds'
+import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 
 type ApplicationRouteView = ApplicationView | 'cost'
 
@@ -55,6 +56,7 @@ interface ApplicationsViewProps {
 export function ApplicationsView({ namespaces, onOpenResource }: ApplicationsViewProps) {
   const query = useApplications(namespaces)
   const { connection } = useConnection()
+  const capabilities = useCapabilitiesContext()
   const apps = useMemo(() => query.data?.applications ?? [], [query.data])
 
   const freshness = (
@@ -175,7 +177,7 @@ function AppDetailRoute({ app, apps, onBack, onOpenResource }: { app: AppRow; ap
   const appWorkloads = app.workloads ?? []
   const singleWorkloadKey = appWorkloads.length === 1 ? workloadKey(appWorkloads[0]) : null
   const selectedWorkloadKey = singleWorkloadKey ?? selectedWorkloadParam
-  const applicationCostAvailable = !singleWorkloadKey && appWorkloads.some((workload) => isOpenCostWorkloadKind(workload.kind))
+  const applicationCostAvailable = capabilities.features?.cost !== false && !singleWorkloadKey && appWorkloads.some((workload) => isOpenCostWorkloadKind(workload.kind))
   const applicationCostSelected = selectedRouteView === 'cost' && applicationCostAvailable
   const historyQuery = useApplicationHistory(app.key, appHistoryNamespaces, { enabled: !selectedWorkloadKey })
   const sourceInventoryEnabled = !selectedWorkloadKey && selectedView === 'topology'

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -27,6 +27,7 @@ import { formatCompactAge } from '@skyhook-io/k8s-ui/utils/format'
 import { ClusterHealthCard } from './ClusterHealthCard'
 import { AlertTriangle, CheckCircle, Loader2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
+import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 
 interface HomeViewProps {
   namespaces: string[]
@@ -47,6 +48,7 @@ interface HomeViewProps {
 export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts }: HomeViewProps) {
   const { data, isLoading, error, dataUpdatedAt, refetch } = useDashboard(namespaces)
   const { connection } = useConnection()
+  const capabilities = useCapabilitiesContext()
   const { data: issuesData, isLoading: issuesLoading, isFetching: issuesFetching, error: issuesError } = useIssues(namespaces)
   const issues = issuesData?.issues ?? []
   const issueCount = issuesData?.total_matched ?? issuesData?.total ?? issues.length
@@ -68,7 +70,7 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
   }, [topology, namespaces])
   // CRDs and Helm load lazily after main dashboard to keep initial load fast
   const { data: crdsData } = useDashboardCRDs(namespaces)
-  const { data: helmData } = useDashboardHelm(namespaces)
+  const { data: helmData } = useDashboardHelm(namespaces, { enabled: capabilities.features?.helm !== false })
 
   if (isLoading) {
     return <PaneLoader label="Loading dashboard…" className="flex-1 min-h-0" />
@@ -161,15 +163,13 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
                   onNavigate={() => onNavigateToView('traffic')}
                 />
               </BandItem>
-              <BandItem>
+              {capabilities.features?.helm !== false && <BandItem>
                 <HelmSummary
                   data={helmData}
                   onNavigate={() => onNavigateToView('helm')}
                 />
-              </BandItem>
-              <BandItem>
-                <CostCard onNavigate={() => onNavigateToView('cost')} />
-              </BandItem>
+              </BandItem>}
+              {capabilities.features?.cost !== false && <BandItem><CostCard onNavigate={() => onNavigateToView('cost')} /></BandItem>}
             </div>
 
             {/* Posture band — same flex-grow wrap so any subset of compliance cards

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -69,9 +69,10 @@ interface PrimaryNavRailProps {
   // which self-nulls without auth so the row vanishes in no-auth OSS).
   onOpenSettings?: () => void
   accountSlot?: ReactNode
+  enabledViews?: Set<string>
 }
 
-export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned, showPinToggle = true, onOpenSettings, accountSlot }: PrimaryNavRailProps) {
+export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned, showPinToggle = true, onOpenSettings, accountSlot, enabledViews }: PrimaryNavRailProps) {
   return (
     <aside
       aria-label="Primary navigation"
@@ -103,7 +104,7 @@ export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned,
           pinned && 'flex-1 min-h-0 overflow-y-auto',
         )}
       >
-        {NAV_ITEMS.map((item) => (
+        {NAV_ITEMS.filter((item) => !enabledViews || enabledViews.has(item.view)).map((item) => (
           <NavRailItem
             key={item.view}
             item={item}

--- a/web/src/components/ui/command-items.ts
+++ b/web/src/components/ui/command-items.ts
@@ -4,6 +4,7 @@ import { useNamespaces, useContexts } from '../../api/client'
 import { CORE_RESOURCES, useAPIResources } from '../../api/apiResources'
 import { getResourceIcon } from '../../utils/resource-icons'
 import { parseContextName } from '../../utils/context-name'
+import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 
 // Drop the disambiguating " (source)" suffix the context list appends, so the
 // GKE/EKS/AKS parser sees the bare context name (mirrors the cluster picker).
@@ -100,6 +101,7 @@ const VIEW_ENTRIES: { view: MainView; label: string; icon: React.ComponentType<{
 // Namespaces, Actions) — shared by the centered modal (embedded) and the
 // standalone omnibar so the two never drift.
 export function useCommandItems(cb: CommandItemCallbacks): CommandItem[] {
+  const capabilities = useCapabilitiesContext()
   const { data: namespacesData } = useNamespaces()
   const { data: contexts } = useContexts()
   const { data: apiResources } = useAPIResources()
@@ -108,6 +110,7 @@ export function useCommandItems(cb: CommandItemCallbacks): CommandItem[] {
     const result: CommandItem[] = []
 
     for (const v of VIEW_ENTRIES) {
+      if ((v.view === 'cost' && capabilities.features?.cost === false) || (v.view === 'helm' && capabilities.features?.helm === false)) continue
       result.push({ id: `view-${v.view}`, label: `Go to ${v.label}`, category: 'Views', icon: v.icon, shortcut: v.shortcut, action: () => cb.onNavigateView(v.view) })
     }
 
@@ -174,5 +177,5 @@ export function useCommandItems(cb: CommandItemCallbacks): CommandItem[] {
 
     return result
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiResources, contexts, namespacesData, cb.onNavigateView, cb.onNavigateKind, cb.onSwitchContext, cb.onSetNamespaces, cb.onToggleTheme, cb.onShowDiagnostics])
+  }, [apiResources, contexts, namespacesData, cb.onNavigateView, cb.onNavigateKind, cb.onSwitchContext, cb.onSetNamespaces, cb.onToggleTheme, cb.onShowDiagnostics, capabilities.features?.cost, capabilities.features?.helm])
 }

--- a/web/src/contexts/CapabilitiesContext.tsx
+++ b/web/src/contexts/CapabilitiesContext.tsx
@@ -19,6 +19,7 @@ const defaultCapabilities: Capabilities = {
     rollouts: true,
   },
   mcpEnabled: true,
+  features: { cost: true, helm: true, gitOpsManagedOnly: false },
   // Default to 'local' for the loading window so the UI renders the
   // OSS standalone shape until /api/capabilities resolves. Both
   // alternatives ('in-cluster', 'cloud') would cause OSS users to
@@ -43,6 +44,7 @@ const restrictedCapabilities: Capabilities = {
     rollouts: false,
   },
   mcpEnabled: false,
+  features: { cost: false, helm: false, gitOpsManagedOnly: false },
   deployment: { mode: 'local' },
 }
 
@@ -109,6 +111,14 @@ export function useCanUpdateSecrets(): boolean {
 
 export function useCanHelmWrite(): boolean {
   return useContext(CapabilitiesContext).helmWrite
+}
+
+export function useFeatureEnabled(feature: 'cost' | 'helm'): boolean {
+  return useContext(CapabilitiesContext).features?.[feature] ?? true
+}
+
+export function useGitOpsManagedOnly(): boolean {
+  return useContext(CapabilitiesContext).features?.gitOpsManagedOnly ?? false
 }
 
 export function useCanNodeWrite(): boolean {


### PR DESCRIPTION
## Summary
- Add operator-controlled Radar surfaces for Cost, native Helm, and GitOps managed-only views.
- Keep GitOps visibility working on management Radar while preserving expected workload Radar behavior.

## Changes
- Add CLI flags: `--disable-cost`, `--disable-helm`, and `--gitops-managed-only`.
- Add Helm values/schema and deployment args under `features`.
- Expose additive `/api/capabilities.features` metadata.
- Gate Cost/OpenCost/rightsizing and native Helm routes/client wiring.
- Hide disabled Cost/Helm UI surfaces, shortcuts, deep links, home cards, and cost tabs.
- Filter topology, SSE, resource lists, and counts to Argo CD/Flux-managed ownership closure when enabled.
- Add managed-only scope indicator.

## Testing
- `go test ./...` passes.
- `cd pkg && go test ./...` passes.
- Helm template with all three feature controls passes.
- `git diff --check` passes.
- `make tsc` blocked by missing local `node_modules/typescript-7`.
- gitleaks reports four pre-existing test-fixture findings only.

## Risks/Notes
- Visual Playwright validation unavailable in this environment.
- No GitOps repository change is included until an upstream Radar release contains this behavior.
- Current upstream latest remains v1.8.1; downstream adoption is release-gated.
- Workload Radar GitOps remains intentionally disabled when its Argo resources are absent; management Radar is the GitOps surface.