### PR TITLE
Fix resource page titles for API name collisions

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -33,7 +33,7 @@ import { ResourceBar } from '../ui/ResourceBar'
 import type { SelectedResource, APIResource } from '../../types'
 import { isForbiddenError } from '../../types/fetch-error'
 import type { NavigateToResource } from '../../utils/navigation'
-import { categorizeResources, CORE_RESOURCES } from '../../utils/api-resources'
+import { categorizeResources, CORE_RESOURCES, findAPIResourceForRoute } from '../../utils/api-resources'
 import {
   getPodStatus,
   getPodRestarts,
@@ -2036,13 +2036,9 @@ function getInitialKindFromURL(
   }
   const group = new URLSearchParams(search).get('apiGroup') || ''
   if (kind) {
-    // Find matching resource from CORE_RESOURCES or use as-is
-    // Only match core resources when no apiGroup is specified (avoids collisions like KNative Service)
-    if (!group) {
-      const coreMatch = CORE_RESOURCES.find(r => r.kind === kind || r.name === kind)
-      if (coreMatch) {
-        return { name: coreMatch.name, kind: coreMatch.kind, group: coreMatch.group }
-      }
+    const coreMatch = findAPIResourceForRoute(undefined, kind, group)
+    if (coreMatch) {
+      return { name: coreMatch.name, kind: coreMatch.kind, group: coreMatch.group }
     }
     return { name: kind, kind: kind, group }
   }

--- a/packages/k8s-ui/src/utils/api-resources.test.ts
+++ b/packages/k8s-ui/src/utils/api-resources.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from 'vitest'
-import { categorizeResources, formatGroupName, shortenGroupName } from './api-resources'
+import { categorizeResources, findAPIResourceForRoute, formatGroupName, shortenGroupName } from './api-resources'
+
+describe('findAPIResourceForRoute', () => {
+  const resources = [
+    { group: 'metrics.k8s.io', version: 'v1beta1', kind: 'PodMetrics', name: 'pods', namespaced: true, isCrd: false, verbs: ['get'] },
+  ]
+
+  it('prefers the canonical core resource when a discovered API has the same plural name', () => {
+    expect(findAPIResourceForRoute(resources, 'pods')?.kind).toBe('Pod')
+  })
+
+  it('respects an explicit API group for a colliding resource', () => {
+    expect(findAPIResourceForRoute(resources, 'pods', 'metrics.k8s.io')?.kind).toBe('PodMetrics')
+  })
+
+  it('resolves a discovered resource without a core collision', () => {
+    const crd = { group: 'example.io', version: 'v1', kind: 'Widget', name: 'widgets', namespaced: true, isCrd: true, verbs: ['list'] }
+    expect(findAPIResourceForRoute([crd], 'widgets')).toBe(crd)
+  })
+
+  it('resolves core resources before discovery loads', () => {
+    expect(findAPIResourceForRoute(undefined, 'pods')?.kind).toBe('Pod')
+  })
+
+  it('falls back to an exact built-in API group before discovery loads', () => {
+    expect(findAPIResourceForRoute(undefined, 'storageclasses', 'storage.k8s.io')).toMatchObject({
+      kind: 'StorageClass',
+      namespaced: false,
+    })
+  })
+
+  it('supports the legacy Kind route form without weakening group matching', () => {
+    expect(findAPIResourceForRoute(undefined, 'Pod')?.name).toBe('pods')
+    expect(findAPIResourceForRoute(undefined, 'Pod', 'metrics.k8s.io')).toBeUndefined()
+  })
+})
 
 describe('formatGroupName', () => {
   it('uses friendly names for common CRD groups seen in clusters', () => {

--- a/packages/k8s-ui/src/utils/api-resources.ts
+++ b/packages/k8s-ui/src/utils/api-resources.ts
@@ -47,8 +47,24 @@ export const CORE_RESOURCES: APIResource[] = [
   { group: 'scheduling.k8s.io', version: 'v1', kind: 'PriorityClass', name: 'priorityclasses', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'node.k8s.io', version: 'v1', kind: 'RuntimeClass', name: 'runtimeclasses', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'coordination.k8s.io', version: 'v1', kind: 'Lease', name: 'leases', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
+  { group: 'storage.k8s.io', version: 'v1', kind: 'StorageClass', name: 'storageclasses', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'storage.k8s.io', version: 'v1', kind: 'VolumeAttachment', name: 'volumeattachments', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
 ]
+
+export function findAPIResourceForRoute(
+  resources: APIResource[] | undefined,
+  routeSlug: string,
+  group = '',
+): APIResource | undefined {
+  const matchesRoute = (resource: APIResource) =>
+    resource.name === routeSlug || resource.kind === routeSlug
+  if (group) {
+    return resources?.find(r => matchesRoute(r) && r.group === group)
+      ?? CORE_RESOURCES.find(r => matchesRoute(r) && r.group === group)
+  }
+  return CORE_RESOURCES.find(matchesRoute)
+    ?? resources?.find(matchesRoute)
+}
 
 // Resources that should be hidden from the sidebar
 const HIDDEN_KINDS = ['PodMetrics', 'NodeMetrics']

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { useDiagnoseLayout } from './components/diagnose/DiagnoseContext'
 import { DiagnoseSurface } from './components/diagnose/DiagnoseSurface'
 import { TopologyGraph, TopologySearch, TopologyBreadcrumb, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill, PaneLoader } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
-import { useAPIResources, CORE_RESOURCES } from './api/apiResources'
+import { useAPIResources, findAPIResourceForRoute } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
 import { ResourcesView } from './components/resources/ResourcesView'
 import { serializeColumnFilters } from './components/resources/resource-utils'
@@ -61,7 +61,7 @@ import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
 import { SettingsDialog } from './components/settings/SettingsDialog'
-import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
+import type { APIResource, TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPlural, pluralToKind, openExternal, apiVersionToGroup, relatedResourcePath, searchHitToSelectedResource } from './utils/navigation'
 import { type OmnibarHandle } from './components/ui/Omnibar'
 import { RadarOmnibar } from './components/ui/RadarOmnibar'
@@ -150,7 +150,8 @@ function getViewFromPath(pathname: string): ExtendedMainView {
 function namespaceFilterDisabled(
   view: ExtendedMainView,
   pathname: string,
-  apiResources?: { name: string; kind: string; namespaced: boolean }[],
+  search = '',
+  apiResources?: APIResource[],
 ): { disabled: boolean; tooltip?: string } {
   if (
     view === 'cost' &&
@@ -170,7 +171,8 @@ function namespaceFilterDisabled(
   }
   if (view === 'resources') {
     const kindSlug = segments[1]
-    const match = kindSlug ? apiResources?.find(r => r.name === kindSlug) : undefined
+    const group = new URLSearchParams(search).get('apiGroup') || ''
+    const match = kindSlug ? findAPIResourceForRoute(apiResources, kindSlug, group) : undefined
     if (match && !match.namespaced) {
       return {
         disabled: true,
@@ -185,7 +187,7 @@ function namespaceFilterDisabled(
 // correct regardless of which component renders it. A detail drawer that opens
 // over a list (?resource=…) is deliberately NOT titled — it's the same page, so
 // it keeps the list's title.
-function radarPageTitle(pathname: string, search = '', apiResources?: { name: string; kind: string; group?: string }[]): string | null {
+function radarPageTitle(pathname: string, search = '', apiResources?: APIResource[]): string | null {
   const decode = (s: string) => {
     try {
       return decodeURIComponent(s)
@@ -196,7 +198,7 @@ function radarPageTitle(pathname: string, search = '', apiResources?: { name: st
   const capitalize = (text: string) =>
     text ? text.charAt(0).toUpperCase() + text.slice(1) : text
   const pluralKindTitle = (kind: string, resourceName: string) =>
-    kind.toLowerCase() === resourceName.toLowerCase() ? kind : englishPlural(kind)
+    kind.toLowerCase() === resourceName.toLowerCase() || /Metrics$/.test(kind) ? kind : englishPlural(kind)
   const pathSegments = pathname.replace(/^\//, '').split('/').filter(Boolean)
   const view = getViewFromPath(pathname)
 
@@ -207,7 +209,8 @@ function radarPageTitle(pathname: string, search = '', apiResources?: { name: st
   if (view === 'resources') {
     const resourceName = decode(pathSegments[1] ?? '')
     if (!resourceName) return 'Resources'
-    const match = apiResources?.find((r) => r.name === resourceName)
+    const group = new URLSearchParams(search).get('apiGroup') || ''
+    const match = findAPIResourceForRoute(apiResources, resourceName, group)
     return pluralKindTitle(match?.kind ?? pluralToKind(resourceName), resourceName)
   }
   // GitOps detail is /gitops/detail/<kind>/<ns>/<name> → the resource name;
@@ -387,10 +390,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
   // View-aware namespace scope: disabled on cluster-scoped surfaces so the
   // chip isn't a dead control next to the cluster switcher.
-  // Fall back to the static core-resource list before discovery loads, so the
-  // chip disables immediately on a cluster-scoped core kind (Nodes, PVs, …)
-  // instead of flickering enabled until /api-resources resolves.
-  const namespaceFilter = namespaceFilterDisabled(mainView, location.pathname, navApiResources ?? CORE_RESOURCES)
+  const namespaceFilter = namespaceFilterDisabled(mainView, location.pathname, location.search, navApiResources)
 
   // One URL-derived tab title for every view (see radarPageTitle). Driving it
   // from the URL — not the mounted component. Off unless the host opts in

--- a/web/src/api/apiResources.ts
+++ b/web/src/api/apiResources.ts
@@ -3,7 +3,7 @@ import type { APIResource } from '../types'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from './config'
 
 // Re-export pure functions from package
-export { categorizeResources, CORE_RESOURCES, formatGroupName, shortenGroupName, getKindLabel, getKindPlural } from '@skyhook-io/k8s-ui'
+export { categorizeResources, CORE_RESOURCES, findAPIResourceForRoute, formatGroupName, shortenGroupName, getKindLabel, getKindPlural } from '@skyhook-io/k8s-ui'
 export type { ResourceCategory } from '@skyhook-io/k8s-ui'
 
 async function fetchJSON<T>(path: string): Promise<T> {


### PR DESCRIPTION
## Summary

Resource pages now show the canonical Kubernetes kind in the browser tab when multiple APIs expose the same plural resource name. This prevents `/resources/pods` from appearing as `PodMetrics · Radar` on clusters with Metrics API discovery.

## What changed

- Resolve unqualified resource routes against canonical core resources before discovered API collisions.
- Honor `apiGroup` when a route explicitly targets a non-core resource with the same plural name.
- Use the same route resolution for document titles, namespace-scope behavior, and initial resource selection.
- Keep cluster-scoped built-in routes stable before discovery completes.
- Cover collisions, explicit groups, discovery fallback, CRDs, and legacy kind routes with unit tests.

## Testing

- `make tsc`
- `make test`
- `cd web && npm test` — 161 tests passed
- `./node_modules/.bin/vitest run packages/k8s-ui/src/utils/api-resources.test.ts packages/k8s-ui/src/utils/pluralize.test.ts` — 28 tests passed
- `make build`
- Playwright visual test at 1920×1080: Pods, explicit PodMetrics, Deployments, Nodes, StorageClasses, and explicit NodeMetrics
