### PR TITLE
fix(installer): avoid GitHub API rate-limit failures

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Check syntax
         run: sh -n install.sh
 
+      - name: Reject unauthenticated GitHub API discovery
+        run: |
+          if grep -Fq 'api.github.com' install.sh install.ps1; then
+            echo "Installers must not use api.github.com for discovery" >&2
+            exit 1
+          fi
+
       - name: Install into an isolated directory
         run: |
           install_dir="$RUNNER_TEMP/radar-bin"
@@ -32,17 +39,14 @@ jobs:
           "$install_dir/kubectl-radar" --version
           test -L "$install_dir/radar"
 
-  windows:
-    name: Windows installer (${{ matrix.shell }})
+  windows-powershell:
+    name: Windows PowerShell 5.1 installer
     runs-on: windows-latest
-    strategy:
-      matrix:
-        shell: [powershell, pwsh]
     steps:
       - uses: actions/checkout@v7
 
       - name: Check syntax
-        shell: ${{ matrix.shell }}
+        shell: powershell
         run: |
           $tokens = $null
           $errors = $null
@@ -57,11 +61,78 @@ jobs:
           }
 
       - name: Install into an isolated directory
-        shell: ${{ matrix.shell }}
+        shell: powershell
         run: |
           $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-local-app-data"
+          $KubectlExe = "$env:LOCALAPPDATA\radar\kubectl-radar.exe"
+          $RadarExe = "$env:LOCALAPPDATA\radar\radar.exe"
+
           Get-Content -Raw ./install.ps1 | Invoke-Expression
-          & "$env:LOCALAPPDATA\radar\kubectl-radar.exe" --version
-          if (-not (Test-Path "$env:LOCALAPPDATA\radar\radar.exe")) {
-            throw "radar.exe alias was not installed"
+
+          if (-not (Test-Path $RadarExe)) {
+            throw "radar.exe was not installed"
+          }
+          Set-Content -LiteralPath $RadarExe -Value "stale alias" -NoNewline
+
+          Get-Content -Raw ./install.ps1 | Invoke-Expression
+
+          $KubectlVersion = (& $KubectlExe --version | Out-String).Trim()
+          $RadarVersion = (& $RadarExe --version | Out-String).Trim()
+          if ($KubectlVersion -ne $RadarVersion) {
+            throw "command versions differ: " +
+              "'$KubectlVersion' != '$RadarVersion'"
+          }
+          $KubectlHash = (Get-FileHash $KubectlExe).Hash
+          $RadarHash = (Get-FileHash $RadarExe).Hash
+          if ($KubectlHash -ne $RadarHash) {
+            throw "radar.exe was not refreshed from kubectl-radar.exe"
+          }
+
+  windows-pwsh:
+    name: PowerShell 7 installer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path ./install.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_ }
+            exit 1
+          }
+
+      - name: Install into an isolated directory
+        shell: pwsh
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-local-app-data"
+          $KubectlExe = "$env:LOCALAPPDATA\radar\kubectl-radar.exe"
+          $RadarExe = "$env:LOCALAPPDATA\radar\radar.exe"
+
+          Get-Content -Raw ./install.ps1 | Invoke-Expression
+
+          if (-not (Test-Path $RadarExe)) {
+            throw "radar.exe was not installed"
+          }
+          Set-Content -LiteralPath $RadarExe -Value "stale alias" -NoNewline
+
+          Get-Content -Raw ./install.ps1 | Invoke-Expression
+
+          $KubectlVersion = (& $KubectlExe --version | Out-String).Trim()
+          $RadarVersion = (& $RadarExe --version | Out-String).Trim()
+          if ($KubectlVersion -ne $RadarVersion) {
+            throw "command versions differ: " +
+              "'$KubectlVersion' != '$RadarVersion'"
+          }
+          $KubectlHash = (Get-FileHash $KubectlExe).Hash
+          $RadarHash = (Get-FileHash $RadarExe).Hash
+          if ($KubectlHash -ne $RadarHash) {
+            throw "radar.exe was not refreshed from kubectl-radar.exe"
           }

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -14,125 +14,51 @@ on:
       - .github/workflows/installers.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   posix:
     name: POSIX installer
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check syntax
-        run: sh -n install.sh
+      - name: Check POSIX script
+        run: |
+          sh -n install.sh
+          shellcheck --shell=sh install.sh
 
-      - name: Reject unauthenticated GitHub API discovery
+      - name: Reject GitHub API discovery in installers
         run: |
           if grep -Fq 'api.github.com' install.sh install.ps1; then
             echo "Installers must not use api.github.com for discovery" >&2
             exit 1
           fi
 
-      - name: Install into an isolated directory
+      - name: Install latest release
         run: |
-          install_dir="$RUNNER_TEMP/radar-bin"
-          mkdir -p "$install_dir"
-          RADAR_INSTALL_DIR="$install_dir" sh ./install.sh
-          "$install_dir/kubectl-radar" --version
-          test -L "$install_dir/radar"
+          sh ./install.sh
+          /usr/local/bin/kubectl-radar --version
 
-  windows-powershell:
-    name: Windows PowerShell 5.1 installer
+  windows:
+    name: Windows installers
     runs-on: windows-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check syntax
+      - name: Install with Windows PowerShell 5.1
         shell: powershell
         run: |
-          $tokens = $null
-          $errors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path ./install.ps1),
-            [ref]$tokens,
-            [ref]$errors
-          ) | Out-Null
-          if ($errors.Count -gt 0) {
-            $errors | ForEach-Object { Write-Error $_ }
-            exit 1
-          }
-
-      - name: Install into an isolated directory
-        shell: powershell
-        run: |
-          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-local-app-data"
-          $KubectlExe = "$env:LOCALAPPDATA\radar\kubectl-radar.exe"
-          $RadarExe = "$env:LOCALAPPDATA\radar\radar.exe"
-
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-windows-powershell"
           Get-Content -Raw ./install.ps1 | Invoke-Expression
+          & "$env:LOCALAPPDATA\radar\kubectl-radar.exe" --version
 
-          if (-not (Test-Path $RadarExe)) {
-            throw "radar.exe was not installed"
-          }
-          Set-Content -LiteralPath $RadarExe -Value "stale alias" -NoNewline
-
-          Get-Content -Raw ./install.ps1 | Invoke-Expression
-
-          $KubectlVersion = (& $KubectlExe --version | Out-String).Trim()
-          $RadarVersion = (& $RadarExe --version | Out-String).Trim()
-          if ($KubectlVersion -ne $RadarVersion) {
-            throw "command versions differ: " +
-              "'$KubectlVersion' != '$RadarVersion'"
-          }
-          $KubectlHash = (Get-FileHash $KubectlExe).Hash
-          $RadarHash = (Get-FileHash $RadarExe).Hash
-          if ($KubectlHash -ne $RadarHash) {
-            throw "radar.exe was not refreshed from kubectl-radar.exe"
-          }
-
-  windows-pwsh:
-    name: PowerShell 7 installer
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Check syntax
+      - name: Install with PowerShell 7
         shell: pwsh
         run: |
-          $tokens = $null
-          $errors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path ./install.ps1),
-            [ref]$tokens,
-            [ref]$errors
-          ) | Out-Null
-          if ($errors.Count -gt 0) {
-            $errors | ForEach-Object { Write-Error $_ }
-            exit 1
-          }
-
-      - name: Install into an isolated directory
-        shell: pwsh
-        run: |
-          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-local-app-data"
-          $KubectlExe = "$env:LOCALAPPDATA\radar\kubectl-radar.exe"
-          $RadarExe = "$env:LOCALAPPDATA\radar\radar.exe"
-
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-pwsh"
           Get-Content -Raw ./install.ps1 | Invoke-Expression
-
-          if (-not (Test-Path $RadarExe)) {
-            throw "radar.exe was not installed"
-          }
-          Set-Content -LiteralPath $RadarExe -Value "stale alias" -NoNewline
-
-          Get-Content -Raw ./install.ps1 | Invoke-Expression
-
-          $KubectlVersion = (& $KubectlExe --version | Out-String).Trim()
-          $RadarVersion = (& $RadarExe --version | Out-String).Trim()
-          if ($KubectlVersion -ne $RadarVersion) {
-            throw "command versions differ: " +
-              "'$KubectlVersion' != '$RadarVersion'"
-          }
-          $KubectlHash = (Get-FileHash $KubectlExe).Hash
-          $RadarHash = (Get-FileHash $RadarExe).Hash
-          if ($KubectlHash -ne $RadarHash) {
-            throw "radar.exe was not refreshed from kubectl-radar.exe"
-          }
+          & "$env:LOCALAPPDATA\radar\kubectl-radar.exe" --version

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -1,0 +1,67 @@
+name: Installer smoke tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - install.sh
+      - install.ps1
+      - .github/workflows/installers.yml
+  pull_request:
+    paths:
+      - install.sh
+      - install.ps1
+      - .github/workflows/installers.yml
+  workflow_dispatch:
+
+jobs:
+  posix:
+    name: POSIX installer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check syntax
+        run: sh -n install.sh
+
+      - name: Install into an isolated directory
+        run: |
+          install_dir="$RUNNER_TEMP/radar-bin"
+          mkdir -p "$install_dir"
+          RADAR_INSTALL_DIR="$install_dir" sh ./install.sh
+          "$install_dir/kubectl-radar" --version
+          test -L "$install_dir/radar"
+
+  windows:
+    name: Windows installer (${{ matrix.shell }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        shell: [powershell, pwsh]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check syntax
+        shell: ${{ matrix.shell }}
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path ./install.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_ }
+            exit 1
+          }
+
+      - name: Install into an isolated directory
+        shell: ${{ matrix.shell }}
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "radar-local-app-data"
+          Get-Content -Raw ./install.ps1 | Invoke-Expression
+          & "$env:LOCALAPPDATA\radar\kubectl-radar.exe" --version
+          if (-not (Test-Path "$env:LOCALAPPDATA\radar\radar.exe")) {
+            throw "radar.exe alias was not installed"
+          }

--- a/install.ps1
+++ b/install.ps1
@@ -77,10 +77,11 @@ if (-not (Test-Path $InstallDir)) {
 
 Move-Item -Path (Join-Path $TmpDir $BinaryName) -Destination $InstallDir -Force
 
-# Install both command names from the same binary. This directory is managed by
-# the installer, so a reinstall must advance both executables together.
+# Create radar.exe symlink/copy for convenience
 $RadarExe = Join-Path $InstallDir "radar.exe"
-Copy-Item -Path (Join-Path $InstallDir $BinaryName) -Destination $RadarExe -Force
+if (-not (Test-Path $RadarExe)) {
+    Copy-Item -Path (Join-Path $InstallDir $BinaryName) -Destination $RadarExe
+}
 
 # Cleanup
 Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -10,11 +10,38 @@ $InstallDir = "$env:LOCALAPPDATA\radar"
 # Only amd64 is supported on Windows
 $Arch = "amd64"
 
-# Get latest release version
+# Resolve the ordinary GitHub web redirect instead of using the REST API.
+# The API's unauthenticated per-IP quota can be exhausted by unrelated users
+# behind the same NAT, while this redirect is the same path browsers use.
 Write-Host "Fetching latest release..." -ForegroundColor Cyan
 try {
-    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
-    $Version = $Release.tag_name -replace '^v', ''
+    $Release = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -UseBasicParsing -MaximumRedirection 5
+
+    # Windows PowerShell 5.1 and PowerShell 7 expose the final response URI on
+    # different response objects. Both runtimes are supported by this script.
+    if ($Release.BaseResponse.PSObject.Properties["ResponseUri"]) {
+        $LatestReleaseUri = $Release.BaseResponse.ResponseUri
+    } elseif ($Release.BaseResponse.PSObject.Properties["RequestMessage"]) {
+        $LatestReleaseUri = $Release.BaseResponse.RequestMessage.RequestUri
+    } else {
+        throw "GitHub response did not include the final release URL"
+    }
+
+    $ExpectedPathPrefix = "/$Repo/releases/tag/v"
+    if ($LatestReleaseUri.Scheme -ne "https" -or
+        $LatestReleaseUri.Host -ne "github.com" -or
+        $LatestReleaseUri.UserInfo -ne "" -or
+        $LatestReleaseUri.Port -ne 443 -or
+        $LatestReleaseUri.Query -ne "" -or
+        $LatestReleaseUri.Fragment -ne "" -or
+        -not $LatestReleaseUri.AbsolutePath.StartsWith($ExpectedPathPrefix, [StringComparison]::Ordinal)) {
+        throw "GitHub redirected to an unexpected release URL: $LatestReleaseUri"
+    }
+
+    $Version = $LatestReleaseUri.AbsolutePath.Substring($ExpectedPathPrefix.Length)
+    if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+        throw "GitHub returned an unexpected release tag: v$Version"
+    }
 } catch {
     Write-Host "Failed to fetch latest version: $_" -ForegroundColor Red
     exit 1
@@ -50,11 +77,10 @@ if (-not (Test-Path $InstallDir)) {
 
 Move-Item -Path (Join-Path $TmpDir $BinaryName) -Destination $InstallDir -Force
 
-# Create radar.exe symlink/copy for convenience
+# Install both command names from the same binary. This directory is managed by
+# the installer, so a reinstall must advance both executables together.
 $RadarExe = Join-Path $InstallDir "radar.exe"
-if (-not (Test-Path $RadarExe)) {
-    Copy-Item -Path (Join-Path $InstallDir $BinaryName) -Destination $RadarExe
-}
+Copy-Item -Path (Join-Path $InstallDir $BinaryName) -Destination $RadarExe -Force
 
 # Cleanup
 Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ set -e
 
 REPO="skyhook-io/radar"
 BINARY_NAME="kubectl-radar"
-INSTALL_DIR="${RADAR_INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="/usr/local/bin"
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ set -e
 
 REPO="skyhook-io/radar"
 BINARY_NAME="kubectl-radar"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${RADAR_INSTALL_DIR:-/usr/local/bin}"
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -34,14 +34,28 @@ case "$OS" in
   *) echo "Unsupported OS: $OS"; exit 1 ;;
 esac
 
-# Get latest release version
+# Resolve the ordinary GitHub web redirect instead of using the REST API.
+# The API's unauthenticated per-IP quota can be exhausted by unrelated users
+# behind the same NAT, while this redirect is the same path browsers use.
 echo "Fetching latest release..."
-VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
-
-if [ -z "$VERSION" ]; then
-  echo "Failed to fetch latest version"
+if ! LATEST_RELEASE_URL=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+  "https://github.com/${REPO}/releases/latest"); then
+  echo "Failed to fetch latest release" >&2
   exit 1
 fi
+
+TAG=${LATEST_RELEASE_URL##*/}
+if [ "$LATEST_RELEASE_URL" != "https://github.com/${REPO}/releases/tag/${TAG}" ]; then
+  echo "Failed to resolve latest release: unexpected redirect URL" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$TAG" | grep -Eq \
+  '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+  echo "Failed to resolve latest release: unexpected tag" >&2
+  exit 1
+fi
+VERSION=${TAG#v}
 
 echo "Installing Radar v${VERSION}..."
 


### PR DESCRIPTION
## Summary

The public bootstrap could download successfully and then fail at `Fetching latest release...`. Both installers discovered the latest tag through the unauthenticated GitHub REST API, whose per-IP quota is shared by users behind the same corporate NAT, VPN, or CI egress.

This changes only bootstrap release discovery. The POSIX and PowerShell installers now use the ordinary GitHub latest-release redirect and no longer depend on that REST quota.

## Mechanism

Both installers request:

```text
https://github.com/skyhook-io/radar/releases/latest
```

They follow the redirect, require its final destination to be the exact HTTPS Radar release-tag path, validate the tag as semantic-version syntax, and then construct the existing versioned release-asset URL. Unexpected hosts, paths, ports, credentials, query strings, fragments, or tag formats fail before a temporary directory or download is created.

- `install.sh` reads curl `url_effective` and compares the complete final URL.
- `install.ps1` reads the final response URI using the respective Windows PowerShell 5.1 and PowerShell 7 response shapes.
- The asset naming, install directories, aliases, and reinstall behavior are unchanged.
- A path-filtered workflow runs ShellCheck and complete installs on Ubuntu, Windows PowerShell 5.1, and PowerShell 7. It also rejects future `api.github.com` discovery in either bootstrap script.

There is deliberately no fallback to `releases.skyhook.io`. Bootstrap only needs a tag, and using the GitHub redirect avoids adding first-party service availability or update telemetry to the initial install path. The in-product update resolver and desktop updater have different metadata requirements and are outside this change.

## Publication boundary

Merging this PR does not create a Radar tag, binary release, image, chart, or package-manager artifact. However, the public `get.radarhq.io` endpoints serve the installer files from `main`, so merging is a live installer publication after the existing cache window. Rollback is a revert on `main` and the same cache propagation path.

## How to test each request

### 1. Bootstrap script delivery

```sh
curl -fsS https://get.radarhq.io -o /tmp/radar-install.sh
sh -n /tmp/radar-install.sh
grep -F github.com/skyhook-io/radar/releases/latest /tmp/radar-install.sh
! grep -Fq api.github.com /tmp/radar-install.sh
```

Expected: HTTP 200, valid shell syntax, the browser-facing latest-release URL is present, and the REST API hostname is absent.

### 2. Latest-tag discovery

```sh
curl -fsSL -o /dev/null \
  -w "status=%{http_code}\neffective_url=%{url_effective}\n" \
  https://github.com/skyhook-io/radar/releases/latest
```

Expected: HTTP 200 and an effective URL of `https://github.com/skyhook-io/radar/releases/tag/v<version>`.

### 3. Versioned release asset

```sh
release_url=$(curl -fsSL -o /dev/null -w "%{url_effective}" \
  https://github.com/skyhook-io/radar/releases/latest)
tag=${release_url##*/}
version=${tag#v}
curl -fsSI \
  "https://github.com/skyhook-io/radar/releases/download/${tag}/radar_v${version}_darwin_arm64.tar.gz"
```

Expected: GitHub returns the release-asset redirect. Substitute the target OS and architecture as needed.

### 4. Complete installers

The `Installer smoke tests` workflow runs the checked-out scripts end to end on Ubuntu, Windows PowerShell 5.1, and PowerShell 7, then executes the installed `kubectl-radar --version`. Use a disposable host if testing the public script manually because it writes to the normal system/user install location.

## Validation

- `sh -n install.sh`
- static no-API guard for both installers
- live latest-release redirect: HTTP 200 to `v1.9.0`
- live `v1.9.0` macOS arm64 asset response
- `make tsc`
- `make test`
- `make build`
- visual test skipped: no UI delta

## Scope

This PR does not change install destinations, command aliases, artifact verification, the in-product update checker, the desktop updater, or any release/publishing workflow.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Installer smoke coverage
- [ ] UI change


