### PR TITLE
Stop eagerly watching deprecated Crossplane Usage API

### DIFF
--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -1547,6 +1547,11 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 			if !res.IsCRD {
 				continue
 			}
+			// Crossplane serves this legacy API with a deprecation warning on every
+			// informer watch renewal. Keep it available on demand, but don't eagerly watch it.
+			if res.Group == "apiextensions.crossplane.io" && res.Name == "usages" {
+				continue
+			}
 			hasList := false
 			hasWatch := false
 			for _, verb := range res.Verbs {

--- a/pkg/k8score/dynamic_cache_discovery_test.go
+++ b/pkg/k8score/dynamic_cache_discovery_test.go
@@ -1,0 +1,71 @@
+package k8score
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestDiscoverAllCRDsDefersDeprecatedCrossplaneUsage(t *testing.T) {
+	legacyUsage := schema.GroupVersionResource{
+		Group: "apiextensions.crossplane.io", Version: "v1beta1", Resource: "usages",
+	}
+	currentUsage := schema.GroupVersionResource{
+		Group: "protection.crossplane.io", Version: "v1beta1", Resource: "usages",
+	}
+	discovery := &ResourceDiscovery{
+		resources: []APIResource{
+			{
+				Group: legacyUsage.Group, Version: legacyUsage.Version, Kind: "Usage", Name: legacyUsage.Resource,
+				IsCRD: true, Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				Group: currentUsage.Group, Version: currentUsage.Version, Kind: "Usage", Name: currentUsage.Resource,
+				IsCRD: true, Verbs: []string{"get", "list", "watch"},
+			},
+		},
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			legacyUsage:  "UsageList",
+			currentUsage: "UsageList",
+		},
+	)
+	cache, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient: dynamicClient,
+		Discovery:     discovery,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	t.Cleanup(cache.Stop)
+
+	cache.DiscoverAllCRDs()
+	select {
+	case <-cache.discoveryDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DiscoverAllCRDs did not complete")
+	}
+
+	if cache.hasCoveringInformer(legacyUsage, "") {
+		t.Fatal("deprecated apiextensions.crossplane.io Usage was eagerly watched")
+	}
+	if !cache.hasCoveringInformer(currentUsage, "") {
+		t.Fatal("protection.crossplane.io Usage was not eagerly watched")
+	}
+
+	if err := cache.EnsureWatching(legacyUsage); err != nil {
+		t.Fatalf("deprecated Usage should remain available on demand: %v", err)
+	}
+	if !cache.WaitForSync(legacyUsage, 5*time.Second) {
+		t.Fatal("deprecated Usage on-demand informer did not sync")
+	}
+}


### PR DESCRIPTION
## Summary

Radar no longer opens a persistent background watch against the deprecated apiextensions.crossplane.io Usage API. This removes the repeated Kubernetes deprecation warning emitted on every informer watch renewal without suppressing other API warnings.

## What changed

- Exclude exactly the apiextensions.crossplane.io/usages resource from automatic small-CRD eager discovery.
- Keep protection.crossplane.io Usage resources on the normal eager-discovery path.
- Preserve on-demand access to the legacy Usage resource when an operator explicitly browses it.
- Add regression coverage for all three boundaries.

## Testing

- make test
- make build
- Visual test skipped: no UI delta.