### PR TITLE
Fix revision history dialog layout

### DIFF
--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import {
   RefreshCw,
   Terminal,
@@ -848,6 +848,35 @@ function ArgoActions({ resource, data, onSync, isSyncing, onRefresh, isRefreshin
 // REVISION HISTORY DIALOG
 // ============================================================================
 
+function RevisionImage({ image, displayImage }: { image: string; displayImage: string }) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const measure = () => setIsTruncated(element.scrollWidth > element.clientWidth)
+    measure()
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [displayImage])
+
+  return (
+    <Tooltip
+      content={image}
+      delay={300}
+      disabled={!isTruncated}
+      preserveWrapperWhenDisabled
+      wrapperClassName="w-full min-w-0"
+    >
+      <span ref={ref} className="block truncate">{displayImage}</span>
+    </Tooltip>
+  )
+}
+
 export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, revisions, isLoading, error, onRollback, isRollingBack }: {
   kind: string
   namespace: string
@@ -908,10 +937,7 @@ export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, re
       open={open}
       onClose={handleClose}
       closable={!isRollingBack}
-      className={clsx(
-        "flex flex-col",
-        diffRevision ? "max-w-5xl w-full max-h-[85vh]" : "max-w-lg w-full"
-      )}
+      className="flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-5xl flex-col"
     >
       <div className="flex items-center justify-between p-4 border-b border-theme-border shrink-0">
         <div className="flex items-center gap-2">
@@ -924,17 +950,20 @@ export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, re
             </span>
           )}
         </div>
-        <button
-          onClick={handleClose}
-          disabled={isRollingBack}
-          className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
-        >
-          <X className="w-5 h-5" />
-        </button>
+        <Tooltip content="Close" delay={150}>
+          <button
+            onClick={handleClose}
+            disabled={isRollingBack}
+            aria-label="Close revision history"
+            className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-        <div className={clsx("p-4 overflow-y-auto", diffRevision ? "max-h-48 shrink-0" : "max-h-80")}>
+        <div className={clsx("min-h-0 overflow-x-hidden overflow-y-auto p-4", diffRevision ? "max-h-48 shrink-0" : "max-h-[65vh]")}>
           {isLoading && (
             <div className="flex items-center justify-center py-8 text-theme-text-secondary text-sm">
               Loading revisions…
@@ -954,7 +983,13 @@ export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, re
           )}
 
           {revisions && revisions.length > 0 && (
-            <table className="w-full text-sm">
+            <table className="w-full table-fixed text-sm">
+              <colgroup>
+                <col className="w-16" />
+                <col />
+                <col className="w-24" />
+                <col className="w-44" />
+              </colgroup>
               <thead>
                 <tr className="text-theme-text-secondary text-left text-xs uppercase tracking-wider">
                   <th className="pb-2 pr-3 font-medium">Rev</th>
@@ -975,17 +1010,15 @@ export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, re
                     <td className="py-2 pr-3 text-theme-text-primary font-mono">
                       #{rev.number}
                     </td>
-                    <td className="py-2 pr-3 text-theme-text-secondary font-mono max-w-[180px]">
-                      <Tooltip content={rev.image} delay={300} wrapperClassName="min-w-0">
-                        <span className="truncate">{getImageTag(rev.image)}</span>
-                      </Tooltip>
+                    <td className="min-w-0 py-2 pr-3 text-theme-text-secondary font-mono">
+                      <RevisionImage image={rev.image} displayImage={getImageTag(rev.image)} />
                     </td>
                     <td className="py-2 pr-3 text-theme-text-secondary whitespace-nowrap">
                       {formatTimeAgo(rev.createdAt)}
                     </td>
                     <td className="py-2 text-right">
                       <div className="flex items-center gap-1 justify-end">
-                        {!rev.isCurrent && rev.template && currentRevision?.template && (
+                        {!rev.isCurrent && confirmRevision !== rev.number && rev.template && currentRevision?.template && (
                           <Tooltip content="Compare with current revision" delay={150}>
                             <button
                               onClick={() => setDiffRevision(diffRevision === rev.number ? null : rev.number)}

--- a/packages/k8s-ui/src/components/ui/Tooltip.test.tsx
+++ b/packages/k8s-ui/src/components/ui/Tooltip.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { Tooltip } from './Tooltip'
+
+function render(preserveWrapperWhenDisabled = false) {
+  return renderToString(
+    <Tooltip content="Full value" disabled preserveWrapperWhenDisabled={preserveWrapperWhenDisabled}>
+      <span>Visible value</span>
+    </Tooltip>,
+  )
+}
+
+describe('Tooltip', () => {
+  it('omits its wrapper when disabled by default', () => {
+    expect(render()).not.toContain('inline-flex max-w-full')
+  })
+
+  it('can preserve its wrapper while disabled for layout-sensitive children', () => {
+    expect(render(true)).toContain('inline-flex max-w-full')
+  })
+})

--- a/packages/k8s-ui/src/components/ui/Tooltip.tsx
+++ b/packages/k8s-ui/src/components/ui/Tooltip.tsx
@@ -29,6 +29,8 @@ interface TooltipProps {
   className?: string
   /** Whether tooltip is disabled */
   disabled?: boolean
+  /** Keep the wrapper mounted while disabled when child layout measurement requires stable DOM ancestry. */
+  preserveWrapperWhenDisabled?: boolean
   /** Additional class for the wrapper span (useful for positioning) */
   wrapperClassName?: string
   /** Inline styles for the wrapper span (useful for absolute positioning) */
@@ -42,6 +44,7 @@ export function Tooltip({
   position = 'top',
   className,
   disabled = false,
+  preserveWrapperWhenDisabled = false,
   wrapperClassName,
   wrapperStyle,
 }: TooltipProps) {
@@ -98,6 +101,9 @@ export function Tooltip({
     if (hideTimeoutRef.current) {
       clearTimeout(hideTimeoutRef.current)
       hideTimeoutRef.current = null
+    }
+    if (activeHide === hideRef.current) {
+      activeHide = null
     }
     setIsVisible(false)
     setCoords(null)
@@ -194,16 +200,7 @@ export function Tooltip({
   // pointer-events-none and never fires mouseleave.
   useEffect(() => {
     if (disabled) {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
-      if (hideTimeoutRef.current) {
-        clearTimeout(hideTimeoutRef.current)
-        hideTimeoutRef.current = null
-      }
-      setIsVisible(false)
-      setCoords(null)
+      hideRef.current()
     }
   }, [disabled])
 
@@ -224,7 +221,7 @@ export function Tooltip({
     }
   }, [isVisible])
 
-  if (disabled || !content) {
+  if ((disabled && !preserveWrapperWhenDisabled) || !content) {
     return <>{children}</>
   }
 
@@ -245,7 +242,7 @@ export function Tooltip({
       >
         {children}
       </span>
-      {isVisible &&
+      {isVisible && !disabled &&
         createPortal(
           <span
             ref={tooltipRef}


### PR DESCRIPTION
## Summary

Makes workload revision history readable at desktop and compact viewport widths, keeping image and action data visible without horizontal scrolling. Full image references are disclosed only when their displayed values are actually truncated.

## What changed

- Use a stable responsive dialog width for list and diff modes, with viewport gutters and a larger scrollable revision area.
- Give revision table columns predictable sizing so long image references truncate while age and actions remain visible.
- Measure image overflow across resizes and enable the shared Tooltip only for truncated text, while preserving stable wrapper layout during measurement.
- Keep rollback confirmation controls inside the action column by replacing that row's compare action with Confirm and Cancel.
- Use the shared Tooltip and an accessible label for the icon-only close action.

## Testing

- make tsc
- make test
- make build
- k8s-ui focused Tooltip tests
- Visual tests against real GKE and EKS deployments at compact and desktop widths, covering list and diff modes, truncated/non-truncated tooltips across resize, rollback confirmation, and the pending rollback label.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to revision history layout, tooltips, and rollback row actions; no API or cluster mutation logic changes beyond existing rollback flows.
> 
> **Overview**
> Improves the workload **Revision History** dialog so the revision list stays readable on narrow and wide viewports without horizontal scrolling.
> 
> The dialog now uses a consistent responsive width (`max-w-5xl` with viewport gutters) and a taller scroll region in list-only mode. The revision table uses **fixed column widths** so age and actions stay visible while long image references truncate in the image column.
> 
> A new **`RevisionImage`** helper measures overflow (including on resize) and only enables the shared **Tooltip** with the full image reference when the displayed tag is actually truncated. That relies on a new **`preserveWrapperWhenDisabled`** option on **Tooltip**, which keeps the trigger wrapper mounted while disabled so truncation measurement stays stable; disabled tooltips no longer render the portal.
> 
> Rollback UX tweaks: the per-row **Compare/Diff** control is hidden while that row is in rollback confirmation, and the header close control gets a tooltip plus **`aria-label`**.
> 
> **Tooltip** cleanup routes the disabled-state effect through the shared hide path and clears the module-level active-tooltip registry when hiding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1d29fc3123aee30d21f3536d4b52426fe3648e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->