### PR TITLE
Restore portable Radar release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ version: 2
 before:
   hooks:
     # Build frontend before Go compilation (gets embedded)
-    - sh -c "cd web && npm install && npm run build"
+    - sh -c "npm ci && npm --workspace web run build"
     # Clean stale files from previous builds before copying fresh output
     - sh -c "rm -rf internal/static/dist && mkdir -p internal/static/dist"
     - sh -c "cp -r web/dist/* internal/static/dist/"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ backend:
 # Build frontend (auto-installs deps if needed)
 frontend:
 	@echo "Building frontend..."
-	@test -d web/node_modules || (echo "Installing npm dependencies..." && cd web && npm install)
+	@test -f node_modules/typescript-7/bin/tsc || (echo "Installing npm dependencies..." && npm install)
 	cd web && npm run build
 
 # Copy built frontend to embed directory
@@ -115,12 +115,12 @@ kill:
 deps:
 	go mod download
 	go mod tidy
-	cd web && npm install
+	npm install
 
 # Install dev tools
 install-tools:
 	go install github.com/air-verse/air@latest
-	cd web && npm install
+	npm install
 
 # Clean build artifacts
 clean:

--- a/cmd/desktop/wails.json
+++ b/cmd/desktop/wails.json
@@ -3,7 +3,7 @@
   "name": "radar-desktop",
   "outputfilename": "Radar",
   "frontend:dir": "../../web",
-  "frontend:install": "npm install",
+  "frontend:install": "npm --prefix .. install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -389,15 +388,9 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 	}
 	defer cleanup()
 
-	// Process-group lifecycle is agent-agnostic: kill the whole group on cancel so
-	// no child agent process outlives the run.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		}
-		return nil
-	}
+	// Process lifecycle is agent-agnostic. The platform helper kills the whole
+	// process group/tree on cancel so no child agent process outlives the run.
+	configureProcessLifecycle(cmd)
 	cmd.WaitDelay = 5 * time.Second
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/ai/process_unix.go
+++ b/internal/ai/process_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package ai
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func configureProcessLifecycle(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
+}
+
+// pidAlive reports whether a process exists (signal 0; EPERM still means
+// alive). PID reuse is theoretically possible but irrelevant at this scale: a
+// false "alive" only delays crash repair until the next boot.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/ai/process_windows.go
+++ b/internal/ai/process_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package ai
+
+import (
+	"os/exec"
+	"strconv"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsStillActive = 259
+
+func configureProcessLifecycle(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+
+		// taskkill /T is the Windows equivalent of killing a Unix process group:
+		// it terminates the agent and every child process it spawned. Fall back to
+		// killing the direct process if taskkill is unavailable or loses a race
+		// with normal process exit.
+		killTree := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+		if err := killTree.Run(); err != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil
+	}
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		// Access denied still proves that the process exists.
+		return err == windows.ERROR_ACCESS_DENIED
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false
+	}
+	return exitCode == windowsStillActive
+}

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -281,17 +280,6 @@ func (m *RunManager) loadPersisted() {
 		m.order = append(m.order, r.ID)
 	}
 	m.evictLocked() // the retention cap may have shrunk since the DB was written
-}
-
-// pidAlive reports whether a process exists (signal 0; EPERM still means
-// alive). PID reuse is theoretically possible but irrelevant at this scale —
-// a false "alive" only delays crash repair until the next boot.
-func pidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	err := syscall.Kill(pid, 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 // newRunID mints a process-independent id. Random (not a counter) because


### PR DESCRIPTION
## Summary

Makes Radar release and desktop builds install the monorepo workspace consistently and restores Windows compatibility for AI process lifecycle handling. A clean checkout can build every advertised CLI archive without relying on pre-existing root dependencies or Unix-only syscalls.

## What changed

### Reproducible workspace builds

- GoReleaser now runs `npm ci` at the repository root and builds the `web` workspace explicitly, so the root-owned TypeScript 7 compiler and locked workspace dependencies are present.
- Make targets install dependencies from the workspace root and detect a partial install by checking the compiler that the frontend actually invokes.
- Direct Wails builds install from the same workspace root instead of creating a web-only dependency tree.

### Cross-platform AI process lifecycle

- Process setup and PID liveness checks now live behind platform-specific helpers.
- Unix retains process-group creation, group cancellation, and signal-zero liveness checks.
- Windows cancels the full agent process tree with the system `taskkill /T /F` command, falls back to direct process termination, and checks liveness with `OpenProcess` plus `GetExitCodeProcess`.
- The shared diagnoser and persisted-run code no longer reference Unix-only `syscall` fields or functions.

## Testing

- `make tsc`
- `make test`
- `make build`
- `env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/radar-windows-release-check.exe ./cmd/explorer`
- `goreleaser release --snapshot --clean` (all five supported OS/architecture targets, archives, checksums, Homebrew formula, and Scoop manifest)
- `git diff --check`
- Visual test skipped: no rendered UI delta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release pipelines and AI subprocess teardown on cancel; behavior change is intentional on Windows but wrong kill logic could leave orphan agent processes.
> 
> **Overview**
> **Release and desktop builds** now install and compile from the **npm workspace root** instead of only `web/`. GoReleaser runs `npm ci` and `npm --workspace web run build`; Make `deps`/`frontend`/`install-tools` use root `npm install` and verify the root **`typescript-7`** compiler before building; Wails **`frontend:install`** runs `npm --prefix .. install` so desktop builds share the same locked tree.
> 
> **Windows builds** for the AI agent path no longer embed Unix-only `syscall` usage in shared code. **`configureProcessLifecycle`** and **`pidAlive`** live in **`process_unix.go`** / **`process_windows.go`**; the diagnoser calls the helper for cancel (Unix process group vs Windows **`taskkill /T /F`** with fallback), and run history still uses **`pidAlive`** to detect foreign live owners without breaking non-Unix targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36425173cb0ce5bdd589d26d4b818bf1d594e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->