### PR TITLE
perf(gitops): typed-cache routing + gated parallel drift fetches for the detail page

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -895,7 +895,7 @@ func typedRouteGVR(kind, group string) (schema.GroupVersionResource, bool) {
 	if group != "" && !TypedKindOwnsGroup(kind, group) {
 		return schema.GroupVersionResource{}, false
 	}
-	return TypedBuiltinGVR(kind)
+	return lookupTypedBuiltinGVR(kind)
 }
 
 // typedObjectToUnstructured converts a typed lister object to unstructured
@@ -931,7 +931,7 @@ func typedObjectToUnstructured(obj runtime.Object, gvr schema.GroupVersionResour
 			apiVersion = gvr.Group + "/" + gvr.Version
 		}
 		u.SetAPIVersion(apiVersion)
-		if kindName, ok := BuiltinKindForResource(gvr.Resource); ok {
+		if kindName, ok := builtinKindForResource(gvr.Resource); ok {
 			u.SetKind(kindName)
 		}
 	}
@@ -945,25 +945,28 @@ func isForbiddenTypedFetch(err error) bool {
 }
 
 // getTypedAsUnstructured serves a single-object read for a typed built-in
-// kind from the typed cache. Tri-state on a nil lister: a kind the RBAC
-// probe disabled stays forbidden, while a deferred informer that simply
-// hasn't synced yet (Secrets/ConfigMaps during the phase-2 warmup window)
-// falls back to a one-off direct GET — never to starting a dynamic informer.
+// kind from the typed cache. Tri-state: a kind whose deferred informer
+// hasn't synced yet falls back to a one-off direct GET — never to starting
+// a dynamic informer; a kind the RBAC probe disabled stays forbidden.
 // handled=false means the typed path can't answer and the caller should fall
 // through to the dynamic cache.
+//
+// The deferred check runs BEFORE the lister read, not on the "forbidden"
+// nil-lister error: several deferred kinds (ServiceAccounts, ReplicaSets,
+// HPAs, LimitRanges, ResourceQuotas) expose a non-nil lister as soon as
+// they're enabled, so during the warmup window they'd otherwise serve
+// empty stores as confident NotFound/empty results.
 func (c *ResourceCache) getTypedAsUnstructured(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace, name string) (*unstructured.Unstructured, bool, error) {
+	if c.IsDeferredPending(gvr.Resource) {
+		return c.typedDirectGet(ctx, gvr, namespace, name)
+	}
 	obj, err := FetchResource(c, kind, namespace, name)
 	if err != nil {
 		if errors.Is(err, ErrUnknownKind) {
 			return nil, false, nil
 		}
 		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
-			dynamicCache := GetDynamicResourceCache()
-			if dynamicCache == nil {
-				return nil, true, fmt.Errorf("dynamic resource cache not initialized")
-			}
-			u, derr := dynamicCache.GetDirect(ctx, gvr, namespace, name)
-			return u, true, derr
+			return c.typedDirectGet(ctx, gvr, namespace, name)
 		}
 		return nil, true, err
 	}
@@ -971,16 +974,37 @@ func (c *ResourceCache) getTypedAsUnstructured(ctx context.Context, gvr schema.G
 	return u, true, cerr
 }
 
+func (c *ResourceCache) typedDirectGet(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, bool, error) {
+	dynamicCache := GetDynamicResourceCache()
+	if dynamicCache == nil {
+		return nil, true, fmt.Errorf("dynamic resource cache not initialized")
+	}
+	u, err := dynamicCache.GetDirect(ctx, gvr, namespace, name)
+	return u, true, err
+}
+
+func (c *ResourceCache) typedDirectList(ctx context.Context, gvr schema.GroupVersionResource, namespace string) ([]*unstructured.Unstructured, bool, error) {
+	dynamicCache := GetDynamicResourceCache()
+	if dynamicCache == nil {
+		return nil, true, fmt.Errorf("dynamic resource cache not initialized")
+	}
+	us, err := dynamicCache.ListDirect(ctx, gvr, namespace)
+	return us, true, err
+}
+
 // listTypedAsUnstructured is the list counterpart of getTypedAsUnstructured,
-// with the same tri-state nil-lister semantics. A namespace filter on a
-// cluster-only kind returns empty to match the dynamic cache's
-// namespace-index behavior (FetchResourceList would ignore the filter and
-// return everything).
+// with the same tri-state semantics (see there for why the deferred check
+// precedes the lister read). A namespace filter on a cluster-only kind
+// returns empty to match the dynamic cache's namespace-index behavior
+// (FetchResourceList would ignore the filter and return everything).
 func (c *ResourceCache) listTypedAsUnstructured(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace string) ([]*unstructured.Unstructured, bool, error) {
 	if namespace != "" {
 		if _, _, clusterOnly := ClusterOnlyKindGVR(kind); clusterOnly {
 			return []*unstructured.Unstructured{}, true, nil
 		}
+	}
+	if c.IsDeferredPending(gvr.Resource) {
+		return c.typedDirectList(ctx, gvr, namespace)
 	}
 	var namespaces []string
 	if namespace != "" {
@@ -992,12 +1016,7 @@ func (c *ResourceCache) listTypedAsUnstructured(ctx context.Context, gvr schema.
 			return nil, false, nil
 		}
 		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
-			dynamicCache := GetDynamicResourceCache()
-			if dynamicCache == nil {
-				return nil, true, fmt.Errorf("dynamic resource cache not initialized")
-			}
-			us, derr := dynamicCache.ListDirect(ctx, gvr, namespace)
-			return us, true, derr
+			return c.typedDirectList(ctx, gvr, namespace)
 		}
 		return nil, true, err
 	}

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -938,12 +938,6 @@ func typedObjectToUnstructured(obj runtime.Object, gvr schema.GroupVersionResour
 	return u, nil
 }
 
-// isForbiddenTypedFetch matches the "forbidden: <resource>" sentinel errors
-// FetchResource/FetchResourceList return when a typed lister is nil.
-func isForbiddenTypedFetch(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "forbidden:")
-}
-
 // getTypedAsUnstructured serves a single-object read for a typed built-in
 // kind from the typed cache. Tri-state: a kind whose deferred informer
 // hasn't synced yet falls back to a one-off direct GET — never to starting
@@ -951,11 +945,12 @@ func isForbiddenTypedFetch(err error) bool {
 // handled=false means the typed path can't answer and the caller should fall
 // through to the dynamic cache.
 //
-// The deferred check runs BEFORE the lister read, not on the "forbidden"
-// nil-lister error: several deferred kinds (ServiceAccounts, ReplicaSets,
-// HPAs, LimitRanges, ResourceQuotas) expose a non-nil lister as soon as
-// they're enabled, so during the warmup window they'd otherwise serve
-// empty stores as confident NotFound/empty results.
+// The deferred check runs BEFORE the lister read: several deferred kinds
+// (ServiceAccounts, ReplicaSets, HPAs, LimitRanges, ResourceQuotas) expose
+// a non-nil lister as soon as they're enabled, so during the warmup window
+// they'd otherwise serve empty stores as confident NotFound/empty results.
+// After it, a nil-lister "forbidden" error can only mean the RBAC probe
+// disabled the kind — returned as-is.
 func (c *ResourceCache) getTypedAsUnstructured(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace, name string) (*unstructured.Unstructured, bool, error) {
 	if c.IsDeferredPending(gvr.Resource) {
 		return c.typedDirectGet(ctx, gvr, namespace, name)
@@ -964,9 +959,6 @@ func (c *ResourceCache) getTypedAsUnstructured(ctx context.Context, gvr schema.G
 	if err != nil {
 		if errors.Is(err, ErrUnknownKind) {
 			return nil, false, nil
-		}
-		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
-			return c.typedDirectGet(ctx, gvr, namespace, name)
 		}
 		return nil, true, err
 	}
@@ -1014,9 +1006,6 @@ func (c *ResourceCache) listTypedAsUnstructured(ctx context.Context, gvr schema.
 	if err != nil {
 		if errors.Is(err, ErrUnknownKind) {
 			return nil, false, nil
-		}
-		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
-			return c.typedDirectList(ctx, gvr, namespace)
 		}
 		return nil, true, err
 	}

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -881,8 +882,144 @@ func (c *ResourceCache) ListDynamic(ctx context.Context, kind string, namespace 
 	return c.ListDynamicWithGroup(ctx, kind, namespace, "")
 }
 
+// typedRouteGVR reports whether a dynamic-cache read for (kind, group) must
+// be served by the typed cache instead of spinning up a dynamic informer
+// that would duplicate a typed one (cluster-wide Secrets/ConfigMaps twice is
+// a real memory cost, and the serial informer startups were the dominant
+// cold-path cost of the GitOps tree). Dispatch mirrors the REST/MCP
+// handlers' convention exactly: an explicit group must be owned by the
+// built-in (CRDs whose kind shadows a built-in, e.g. Knative Service, keep
+// their dynamic route); an empty group means "the built-in if this name is
+// built-in".
+func typedRouteGVR(kind, group string) (schema.GroupVersionResource, bool) {
+	if group != "" && !TypedKindOwnsGroup(kind, group) {
+		return schema.GroupVersionResource{}, false
+	}
+	return TypedBuiltinGVR(kind)
+}
+
+// typedObjectToUnstructured converts a typed lister object to unstructured
+// and stamps apiVersion/kind (informer objects carry no TypeMeta). The
+// conversion allocates fresh maps, so the shared informer object is never
+// mutated — which also makes the in-place strip below safe.
+func typedObjectToUnstructured(obj runtime.Object, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error) {
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: m}
+	// Match the dynamic path's outward contract (StripUnstructuredFields):
+	// no managedFields, no kubectl last-applied. The typed informer
+	// transform (DropManagedFields) covers only its explicit kind list —
+	// RBAC kinds among others fall through with last-applied intact, and
+	// exposing it here would leak a full JSON copy of the object into every
+	// tree/list payload. Stripped in place: the converted map is fresh.
+	unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
+	if annotations := u.GetAnnotations(); annotations != nil {
+		if _, ok := annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+			delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+			if len(annotations) == 0 {
+				u.SetAnnotations(nil)
+			} else {
+				u.SetAnnotations(annotations)
+			}
+		}
+	}
+	if u.GetAPIVersion() == "" || u.GetKind() == "" {
+		apiVersion := gvr.Version
+		if gvr.Group != "" {
+			apiVersion = gvr.Group + "/" + gvr.Version
+		}
+		u.SetAPIVersion(apiVersion)
+		if kindName, ok := BuiltinKindForResource(gvr.Resource); ok {
+			u.SetKind(kindName)
+		}
+	}
+	return u, nil
+}
+
+// isForbiddenTypedFetch matches the "forbidden: <resource>" sentinel errors
+// FetchResource/FetchResourceList return when a typed lister is nil.
+func isForbiddenTypedFetch(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "forbidden:")
+}
+
+// getTypedAsUnstructured serves a single-object read for a typed built-in
+// kind from the typed cache. Tri-state on a nil lister: a kind the RBAC
+// probe disabled stays forbidden, while a deferred informer that simply
+// hasn't synced yet (Secrets/ConfigMaps during the phase-2 warmup window)
+// falls back to a one-off direct GET — never to starting a dynamic informer.
+// handled=false means the typed path can't answer and the caller should fall
+// through to the dynamic cache.
+func (c *ResourceCache) getTypedAsUnstructured(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace, name string) (*unstructured.Unstructured, bool, error) {
+	obj, err := FetchResource(c, kind, namespace, name)
+	if err != nil {
+		if errors.Is(err, ErrUnknownKind) {
+			return nil, false, nil
+		}
+		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
+			dynamicCache := GetDynamicResourceCache()
+			if dynamicCache == nil {
+				return nil, true, fmt.Errorf("dynamic resource cache not initialized")
+			}
+			u, derr := dynamicCache.GetDirect(ctx, gvr, namespace, name)
+			return u, true, derr
+		}
+		return nil, true, err
+	}
+	u, cerr := typedObjectToUnstructured(obj, gvr)
+	return u, true, cerr
+}
+
+// listTypedAsUnstructured is the list counterpart of getTypedAsUnstructured,
+// with the same tri-state nil-lister semantics. A namespace filter on a
+// cluster-only kind returns empty to match the dynamic cache's
+// namespace-index behavior (FetchResourceList would ignore the filter and
+// return everything).
+func (c *ResourceCache) listTypedAsUnstructured(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace string) ([]*unstructured.Unstructured, bool, error) {
+	if namespace != "" {
+		if _, _, clusterOnly := ClusterOnlyKindGVR(kind); clusterOnly {
+			return []*unstructured.Unstructured{}, true, nil
+		}
+	}
+	var namespaces []string
+	if namespace != "" {
+		namespaces = []string{namespace}
+	}
+	objs, err := FetchResourceList(c, kind, namespaces)
+	if err != nil {
+		if errors.Is(err, ErrUnknownKind) {
+			return nil, false, nil
+		}
+		if isForbiddenTypedFetch(err) && c.IsDeferredPending(gvr.Resource) {
+			dynamicCache := GetDynamicResourceCache()
+			if dynamicCache == nil {
+				return nil, true, fmt.Errorf("dynamic resource cache not initialized")
+			}
+			us, derr := dynamicCache.ListDirect(ctx, gvr, namespace)
+			return us, true, derr
+		}
+		return nil, true, err
+	}
+	out := make([]*unstructured.Unstructured, 0, len(objs))
+	for _, obj := range objs {
+		u, cerr := typedObjectToUnstructured(obj, gvr)
+		if cerr != nil {
+			return nil, true, cerr
+		}
+		out = append(out, u)
+	}
+	return out, true, nil
+}
+
 // ListDynamicWithGroup returns resources, using the group to disambiguate
 func (c *ResourceCache) ListDynamicWithGroup(ctx context.Context, kind string, namespace string, group string) ([]*unstructured.Unstructured, error) {
+	if gvr, ok := typedRouteGVR(kind, group); ok {
+		if out, handled, err := c.listTypedAsUnstructured(ctx, gvr, kind, namespace); handled {
+			return out, err
+		}
+	}
+
 	discovery := GetResourceDiscovery()
 	if discovery == nil {
 		return nil, fmt.Errorf("resource discovery not initialized")
@@ -961,6 +1098,17 @@ func (c *ResourceCache) GetDynamicWithGroupPreserveLastApplied(ctx context.Conte
 }
 
 func (c *ResourceCache) getDynamicWithGroup(ctx context.Context, kind string, namespace string, name string, group string, preserveLastApplied bool) (*unstructured.Unstructured, error) {
+	// preserveLastApplied must never take the typed route: the typed cache
+	// strips kubectl last-applied at ingestion, so serving drift reads from it
+	// would silently return "no drift" for every built-in kind.
+	if !preserveLastApplied {
+		if gvr, ok := typedRouteGVR(kind, group); ok {
+			if u, handled, err := c.getTypedAsUnstructured(ctx, gvr, kind, namespace, name); handled {
+				return u, err
+			}
+		}
+	}
+
 	discovery := GetResourceDiscovery()
 	if discovery == nil {
 		return nil, fmt.Errorf("resource discovery not initialized")

--- a/internal/k8s/cache_typed_route_test.go
+++ b/internal/k8s/cache_typed_route_test.go
@@ -1,0 +1,269 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestTypedRouteGVRDispatch(t *testing.T) {
+	cases := []struct {
+		kind, group string
+		want        bool
+	}{
+		{"Deployment", "apps", true},
+		{"Deployment", "", true},
+		{"deployment", "apps", true},
+		{"Service", "", true},
+		{"Service", "serving.knative.dev", false}, // Knative Service stays dynamic
+		{"ConfigMap", "", true},
+		{"Prometheus", "monitoring.coreos.com", false},
+		{"Endpoints", "", false},      // typed=false: bypass kind stays dynamic
+		{"EndpointSlice", "discovery.k8s.io", false},
+		{"ClusterRole", "rbac.authorization.k8s.io", true},
+		{"Application", "argoproj.io", false},
+	}
+	for _, tc := range cases {
+		if _, got := typedRouteGVR(tc.kind, tc.group); got != tc.want {
+			t.Errorf("typedRouteGVR(%q, %q) = %v, want %v", tc.kind, tc.group, got, tc.want)
+		}
+	}
+}
+
+// GitOps tree/insights enrichment reads built-in kinds through the dynamic
+// accessors. Those reads must come from the typed cache — a dynamic informer
+// for a typed kind duplicates a cluster-wide watch (double memory for
+// Secrets/ConfigMaps) and its serial startup was the dominant cold-path cost
+// of the GitOps detail page.
+func TestTypedKindsServedFromTypedCacheWithoutDynamicInformer(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	client := fakeclientset.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "billing", Namespace: "prod"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "prod"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "reader"}},
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	if err := InitTestDynamicResourceCache(dyn, nil); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+
+	dep, err := cache.GetDynamicWithGroup(context.Background(), "Deployment", "prod", "billing", "apps")
+	if err != nil {
+		t.Fatalf("GetDynamicWithGroup(Deployment): %v", err)
+	}
+	if dep.GetAPIVersion() != "apps/v1" || dep.GetKind() != "Deployment" {
+		t.Fatalf("Deployment GVK = %s/%s, want apps/v1/Deployment", dep.GetAPIVersion(), dep.GetKind())
+	}
+
+	// Empty group means "the built-in" across the server's dispatch.
+	if _, err := cache.GetDynamicWithGroup(context.Background(), "Deployment", "prod", "billing", ""); err != nil {
+		t.Fatalf("GetDynamicWithGroup(Deployment, no group): %v", err)
+	}
+
+	cms, err := cache.ListDynamicWithGroup(context.Background(), "ConfigMap", "prod", "")
+	if err != nil {
+		t.Fatalf("ListDynamicWithGroup(ConfigMap): %v", err)
+	}
+	if len(cms) != 1 || cms[0].GetKind() != "ConfigMap" || cms[0].GetAPIVersion() != "v1" {
+		t.Fatalf("ConfigMap list = %#v, want one item with v1/ConfigMap GVK", cms)
+	}
+
+	cr, err := cache.GetDynamicWithGroup(context.Background(), "ClusterRole", "", "reader", "rbac.authorization.k8s.io")
+	if err != nil {
+		t.Fatalf("GetDynamicWithGroup(ClusterRole): %v", err)
+	}
+	if cr.GetKind() != "ClusterRole" {
+		t.Fatalf("ClusterRole kind = %q", cr.GetKind())
+	}
+
+	if count := GetDynamicResourceCache().GetInformerCount(); count != 0 {
+		t.Fatalf("typed-kind reads started %d dynamic informer(s), want 0", count)
+	}
+}
+
+// The typed informer transform strips last-applied only for kinds in its
+// explicit switch — RBAC kinds fall through with the annotation intact.
+// The typed route must strip it on the way out or every tree/list payload
+// leaks a full JSON copy of the object (the dynamic path never exposes it).
+func TestTypedRouteStripsLastAppliedAndManagedFields(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	client := fakeclientset.NewSimpleClientset(
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
+			Name: "leaky",
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"kind":"ClusterRole"}`,
+				"keep": "me",
+			},
+		}},
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	if err := InitTestDynamicResourceCache(dyn, nil); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	got, err := GetResourceCache().GetDynamicWithGroup(context.Background(), "ClusterRole", "", "leaky", "rbac.authorization.k8s.io")
+	if err != nil {
+		t.Fatalf("GetDynamicWithGroup: %v", err)
+	}
+	if _, ok := got.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		t.Fatal("typed route leaked kubectl last-applied to an outward reader")
+	}
+	if got.GetAnnotations()["keep"] != "me" {
+		t.Fatalf("other annotations must survive the strip: %v", got.GetAnnotations())
+	}
+	if _, found, _ := unstructured.NestedSlice(got.Object, "metadata", "managedFields"); found {
+		t.Fatal("typed route leaked managedFields")
+	}
+}
+
+func TestTypedKindNotFoundMapsToAPINotFound(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	if err := InitTestResourceCache(fakeclientset.NewSimpleClientset()); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	if err := InitTestDynamicResourceCache(dyn, nil); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	_, err := GetResourceCache().GetDynamicWithGroup(context.Background(), "Deployment", "prod", "missing", "apps")
+	if err == nil {
+		t.Fatal("expected NotFound error")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("error %v is not an apierrors NotFound; HTTP handlers map that to 404", err)
+	}
+}
+
+// A cluster-scoped typed kind listed with a namespace filter must return
+// empty (the dynamic cache's namespace index behavior), not the full
+// cluster-wide set FetchResourceList would produce.
+func TestClusterScopedTypedListWithNamespaceFilterReturnsEmpty(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	client := fakeclientset.NewSimpleClientset(
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "reader"}},
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	if err := InitTestDynamicResourceCache(dyn, nil); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	items, err := GetResourceCache().ListDynamicWithGroup(context.Background(), "ClusterRole", "prod", "rbac.authorization.k8s.io")
+	if err != nil {
+		t.Fatalf("ListDynamicWithGroup: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("namespace-filtered cluster-scoped list returned %d items, want 0", len(items))
+	}
+}
+
+// Drift needs kubectl last-applied, which the typed cache strips at
+// ingestion. The preserve variant must therefore keep its direct-GET path
+// even for typed kinds — routing it typed would silently report "no drift"
+// for every built-in.
+func TestPreserveLastAppliedBypassesTypedCache(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	lastApplied := `{"kind":"Deployment"}`
+	client := fakeclientset.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "billing", Namespace: "prod"}},
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	liveDep := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "billing",
+			"namespace": "prod",
+			"annotations": map[string]any{
+				"kubectl.kubernetes.io/last-applied-configuration": lastApplied,
+			},
+		},
+	}}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "DeploymentList"},
+		liveDep,
+	)
+	if err := InitTestDynamicResourceCache(dyn, []APIResource{{
+		Group: "apps", Version: "v1", Kind: "Deployment", Name: "deployments", Namespaced: true,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	got, err := GetResourceCache().GetDynamicWithGroupPreserveLastApplied(context.Background(), "Deployment", "prod", "billing", "apps")
+	if err != nil {
+		t.Fatalf("GetDynamicWithGroupPreserveLastApplied: %v", err)
+	}
+	if got.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"] != lastApplied {
+		t.Fatalf("last-applied not preserved — the preserve path was routed through the typed cache: %v", got.GetAnnotations())
+	}
+	if count := GetDynamicResourceCache().GetInformerCount(); count != 0 {
+		t.Fatalf("preserve path started %d dynamic informer(s), want direct GET", count)
+	}
+}
+
+// Every kind the typed table marks typed=true must be handled by both
+// FetchResource and FetchResourceList — a table entry without a switch case
+// (IngressClass was one) silently regresses that kind to "unknown" once the
+// dynamic accessors route typed-first.
+func TestTypedBuiltinTableParityWithFetchSwitches(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	if err := InitTestResourceCache(fakeclientset.NewSimpleClientset()); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+
+	seen := map[string]bool{}
+	for form, gvr := range typedBuiltinGVRs {
+		if seen[gvr.Resource] {
+			continue
+		}
+		seen[gvr.Resource] = true
+
+		if _, err := FetchResource(cache, form, "ns", "name"); errors.Is(err, ErrUnknownKind) {
+			t.Errorf("FetchResource(%q → %s) returned ErrUnknownKind; typed table and switch are out of sync", form, gvr.Resource)
+		}
+		if _, err := FetchResourceList(cache, form, nil); errors.Is(err, ErrUnknownKind) {
+			t.Errorf("FetchResourceList(%q → %s) returned ErrUnknownKind; typed table and switch are out of sync", form, gvr.Resource)
+		}
+		if _, ok := BuiltinKindForResource(gvr.Resource); !ok {
+			t.Errorf("BuiltinKindForResource(%q) missing; converted objects would lack a kind", gvr.Resource)
+		}
+	}
+}

--- a/internal/k8s/cache_typed_route_test.go
+++ b/internal/k8s/cache_typed_route_test.go
@@ -262,8 +262,8 @@ func TestTypedBuiltinTableParityWithFetchSwitches(t *testing.T) {
 		if _, err := FetchResourceList(cache, form, nil); errors.Is(err, ErrUnknownKind) {
 			t.Errorf("FetchResourceList(%q → %s) returned ErrUnknownKind; typed table and switch are out of sync", form, gvr.Resource)
 		}
-		if _, ok := BuiltinKindForResource(gvr.Resource); !ok {
-			t.Errorf("BuiltinKindForResource(%q) missing; converted objects would lack a kind", gvr.Resource)
+		if _, ok := builtinKindForResource(gvr.Resource); !ok {
+			t.Errorf("builtinKindForResource(%q) missing; converted objects would lack a kind", gvr.Resource)
 		}
 	}
 }

--- a/internal/k8s/fetch.go
+++ b/internal/k8s/fetch.go
@@ -98,22 +98,22 @@ var builtinGVRs, typedBuiltinGVRs, builtinKindByResource = func() (map[string]sc
 	return m, typed, kinds
 }()
 
-// TypedBuiltinGVR returns the canonical GVR for a built-in kind (or alias)
+// lookupTypedBuiltinGVR returns the canonical GVR for a built-in kind (or alias)
 // that is served by the typed cache, regardless of group. Callers that must
 // be CRD-collision-safe should pair this with a group check (see
 // TypedKindOwnsGroup); an empty group in the caller's hands conventionally
 // means "the built-in resource" across the server (the REST/MCP handlers
 // dispatch the same way).
-func TypedBuiltinGVR(kind string) (schema.GroupVersionResource, bool) {
+func lookupTypedBuiltinGVR(kind string) (schema.GroupVersionResource, bool) {
 	gvr, ok := typedBuiltinGVRs[strings.ToLower(kind)]
 	return gvr, ok
 }
 
-// BuiltinKindForResource returns the canonical CamelCase Kind for a built-in
+// builtinKindForResource returns the canonical CamelCase Kind for a built-in
 // plural resource name ("deployments" → "Deployment"). Used to stamp
 // apiVersion/kind on unstructured conversions of typed lister objects, which
 // carry no TypeMeta.
-func BuiltinKindForResource(resource string) (string, bool) {
+func builtinKindForResource(resource string) (string, bool) {
 	k, ok := builtinKindByResource[resource]
 	return k, ok
 }

--- a/internal/k8s/fetch.go
+++ b/internal/k8s/fetch.go
@@ -36,55 +36,58 @@ var ErrUnknownKind = fmt.Errorf("unknown typed kind")
 //     would silently return nil and drop drift for built-in managed resources.
 //
 // Keep typed=true in sync with the typed switches in this file and internal/server.
-var builtinGVRs, typedBuiltinGVRs = func() (map[string]schema.GroupVersionResource, map[string]schema.GroupVersionResource) {
+var builtinGVRs, typedBuiltinGVRs, builtinKindByResource = func() (map[string]schema.GroupVersionResource, map[string]schema.GroupVersionResource, map[string]string) {
 	defs := []struct {
 		forms    []string
 		group    string
 		version  string
 		resource string
+		kind     string
 		typed    bool
 	}{
-		{[]string{"pod", "pods", "po"}, "", "v1", "pods", true},
-		{[]string{"service", "services", "svc"}, "", "v1", "services", true},
-		{[]string{"configmap", "configmaps", "cm"}, "", "v1", "configmaps", true},
-		{[]string{"secret", "secrets"}, "", "v1", "secrets", true},
-		{[]string{"event", "events"}, "", "v1", "events", true},
-		{[]string{"endpoint", "endpoints", "ep"}, "", "v1", "endpoints", false},
-		{[]string{"persistentvolumeclaim", "persistentvolumeclaims", "pvc", "pvcs"}, "", "v1", "persistentvolumeclaims", true},
-		{[]string{"node", "nodes", "no"}, "", "v1", "nodes", true},
-		{[]string{"namespace", "namespaces", "ns"}, "", "v1", "namespaces", true},
-		{[]string{"persistentvolume", "persistentvolumes", "pv", "pvs"}, "", "v1", "persistentvolumes", true},
-		{[]string{"serviceaccount", "serviceaccounts", "sa"}, "", "v1", "serviceaccounts", true},
-		{[]string{"limitrange", "limitranges"}, "", "v1", "limitranges", true},
-		{[]string{"resourcequota", "resourcequotas"}, "", "v1", "resourcequotas", true},
-		{[]string{"deployment", "deployments", "deploy", "deploys"}, "apps", "v1", "deployments", true},
-		{[]string{"daemonset", "daemonsets", "ds"}, "apps", "v1", "daemonsets", true},
-		{[]string{"statefulset", "statefulsets", "sts"}, "apps", "v1", "statefulsets", true},
-		{[]string{"replicaset", "replicasets", "rs"}, "apps", "v1", "replicasets", true},
-		{[]string{"job", "jobs"}, "batch", "v1", "jobs", true},
-		{[]string{"cronjob", "cronjobs", "cj"}, "batch", "v1", "cronjobs", true},
-		{[]string{"hpa", "hpas", "horizontalpodautoscaler", "horizontalpodautoscalers"}, "autoscaling", "v2", "horizontalpodautoscalers", true},
-		{[]string{"ingress", "ingresses"}, "networking.k8s.io", "v1", "ingresses", true},
-		{[]string{"networkpolicy", "networkpolicies", "netpol", "netpols"}, "networking.k8s.io", "v1", "networkpolicies", true},
-		{[]string{"ingressclass", "ingressclasses"}, "networking.k8s.io", "v1", "ingressclasses", true},
-		{[]string{"endpointslice", "endpointslices"}, "discovery.k8s.io", "v1", "endpointslices", false},
-		{[]string{"lease", "leases"}, "coordination.k8s.io", "v1", "leases", false},
-		{[]string{"priorityclass", "priorityclasses", "pc"}, "scheduling.k8s.io", "v1", "priorityclasses", false},
-		{[]string{"runtimeclass", "runtimeclasses"}, "node.k8s.io", "v1", "runtimeclasses", false},
-		{[]string{"mutatingwebhookconfiguration", "mutatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "mutatingwebhookconfigurations", false},
-		{[]string{"validatingwebhookconfiguration", "validatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "validatingwebhookconfigurations", false},
-		{[]string{"volumeattachment", "volumeattachments"}, "storage.k8s.io", "v1", "volumeattachments", false},
-		{[]string{"poddisruptionbudget", "poddisruptionbudgets", "pdb", "pdbs"}, "policy", "v1", "poddisruptionbudgets", true},
-		{[]string{"storageclass", "storageclasses", "sc"}, "storage.k8s.io", "v1", "storageclasses", true},
-		{[]string{"role", "roles"}, "rbac.authorization.k8s.io", "v1", "roles", true},
-		{[]string{"clusterrole", "clusterroles"}, "rbac.authorization.k8s.io", "v1", "clusterroles", true},
-		{[]string{"rolebinding", "rolebindings"}, "rbac.authorization.k8s.io", "v1", "rolebindings", true},
-		{[]string{"clusterrolebinding", "clusterrolebindings"}, "rbac.authorization.k8s.io", "v1", "clusterrolebindings", true},
+		{[]string{"pod", "pods", "po"}, "", "v1", "pods", "Pod", true},
+		{[]string{"service", "services", "svc"}, "", "v1", "services", "Service", true},
+		{[]string{"configmap", "configmaps", "cm"}, "", "v1", "configmaps", "ConfigMap", true},
+		{[]string{"secret", "secrets"}, "", "v1", "secrets", "Secret", true},
+		{[]string{"event", "events"}, "", "v1", "events", "Event", true},
+		{[]string{"endpoint", "endpoints", "ep"}, "", "v1", "endpoints", "Endpoints", false},
+		{[]string{"persistentvolumeclaim", "persistentvolumeclaims", "pvc", "pvcs"}, "", "v1", "persistentvolumeclaims", "PersistentVolumeClaim", true},
+		{[]string{"node", "nodes", "no"}, "", "v1", "nodes", "Node", true},
+		{[]string{"namespace", "namespaces", "ns"}, "", "v1", "namespaces", "Namespace", true},
+		{[]string{"persistentvolume", "persistentvolumes", "pv", "pvs"}, "", "v1", "persistentvolumes", "PersistentVolume", true},
+		{[]string{"serviceaccount", "serviceaccounts", "sa"}, "", "v1", "serviceaccounts", "ServiceAccount", true},
+		{[]string{"limitrange", "limitranges"}, "", "v1", "limitranges", "LimitRange", true},
+		{[]string{"resourcequota", "resourcequotas"}, "", "v1", "resourcequotas", "ResourceQuota", true},
+		{[]string{"deployment", "deployments", "deploy", "deploys"}, "apps", "v1", "deployments", "Deployment", true},
+		{[]string{"daemonset", "daemonsets", "ds"}, "apps", "v1", "daemonsets", "DaemonSet", true},
+		{[]string{"statefulset", "statefulsets", "sts"}, "apps", "v1", "statefulsets", "StatefulSet", true},
+		{[]string{"replicaset", "replicasets", "rs"}, "apps", "v1", "replicasets", "ReplicaSet", true},
+		{[]string{"job", "jobs"}, "batch", "v1", "jobs", "Job", true},
+		{[]string{"cronjob", "cronjobs", "cj"}, "batch", "v1", "cronjobs", "CronJob", true},
+		{[]string{"hpa", "hpas", "horizontalpodautoscaler", "horizontalpodautoscalers"}, "autoscaling", "v2", "horizontalpodautoscalers", "HorizontalPodAutoscaler", true},
+		{[]string{"ingress", "ingresses"}, "networking.k8s.io", "v1", "ingresses", "Ingress", true},
+		{[]string{"networkpolicy", "networkpolicies", "netpol", "netpols"}, "networking.k8s.io", "v1", "networkpolicies", "NetworkPolicy", true},
+		{[]string{"ingressclass", "ingressclasses"}, "networking.k8s.io", "v1", "ingressclasses", "IngressClass", true},
+		{[]string{"endpointslice", "endpointslices"}, "discovery.k8s.io", "v1", "endpointslices", "EndpointSlice", false},
+		{[]string{"lease", "leases"}, "coordination.k8s.io", "v1", "leases", "Lease", false},
+		{[]string{"priorityclass", "priorityclasses", "pc"}, "scheduling.k8s.io", "v1", "priorityclasses", "PriorityClass", false},
+		{[]string{"runtimeclass", "runtimeclasses"}, "node.k8s.io", "v1", "runtimeclasses", "RuntimeClass", false},
+		{[]string{"mutatingwebhookconfiguration", "mutatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "mutatingwebhookconfigurations", "MutatingWebhookConfiguration", false},
+		{[]string{"validatingwebhookconfiguration", "validatingwebhookconfigurations"}, "admissionregistration.k8s.io", "v1", "validatingwebhookconfigurations", "ValidatingWebhookConfiguration", false},
+		{[]string{"volumeattachment", "volumeattachments"}, "storage.k8s.io", "v1", "volumeattachments", "VolumeAttachment", false},
+		{[]string{"poddisruptionbudget", "poddisruptionbudgets", "pdb", "pdbs"}, "policy", "v1", "poddisruptionbudgets", "PodDisruptionBudget", true},
+		{[]string{"storageclass", "storageclasses", "sc"}, "storage.k8s.io", "v1", "storageclasses", "StorageClass", true},
+		{[]string{"role", "roles"}, "rbac.authorization.k8s.io", "v1", "roles", "Role", true},
+		{[]string{"clusterrole", "clusterroles"}, "rbac.authorization.k8s.io", "v1", "clusterroles", "ClusterRole", true},
+		{[]string{"rolebinding", "rolebindings"}, "rbac.authorization.k8s.io", "v1", "rolebindings", "RoleBinding", true},
+		{[]string{"clusterrolebinding", "clusterrolebindings"}, "rbac.authorization.k8s.io", "v1", "clusterrolebindings", "ClusterRoleBinding", true},
 	}
 	m := make(map[string]schema.GroupVersionResource)
 	typed := make(map[string]schema.GroupVersionResource)
+	kinds := make(map[string]string)
 	for _, d := range defs {
 		gvr := schema.GroupVersionResource{Group: d.group, Version: d.version, Resource: d.resource}
+		kinds[d.resource] = d.kind
 		for _, f := range d.forms {
 			m[f] = gvr
 			if d.typed {
@@ -92,8 +95,28 @@ var builtinGVRs, typedBuiltinGVRs = func() (map[string]schema.GroupVersionResour
 			}
 		}
 	}
-	return m, typed
+	return m, typed, kinds
 }()
+
+// TypedBuiltinGVR returns the canonical GVR for a built-in kind (or alias)
+// that is served by the typed cache, regardless of group. Callers that must
+// be CRD-collision-safe should pair this with a group check (see
+// TypedKindOwnsGroup); an empty group in the caller's hands conventionally
+// means "the built-in resource" across the server (the REST/MCP handlers
+// dispatch the same way).
+func TypedBuiltinGVR(kind string) (schema.GroupVersionResource, bool) {
+	gvr, ok := typedBuiltinGVRs[strings.ToLower(kind)]
+	return gvr, ok
+}
+
+// BuiltinKindForResource returns the canonical CamelCase Kind for a built-in
+// plural resource name ("deployments" → "Deployment"). Used to stamp
+// apiVersion/kind on unstructured conversions of typed lister objects, which
+// carry no TypeMeta.
+func BuiltinKindForResource(resource string) (string, bool) {
+	k, ok := builtinKindByResource[resource]
+	return k, ok
+}
 
 // TypedKindOwnsGroup reports whether (kind, group) names a built-in kind
 // addressed by its own API group — i.e. it must resolve via the typed cache,
@@ -653,6 +676,15 @@ func FetchResourceList(cache *ResourceCache, kind string, namespaces []string) (
 			return nil, err
 		}
 		return ToRuntimeObjects(items), nil
+	case "ingressclasses":
+		if cache.IngressClasses() == nil {
+			return nil, fmt.Errorf("forbidden: ingressclasses")
+		}
+		items, err := cache.IngressClasses().List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
+		return ToRuntimeObjects(items), nil
 	default:
 		return nil, ErrUnknownKind
 	}
@@ -799,6 +831,11 @@ func FetchResource(cache *ResourceCache, kind, namespace, name string) (runtime.
 			return nil, fmt.Errorf("forbidden: clusterrolebindings")
 		}
 		return cache.ClusterRoleBindings().Get(name)
+	case "ingressclasses":
+		if cache.IngressClasses() == nil {
+			return nil, fmt.Errorf("forbidden: ingressclasses")
+		}
+		return cache.IngressClasses().Get(name)
 	default:
 		return nil, ErrUnknownKind
 	}
@@ -868,6 +905,9 @@ func SetTypeMeta(resource any) {
 	case *networkingv1.NetworkPolicy:
 		r.APIVersion = "networking.k8s.io/v1"
 		r.Kind = "NetworkPolicy"
+	case *networkingv1.IngressClass:
+		r.APIVersion = "networking.k8s.io/v1"
+		r.Kind = "IngressClass"
 	case *corev1.ServiceAccount:
 		r.APIVersion = "v1"
 		r.Kind = "ServiceAccount"

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -44,6 +44,9 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 		"rolebindings":             true,
 		"clusterrolebindings":      true,
 		"serviceaccounts":          true,
+		"ingressclasses":           true,
+		"networkpolicies":          true,
+		"limitranges":              true,
 	}
 
 	cfg := k8score.CacheConfig{

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -16,7 +16,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/skyhook-io/radar/internal/argocd"
 	"github.com/skyhook-io/radar/internal/auth"
@@ -111,6 +110,7 @@ func (s *Server) buildGitOpsTree(ctx context.Context, req *gitopsRequest) (*gito
 
 	return gitopstree.NewBuilder(req.Cache, topo).
 		WithAllowedNamespaces(req.AllowedNamespaces).
+		WithUnknownKindMatcher(func(err error) bool { return errors.Is(err, k8s.ErrUnknownDynamicKind) }).
 		Build(ctx, req.Kind, req.Namespace, req.Name, req.Group)
 }
 
@@ -178,6 +178,7 @@ func (s *Server) handleGitOpsInsights(w http.ResponseWriter, r *http.Request) {
 		return s.canAccessGitOpsRef(r, req, group, kind, namespace, name, false)
 	}
 	resolver := newInsightsResolver(r.Context(), req.Cache, req.AllowedNamespaces, canAccess)
+	resolver.prefetchLive(gitopsinsights.ManagedResourceRows(root), gitopsinsights.OperationPhase(root))
 	insight := gitopsinsights.Build(root, tree, resolver)
 	insight.Warnings = appendWarnings(insight.Warnings, tree.Warnings...)
 	insight = s.filterGitOpsInsightForUser(r, req, insight)
@@ -677,10 +678,109 @@ type insightsResolver struct {
 	composeOnce     sync.Once
 	composedFlat    []issues.Issue
 	composedGrouped []issues.Issue
+
+	// livePrefetched flips GetLive into map-only mode: prefetchLive resolved
+	// (or deliberately skipped) every ref the Changes builder will ask for,
+	// so a map miss means gated-out or failed — never "fetch it now". The
+	// per-call direct-GET path survives only for resolvers that never ran
+	// prefetch (tests, future hosts).
+	livePrefetched bool
+	liveObjects    map[string]*unstructured.Unstructured
+
+	// eventIndex replaces the per-resource namespace scan: one pass over the
+	// event lister per request, buckets keyed kind|ns|name. Group filtering
+	// stays at lookup time (eventMatchesGroup) so colliding kinds (core
+	// Service vs Knative Service) don't cross-contaminate buckets.
+	eventsOnce sync.Once
+	eventIndex map[string][]*corev1.Event
 }
 
 func newInsightsResolver(ctx context.Context, cache *k8s.ResourceCache, allowed []string, canAccess func(group, kind, namespace, name string) bool) *insightsResolver {
 	return &insightsResolver{ctx: ctx, cache: cache, allowedNamespaces: allowed, canAccess: canAccess}
+}
+
+// gitopsLiveGETConcurrency bounds process-wide concurrency of the drift
+// live-state GETs (GetDynamicWithGroupPreserveLastApplied is a direct
+// apiserver round-trip by design — caches strip last-applied). Process-wide
+// rather than per-request so N users on N apps can't multiply the fan-out;
+// the rest client's QPS=50/Burst=100 is the second backstop.
+const gitopsLiveGETConcurrency = 16
+
+var gitopsLiveGETSem = make(chan struct{}, gitopsLiveGETConcurrency)
+
+func liveObjectKey(group, kind, namespace, name string) string {
+	return group + "|" + kind + "|" + namespace + "|" + name
+}
+
+// prefetchLive resolves live objects for the rows the Changes builder will
+// request, then flips GetLive to map-only mode. Two gates decide what is
+// fetched at all:
+//
+//   - operation phase: while a sync runs (Running/Terminating — the UI polls
+//     at 2s exactly then), no live state is fetched. Mid-apply drift is
+//     churn, and the poll must stay a pure cache read.
+//   - row state: only rows the controller reports as not cleanly Synced (or
+//     carrying a sync error) are fetched. Drift on a Synced row is the
+//     false-positive class Argo itself suppresses via normalization +
+//     ignoreDifferences.
+//
+// RBAC gates (namespace allowlist + per-ref access) run serially BEFORE any
+// fetch is scheduled — same checks GetLive applied per-call, same caches
+// behind them — so parallelism never widens what a user can read.
+func (r *insightsResolver) prefetchLive(rows []gitopsinsights.ManagedResourceRow, operationPhase string) {
+	r.liveObjects = make(map[string]*unstructured.Unstructured, len(rows))
+	r.livePrefetched = true
+	if operationPhase == "Running" || operationPhase == "Terminating" {
+		return
+	}
+	targets := make([]gitopsinsights.Ref, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row.Sync == "Synced" && !row.HasSyncError {
+			continue
+		}
+		if !r.namespaceAllowed(row.Ref.Namespace) {
+			continue
+		}
+		if r.canAccess != nil && !r.canAccess(row.Ref.Group, row.Ref.Kind, row.Ref.Namespace, row.Ref.Name) {
+			continue
+		}
+		key := liveObjectKey(row.Ref.Group, row.Ref.Kind, row.Ref.Namespace, row.Ref.Name)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, row.Ref)
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, ref := range targets {
+		wg.Add(1)
+		go func(ref gitopsinsights.Ref) {
+			defer wg.Done()
+			gitopsLiveGETSem <- struct{}{}
+			defer func() { <-gitopsLiveGETSem }()
+
+			obj, err := r.cache.GetDynamicWithGroupPreserveLastApplied(r.ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
+			if err != nil {
+				// Unknown-kind misses were already surfaced by the tree
+				// build's response warning; NotFound is a normal state for
+				// Missing resources. Everything else is worth one line.
+				if !apierrors.IsNotFound(err) && !errors.Is(err, k8s.ErrUnknownDynamicKind) {
+					log.Printf("[gitops] insights live prefetch %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+				}
+				return
+			}
+			mu.Lock()
+			r.liveObjects[liveObjectKey(ref.Group, ref.Kind, ref.Namespace, ref.Name)] = obj
+			mu.Unlock()
+		}(ref)
+	}
+	wg.Wait()
 }
 
 // recentEventsCap bounds events returned per resource. Beyond ~5 the user
@@ -691,6 +791,13 @@ const recentEventsCap = 5
 func (r *insightsResolver) GetLive(group, kind, namespace, name string) *unstructured.Unstructured {
 	if r == nil || r.cache == nil || name == "" || kind == "" {
 		return nil
+	}
+	if r.livePrefetched {
+		// Map-only: prefetchLive already resolved (or deliberately gated
+		// out) every ref the Changes builder asks for. Falling back to a
+		// direct GET here would silently rebuild the serial per-resource
+		// fan-out this path exists to remove.
+		return r.liveObjects[liveObjectKey(group, kind, namespace, name)]
 	}
 	if !r.namespaceAllowed(namespace) {
 		return nil
@@ -742,6 +849,24 @@ func (r *insightsResolver) ResourceProblems(group, kind, namespace, name string)
 	return out
 }
 
+// buildEventIndex runs once per resolver: a single pass over the event
+// lister into buckets keyed kind|ns|name. The previous shape listed and
+// scanned the namespace's full event set once per managed resource —
+// O(resources × events) per request, which becomes the dominant CPU cost
+// once the live-GET fan-out is gone.
+func (r *insightsResolver) buildEventIndex() {
+	r.eventIndex = map[string][]*corev1.Event{}
+	items, err := r.cache.Events().List(labels.Everything())
+	if err != nil {
+		log.Printf("[gitops] insights event index build failed: %v", err)
+		return
+	}
+	for _, e := range items {
+		key := e.InvolvedObject.Kind + "|" + e.InvolvedObject.Namespace + "|" + e.InvolvedObject.Name
+		r.eventIndex[key] = append(r.eventIndex[key], e)
+	}
+}
+
 func (r *insightsResolver) RecentEvents(group, kind, namespace, name string) []gitopsinsights.EventSummary {
 	if r == nil || r.cache == nil || r.cache.Events() == nil {
 		return nil
@@ -752,40 +877,14 @@ func (r *insightsResolver) RecentEvents(group, kind, namespace, name string) []g
 	if r.canAccess != nil && !r.canAccess(group, kind, namespace, name) {
 		return nil
 	}
-	// Lister scope: namespace-scoped lookup is cheaper than cluster-wide
-	// + filter; cluster-scoped resources (namespace="") fall back to the
-	// cross-namespace lister and are matched only by kind+name.
-	var events []runtime.Object
-	if namespace != "" {
-		items, err := r.cache.Events().Events(namespace).List(labels.Everything())
-		if err != nil {
-			log.Printf("[gitops] insights RecentEvents list ns=%s %s/%s/%s failed: %v", namespace, group, kind, name, err)
-			return nil
-		}
-		events = make([]runtime.Object, 0, len(items))
-		for _, e := range items {
-			events = append(events, e)
-		}
-	} else {
-		items, err := r.cache.Events().List(labels.Everything())
-		if err != nil {
-			log.Printf("[gitops] insights RecentEvents cluster-list %s/%s/%s failed: %v", group, kind, name, err)
-			return nil
-		}
-		events = make([]runtime.Object, 0, len(items))
-		for _, e := range items {
-			events = append(events, e)
-		}
-	}
-	matched := make([]*corev1.Event, 0, recentEventsCap)
-	for _, ro := range events {
-		e, ok := ro.(*corev1.Event)
-		if !ok {
-			continue
-		}
-		if e.InvolvedObject.Kind != kind || e.InvolvedObject.Name != name {
-			continue
-		}
+	r.eventsOnce.Do(r.buildEventIndex)
+	// Group filtering happens inside the bucket: the index key deliberately
+	// omits group so events whose involvedObject.apiVersion is empty (some
+	// informers strip it) still land next to their resource, matching the
+	// old scan's eventMatchesGroup semantics for colliding kinds.
+	bucket := r.eventIndex[kind+"|"+namespace+"|"+name]
+	matched := make([]*corev1.Event, 0, len(bucket))
+	for _, e := range bucket {
 		if !eventMatchesGroup(group, e.InvolvedObject.APIVersion) {
 			continue
 		}

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -872,21 +872,53 @@ func (r *insightsResolver) ResourceProblems(group, kind, namespace, name string)
 }
 
 // buildEventIndex runs once per resolver: a single pass over the event
-// lister into buckets keyed kind|ns|name. The previous shape listed and
-// scanned the namespace's full event set once per managed resource —
-// O(resources × events) per request, which becomes the dominant CPU cost
-// once the live-GET fan-out is gone.
+// lister into buckets. The previous shape listed and scanned the
+// namespace's full event set once per managed resource — O(resources ×
+// events) per request, which becomes the dominant CPU cost once the
+// live-GET fan-out is gone.
 func (r *insightsResolver) buildEventIndex() {
-	r.eventIndex = map[string][]*corev1.Event{}
 	items, err := r.cache.Events().List(labels.Everything())
 	if err != nil {
 		log.Printf("[gitops] insights event index build failed: %v", err)
+		r.eventIndex = map[string][]*corev1.Event{}
 		return
 	}
+	r.eventIndex = indexEventsByInvolvedObject(items)
+}
+
+// indexEventsByInvolvedObject buckets events by involvedObject kind|name
+// ONLY. Namespace filtering happens at lookup time against the EVENT's own
+// namespace — matching the old per-resource scan, which listed the
+// resource's namespace (event.Namespace scoping) and matched involvedObject
+// by kind+name alone. Keying on involvedObject.Namespace instead would drop
+// events from controllers that leave it empty; the group stays out of the
+// key for the same reason (some informers strip apiVersion).
+func indexEventsByInvolvedObject(items []*corev1.Event) map[string][]*corev1.Event {
+	idx := make(map[string][]*corev1.Event, len(items))
 	for _, e := range items {
-		key := e.InvolvedObject.Kind + "|" + e.InvolvedObject.Namespace + "|" + e.InvolvedObject.Name
-		r.eventIndex[key] = append(r.eventIndex[key], e)
+		key := e.InvolvedObject.Kind + "|" + e.InvolvedObject.Name
+		idx[key] = append(idx[key], e)
 	}
+	return idx
+}
+
+// matchIndexedEvents reproduces the old scan's semantics over a bucket:
+// namespace != "" keeps only events living in that namespace (the old code
+// used a namespace-scoped lister); namespace == "" (cluster-scoped ref)
+// matches across all namespaces; group filters via eventMatchesGroup.
+func matchIndexedEvents(index map[string][]*corev1.Event, group, kind, namespace, name string) []*corev1.Event {
+	bucket := index[kind+"|"+name]
+	matched := make([]*corev1.Event, 0, len(bucket))
+	for _, e := range bucket {
+		if namespace != "" && e.Namespace != namespace {
+			continue
+		}
+		if !eventMatchesGroup(group, e.InvolvedObject.APIVersion) {
+			continue
+		}
+		matched = append(matched, e)
+	}
+	return matched
 }
 
 func (r *insightsResolver) RecentEvents(group, kind, namespace, name string) []gitopsinsights.EventSummary {
@@ -900,18 +932,7 @@ func (r *insightsResolver) RecentEvents(group, kind, namespace, name string) []g
 		return nil
 	}
 	r.eventsOnce.Do(r.buildEventIndex)
-	// Group filtering happens inside the bucket: the index key deliberately
-	// omits group so events whose involvedObject.apiVersion is empty (some
-	// informers strip it) still land next to their resource, matching the
-	// old scan's eventMatchesGroup semantics for colliding kinds.
-	bucket := r.eventIndex[kind+"|"+namespace+"|"+name]
-	matched := make([]*corev1.Event, 0, len(bucket))
-	for _, e := range bucket {
-		if !eventMatchesGroup(group, e.InvolvedObject.APIVersion) {
-			continue
-		}
-		matched = append(matched, e)
-	}
+	matched := matchIndexedEvents(r.eventIndex, group, kind, namespace, name)
 	// Newest-first by lastTimestamp (falls back to eventTime / firstTimestamp
 	// for events that don't fill it). Cap to recentEventsCap after sort so
 	// we always return the most recent ones.

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -756,30 +756,51 @@ func (r *insightsResolver) prefetchLive(rows []gitopsinsights.ManagedResourceRow
 		return
 	}
 
+	// Fixed worker pool, not goroutine-per-ref, so a huge app costs at most
+	// gitopsLiveGETConcurrency goroutines per request. Each unit of work
+	// still acquires the process-wide semaphore (shared across requests),
+	// respecting request cancellation while it waits.
+	workers := gitopsLiveGETConcurrency
+	if len(targets) < workers {
+		workers = len(targets)
+	}
+	work := make(chan gitopsinsights.Ref)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
-	for _, ref := range targets {
+	for i := 0; i < workers; i++ {
 		wg.Add(1)
-		go func(ref gitopsinsights.Ref) {
+		go func() {
 			defer wg.Done()
-			gitopsLiveGETSem <- struct{}{}
-			defer func() { <-gitopsLiveGETSem }()
-
-			obj, err := r.cache.GetDynamicWithGroupPreserveLastApplied(r.ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
-			if err != nil {
-				// Unknown-kind misses were already surfaced by the tree
-				// build's response warning; NotFound is a normal state for
-				// Missing resources. Everything else is worth one line.
-				if !apierrors.IsNotFound(err) && !errors.Is(err, k8s.ErrUnknownDynamicKind) {
-					log.Printf("[gitops] insights live prefetch %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+			for ref := range work {
+				select {
+				case gitopsLiveGETSem <- struct{}{}:
+				case <-r.ctx.Done():
+					return
 				}
-				return
+				obj, err := r.cache.GetDynamicWithGroupPreserveLastApplied(r.ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
+				<-gitopsLiveGETSem
+				if err != nil {
+					// Unknown-kind misses were already surfaced by the tree
+					// build's response warning; NotFound is a normal state for
+					// Missing resources. Everything else is worth one line.
+					if !apierrors.IsNotFound(err) && !errors.Is(err, k8s.ErrUnknownDynamicKind) {
+						log.Printf("[gitops] insights live prefetch %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+					}
+					continue
+				}
+				mu.Lock()
+				r.liveObjects[liveObjectKey(ref.Group, ref.Kind, ref.Namespace, ref.Name)] = obj
+				mu.Unlock()
 			}
-			mu.Lock()
-			r.liveObjects[liveObjectKey(ref.Group, ref.Kind, ref.Namespace, ref.Name)] = obj
-			mu.Unlock()
-		}(ref)
+		}()
 	}
+	for _, ref := range targets {
+		select {
+		case work <- ref:
+		case <-r.ctx.Done():
+		}
+	}
+	close(work)
 	wg.Wait()
 }
 

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skyhook-io/radar/pkg/argoapi"
 	gitopsinsights "github.com/skyhook-io/radar/pkg/gitops/insights"
 	gitopstree "github.com/skyhook-io/radar/pkg/gitops/tree"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -783,7 +784,7 @@ func (r *insightsResolver) prefetchLive(rows []gitopsinsights.ManagedResourceRow
 					// Unknown-kind misses were already surfaced by the tree
 					// build's response warning; NotFound is a normal state for
 					// Missing resources. Everything else is worth one line.
-					if !apierrors.IsNotFound(err) && !errors.Is(err, k8s.ErrUnknownDynamicKind) {
+					if !apierrors.IsNotFound(err) && !errors.Is(err, k8score.ErrResourceNotFound) && !errors.Is(err, k8s.ErrUnknownDynamicKind) {
 						log.Printf("[gitops] insights live prefetch %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
 					}
 					continue

--- a/internal/server/gitops_prefetch_test.go
+++ b/internal/server/gitops_prefetch_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -185,5 +187,42 @@ func TestManagedResourceRowsAndOperationPhase(t *testing.T) {
 	}
 	if phase := gitopsinsights.OperationPhase(app); phase != "Running" {
 		t.Fatalf("OperationPhase = %q, want Running", phase)
+	}
+}
+
+// The index must reproduce the old per-resource scan exactly: events are
+// matched by involvedObject kind+name within the EVENT's own namespace —
+// involvedObject.namespace is deliberately not consulted (controllers can
+// leave it empty), and a cluster-scoped ref (namespace "") matches across
+// all namespaces.
+func TestMatchIndexedEventsNamespaceSemantics(t *testing.T) {
+	ev := func(ns, kind, name, involvedNS, reason string) *corev1.Event {
+		return &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: ns, Name: reason + "-ev"},
+			InvolvedObject: corev1.ObjectReference{Kind: kind, Name: name, Namespace: involvedNS},
+			Reason:         reason,
+		}
+	}
+	idx := indexEventsByInvolvedObject([]*corev1.Event{
+		ev("prod", "Deployment", "billing", "prod", "InNS"),
+		ev("prod", "Deployment", "billing", "", "EmptyInvolvedNS"),
+		ev("staging", "Deployment", "billing", "staging", "OtherNS"),
+		ev("", "ClusterRole", "reader", "", "ClusterScoped"),
+	})
+
+	got := matchIndexedEvents(idx, "apps", "Deployment", "prod", "billing")
+	reasons := map[string]bool{}
+	for _, e := range got {
+		reasons[e.Reason] = true
+	}
+	if !reasons["InNS"] || !reasons["EmptyInvolvedNS"] {
+		t.Fatalf("events in the ref's namespace must match regardless of involvedObject.namespace: %v", reasons)
+	}
+	if reasons["OtherNS"] {
+		t.Fatal("event living in another namespace must not match a namespaced ref")
+	}
+
+	if got := matchIndexedEvents(idx, "", "ClusterRole", "", "reader"); len(got) != 1 {
+		t.Fatalf("cluster-scoped ref should match across namespaces, got %d", len(got))
 	}
 }

--- a/internal/server/gitops_prefetch_test.go
+++ b/internal/server/gitops_prefetch_test.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	gitopsinsights "github.com/skyhook-io/radar/pkg/gitops/insights"
+)
+
+const testLastApplied = `{"kind":"Deployment","spec":{"replicas":1}}`
+
+// prefetchTestEnv wires the dynamic test cache with one live Deployment
+// carrying last-applied, and returns the fake dynamic client so tests can
+// count the direct GETs prefetchLive issued. The typed cache is TestMain's
+// shared package fixture — do NOT re-init or reset it here; that would tear
+// down the fixture every later test in the package depends on.
+func prefetchTestEnv(t *testing.T) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	liveDep := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "billing",
+			"namespace": "prod",
+			"annotations": map[string]any{
+				"kubectl.kubernetes.io/last-applied-configuration": testLastApplied,
+			},
+		},
+	}}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "DeploymentList"},
+		liveDep,
+	)
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{{
+		Group: "apps", Version: "v1", Kind: "Deployment", Name: "deployments", Namespaced: true,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+	return dyn
+}
+
+// resolverCache returns the package fixture's typed cache; the resolver only
+// needs it non-nil (preserve-last-applied GETs go through the dynamic
+// singleton wired above).
+func resolverCache() *k8s.ResourceCache {
+	return k8s.GetResourceCache()
+}
+
+func countGets(dyn *dynamicfake.FakeDynamicClient) int {
+	n := 0
+	for _, a := range dyn.Actions() {
+		if a.GetVerb() == "get" {
+			n++
+		}
+	}
+	return n
+}
+
+func outOfSyncRow() gitopsinsights.ManagedResourceRow {
+	return gitopsinsights.ManagedResourceRow{
+		Ref:  gitopsinsights.Ref{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"},
+		Sync: "OutOfSync",
+	}
+}
+
+func TestPrefetchLiveFetchesOutOfSyncRow(t *testing.T) {
+	dyn := prefetchTestEnv(t)
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
+
+	if got := countGets(dyn); got != 1 {
+		t.Fatalf("prefetch issued %d GETs, want 1", got)
+	}
+	live := r.GetLive("apps", "Deployment", "prod", "billing")
+	if live == nil {
+		t.Fatal("GetLive returned nil for prefetched ref")
+	}
+	if live.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"] != testLastApplied {
+		t.Fatalf("prefetched object lost last-applied: %v", live.GetAnnotations())
+	}
+	// Map-only mode: a second GetLive must not issue another GET.
+	_ = r.GetLive("apps", "Deployment", "prod", "billing")
+	if got := countGets(dyn); got != 1 {
+		t.Fatalf("GetLive after prefetch issued extra GETs (total %d, want 1)", got)
+	}
+}
+
+// While a sync operation runs, the UI polls insights every 2s purely to
+// track progress — the poll must be a cache read, not an apiserver fan-out.
+func TestPrefetchLiveSkipsAllFetchesWhileOperationRuns(t *testing.T) {
+	dyn := prefetchTestEnv(t)
+	for _, phase := range []string{"Running", "Terminating"} {
+		r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+		r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, phase)
+		if got := countGets(dyn); got != 0 {
+			t.Fatalf("phase %s: prefetch issued %d GETs, want 0", phase, got)
+		}
+		if live := r.GetLive("apps", "Deployment", "prod", "billing"); live != nil {
+			t.Fatalf("phase %s: GetLive fell back to a direct fetch", phase)
+		}
+	}
+}
+
+// Synced rows without a sync error carry no drift signal worth a round-trip
+// — Argo's own normalization suppresses what a last-applied diff would show.
+func TestPrefetchLiveSkipsCleanlySyncedRows(t *testing.T) {
+	dyn := prefetchTestEnv(t)
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r.prefetchLive([]gitopsinsights.ManagedResourceRow{{
+		Ref:  gitopsinsights.Ref{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"},
+		Sync: "Synced",
+	}}, "")
+	if got := countGets(dyn); got != 0 {
+		t.Fatalf("prefetch issued %d GETs for a Synced row, want 0", got)
+	}
+
+	// A Synced row that recorded a sync error is still worth the fetch.
+	r2 := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r2.prefetchLive([]gitopsinsights.ManagedResourceRow{{
+		Ref:          gitopsinsights.Ref{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"},
+		Sync:         "Synced",
+		HasSyncError: true,
+	}}, "")
+	if got := countGets(dyn); got != 1 {
+		t.Fatalf("prefetch issued %d GETs for a Synced row with sync error, want 1", got)
+	}
+}
+
+// RBAC gates run before any fetch is scheduled: parallelism must never widen
+// what a user can read, and a denied ref must not cost a round-trip.
+func TestPrefetchLiveHonorsRBACGatesBeforeFetching(t *testing.T) {
+	dyn := prefetchTestEnv(t)
+
+	denyAll := func(group, kind, namespace, name string) bool { return false }
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, denyAll)
+	r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
+	if got := countGets(dyn); got != 0 {
+		t.Fatalf("prefetch issued %d GETs for access-denied ref, want 0", got)
+	}
+	if live := r.GetLive("apps", "Deployment", "prod", "billing"); live != nil {
+		t.Fatal("GetLive returned an object the access gate denied")
+	}
+
+	// Namespace allowlist gate: ref outside the allowed set is not fetched.
+	r2 := newInsightsResolver(context.Background(), resolverCache(), []string{"other"}, nil)
+	r2.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
+	if got := countGets(dyn); got != 0 {
+		t.Fatalf("prefetch issued %d GETs for ref outside namespace allowlist, want 0", got)
+	}
+}
+
+func TestManagedResourceRowsAndOperationPhase(t *testing.T) {
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "a", "namespace": "argocd"},
+		"status": map[string]any{
+			"operationState": map[string]any{"phase": "Running"},
+			"resources": []any{
+				map[string]any{"group": "apps", "kind": "Deployment", "namespace": "prod", "name": "billing", "status": "OutOfSync"},
+				map[string]any{"kind": "Service", "namespace": "prod", "name": "billing", "status": "Synced",
+					"syncResult": map[string]any{"status": "SyncFailed", "message": "webhook denied"}},
+				map[string]any{"kind": "", "name": "dropped"},
+			},
+		},
+	}}
+	rows := gitopsinsights.ManagedResourceRows(app)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (kindless row dropped): %#v", len(rows), rows)
+	}
+	if rows[0].Sync != "OutOfSync" || rows[0].HasSyncError {
+		t.Fatalf("row 0 = %#v", rows[0])
+	}
+	if !rows[1].HasSyncError {
+		t.Fatalf("row 1 should flag sync error: %#v", rows[1])
+	}
+	if phase := gitopsinsights.OperationPhase(app); phase != "Running" {
+		t.Fatalf("OperationPhase = %q, want Running", phase)
+	}
+}

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/settings"
+	gitopstree "github.com/skyhook-io/radar/pkg/gitops/tree"
 )
 
 // NamespaceScopeMode is the closed enum the frontend's `mode` discriminator
@@ -168,6 +169,7 @@ func (s *Server) invalidatePostContextSwitchCaches() {
 	clearPackagesCache()
 	clearApplicationsCache()
 	s.vitalsMetrics.clear()
+	gitopstree.ResetUnknownKindLogDedup()
 }
 
 // loadSavedNamespacePreference seeds the per-user map on first reach.

--- a/pkg/gitops/insights/insights.go
+++ b/pkg/gitops/insights/insights.go
@@ -876,6 +876,63 @@ func ignoreDifferenceKindLabel(group, kind string) string {
 	return group + "/" + kind
 }
 
+// ManagedResourceRow is the minimal projection of one Argo Application
+// status.resources entry — just enough for a host to decide which resources
+// deserve a live-state fetch (drift is only meaningful where the controller
+// reports the row as not cleanly Synced) without building full Changes.
+type ManagedResourceRow struct {
+	Ref          Ref
+	Sync         string
+	HasSyncError bool
+}
+
+// ManagedResourceRows parses status.resources into rows. Same source and
+// filtering as the Changes builder (rows without kind+name are dropped);
+// hosts use it to schedule the Resolver's live-state prefetch before Build.
+func ManagedResourceRows(root *unstructured.Unstructured) []ManagedResourceRow {
+	if root == nil {
+		return nil
+	}
+	raw, _, _ := unstructured.NestedSlice(root.Object, "status", "resources")
+	out := make([]ManagedResourceRow, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		ref := Ref{
+			Group:     gitops.StringValue(m["group"]),
+			Kind:      gitops.StringValue(m["kind"]),
+			Namespace: gitops.StringValue(m["namespace"]),
+			Name:      gitops.StringValue(m["name"]),
+		}
+		if ref.Kind == "" || ref.Name == "" {
+			continue
+		}
+		row := ManagedResourceRow{Ref: ref, Sync: gitops.StringValue(m["status"])}
+		if sr, ok := m["syncResult"].(map[string]any); ok {
+			status := gitops.StringValue(sr["status"])
+			if status != "Synced" && status != "Pruned" && gitops.StringValue(sr["message"]) != "" {
+				row.HasSyncError = true
+			}
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// OperationPhase returns status.operationState.phase ("" when absent).
+// Hosts use it to skip live-state enrichment while a sync is in flight —
+// the 2s progress poll should be a cache read, not an apiserver fan-out,
+// and mid-apply drift is churn rather than signal.
+func OperationPhase(root *unstructured.Unstructured) string {
+	if root == nil {
+		return ""
+	}
+	phase, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "phase")
+	return phase
+}
+
 func argoResourceChanges(root *unstructured.Unstructured, resolver Resolver) []Change {
 	raw, _, _ := unstructured.NestedSlice(root.Object, "status", "resources")
 	// Pre-parse the Application's spec.ignoreDifferences so each resource's

--- a/pkg/gitops/tree/builder.go
+++ b/pkg/gitops/tree/builder.go
@@ -6,11 +6,25 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/skyhook-io/radar/pkg/topology"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// enrichConcurrency bounds the parallel live-object enrichment fan-out per
+// build. Most lookups are informer-cache hits (microseconds); the bound
+// exists for the slow minority — first-touch informer warmup for CRD kinds
+// and the CustomResourceDefinition/APIService direct-GET bypass — so a large
+// app can't open unbounded apiserver connections.
+const enrichConcurrency = 8
+
+// ErrUnknownKindMatcher lets the builder classify provider errors without
+// importing internal packages: hosts inject the sentinel their DynamicGetter
+// returns for kinds missing from API discovery. Nil means no classification
+// (every error is treated as ordinary).
+type ErrUnknownKindMatcher func(error) bool
 
 // DynamicGetter is the small dynamic-cache surface needed by the tree builder.
 type DynamicGetter interface {
@@ -22,6 +36,7 @@ type Builder struct {
 	dynamic           DynamicGetter
 	topo              *topology.Topology
 	allowedNamespaces []string
+	isUnknownKind     ErrUnknownKindMatcher
 }
 
 func NewBuilder(dynamic DynamicGetter, topo *topology.Topology) *Builder {
@@ -32,6 +47,16 @@ func NewBuilder(dynamic DynamicGetter, topo *topology.Topology) *Builder {
 // is allowed to inspect. nil means all namespaces; an empty slice means none.
 func (b *Builder) WithAllowedNamespaces(namespaces []string) *Builder {
 	b.allowedNamespaces = namespaces
+	return b
+}
+
+// WithUnknownKindMatcher wires the host's unknown-kind sentinel classifier
+// (typically errors.Is against the dynamic cache's ErrUnknownDynamicKind).
+// When set, refs whose kind is missing from API discovery are fetched once
+// per kind instead of once per resource, logged once per kind per process,
+// and surfaced as a single response warning.
+func (b *Builder) WithUnknownKindMatcher(m ErrUnknownKindMatcher) *Builder {
+	b.isUnknownKind = m
 	return b
 }
 
@@ -97,10 +122,23 @@ func (b *Builder) Build(ctx context.Context, kind, namespace, name, group string
 		nodes[rootNode.ID] = mergeData(rootNode, liveRoot.Data)
 	}
 
+	var fluxRelated []relatedResource
+	if tool == ToolFluxCD {
+		fluxRelated = fluxRelatedResources(root)
+	}
+	enrichRefs := make([]ResourceRef, 0, len(managed)+len(fluxRelated))
+	for _, res := range managed {
+		enrichRefs = append(enrichRefs, res.Ref)
+	}
+	for _, res := range fluxRelated {
+		enrichRefs = append(enrichRefs, res.Ref)
+	}
+	objects, unknownKinds := b.prefetchObjects(ctx, enrichRefs)
+
 	for _, res := range managed {
 		id := nodeID(res.Ref)
 		declaredIDs[id] = true
-		obj := b.getAllowedObject(ctx, res.Ref)
+		obj := objects[refKey(res.Ref)]
 		if live, ok := findTopoNode(topoByRef, res.Ref); ok {
 			nodes[id] = mergeData(enrichNodeFromObject(nodeFromTopology(live, res.Ref, RoleDeclared, tool, res.Sync, res.Health), obj), res.Data)
 			topoIDByTreeID[id] = live.ID
@@ -111,12 +149,12 @@ func (b *Builder) Build(ctx context.Context, kind, namespace, name, group string
 	}
 
 	if tool == ToolFluxCD {
-		for _, res := range fluxRelatedResources(root) {
+		for _, res := range fluxRelated {
 			id := nodeID(res.Ref)
 			if id == rootNode.ID {
 				continue
 			}
-			obj := b.getAllowedObject(ctx, res.Ref)
+			obj := objects[refKey(res.Ref)]
 			// Derive sync/health from the related CR's own Ready/Reconciling/
 			// Stalled conditions. Without this, source CRs render with empty
 			// Health and the frontend falls back to the generic topology
@@ -214,27 +252,148 @@ func (b *Builder) Build(ctx context.Context, kind, namespace, name, group string
 	if r, ok := nodes[rootNode.ID]; ok {
 		mergedRoot = r
 	}
+	warnings := b.topoWarnings()
+	if w := unknownKindsWarning(unknownKinds); w != "" {
+		warnings = append(append([]string{}, warnings...), w)
+	}
 	return &ResourceTree{
 		Root:     mergedRoot,
 		Nodes:    nodeList,
 		Edges:    edgeList,
-		Warnings: b.topoWarnings(),
+		Warnings: warnings,
 		Summary:  summary,
 	}, root, nil
 }
 
-func (b *Builder) getAllowedObject(ctx context.Context, ref ResourceRef) *unstructured.Unstructured {
-	if ref.Name == "" || !b.canEnrich(ref) {
-		return nil
+// unknownKindLog dedupes the "kind unavailable in discovery" log line
+// process-wide: the GitOps detail page rebuilds the tree on every poll tick,
+// so per-build logging still floods at 30 lines/min per absent kind. The
+// response Warning (per build) is the user-facing signal; the log is for
+// operators. Reset on kubeconfig context switch — a kind absent in one
+// cluster may be absent in the next for a different reason, and that is
+// worth one fresh line.
+var unknownKindLog = struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+}{seen: map[string]struct{}{}}
+
+func logUnknownKindOnce(kind, group string) {
+	key := kind + "|" + group
+	unknownKindLog.mu.Lock()
+	defer unknownKindLog.mu.Unlock()
+	if _, ok := unknownKindLog.seen[key]; ok {
+		return
 	}
-	obj, err := b.dynamic.GetDynamicWithGroup(ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Printf("[gitops/tree] enrich %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+	unknownKindLog.seen[key] = struct{}{}
+	log.Printf("[gitops/tree] kind %s (group %q) is unavailable in this cluster's API discovery; skipping live enrichment for its resources", kind, group)
+}
+
+// ResetUnknownKindLogDedup clears the process-wide unknown-kind log dedup.
+// Hosts call it when the connected cluster changes.
+func ResetUnknownKindLogDedup() {
+	unknownKindLog.mu.Lock()
+	defer unknownKindLog.mu.Unlock()
+	unknownKindLog.seen = map[string]struct{}{}
+}
+
+// prefetchObjects resolves the live object for every enrichable ref with
+// bounded parallelism, returning them keyed by refKey. Kinds the matcher
+// classifies as unknown-to-discovery are negative-cached so one absent CRD
+// costs one lookup instead of one per resource, and are returned (sorted)
+// for the caller's response warning.
+//
+// Enrichment stays best-effort: per-ref failures nil out that ref's entry
+// exactly like the serial loop did. Determinism of the final tree is owned
+// by materialize's sort, so fetch-completion order is irrelevant.
+func (b *Builder) prefetchObjects(ctx context.Context, refs []ResourceRef) (map[string]*unstructured.Unstructured, []string) {
+	targets := make([]ResourceRef, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if ref.Name == "" || !b.canEnrich(ref) {
+			continue
 		}
-		return nil
+		key := refKey(ref)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, ref)
 	}
-	return obj
+	if len(targets) == 0 {
+		return map[string]*unstructured.Unstructured{}, nil
+	}
+
+	var (
+		mu           sync.Mutex
+		objects      = make(map[string]*unstructured.Unstructured, len(targets))
+		unknownKinds = map[string]struct{}{}
+	)
+	kindKey := func(ref ResourceRef) string { return ref.Kind + "|" + ref.Group }
+
+	sem := make(chan struct{}, enrichConcurrency)
+	var wg sync.WaitGroup
+	for _, ref := range targets {
+		wg.Add(1)
+		go func(ref ResourceRef) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			mu.Lock()
+			_, skip := unknownKinds[kindKey(ref)]
+			mu.Unlock()
+			if skip {
+				return
+			}
+
+			obj, err := b.dynamic.GetDynamicWithGroup(ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
+			if err != nil {
+				if b.isUnknownKind != nil && b.isUnknownKind(err) {
+					mu.Lock()
+					unknownKinds[kindKey(ref)] = struct{}{}
+					mu.Unlock()
+					logUnknownKindOnce(ref.Kind, ref.Group)
+				} else if !apierrors.IsNotFound(err) {
+					log.Printf("[gitops/tree] enrich %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+				}
+				return
+			}
+			mu.Lock()
+			objects[refKey(ref)] = obj
+			mu.Unlock()
+		}(ref)
+	}
+	wg.Wait()
+
+	if len(unknownKinds) == 0 {
+		return objects, nil
+	}
+	labels := make([]string, 0, len(unknownKinds))
+	for k := range unknownKinds {
+		parts := strings.SplitN(k, "|", 2)
+		label := parts[0]
+		if len(parts) == 2 && parts[1] != "" {
+			label = parts[0] + " (" + parts[1] + ")"
+		}
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return objects, labels
+}
+
+// unknownKindsWarning renders the response warning for kinds that are absent
+// from the cluster's API discovery. Deliberately says "unavailable" rather
+// than "not installed": incomplete discovery, RBAC-limited discovery, and a
+// remote-cluster Argo destination all produce the same miss.
+func unknownKindsWarning(kinds []string) string {
+	if len(kinds) == 0 {
+		return ""
+	}
+	noun := "kind is"
+	if len(kinds) > 1 {
+		noun = "kinds are"
+	}
+	return fmt.Sprintf("%d resource %s unavailable in this cluster's API discovery (%s); those nodes reflect controller status only.", len(kinds), noun, strings.Join(kinds, ", "))
 }
 
 func (b *Builder) canEnrich(ref ResourceRef) bool {

--- a/pkg/gitops/tree/builder.go
+++ b/pkg/gitops/tree/builder.go
@@ -298,9 +298,10 @@ func ResetUnknownKindLogDedup() {
 
 // prefetchObjects resolves the live object for every enrichable ref with
 // bounded parallelism, returning them keyed by refKey. Kinds the matcher
-// classifies as unknown-to-discovery are negative-cached so one absent CRD
-// costs one lookup instead of one per resource, and are returned (sorted)
-// for the caller's response warning.
+// classifies as unknown-to-discovery are negative-cached (best-effort — see
+// the worker loop) so an absent CRD skips the bulk of its refs instead of
+// paying one lookup per resource, and are returned (sorted) for the
+// caller's response warning.
 //
 // Enrichment stays best-effort: per-ref failures nil out that ref's entry
 // exactly like the serial loop did. Determinism of the final tree is owned
@@ -330,39 +331,54 @@ func (b *Builder) prefetchObjects(ctx context.Context, refs []ResourceRef) (map[
 	)
 	kindKey := func(ref ResourceRef) string { return ref.Kind + "|" + ref.Group }
 
-	sem := make(chan struct{}, enrichConcurrency)
-	var wg sync.WaitGroup
-	for _, ref := range targets {
-		wg.Add(1)
-		go func(ref ResourceRef) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			mu.Lock()
-			_, skip := unknownKinds[kindKey(ref)]
-			mu.Unlock()
-			if skip {
-				return
-			}
-
-			obj, err := b.dynamic.GetDynamicWithGroup(ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
-			if err != nil {
-				if b.isUnknownKind != nil && b.isUnknownKind(err) {
-					mu.Lock()
-					unknownKinds[kindKey(ref)] = struct{}{}
-					mu.Unlock()
-					logUnknownKindOnce(ref.Kind, ref.Group)
-				} else if !apierrors.IsNotFound(err) {
-					log.Printf("[gitops/tree] enrich %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
-				}
-				return
-			}
-			mu.Lock()
-			objects[refKey(ref)] = obj
-			mu.Unlock()
-		}(ref)
+	// Fixed worker pool, not goroutine-per-ref: a 10k-resource app must cost
+	// enrichConcurrency goroutines, not 10k queued behind a semaphore.
+	workers := enrichConcurrency
+	if len(targets) < workers {
+		workers = len(targets)
 	}
+	work := make(chan ResourceRef)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ref := range work {
+				mu.Lock()
+				_, skip := unknownKinds[kindKey(ref)]
+				mu.Unlock()
+				if skip {
+					continue
+				}
+
+				obj, err := b.dynamic.GetDynamicWithGroup(ctx, ref.Kind, ref.Namespace, ref.Name, ref.Group)
+				if err != nil {
+					if b.isUnknownKind != nil && b.isUnknownKind(err) {
+						// Best-effort collapse: in-flight workers on the same
+						// kind may still complete their lookup, but an
+						// unknown-kind miss is a local discovery-map lookup —
+						// no API round-trip — so the cache's job is skipping
+						// the remaining queue and deduping the log, not
+						// enforcing exactly-once.
+						mu.Lock()
+						unknownKinds[kindKey(ref)] = struct{}{}
+						mu.Unlock()
+						logUnknownKindOnce(ref.Kind, ref.Group)
+					} else if !apierrors.IsNotFound(err) {
+						log.Printf("[gitops/tree] enrich %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
+					}
+					continue
+				}
+				mu.Lock()
+				objects[refKey(ref)] = obj
+				mu.Unlock()
+			}
+		}()
+	}
+	for _, ref := range targets {
+		work <- ref
+	}
+	close(work)
 	wg.Wait()
 
 	if len(unknownKinds) == 0 {

--- a/pkg/gitops/tree/builder.go
+++ b/pkg/gitops/tree/builder.go
@@ -2,16 +2,27 @@ package tree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/topology"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// isEnrichNotFound treats both miss shapes as "resource absent": typed-cache
+// reads return apierrors NotFound, dynamic informer reads return the plain
+// k8score sentinel. Absence is a normal state for tree enrichment — Missing
+// resources and hub-spoke apps whose workloads live on a remote cluster —
+// so neither deserves a log line.
+func isEnrichNotFound(err error) bool {
+	return apierrors.IsNotFound(err) || errors.Is(err, k8score.ErrResourceNotFound)
+}
 
 // enrichConcurrency bounds the parallel live-object enrichment fan-out per
 // build. Most lookups are informer-cache hits (microseconds); the bound
@@ -364,7 +375,7 @@ func (b *Builder) prefetchObjects(ctx context.Context, refs []ResourceRef) (map[
 						unknownKinds[kindKey(ref)] = struct{}{}
 						mu.Unlock()
 						logUnknownKindOnce(ref.Kind, ref.Group)
-					} else if !apierrors.IsNotFound(err) {
+					} else if !isEnrichNotFound(err) {
 						log.Printf("[gitops/tree] enrich %s/%s %s/%s failed: %v", ref.Group, ref.Kind, ref.Namespace, ref.Name, err)
 					}
 					continue

--- a/pkg/gitops/tree/builder_test.go
+++ b/pkg/gitops/tree/builder_test.go
@@ -2,6 +2,10 @@ package tree
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/skyhook-io/radar/pkg/topology"
@@ -10,16 +14,30 @@ import (
 
 type fakeDynamic struct {
 	objects map[string]*unstructured.Unstructured
-	calls   []ResourceRef
+	errs    map[string]error
+
+	mu    sync.Mutex
+	calls []ResourceRef
 }
 
 func (f *fakeDynamic) GetDynamicWithGroup(_ context.Context, kind string, namespace string, name string, group string) (*unstructured.Unstructured, error) {
 	ref := ResourceRef{Group: group, Kind: kind, Namespace: namespace, Name: name}
+	f.mu.Lock()
 	f.calls = append(f.calls, ref)
+	f.mu.Unlock()
+	if err := f.errs[refKey(ref)]; err != nil {
+		return nil, err
+	}
 	if obj := f.objects[refKey(ref)]; obj != nil {
 		return obj, nil
 	}
 	return f.objects[refKey(ResourceRef{Group: group, Kind: "Application", Namespace: namespace, Name: name})], nil
+}
+
+func (f *fakeDynamic) recordedCalls() []ResourceRef {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]ResourceRef{}, f.calls...)
 }
 
 func TestBuildArgoTreeUsesManagedInventoryAndOwnershipEdges(t *testing.T) {
@@ -158,9 +176,119 @@ func assertNoEdge(t *testing.T, tree *ResourceTree, source string, target string
 
 func assertNoDynamicCall(t *testing.T, dynamic *fakeDynamic, ref ResourceRef) {
 	t.Helper()
-	for _, call := range dynamic.calls {
+	for _, call := range dynamic.recordedCalls() {
 		if call.Group == ref.Group && call.Kind == ref.Kind && call.Namespace == ref.Namespace && call.Name == ref.Name {
 			t.Fatalf("unexpected dynamic lookup for %#v", ref)
 		}
+	}
+}
+
+func TestBuildUnknownKindWarnsOnceAndKeepsSyntheticNodes(t *testing.T) {
+	unknownErr := errors.New("unknown resource kind: Prometheus (group: monitoring.coreos.com)")
+	resources := make([]any, 0, 13)
+	for i := 0; i < 12; i++ {
+		resources = append(resources, map[string]any{
+			"group": "monitoring.coreos.com", "kind": "Prometheus", "namespace": "monitoring",
+			"name": fmt.Sprintf("prom-%d", i), "status": "Synced",
+		})
+	}
+	resources = append(resources, map[string]any{
+		"group": "apps", "kind": "Deployment", "namespace": "prod", "name": "billing", "status": "Synced",
+	})
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "monitoring", "namespace": "argocd"},
+		"status":     map[string]any{"resources": resources},
+	}}
+	deployment := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "billing", "namespace": "prod", "labels": map[string]any{"a": "b"}},
+	}}
+	dynamic := &fakeDynamic{
+		objects: map[string]*unstructured.Unstructured{
+			refKey(ResourceRef{Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "monitoring"}): app,
+			refKey(ResourceRef{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"}):              deployment,
+		},
+		errs: map[string]error{},
+	}
+	for i := 0; i < 12; i++ {
+		dynamic.errs[refKey(ResourceRef{Group: "monitoring.coreos.com", Kind: "Prometheus", Namespace: "monitoring", Name: fmt.Sprintf("prom-%d", i)})] = unknownErr
+	}
+
+	tree, _, err := NewBuilder(dynamic, nil).
+		WithUnknownKindMatcher(func(err error) bool { return errors.Is(err, unknownErr) }).
+		Build(context.Background(), "applications", "argocd", "monitoring", "argoproj.io")
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	var warned []string
+	for _, w := range tree.Warnings {
+		if strings.Contains(w, "unavailable in this cluster's API discovery") {
+			warned = append(warned, w)
+		}
+	}
+	if len(warned) != 1 {
+		t.Fatalf("want exactly one unknown-kind warning, got %d: %v", len(warned), tree.Warnings)
+	}
+	if !strings.Contains(warned[0], "Prometheus (monitoring.coreos.com)") {
+		t.Fatalf("warning should name the kind+group: %q", warned[0])
+	}
+
+	// The nodes still render from Argo's status.resources — an absent CRD
+	// hides enrichment, never the resource itself.
+	assertNodeRole(t, tree, ResourceRef{Group: "monitoring.coreos.com", Kind: "Prometheus", Namespace: "monitoring", Name: "prom-0"}, RoleDeclared)
+	// The known kind was still enriched.
+	depID := nodeID(ResourceRef{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"})
+	for _, node := range tree.Nodes {
+		if node.ID == depID {
+			if _, ok := node.Data["labels"]; !ok {
+				t.Fatalf("Deployment node missing enrichment: %#v", node.Data)
+			}
+		}
+	}
+}
+
+func TestBuildParallelEnrichmentMatchesObjects(t *testing.T) {
+	resources := make([]any, 0, 40)
+	objects := map[string]*unstructured.Unstructured{}
+	for i := 0; i < 40; i++ {
+		name := fmt.Sprintf("cm-%d", i)
+		resources = append(resources, map[string]any{"kind": "ConfigMap", "namespace": "prod", "name": name, "status": "Synced"})
+		objects[refKey(ResourceRef{Kind: "ConfigMap", Namespace: "prod", Name: name})] = &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name, "namespace": "prod", "uid": "uid-" + name},
+		}}
+	}
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "cms", "namespace": "argocd"},
+		"status":     map[string]any{"resources": resources},
+	}}
+	objects[refKey(ResourceRef{Group: "argoproj.io", Kind: "Application", Namespace: "argocd", Name: "cms"})] = app
+
+	tree, _, err := NewBuilder(&fakeDynamic{objects: objects}, nil).
+		Build(context.Background(), "applications", "argocd", "cms", "argoproj.io")
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	// Every node must carry its own object's UID — a mismatched UID would
+	// mean the parallel prefetch wired an object to the wrong ref.
+	found := 0
+	for _, node := range tree.Nodes {
+		if node.Ref.Kind != "ConfigMap" {
+			continue
+		}
+		found++
+		if node.Ref.UID != "uid-"+node.Ref.Name {
+			t.Fatalf("node %s has UID %q, want %q", node.Ref.Name, node.Ref.UID, "uid-"+node.Ref.Name)
+		}
+	}
+	if found != 40 {
+		t.Fatalf("found %d ConfigMap nodes, want 40", found)
 	}
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -68,6 +69,13 @@ type DynamicResourceCache struct {
 	// — including namespace-scoped informers created lazily after registration
 	// — so derived caches keep receiving events. Guarded by mu.
 	gvrHandlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
+
+	// watchStarts collapses concurrent ensureWatching calls for the same
+	// (gvr, ns) into one probe + informer start. The access probe runs
+	// outside d.mu, so without this a parallel fan-out over N objects of an
+	// unwatched kind would issue N redundant limit=1 list probes before one
+	// caller wins startWatching.
+	watchStarts singleflight.Group
 
 	// CRD discovery completion callbacks
 	crdCallbacks   []func()
@@ -171,27 +179,36 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 
 	// Probe access (cluster-wide first, then fallback namespaces) BEFORE
 	// acquiring the write lock; the result tells us which scopes to watch.
-	scopes, complete, err := d.probeScopes(gvr, preferredNS)
-	if err != nil {
-		return fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
-	}
-
-	for _, scopeNS := range scopes {
-		if err := d.startWatching(gvr, scopeNS); err != nil {
-			return err
+	// Singleflight per (gvr, preferredNS): concurrent callers — e.g. a
+	// parallel enrichment fan-out over many objects of one unwatched kind —
+	// share one probe fan-out + informer start instead of stampeding the
+	// apiserver with redundant limit=1 lists.
+	_, err, _ := d.watchStarts.Do(gvr.String()+"|"+preferredNS, func() (any, error) {
+		if d.hasCoveringInformer(gvr, preferredNS) {
+			return nil, nil
 		}
-	}
-	if preferredNS == "" && complete {
-		// The all-namespaces scope for this GVR is settled — informers exist
-		// for every granted scope. Mark it so the next all-namespaces read
-		// doesn't re-probe cluster-wide plus every candidate. An incomplete
-		// walk (deadline hit mid-fanout) is deliberately NOT marked, so the
-		// next read finishes the job.
-		d.mu.Lock()
-		d.fallbackResolved[gvr] = true
-		d.mu.Unlock()
-	}
-	return nil
+		scopes, complete, err := d.probeScopes(gvr, preferredNS)
+		if err != nil {
+			return nil, fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
+		}
+		for _, scopeNS := range scopes {
+			if err := d.startWatching(gvr, scopeNS); err != nil {
+				return nil, err
+			}
+		}
+		if preferredNS == "" && complete {
+			// The all-namespaces scope for this GVR is settled — informers exist
+			// for every granted scope. Mark it so the next all-namespaces read
+			// doesn't re-probe cluster-wide plus every candidate. An incomplete
+			// walk (deadline hit mid-fanout) is deliberately NOT marked, so the
+			// next read finishes the job.
+			d.mu.Lock()
+			d.fallbackResolved[gvr] = true
+			d.mu.Unlock()
+		}
+		return nil, nil
+	})
+	return err
 }
 
 // hasCoveringInformer reports whether an existing informer already serves


### PR DESCRIPTION
## Problem

The GitOps detail page paid three architectural costs on every visit, measured on a GKE cluster against a 126-resource / 17-kind Argo app (`kube-prometheus-stack`):

1. **Serial duplicate informer startup (tree cold: 5.9s).** `getDynamicWithGroup` had no typed-cache dispatch, so tree enrichment spun up cluster-wide **dynamic** informers for ConfigMap, Secret, Service, ServiceAccount, Deployment, DaemonSet, and the RBAC kinds — one at a time, duplicating the typed informers that already watch those kinds (double memory for cluster-wide Secrets/ConfigMaps, permanently).
2. **Serial per-resource drift GETs (insights: 20.7s, every request).** Each insights request issued one direct apiserver GET per managed resource (~152ms each, serial) to read `last-applied` for drift — unconditionally, including for Synced rows, and re-issued in full by the UI's 2s poll during a running sync.
3. **Per-resource noise for absent resources and kinds.** Kinds missing from discovery (e.g. an app declaring `Prometheus`/`Alertmanager` CRs whose CRDs aren't applied) logged one error per resource per request with no user-facing signal, and hub-spoke apps (controller local, workloads on a remote cluster) logged every remote resource as an enrichment failure.

## What changed

**Typed-cache-first routing** in `GetDynamicWithGroup`/`ListDynamicWithGroup` — the same `TypedKindOwnsGroup` dispatch the REST/MCP handlers already use, now applied at the shared accessor, so the GitOps tree, the managed-resources scan, and the issues provider all stop starting duplicate informers. Routing is deferred-aware: kinds whose deferred informer hasn't synced yet are checked via `IsDeferredPending` *before* the lister read (several deferred kinds expose non-nil listers pre-sync that would serve empty stores as confident NotFound) and fall back to a one-off direct GET; RBAC-disabled kinds stay forbidden. Converted objects are GVK-stamped and strip `managedFields` + `last-applied` (the typed transform's kind switch misses RBAC kinds; without the strip, tree payloads would carry full last-applied JSON). `GetDynamicWithGroupPreserveLastApplied` is untouched — drift genuinely needs last-applied, which every cache strips by design.

**Insights drift fetches: bounded-parallel, gated, request-scoped.** Live-state GETs are prefetched by a fixed worker pool behind a process-wide semaphore (16), only for rows the controller reports as not cleanly Synced (or carrying a sync error), and skipped entirely while `operationState.phase` is Running/Terminating — the 2s progress poll is a pure cache read. RBAC gates (namespace allowlist + per-ref access) run serially before any fetch is scheduled; `GetLive` is map-only after prefetch, so a gated-out ref can never trigger a fallback fetch.

**Tree enrichment parallelized** (fixed worker pool, Flux related-resources included); `ensureWatching` gains per-`(gvr, ns)` singleflight so parallel fan-out can't stampede access probes — the singleflight wraps the whole multi-namespace scope walk, including the `fallbackResolved` marker.

**Absent resources and kinds are explicit, not noisy.** Kinds missing from discovery are negative-cached per build, logged once per kind per process (reset on context switch), and surfaced as one response warning — *"N resource kinds are unavailable in this cluster's API discovery (…); those nodes reflect controller status only."* Nodes still render from controller status. A resource that's simply absent from this cluster (Missing health, or a hub-spoke app's remote workloads) is a normal state: both NotFound shapes (`apierrors` and the dynamic cache's miss sentinel) are silent.

**`RecentEvents`** builds one per-request index instead of rescanning the namespace's event list once per managed resource (was O(resources × events)). Buckets key on involvedObject kind|name with the namespace filter applied at lookup against the event's own namespace — preserving the scan's exact matching semantics (events with an empty `involvedObject.namespace` still surface; cluster-scoped refs match across namespaces).

**IngressClass** added to `FetchResource`/`FetchResourceList` (the typed table had it; the switches didn't) + a table-parity regression test.

## Before / after (same cluster, same apps, fresh process each)

| Scenario | Before | After |
|---|---|---|
| kube-prometheus-stack (126 res, 17 kinds) — tree, cold | 5.94s | **0.59s** |
| — tree, warm | 1.55s | **0.32s** |
| — insights (every request) | 20.7s | **0.33s** |
| — concurrent page-load (tree + insights) | 20.8s | **0.33s** |
| — apiserver GETs per insights request | 126 serial | 11 parallel (OutOfSync rows only); **0** during a running sync |
| billing-staging (6 res) — tree / insights | 1.6s / 0.9s | **1.5ms / 1.4ms** |
| dynamic informers started by one page view | +10 cluster-wide (duplicating typed) | **0** |

Output equivalence verified against the live cluster: identical node/edge sets and per-node fields (the only delta is the new warnings entry).

## Behavior changes to be aware of

- **Synced rows no longer show a last-applied drift chip.** That drift was largely the false-positive class Argo itself suppresses via normalization + `ignoreDifferences` (the gap the `IgnoredDifferences.UnsupportedRuleCount` warning exists to apologize for). Rows that are OutOfSync or recorded a sync error keep full drift.
- **No drift chips while a sync is running** — mid-apply drift is churn; they return on the first quiescent response.
- Kinds absent from discovery produce one warning banner instead of silent per-resource log spam; absent resources (Missing / remote destinations) log nothing.

## Testing

- Regression tests: typed kinds never start dynamic informers; GVK stamping; last-applied/managedFields stripped on typed-route reads; NotFound maps to `apierrors` 404; cluster-scoped list with namespace filter stays empty; typed-table ↔ Fetch-switch parity; preserve-last-applied bypasses the typed route; prefetch gating (phase, row state, RBAC-denied refs never fetched, map-only GetLive); unknown-kind single warning + synthetic nodes; parallel enrichment object↔ref integrity; event-index matching semantics (empty involvedObject.namespace, cross-namespace name collisions, cluster-scoped refs).
- `make test` (27 packages), `-race` on all touched packages in both modules, `make tsc`, `golangci-lint --new-from-rev=main` clean.
- **Live verification on four clusters**: GKE nonprod (benchmark + output-equivalence diff), GKE management cluster (Argo hub — hub-spoke apps with remote destinations, 64 apps), EKS eks-infra (34 apps incl. a 78-node OutOfSync chart exercising the parallel drift GETs), and the kind gitops-demo cluster (Argo healthy/drift/broken/ApplicationSet + Flux Kustomization healthy/broken/suspended + HelmRelease healthy/broken). Three live in-app context switches: zero panics, zero duplicate core-kind informers, zero log spam.
- Visual-test skipped: no rendered-surface change (response shapes unchanged; drift-chip absence is existing nil-drift rendering).