### PR TITLE
Per-kind progressive readiness during initial sync

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -457,7 +457,6 @@ func InitResourceCache(ctx context.Context) error {
 			return
 		}
 
-		initialSyncComplete = core.IsSyncComplete()
 		// Only the no-enabled-resources path (OnInformersStarted never ran)
 		// reaches here with a nil embedded pointer; when the callback did run
 		// it already set the same core, and rewriting it would race with
@@ -471,6 +470,7 @@ func InitResourceCache(ctx context.Context) error {
 			initErr = fmt.Errorf("cluster changed during cache initialization")
 			return
 		}
+		initialSyncComplete = core.IsSyncComplete()
 	})
 	return initErr
 }

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -304,6 +305,17 @@ var (
 	resourceCache *ResourceCache
 	cacheOnce     = new(sync.Once)
 	cacheMu       sync.Mutex
+	// syncingCache is the mid-Phase-1 handle published by OnInformersStarted:
+	// structurally complete but not synced — every read through it MUST gate on
+	// KindReadinessFor. Cleared on promotion (resourceCache assigned), on init
+	// failure, and on reset. Guarded by cacheMu.
+	syncingCache *ResourceCache
+	// cacheGeneration invalidates in-flight cache constructions: a context
+	// switch bumps it (via ResetResourceCache), and any publish/promote/clear
+	// from an older generation becomes a no-op — without this, an old
+	// cluster's construction finishing late could republish that cluster's
+	// cache over the new one. Guarded by cacheMu.
+	cacheGeneration uint64
 )
 
 // tombstones retains recently-seen resource enrichment (owner/labels/createdAt)
@@ -324,6 +336,14 @@ func InitResourceCache(ctx context.Context) error {
 			initErr = fmt.Errorf("cannot create resource cache: k8s client not initialized")
 			return
 		}
+
+		// Generation snapshot at entry — BEFORE the permission probes. A
+		// context switch during probing bumps the generation, and this
+		// construction must not adopt the new one: every publish below would
+		// otherwise install the old cluster's cache under the new identity.
+		cacheMu.Lock()
+		gen := cacheGeneration
+		cacheMu.Unlock()
 
 		// Probe per-resource list access before creating informers. The
 		// returned scope map is authoritative for both enablement and
@@ -417,27 +437,149 @@ func InitResourceCache(ctx context.Context) error {
 			IsNoisyResource: isNoisyResource,
 		}
 
+		wrapped := &ResourceCache{
+			secretsEnabled:   scopes["secrets"].Enabled,
+			argoDrift:        newArgoDriftTracker(),
+			secretWriteTimes: secretWriteTimes,
+		}
+		// OnInformersStarted runs synchronously inside NewResourceCache, so
+		// wrapped.ResourceCache is visible-before-publication under cacheMu.
+		cfg.OnInformersStarted = func(syncing *k8score.ResourceCache) {
+			wrapped.ResourceCache = syncing
+			publishSyncingCache(wrapped, gen)
+		}
+		cfg.DebugSyncDelays = parseDebugSyncDelays(os.Getenv("RADAR_DEBUG_SYNC_DELAY"))
+
 		core, err := k8score.NewResourceCache(cfg)
 		if err != nil {
+			clearSyncingCacheForGen(gen)
 			initErr = err
 			return
 		}
 
 		initialSyncComplete = core.IsSyncComplete()
+		// Only the no-enabled-resources path (OnInformersStarted never ran)
+		// reaches here with a nil embedded pointer; when the callback did run
+		// it already set the same core, and rewriting it would race with
+		// handlers reading the published wrapper.
+		if wrapped.ResourceCache == nil {
+			wrapped.ResourceCache = core
+		}
 
-		resourceCache = &ResourceCache{
-			ResourceCache:    core,
-			secretsEnabled:   scopes["secrets"].Enabled,
-			argoDrift:        newArgoDriftTracker(),
-			secretWriteTimes: secretWriteTimes,
+		if !promoteCache(wrapped, gen) {
+			core.Stop()
+			initErr = fmt.Errorf("cluster changed during cache initialization")
+			return
 		}
 	})
 	return initErr
 }
 
+// publishSyncingCache installs wrapped as the mid-sync handle unless the
+// cache generation moved (a context switch invalidated this construction).
+func publishSyncingCache(wrapped *ResourceCache, gen uint64) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if cacheGeneration == gen {
+		syncingCache = wrapped
+	}
+}
+
+// clearSyncingCacheForGen retires the mid-sync handle after a failed
+// construction — but only for its own generation, so a stale failure can't
+// clear a newer construction's handle.
+func clearSyncingCacheForGen(gen uint64) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if cacheGeneration == gen {
+		syncingCache = nil
+	}
+}
+
+// promoteCache installs wrapped as the ready singleton and retires the
+// mid-sync handle. Returns false when the generation moved — the caller owns
+// stopping the now-orphaned core.
+func promoteCache(wrapped *ResourceCache, gen uint64) bool {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if cacheGeneration != gen {
+		return false
+	}
+	resourceCache = wrapped
+	syncingCache = nil
+	return true
+}
+
+// parseDebugSyncDelays parses RADAR_DEBUG_SYNC_DELAY — a development seam for
+// exercising the progressive-readiness window on fast clusters. Accepts a
+// bare duration ("60s", applied to pods) or per-kind pairs
+// ("pods=60s,deployments=10s"). Returns nil for empty/invalid input.
+func parseDebugSyncDelays(raw string) map[string]time.Duration {
+	if raw == "" {
+		return nil
+	}
+	delays := map[string]time.Duration{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, val, found := strings.Cut(part, "=")
+		if !found {
+			key, val = "pods", part
+		}
+		d, err := time.ParseDuration(strings.TrimSpace(val))
+		if err != nil || d <= 0 {
+			log.Printf("[cache] ignoring invalid RADAR_DEBUG_SYNC_DELAY entry %q: %v", part, err)
+			continue
+		}
+		delays[strings.TrimSpace(key)] = d
+	}
+	if len(delays) == 0 {
+		return nil
+	}
+	log.Printf("[cache] DEBUG: artificial informer sync delays active: %v", delays)
+	return delays
+}
+
 // GetResourceCache returns the singleton cache instance.
 func GetResourceCache() *ResourceCache {
 	return resourceCache
+}
+
+// KindReadiness re-exports the k8score readiness vocabulary for handler use.
+type KindReadiness = k8score.KindReadiness
+
+const (
+	KindUnavailable = k8score.KindUnavailable
+	KindPending     = k8score.KindPending
+	KindReady       = k8score.KindReady
+	KindFailed      = k8score.KindFailed
+)
+
+// GetSyncingResourceCache returns the mid-sync cache handle published by
+// OnInformersStarted, or nil when no construction is in flight. Reads through
+// it MUST gate on KindReadinessFor — its listers are incomplete by definition.
+func GetSyncingResourceCache() *ResourceCache {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	return syncingCache
+}
+
+// ReadableCacheForKind picks the cache a typed-kind read should serve from:
+// the promoted singleton when it exists (post-Phase-1 — readiness still
+// gates promoted/deferred kinds that are syncing in background), otherwise
+// the mid-sync handle. A nil cache means no construction has produced a
+// handle yet (probing, or disconnected) — callers respond "not ready".
+// key is an informer key (lowercase plural, e.g. "pods").
+func ReadableCacheForKind(key string) (*ResourceCache, KindReadiness) {
+	if c := GetResourceCache(); c != nil {
+		return c, c.KindReadinessFor(key)
+	}
+	if c := GetSyncingResourceCache(); c != nil {
+		return c, c.KindReadinessFor(key)
+	}
+	return nil, KindUnavailable
 }
 
 // ResetResourceCache stops and clears the resource cache so it can be
@@ -446,6 +588,14 @@ func ResetResourceCache() {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 
+	// Invalidate any in-flight construction: its publishes become no-ops and
+	// its core is stopped on return (see the generation check in
+	// InitResourceCache).
+	cacheGeneration++
+	if syncingCache != nil {
+		syncingCache.Stop()
+		syncingCache = nil
+	}
 	if resourceCache != nil {
 		resourceCache.Stop()
 		resourceCache = nil

--- a/internal/k8s/cache_progressive_test.go
+++ b/internal/k8s/cache_progressive_test.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+)
+
+// snapshotCacheGlobals isolates a test from (and restores) the package-level
+// cache singleton state the generation guards operate on.
+func snapshotCacheGlobals(t *testing.T) {
+	t.Helper()
+	cacheMu.Lock()
+	prevRC, prevSC, prevGen := resourceCache, syncingCache, cacheGeneration
+	resourceCache, syncingCache = nil, nil
+	cacheMu.Unlock()
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		resourceCache, syncingCache, cacheGeneration = prevRC, prevSC, prevGen
+		cacheMu.Unlock()
+	})
+}
+
+func currentGen() uint64 {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	return cacheGeneration
+}
+
+func bumpGen() {
+	cacheMu.Lock()
+	cacheGeneration++
+	cacheMu.Unlock()
+}
+
+func TestPublishSyncingCache_GenerationGuard(t *testing.T) {
+	snapshotCacheGlobals(t)
+	w := &ResourceCache{}
+
+	gen := currentGen()
+	publishSyncingCache(w, gen)
+	if GetSyncingResourceCache() != w {
+		t.Fatal("publish with current generation did not install the handle")
+	}
+
+	// A context switch bumps the generation; a stale construction's publish
+	// must be a no-op — otherwise the old cluster's cache resurfaces.
+	bumpGen()
+	cacheMu.Lock()
+	syncingCache = nil
+	cacheMu.Unlock()
+	publishSyncingCache(w, gen)
+	if GetSyncingResourceCache() != nil {
+		t.Fatal("stale-generation publish installed an old cluster's handle")
+	}
+}
+
+func TestPromoteCache_GenerationGuard(t *testing.T) {
+	snapshotCacheGlobals(t)
+	w := &ResourceCache{}
+
+	gen := currentGen()
+	publishSyncingCache(w, gen)
+	if !promoteCache(w, gen) {
+		t.Fatal("promotion with current generation failed")
+	}
+	if GetResourceCache() != w {
+		t.Fatal("promotion did not install the singleton")
+	}
+	if GetSyncingResourceCache() != nil {
+		t.Fatal("promotion did not retire the mid-sync handle")
+	}
+
+	// Stale promotion after a switch must refuse (caller stops the core).
+	cacheMu.Lock()
+	resourceCache = nil
+	cacheMu.Unlock()
+	bumpGen()
+	if promoteCache(w, gen) {
+		t.Fatal("stale-generation promotion succeeded")
+	}
+	if GetResourceCache() != nil {
+		t.Fatal("stale promotion installed the singleton")
+	}
+}
+
+func TestClearSyncingCacheForGen_OnlyOwnGeneration(t *testing.T) {
+	snapshotCacheGlobals(t)
+	old := &ResourceCache{}
+	oldGen := currentGen()
+
+	// A newer construction published its handle; the old generation's
+	// failure cleanup must not clear it.
+	bumpGen()
+	fresh := &ResourceCache{}
+	publishSyncingCache(fresh, currentGen())
+
+	clearSyncingCacheForGen(oldGen)
+	if GetSyncingResourceCache() != fresh {
+		t.Fatal("stale-generation clear removed the newer construction's handle")
+	}
+	_ = old
+}
+
+func TestResetResourceCache_InvalidatesInFlightConstruction(t *testing.T) {
+	snapshotCacheGlobals(t)
+	w := &ResourceCache{}
+	gen := currentGen()
+	publishSyncingCache(w, gen)
+
+	ResetResourceCache()
+
+	if GetSyncingResourceCache() != nil {
+		t.Fatal("reset left the mid-sync handle published")
+	}
+	if promoteCache(w, gen) {
+		t.Fatal("reset did not invalidate the in-flight construction's generation")
+	}
+}
+
+func TestParseDebugSyncDelays(t *testing.T) {
+	cases := []struct {
+		in   string
+		want map[string]time.Duration
+	}{
+		{"", nil},
+		{"60s", map[string]time.Duration{"pods": 60 * time.Second}},
+		{"pods=90s,deployments=10s", map[string]time.Duration{"pods": 90 * time.Second, "deployments": 10 * time.Second}},
+		{"bogus", nil},
+		{"pods=bogus,nodes=5s", map[string]time.Duration{"nodes": 5 * time.Second}},
+	}
+	for _, c := range cases {
+		got := parseDebugSyncDelays(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("parseDebugSyncDelays(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for k, v := range c.want {
+			if got[k] != v {
+				t.Errorf("parseDebugSyncDelays(%q)[%s] = %v, want %v", c.in, k, got[k], v)
+			}
+		}
+	}
+}

--- a/internal/server/resource_gating_test.go
+++ b/internal/server/resource_gating_test.go
@@ -1,0 +1,24 @@
+package server
+
+import "testing"
+
+func TestInformerKeyForKind_AliasesResolveToInformerKeys(t *testing.T) {
+	cases := map[string]string{
+		"pods": "pods", "pod": "pods",
+		"hpa": "horizontalpodautoscalers", "hpas": "horizontalpodautoscalers",
+		"horizontalpodautoscaler": "horizontalpodautoscalers",
+		"pvc": "persistentvolumeclaims", "pvcs": "persistentvolumeclaims",
+		"pv": "persistentvolumes", "sc": "storageclasses",
+		"pdb": "poddisruptionbudgets", "netpol": "networkpolicies",
+		"deployment": "deployments", "namespaces": "namespaces",
+		// Outside the typed set: CRDs (and EndpointSlice, which has no typed
+		// informer) fall through to dynamic handling.
+		"endpointslice": "", "endpointslices": "",
+		"applications": "", "kustomizations": "", "no-such-kind": "",
+	}
+	for in, want := range cases {
+		if got := informerKeyForKind(in); got != want {
+			t.Errorf("informerKeyForKind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1582,7 +1582,7 @@ func (s *Server) preflightResourceList(r *http.Request, kind, group string, name
 }
 
 func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
-	if !s.requireConnected(w) {
+	if !s.requireConnectedOrSyncing(w) {
 		return
 	}
 	kind := normalizeKind(chi.URLParam(r, "kind"))
@@ -1611,9 +1611,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	}
 	namespaces = finalNamespaces
 
-	cache := k8s.GetResourceCache()
-	if cache == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+	cache, ok := s.gateResourceRead(w, kind, group)
+	if !ok {
 		return
 	}
 
@@ -2018,6 +2017,149 @@ func normalizeKind(kind string) string {
 	return strings.ToLower(kind)
 }
 
+// informerKeyForKind maps a normalized URL kind segment — including the
+// aliases the list/get handlers accept — to its typed informer key. Returns
+// "" for kinds outside the typed informer set (CRDs, dynamic fallthrough).
+func informerKeyForKind(kind string) string {
+	switch kind {
+	case "pods", "pod":
+		return "pods"
+	case "services", "service":
+		return "services"
+	case "deployments", "deployment":
+		return "deployments"
+	case "daemonsets", "daemonset":
+		return "daemonsets"
+	case "statefulsets", "statefulset":
+		return "statefulsets"
+	case "replicasets", "replicaset":
+		return "replicasets"
+	case "ingresses", "ingress":
+		return "ingresses"
+	case "ingressclasses", "ingressclass":
+		return "ingressclasses"
+	case "configmaps", "configmap":
+		return "configmaps"
+	case "secrets", "secret":
+		return "secrets"
+	case "events", "event":
+		return "events"
+	case "persistentvolumeclaims", "persistentvolumeclaim", "pvcs", "pvc":
+		return "persistentvolumeclaims"
+	case "persistentvolumes", "persistentvolume", "pvs", "pv":
+		return "persistentvolumes"
+	case "storageclasses", "storageclass", "sc":
+		return "storageclasses"
+	case "poddisruptionbudgets", "poddisruptionbudget", "pdbs", "pdb":
+		return "poddisruptionbudgets"
+	case "serviceaccounts", "serviceaccount":
+		return "serviceaccounts"
+	case "jobs", "job":
+		return "jobs"
+	case "cronjobs", "cronjob":
+		return "cronjobs"
+	case "hpas", "hpa", "horizontalpodautoscalers", "horizontalpodautoscaler":
+		return "horizontalpodautoscalers"
+	case "nodes", "node":
+		return "nodes"
+	case "namespaces", "namespace":
+		return "namespaces"
+	case "limitranges", "limitrange":
+		return "limitranges"
+	case "resourcequotas", "resourcequota":
+		return "resourcequotas"
+	case "networkpolicies", "networkpolicy", "netpol":
+		return "networkpolicies"
+	case "roles", "role":
+		return "roles"
+	case "clusterroles", "clusterrole":
+		return "clusterroles"
+	case "rolebindings", "rolebinding":
+		return "rolebindings"
+	case "clusterrolebindings", "clusterrolebinding":
+		return "clusterrolebindings"
+	}
+	return ""
+}
+
+// gateResourceRead enforces per-kind readiness for the typed resource read
+// handlers and picks which cache serves the request. Post-connect that is
+// the promoted singleton — readiness still gates deferred/promoted kinds
+// syncing in background, which previously could render a partial store as an
+// empty or truncated list. During initial sync it is the mid-sync handle, so
+// kinds become readable one by one instead of waiting behind the global
+// connected gate.
+//
+// Returns (cache, true) when the read may proceed; otherwise writes the
+// response and returns (nil, false). Kinds outside the typed informer set —
+// and typed kinds with no informer on this cluster (RBAC-disabled) — fall
+// through with ok=true so the handlers' existing dynamic/forbidden semantics
+// apply unchanged; the dynamic path keeps the connected gate (the dynamic
+// cache exists only after full initialization).
+func (s *Server) gateResourceRead(w http.ResponseWriter, kind, group string) (*k8s.ResourceCache, bool) {
+	key := informerKeyForKind(kind)
+	if key == "" || (group != "" && !k8s.TypedKindOwnsGroup(kind, group)) {
+		if !s.requireConnected(w) {
+			return nil, false
+		}
+		cache := k8s.GetResourceCache()
+		if cache == nil {
+			s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+			return nil, false
+		}
+		return cache, true
+	}
+	cache, readiness := k8s.ReadableCacheForKind(key)
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Not connected to cluster")
+		return nil, false
+	}
+	switch readiness {
+	case k8s.KindPending:
+		s.writeErrorCode(w, http.StatusServiceUnavailable, "kind_sync_pending",
+			fmt.Sprintf("%s are still loading, please retry shortly", key))
+		return nil, false
+	case k8s.KindFailed:
+		s.writeErrorCode(w, http.StatusServiceUnavailable, "kind_sync_failed",
+			fmt.Sprintf("%s failed to load within the sync deadline", key))
+		return nil, false
+	case k8s.KindUnavailable:
+		// No informer for a typed-vocabulary kind (RBAC-disabled). The
+		// existing forbidden semantics need the fully-initialized stack —
+		// mid-sync there is no dynamic cache to fall through to, so answer
+		// "still loading" rather than 500 off a half-built path.
+		if k8s.GetResourceCache() == nil {
+			s.writeErrorCode(w, http.StatusServiceUnavailable, "kind_sync_pending",
+				fmt.Sprintf("%s are still loading, please retry shortly", key))
+			return nil, false
+		}
+		return cache, true
+	default: // KindReady
+		return cache, true
+	}
+}
+
+// requireConnectedOrSyncing is the progressive-read variant of
+// requireConnected: during initial sync the mid-sync cache handle stands in
+// for connectedness, and per-kind readiness (gateResourceRead) does the real
+// gating. Fully disconnected states keep the exact 503 they had before.
+func (s *Server) requireConnectedOrSyncing(w http.ResponseWriter) bool {
+	if k8s.IsConnected() {
+		return true
+	}
+	// Cache handles stand in for connectedness only during startup: the
+	// mid-sync handle while Phase 1 runs, and the promoted singleton in the
+	// window where later subsystems (discovery, helm, traffic) are still
+	// initializing. A disconnected cluster keeps its 503 even though a stale
+	// handle may still exist.
+	if k8s.GetConnectionStatus().State == k8s.StateConnecting &&
+		(k8s.GetSyncingResourceCache() != nil || k8s.GetResourceCache() != nil) {
+		return true
+	}
+	s.writeError(w, http.StatusServiceUnavailable, "Not connected to cluster")
+	return false
+}
+
 // setTypeMeta sets the APIVersion and Kind fields on typed resources.
 // Delegates to k8s.SetTypeMeta.
 func setTypeMeta(resource any) {
@@ -2089,7 +2231,7 @@ func (s *Server) preflightResourceGet(r *http.Request, kind, namespace, name, gr
 }
 
 func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
-	if !s.requireConnected(w) {
+	if !s.requireConnectedOrSyncing(w) {
 		return
 	}
 	kind := normalizeKind(chi.URLParam(r, "kind"))
@@ -2116,9 +2258,8 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cache := k8s.GetResourceCache()
-	if cache == nil {
-		s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+	cache, ok := s.gateResourceRead(w, kind, group)
+	if !ok {
 		return
 	}
 
@@ -2382,12 +2523,16 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 
 	// Get relationships from cached topology. Pass the already-fetched
 	// resource so ManagedBy synthesis uses the authoritative object instead
-	// of a group-blind kind/name lookup.
+	// of a group-blind kind/name lookup. Skipped while serving from the
+	// mid-sync handle (ready singleton still nil) — relationships computed
+	// against a partially-synced cache would be silently incomplete.
 	var relationships *topology.Relationships
-	if cachedTopo, relIdx := s.broadcaster.GetCachedTopologyWithIndex(); cachedTopo != nil {
-		relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
-			k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-			k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), relIdx)
+	if k8s.GetResourceCache() != nil {
+		if cachedTopo, relIdx := s.broadcaster.GetCachedTopologyWithIndex(); cachedTopo != nil {
+			relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
+				k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
+				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), relIdx)
+		}
 	}
 
 	// Return resource with relationships
@@ -3951,7 +4096,7 @@ func (s *Server) handleConnectionStatus(w http.ResponseWriter, r *http.Request) 
 	status := k8s.GetConnectionStatus()
 	contexts, _ := k8s.GetAvailableContexts() // Always works (reads kubeconfig)
 
-	s.writeJSON(w, map[string]any{
+	resp := map[string]any{
 		"state":           status.State,
 		"context":         status.Context,
 		"clusterName":     status.ClusterName,
@@ -3959,7 +4104,22 @@ func (s *Server) handleConnectionStatus(w http.ResponseWriter, r *http.Request) 
 		"errorType":       status.ErrorType,
 		"progressMessage": status.ProgressMsg,
 		"contexts":        contexts,
-	})
+	}
+	// While the initial sync is running, expose per-kind readiness so the
+	// frontend can render the app shell progressively instead of the splash.
+	// GetSyncSnapshot is deliberately cheap (no lister walks) — this endpoint
+	// is polled sub-second during the connecting phase.
+	if status.State == k8s.StateConnecting {
+		if syncing := k8s.GetSyncingResourceCache(); syncing != nil {
+			resp["syncStatus"] = syncing.GetSyncSnapshot()
+		} else if promoted := k8s.GetResourceCache(); promoted != nil {
+			// Phase-1 done but later subsystems still initializing: keep the
+			// progressive shell up (deferred kinds keep ticking) instead of
+			// collapsing back to the splash until 'connected'.
+			resp["syncStatus"] = promoted.GetSyncSnapshot()
+		}
+	}
+	s.writeJSON(w, resp)
 }
 
 func (s *Server) handleConnectionRetry(w http.ResponseWriter, r *http.Request) {

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -57,6 +57,11 @@ type ResourceCache struct {
 	// concurrent reads without informerMu. Backs KindReadiness, which must
 	// answer from the informer's own state (statuses lag behind by design).
 	syncFnsByKey map[string]cache.InformerSynced
+	// backgroundKeys marks kinds that sync independently with no deadline
+	// (Events). They share deferredSynced tracking but must never classify
+	// as failed off the deferred-timeout flag — a late Events LIST on a big
+	// cluster is normal, not terminal.
+	backgroundKeys map[string]bool
 }
 
 // InformerSyncStatus tracks the sync state of a single informer.
@@ -609,6 +614,10 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			// and shouldn't block topology completion or warmup transition.
 			backgroundSyncFuncs = append(backgroundSyncFuncs, synced)
 			backgroundKeys = append(backgroundKeys, s.key)
+			if rc.backgroundKeys == nil {
+				rc.backgroundKeys = map[string]bool{}
+			}
+			rc.backgroundKeys[s.key] = true
 		} else if isDeferred {
 			deferredSyncFuncs = append(deferredSyncFuncs, synced)
 			deferredKeys = append(deferredKeys, s.key)
@@ -1793,11 +1802,12 @@ func (rc *ResourceCache) KindReadinessFor(key string) KindReadiness {
 	if fn() {
 		return KindReady
 	}
-	if rc.deferredFailed.Load() {
+	if rc.deferredFailed.Load() && !rc.backgroundKeys[key] {
 		// The give-up deadline only covers kinds in the deferred tracking set
 		// (statically deferred + promoted criticals). A kind mid-Phase-1 is
 		// still pending even if a previous generation's flag lingers — the
-		// tracking map tells them apart.
+		// tracking map tells them apart. Background kinds (Events) share the
+		// tracking map but have no deadline: they stay pending, not failed.
 		rc.deferredMu.RLock()
 		_, tracked := rc.deferredSynced[key]
 		rc.deferredMu.RUnlock()

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -51,6 +51,12 @@ type ResourceCache struct {
 	informerMu       sync.RWMutex
 	promotedKinds    []string // set when SyncTimeout fires; empty on normal sync
 	syncStartTime    time.Time
+
+	// syncFnsByKey holds each enabled kind's live HasSynced func, keyed by
+	// informer key ("pods"). Immutable after construction — safe for
+	// concurrent reads without informerMu. Backs KindReadiness, which must
+	// answer from the informer's own state (statuses lag behind by design).
+	syncFnsByKey map[string]cache.InformerSynced
 }
 
 // InformerSyncStatus tracks the sync state of a single informer.
@@ -577,9 +583,26 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			run = inf.Run
 		}
 
+		if delay := cfg.DebugSyncDelays[s.key]; delay > 0 {
+			inner := run
+			run = func(stopCh <-chan struct{}) {
+				stdlog.Printf("DEBUG: delaying %s informer start by %v (DebugSyncDelays)", s.key, delay)
+				select {
+				case <-time.After(delay):
+				case <-stopCh:
+					return
+				}
+				inner(stopCh)
+			}
+		}
+
 		isDeferred := deferredTypes[s.key]
 		entry := informerEntry{kind: s.kind, key: s.key, deferred: isDeferred, synced: synced, run: run}
 		allEntries = append(allEntries, entry)
+		if rc.syncFnsByKey == nil {
+			rc.syncFnsByKey = map[string]cache.InformerSynced{}
+		}
+		rc.syncFnsByKey[s.key] = synced
 
 		if isDeferred && s.isEvent {
 			// Events sync independently — they can take 60s+ on large clusters
@@ -621,6 +644,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		}
 	}
 
+
 	if len(backgroundKeys) > 0 {
 		stdlog.Printf("Starting resource cache: %d critical + %d deferred + %d background informers (%d total)",
 			len(criticalSyncFuncs), len(deferredSyncFuncs), len(backgroundSyncFuncs), enabledCount)
@@ -630,6 +654,15 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 	}
 	syncStart := time.Now()
 	rc.syncStartTime = syncStart
+
+	// Hand out the still-syncing handle for progressive per-kind reads.
+	// Deliberately after informer start + status registration + sync-start
+	// stamping and before the Phase-1 wait: the handle is structurally
+	// complete, only sync state is in flux, and KindReadinessFor answers
+	// that per kind.
+	if cfg.OnInformersStarted != nil {
+		cfg.OnInformersStarted(rc)
+	}
 
 	// Track per-informer sync completion in background goroutines.
 	// Each goroutine updates the InformerSyncStatus when its informer syncs.
@@ -1722,6 +1755,121 @@ func (rc *ResourceCache) isReady(key string) bool {
 	rc.deferredMu.RLock()
 	defer rc.deferredMu.RUnlock()
 	return rc.deferredSynced[key]
+}
+
+// KindReadiness classifies a typed kind's serveability. It is meaningful at
+// any point in the cache lifecycle, including during the Phase-1 sync wait
+// (via the OnInformersStarted handle).
+type KindReadiness int
+
+const (
+	// KindUnavailable: no informer for this kind (RBAC-disabled, unknown key,
+	// or not part of the typed set). Callers fall through to their existing
+	// forbidden/not-found/dynamic semantics.
+	KindUnavailable KindReadiness = iota
+	// KindPending: the informer exists but its initial LIST hasn't completed.
+	// Serving now would render a partial store as truth — callers must
+	// respond "still loading", never an incomplete list.
+	KindPending
+	// KindReady: the informer's store is complete; serve normally.
+	KindReady
+	// KindFailed: the deferred-sync deadline fired with this kind still
+	// unsynced — terminal for this cache generation. Callers should return a
+	// terminal error, not "retry shortly".
+	KindFailed
+)
+
+// KindReadinessFor reports whether key can be served from this cache right
+// now. Keys are informer keys (lowercase plural, e.g. "pods") — the same
+// vocabulary as DeferredTypes and InformerSyncStatus.Key.
+func (rc *ResourceCache) KindReadinessFor(key string) KindReadiness {
+	if rc == nil || !rc.isEnabled(key) {
+		return KindUnavailable
+	}
+	fn := rc.syncFnsByKey[key]
+	if fn == nil {
+		return KindUnavailable
+	}
+	if fn() {
+		return KindReady
+	}
+	if rc.deferredFailed.Load() {
+		// The give-up deadline only covers kinds in the deferred tracking set
+		// (statically deferred + promoted criticals). A kind mid-Phase-1 is
+		// still pending even if a previous generation's flag lingers — the
+		// tracking map tells them apart.
+		rc.deferredMu.RLock()
+		_, tracked := rc.deferredSynced[key]
+		rc.deferredMu.RUnlock()
+		if tracked {
+			return KindFailed
+		}
+	}
+	return KindPending
+}
+
+// KindSyncState is one kind's live sync state in a SyncSnapshot.
+type KindSyncState struct {
+	Kind     string `json:"kind"`
+	Key      string `json:"key"`
+	Synced   bool   `json:"synced"`
+	Deferred bool   `json:"deferred"`
+}
+
+// SyncSnapshot is a lightweight progress report for connection-status
+// payloads: per-kind live sync state without the lister walks GetSyncStatus
+// does for item counts. Cheap enough for sub-second polling during sync.
+type SyncSnapshot struct {
+	Phase          SyncPhase       `json:"phase"`
+	CriticalTotal  int             `json:"criticalTotal"`
+	CriticalSynced int             `json:"criticalSynced"`
+	DeferredTotal  int             `json:"deferredTotal"`
+	DeferredSynced int             `json:"deferredSynced"`
+	Kinds          []KindSyncState `json:"kinds"`
+}
+
+// GetSyncSnapshot returns the live per-kind sync state. Unlike GetSyncStatus
+// it reads each informer's HasSynced directly (no status-goroutine lag) and
+// never touches listers.
+func (rc *ResourceCache) GetSyncSnapshot() SyncSnapshot {
+	if rc == nil {
+		return SyncSnapshot{Phase: SyncPhaseNotStarted}
+	}
+	rc.informerMu.RLock()
+	statuses := make([]InformerSyncStatus, len(rc.informerStatuses))
+	copy(statuses, rc.informerStatuses)
+	rc.informerMu.RUnlock()
+
+	snap := SyncSnapshot{Kinds: make([]KindSyncState, 0, len(statuses))}
+	for _, s := range statuses {
+		synced := false
+		if fn := rc.syncFnsByKey[s.Key]; fn != nil {
+			synced = fn()
+		}
+		snap.Kinds = append(snap.Kinds, KindSyncState{Kind: s.Kind, Key: s.Key, Synced: synced, Deferred: s.Deferred})
+		if s.Deferred {
+			snap.DeferredTotal++
+			if synced {
+				snap.DeferredSynced++
+			}
+		} else {
+			snap.CriticalTotal++
+			if synced {
+				snap.CriticalSynced++
+			}
+		}
+	}
+	switch {
+	case rc.syncStartTime.IsZero():
+		snap.Phase = SyncPhaseNotStarted
+	case !rc.syncComplete.Load():
+		snap.Phase = SyncPhaseCritical
+	case !rc.IsDeferredSynced():
+		snap.Phase = SyncPhaseDeferred
+	default:
+		snap.Phase = SyncPhaseComplete
+	}
+	return snap
 }
 
 // IsDeferredPending returns true when the resource type passed RBAC checks

--- a/pkg/k8score/cache_progressive_test.go
+++ b/pkg/k8score/cache_progressive_test.go
@@ -1,0 +1,143 @@
+package k8score
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// waitForCondition polls until fn() is true or the deadline passes.
+func waitForCondition(t *testing.T, what string, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// While one kind's initial LIST is blocked, the mid-sync handle must report
+// the others Ready and the blocked kind Pending — never serve it as empty.
+func TestNewResourceCache_ProgressiveReadinessDuringSync(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	// The fake clientset serializes the whole reaction chain under one lock,
+	// so a reactor must never block — fail the LIST until released instead
+	// (the reflector retries with backoff, keeping the kind unsynced).
+	release := make(chan struct{})
+	client.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		select {
+		case <-release:
+			return false, nil, nil // fall through to the default empty list
+		default:
+			return true, nil, errors.New("simulated slow LIST")
+		}
+	})
+
+	started := make(chan *ResourceCache, 1)
+	done := make(chan struct{})
+	var rc *ResourceCache
+	var buildErr error
+	go func() {
+		rc, buildErr = NewResourceCache(CacheConfig{
+			Client: client,
+			ResourceTypes: map[string]bool{
+				Pods:     true,
+				Services: true,
+			},
+			OnInformersStarted: func(h *ResourceCache) { started <- h },
+		})
+		close(done)
+	}()
+
+	var handle *ResourceCache
+	select {
+	case handle = <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnInformersStarted was not invoked before Phase-1 wait")
+	}
+
+	waitForCondition(t, "services to sync while pods LIST is blocked", func() bool {
+		return handle.KindReadinessFor(Services) == KindReady
+	})
+	if got := handle.KindReadinessFor(Pods); got != KindPending {
+		t.Errorf("pods readiness during blocked LIST = %v, want KindPending", got)
+	}
+	if got := handle.KindReadinessFor(Secrets); got != KindUnavailable {
+		t.Errorf("disabled kind readiness = %v, want KindUnavailable", got)
+	}
+	if got := handle.KindReadinessFor("no-such-kind"); got != KindUnavailable {
+		t.Errorf("unknown kind readiness = %v, want KindUnavailable", got)
+	}
+
+	snap := handle.GetSyncSnapshot()
+	if snap.Phase != SyncPhaseCritical {
+		t.Errorf("snapshot phase mid-sync = %q, want %q", snap.Phase, SyncPhaseCritical)
+	}
+	var sawPodsPending, sawServicesSynced bool
+	for _, k := range snap.Kinds {
+		if k.Key == Pods && !k.Synced {
+			sawPodsPending = true
+		}
+		if k.Key == Services && k.Synced {
+			sawServicesSynced = true
+		}
+	}
+	if !sawPodsPending || !sawServicesSynced {
+		t.Errorf("snapshot kinds = %+v, want pods unsynced + services synced", snap.Kinds)
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("NewResourceCache did not return after LIST unblocked")
+	}
+	if buildErr != nil {
+		t.Fatalf("NewResourceCache: %v", buildErr)
+	}
+	defer rc.Stop()
+
+	if got := rc.KindReadinessFor(Pods); got != KindReady {
+		t.Errorf("pods readiness after sync = %v, want KindReady", got)
+	}
+	if snap := rc.GetSyncSnapshot(); snap.CriticalSynced != snap.CriticalTotal {
+		t.Errorf("post-sync snapshot critical %d/%d, want all synced", snap.CriticalSynced, snap.CriticalTotal)
+	}
+}
+
+// A deferred kind that never syncs before the deferred deadline must go
+// terminal (KindFailed), not report Pending forever.
+func TestKindReadinessFor_FailedAfterDeferredTimeout(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated permanently failing LIST")
+	})
+
+	rc, err := NewResourceCache(CacheConfig{
+		Client: client,
+		ResourceTypes: map[string]bool{
+			Services:   true,
+			ConfigMaps: true,
+		},
+		DeferredTypes:       map[string]bool{ConfigMaps: true},
+		DeferredSyncTimeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	defer rc.Stop()
+
+	waitForCondition(t, "deferred deadline to mark configmaps failed", func() bool {
+		return rc.KindReadinessFor(ConfigMaps) == KindFailed
+	})
+	if got := rc.KindReadinessFor(Services); got != KindReady {
+		t.Errorf("services readiness = %v, want KindReady (unaffected by sibling failure)", got)
+	}
+}

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -237,6 +237,22 @@ type CacheConfig struct {
 	// unaffected. Zero means wait indefinitely.
 	DeferredSyncTimeout time.Duration
 
+	// OnInformersStarted is invoked once, after all critical informers have
+	// been started and per-informer tracking is registered, but before the
+	// blocking Phase-1 sync wait. It hands callers the cache while it is
+	// still syncing so they can serve per-kind progressive reads (see
+	// KindReadiness). The handle is fully constructed but NOT synced —
+	// callers must gate reads on per-kind readiness, never assume complete
+	// listers. May be nil. Not called on the no-enabled-resources path
+	// (the cache returns already-complete there).
+	OnInformersStarted func(*ResourceCache)
+
+	// DebugSyncDelays artificially delays the start of the named informers
+	// (keyed by informer key, e.g. "pods") — a development seam for
+	// exercising the progressive-readiness window on fast clusters. Never
+	// set in production paths.
+	DebugSyncDelays map[string]time.Duration
+
 	// ListPageSize, when > 0, makes high-cardinality informers fetch their
 	// initial LIST in pages of this size via a consistent (resourceVersion="")
 	// read instead of one unpaginated response. This mitigates response-read

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,7 @@ import { useMediaQuery } from './hooks/useMediaQuery'
 import { ContextSwitchProvider, useContextSwitch } from './context/ContextSwitchContext'
 import { ConnectionProvider, useConnection } from './context/ConnectionContext'
 import { ConnectionErrorView } from './components/ConnectionErrorView'
+import { SyncProgressPanel } from './components/SyncProgressPanel'
 import { CapabilitiesProvider, useCapabilitiesContext } from './contexts/CapabilitiesContext'
 import { UserMenu } from './components/UserMenu'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
@@ -932,6 +933,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   const contentReady = !isSwitching && !authMePending &&
     !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected'
 
+  // Progressive shell during the initial informer sync: once the server
+  // publishes per-kind sync progress, render the app instead of the splash.
+  // Resource views serve kinds as they become ready; everything else shows
+  // the sync progress panel until 'connected'.
+  const shellDuringSync = !isSwitching && !authMePending &&
+    !(authMe?.authEnabled && !authMe?.username) &&
+    connection.state === 'connecting' && !!connection.syncStatus?.kinds?.length
+  const viewsSyncGated = shellDuringSync && mainView !== 'resources'
+
   const { clusterLoadState, showHomeClusterLoadFallback, clusterLoadInitial } = useClusterLoadState({
     namespaces,
     mainView,
@@ -1148,16 +1158,22 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   const clusterConnectionState = connection.state
   const clusterConnected = clusterConnectionState === 'connected'
   const liveUpdatesDisconnected = clusterConnected && !eventStreamConnected && !eventStreamConnecting
+  // During the progressive shell, the header label carries the global sync
+  // progress — the one place that explains why some views are open and
+  // others still loading.
+  const syncProgressLabel = connection.syncStatus
+    ? `Loading cluster data — ${connection.syncStatus.criticalSynced + connection.syncStatus.deferredSynced} of ${connection.syncStatus.criticalTotal + connection.syncStatus.deferredTotal} ready`
+    : 'Connecting'
   const headerConnectionLabel =
     clusterConnectionState === 'disconnected' ? 'Disconnected' :
-    clusterConnectionState === 'connecting' ? 'Connecting' :
+    clusterConnectionState === 'connecting' ? syncProgressLabel :
     liveUpdatesDisconnected ? 'Live updates disconnected' :
     clusterLoadState.loading ? `Connected — ${clusterLoadState.message}` :
     crdDiscoveryStatus === 'discovering' ? 'Connected — discovering Custom Resources...' :
     'Connected'
   const headerConnectionDisplayLabel =
     clusterConnectionState === 'disconnected' ? 'Disconnected' :
-    clusterConnectionState === 'connecting' ? 'Connecting' :
+    clusterConnectionState === 'connecting' ? syncProgressLabel :
     liveUpdatesDisconnected ? 'Live updates disconnected' :
     showClusterWarmupLabel ? clusterLoadState.message :
     crdDiscoveryStatus === 'discovering' ? 'Discovering Custom Resources…' :
@@ -1921,7 +1937,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {/* Connecting view — shown during initial connection or retry.
           Icon is pane-anchored so its screen position matches the
           host hub splash across cross-document transitions. */}
-      {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
+      {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && !shellDuringSync && (
         <PaneLoader
           label="Connecting to cluster"
           className="flex-1 min-h-0 bg-theme-base"
@@ -1982,10 +1998,18 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {/* inert while a fullscreen detail overlay covers the views — keeps the
           retained background list out of the focus order + a11y tree (the visual
           cover already blocks pointer events). */}
-      {contentReady && <div className="flex-1 flex overflow-hidden" inert={expandedView}>
+      {(contentReady || shellDuringSync) && <div className="flex-1 flex overflow-hidden" inert={expandedView}>
         <ErrorBoundary>
+        {/* Initial sync in progress: views that need the full cluster dataset
+            show per-kind progress instead; resource views work as kinds sync. */}
+        {viewsSyncGated && connection.syncStatus && (
+          <SyncProgressPanel
+            syncStatus={connection.syncStatus}
+            onNavigateToKind={(key) => navigate({ pathname: `/resources/${key}` })}
+          />
+        )}
         {/* Home dashboard */}
-        {mainView === 'home' && (
+        {!viewsSyncGated && mainView === 'home' && (
           <HomeView
             namespaces={namespaces}
             topology={topology}
@@ -2033,7 +2057,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         )}
 
         {/* Topology view */}
-        {mainView === 'topology' && (
+        {!viewsSyncGated && mainView === 'topology' && (
           <>
             {topology?.requiresNamespaceFilter && namespaces.length === 0 ? (
               /* Large cluster: prompt user to select a namespace */
@@ -2161,7 +2185,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         )}
 
         {/* Timeline view */}
-        {mainView === 'timeline' && (
+        {!viewsSyncGated && mainView === 'timeline' && (
           <TimelineView
             namespaces={namespaces}
             onResourceClick={(resource) => {
@@ -2179,7 +2203,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           />
         )}
 
-        {mainView === 'helm' && (
+        {!viewsSyncGated && mainView === 'helm' && (
           <HelmView
             namespaces={namespaces}
             selectedRelease={selectedHelmRelease}
@@ -2187,13 +2211,13 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           />
         )}
 
-        {mainView === 'helmCompare' && (
+        {!viewsSyncGated && mainView === 'helmCompare' && (
           <HelmCompareRoute />
         )}
 
         {/* GitOps view (inline only when the host hasn't taken it over — see
             the takeover splash below). */}
-        {mainView === 'gitops' && !isViewTakenOver('gitops') && (
+        {!viewsSyncGated && mainView === 'gitops' && !isViewTakenOver('gitops') && (
           <GitOpsView
             namespaces={namespaces}
             onOpenResource={(resource) => {
@@ -2208,7 +2232,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         )}
 
         {/* Applications view — deployable software grouped by app/release evidence */}
-        {mainView === 'applications' && (
+        {!viewsSyncGated && mainView === 'applications' && (
           <ApplicationsView
             namespaces={namespaces}
             onOpenResource={(resource) => {
@@ -2229,12 +2253,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         )}
 
         {/* Traffic view */}
-        {mainView === 'traffic' && (
+        {!viewsSyncGated && mainView === 'traffic' && (
           <TrafficView namespaces={namespaces} />
         )}
 
         {/* Cost detail view */}
-        {mainView === 'cost' && (
+        {!viewsSyncGated && mainView === 'cost' && (
           <CostView namespaces={namespaces} onBack={() => setMainView('home')} onOpenResource={navigateToResource} />
         )}
 
@@ -2252,7 +2276,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
         {/* Best practices detail view (inline only when the host hasn't taken
             Checks over — standalone OSS, or Cloud without a checks takeover). */}
-        {mainView === 'checks' && !isViewTakenOver('checks') && (
+        {!viewsSyncGated && mainView === 'checks' && !isViewTakenOver('checks') && (
           <AuditView
             namespaces={namespaces}
             onNavigateToResource={navigateToResourceList}
@@ -2264,7 +2288,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             Hub fleet uses; a GitOps reconciler subject routes to its detail page,
             other resources open the standard resource view. Inline only when the
             host hasn't taken it over. */}
-        {mainView === 'issues' && !isViewTakenOver('issues') && (
+        {!viewsSyncGated && mainView === 'issues' && !isViewTakenOver('issues') && (
           <IssuesPane
             namespaces={namespaces}
             onNavigateToResource={navigateFromIssue}
@@ -2274,7 +2298,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         {/* Workload full view — the standalone fullscreen route for non-list
             surfaces and deep links. Expand-from-drawer is the ?full=1 overlay on
             /resources instead, so it never routes here. */}
-        {mainView === 'workload' && (
+        {!viewsSyncGated && mainView === 'workload' && (
           <WorkloadViewRoute
             onNavigateToResource={(resource) => {
               navigate(relatedResourcePath(resource))
@@ -2283,7 +2307,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         )}
 
         {/* Compare two resources of the same kind side-by-side */}
-        {mainView === 'compare' && <CompareViewRoute />}
+        {!viewsSyncGated && mainView === 'compare' && <CompareViewRoute />}
 
         </ErrorBoundary>
       </div>}
@@ -2292,7 +2316,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {/* Resource detail drawer — stays mounted, expands to full-screen WorkloadView.
           Gated on contentReady so it never renders over the connecting/switching
           splash (which would push the centered logo off-center). */}
-      {contentReady && resourceDrawer.shouldRender && drawerResource && (
+      {(contentReady || shellDuringSync) && resourceDrawer.shouldRender && drawerResource && (
         <ResourceDetailDrawer
           resource={drawerResource}
           initialTab={drawerInitialTab}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -132,6 +132,37 @@ export function isForbiddenError(error: unknown): boolean {
   return error instanceof ApiError && error.status === 403
 }
 
+// isKindSyncPending matches the 503 the resource read handlers return while a
+// kind's informer is still completing its initial sync — the caller should
+// keep polling, not surface an error.
+export function isKindSyncPending(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 503 && error.data?.error_code === 'kind_sync_pending'
+}
+
+// isKindSyncFailed matches the terminal variant: the kind never synced within
+// the deadline for this connection. Retrying won't help — show the error.
+export function isKindSyncFailed(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 503 && error.data?.error_code === 'kind_sync_failed'
+}
+
+// SyncKindState / SyncStatusSnapshot mirror k8score's SyncSnapshot — attached
+// to the connection-status payload while the initial informer sync is running.
+export interface SyncKindState {
+  kind: string
+  key: string
+  synced: boolean
+  deferred: boolean
+}
+
+export interface SyncStatusSnapshot {
+  phase: string
+  criticalTotal: number
+  criticalSynced: number
+  deferredTotal: number
+  deferredSynced: number
+  kinds: SyncKindState[]
+}
+
 const METRICS_API_GROUP_TOKENS = ['metrics', 'k8s', 'io'] as const
 
 function mentionsMetricsAPIGroup(message: string): boolean {
@@ -1451,6 +1482,11 @@ export function useResource<T>(
       fetchJSON(`/resources/${kind}/${ns}/${name}${queryString ? `?${queryString}` : ''}`),
     enabled: (options?.enabled ?? true) && Boolean(kind && name), // namespace can be empty for cluster-scoped resources
     refetchInterval: options?.refetchInterval,
+    // Kind still completing its initial sync: stay in loading and poll until
+    // it becomes readable instead of erroring out (deep links during startup).
+    retry: (failureCount, error) => isKindSyncPending(error) ? true : failureCount < 3,
+    retryDelay: (failureCount, error) =>
+      isKindSyncPending(error) ? 2000 : Math.min(1000 * 2 ** failureCount, 30000),
   })
 
   // Extract resource and relationships from the response

--- a/web/src/components/SyncProgressPanel.tsx
+++ b/web/src/components/SyncProgressPanel.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import { Loader2, ArrowRight } from 'lucide-react'
+import { StatusDot } from '@skyhook-io/k8s-ui'
+import type { SyncStatusSnapshot } from '../api/client'
+
+// Shown in place of views that need the full cluster dataset while the
+// initial informer sync is still running. Resource views for already-synced
+// kinds work during this window — the per-kind list doubles as the map of
+// what's usable right now.
+export function SyncProgressPanel({
+  syncStatus,
+  onNavigateToKind,
+}: {
+  syncStatus: SyncStatusSnapshot
+  onNavigateToKind: (key: string) => void
+}) {
+  const total = syncStatus.criticalTotal + syncStatus.deferredTotal
+  const synced = syncStatus.criticalSynced + syncStatus.deferredSynced
+  const kinds = useMemo(
+    () => [...syncStatus.kinds].sort((a, b) => {
+      if (a.synced !== b.synced) return a.synced ? -1 : 1
+      return a.kind.localeCompare(b.kind)
+    }),
+    [syncStatus.kinds],
+  )
+
+  return (
+    <div className="flex-1 flex items-center justify-center overflow-y-auto bg-theme-base">
+      <div className="max-w-xl w-full px-8 py-10">
+        <div className="flex items-center gap-3 mb-1">
+          <Loader2 className="w-5 h-5 animate-spin text-theme-text-tertiary" />
+          <h2 className="text-lg font-semibold text-theme-text-primary">Loading cluster data</h2>
+        </div>
+        <p className="text-sm text-theme-text-secondary mb-6">
+          {synced} of {total} resource types ready — views open as their data finishes loading.
+          This view needs the full dataset and will appear automatically.
+        </p>
+        <div className="card-inner grid grid-cols-2 gap-x-6 gap-y-1.5 max-h-80 overflow-y-auto">
+          {kinds.map((k) => (
+            <div key={k.key} className="flex items-center gap-2 min-w-0 text-sm">
+              <StatusDot tone={k.synced ? 'healthy' : 'neutral'} size="sm" className="shrink-0" />
+              {k.synced ? (
+                <button
+                  onClick={() => onNavigateToKind(k.key)}
+                  className="group flex items-center gap-1 min-w-0 text-theme-text-primary hover:text-theme-brand transition-colors"
+                >
+                  <span className="truncate">{k.kind}</span>
+                  <ArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                </button>
+              ) : (
+                <span className="truncate text-theme-text-tertiary animate-pulse">{k.kind}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
+import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, isKindSyncPending, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
 import { isBadgeWorthy } from '../../utils/auditBadges'
 import type { AuditBadgeMessage } from '@skyhook-io/k8s-ui'
 import { apiUrl, getAuthHeaders, getCredentialsMode, stripBasename } from '../../api/config'
@@ -189,7 +189,12 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const selectedCountKnown = selectedCountKey ? hasResourceCount(countsData?.counts, selectedCountKey) : false
   const selectedCountUnavailable = selectedCountKey ? countsData?.unavailable?.includes(selectedCountKey) ?? false : false
   const isSelectedKindGuarded = selectedCountKey !== '' && LARGE_RESOURCE_LIST_GUARD_KEYS.has(selectedCountKey)
-  const waitingForGuardCount = isSelectedKindGuarded && !countsData && !countsIsError
+  // While still 'connecting', /resource-counts is unavailable — its error
+  // must NOT unlatch the large-list guard, or a huge Pods list could fetch
+  // unguarded on exactly the clusters the guard protects. Counts arrive
+  // right after 'connected' and settle the guard then.
+  const syncShellActive = connection.state === 'connecting'
+  const waitingForGuardCount = isSelectedKindGuarded && !countsData && (!countsIsError || syncShellActive)
   const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCountKnown && (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT))
   const selectedKindQueryBlocked = waitingForGuardCount || largeListBlocked
   const podCount = countsData?.counts.Pod
@@ -253,8 +258,15 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     refetchInterval: 120000, // Safety net — SSE k8s_event drives near-real-time invalidation
     retry: (failureCount: number, error: Error) => {
       if (isForbiddenError(error)) return false
+      // Initial informer sync still running for this kind: keep the query in
+      // its loading state and retry until the kind becomes readable — the
+      // header's sync-progress label explains the wait. The terminal variant
+      // (kind_sync_failed) falls through to the normal error path.
+      if (isKindSyncPending(error)) return true
       return failureCount < 3
     },
+    retryDelay: (failureCount: number, error: Error) =>
+      isKindSyncPending(error) ? 2000 : Math.min(1000 * 2 ** failureCount, 30000),
   })
 
   // Map to ResourceQueryResult shape

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -161,6 +161,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
         state: 'connecting',
         error: undefined,
         progressMessage: 'Connecting to cluster...',
+        // A retry is a fresh attempt — per-kind progress from the previous
+        // attempt would mislabel readiness until the next poll.
+        syncStatus: undefined,
       }))
     },
     onSuccess: (result) => {

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useCallback, useEffect, useRef, Re
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ContextInfo } from '../types'
 import { getApiBase } from '../api/config'
-import { apiFetch } from '../api/client'
+import { apiFetch, type SyncStatusSnapshot } from '../api/client'
 
 export type ConnectionStateType = 'connected' | 'disconnected' | 'connecting'
 
@@ -13,6 +13,10 @@ export interface ConnectionState {
   error?: string
   errorType?: string // config, auth, rbac, network, timeout, tls, unknown
   progressMessage?: string
+  // Per-kind readiness while the initial informer sync runs ('connecting'
+  // with informers started). Drives the progressive app shell — absent once
+  // connected or before informers exist.
+  syncStatus?: SyncStatusSnapshot
 }
 
 interface ConnectionStatusResponse extends ConnectionState {
@@ -124,7 +128,22 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
           error: data.error,
           errorType: data.errorType,
           progressMessage: data.progressMessage,
+          syncStatus: data.syncStatus,
         })
+        // The progressive shell renders real resource lists while still
+        // 'connecting'. A query client shared across cluster mounts may hold
+        // another cluster's data under identical keys — drop it before the
+        // shell can show it (the 'connected' path repeats this for the
+        // full-refresh case).
+        if (data.state === 'connecting' && data.syncStatus && cacheWarmAtMountRef.current) {
+          cacheWarmAtMountRef.current = false
+          queryClient.removeQueries({ predicate: (q) => q.queryKey[0] !== 'connection-status' })
+        }
+      } else if (data.state === 'connecting' && data.syncStatus) {
+        // SSE owns the state fields, but connection_state frames don't carry
+        // per-kind sync progress — merge it from the poll so the progressive
+        // shell keeps ticking while still connecting.
+        setConnection(prev => prev.state === 'connecting' ? { ...prev, syncStatus: data.syncStatus } : prev)
       }
     }
   }, [data])
@@ -253,6 +272,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       // state and wait for either 'connected' (sync done) or 'disconnected' (failure).
       if (prev.state === 'connected' && status.state === 'connecting') {
         return prev
+      }
+      // connection_state frames don't carry per-kind sync progress — keep the
+      // last polled snapshot while still connecting, or each SSE progress
+      // frame would flicker the progressive shell back to the splash.
+      if (status.state === 'connecting' && !status.syncStatus && prev.state === 'connecting') {
+        return { ...status, syncStatus: prev.syncStatus }
       }
       return status
     })

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -146,7 +146,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
         setConnection(prev => prev.state === 'connecting' ? { ...prev, syncStatus: data.syncStatus } : prev)
       }
     }
-  }, [data])
+  }, [data, queryClient])
 
   // Retry mutation
   const retryMutation = useMutation({


### PR DESCRIPTION
Fixes #1149.

## What

On large clusters the initial informer sync takes minutes, and until now the entire UI sat behind a splash screen with every read returning 503 until the critical set — including pods, typically the slowest LIST — finished. Radar now becomes usable **per kind, as each informer completes**: navigate to Deployments while Pods is still listing and the full Deployments view works; the Pods view shows a loading state and appears the moment its data is complete.

**Honest bound:** the pods view itself can't appear faster than the pods LIST — the win is every other view, plus a legible app with visible per-kind progress instead of an opaque splash.

## How it works

**Readiness, not reordering.** Informers already start in parallel; there is no queue to jump. The change is exposing per-kind sync state and gating reads on it:

- `k8score`: `OnInformersStarted` hands out the cache mid-Phase-1; `KindReadinessFor` classifies a kind `ready / pending / failed / unavailable` from live informer state; `GetSyncSnapshot` reports per-kind progress cheaply (no lister walks — the connection endpoint polls sub-second during sync).
- `internal/k8s`: a **generation-guarded** `syncingCache` handle alongside the untouched `resourceCache` singleton (its non-nil ⇒ synced invariant holds everywhere else). A context switch mid-construction invalidates every publish/promotion from the stale build — this also closes a pre-existing race where a construction finishing after a switch could republish the old cluster's cache.
- `server`: the resource list/get handlers gate per kind — `503 {error_code: kind_sync_pending}` while an informer syncs, `kind_sync_failed` when it never will — and serve from whichever cache exists. **This also fixes a shipped false-empty bug:** post-connect, promoted criticals and `isEnabled`-only listers (ReplicaSets, HPAs, ServiceAccounts…) could render a partial store as a complete list. Dynamic/CRD reads keep the connected gate (no dynamic cache exists mid-sync). Single-GET serves without relationship enrichment while the topology cache doesn't exist. A disconnected cluster still 503s everywhere — cache handles stand in for connectedness only during `connecting`.
- `web`: the splash is replaced by the app shell as soon as informers start. Resource views work per kind — a pending kind stays in its loading state (**an unsynced kind never renders as an empty list**) and populates automatically. Views needing the full dataset (Home, Topology, Timeline, …) show a per-kind progress panel with links to ready kinds. The header carries "Loading cluster data — x of y ready". The large-list guard holds while counts are unavailable, and warm shared query caches (embedded multi-cluster mounts) are dropped before the shell can show another cluster's data.

`RADAR_DEBUG_SYNC_DELAY=pods=120s` (dev seam) simulates a slow kind for testing/demoing the window.

## Testing

- New deterministic tests: k8score progressive readiness via blocked-LIST fake-client reactors (pending → ready, deferred-timeout → failed), generation-guard publish/promote/clear vs reset, alias→informer-key mapping, debug-delay parsing. Full `go test ./...` + k8score module + `tsc` + frontend build green.
- Visual-tested against a live GKE cluster with the delay seam: progress panel with per-kind links → full Deployments list (92 items) during sync → Pods loading state → automatic transition to the complete dashboard on connect. Fast-cluster path regression-checked (no delay: straight to connected, no syncStatus in payload).

## Deliberate scope cuts

- Aggregate views stay gated until connected — partial topology/audit would mislead.
- `/resource-counts` isn't progressive yet, so guarded kinds (Pod/Event/ReplicaSet/EndpointSlice) hold their large-list guard until connected — the safe direction; progressive counts is a natural follow-up.
- Events sync in the background with no deadline by design; its view polls while open rather than erroring (previously it error'd out after 3 retries mid-sync).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster connection gating, cache singleton lifecycle on context switches, and what resource APIs return during sync—high user impact but guarded by generation checks and explicit readiness errors instead of silent wrong data.
> 
> **Overview**
> Large clusters used to block the whole UI on a connecting splash until critical informers (often pods) finished listing. This PR exposes **per-kind sync state** so resource list/get handlers and the web shell can open **one kind at a time** while others are still pending.
> 
> **Backend:** `k8score` adds `OnInformersStarted`, `KindReadinessFor` (ready/pending/failed/unavailable), `GetSyncSnapshot`, and optional `DebugSyncDelays`. `internal/k8s` publishes a generation-guarded mid-sync `syncingCache` before Phase-1 completes; `ResetResourceCache` bumps `cacheGeneration` so stale constructions cannot republish an old cluster’s cache after a context switch. Resource handlers use `gateResourceRead` / `requireConnectedOrSyncing` and return `503` with `kind_sync_pending` or `kind_sync_failed` instead of serving partial stores as empty lists. Connection status includes `syncStatus` while `connecting`.
> 
> **Frontend:** When `syncStatus` is present, the app shell replaces the splash; resource views load per kind (pending kinds keep polling); Home/Topology/etc. show `SyncProgressPanel` until connected. React Query retries on `kind_sync_pending`; shared query caches are cleared when progressive sync starts to avoid cross-cluster stale data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eedcbcce8886ef0a4320daf968b96e3d17c6d550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->