### PR TITLE
fix(ai): surface actionable CLI failures

### DIFF
--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -15,6 +15,8 @@ import (
 type Agent interface {
 	// Name is the stable backend identifier ("claude", "codex").
 	Name() string
+	// SigninCmd is shown when the CLI reports that it is signed out.
+	SigninCmd() string
 	// command builds the fully-configured *exec.Cmd for one turn (bin, args, env,
 	// cwd) plus a cleanup for any temp files it created.
 	command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error)

--- a/internal/ai/agent_claude.go
+++ b/internal/ai/agent_claude.go
@@ -16,6 +16,8 @@ type claudeAgent struct{ bin string }
 
 func (a *claudeAgent) Name() string { return "claude" }
 
+func (a *claudeAgent) SigninCmd() string { return "claude auth login" }
+
 func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
 	cfgPath, cleanup, err := writeMCPConfig(s.mcpURL)
 	if err != nil {

--- a/internal/ai/agent_codex.go
+++ b/internal/ai/agent_codex.go
@@ -24,6 +24,8 @@ type codexAgent struct{ bin string }
 
 func (a *codexAgent) Name() string { return "codex" }
 
+func (a *codexAgent) SigninCmd() string { return "codex login" }
+
 func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
 	// Codex has no system-prompt flag; the framing rides on the first turn's
 	// prompt (the resumed session already carries it).

--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -32,6 +32,8 @@ type cursorAgent struct{ bin string }
 
 func (a *cursorAgent) Name() string { return "cursor-agent" }
 
+func (a *cursorAgent) SigninCmd() string { return "cursor-agent login" }
+
 func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
 	// Cursor has no system-prompt flag; the framing rides on the first turn's
 	// prompt (the resumed session already carries it).

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -131,6 +131,9 @@ type Diagnosis struct {
 	// SessionID is the CLI session this turn ran in — pass it back as
 	// Request.SessionID to continue the conversation.
 	SessionID string `json:"sessionId"`
+	// cliErrText preserves failures reported in a stream-json result instead of stderr.
+	cliErrText string
+	cliErrored bool
 }
 
 // StreamEvent is one normalized event emitted during an investigation.
@@ -406,17 +409,18 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 	onEvent(StreamEvent{Type: "phase", Phase: "investigating"})
 	diag := agent.parseStream(stdout, onEvent)
 
-	if err := cmd.Wait(); err != nil {
+	waitErr := cmd.Wait()
+	if waitErr != nil {
 		if ctx.Err() != nil {
 			return Diagnosis{}, ctx.Err()
 		}
-		// A nonzero exit is forgiven ONLY when the agent completed a structured
-		// verdict (the trailing JSON block parsed) — then the exit noise is
-		// incidental. Free-text alone means the process died mid-stream; showing
-		// that as a calm "done" would pass a failure off as a finished analysis.
-		if !diag.structured() {
-			return Diagnosis{}, agentExitError(agent.Name(), stderr.String())
-		}
+	}
+	// A structured verdict wins over trailing process noise. Without one, either a
+	// nonzero exit or an explicit stream error must remain a failed investigation.
+	if !diag.structured() && (waitErr != nil || diag.cliErrored) {
+		return Diagnosis{}, agentExitError(
+			agent.Name(), agent.SigninCmd(), diag.cliErrText, stderr.String(),
+		)
 	}
 	return diag, nil
 }
@@ -639,7 +643,7 @@ func (c *cappedBuffer) String() string {
 	return c.buf.String()
 }
 
-func formatStderr(s string) string {
+func formatExitDetails(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return ""
@@ -650,13 +654,18 @@ func formatStderr(s string) string {
 	return ": " + s
 }
 
-// agentExitError turns a non-zero agent exit into a user-legible message. Best
-// effort: the common, actionable failures (the CLI isn't signed in; rate-limited)
-// get a plain-language lead; everything else gets a generic line. The raw stderr
-// tail is kept appended so power users can still debug. stderr is the CLI's own
-// diagnostics (the model's output is on stdout), so matching it here is sound.
-func agentExitError(name, stderr string) error {
-	low := strings.ToLower(stderr)
+// agentExitError classifies known failures and preserves both output channels for
+// unknown ones, since CLIs disagree about where terminal errors are written.
+func agentExitError(name, signinCmd, cliErrText, stderr string) error {
+	details := strings.TrimSpace(cliErrText)
+	cleanStderr := strings.TrimSpace(stderr)
+	if cleanStderr != "" && cleanStderr != details {
+		if details != "" {
+			details += "\n"
+		}
+		details += cleanStderr
+	}
+	low := strings.ToLower(details)
 	contains := func(subs ...string) bool {
 		for _, s := range subs {
 			if strings.Contains(low, s) {
@@ -666,18 +675,17 @@ func agentExitError(name, stderr string) error {
 		return false
 	}
 	switch {
-	case contains("not logged in", "logged out", "not authenticated", "unauthorized",
-		"401", "invalid api key", "no api key", "please log in", "please run", "/login", "authenticate"):
-		return fmt.Errorf("%s isn't signed in — run `%s` in a terminal to log in, then try again%s",
-			name, name, formatStderr(stderr))
+	case contains("not logged in", "logged out", "not authenticated", "authentication required",
+		"sign in required", "login required", "please log in", "/login"):
+		return fmt.Errorf("%s isn't signed in. Run `%s` in a terminal to sign in, then try again%s", name, signinCmd, formatExitDetails(details))
+	case contains("invalid api key", "no api key"):
+		return fmt.Errorf("%s couldn't authenticate. Run `%s` to sign in, or check its API credentials, then try again%s", name, signinCmd, formatExitDetails(details))
 	case contains("rate limit", "rate-limit", "429", "529", "quota", "overloaded", "too many requests"):
-		return fmt.Errorf("%s is rate-limited or over quota right now — wait a moment and try again%s",
-			name, formatStderr(stderr))
-	case contains("max turns", "maximum turns", "turn limit"):
-		return fmt.Errorf("%s hit its step limit before finishing — try a more specific follow-up%s",
-			name, formatStderr(stderr))
+		return fmt.Errorf("%s is rate-limited or over quota. Wait a moment, then try again%s", name, formatExitDetails(details))
+	case contains("max turns", "maximum turns", "turn limit", "error_max_turns"):
+		return fmt.Errorf("%s hit its step limit before finishing. Try again, or ask a narrower follow-up%s", name, formatExitDetails(details))
 	default:
-		return fmt.Errorf("%s stopped unexpectedly%s", name, formatStderr(stderr))
+		return fmt.Errorf("%s stopped unexpectedly%s", name, formatExitDetails(details))
 	}
 }
 
@@ -698,6 +706,8 @@ type cliEvent struct {
 		} `json:"content"`
 	} `json:"message"`
 	Result       string   `json:"result"`
+	Subtype      string   `json:"subtype"`
+	IsError      bool     `json:"is_error"`
 	TotalCostUSD *float64 `json:"total_cost_usd"`
 	NumTurns     int      `json:"num_turns"`
 	SessionID    string   `json:"session_id"`
@@ -708,6 +718,8 @@ func parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	sc.Buffer(make([]byte, 0, 64*1024), 8<<20)
 	starts := map[string]time.Time{}
 	var finalText string
+	var resultIsError bool
+	var resultSubtype string
 	var cost *float64
 	var turns int
 	var sessionID string
@@ -784,6 +796,8 @@ func parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 			}
 		case "result":
 			finalText = ev.Result
+			resultIsError = ev.IsError
+			resultSubtype = ev.Subtype
 			cost = ev.TotalCostUSD
 			turns = ev.NumTurns
 			sessionID = ev.SessionID
@@ -794,6 +808,16 @@ func parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	d.CostUSD = cost
 	d.Turns = turns
 	d.SessionID = sessionID
+	// A CLI that aborts (auth failure, rate limit, …) reports the reason via an
+	// is_error result on stdout, not stderr. Keep that text so the exit-error
+	// builder can turn it into an actionable message.
+	if resultIsError {
+		d.cliErrored = true
+		d.cliErrText = strings.TrimSpace(finalText)
+		if d.cliErrText == "" {
+			d.cliErrText = strings.TrimSpace(resultSubtype)
+		}
+	}
 	return d
 }
 

--- a/internal/ai/diagnoser_test.go
+++ b/internal/ai/diagnoser_test.go
@@ -251,22 +251,25 @@ func TestDetectAgents_OnlyKnownNames(t *testing.T) {
 // TestAgentExitError_Classifies pins the best-effort error taxonomy: common
 // actionable failures get a plain-language lead; the rest get a generic line.
 func TestAgentExitError_Classifies(t *testing.T) {
-	cases := []struct{ stderr, want string }{
+	cases := []struct{ detail, want string }{
 		{"Error: Not logged in. Please run claude login", "isn't signed in"},
-		{"request failed: 401 unauthorized", "isn't signed in"},
+		{"invalid API key", "check its API credentials"},
 		{"API error 429: rate limit exceeded", "rate-limited"},
 		{"overloaded_error: server is overloaded", "rate-limited"},
 		{"reached max turns", "step limit"},
 		{"panic: nil pointer", "stopped unexpectedly"},
 	}
 	for _, c := range cases {
-		if got := agentExitError("claude", c.stderr).Error(); !strings.Contains(got, c.want) {
-			t.Errorf("stderr %q → %q, want substring %q", c.stderr, got, c.want)
+		if got := agentExitError("claude", "claude auth login", c.detail, "").Error(); !strings.Contains(got, c.want) {
+			t.Errorf("detail %q → %q, want substring %q", c.detail, got, c.want)
 		}
 	}
-	// The raw tail is preserved for debugging.
-	if got := agentExitError("codex", "boom detail").Error(); !strings.Contains(got, "boom detail") {
-		t.Errorf("expected raw stderr tail preserved, got %q", got)
+	if got := agentExitError("claude", "claude auth login", "Not logged in", "incidental warning").Error(); !strings.Contains(got, "claude auth login") {
+		t.Errorf("expected sign-in command in message, got %q", got)
+	}
+	got := agentExitError("claude", "claude auth login", "request failed: 401 unauthorized", "provider rejected the token").Error()
+	if !strings.Contains(got, "stopped unexpectedly") || !strings.Contains(got, "401 unauthorized") || !strings.Contains(got, "provider rejected the token") {
+		t.Errorf("ambiguous auth failure should preserve both details, got %q", got)
 	}
 }
 
@@ -344,13 +347,13 @@ func TestParseStream_InterleavesNarration(t *testing.T) {
 // agent exit is forgiven only when a STRUCTURED verdict parsed (the trailing
 // JSON block) — free-text alone means the process died mid-stream and must
 // surface as an error, never as a calm "done".
-func TestDiagnoseStream_NonzeroExit(t *testing.T) {
-	mkCLI := func(t *testing.T, resultLine string) string {
+func TestDiagnoseStream_ProcessAndStreamErrors(t *testing.T) {
+	mkCLI := func(t *testing.T, resultLine, exitCode string) string {
 		t.Helper()
 		dir := t.TempDir()
 		bin := dir + "/claude"
 		// printf %s, not echo — sh's echo may expand \n escapes inside the JSON.
-		script := "#!/bin/sh\nprintf '%s\\n' '" + resultLine + "'\nexit 3\n"
+		script := "#!/bin/sh\nprintf '%s\\n' '" + resultLine + "'\nexit " + exitCode + "\n"
 		if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -368,12 +371,32 @@ func TestDiagnoseStream_NonzeroExit(t *testing.T) {
 	}
 
 	freeText := `{"type":"result","result":"got halfway through checking the pod","num_turns":1}`
-	if _, err := run(t, mkCLI(t, freeText)); err == nil {
+	if _, err := run(t, mkCLI(t, freeText, "3")); err == nil {
 		t.Error("nonzero exit with free-text-only output must return an error")
 	}
 
+	authErr := `{"type":"result","result":"Not logged in · Please run /login","is_error":true,"num_turns":1}`
+	for _, exitCode := range []string{"0", "3"} {
+		_, err := run(t, mkCLI(t, authErr, exitCode))
+		if err == nil {
+			t.Fatalf("is_error result with exit %s must return an error", exitCode)
+		}
+		if !strings.Contains(err.Error(), "isn't signed in") {
+			t.Errorf("auth failure with exit %s should surface the sign-in hint, got: %v", exitCode, err)
+		}
+	}
+
+	emptyMaxTurnsErr := `{"type":"result","subtype":"error_max_turns","is_error":true,"num_turns":1}`
+	_, err := run(t, mkCLI(t, emptyMaxTurnsErr, "0"))
+	if err == nil {
+		t.Fatal("is_error result without result text must return an error")
+	}
+	if !strings.Contains(err.Error(), "step limit") || !strings.Contains(err.Error(), "error_max_turns") {
+		t.Errorf("empty max-turns error should classify and preserve its subtype, got: %v", err)
+	}
+
 	structured := "{\"type\":\"result\",\"result\":\"```json\\n{\\\"root_cause\\\":\\\"bad tag\\\",\\\"remediation\\\":[\\\"fix it\\\"]}\\n```\",\"num_turns\":1}"
-	diag, err := run(t, mkCLI(t, structured))
+	diag, err := run(t, mkCLI(t, structured, "3"))
 	if err != nil {
 		t.Fatalf("nonzero exit with a complete structured verdict should be forgiven, got %v", err)
 	}

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -361,6 +361,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     startRunRef.current(t);
   }, []);
   const openRun = useCallback((id: string) => {
+    setStartError(null);
     setActiveRunId(id);
     setView("investigation");
     setOpen(true);

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -44,7 +44,11 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
-  const { refreshRuns, openInvestigation } = useDiagnose();
+  const { refreshRuns, openInvestigation, startError } = useDiagnose();
+  const retryDiagnosis = useCallback(
+    () => openInvestigation({ kind, namespace, name }),
+    [openInvestigation, kind, namespace, name],
+  );
   const queryClient = useQueryClient();
   const [turns, setTurns] = useState<Turn[]>([]);
   // The run is gone server-side (evicted past the retention cap, or lost on a
@@ -505,14 +509,23 @@ export function InvestigationView({
                   onApply={canApply ? requestApply : undefined}
                   onAsk={isLast && !busy && !stale ? askFollowup : undefined}
                   onCheckStatus={canCheck ? checkStatus : undefined}
+                  onRetryDiagnosis={
+                    isLast &&
+                    t.status === "error" &&
+                    !t.question &&
+                    !t.apply &&
+                    !stale
+                      ? retryDiagnosis
+                      : undefined
+                  }
                   hideVerdict={pinned && i === pinnedIdx}
                 />
               );
             })}
-            {actionError && (
+            {(actionError || startError) && (
               <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
-                <span>{actionError}</span>
+                <span>{actionError || startError}</span>
               </div>
             )}
           </div>

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -402,6 +402,7 @@ export function TurnView({
   onApply,
   onAsk,
   onCheckStatus,
+  onRetryDiagnosis,
   hideVerdict = false,
 }: {
   turn: Turn;
@@ -410,6 +411,7 @@ export function TurnView({
   onApply?: (fix: string) => void;
   onAsk?: (question: string) => void;
   onCheckStatus?: () => void;
+  onRetryDiagnosis?: () => void;
   // In the maximized workspace the pinned turn's verdict renders in the side rail,
   // so the transcript suppresses its own copy (reasoning + tool calls still show).
   hideVerdict?: boolean;
@@ -469,7 +471,18 @@ export function TurnView({
       {turn.status === "error" && turn.error && (
         <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
-          <span>{turn.error}</span>
+          <div className="flex min-w-0 flex-col gap-2">
+            <span className="whitespace-pre-wrap break-words">{turn.error}</span>
+            {onRetryDiagnosis && (
+              <button
+                type="button"
+                onClick={onRetryDiagnosis}
+                className="btn-brand self-start px-3 py-1 text-xs"
+              >
+                Retry diagnosis
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

AI diagnosis now surfaces actionable CLI authentication, quota, and step-limit failures instead of generic “stopped unexpectedly” errors. Failed initial diagnoses can be retried directly from the error banner.

## What changed

- Reads stream-json `result` events’ `is_error` and subtype fields, including explicit failures where the process exits successfully or returns no result text.
- Preserves stdout and stderr evidence for diagnosis failures while mapping explicit sign-out, API credential, rate-limit, and max-turn cases to concise guidance.
- Uses each agent’s actual sign-in command: `claude auth login`, `codex login`, or `cursor-agent login`.
- Adds “Retry diagnosis” only for failed initial read-only investigations. Follow-up and Apply failures are not replayed because Apply may have partially changed cluster state.
- Keeps retry-start errors visible in the existing transcript and avoids duplicate retry actions on stale runs.

## Testing

- `go test ./internal/ai/`
- `make tsc`
- `make test`
- `make build`
- `git diff --check`

Visual testing was skipped: the UI delta is confined to an existing error banner, and reproducing the failure path requires deliberately breaking a local agent credential or run-start path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes error classification and diagnosis failure gating plus small UI affordances; no auth, cluster write, or data-model changes.
> 
> **Overview**
> Improves how **local agent CLI failures** are detected and shown during AI diagnosis, instead of generic “stopped unexpectedly” messages.
> 
> **Backend:** Each `Agent` exposes **`SigninCmd()`** (`claude auth login`, `codex login`, `cursor-agent login`). Claude stream-json parsing records **`is_error`** / **`subtype`** on `result` events into `Diagnosis`, and **`DiagnoseStream`** fails when there is no structured verdict and either the process exits nonzero **or** the stream reported an error—even on exit 0. **`agentExitError`** merges stdout error text with stderr, classifies sign-out, bad API keys, rate limits, and max-turns (`error_max_turns`), and surfaces the correct sign-in command.
> 
> **UI:** Failed **initial** read-only turns get a **Retry diagnosis** action (not follow-ups or apply). **`startError`** is cleared when reopening a run and shown in the investigation transcript alongside turn errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70bbb01442ef8e230d676c926239ca6ed22790b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->