### PR TITLE
Add Hub-backed radar cloud status for in-cluster installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ kubectl radar
 radar
 ```
 
+To inspect an in-cluster Radar Cloud installation without changing it:
+
+```bash
+radar cloud status
+radar cloud status --context my-cluster
+radar cloud status --context my-cluster --namespace radar --release radar
+```
+
+The command reports installation ownership, chart and image, agent readiness,
+and Cloud configuration without printing the connection token. Passing both
+`--namespace` and `--release` selects an exact installation. Live tunnel status
+is reported by Radar Cloud using the token in the referenced Kubernetes Secret.
+If the Secret or Hub is unavailable, local installation diagnostics still run.
+
 **CLI Flags**
 
 | Flag | Default | Description |

--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -5,6 +5,7 @@ package main
 // os.Args[1]=="cloud" check there).
 //
 //	radar cloud install     install an in-cluster agent connected to Cloud
+//	radar cloud status      inspect an in-cluster Cloud installation
 //
 // Local-process preview connections are not available yet. The reserved
 // `connect` command exits before contacting the hub and points users to the
@@ -37,6 +38,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -66,6 +68,8 @@ func runCloudSubcommand() {
 	case "install":
 		cloudInstall(rest)
 		os.Exit(0)
+	case "status":
+		os.Exit(cloudStatus(rest, os.Stdout, os.Stderr))
 	case "-h", "--help", "help":
 		cloudUsage(os.Stdout)
 		os.Exit(0)
@@ -81,11 +85,16 @@ func cloudUsage(w *os.File) {
 
 Usage:
   radar cloud install [--context NAME] [-y|--yes] [--namespace NS] [--release NAME] [--adopt-existing] [--hub-url URL] [--name NAME] [--dry-run]
+  radar cloud status [--context NAME] [--namespace NS --release NAME]
 
 install  Connect one kubeconfig cluster to Radar. Installs Radar when absent,
          or offers a safe native-Helm adoption / GitOps handoff when detected.
          An explicit --context is used directly; otherwise the current context
          must be confirmed unless -y/--yes is set.
+
+status   Inspect the Radar installation in one kubeconfig cluster. Reports
+         ownership, Cloud configuration, agent readiness, and Hub-reported
+         tunnel health without changing Kubernetes.
 
 Flags (install):
   --context NAME   Kubernetes context to install into (default: current context)
@@ -104,6 +113,11 @@ Flags (install):
   --dry-run        Run the permission preflight + print the plan; install nothing
   --no-browser     Print the approval URL instead of opening a browser
   --browser NAME   Browser to use for approval (default: Radar config / OS default)
+
+Flags (status):
+  --context NAME   Kubernetes context to inspect (default: current context)
+  --namespace NS   Exact namespace (requires --release)
+  --release NAME   Exact Helm release (requires --namespace)
 `)
 }
 
@@ -603,36 +617,51 @@ type localInstallClients struct {
 	Releases   cloudReleaseInspector
 }
 
-func buildLocalInstallClients(kubeconfig, contextName string) (localInstallClients, error) {
+type localKubernetesClients struct {
+	Kubernetes kubernetes.Interface
+	Dynamic    dynamic.Interface
+	Discovery  discovery.DiscoveryInterface
+	RESTConfig *rest.Config
+}
+
+func buildLocalKubernetesClients(kubeconfig, contextName string) (localKubernetesClients, error) {
 	rules := connectLoadingRules(kubeconfig)
 	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{CurrentContext: contextName}).ClientConfig()
 	if err != nil {
-		return localInstallClients{}, fmt.Errorf("no reachable kubeconfig context: %w", err)
+		return localKubernetesClients{}, fmt.Errorf("no reachable kubeconfig context: %w", err)
 	}
-	// Helm's non-cancelable mutation avoids returning while its background apply
-	// is still running. Bound each Kubernetes request so that critical section
-	// cannot hang forever on a dead apiserver connection.
+	// Bound each Kubernetes request so status and install cannot hang forever on
+	// a dead apiserver connection. This also bounds Helm's non-cancelable apply
+	// critical section when the caller initializes Helm with this config.
 	if restCfg.Timeout <= 0 || restCfg.Timeout > cloudKubernetesRequestTimeout {
 		restCfg.Timeout = cloudKubernetesRequestTimeout
 	}
 	kc, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
-		return localInstallClients{}, fmt.Errorf("kube client: %w", err)
+		return localKubernetesClients{}, fmt.Errorf("kube client: %w", err)
 	}
 	dc, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
-		return localInstallClients{}, fmt.Errorf("dynamic kube client: %w", err)
+		return localKubernetesClients{}, fmt.Errorf("dynamic kube client: %w", err)
+	}
+	return localKubernetesClients{Kubernetes: kc, Dynamic: dc, Discovery: kc.Discovery(), RESTConfig: restCfg}, nil
+}
+
+func buildLocalInstallClients(kubeconfig, contextName string) (localInstallClients, error) {
+	clients, err := buildLocalKubernetesClients(kubeconfig, contextName)
+	if err != nil {
+		return localInstallClients{}, err
 	}
 	// Hand Helm the SAME resolved rest.Config, not a kubeconfig path — otherwise
 	// a multi-file KUBECONFIG could leave Helm on a different current-context
 	// (cluster B) than the preflight/Secret client (cluster A).
-	if err := helm.InitializeWithRESTConfig(restCfg); err != nil {
+	if err := helm.InitializeWithRESTConfig(clients.RESTConfig); err != nil {
 		return localInstallClients{}, fmt.Errorf("helm init: %w", err)
 	}
 	return localInstallClients{
-		Kubernetes: kc,
-		Dynamic:    dc,
-		Discovery:  kc.Discovery(),
+		Kubernetes: clients.Kubernetes,
+		Dynamic:    clients.Dynamic,
+		Discovery:  clients.Discovery,
 		Helm:       helm.GetClient(),
 		Releases:   helm.GetClient(),
 	}, nil

--- a/cmd/explorer/cloud_install_plan.go
+++ b/cmd/explorer/cloud_install_plan.go
@@ -55,13 +55,7 @@ func classifyCloudInstallPlan(
 	namespace, release string,
 	explicitTarget bool,
 ) (cloudInstallPlan, error) {
-	var candidates []cloudinstall.RadarTarget
-	if explicitTarget {
-		candidates = result.Selected
-	} else {
-		candidates = append(candidates, result.Namespace...)
-		candidates = append(candidates, result.ClusterWide...)
-	}
+	candidates := discoveredRadarTargets(result, explicitTarget)
 	if len(candidates) > 1 {
 		return cloudInstallPlan{}, fmt.Errorf(
 			"found multiple Radar installations; choose one explicitly with --namespace and --release:\n%s",
@@ -146,6 +140,14 @@ func classifyCloudInstallPlan(
 	default:
 		return cloudInstallPlan{}, fmt.Errorf("unrecognized Helm release state %q", inspection.State)
 	}
+}
+
+func discoveredRadarTargets(result cloudinstall.DiscoveryResult, exactTarget bool) []cloudinstall.RadarTarget {
+	if exactTarget {
+		return result.Selected
+	}
+	targets := append([]cloudinstall.RadarTarget{}, result.Namespace...)
+	return append(targets, result.ClusterWide...)
 }
 
 func formatRadarTargets(targets []cloudinstall.RadarTarget) string {

--- a/cmd/explorer/cloud_status.go
+++ b/cmd/explorer/cloud_status.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/cloud"
+	"github.com/skyhook-io/radar/internal/cloudinstall"
+	"github.com/skyhook-io/radar/internal/config"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type hubTunnelVerdict uint8
+
+const (
+	hubTunnelUnavailable hubTunnelVerdict = iota
+	hubTunnelHealthy
+	hubTunnelUnhealthy
+)
+
+type hubTunnelResult struct {
+	verdict         hubTunnelVerdict
+	summary         string
+	hubClusterID    string
+	lastConnectedAt *time.Time
+	detail          string
+	next            string
+}
+
+type agentStatusGetter interface {
+	Get(context.Context, string) (*cloud.AgentStatusResponse, error)
+}
+
+func cloudStatus(args []string, out, errOut io.Writer) int {
+	fs := flag.NewFlagSet("cloud status", flag.ContinueOnError)
+	var flagOutput bytes.Buffer
+	fs.SetOutput(&flagOutput)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: radar cloud status [--context NAME] [--namespace NS --release NAME]")
+		fmt.Fprintln(fs.Output(), "Without both --namespace and --release, Radar discovers installations across visible namespaces.")
+		fs.PrintDefaults()
+	}
+	namespace := fs.String("namespace", cloudinstall.DefaultInstallNamespace, "Exact namespace (requires --release)")
+	release := fs.String("release", cloudinstall.DefaultReleaseName, "Exact Helm release (requires --namespace)")
+	contextName := fs.String("context", "", "Kubernetes context to inspect (default: current context)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			_, _ = io.Copy(out, &flagOutput)
+			return 0
+		}
+		_, _ = io.Copy(errOut, &flagOutput)
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(errOut, "cloud status: unexpected argument %q\n", fs.Arg(0))
+		return 2
+	}
+
+	explicitNamespace, explicitRelease := false, false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "namespace":
+			explicitNamespace = true
+		case "release":
+			explicitRelease = true
+		}
+	})
+	if explicitNamespace != explicitRelease {
+		fmt.Fprintln(errOut, "cloud status: --namespace and --release must be passed together to select one installation")
+		return 2
+	}
+	normalizedNamespace, normalizedRelease, err := normalizeCloudInstallNames(*namespace, *release)
+	if err != nil {
+		fmt.Fprintf(errOut, "cloud status: %v\n", err)
+		return 2
+	}
+
+	fileCfg := config.Load()
+	if len(fileCfg.KubeconfigDirs) > 0 {
+		fmt.Fprintln(errOut, "`radar cloud status` cannot choose one cluster while config.json's `kubeconfigDirs` setting is enabled.")
+		fmt.Fprintln(errOut, "Clear `kubeconfigDirs` in Radar Settings (or ~/.radar/config.json), then select one current context with KUBECONFIG or config.json's `kubeconfig`.")
+		return 1
+	}
+	ctxName, err := resolveCloudInstallContext(fileCfg.Kubeconfig, strings.TrimSpace(*contextName))
+	if err != nil {
+		fmt.Fprintf(errOut, "cloud status: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(out, "Kubernetes context: %q\n", ctxName)
+	clients, err := buildLocalKubernetesClients(fileCfg.Kubeconfig, ctxName)
+	if err != nil {
+		fmt.Fprintf(errOut, "cloud status: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := signalContext()
+	defer cancel()
+	exactTarget := cloudInstallUsesExactTarget(explicitNamespace, explicitRelease)
+	result, err := cloudinstall.DiscoverRadarTargets(ctx, clients.Kubernetes, clients.Dynamic, cloudinstall.DiscoveryOptions{
+		Namespace: normalizedNamespace, ReleaseName: normalizedRelease, ClusterWide: !exactTarget,
+	})
+	if err != nil {
+		fmt.Fprintln(errOut, "cloud status: could not inspect Radar in this Kubernetes context")
+		fmt.Fprintf(errOut, "Details: %v\n", err)
+		if apierrors.IsForbidden(err) {
+			if exactTarget {
+				fmt.Fprintf(errOut, "Next: confirm this account can list Deployments in namespace %q.\n", normalizedNamespace)
+			} else {
+				fmt.Fprintln(errOut, "Next: pass both --namespace NS and --release NAME to inspect an installation this account can read.")
+			}
+		}
+		return 1
+	}
+
+	targets := discoveredRadarTargets(result, exactTarget)
+	var tunnel hubTunnelResult
+	if len(targets) == 1 {
+		tunnel = checkHubTunnelStatus(ctx, clients.Kubernetes, targets[0])
+	}
+	fmt.Fprintf(out, "\nStatus: %s\n\n", cloudStatusHeadline(targets, result.ClusterWideError, tunnel))
+	code := printCloudDiscoveryStatus(out, errOut, targets, result.ClusterWideError, exactTarget, normalizedNamespace, normalizedRelease)
+	if len(targets) == 1 {
+		if targets[0].Runtime.AlreadyCloud {
+			printHubTunnelStatus(out, targets[0], tunnel)
+		} else if tunnel.next != "" {
+			fmt.Fprintf(out, "\nNext: %s\n", tunnel.next)
+		}
+		if tunnel.verdict == hubTunnelUnhealthy {
+			return 1
+		}
+	}
+	return code
+}
+
+func printCloudDiscoveryStatus(out, errOut io.Writer, targets []cloudinstall.RadarTarget, clusterWideErr error, exactTarget bool, namespace, release string) int {
+	if clusterWideErr != nil {
+		fmt.Fprintf(errOut, "Warning: Radar could not inspect all visible namespaces: %v\n", clusterWideErr)
+	}
+	switch len(targets) {
+	case 0:
+		if exactTarget {
+			fmt.Fprintln(out, "Radar installation: not found")
+			fmt.Fprintf(out, "Checked for a Radar Deployment with release label %q in namespace %q.\n", release, namespace)
+		} else if clusterWideErr != nil {
+			fmt.Fprintln(out, "Radar installation: none found in namespaces this account can inspect")
+			fmt.Fprintln(out, "Other installations could not be ruled out. Pass --namespace and --release to inspect one directly.")
+		} else {
+			fmt.Fprintln(out, "Radar installation: not found")
+			fmt.Fprintln(out, "Run `radar cloud install` to connect this cluster.")
+		}
+		return 1
+	case 1:
+		healthy := printCloudStatus(out, targets[0])
+		if clusterWideErr != nil {
+			fmt.Fprintln(out, "Discovery: incomplete; other Radar installations could not be ruled out")
+			fmt.Fprintln(out, "Pass --namespace and --release to make the target explicit.")
+			return 1
+		}
+		if healthy {
+			return 0
+		}
+		return 1
+	default:
+		fmt.Fprintf(errOut, "cloud status: found multiple Radar installations; choose one explicitly with --namespace and --release:\n%s\n", formatRadarTargets(targets))
+		return 1
+	}
+}
+
+func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
+	runtime := target.Runtime
+	fmt.Fprintf(out, "Radar installation: %s/%s\n", target.Namespace, target.DeploymentName)
+	fmt.Fprintf(out, "Managed by: %s\n", cloudOwnershipLabel(target))
+	if target.Chart != "" {
+		fmt.Fprintf(out, "Chart: %s\n", target.Chart)
+	}
+	if runtime.Image != "" {
+		fmt.Fprintf(out, "Image: %s\n", runtime.Image)
+	}
+
+	ready := cloudAgentHealthy(runtime)
+	if runtime.DesiredReplicas == 0 {
+		fmt.Fprintln(out, "Agent: scaled to zero")
+	} else if !runtime.StatusObserved {
+		fmt.Fprintf(out, "Agent: rollout status pending (%d/%d replicas ready)\n", runtime.ReadyReplicas, runtime.DesiredReplicas)
+	} else if !ready {
+		oldReplicas := runtime.TotalReplicas - runtime.UpdatedReplicas
+		if oldReplicas > 0 {
+			noun := "replica"
+			if oldReplicas != 1 {
+				noun = "replicas"
+			}
+			fmt.Fprintf(
+				out,
+				"Agent: rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available; %d old %s still running; readiness includes old replicas)\n",
+				runtime.UpdatedReplicas,
+				runtime.DesiredReplicas,
+				runtime.ReadyReplicas,
+				runtime.DesiredReplicas,
+				runtime.AvailableReplicas,
+				runtime.DesiredReplicas,
+				oldReplicas,
+				noun,
+			)
+		} else {
+			fmt.Fprintf(
+				out,
+				"Agent: rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available)\n",
+				runtime.UpdatedReplicas,
+				runtime.DesiredReplicas,
+				runtime.ReadyReplicas,
+				runtime.DesiredReplicas,
+				runtime.AvailableReplicas,
+				runtime.DesiredReplicas,
+			)
+		}
+	} else {
+		fmt.Fprintf(out, "Agent: %d/%d replicas ready\n", runtime.ReadyReplicas, runtime.DesiredReplicas)
+	}
+
+	if !runtime.AlreadyCloud {
+		fmt.Fprintln(out, "Cloud configuration: not configured")
+		return false
+	}
+
+	missing := missingCloudConfiguration(runtime)
+	if len(missing) > 0 {
+		fmt.Fprintf(out, "Cloud configuration: incomplete (missing %s)\n", strings.Join(missing, ", "))
+	} else {
+		fmt.Fprintln(out, "Cloud configuration: present")
+	}
+	if runtime.CloudModeUnresolved {
+		fmt.Fprintln(out, "Cloud mode: configured from a referenced value (value not inspected)")
+	}
+	if runtime.CloudURL != "" {
+		fmt.Fprintf(out, "Hub: %s\n", runtime.CloudURL)
+	} else if runtime.CloudURLUnresolved {
+		fmt.Fprintln(out, "Hub: configured from a referenced value (value not inspected)")
+	}
+	if runtime.ClusterName != "" {
+		fmt.Fprintf(out, "Configured cluster reference: %s\n", runtime.ClusterName)
+	} else if runtime.ClusterNameUnresolved {
+		fmt.Fprintln(out, "Configured cluster reference: sourced from a referenced value (value not inspected)")
+	}
+	return ready && len(missing) == 0
+}
+
+func cloudAgentHealthy(runtime cloudinstall.DeploymentRuntime) bool {
+	return runtime.StatusObserved &&
+		runtime.DesiredReplicas > 0 &&
+		runtime.TotalReplicas == runtime.DesiredReplicas &&
+		runtime.UpdatedReplicas == runtime.DesiredReplicas &&
+		runtime.ReadyReplicas >= runtime.DesiredReplicas &&
+		runtime.AvailableReplicas >= runtime.DesiredReplicas
+}
+
+func cloudStatusHeadline(targets []cloudinstall.RadarTarget, clusterWideErr error, tunnel hubTunnelResult) string {
+	switch len(targets) {
+	case 0:
+		if clusterWideErr != nil {
+			return "Radar installation status is inconclusive; some namespaces could not be inspected."
+		}
+		return "Radar is not installed in this cluster."
+	case 1:
+		headline := cloudTargetStatusHeadline(targets[0], tunnel)
+		if clusterWideErr != nil {
+			return headline + " Discovery was incomplete, so other installations may exist."
+		}
+		return headline
+	default:
+		return "Multiple Radar installations were found; choose one explicitly."
+	}
+}
+
+func cloudTargetStatusHeadline(target cloudinstall.RadarTarget, tunnel hubTunnelResult) string {
+	runtime := target.Runtime
+	agentHealthy := cloudAgentHealthy(runtime)
+	if !runtime.AlreadyCloud {
+		if agentHealthy {
+			return "Radar is healthy, but not configured for Cloud."
+		}
+		return "Radar needs attention: its agent is not healthy, and Cloud is not configured."
+	}
+	if len(missingCloudConfiguration(runtime)) > 0 {
+		if agentHealthy {
+			return "Radar is running, but its Cloud configuration is incomplete."
+		}
+		return "Radar needs attention: its agent is not healthy, and its Cloud configuration is incomplete."
+	}
+
+	switch tunnel.verdict {
+	case hubTunnelHealthy:
+		if agentHealthy {
+			return "Radar is healthy and connected to the Hub."
+		}
+		return "Radar is connected to the Hub, but its agent is not healthy."
+	case hubTunnelUnhealthy:
+		connection := "its Cloud connection failed"
+		switch tunnel.summary {
+		case "disconnected":
+			connection = "it is disconnected from the Hub"
+		case "never connected":
+			connection = "it has never connected to the Hub"
+		case "failed — the Hub rejected the connection token":
+			connection = "the Hub rejected its connection token"
+		case "failed — the connection Secret was not found":
+			connection = "its connection Secret is missing"
+		case "failed — the connection Secret has no usable token":
+			connection = "its connection Secret has no usable token"
+		}
+		if agentHealthy {
+			return "Radar is installed, but " + connection + "."
+		}
+		return "Radar needs attention: its agent is not healthy, and " + connection + "."
+	default:
+		if agentHealthy {
+			return "Radar is healthy; live Cloud connection status could not be verified."
+		}
+		return "Radar needs attention: its agent is not healthy, and live Cloud connection status could not be verified."
+	}
+}
+
+func printHubTunnelStatus(out io.Writer, target cloudinstall.RadarTarget, result hubTunnelResult) {
+	fmt.Fprintf(out, "\nCloud connection: %s\n", result.summary)
+	if result.hubClusterID != "" && result.hubClusterID != target.Runtime.ClusterName {
+		fmt.Fprintf(out, "Hub cluster ID: %s\n", result.hubClusterID)
+	}
+	if result.lastConnectedAt != nil {
+		label := "Previous connection started"
+		if result.verdict == hubTunnelHealthy {
+			label = "Connected since"
+		}
+		fmt.Fprintf(out, "%s: %s\n", label, result.lastConnectedAt.UTC().Format(time.RFC3339))
+	}
+	if result.detail != "" {
+		fmt.Fprintf(out, "Details: %s\n", result.detail)
+	}
+	if result.next != "" {
+		fmt.Fprintf(out, "Next: %s\n", result.next)
+	}
+}
+
+func checkHubTunnelStatus(ctx context.Context, kc kubernetes.Interface, target cloudinstall.RadarTarget) hubTunnelResult {
+	runtime := target.Runtime
+	if !runtime.AlreadyCloud {
+		return hubTunnelResult{
+			summary: "not configured",
+			next:    "run `radar cloud install` to connect this installation.",
+		}
+	}
+	if missing := missingCloudConfiguration(runtime); len(missing) > 0 {
+		return hubTunnelResult{
+			summary: "not checked — the Cloud configuration is incomplete",
+			detail:  "Missing " + strings.Join(missing, ", "),
+			next:    "complete the Cloud settings above, then run this command again.",
+		}
+	}
+	if runtime.CloudURL == "" {
+		return hubTunnelResult{
+			summary: "not checked — the Hub URL cannot be read from the Deployment",
+			next:    "make the Hub URL directly inspectable, then run this command again.",
+		}
+	}
+	client, err := cloud.NewAgentStatusClient(runtime.CloudURL)
+	if err != nil {
+		return hubTunnelResult{
+			summary: "not checked — the configured Hub URL is invalid",
+			detail:  err.Error(),
+			next:    "correct the Hub URL, then run this command again.",
+		}
+	}
+	return checkHubTunnelStatusWithClient(ctx, kc, target, client)
+}
+
+func checkHubTunnelStatusWithClient(ctx context.Context, kc kubernetes.Interface, target cloudinstall.RadarTarget, client agentStatusGetter) hubTunnelResult {
+	runtime := target.Runtime
+	if runtime.CloudTokenSecretName == "" || runtime.CloudTokenSecretKey == "" {
+		return hubTunnelResult{
+			summary: "not checked — the connection token is not sourced from a Kubernetes Secret",
+			next:    "migrate the token to cloud.existingSecret to enable this check.",
+		}
+	}
+	secretRef := target.Namespace + "/" + runtime.CloudTokenSecretName
+	secret, err := kc.CoreV1().Secrets(target.Namespace).Get(ctx, runtime.CloudTokenSecretName, metav1.GetOptions{})
+	if apierrors.IsForbidden(err) {
+		return hubTunnelResult{
+			summary: "not checked — Kubernetes denied access to the connection Secret",
+			detail:  fmt.Sprintf("Secret %q", secretRef),
+			next:    "run this command with an account that can read the Secret, or verify the connection in the Hub.",
+		}
+	}
+	if apierrors.IsNotFound(err) {
+		return hubTunnelResult{
+			verdict: hubTunnelUnhealthy,
+			summary: "failed — the connection Secret was not found",
+			detail:  fmt.Sprintf("Secret %q", secretRef),
+			next:    "restore the Secret or correct cloud.existingSecret, then run this command again.",
+		}
+	}
+	if err != nil {
+		return hubTunnelResult{
+			summary: "not checked — the connection Secret could not be read",
+			detail:  fmt.Sprintf("Secret %q: %v", secretRef, err),
+			next:    "resolve the Kubernetes error, then run this command again.",
+		}
+	}
+	token := string(secret.Data[runtime.CloudTokenSecretKey])
+	if token == "" {
+		return hubTunnelResult{
+			verdict: hubTunnelUnhealthy,
+			summary: "failed — the connection Secret has no usable token",
+			detail:  fmt.Sprintf("Secret %q, key %q", secretRef, runtime.CloudTokenSecretKey),
+			next:    "restore the token key, then restart the Radar agent.",
+		}
+	}
+	status, err := client.Get(ctx, token)
+	result := evaluateHubTunnelStatus(status, err)
+	if errors.Is(err, cloud.ErrAgentStatusUnauthorized) {
+		result.detail = fmt.Sprintf("Kubernetes Secret %q, key %q", secretRef, runtime.CloudTokenSecretKey)
+		result.next = "generate a new cluster token in the Hub, update this Secret, then restart the Radar agent."
+	}
+	return result
+}
+
+func evaluateHubTunnelStatus(status *cloud.AgentStatusResponse, err error) hubTunnelResult {
+	if errors.Is(err, cloud.ErrAgentStatusUnauthorized) {
+		return hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "failed — the Hub rejected the connection token"}
+	}
+	if errors.Is(err, cloud.ErrAgentStatusEndpointNotFound) {
+		return hubTunnelResult{
+			summary: "not checked — the Hub status endpoint was not found",
+			detail:  "GET /api/agent/status returned HTTP 404",
+			next:    "verify the connection in the Hub's cluster list; if this is a self-hosted Hub, upgrade it to a version that supports live connection status.",
+		}
+	}
+	if err != nil {
+		return hubTunnelResult{
+			summary: "not checked — the Hub status request failed",
+			detail:  err.Error(),
+			next:    "check Hub availability and this machine's network access, then try again.",
+		}
+	}
+	switch status.Status {
+	case "connected":
+		return hubTunnelResult{
+			verdict: hubTunnelHealthy, summary: "connected", hubClusterID: status.ClusterID, lastConnectedAt: status.LastConnectedAt,
+		}
+	case "disconnected":
+		return hubTunnelResult{
+			verdict: hubTunnelUnhealthy, summary: "disconnected", hubClusterID: status.ClusterID, lastConnectedAt: status.LastConnectedAt,
+			next: "check the Radar agent state above and its Cloud connection logs.",
+		}
+	case "never_connected":
+		return hubTunnelResult{
+			verdict: hubTunnelUnhealthy, summary: "never connected", hubClusterID: status.ClusterID,
+			next: "check the Radar agent state above and its Cloud connection logs.",
+		}
+	default:
+		return hubTunnelResult{
+			verdict: hubTunnelUnhealthy,
+			summary: "failed — the Hub returned an unknown connection state",
+			detail:  fmt.Sprintf("Hub cluster %q reported status %q", status.ClusterID, status.Status),
+			next:    "check the Hub version and logs.",
+		}
+	}
+}
+
+func missingCloudConfiguration(runtime cloudinstall.DeploymentRuntime) []string {
+	var missing []string
+	if !runtime.CloudURLConfigured || (runtime.CloudURL == "" && !runtime.CloudURLUnresolved) {
+		missing = append(missing, "Hub URL")
+	}
+	if !runtime.CloudModeConfigured {
+		missing = append(missing, "Cloud mode")
+	} else if !runtime.CloudMode && !runtime.CloudModeUnresolved {
+		missing = append(missing, "enabled Cloud mode")
+	}
+	if !runtime.ClusterNameConfigured || (runtime.ClusterName == "" && !runtime.ClusterNameUnresolved) {
+		missing = append(missing, "cluster ID")
+	}
+	if !runtime.CloudTokenConfigured {
+		missing = append(missing, "connection token")
+	}
+	return missing
+}
+
+func cloudOwnershipLabel(target cloudinstall.RadarTarget) string {
+	switch target.Ownership.Classification {
+	case cloudinstall.OwnershipNativeHelm:
+		if target.ReleaseName != "" {
+			return fmt.Sprintf("Helm release %q", target.ReleaseName)
+		}
+		return "Helm"
+	case cloudinstall.OwnershipGitOpsVerified:
+		for _, controller := range target.Ownership.Controllers {
+			if controller.Verification != cloudinstall.ControllerVerified {
+				continue
+			}
+			ref := controller.Ref
+			name := ref.Name
+			if ref.Namespace != "" {
+				name = ref.Namespace + "/" + name
+			}
+			return fmt.Sprintf("GitOps (%s %s)", ref.Kind, name)
+		}
+		return "GitOps"
+	case cloudinstall.OwnershipGitOpsSuspected:
+		return "GitOps evidence (suspected; not verified)"
+	case cloudinstall.OwnershipGitOpsUnreadable:
+		return "GitOps controller (not readable)"
+	case cloudinstall.OwnershipGitOpsStale:
+		return "GitOps reference (stale)"
+	case cloudinstall.OwnershipAmbiguous:
+		return "ambiguous ownership"
+	case cloudinstall.OwnershipGeneric:
+		return "unmanaged"
+	default:
+		return "unknown"
+	}
+}

--- a/cmd/explorer/cloud_status.go
+++ b/cmd/explorer/cloud_status.go
@@ -124,6 +124,10 @@ func cloudStatus(args []string, out, errOut io.Writer) int {
 	var tunnel hubTunnelResult
 	if len(targets) == 1 {
 		tunnel = checkHubTunnelStatus(ctx, clients.Kubernetes, targets[0])
+		if ctx.Err() != nil {
+			fmt.Fprintln(errOut, "cloud status: interrupted")
+			return 1
+		}
 	}
 	fmt.Fprintf(out, "\nStatus: %s\n\n", cloudStatusHeadline(targets, result.ClusterWideError, tunnel))
 	code := printCloudDiscoveryStatus(out, errOut, targets, result.ClusterWideError, exactTarget, normalizedNamespace, normalizedRelease)
@@ -314,6 +318,8 @@ func cloudTargetStatusHeadline(target cloudinstall.RadarTarget, tunnel hubTunnel
 			connection = "its connection Secret is missing"
 		case "failed — the connection Secret has no usable token":
 			connection = "its connection Secret has no usable token"
+		case "failed — the configured Hub URL is invalid":
+			connection = "its configured Hub URL is invalid"
 		}
 		if agentHealthy {
 			return "Radar is installed, but " + connection + "."
@@ -371,7 +377,8 @@ func checkHubTunnelStatus(ctx context.Context, kc kubernetes.Interface, target c
 	client, err := cloud.NewAgentStatusClient(runtime.CloudURL)
 	if err != nil {
 		return hubTunnelResult{
-			summary: "not checked — the configured Hub URL is invalid",
+			verdict: hubTunnelUnhealthy,
+			summary: "failed — the configured Hub URL is invalid",
 			detail:  err.Error(),
 			next:    "correct the Hub URL, then run this command again.",
 		}

--- a/cmd/explorer/cloud_status_test.go
+++ b/cmd/explorer/cloud_status_test.go
@@ -1,0 +1,491 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/cloud"
+	"github.com/skyhook-io/radar/internal/cloudinstall"
+	"github.com/skyhook-io/radar/pkg/subject"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCloudStatusHelp(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := cloudStatus([]string{"--help"}, &out, &errOut); code != 0 {
+		t.Fatalf("cloud status --help exit code = %d", code)
+	}
+	if !strings.Contains(out.String(), "Usage: radar cloud status") || !strings.Contains(out.String(), "--namespace and --release") || errOut.Len() != 0 {
+		t.Fatalf("help stdout = %q, stderr = %q", out.String(), errOut.String())
+	}
+}
+
+func TestCloudStatusRequiresCompleteExactTarget(t *testing.T) {
+	for _, args := range [][]string{{"--namespace", "radar"}, {"--release", "radar"}} {
+		var out, errOut bytes.Buffer
+		if code := cloudStatus(args, &out, &errOut); code != 2 {
+			t.Fatalf("cloud status %v exit code = %d, want 2", args, code)
+		}
+		if !strings.Contains(errOut.String(), "must be passed together") {
+			t.Fatalf("cloud status %v stderr = %q", args, errOut.String())
+		}
+	}
+}
+
+func TestDiscoveredRadarTargetsUsesExactSelection(t *testing.T) {
+	selected := cloudinstall.RadarTarget{DeploymentName: "selected"}
+	namespace := cloudinstall.RadarTarget{DeploymentName: "namespace"}
+	clusterWide := cloudinstall.RadarTarget{DeploymentName: "cluster-wide"}
+	result := cloudinstall.DiscoveryResult{
+		Selected: []cloudinstall.RadarTarget{selected}, Namespace: []cloudinstall.RadarTarget{namespace}, ClusterWide: []cloudinstall.RadarTarget{clusterWide},
+	}
+	if got := discoveredRadarTargets(result, true); len(got) != 1 || got[0].DeploymentName != "selected" {
+		t.Fatalf("exact targets = %#v", got)
+	}
+	if got := discoveredRadarTargets(result, false); len(got) != 2 || got[0].DeploymentName != "namespace" || got[1].DeploymentName != "cluster-wide" {
+		t.Fatalf("discovered targets = %#v", got)
+	}
+}
+
+func TestPrintCloudStatusConfiguredReady(t *testing.T) {
+	target := cloudinstall.RadarTarget{
+		Namespace: "radar", DeploymentName: "radar", ReleaseName: "radar", Chart: "radar-1.8.1",
+		Ownership: cloudinstall.TargetOwnership{Classification: cloudinstall.OwnershipNativeHelm},
+		Runtime: cloudinstall.DeploymentRuntime{
+			Image: "ghcr.io/skyhook-io/radar:1.8.1", DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1,
+			ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+			AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+			ClusterNameConfigured: true, ClusterName: "cluster-123", CloudTokenConfigured: true,
+		},
+	}
+	var out bytes.Buffer
+	if ok := printCloudStatus(&out, target); !ok {
+		t.Fatal("configured ready status = false")
+	}
+	got := out.String()
+	for _, want := range []string{
+		"radar/radar", `Helm release "radar"`, "1/1 replicas ready", "Cloud configuration: present",
+		"wss://api.radarhq.io/agent", "Configured cluster reference: cluster-123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "connection token") {
+		t.Fatalf("configured status exposed token detail:\n%s", got)
+	}
+}
+
+type fakeAgentStatusGetter struct {
+	status *cloud.AgentStatusResponse
+	err    error
+	token  string
+}
+
+func (f *fakeAgentStatusGetter) Get(_ context.Context, token string) (*cloud.AgentStatusResponse, error) {
+	f.token = token
+	return f.status, f.err
+}
+
+func TestCheckHubTunnelStatusReadsReferencedSecret(t *testing.T) {
+	connectedAt := time.Date(2026, time.July, 18, 7, 30, 0, 0, time.UTC)
+	target := cloudinstall.RadarTarget{Namespace: "radar", Runtime: cloudinstall.DeploymentRuntime{
+		ClusterName: "prod-us-east", CloudTokenSecretName: "radar-cloud-config", CloudTokenSecretKey: "token",
+	}}
+	kc := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "radar-cloud-config", Namespace: "radar"},
+		Data:       map[string][]byte{"token": []byte("rhc_secret")},
+	})
+	client := &fakeAgentStatusGetter{status: &cloud.AgentStatusResponse{
+		ClusterID: "clus_123", Status: "connected", LastConnectedAt: &connectedAt,
+	}}
+
+	got := checkHubTunnelStatusWithClient(context.Background(), kc, target, client)
+	if got.verdict != hubTunnelHealthy || got.summary != "connected" || got.hubClusterID != "clus_123" || got.lastConnectedAt == nil || !got.lastConnectedAt.Equal(connectedAt) {
+		t.Fatalf("result = %#v", got)
+	}
+	if client.token != "rhc_secret" {
+		t.Fatalf("client token = %q", client.token)
+	}
+}
+
+func TestCheckHubTunnelStatusUnavailableWithoutSecretReference(t *testing.T) {
+	target := cloudinstall.RadarTarget{Namespace: "radar", Runtime: cloudinstall.DeploymentRuntime{ClusterName: "clus_123"}}
+	client := &fakeAgentStatusGetter{}
+	got := checkHubTunnelStatusWithClient(context.Background(), fake.NewSimpleClientset(), target, client)
+	if got.verdict != hubTunnelUnavailable || !strings.Contains(got.summary, "not sourced from a Kubernetes Secret") || !strings.Contains(got.next, "cloud.existingSecret") {
+		t.Fatalf("result = %#v", got)
+	}
+	if client.token != "" {
+		t.Fatal("client called without a Secret reference")
+	}
+}
+
+func TestCheckHubTunnelStatusFailsForBrokenSecretReference(t *testing.T) {
+	target := cloudinstall.RadarTarget{Namespace: "radar", Runtime: cloudinstall.DeploymentRuntime{
+		CloudTokenSecretName: "radar-cloud-config", CloudTokenSecretKey: "token",
+	}}
+	for _, tc := range []struct {
+		name string
+		kc   *fake.Clientset
+		want string
+	}{
+		{name: "missing Secret", kc: fake.NewSimpleClientset(), want: "connection Secret was not found"},
+		{name: "empty token", kc: fake.NewSimpleClientset(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "radar-cloud-config", Namespace: "radar"},
+			Data:       map[string][]byte{"token": {}},
+		}), want: "connection Secret has no usable token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAgentStatusGetter{}
+			got := checkHubTunnelStatusWithClient(context.Background(), tc.kc, target, client)
+			if got.verdict != hubTunnelUnhealthy || !strings.Contains(got.summary, tc.want) || got.next == "" {
+				t.Fatalf("result = %#v", got)
+			}
+			if client.token != "" {
+				t.Fatal("client called with a broken Secret reference")
+			}
+		})
+	}
+}
+
+func TestEvaluateHubTunnelStatusHealthContract(t *testing.T) {
+	connectedAt := time.Date(2026, time.July, 18, 7, 30, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name    string
+		status  *cloud.AgentStatusResponse
+		err     error
+		verdict hubTunnelVerdict
+		want    string
+	}{
+		{name: "disconnected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "disconnected", LastConnectedAt: &connectedAt}, verdict: hubTunnelUnhealthy, want: "disconnected"},
+		{name: "never connected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "never_connected"}, verdict: hubTunnelUnhealthy, want: "never connected"},
+		{name: "rejected", err: cloud.ErrAgentStatusUnauthorized, verdict: hubTunnelUnhealthy, want: "rejected the connection token"},
+		{name: "status endpoint not found", err: cloud.ErrAgentStatusEndpointNotFound, verdict: hubTunnelUnavailable, want: "status endpoint was not found"},
+		{name: "network unavailable", err: errors.New("dial timeout"), verdict: hubTunnelUnavailable, want: "Hub status request failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evaluateHubTunnelStatus(tc.status, tc.err)
+			actual := strings.Join([]string{got.summary, got.detail, got.next}, "\n")
+			if got.verdict != tc.verdict || !strings.Contains(actual, tc.want) {
+				t.Fatalf("result = %#v", got)
+			}
+			if tc.name == "disconnected" && (got.lastConnectedAt == nil || !got.lastConnectedAt.Equal(connectedAt)) {
+				t.Fatalf("disconnected timestamp = %#v", got.lastConnectedAt)
+			}
+		})
+	}
+}
+
+func TestPrintHubTunnelStatusKeepsBottomLineReadableAndExpertIdentityWhenNeeded(t *testing.T) {
+	connectedAt := time.Date(2026, time.July, 18, 7, 30, 0, 0, time.UTC)
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{ClusterName: "prod-us-east"}}
+	result := hubTunnelResult{
+		verdict: hubTunnelHealthy, summary: "connected", hubClusterID: "clus_123", lastConnectedAt: &connectedAt,
+	}
+	var out bytes.Buffer
+	printHubTunnelStatus(&out, target, result)
+	got := out.String()
+	for _, want := range []string{
+		"\nCloud connection: connected\n", "Hub cluster ID: clus_123", "Connected since: 2026-07-18T07:30:00Z",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status missing %q:\n%s", want, got)
+		}
+	}
+
+	out.Reset()
+	target.Runtime.ClusterName = "clus_123"
+	printHubTunnelStatus(&out, target, result)
+	if strings.Contains(out.String(), "Hub cluster ID:") {
+		t.Fatalf("matching configured and authenticated cluster IDs were repeated:\n%s", out.String())
+	}
+}
+
+func TestCloudStatusHeadlineSynthesizesHumanVerdict(t *testing.T) {
+	healthyRuntime := cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "clus_123", CloudTokenConfigured: true,
+	}
+	for _, tc := range []struct {
+		name    string
+		targets []cloudinstall.RadarTarget
+		err     error
+		tunnel  hubTunnelResult
+		want    string
+	}{
+		{name: "not installed", want: "not installed"},
+		{name: "inconclusive discovery", err: errors.New("forbidden"), want: "inconclusive"},
+		{name: "multiple", targets: []cloudinstall.RadarTarget{{}, {}}, want: "Multiple Radar installations"},
+		{name: "connected", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: "healthy and connected"},
+		{name: "connected with partial discovery", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, err: errors.New("forbidden"), tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: "Discovery was incomplete"},
+		{name: "disconnected", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "disconnected"}, want: "disconnected from the Hub"},
+		{name: "rejected token", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "failed — the Hub rejected the connection token"}, want: "rejected its connection token"},
+		{name: "missing Secret", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "failed — the connection Secret was not found"}, want: "connection Secret is missing"},
+		{name: "empty token", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "failed — the connection Secret has no usable token"}, want: "no usable token"},
+		{name: "unverified", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, want: "could not be verified"},
+		{name: "not configured", targets: []cloudinstall.RadarTarget{{Runtime: cloudinstall.DeploymentRuntime{DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true}}}, want: "not configured for Cloud"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cloudStatusHeadline(tc.targets, tc.err, tc.tunnel); !strings.Contains(got, tc.want) {
+				t.Fatalf("headline = %q, want substring %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckHubTunnelStatusRejectedTokenNamesCredentialAndRecovery(t *testing.T) {
+	target := cloudinstall.RadarTarget{Namespace: "radar", Runtime: cloudinstall.DeploymentRuntime{
+		CloudTokenSecretName: "radar-cloud-config", CloudTokenSecretKey: "token",
+	}}
+	kc := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "radar-cloud-config", Namespace: "radar"},
+		Data:       map[string][]byte{"token": []byte("rhc_rejected")},
+	})
+	client := &fakeAgentStatusGetter{err: cloud.ErrAgentStatusUnauthorized}
+
+	got := checkHubTunnelStatusWithClient(context.Background(), kc, target, client)
+	if got.verdict != hubTunnelUnhealthy || !strings.Contains(got.summary, "rejected the connection token") ||
+		!strings.Contains(got.detail, `Kubernetes Secret "radar/radar-cloud-config", key "token"`) ||
+		!strings.Contains(got.next, "generate a new cluster token in the Hub") {
+		t.Fatalf("result = %#v", got)
+	}
+}
+
+func TestCheckHubTunnelStatusExplainsUnconfiguredAndIncompleteInstallations(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		runtime cloudinstall.DeploymentRuntime
+		want    string
+	}{
+		{name: "not configured", want: "not configured"},
+		{name: "incomplete", runtime: cloudinstall.DeploymentRuntime{AlreadyCloud: true}, want: "configuration is incomplete"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkHubTunnelStatus(context.Background(), fake.NewSimpleClientset(), cloudinstall.RadarTarget{Runtime: tc.runtime})
+			if !strings.Contains(got.summary, tc.want) || got.next == "" {
+				t.Fatalf("result = %#v", got)
+			}
+		})
+	}
+}
+
+func TestPrintCloudStatusIncompleteOrUnreadyFails(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target cloudinstall.RadarTarget
+		want   string
+	}{
+		{
+			name: "not configured",
+			target: cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+				DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+			}},
+			want: "not configured",
+		},
+		{
+			name: "missing token",
+			target: cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+				DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+				AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+				CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+				ClusterNameConfigured: true, ClusterName: "cluster-123",
+			}},
+			want: "missing connection token",
+		},
+		{
+			name: "unready",
+			target: cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+				DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, StatusObserved: true,
+				AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true,
+				ClusterNameConfigured: true, CloudTokenConfigured: true,
+			}},
+			want: "0/1 ready",
+		},
+		{
+			name: "scaled to zero",
+			target: cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+				StatusObserved: true, AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+				CloudURLConfigured: true, ClusterNameConfigured: true, CloudTokenConfigured: true,
+			}},
+			want: "scaled to zero",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if ok := printCloudStatus(&out, tc.target); ok {
+				t.Fatal("status = true")
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("status missing %q:\n%s", tc.want, out.String())
+			}
+		})
+	}
+}
+
+func TestPrintCloudStatusAcceptsSourcedCloudMode(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true, AlreadyCloud: true,
+		CloudModeConfigured: true, CloudModeUnresolved: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "cluster-123", CloudTokenConfigured: true,
+	}}
+	var out bytes.Buffer
+	if ok := printCloudStatus(&out, target); !ok {
+		t.Fatalf("sourced Cloud mode status = false:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "referenced value (value not inspected)") {
+		t.Fatalf("sourced Cloud mode uncertainty not disclosed:\n%s", out.String())
+	}
+}
+
+func TestPrintCloudStatusDisclosesReferencedHubAndClusterValues(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true, AlreadyCloud: true,
+		CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true, CloudURLUnresolved: true,
+		ClusterNameConfigured: true, ClusterNameUnresolved: true, CloudTokenConfigured: true,
+	}}
+	var out bytes.Buffer
+	if ok := printCloudStatus(&out, target); !ok {
+		t.Fatalf("referenced Cloud configuration status = false:\n%s", out.String())
+	}
+	for _, want := range []string{"Hub: configured from a referenced value", "Configured cluster reference: sourced from a referenced value"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestMissingCloudConfigurationRejectsEmptyLiteralValues(t *testing.T) {
+	runtime := cloudinstall.DeploymentRuntime{
+		CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true,
+		ClusterNameConfigured: true, CloudTokenConfigured: true,
+	}
+	got := strings.Join(missingCloudConfiguration(runtime), ", ")
+	if !strings.Contains(got, "Hub URL") || !strings.Contains(got, "cluster ID") {
+		t.Fatalf("missing configuration = %q", got)
+	}
+}
+
+func TestPrintCloudStatusRequiresObservedReadyDeployment(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, ReadyReplicas: 3, AlreadyCloud: true,
+		CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true,
+		ClusterNameConfigured: true, CloudTokenConfigured: true,
+	}}
+	var out bytes.Buffer
+	if ok := printCloudStatus(&out, target); ok {
+		t.Fatalf("stale rollout status = true:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "rollout status pending") {
+		t.Fatalf("status = %q", out.String())
+	}
+}
+
+func TestPrintCloudStatusRejectsStuckRolloutMaskedByOldReadyPod(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 2, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true, CloudURLConfigured: true,
+		ClusterNameConfigured: true, CloudTokenConfigured: true,
+	}}
+	var out bytes.Buffer
+	if ok := printCloudStatus(&out, target); ok {
+		t.Fatalf("stuck rollout status = true:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "rollout incomplete") || !strings.Contains(out.String(), "1 old replica still running") {
+		t.Fatalf("status did not expose stuck rollout:\n%s", out.String())
+	}
+}
+
+func TestPrintCloudDiscoveryStatusDoesNotClaimAbsenceAfterPartialScan(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := printCloudDiscoveryStatus(&out, &errOut, nil, errors.New("forbidden"), false, "radar", "radar")
+	if code != 1 || !strings.Contains(out.String(), "none found in namespaces this account can inspect") || !strings.Contains(out.String(), "could not be ruled out") {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, out.String(), errOut.String())
+	}
+	if strings.Contains(out.String(), "cloud install") {
+		t.Fatalf("partial discovery recommended a new install: %q", out.String())
+	}
+}
+
+func TestPrintCloudDiscoveryStatusHealthyTargetStillFailsAfterPartialScan(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "cluster-123", CloudTokenConfigured: true,
+	}}
+	var out, errOut bytes.Buffer
+	code := printCloudDiscoveryStatus(&out, &errOut, []cloudinstall.RadarTarget{target}, errors.New("forbidden"), false, "radar", "radar")
+	if code != 1 || !strings.Contains(out.String(), "Discovery: incomplete") || !strings.Contains(errOut.String(), "could not inspect all visible namespaces") {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, out.String(), errOut.String())
+	}
+}
+
+func TestPrintCloudDiscoveryStatusHealthyExactTargetSucceeds(t *testing.T) {
+	target := cloudinstall.RadarTarget{Runtime: cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "cluster-123", CloudTokenConfigured: true,
+	}}
+	var out, errOut bytes.Buffer
+	if code := printCloudDiscoveryStatus(&out, &errOut, []cloudinstall.RadarTarget{target}, nil, true, "radar", "radar"); code != 0 {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, out.String(), errOut.String())
+	}
+}
+
+func TestPrintCloudDiscoveryStatusExactTargetDescribesDeploymentLookup(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := printCloudDiscoveryStatus(&out, &errOut, nil, nil, true, "radar-system", "radar-prod")
+	if code != 1 || errOut.Len() != 0 {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), `Radar Deployment with release label "radar-prod" in namespace "radar-system"`) {
+		t.Fatalf("status misdescribed exact lookup: %q", out.String())
+	}
+	if strings.Contains(out.String(), "Checked Helm release") {
+		t.Fatalf("status claimed to inspect Helm storage: %q", out.String())
+	}
+}
+
+func TestCloudOwnershipLabelGitOps(t *testing.T) {
+	target := cloudinstall.RadarTarget{Ownership: cloudinstall.TargetOwnership{
+		Classification: cloudinstall.OwnershipGitOpsVerified,
+		Controllers: []cloudinstall.ControllerCandidate{
+			{Ref: subject.Ref{Kind: "HelmRelease", Namespace: "flux-system", Name: "old-radar"}, Verification: cloudinstall.ControllerStale},
+			{Ref: subject.Ref{Kind: "Application", Namespace: "argocd", Name: "radar"}, Verification: cloudinstall.ControllerVerified},
+		},
+	}}
+	if got := cloudOwnershipLabel(target); got != "GitOps (Application argocd/radar)" {
+		t.Fatalf("ownership = %q", got)
+	}
+}
+
+func TestCloudOwnershipLabelUnmanaged(t *testing.T) {
+	target := cloudinstall.RadarTarget{Ownership: cloudinstall.TargetOwnership{Classification: cloudinstall.OwnershipGeneric}}
+	if got := cloudOwnershipLabel(target); got != "unmanaged" {
+		t.Fatalf("ownership = %q", got)
+	}
+}
+
+func TestCloudOwnershipLabelUncertainGitOpsStates(t *testing.T) {
+	for classification, want := range map[cloudinstall.OwnershipClassification]string{
+		cloudinstall.OwnershipGitOpsSuspected:  "suspected",
+		cloudinstall.OwnershipGitOpsUnreadable: "not readable",
+		cloudinstall.OwnershipGitOpsStale:      "stale",
+	} {
+		target := cloudinstall.RadarTarget{Ownership: cloudinstall.TargetOwnership{Classification: classification}}
+		if got := cloudOwnershipLabel(target); !strings.Contains(got, want) {
+			t.Errorf("ownership %q label = %q, want %q", classification, got, want)
+		}
+	}
+}

--- a/cmd/explorer/cloud_status_test.go
+++ b/cmd/explorer/cloud_status_test.go
@@ -278,6 +278,22 @@ func TestCheckHubTunnelStatusExplainsUnconfiguredAndIncompleteInstallations(t *t
 	}
 }
 
+func TestCheckHubTunnelStatusFailsForInvalidHubURL(t *testing.T) {
+	runtime := cloudinstall.DeploymentRuntime{
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "://invalid",
+		ClusterNameConfigured: true, ClusterName: "clus_123", CloudTokenConfigured: true,
+	}
+
+	got := checkHubTunnelStatus(context.Background(), fake.NewSimpleClientset(), cloudinstall.RadarTarget{Runtime: runtime})
+	if got.verdict != hubTunnelUnhealthy || !strings.Contains(got.summary, "configured Hub URL is invalid") || got.next == "" {
+		t.Fatalf("result = %#v", got)
+	}
+	if headline := cloudTargetStatusHeadline(cloudinstall.RadarTarget{Runtime: runtime}, got); !strings.Contains(headline, "configured Hub URL is invalid") {
+		t.Fatalf("headline = %q", headline)
+	}
+}
+
 func TestPrintCloudStatusIncompleteOrUnreadyFails(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/cloud/agent_status.go
+++ b/internal/cloud/agent_status.go
@@ -1,0 +1,86 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const maxAgentStatusBodyBytes = 8 << 10
+
+var (
+	ErrAgentStatusUnauthorized     = errors.New("Hub rejected the cluster token")
+	ErrAgentStatusEndpointNotFound = errors.New("Hub agent status endpoint was not found")
+)
+
+// AgentStatusResponse is the Hub's live view of one cluster's tunnel.
+// LastConnectedAt is the start of the current connection when connected and
+// the start of the most recent connection when disconnected.
+type AgentStatusResponse struct {
+	ClusterID       string     `json:"cluster_id"`
+	Status          string     `json:"status"`
+	LastConnectedAt *time.Time `json:"last_connected_at,omitempty"`
+}
+
+// AgentStatusClient reuses the Hub client's validation and no-redirect
+// transport policy while targeting the cluster-token status endpoint.
+type AgentStatusClient struct {
+	*ConnectClient
+}
+
+func NewAgentStatusClient(cloudURL string) (*AgentStatusClient, error) {
+	hubOrigin, err := HubOriginFromWebSocketURL(cloudURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Hub agent URL: %w", err)
+	}
+	c := NewConnectClient(hubOrigin)
+	c.HTTP.Timeout = 5 * time.Second
+	return &AgentStatusClient{ConnectClient: c}, nil
+}
+
+func (c *AgentStatusClient) Get(ctx context.Context, token string) (*AgentStatusResponse, error) {
+	if token == "" {
+		return nil, errors.New("cluster token is required")
+	}
+	if err := c.validateHubOrigin(); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.HubBase+"/api/agent/status", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build agent status request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("query Hub agent status: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrAgentStatusUnauthorized
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrAgentStatusEndpointNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("query Hub agent status: Hub returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAgentStatusBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read Hub agent status: %w", err)
+	}
+	if len(body) > maxAgentStatusBodyBytes {
+		return nil, errors.New("read Hub agent status: response is too large")
+	}
+	var status AgentStatusResponse
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, fmt.Errorf("decode Hub agent status: %w", err)
+	}
+	if status.ClusterID == "" || status.Status == "" {
+		return nil, errors.New("decode Hub agent status: cluster_id and status are required")
+	}
+	return &status, nil
+}

--- a/internal/cloud/agent_status_test.go
+++ b/internal/cloud/agent_status_test.go
@@ -1,0 +1,101 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAgentStatusClientGet(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://api.radarhq.io/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://api.radarhq.io/api/agent/status" {
+			t.Fatalf("URL = %q", r.URL.String())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer rhc_secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"cluster_id":"clus_123","status":"connected","last_connected_at":"2026-07-18T07:30:00Z"}`)),
+		}, nil
+	})}
+
+	got, err := c.Get(context.Background(), "rhc_secret")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ClusterID != "clus_123" || got.Status != "connected" || got.LastConnectedAt == nil || got.LastConnectedAt.UTC().Format("2006-01-02T15:04:05Z") != "2026-07-18T07:30:00Z" {
+		t.Fatalf("status = %#v", got)
+	}
+}
+
+func TestAgentStatusClientRejectsUnauthorizedWithoutResponseBodyLeak(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://api.radarhq.io/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("echoed rhc_secret")),
+		}, nil
+	})}
+
+	_, err = c.Get(context.Background(), "rhc_secret")
+	if !errors.Is(err, ErrAgentStatusUnauthorized) {
+		t.Fatalf("Get error = %v", err)
+	}
+	if strings.Contains(err.Error(), "rhc_secret") {
+		t.Fatalf("Get error exposed credential: %v", err)
+	}
+}
+
+func TestAgentStatusClientRecognizesMissingStatusEndpoint(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://acme.radarhq.io/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("not found")),
+		}, nil
+	})}
+
+	_, err = c.Get(context.Background(), "rhc_secret")
+	if !errors.Is(err, ErrAgentStatusEndpointNotFound) {
+		t.Fatalf("Get error = %v", err)
+	}
+}
+
+func TestAgentStatusClientRejectsRedirects(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://api.radarhq.io/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Status:     "307 Temporary Redirect",
+			Header:     http.Header{"Location": []string{"https://attacker.example/status"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})}
+
+	if _, err := c.Get(context.Background(), "rhc_secret"); err == nil || !strings.Contains(err.Error(), "redirects are not allowed") {
+		t.Fatalf("Get error = %v", err)
+	}
+}

--- a/internal/cloud/url.go
+++ b/internal/cloud/url.go
@@ -93,6 +93,30 @@ func ValidateWebSocketURL(raw string) error {
 	return nil
 }
 
+// HubOriginFromWebSocketURL derives the Hub API origin from an agent endpoint.
+// Agent URLs are issued as ws(s)://host/agent; status calls use the same
+// authority over http(s) and never carry path/query data across protocols.
+func HubOriginFromWebSocketURL(raw string) (string, error) {
+	if err := ValidateWebSocketURL(raw); err != nil {
+		return "", err
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", errors.New("cloud WebSocket URL is invalid")
+	}
+	if u.Scheme == "wss" {
+		u.Scheme = "https"
+	} else {
+		u.Scheme = "http"
+	}
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	return u.String(), nil
+}
+
 func validateURLPort(u *url.URL) error {
 	port := u.Port()
 	if port == "" {

--- a/internal/cloud/url_test.go
+++ b/internal/cloud/url_test.go
@@ -94,6 +94,31 @@ func TestValidateHubOriginTransportPolicy(t *testing.T) {
 	}
 }
 
+func TestHubOriginFromWebSocketURL(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "wss://api.radarhq.io/agent", want: "https://api.radarhq.io"},
+		{raw: "wss://hub.example:8443/agent?transport=websocket", want: "https://hub.example:8443"},
+		{raw: "ws://localhost:9091/agent", want: "http://localhost:9091"},
+		{raw: "ws://[::1]:9091/agent", want: "http://[::1]:9091"},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := HubOriginFromWebSocketURL(tc.raw)
+			if err != nil {
+				t.Fatalf("HubOriginFromWebSocketURL(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("HubOriginFromWebSocketURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+	if _, err := HubOriginFromWebSocketURL("ws://api.radarhq.io/agent"); err == nil {
+		t.Fatal("plaintext remote WebSocket URL unexpectedly accepted")
+	}
+}
+
 func TestConfigValidateRejectsPlaintextRemoteCloudURL(t *testing.T) {
 	cfg := Config{
 		URL:       "ws://api.radarhq.io/agent",

--- a/internal/cloudinstall/discovery.go
+++ b/internal/cloudinstall/discovery.go
@@ -70,14 +70,25 @@ type RadarTarget struct {
 
 type DeploymentRuntime struct {
 	Image                 string
+	DesiredReplicas       int32
+	TotalReplicas         int32
+	UpdatedReplicas       int32
+	ReadyReplicas         int32
+	AvailableReplicas     int32
+	StatusObserved        bool
 	AuthMode              string
 	CloudModeConfigured   bool
 	CloudMode             bool
+	CloudModeUnresolved   bool
 	CloudURL              string
 	CloudURLConfigured    bool
+	CloudURLUnresolved    bool
 	ClusterName           string
 	ClusterNameConfigured bool
+	ClusterNameUnresolved bool
 	CloudTokenConfigured  bool
+	CloudTokenSecretName  string
+	CloudTokenSecretKey   string
 	AlreadyCloud          bool
 }
 
@@ -200,10 +211,18 @@ func isOfficialRadarChartLabel(label string) bool {
 
 func inspectDeploymentRuntime(deployment *appsv1.Deployment) DeploymentRuntime {
 	runtime := DeploymentRuntime{AuthMode: "none"}
-	cloudModeUnresolved := false
 	if deployment == nil {
 		return runtime
 	}
+	runtime.DesiredReplicas = 1
+	if deployment.Spec.Replicas != nil {
+		runtime.DesiredReplicas = *deployment.Spec.Replicas
+	}
+	runtime.TotalReplicas = deployment.Status.Replicas
+	runtime.UpdatedReplicas = deployment.Status.UpdatedReplicas
+	runtime.ReadyReplicas = deployment.Status.ReadyReplicas
+	runtime.AvailableReplicas = deployment.Status.AvailableReplicas
+	runtime.StatusObserved = deployment.Status.ObservedGeneration >= deployment.Generation
 	var container *corev1.Container
 	for i := range deployment.Spec.Template.Spec.Containers {
 		if deployment.Spec.Template.Spec.Containers[i].Name == chartName {
@@ -221,14 +240,14 @@ func inspectDeploymentRuntime(deployment *appsv1.Deployment) DeploymentRuntime {
 	}
 	runtime.CloudURL, runtime.CloudURLConfigured = argumentValue(container.Args, "--cloud-url")
 	runtime.ClusterName, runtime.ClusterNameConfigured = argumentValue(container.Args, "--cluster-name")
-	_, cloudTokenArg := argumentValue(container.Args, "--cloud-token")
+	cloudTokenValue, cloudTokenArg := argumentValue(container.Args, "--cloud-token")
 
 	for _, env := range container.Env {
 		switch env.Name {
 		case "RADAR_CLOUD_MODE":
 			runtime.CloudModeConfigured = true
 			if env.ValueFrom != nil {
-				cloudModeUnresolved = true
+				runtime.CloudModeUnresolved = true
 			} else {
 				runtime.CloudMode, _ = strconv.ParseBool(env.Value)
 			}
@@ -236,18 +255,24 @@ func inspectDeploymentRuntime(deployment *appsv1.Deployment) DeploymentRuntime {
 			if !runtime.CloudURLConfigured {
 				runtime.CloudURL = env.Value
 				runtime.CloudURLConfigured = env.Value != "" || env.ValueFrom != nil
+				runtime.CloudURLUnresolved = env.ValueFrom != nil
 			}
 		case "RADAR_CLOUD_CLUSTER_NAME":
 			if !runtime.ClusterNameConfigured {
 				runtime.ClusterName = env.Value
 				runtime.ClusterNameConfigured = env.Value != "" || env.ValueFrom != nil
+				runtime.ClusterNameUnresolved = env.ValueFrom != nil
 			}
 		case "RADAR_CLOUD_TOKEN":
 			runtime.CloudTokenConfigured = env.Value != "" || env.ValueFrom != nil
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				runtime.CloudTokenSecretName = env.ValueFrom.SecretKeyRef.Name
+				runtime.CloudTokenSecretKey = env.ValueFrom.SecretKeyRef.Key
+			}
 		}
 	}
-	runtime.CloudTokenConfigured = runtime.CloudTokenConfigured || cloudTokenArg
-	runtime.AlreadyCloud = runtime.CloudMode || cloudModeUnresolved || runtime.CloudURLConfigured || runtime.ClusterNameConfigured || runtime.CloudTokenConfigured
+	runtime.CloudTokenConfigured = runtime.CloudTokenConfigured || (cloudTokenArg && cloudTokenValue != "")
+	runtime.AlreadyCloud = runtime.CloudMode || runtime.CloudModeUnresolved || runtime.CloudURLConfigured || runtime.ClusterNameConfigured || runtime.CloudTokenConfigured
 	return runtime
 }
 

--- a/internal/cloudinstall/discovery_test.go
+++ b/internal/cloudinstall/discovery_test.go
@@ -3,6 +3,8 @@ package cloudinstall
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,6 +78,14 @@ func TestDiscoverRadarTargetsNativeHelmSelectedTarget(t *testing.T) {
 		"meta.helm.sh/release-name":      "radar",
 		"meta.helm.sh/release-namespace": "radar",
 	})
+	replicas := int32(2)
+	deployment.Spec.Replicas = &replicas
+	deployment.Generation = 3
+	deployment.Status.ObservedGeneration = 3
+	deployment.Status.Replicas = 2
+	deployment.Status.UpdatedReplicas = 1
+	deployment.Status.ReadyReplicas = 1
+	deployment.Status.AvailableReplicas = 1
 	kc := kubernetesfake.NewSimpleClientset(deployment)
 
 	result, err := DiscoverRadarTargets(context.Background(), kc, nil, DiscoveryOptions{})
@@ -89,6 +99,9 @@ func TestDiscoverRadarTargetsNativeHelmSelectedTarget(t *testing.T) {
 	if target.Namespace != "radar" || target.DeploymentName != "radar" || target.ReleaseName != "radar" || target.Chart != "radar-1.6.0" {
 		t.Fatalf("unexpected target: %#v", target)
 	}
+	if target.Runtime.DesiredReplicas != 2 || target.Runtime.TotalReplicas != 2 || target.Runtime.UpdatedReplicas != 1 || target.Runtime.ReadyReplicas != 1 || target.Runtime.AvailableReplicas != 1 || !target.Runtime.StatusObserved {
+		t.Fatalf("runtime replicas = %#v, want 1/2 updated, ready, and available", target.Runtime)
+	}
 	if target.Ownership.Classification != OwnershipNativeHelm {
 		t.Fatalf("ownership = %q, want %q", target.Ownership.Classification, OwnershipNativeHelm)
 	}
@@ -97,6 +110,72 @@ func TestDiscoverRadarTargetsNativeHelmSelectedTarget(t *testing.T) {
 	}
 	if !target.Ownership.NativeHelmMatchesTarget {
 		t.Fatal("native Helm metadata should match selected target")
+	}
+}
+
+func TestDiscoverRadarTargetsMarksSourcedCloudModeUnresolved(t *testing.T) {
+	deployment := radarDeployment("radar", "radar", "radar", nil, nil)
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "radar",
+		Env: []corev1.EnvVar{{
+			Name: "RADAR_CLOUD_MODE",
+			ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "radar-config"}, Key: "cloud-mode",
+			}},
+		}},
+	}}
+
+	result, err := DiscoverRadarTargets(context.Background(), kubernetesfake.NewSimpleClientset(deployment), nil, DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("DiscoverRadarTargets: %v", err)
+	}
+	runtime := result.Selected[0].Runtime
+	if !runtime.CloudModeConfigured || !runtime.CloudModeUnresolved || !runtime.AlreadyCloud {
+		t.Fatalf("cloud runtime = %#v", runtime)
+	}
+}
+
+func TestDiscoverRadarTargetsMarksSourcedCloudIdentityUnresolved(t *testing.T) {
+	deployment := radarDeployment("radar", "radar", "radar", nil, nil)
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "radar",
+		Env: []corev1.EnvVar{
+			{Name: "RADAR_CLOUD_URL", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "radar-cloud"}, Key: "url"}}},
+			{Name: "RADAR_CLOUD_CLUSTER_NAME", ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "radar-config"}, Key: "cluster"}}},
+		},
+	}}
+
+	result, err := DiscoverRadarTargets(context.Background(), kubernetesfake.NewSimpleClientset(deployment), nil, DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("DiscoverRadarTargets: %v", err)
+	}
+	runtime := result.Selected[0].Runtime
+	if !runtime.CloudURLConfigured || !runtime.CloudURLUnresolved || !runtime.ClusterNameConfigured || !runtime.ClusterNameUnresolved {
+		t.Fatalf("cloud runtime = %#v", runtime)
+	}
+}
+
+func TestDiscoverRadarTargetsNeverRetainsLiteralCloudToken(t *testing.T) {
+	const token = "rhc_super_secret_literal"
+	deployment := radarDeployment("radar", "radar", "radar", nil, nil)
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "radar",
+		Args: []string{"--cloud-token", token},
+	}}
+
+	result, err := DiscoverRadarTargets(context.Background(), kubernetesfake.NewSimpleClientset(deployment), nil, DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("DiscoverRadarTargets: %v", err)
+	}
+	runtime := result.Selected[0].Runtime
+	if !runtime.CloudTokenConfigured {
+		t.Fatal("literal Cloud token was not detected as configured")
+	}
+	if runtime.CloudTokenSecretName != "" || runtime.CloudTokenSecretKey != "" {
+		t.Fatalf("literal Cloud token invented Secret reference: %#v", runtime)
+	}
+	if strings.Contains(fmt.Sprintf("%#v", runtime), token) {
+		t.Fatal("deployment runtime retained the literal Cloud token")
 	}
 }
 
@@ -451,6 +530,9 @@ func TestDiscoverRadarTargetsSummarizesLiveRuntime(t *testing.T) {
 	}
 	if !runtime.CloudModeConfigured || !runtime.CloudMode || runtime.CloudURL != "wss://api.radarhq.io/agent" || !runtime.CloudURLConfigured || runtime.ClusterName != "cluster-id" || !runtime.ClusterNameConfigured || !runtime.CloudTokenConfigured || !runtime.AlreadyCloud {
 		t.Fatalf("cloud runtime = %#v", runtime)
+	}
+	if runtime.CloudTokenSecretName != "radar-cloud-config" || runtime.CloudTokenSecretKey != "token" {
+		t.Fatalf("Cloud token Secret reference = %q/%q", runtime.CloudTokenSecretName, runtime.CloudTokenSecretKey)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a read-only `radar cloud status` command so operators can answer two questions from the kubeconfig context they already use: is the in-cluster Radar agent healthy, and is its Cloud tunnel actually connected? Output leads with a plain-language verdict, retains detailed Kubernetes and Hub diagnostics for experts, and never prints the cluster token.

## What changed

- Adds `radar cloud status` with `--context` and paired `--namespace` / `--release` target selection.
- Reuses Radar discovery and ownership classification for native Helm and GitOps-managed installations.
- Leads with a synthesized status such as healthy and connected, disconnected, rejected token, incomplete configuration, or live status not verified.
- Reports ownership, chart and image, Deployment rollout health, Cloud configuration, Hub URL, configured cluster reference, Hub-authenticated cluster ID when distinct, and connection timestamps.
- Adds state-specific `Details:` and `Next:` guidance for rejected credentials, Secret access and shape problems, network or Hub failures, and missing status endpoints.
- Reads a referenced Secret only when needed and sends the token only in the Bearer header. Redirects are rejected, responses are bounded, and token values are never retained in discovery data or printed.
- Returns non-zero for local installation failures and Hub-confirmed disconnected, never-connected, or rejected-token states. Inconclusive Hub checks remain diagnostic and do not override otherwise healthy local status.
- Documents the command and Hub-backed behavior in the README.

## Testing

- `go test ./cmd/explorer ./internal/cloud ./internal/cloudinstall`
- `make tsc`
- `make test`
- `make build`
- Live checks against connected, disconnected, reconnecting, rejected-token, missing-endpoint, non-Secret-token, and unreachable-context states.
- Visual test skipped: no rendered UI delta.

## Dependency

Live tunnel reporting uses skyhook-dev/radar-hub#109. Local Kubernetes diagnostics remain useful when live Hub status cannot be checked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The CLI reads cluster connection Secrets and sends tokens to the Hub for live status, but values are not printed and discovery avoids retaining literal tokens; behavior is covered by tests and reuses existing Hub client transport policy.
> 
> **Overview**
> Adds **`radar cloud status`**, a read-only CLI to inspect in-cluster Radar Cloud installs from the current kubeconfig context (optional `--context`, paired `--namespace` / `--release` for a single target).
> 
> The command reuses existing discovery and ownership classification, prints a plain-language headline plus rollout health, chart/image, and Cloud settings **without exposing the cluster token**, and optionally calls the Hub **`GET /api/agent/status`** using a token read only from a referenced Secret (Bearer header, bounded body, no redirects). Exit codes reflect missing/unhealthy agents and Hub-confirmed disconnected, never-connected, or rejected-token states; inconclusive Hub checks stay diagnostic.
> 
> Supporting changes: **`buildLocalKubernetesClients`** for status (install still uses Helm via the same kube client split), shared **`discoveredRadarTargets`**, richer **`DeploymentRuntime`** (replica rollout fields, unresolved env refs, Secret key refs only—no literal tokens), **`HubOriginFromWebSocketURL`**, and **`AgentStatusClient`** in `internal/cloud`. README documents usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5036dd9d28e67cbde7f6dc3124702ddc3a686f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->