### PR TITLE
feat(resources): add column filter inversion

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -4884,7 +4884,14 @@ export function ResourcesView({
                                 )}
                               >
                                 <ListFilter className="w-3 h-3" />
-                                {hasActiveFilter && <span className="text-[10px] leading-none font-semibold">{activeFilterValues.length}</span>}
+                                {hasActiveFilter && (
+                                  <span
+                                    className="text-[10px] leading-none font-semibold"
+                                    aria-label={`${activeFilterValues.length} ${columnFilterExcludes[col.key] ? 'excluded' : 'included'} value${activeFilterValues.length === 1 ? '' : 's'}`}
+                                  >
+                                    {columnFilterExcludes[col.key] ? `≠ ${activeFilterValues.length}` : activeFilterValues.length}
+                                  </span>
+                                )}
                               </button>
                               {hasActiveFilter && (
                                 <button

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -131,6 +131,7 @@ import {
   serializeColumnFilters,
   parseColumnFilterInverts,
   serializeColumnFilterInverts,
+  reconcileColumnFilterInverts,
   podMatchesProblemCategory,
   SEVERITY_DOT_COLOR,
 } from './resource-utils'
@@ -2103,7 +2104,10 @@ function getInitialFiltersFromURL() {
   const params = new URLSearchParams(window.location.search)
   // Parse generic column filters
   const columnFilters = parseColumnFilters(params.get('filters'))
-  const columnFilterInverts = parseColumnFilterInverts(params.get('filterInvert'))
+  const columnFilterInverts = reconcileColumnFilterInverts(
+    parseColumnFilterInverts(params.get('filterInvert')),
+    columnFilters,
+  )
   const result = {
     search: params.get('search') || '',
     regex: params.get('regex') === 'true',

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -129,6 +129,8 @@ import {
   getCellFilterValue,
   parseColumnFilters,
   serializeColumnFilters,
+  parseColumnFilterInverts,
+  serializeColumnFilterInverts,
   podMatchesProblemCategory,
   SEVERITY_DOT_COLOR,
 } from './resource-utils'
@@ -2101,10 +2103,12 @@ function getInitialFiltersFromURL() {
   const params = new URLSearchParams(window.location.search)
   // Parse generic column filters
   const columnFilters = parseColumnFilters(params.get('filters'))
+  const columnFilterInverts = parseColumnFilterInverts(params.get('filterInvert'))
   const result = {
     search: params.get('search') || '',
     regex: params.get('regex') === 'true',
     columnFilters,
+    columnFilterInverts,
     problemFilters: params.get('problems')?.split(',').filter(Boolean) || [],
     showInactive: params.get('showInactive') === 'true',
     labelSelector: params.get('labels') || '', // e.g., "app=caretta,version=v1"
@@ -2188,6 +2192,7 @@ export function ResourcesView({
   const [sortDirection, setSortDirection] = useState<SortDirection>(null)
   // Filter state
   const [columnFilters, setColumnFilters] = useState<Record<string, string[]>>(initialFilters.columnFilters)
+  const [columnFilterInverts, setColumnFilterInverts] = useState<Record<string, boolean>>(initialFilters.columnFilterInverts)
   const [problemFilters, setProblemFilters] = useState<string[]>(initialFilters.problemFilters)
   const [openColumnFilter, setOpenColumnFilter] = useState<string | null>(null)
   const [columnFilterSearch, setColumnFilterSearch] = useState('')
@@ -2237,6 +2242,24 @@ export function ResourcesView({
       delete next[key]
       return next
     })
+    setColumnFilterInverts(prev => {
+      if (!prev[key]) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }, [])
+
+  const toggleColumnFilterInvert = useCallback((key: string) => {
+    setColumnFilterInverts(prev => {
+      const next = { ...prev }
+      if (next[key]) {
+        delete next[key]
+      } else {
+        next[key] = true
+      }
+      return next
+    })
   }, [])
 
   const toggleColumnFilterValue = useCallback((key: string, value: string) => {
@@ -2248,6 +2271,14 @@ export function ResourcesView({
         const updated = current.filter(v => v !== value)
         if (updated.length === 0) {
           delete next[key]
+          // Inversion is meaningless with no selected values — drop it so a
+          // stale invert flag doesn't linger in the URL or re-arm on reselect.
+          setColumnFilterInverts(inv => {
+            if (!inv[key]) return inv
+            const nextInv = { ...inv }
+            delete nextInv[key]
+            return nextInv
+          })
         } else {
           next[key] = updated
         }
@@ -2944,6 +2975,13 @@ export function ResourcesView({
       setColumnFilters(newFilters.columnFilters)
     }
 
+    // Update column filter inverts if changed
+    const newInvertStr = serializeColumnFilterInverts(newFilters.columnFilterInverts)
+    const currentInvertStr = serializeColumnFilterInverts(columnFilterInverts)
+    if (newInvertStr !== currentInvertStr) {
+      setColumnFilterInverts(newFilters.columnFilterInverts)
+    }
+
     // Reset the flag after a tick to allow normal URL updates
     requestAnimationFrame(() => {
       isSyncingFromURL.current = false
@@ -2969,6 +3007,7 @@ export function ResourcesView({
     search: string,
     regex: boolean,
     colFilters: Record<string, string[]>,
+    colInverts: Record<string, boolean>,
     problems: string[],
     showInactive: boolean,
     resourceNs?: string,
@@ -3001,6 +3040,16 @@ export function ResourcesView({
       params.set('filters', filtersStr)
     } else {
       params.delete('filters')
+    }
+    // Only persist inverts for columns that still have active values — a bare
+    // invert flag filters nothing and would just be URL noise.
+    const invertStr = serializeColumnFilterInverts(
+      Object.fromEntries(Object.entries(colInverts).filter(([k, on]) => on && (colFilters[k]?.length ?? 0) > 0))
+    )
+    if (invertStr) {
+      params.set('filterInvert', invertStr)
+    } else {
+      params.delete('filterInvert')
     }
     if (problems.length > 0) {
       params.set('problems', problems.join(','))
@@ -3058,6 +3107,7 @@ export function ResourcesView({
     setSearchTerm('')
     setRegexMode(false)
     setColumnFilters({})
+    setColumnFilterInverts({})
     setProblemFilters([])
     setLabelSelector('')
     setOwnerKind('')
@@ -3067,7 +3117,7 @@ export function ResourcesView({
     // params are out of scope here; the host's onClearNamespaces (and its
     // own state→URL sync) owns namespace cleanup.
     const params = new URLSearchParams(window.location.search)
-    for (const key of ['search', 'regex', 'filters', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
+    for (const key of ['search', 'regex', 'filters', 'filterInvert', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
       params.delete(key)
     }
     navigate({ pathname: window.location.pathname, search: params.toString() }, { replace: true })
@@ -3124,8 +3174,8 @@ export function ResourcesView({
     shouldPushHistory.current = false
     prevSelectedResourceRef.current = current
 
-    updateURL(selectedKind, searchTerm, regexMode, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
-  }, [selectedKind, searchTerm, regexMode, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
+    updateURL(selectedKind, searchTerm, regexMode, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
+  }, [selectedKind, searchTerm, regexMode, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
 
   // Handle resource click from URL on mount
   useEffect(() => {
@@ -3425,6 +3475,7 @@ export function ResourcesView({
     setOpenColumnFilter(null)
     if (!isSyncingFromURL.current) {
       setColumnFilters({})
+      setColumnFilterInverts({})
     }
     setProblemFilters([])
   }, [selectedKind.name])
@@ -3598,7 +3649,8 @@ export function ResourcesView({
         activeColFilters.every(([col, vals]) => {
           const extra = extraColumnsByKey.get(col)
           const cellVal = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col, kindLower)
-          return vals.includes(cellVal)
+          const match = vals.includes(cellVal)
+          return columnFilterInverts[col] ? !match : match
         })
       )
     }
@@ -3741,7 +3793,7 @@ export function ResourcesView({
     }
 
     return result
-  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
+  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
 
   // For nodes table: compute the majority minor version so outliers can be highlighted
   const majorityNodeMinorVersion = useMemo(() => {
@@ -4693,7 +4745,7 @@ export function ResourcesView({
                         className="flex items-center gap-1 px-2 py-1 text-xs selection selection-text rounded-md hover:selection-strong transition-colors"
                       >
                         <ListFilter className="w-3 h-3" />
-                        <span>{key}: {vals.join(', ')}</span>
+                        <span>{key}: {columnFilterInverts[key] ? 'not ' : ''}{vals.join(', ')}</span>
                         <X className="w-3 h-3" />
                       </button>
                     ))}
@@ -4913,6 +4965,18 @@ export function ResourcesView({
                                   <div className="px-3 py-2 text-xs text-theme-text-disabled">No matches</div>
                                 )}
                               </div>
+                              {activeFilterValues.length > 0 && (
+                                <button
+                                  onClick={() => toggleColumnFilterInvert(col.key)}
+                                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs border-t border-theme-border text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary transition-colors"
+                                  title="Show rows that do NOT match the selected values"
+                                >
+                                  <span className={clsx('w-3 h-3 shrink-0 rounded-sm border flex items-center justify-center', columnFilterInverts[col.key] ? 'bg-skyhook-500 border-skyhook-500' : 'border-theme-border')}>
+                                    {columnFilterInverts[col.key] && <Check className="w-2 h-2 text-white" />}
+                                  </span>
+                                  <span>Invert (show non-matching)</span>
+                                </button>
+                              )}
                             </div>
                           )
                         })()}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2582,6 +2582,12 @@ export function ResourcesView({
       delete next[key]
       return next
     })
+    setColumnFilterExcludes(prev => {
+      if (!(key in prev)) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
     if (sortColumn === key) {
       setSortColumn(null)
       setSortDirection(null)
@@ -5997,11 +6003,13 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
           <button
             onClick={(e) => {
               e.stopPropagation()
-              // Merge node filter into existing column filters via URL
+              // Merge node filter into existing column filters via URL,
+              // preserving any exclude operators already set on other columns.
               const params = new URLSearchParams(window.location.search)
               const existing = parseColumnFilters(params.get('filters'))
+              const existingExcludes = parseColumnFilterExcludes(params.get('filters'))
               existing['node'] = [nodeVal]
-              params.set('filters', serializeColumnFilters(existing))
+              params.set('filters', serializeColumnFilters(existing, existingExcludes))
               navigate?.(`/resources/pods?${params.toString()}`)
             }}
             className="text-sm text-blue-400 hover:text-blue-300 hover:underline truncate block text-left"

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -129,9 +129,7 @@ import {
   getCellFilterValue,
   parseColumnFilters,
   serializeColumnFilters,
-  parseColumnFilterInverts,
-  serializeColumnFilterInverts,
-  reconcileColumnFilterInverts,
+  parseColumnFilterExcludes,
   podMatchesProblemCategory,
   SEVERITY_DOT_COLOR,
 } from './resource-utils'
@@ -2103,16 +2101,14 @@ export function deriveSidebarResourceCounts(
 function getInitialFiltersFromURL() {
   const params = new URLSearchParams(window.location.search)
   // Parse generic column filters
-  const columnFilters = parseColumnFilters(params.get('filters'))
-  const columnFilterInverts = reconcileColumnFilterInverts(
-    parseColumnFilterInverts(params.get('filterInvert')),
-    columnFilters,
-  )
+  const filtersParam = params.get('filters')
+  const columnFilters = parseColumnFilters(filtersParam)
+  const columnFilterExcludes = parseColumnFilterExcludes(filtersParam)
   const result = {
     search: params.get('search') || '',
     regex: params.get('regex') === 'true',
     columnFilters,
-    columnFilterInverts,
+    columnFilterExcludes,
     problemFilters: params.get('problems')?.split(',').filter(Boolean) || [],
     showInactive: params.get('showInactive') === 'true',
     labelSelector: params.get('labels') || '', // e.g., "app=caretta,version=v1"
@@ -2196,7 +2192,7 @@ export function ResourcesView({
   const [sortDirection, setSortDirection] = useState<SortDirection>(null)
   // Filter state
   const [columnFilters, setColumnFilters] = useState<Record<string, string[]>>(initialFilters.columnFilters)
-  const [columnFilterInverts, setColumnFilterInverts] = useState<Record<string, boolean>>(initialFilters.columnFilterInverts)
+  const [columnFilterExcludes, setColumnFilterExcludes] = useState<Record<string, boolean>>(initialFilters.columnFilterExcludes)
   const [problemFilters, setProblemFilters] = useState<string[]>(initialFilters.problemFilters)
   const [openColumnFilter, setOpenColumnFilter] = useState<string | null>(null)
   const [columnFilterSearch, setColumnFilterSearch] = useState('')
@@ -2246,7 +2242,7 @@ export function ResourcesView({
       delete next[key]
       return next
     })
-    setColumnFilterInverts(prev => {
+    setColumnFilterExcludes(prev => {
       if (!prev[key]) return prev
       const next = { ...prev }
       delete next[key]
@@ -2254,13 +2250,14 @@ export function ResourcesView({
     })
   }, [])
 
-  const toggleColumnFilterInvert = useCallback((key: string) => {
-    setColumnFilterInverts(prev => {
+  const setColumnFilterMode = useCallback((key: string, exclude: boolean) => {
+    setColumnFilterExcludes(prev => {
+      if (Boolean(prev[key]) === exclude) return prev
       const next = { ...prev }
-      if (next[key]) {
-        delete next[key]
-      } else {
+      if (exclude) {
         next[key] = true
+      } else {
+        delete next[key]
       }
       return next
     })
@@ -2275,9 +2272,9 @@ export function ResourcesView({
         const updated = current.filter(v => v !== value)
         if (updated.length === 0) {
           delete next[key]
-          // Inversion is meaningless with no selected values — drop it so a
-          // stale invert flag doesn't linger in the URL or re-arm on reselect.
-          setColumnFilterInverts(inv => {
+          // The operator is meaningless with no selected values — drop it so a
+          // stale exclude flag doesn't linger in state or re-arm on reselect.
+          setColumnFilterExcludes(inv => {
             if (!inv[key]) return inv
             const nextInv = { ...inv }
             delete nextInv[key]
@@ -2979,11 +2976,10 @@ export function ResourcesView({
       setColumnFilters(newFilters.columnFilters)
     }
 
-    // Update column filter inverts if changed
-    const newInvertStr = serializeColumnFilterInverts(newFilters.columnFilterInverts)
-    const currentInvertStr = serializeColumnFilterInverts(columnFilterInverts)
-    if (newInvertStr !== currentInvertStr) {
-      setColumnFilterInverts(newFilters.columnFilterInverts)
+    // Update column filter operators (include/exclude) if changed
+    const excludeKeys = (m: Record<string, boolean>) => Object.keys(m).filter(k => m[k]).sort().join(',')
+    if (excludeKeys(newFilters.columnFilterExcludes) !== excludeKeys(columnFilterExcludes)) {
+      setColumnFilterExcludes(newFilters.columnFilterExcludes)
     }
 
     // Reset the flag after a tick to allow normal URL updates
@@ -3011,7 +3007,7 @@ export function ResourcesView({
     search: string,
     regex: boolean,
     colFilters: Record<string, string[]>,
-    colInverts: Record<string, boolean>,
+    colExcludes: Record<string, boolean>,
     problems: string[],
     showInactive: boolean,
     resourceNs?: string,
@@ -3038,22 +3034,17 @@ export function ResourcesView({
     } else {
       params.delete('regex')
     }
-    // Write column filters as `filters` param; remove legacy `status` param
-    const filtersStr = serializeColumnFilters(colFilters)
+    // Write column filters as `filters` param; the exclude operator is folded
+    // into each column entry, so it can never drift from the values it negates.
+    // Guard against a stale exclude flag on a column with no active values.
+    const activeExcludes = Object.fromEntries(
+      Object.entries(colExcludes).filter(([k, on]) => on && (colFilters[k]?.length ?? 0) > 0)
+    )
+    const filtersStr = serializeColumnFilters(colFilters, activeExcludes)
     if (filtersStr) {
       params.set('filters', filtersStr)
     } else {
       params.delete('filters')
-    }
-    // Only persist inverts for columns that still have active values — a bare
-    // invert flag filters nothing and would just be URL noise.
-    const invertStr = serializeColumnFilterInverts(
-      Object.fromEntries(Object.entries(colInverts).filter(([k, on]) => on && (colFilters[k]?.length ?? 0) > 0))
-    )
-    if (invertStr) {
-      params.set('filterInvert', invertStr)
-    } else {
-      params.delete('filterInvert')
     }
     if (problems.length > 0) {
       params.set('problems', problems.join(','))
@@ -3111,7 +3102,7 @@ export function ResourcesView({
     setSearchTerm('')
     setRegexMode(false)
     setColumnFilters({})
-    setColumnFilterInverts({})
+    setColumnFilterExcludes({})
     setProblemFilters([])
     setLabelSelector('')
     setOwnerKind('')
@@ -3121,7 +3112,7 @@ export function ResourcesView({
     // params are out of scope here; the host's onClearNamespaces (and its
     // own state→URL sync) owns namespace cleanup.
     const params = new URLSearchParams(window.location.search)
-    for (const key of ['search', 'regex', 'filters', 'filterInvert', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
+    for (const key of ['search', 'regex', 'filters', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
       params.delete(key)
     }
     navigate({ pathname: window.location.pathname, search: params.toString() }, { replace: true })
@@ -3178,8 +3169,8 @@ export function ResourcesView({
     shouldPushHistory.current = false
     prevSelectedResourceRef.current = current
 
-    updateURL(selectedKind, searchTerm, regexMode, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
-  }, [selectedKind, searchTerm, regexMode, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
+    updateURL(selectedKind, searchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
+  }, [selectedKind, searchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
 
   // Handle resource click from URL on mount
   useEffect(() => {
@@ -3479,7 +3470,7 @@ export function ResourcesView({
     setOpenColumnFilter(null)
     if (!isSyncingFromURL.current) {
       setColumnFilters({})
-      setColumnFilterInverts({})
+      setColumnFilterExcludes({})
     }
     setProblemFilters([])
   }, [selectedKind.name])
@@ -3654,7 +3645,7 @@ export function ResourcesView({
           const extra = extraColumnsByKey.get(col)
           const cellVal = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col, kindLower)
           const match = vals.includes(cellVal)
-          return columnFilterInverts[col] ? !match : match
+          return columnFilterExcludes[col] ? !match : match
         })
       )
     }
@@ -3797,7 +3788,7 @@ export function ResourcesView({
     }
 
     return result
-  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, columnFilterInverts, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
+  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
 
   // For nodes table: compute the majority minor version so outliers can be highlighted
   const majorityNodeMinorVersion = useMemo(() => {
@@ -4749,7 +4740,7 @@ export function ResourcesView({
                         className="flex items-center gap-1 px-2 py-1 text-xs selection selection-text rounded-md hover:selection-strong transition-colors"
                       >
                         <ListFilter className="w-3 h-3" />
-                        <span>{key}: {columnFilterInverts[key] ? 'not ' : ''}{vals.join(', ')}</span>
+                        <span>{key}: {columnFilterExcludes[key] ? 'not ' : ''}{vals.join(', ')}</span>
                         <X className="w-3 h-3" />
                       </button>
                     ))}
@@ -4921,6 +4912,34 @@ export function ResourcesView({
                               )}
                               onClick={(e) => e.stopPropagation()}
                             >
+                              <div className="flex items-center gap-1 p-1.5 border-b border-theme-border" role="group" aria-label={`${col.label} filter mode`}>
+                                <button
+                                  onClick={() => setColumnFilterMode(col.key, false)}
+                                  aria-pressed={!columnFilterExcludes[col.key]}
+                                  className={clsx(
+                                    'flex-1 px-2 py-1 text-xs rounded transition-colors',
+                                    !columnFilterExcludes[col.key]
+                                      ? 'selection-strong selection-text'
+                                      : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
+                                  )}
+                                  title="Show rows matching the selected values"
+                                >
+                                  Include
+                                </button>
+                                <button
+                                  onClick={() => setColumnFilterMode(col.key, true)}
+                                  aria-pressed={Boolean(columnFilterExcludes[col.key])}
+                                  className={clsx(
+                                    'flex-1 px-2 py-1 text-xs rounded transition-colors',
+                                    columnFilterExcludes[col.key]
+                                      ? 'selection-strong selection-text'
+                                      : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
+                                  )}
+                                  title="Show rows that do NOT match the selected values"
+                                >
+                                  Exclude
+                                </button>
+                              </div>
                               {values.length > 5 ? (
                                 <div className="flex items-center gap-2 p-2 border-b border-theme-border">
                                   <div className="relative flex-1">
@@ -4969,18 +4988,6 @@ export function ResourcesView({
                                   <div className="px-3 py-2 text-xs text-theme-text-disabled">No matches</div>
                                 )}
                               </div>
-                              {activeFilterValues.length > 0 && (
-                                <button
-                                  onClick={() => toggleColumnFilterInvert(col.key)}
-                                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs border-t border-theme-border text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary transition-colors"
-                                  title="Show rows that do NOT match the selected values"
-                                >
-                                  <span className={clsx('w-3 h-3 shrink-0 rounded-sm border flex items-center justify-center', columnFilterInverts[col.key] ? 'bg-skyhook-500 border-skyhook-500' : 'border-theme-border')}>
-                                    {columnFilterInverts[col.key] && <Check className="w-2 h-2 text-white" />}
-                                  </span>
-                                  <span>Invert (show non-matching)</span>
-                                </button>
-                              )}
                             </div>
                           )
                         })()}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -6009,6 +6009,10 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
               const existing = parseColumnFilters(params.get('filters'))
               const existingExcludes = parseColumnFilterExcludes(params.get('filters'))
               existing['node'] = [nodeVal]
+              // Clicking a node means "show pods on this node", so force the
+              // node column back to include mode even if it was previously
+              // set to exclude — otherwise the shortcut would hide those pods.
+              delete existingExcludes['node']
               params.set('filters', serializeColumnFilters(existing, existingExcludes))
               navigate?.(`/resources/pods?${params.toString()}`)
             }}

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -93,4 +93,12 @@ describe('column filter include/exclude operator', () => {
     expect(({} as Record<string, unknown>).polluted).toBeUndefined()
     expect(parseColumnFilterExcludes('__proto__:exclude:Running')).toEqual({})
   })
+
+  it('lets the last segment win the mode when a column repeats', () => {
+    expect(parseColumnFilters('status:exclude:Running|status:Completed')).toEqual({ status: ['Completed'] })
+    expect(parseColumnFilterExcludes('status:exclude:Running|status:Completed')).toEqual({})
+
+    expect(parseColumnFilters('status:Running|status:exclude:Completed')).toEqual({ status: ['Completed'] })
+    expect(parseColumnFilterExcludes('status:Running|status:exclude:Completed')).toEqual({ status: true })
+  })
 })

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -85,4 +85,12 @@ describe('column filter include/exclude operator', () => {
     expect(parseColumnFilterExcludes(null)).toEqual({})
     expect(serializeColumnFilters({})).toBe('')
   })
+
+  it('ignores prototype-polluting keys from a crafted param', () => {
+    const parsed = parseColumnFilters('__proto__:Running|constructor:x|status:Running')
+    expect(parsed).toEqual({ status: ['Running'] })
+    expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(false)
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(parseColumnFilterExcludes('__proto__:exclude:Running')).toEqual({})
+  })
 })

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   parseColumnFilters,
   serializeColumnFilters,
-  parseColumnFilterInverts,
-  serializeColumnFilterInverts,
-  reconcileColumnFilterInverts,
+  parseColumnFilterExcludes,
 } from './resource-utils'
 
 describe('column filter serialization round-trip', () => {
@@ -29,50 +27,62 @@ describe('column filter serialization round-trip', () => {
   it('parses legacy unencoded built-in keys', () => {
     expect(parseColumnFilters('status:Running')).toEqual({ status: ['Running'] })
   })
-})
 
-describe('column filter invert serialization round-trip', () => {
-  it('round-trips inverted built-in keys', () => {
-    const inverts = { status: true, namespace: true }
-    expect(parseColumnFilterInverts(serializeColumnFilterInverts(inverts))).toEqual(inverts)
-  })
-
-  it('drops false entries', () => {
-    expect(serializeColumnFilterInverts({ status: true, namespace: false })).toBe('status')
-  })
-
-  it('encodes custom-column keys whose comma would collide with the delimiter', () => {
-    const inverts = { 'label:tier,zone': true }
-    const serialized = serializeColumnFilterInverts(inverts)
-    expect(serialized).toBe('label%3Atier%2Czone')
-    expect(parseColumnFilterInverts(serialized)).toEqual(inverts)
-  })
-
-  it('returns an empty object for empty/absent params', () => {
-    expect(parseColumnFilterInverts('')).toEqual({})
-    expect(parseColumnFilterInverts(null)).toEqual({})
-    expect(serializeColumnFilterInverts({})).toBe('')
+  it('treats a two-part filter as implicit include (no excludes)', () => {
+    expect(parseColumnFilterExcludes('status:Running')).toEqual({})
   })
 })
 
-describe('reconcileColumnFilterInverts', () => {
-  it('keeps invert flags for columns that have selected values', () => {
-    const inverts = { status: true, namespace: true }
-    const filters = { status: ['Running'], namespace: ['default'] }
-    expect(reconcileColumnFilterInverts(inverts, filters)).toEqual(inverts)
+describe('column filter include/exclude operator', () => {
+  it('serializes excluded columns with the explicit exclude operator', () => {
+    const filters = { status: ['Running', 'Completed'], namespace: ['default'] }
+    const excludes = { status: true }
+    expect(serializeColumnFilters(filters, excludes)).toBe(
+      'status:exclude:Running,Completed|namespace:default'
+    )
   })
 
-  it('drops orphan flags for columns with no selected values', () => {
-    const inverts = { status: true, namespace: true }
-    const filters = { status: ['Running'] }
-    expect(reconcileColumnFilterInverts(inverts, filters)).toEqual({ status: true })
+  it('round-trips values through an excluded column', () => {
+    const filters = { status: ['Running', 'Completed'] }
+    const serialized = serializeColumnFilters(filters, { status: true })
+    expect(parseColumnFilters(serialized)).toEqual(filters)
+    expect(parseColumnFilterExcludes(serialized)).toEqual({ status: true })
   })
 
-  it('drops a flag whose column has an empty values array', () => {
-    expect(reconcileColumnFilterInverts({ status: true }, { status: [] })).toEqual({})
+  it('parses the explicit include operator as non-excluded', () => {
+    expect(parseColumnFilters('namespace:include:default')).toEqual({ namespace: ['default'] })
+    expect(parseColumnFilterExcludes('namespace:include:default')).toEqual({})
   })
 
-  it('returns an empty object when there are no filters', () => {
-    expect(reconcileColumnFilterInverts({ status: true }, {})).toEqual({})
+  it('keeps a value literally named "exclude" in the two-part form', () => {
+    expect(parseColumnFilters('reason:exclude')).toEqual({ reason: ['exclude'] })
+    expect(parseColumnFilterExcludes('reason:exclude')).toEqual({})
+  })
+
+  it('handles a value literally named "exclude" under the exclude operator', () => {
+    const serialized = serializeColumnFilters({ reason: ['exclude'] }, { reason: true })
+    expect(serialized).toBe('reason:exclude:exclude')
+    expect(parseColumnFilters(serialized)).toEqual({ reason: ['exclude'] })
+    expect(parseColumnFilterExcludes(serialized)).toEqual({ reason: true })
+  })
+
+  it('does not emit an operator for an excluded column with no values', () => {
+    expect(serializeColumnFilters({ status: [] }, { status: true })).toBe('')
+    expect(parseColumnFilterExcludes('')).toEqual({})
+  })
+
+  it('preserves the exclude operator for custom-column keys', () => {
+    const filters = { 'label:tier': ['control-plane'] }
+    const serialized = serializeColumnFilters(filters, { 'label:tier': true })
+    expect(serialized).toBe('label%3Atier:exclude:control-plane')
+    expect(parseColumnFilters(serialized)).toEqual(filters)
+    expect(parseColumnFilterExcludes(serialized)).toEqual({ 'label:tier': true })
+  })
+
+  it('returns empty structures for empty/absent params', () => {
+    expect(parseColumnFilters('')).toEqual({})
+    expect(parseColumnFilters(null)).toEqual({})
+    expect(parseColumnFilterExcludes(null)).toEqual({})
+    expect(serializeColumnFilters({})).toBe('')
   })
 })

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { parseColumnFilters, serializeColumnFilters } from './resource-utils'
+import {
+  parseColumnFilters,
+  serializeColumnFilters,
+  parseColumnFilterInverts,
+  serializeColumnFilterInverts,
+} from './resource-utils'
 
 describe('column filter serialization round-trip', () => {
   it('round-trips built-in keys', () => {
@@ -22,5 +27,29 @@ describe('column filter serialization round-trip', () => {
 
   it('parses legacy unencoded built-in keys', () => {
     expect(parseColumnFilters('status:Running')).toEqual({ status: ['Running'] })
+  })
+})
+
+describe('column filter invert serialization round-trip', () => {
+  it('round-trips inverted built-in keys', () => {
+    const inverts = { status: true, namespace: true }
+    expect(parseColumnFilterInverts(serializeColumnFilterInverts(inverts))).toEqual(inverts)
+  })
+
+  it('drops false entries', () => {
+    expect(serializeColumnFilterInverts({ status: true, namespace: false })).toBe('status')
+  })
+
+  it('encodes custom-column keys whose comma would collide with the delimiter', () => {
+    const inverts = { 'label:tier,zone': true }
+    const serialized = serializeColumnFilterInverts(inverts)
+    expect(serialized).toBe('label%3Atier%2Czone')
+    expect(parseColumnFilterInverts(serialized)).toEqual(inverts)
+  })
+
+  it('returns an empty object for empty/absent params', () => {
+    expect(parseColumnFilterInverts('')).toEqual({})
+    expect(parseColumnFilterInverts(null)).toEqual({})
+    expect(serializeColumnFilterInverts({})).toBe('')
   })
 })

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -4,6 +4,7 @@ import {
   serializeColumnFilters,
   parseColumnFilterInverts,
   serializeColumnFilterInverts,
+  reconcileColumnFilterInverts,
 } from './resource-utils'
 
 describe('column filter serialization round-trip', () => {
@@ -51,5 +52,27 @@ describe('column filter invert serialization round-trip', () => {
     expect(parseColumnFilterInverts('')).toEqual({})
     expect(parseColumnFilterInverts(null)).toEqual({})
     expect(serializeColumnFilterInverts({})).toBe('')
+  })
+})
+
+describe('reconcileColumnFilterInverts', () => {
+  it('keeps invert flags for columns that have selected values', () => {
+    const inverts = { status: true, namespace: true }
+    const filters = { status: ['Running'], namespace: ['default'] }
+    expect(reconcileColumnFilterInverts(inverts, filters)).toEqual(inverts)
+  })
+
+  it('drops orphan flags for columns with no selected values', () => {
+    const inverts = { status: true, namespace: true }
+    const filters = { status: ['Running'] }
+    expect(reconcileColumnFilterInverts(inverts, filters)).toEqual({ status: true })
+  })
+
+  it('drops a flag whose column has an empty values array', () => {
+    expect(reconcileColumnFilterInverts({ status: true }, { status: [] })).toEqual({})
+  })
+
+  it('returns an empty object when there are no filters', () => {
+    expect(reconcileColumnFilterInverts({ status: true }, {})).toEqual({})
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1863,6 +1863,29 @@ export function serializeColumnFilters(filters: Record<string, string[]>): strin
   return result
 }
 
+// Which columns have their filter inverted (show non-matching rows). Serialized
+// as a comma-separated list of URI-encoded column keys; keys are encoded so a
+// custom-column key's own comma or colon (e.g. "label:tier") survives.
+export function parseColumnFilterInverts(param: string | null): Record<string, boolean> {
+  if (!param) return {}
+  const inverts: Record<string, boolean> = {}
+  for (const raw of param.split(',')) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    let key: string
+    try { key = decodeURIComponent(trimmed) } catch { key = trimmed }
+    if (key) inverts[key] = true
+  }
+  return inverts
+}
+
+export function serializeColumnFilterInverts(inverts: Record<string, boolean>): string {
+  return Object.entries(inverts)
+    .filter(([, on]) => on)
+    .map(([k]) => encodeURIComponent(k))
+    .join(',')
+}
+
 export function getCellFilterValue(resource: any, column: string, kind: string): string {
   try {
   const kindLower = kind.toLowerCase()

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1827,79 +1827,84 @@ export function formatResources(resources: any): string {
  * Used by the generic column filter system to match resources against filter values.
  * Reuses existing utility functions for kind-specific columns.
  */
-// Parse column filters from URL `filters` param (format: "col:val1,val2|col2:val3")
-// Uses `|` as pair separator between columns, `,` between values within a column.
-// Multi-select: each column key maps to an array of selected values.
+// Parse column filters from URL `filters` param. Each column is either
+// "col:val1,val2" (implicit include) or "col:exclude:val1,val2" (explicit
+// operator). `|` separates columns, `,` separates values within a column.
+// Keys and values are URI-encoded so their own delimiters survive; the operator,
+// when present, is the literal token "include" or "exclude".
 export function parseColumnFilters(filtersParam: string | null): Record<string, string[]> {
   if (!filtersParam) return {}
   const filters: Record<string, string[]> = {}
   for (const pair of filtersParam.split('|')) {
-    const colonIdx = pair.indexOf(':')
-    if (colonIdx > 0) {
-      const rawKey = pair.slice(0, colonIdx).trim()
-      const valStr = pair.slice(colonIdx + 1).trim()
-      // Keys are URI-encoded so a custom-column key's own colon (e.g.
-      // "label:tier") doesn't collide with the key:value delimiter.
-      let key: string
-      try { key = decodeURIComponent(rawKey) } catch { key = rawKey }
-      if (key && valStr) {
-        filters[key] = valStr.split(',').map(v => {
-          try { return decodeURIComponent(v.trim()) } catch { return v.trim() }
-        }).filter(Boolean)
-      }
-    }
+    const parsed = parseColumnFilterPair(pair)
+    if (parsed) filters[parsed.key] = parsed.values
   }
   return filters
 }
 
-// Serialize column filters to URL param format. Keys and values are both
-// URI-encoded so a colon inside a custom-column key (e.g. "label:tier") or a
-// comma inside a value (e.g. "Ready,SchedulingDisabled") survives the round-trip.
-export function serializeColumnFilters(filters: Record<string, string[]>): string {
-  const result = Object.entries(filters)
-    .filter(([, v]) => v.length > 0)
-    .map(([k, vals]) => `${encodeURIComponent(k)}:${vals.map(v => encodeURIComponent(v)).join(',')}`)
-    .join('|')
-  return result
-}
-
-// Which columns have their filter inverted (show non-matching rows). Serialized
-// as a comma-separated list of URI-encoded column keys; keys are encoded so a
-// custom-column key's own comma or colon (e.g. "label:tier") survives.
-export function parseColumnFilterInverts(param: string | null): Record<string, boolean> {
-  if (!param) return {}
-  const inverts: Record<string, boolean> = {}
-  for (const raw of param.split(',')) {
-    const trimmed = raw.trim()
-    if (!trimmed) continue
-    let key: string
-    try { key = decodeURIComponent(trimmed) } catch { key = trimmed }
-    if (key) inverts[key] = true
-  }
-  return inverts
-}
-
-export function serializeColumnFilterInverts(inverts: Record<string, boolean>): string {
-  return Object.entries(inverts)
-    .filter(([, on]) => on)
-    .map(([k]) => encodeURIComponent(k))
-    .join(',')
-}
-
-// An invert flag is only meaningful for a column that has selected values.
-// Drop lone flags (e.g. from a hand-edited or stale URL) so they can't lie
-// dormant and flip matching to negated the moment values are added.
-export function reconcileColumnFilterInverts(
-  inverts: Record<string, boolean>,
+// Serialize column filters to URL param format. Columns listed in `excludes`
+// emit the explicit "exclude" operator; all others keep the backwards-compatible
+// two-part shape. Keys and values are both URI-encoded so a colon inside a
+// custom-column key (e.g. "label:tier") or a comma inside a value (e.g.
+// "Ready,SchedulingDisabled") survives the round-trip.
+export function serializeColumnFilters(
   filters: Record<string, string[]>,
-): Record<string, boolean> {
-  const result: Record<string, boolean> = {}
-  for (const key of Object.keys(inverts)) {
-    if (inverts[key] && filters[key]?.length) {
-      result[key] = true
+  excludes?: Record<string, boolean>,
+): string {
+  return Object.entries(filters)
+    .filter(([, v]) => v.length > 0)
+    .map(([k, vals]) => {
+      const op = excludes?.[k] ? 'exclude:' : ''
+      return `${encodeURIComponent(k)}:${op}${vals.map(v => encodeURIComponent(v)).join(',')}`
+    })
+    .join('|')
+}
+
+// Which columns are in exclude mode (show non-matching rows). Read from the same
+// `filters` param so the operator can't drift out of sync with the values it
+// negates — a lone exclude operator with no values is structurally impossible.
+export function parseColumnFilterExcludes(filtersParam: string | null): Record<string, boolean> {
+  if (!filtersParam) return {}
+  const excludes: Record<string, boolean> = {}
+  for (const pair of filtersParam.split('|')) {
+    const parsed = parseColumnFilterPair(pair)
+    if (parsed && parsed.exclude && parsed.values.length) excludes[parsed.key] = true
+  }
+  return excludes
+}
+
+// Split a single "col[:operator]:values" pair into its decoded key, values, and
+// whether the explicit exclude operator was present. The first literal colon
+// delimits key from the rest (keys are encoded, so their own colons don't
+// count); an optional leading "include"/"exclude" token in the remainder is the
+// operator. Any other leading token is treated as a value (two-part form), so a
+// value literally named "exclude" without a following colon round-trips.
+function parseColumnFilterPair(
+  pair: string,
+): { key: string; values: string[]; exclude: boolean } | null {
+  const colonIdx = pair.indexOf(':')
+  if (colonIdx <= 0) return null
+  const rawKey = pair.slice(0, colonIdx).trim()
+  let rest = pair.slice(colonIdx + 1).trim()
+  let key: string
+  try { key = decodeURIComponent(rawKey) } catch { key = rawKey }
+  if (!key) return null
+
+  let exclude = false
+  const opIdx = rest.indexOf(':')
+  if (opIdx >= 0) {
+    const op = rest.slice(0, opIdx).trim().toLowerCase()
+    if (op === 'exclude' || op === 'include') {
+      exclude = op === 'exclude'
+      rest = rest.slice(opIdx + 1).trim()
     }
   }
-  return result
+  if (!rest) return null
+  const values = rest.split(',').map(v => {
+    try { return decodeURIComponent(v.trim()) } catch { return v.trim() }
+  }).filter(Boolean)
+  if (!values.length) return null
+  return { key, values, exclude }
 }
 
 export function getCellFilterValue(resource: any, column: string, kind: string): string {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1889,6 +1889,10 @@ function parseColumnFilterPair(
   let key: string
   try { key = decodeURIComponent(rawKey) } catch { key = rawKey }
   if (!key) return null
+  // Guard against prototype-pollution: the key becomes an object property name
+  // downstream, and it comes straight from the URL. Reject the well-known
+  // dangerous names so a crafted `filters` param can't touch the prototype.
+  if (key === '__proto__' || key === 'prototype' || key === 'constructor') return null
 
   let exclude = false
   const opIdx = rest.indexOf(':')

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1833,8 +1833,10 @@ export function formatResources(resources: any): string {
 // Keys and values are URI-encoded so their own delimiters survive; the operator,
 // when present, is the literal token "include" or "exclude".
 export function parseColumnFilters(filtersParam: string | null): Record<string, string[]> {
-  if (!filtersParam) return {}
-  const filters: Record<string, string[]> = {}
+  // Prototype-less accumulator: the keys come from the URL, so a plain object
+  // would expose Object.prototype as a write target (js/remote-property-injection).
+  const filters: Record<string, string[]> = Object.create(null)
+  if (!filtersParam) return filters
   for (const pair of filtersParam.split('|')) {
     const parsed = parseColumnFilterPair(pair)
     // Guard the dynamic write: the key comes from the URL, so reject the
@@ -1868,8 +1870,9 @@ export function serializeColumnFilters(
 // `filters` param so the operator can't drift out of sync with the values it
 // negates — a lone exclude operator with no values is structurally impossible.
 export function parseColumnFilterExcludes(filtersParam: string | null): Record<string, boolean> {
-  if (!filtersParam) return {}
-  const excludes: Record<string, boolean> = {}
+  // Prototype-less accumulator: see parseColumnFilters (js/remote-property-injection).
+  const excludes: Record<string, boolean> = Object.create(null)
+  if (!filtersParam) return excludes
   for (const pair of filtersParam.split('|')) {
     const parsed = parseColumnFilterPair(pair)
     // Guard the dynamic write against prototype-polluting keys from the URL

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1878,10 +1878,17 @@ export function parseColumnFilterExcludes(filtersParam: string | null): Record<s
     // Guard the dynamic write against prototype-polluting keys from the URL
     // right at the assignment (js/remote-property-injection).
     if (
-      parsed && parsed.exclude && parsed.values.length &&
+      parsed && parsed.values.length &&
       parsed.key !== '__proto__' && parsed.key !== 'prototype' && parsed.key !== 'constructor'
     ) {
-      excludes[parsed.key] = true
+      // Values are last-write-wins per key in parseColumnFilters, so the mode
+      // must track the same final segment: a later include overrides an
+      // earlier exclude for the same column, otherwise the two disagree.
+      if (parsed.exclude) {
+        excludes[parsed.key] = true
+      } else {
+        delete excludes[parsed.key]
+      }
     }
   }
   return excludes

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1837,7 +1837,11 @@ export function parseColumnFilters(filtersParam: string | null): Record<string, 
   const filters: Record<string, string[]> = {}
   for (const pair of filtersParam.split('|')) {
     const parsed = parseColumnFilterPair(pair)
-    if (parsed) filters[parsed.key] = parsed.values
+    // Guard the dynamic write: the key comes from the URL, so reject the
+    // prototype-polluting names right at the assignment (js/remote-property-injection).
+    if (parsed && parsed.key !== '__proto__' && parsed.key !== 'prototype' && parsed.key !== 'constructor') {
+      filters[parsed.key] = parsed.values
+    }
   }
   return filters
 }
@@ -1868,7 +1872,14 @@ export function parseColumnFilterExcludes(filtersParam: string | null): Record<s
   const excludes: Record<string, boolean> = {}
   for (const pair of filtersParam.split('|')) {
     const parsed = parseColumnFilterPair(pair)
-    if (parsed && parsed.exclude && parsed.values.length) excludes[parsed.key] = true
+    // Guard the dynamic write against prototype-polluting keys from the URL
+    // right at the assignment (js/remote-property-injection).
+    if (
+      parsed && parsed.exclude && parsed.values.length &&
+      parsed.key !== '__proto__' && parsed.key !== 'prototype' && parsed.key !== 'constructor'
+    ) {
+      excludes[parsed.key] = true
+    }
   }
   return excludes
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1886,6 +1886,22 @@ export function serializeColumnFilterInverts(inverts: Record<string, boolean>): 
     .join(',')
 }
 
+// An invert flag is only meaningful for a column that has selected values.
+// Drop lone flags (e.g. from a hand-edited or stale URL) so they can't lie
+// dormant and flip matching to negated the moment values are added.
+export function reconcileColumnFilterInverts(
+  inverts: Record<string, boolean>,
+  filters: Record<string, string[]>,
+): Record<string, boolean> {
+  const result: Record<string, boolean> = {}
+  for (const key of Object.keys(inverts)) {
+    if (inverts[key] && filters[key]?.length) {
+      result[key] = true
+    }
+  }
+  return result
+}
+
 export function getCellFilterValue(resource: any, column: string, kind: string): string {
   try {
   const kindLower = kind.toLowerCase()


### PR DESCRIPTION
## Description

Adds an **Invert** toggle to Resources-tab column filters. Selecting values like `status=Running` and enabling Invert flips the filter to show every row that does **not** match — e.g. "show me all pods that are NOT Running" without re-editing the filter each time states change.

- New per-column invert state, persisted in the URL via a `filterInvert` param (round-trip serialize/parse helpers live in `resource-utils`).
- Invert is dropped automatically when a column's values are cleared, so a bare flag never lingers as URL noise or silently re-arms when values are reselected.
- The active-filter pill shows the negated form (`not …`) when a column is inverted.
- Invert-only (no selected values) is a no-op and doesn't count as an active filter.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How has this been tested?

- [x] Tested locally with minikube/kind
- [x] Added/updated unit tests

Details:
- Added 4 round-trip unit tests for the invert serialization helpers in `column-filter-serialization.test.ts`.
- `make tsc` passes; `k8s-ui` vitest (1255 tests) and `web` vitest (161 tests) pass; production frontend build succeeds.
- Verified in the UI against a `kind` cluster: filtering `status=Running` (9 pods) then enabling Invert correctly shows only the single non-Running pod, and the URL serializes to `?filters=status:Running&filterInvert=status`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to client-side table filtering and URL serialization, with added guards on URL-derived object keys; no server or auth impact.
> 
> **Overview**
> Resources table column filters can now run in **Exclude** mode so rows matching the selected values are hidden instead of shown. Each column’s dropdown gets **Include** / **Exclude** toggles; active pills and header badges reflect negation (`not …`, `≠` count).
> 
> Exclude mode is stored in the existing `filters` query string via an `exclude` operator on each column (e.g. `status:exclude:Running`), with parse/serialize helpers extended in `resource-utils` and round-trip tests added. Exclude flags are cleared when a column has no values, when filters are reset, or when switching resource kinds; the node shortcut to filter pods by node always forces include for that column.
> 
> URL parsing now shares a pair parser and rejects prototype-polluting keys when building filter maps from query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff82bb81135c47c3c70e7359304ac0425a694ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->