### PR TITLE
Extend per-issue change correlation to warning-severity issues

### DIFF
--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -129,41 +129,10 @@ func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Durat
 		}
 		return
 	}
-	changes = annotateOnsetOrder(changes, iss.FirstSeen)
 	if len(changes) > correlationChangeCap {
 		changes = changes[:correlationChangeCap]
 	}
 	iss.CorrelatedChanges = changes
-}
-
-// onsetSlop absorbs detection lag and clock skew between a change landing
-// and the resulting condition transition: a change within this margin after
-// first_seen may still explain the onset, so it is not flagged.
-const onsetSlop = 2 * time.Minute
-
-// annotateOnsetOrder marks changes that postdate the issue's onset
-// (first_seen + slop) with AfterIssueOnset — deterministic causal-direction
-// evidence: such a change cannot explain why the issue began, though it may
-// explain later behavior. Pre-onset changes are ordered first so the cap
-// never drops a possible cause in favor of a post-onset edit. No filtering:
-// the consumer weighs.
-func annotateOnsetOrder(changes []issuesapi.RecentChange, firstSeen time.Time) []issuesapi.RecentChange {
-	if firstSeen.IsZero() {
-		return changes
-	}
-	cutoff := firstSeen.Add(onsetSlop)
-	pre := make([]issuesapi.RecentChange, 0, len(changes))
-	post := make([]issuesapi.RecentChange, 0)
-	for _, c := range changes {
-		ts, err := time.Parse(time.RFC3339, c.Timestamp)
-		if err != nil || !ts.After(cutoff) {
-			pre = append(pre, c) // unparseable ⇒ unknown ⇒ no claim
-			continue
-		}
-		c.AfterIssueOnset = true
-		post = append(post, c)
-	}
-	return append(pre, post...)
 }
 
 func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -20,10 +20,11 @@ import (
 // truthfully carries no_recent_changes; an incident workload carries the
 // correlated change refs; the consumer weighs them.
 const (
-	// correlationIssueCap bounds the per-issue lookups per response. When the
-	// cap skips criticals, Response.CorrelationTruncated says so explicitly —
-	// an unmarked issue under truncation means "not checked", never "no
-	// changes".
+	// correlationIssueCap bounds the per-issue lookups per response, shared
+	// by criticals and warnings — criticals consume slots first, so a
+	// warning can never cost a critical its lookup. When the cap skips
+	// issues, Response.CorrelationTruncated says so explicitly — an unmarked
+	// issue under truncation means "not checked", never "no changes".
 	correlationIssueCap = 10
 	// correlationChangeCap bounds refs per issue: the top-ranked few changes
 	// are the evidence; the full feed stays one get_changes call away.
@@ -57,65 +58,78 @@ func correlationWindow() time.Duration {
 }
 
 // attachIssueChangeCorrelation fills CorrelatedChanges / NoRecentChanges on
-// critical issues. Single-namespace responses only — cross-namespace listings
-// are inventory sweeps where per-issue timeline lookups would multiply cost
-// without a triage question on the table.
+// critical and warning issues. Single-namespace responses only —
+// cross-namespace listings are inventory sweeps where per-issue timeline
+// lookups would multiply cost without a triage question on the table.
+//
+// Two passes share one cap: every critical is checked before any warning, so
+// cap priority never depends on the response's sort order. Warnings matter
+// because the active fault in a degraded-not-down incident is often
+// warning-severity (e.g. a Service selector matching no pods) — leaving it
+// uncorrelated hands the loudest chronic critical the only evidence trail.
 func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse) {
 	window := correlationWindow()
 	if window == 0 {
 		return // not enough observation to claim anything, in either direction
 	}
 	checked := 0
-	for i := range resp.Issues {
-		iss := &resp.Issues[i]
-		if iss.Severity != issuesapi.SeverityCritical {
-			continue
-		}
-		// Only kinds whose changes the feed records can truthfully claim "no
-		// changes" — for untracked kinds the marker is omitted (= unknown).
-		nativeHelmIssue := iss.Kind == "HelmRelease" && iss.Group == issues.NativeHelmGroup
-		if !nativeHelmIssue && !meaningfulchanges.TrackedKind(iss.Kind) {
-			continue
-		}
-		if checked >= correlationIssueCap {
-			resp.CorrelationTruncated = true
-			return
-		}
-		checked++
-
-		var changes []issuesapi.RecentChange
-		var saturated bool
-		var err error
-		if nativeHelmIssue {
-			changes, saturated, err = helmIssueChangesForCorrelation(ctx, iss, window)
-		} else {
-			changes, saturated, err = correlationChangesForIssue(ctx, iss, window)
-		}
-		if err != nil {
-			log.Printf("[mcp] issue change correlation failed for %s %s/%s: %v", iss.Kind, iss.Namespace, iss.Name, err)
-			continue // marker omitted = unknown, never a false "no changes"
-		}
-		// The marker's contract is non-status evidence: status churn on a
-		// failing workload is the SYMPTOM, not a change that could explain it
-		// — including it would make every failing issue read as "correlated".
-		changes = filterSpecConfigChanges(changes)
-		if len(changes) == 0 {
-			// A saturated candidate fetch may have missed older changes in
-			// the window (churn-heavy subjects overflow the newest-N query) —
-			// that's unknown, not "no changes".
-			if saturated {
+	for _, severity := range []issuesapi.Severity{issuesapi.SeverityCritical, issuesapi.SeverityWarning} {
+		for i := range resp.Issues {
+			iss := &resp.Issues[i]
+			if iss.Severity != severity {
 				continue
 			}
-			iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
-				WindowSeconds: int(window.Seconds()),
+			// Only kinds whose changes the feed records can truthfully claim "no
+			// changes" — for untracked kinds the marker is omitted (= unknown).
+			nativeHelmIssue := iss.Kind == "HelmRelease" && iss.Group == issues.NativeHelmGroup
+			if !nativeHelmIssue && !meaningfulchanges.TrackedKind(iss.Kind) {
+				continue
 			}
-			continue
+			if checked >= correlationIssueCap {
+				resp.CorrelationTruncated = true
+				return
+			}
+			checked++
+			correlateIssue(ctx, iss, window, nativeHelmIssue)
 		}
-		if len(changes) > correlationChangeCap {
-			changes = changes[:correlationChangeCap]
-		}
-		iss.CorrelatedChanges = changes
 	}
+}
+
+// correlateIssue attaches CorrelatedChanges or NoRecentChanges to one issue,
+// or neither when the answer is unknown (fetch error, saturated fetch).
+func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Duration, nativeHelmIssue bool) {
+	var changes []issuesapi.RecentChange
+	var saturated bool
+	var err error
+	if nativeHelmIssue {
+		changes, saturated, err = helmIssueChangesForCorrelation(ctx, iss, window)
+	} else {
+		changes, saturated, err = correlationChangesForIssue(ctx, iss, window)
+	}
+	if err != nil {
+		log.Printf("[mcp] issue change correlation failed for %s %s/%s: %v", iss.Kind, iss.Namespace, iss.Name, err)
+		return // marker omitted = unknown, never a false "no changes"
+	}
+	// The marker's contract is non-status evidence: status churn on a
+	// failing workload is the SYMPTOM, not a change that could explain it
+	// — including it would make every failing issue read as "correlated".
+	changes = filterSpecConfigChanges(changes)
+	if len(changes) == 0 {
+		// A saturated candidate fetch may have missed older changes in
+		// the window (churn-heavy subjects overflow the newest-N query) —
+		// that's unknown, not "no changes".
+		if saturated {
+			return
+		}
+		iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
+			WindowSeconds: int(window.Seconds()),
+		}
+		return
+	}
+	if len(changes) > correlationChangeCap {
+		changes = changes[:correlationChangeCap]
+	}
+	iss.CorrelatedChanges = changes
 }
 
 func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -81,8 +81,11 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 			}
 			// Only kinds whose changes the feed records can truthfully claim "no
 			// changes" — for untracked kinds the marker is omitted (= unknown).
+			// Group-aware: a CRD issue whose kind collides with a tracked one
+			// (Knative Service vs core Service) must not be correlated against
+			// the same-named core object's changes.
 			nativeHelmIssue := iss.Kind == "HelmRelease" && iss.Group == issues.NativeHelmGroup
-			if !nativeHelmIssue && !meaningfulchanges.TrackedKind(iss.Kind) {
+			if !nativeHelmIssue && !meaningfulchanges.TrackedKindForGroup(iss.Kind, iss.Group) {
 				continue
 			}
 			if checked >= correlationIssueCap {
@@ -126,10 +129,41 @@ func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Durat
 		}
 		return
 	}
+	changes = annotateOnsetOrder(changes, iss.FirstSeen)
 	if len(changes) > correlationChangeCap {
 		changes = changes[:correlationChangeCap]
 	}
 	iss.CorrelatedChanges = changes
+}
+
+// onsetSlop absorbs detection lag and clock skew between a change landing
+// and the resulting condition transition: a change within this margin after
+// first_seen may still explain the onset, so it is not flagged.
+const onsetSlop = 2 * time.Minute
+
+// annotateOnsetOrder marks changes that postdate the issue's onset
+// (first_seen + slop) with AfterIssueOnset — deterministic causal-direction
+// evidence: such a change cannot explain why the issue began, though it may
+// explain later behavior. Pre-onset changes are ordered first so the cap
+// never drops a possible cause in favor of a post-onset edit. No filtering:
+// the consumer weighs.
+func annotateOnsetOrder(changes []issuesapi.RecentChange, firstSeen time.Time) []issuesapi.RecentChange {
+	if firstSeen.IsZero() {
+		return changes
+	}
+	cutoff := firstSeen.Add(onsetSlop)
+	pre := make([]issuesapi.RecentChange, 0, len(changes))
+	post := make([]issuesapi.RecentChange, 0)
+	for _, c := range changes {
+		ts, err := time.Parse(time.RFC3339, c.Timestamp)
+		if err != nil || !ts.After(cutoff) {
+			pre = append(pre, c) // unparseable ⇒ unknown ⇒ no claim
+			continue
+		}
+		c.AfterIssueOnset = true
+		post = append(post, c)
+	}
+	return append(pre, post...)
 }
 
 func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -347,6 +347,81 @@ func TestAttachIssueChangeCorrelation_WarningOnlyTruncation(t *testing.T) {
 	}
 }
 
+// A CRD issue whose kind collides with a tracked core kind (Knative Service
+// vs core Service) must not be correlated against the same-named core
+// object's changes — and must not carry a marker either way (its own changes
+// are not tracked, so "no changes" would be a false statement).
+func TestAttachIssueChangeCorrelation_GroupCollisionNotCorrelated(t *testing.T) {
+	store := initCorrelationStore(t)
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "core-svc-change", Timestamp: time.Now().Add(-5 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Service", Namespace: "shop", Name: "web",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "spec.selector.app", OldValue: "a", NewValue: "b"}}, Summary: "selector changed"},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	knative := warningIssue("Service", "web")
+	knative.Group = "serving.knative.dev"
+	core := warningIssue("Service", "web") // Group empty = unknown/core, keeps correlating
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{knative, core}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	if k := resp.Issues[0]; k.NoRecentChanges != nil || len(k.CorrelatedChanges) != 0 {
+		t.Fatalf("Knative-group Service must not be correlated against core Service changes: %+v", k)
+	}
+	if c := resp.Issues[1]; len(c.CorrelatedChanges) != 1 {
+		t.Fatalf("core Service should still correlate its own change, got %+v", c)
+	}
+}
+
+// Every kind the feed tracks must have a group entry — a kind added to
+// specKinds/configKinds without one silently stops correlating.
+func TestTrackedKindGroups_CoversAllTrackedKinds(t *testing.T) {
+	for _, kind := range []string{
+		"ConfigMap", "Secret",
+		"Deployment", "StatefulSet", "DaemonSet", "Service", "Ingress",
+		"HorizontalPodAutoscaler", "Application", "Kustomization", "HelmRelease",
+		"GitRepository", "OCIRepository", "HelmRepository",
+		"ResourceQuota", "LimitRange",
+		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
+	} {
+		if !meaningfulchanges.TrackedKindForGroup(kind, "") {
+			t.Errorf("tracked kind %q has no group entry — correlation silently disabled for it", kind)
+		}
+	}
+}
+
+// Changes that postdate the issue's onset are annotated after_issue_onset
+// and ordered after pre-onset changes, so the cap never drops a possible
+// cause in favor of a post-onset edit.
+func TestAnnotateOnsetOrder(t *testing.T) {
+	now := time.Now()
+	firstSeen := now.Add(-30 * time.Minute)
+	pre := issuesapi.RecentChange{Name: "pre", Timestamp: now.Add(-45 * time.Minute).Format(time.RFC3339)}
+	post := issuesapi.RecentChange{Name: "post", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339)}
+	within := issuesapi.RecentChange{Name: "within-slop", Timestamp: firstSeen.Add(time.Minute).Format(time.RFC3339)}
+	bad := issuesapi.RecentChange{Name: "unparseable", Timestamp: "not-a-time"}
+
+	out := annotateOnsetOrder([]issuesapi.RecentChange{post, pre, within, bad}, firstSeen)
+	if len(out) != 4 {
+		t.Fatalf("len = %d, want 4 (annotate, never filter)", len(out))
+	}
+	if out[len(out)-1].Name != "post" || !out[len(out)-1].AfterIssueOnset {
+		t.Fatalf("post-onset change should sort last and be annotated: %+v", out)
+	}
+	for _, c := range out[:3] {
+		if c.AfterIssueOnset {
+			t.Errorf("%s wrongly annotated after_issue_onset (slop/parse rules)", c.Name)
+		}
+	}
+	if zero := annotateOnsetOrder([]issuesapi.RecentChange{post}, time.Time{}); zero[0].AfterIssueOnset {
+		t.Error("unknown onset must not annotate")
+	}
+}
+
 // Worst-case correlation payload (cap × changes × field diffs, with realistic
 // field values) stays bounded — a guard against unnoticed schema growth now
 // that warnings are eligible too.

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -377,6 +377,33 @@ func TestAttachIssueChangeCorrelation_GroupCollisionNotCorrelated(t *testing.T) 
 	}
 }
 
+// Reverse collision direction: a CORE Service issue must not absorb a
+// same-named Knative Service's change events — candidate events are group
+// filtered, so the core subject truthfully reports no_recent_changes.
+func TestAttachIssueChangeCorrelation_CoreIssueIgnoresCRDEvents(t *testing.T) {
+	store := initCorrelationStore(t)
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "knative-svc-change", Timestamp: time.Now().Add(-5 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Service", APIVersion: "serving.knative.dev/v1", Namespace: "shop", Name: "web",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "spec.template", OldValue: "a", NewValue: "b"}}, Summary: "revision changed"},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{warningIssue("Service", "web")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	core := resp.Issues[0]
+	if len(core.CorrelatedChanges) != 0 {
+		t.Fatalf("core Service issue absorbed a Knative Service's change: %+v", core.CorrelatedChanges)
+	}
+	if core.NoRecentChanges == nil {
+		t.Fatalf("core Service should truthfully report no tracked (core) changes, got %+v", core)
+	}
+}
+
 // Worst-case correlation payload (cap × changes × field diffs, with realistic
 // field values) stays bounded — a guard against unnoticed schema growth now
 // that warnings are eligible too.

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -404,6 +404,36 @@ func TestAttachIssueChangeCorrelation_CoreIssueIgnoresCRDEvents(t *testing.T) {
 	}
 }
 
+// Crowding: when mismatched-group events fill the bounded candidate window,
+// the answer is UNKNOWN (saturated), never a false no_recent_changes — an
+// older core change may sit beyond the events the query consumed.
+func TestAttachIssueChangeCorrelation_CRDCrowdingIsUnknownNotNoChanges(t *testing.T) {
+	store := initCorrelationStore(t)
+	now := time.Now()
+	for i := 0; i < 100; i++ { // name-filtered candidate limit
+		if err := store.Append(context.Background(), timeline.TimelineEvent{
+			ID: fmt.Sprintf("knative-%d", i), Timestamp: now.Add(-time.Duration(i) * time.Second),
+			Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+			Kind: "Service", APIVersion: "serving.knative.dev/v1", Namespace: "shop", Name: "web",
+			EventType: timeline.EventTypeUpdate,
+			Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "spec.template", OldValue: i, NewValue: i + 1}}, Summary: "revision churn"},
+		}); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{warningIssue("Service", "web")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	core := resp.Issues[0]
+	if len(core.CorrelatedChanges) != 0 {
+		t.Fatalf("core issue absorbed CRD events: %+v", core.CorrelatedChanges)
+	}
+	if core.NoRecentChanges != nil {
+		t.Fatalf("crowded window must read as unknown (saturated), not no_recent_changes: %+v", core.NoRecentChanges)
+	}
+}
+
 // Worst-case correlation payload (cap × changes × field diffs, with realistic
 // field values) stays bounded — a guard against unnoticed schema growth now
 // that warnings are eligible too.

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -53,6 +54,14 @@ func criticalIssue(kind, name string) issuesapi.Issue {
 	}
 }
 
+func warningIssue(kind, name string) issuesapi.Issue {
+	return issuesapi.Issue{
+		Severity: issuesapi.SeverityWarning,
+		Kind:     kind, Namespace: "shop", Name: name,
+		Reason: "SelectorMatchesNoPods",
+	}
+}
+
 // The changed workload gets correlated_changes; the chronic one gets an
 // explicit no_recent_changes marker with the window.
 func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
@@ -78,10 +87,23 @@ func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
 		t.Fatalf("append quiet status: %v", err)
 	}
 
+	// A warning-severity Service whose selector was just changed — the
+	// degraded-not-down case warning correlation exists for.
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "svc-selector", Timestamp: time.Now().Add(-3 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Service", Namespace: "shop", Name: "warn-changed",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "spec.selector.app", OldValue: "cart", NewValue: "cartt"}}, Summary: "selector changed"},
+	}); err != nil {
+		t.Fatalf("append service selector: %v", err)
+	}
+
 	resp := issues.ListResponse{Issues: []issuesapi.Issue{
 		criticalIssue("Deployment", "web"),
 		criticalIssue("Deployment", "quiet"),
-		{Severity: issuesapi.SeverityWarning, Kind: "Deployment", Namespace: "shop", Name: "warn-only"},
+		warningIssue("Service", "warn-changed"),
+		warningIssue("Deployment", "warn-quiet"),
 		criticalIssue("Pod", "standalone"), // untracked kind: no marker either way
 	}}
 	attachIssueChangeCorrelation(context.Background(), &resp)
@@ -97,10 +119,15 @@ func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
 	if quiet.NoRecentChanges == nil || quiet.NoRecentChanges.WindowSeconds != 3600 {
 		t.Fatalf("quiet should carry no_recent_changes{3600} despite status churn, got %+v (correlated=%+v)", quiet.NoRecentChanges, quiet.CorrelatedChanges)
 	}
-	if warn := resp.Issues[2]; warn.NoRecentChanges != nil || len(warn.CorrelatedChanges) != 0 {
-		t.Fatalf("warning issues must not be correlated: %+v", warn)
+	warn := resp.Issues[2]
+	if len(warn.CorrelatedChanges) != 1 || warn.CorrelatedChanges[0].Kind != "Service" || warn.CorrelatedChanges[0].Name != "warn-changed" {
+		t.Fatalf("warning issue should carry its subject's spec change, got %+v", warn.CorrelatedChanges)
 	}
-	if pod := resp.Issues[3]; pod.NoRecentChanges != nil || len(pod.CorrelatedChanges) != 0 {
+	warnQuiet := resp.Issues[3]
+	if warnQuiet.NoRecentChanges == nil {
+		t.Fatalf("unchanged warning subject should carry no_recent_changes, got %+v", warnQuiet)
+	}
+	if pod := resp.Issues[4]; pod.NoRecentChanges != nil || len(pod.CorrelatedChanges) != 0 {
 		t.Fatalf("untracked kinds must not carry markers (cannot truthfully claim 'no changes'): %+v", pod)
 	}
 	if resp.CorrelationTruncated {
@@ -258,4 +285,101 @@ func TestAttachIssueChangeCorrelation_Truncation(t *testing.T) {
 	if last.NoRecentChanges != nil || len(last.CorrelatedChanges) > 0 {
 		t.Fatalf("issue past cap must be unmarked: %+v", last)
 	}
+}
+
+// Criticals own the cap regardless of where they sit in the response: a
+// pile of warnings listed first must not consume the criticals' slots.
+func TestAttachIssueChangeCorrelation_CriticalsPriorityUnderCap(t *testing.T) {
+	initCorrelationStore(t)
+
+	var list []issuesapi.Issue
+	for i := 0; i < correlationIssueCap+2; i++ {
+		list = append(list, warningIssue("Deployment", fmt.Sprintf("warn-%d", i)))
+	}
+	list = append(list, criticalIssue("Deployment", "crit-a"), criticalIssue("Deployment", "crit-b"))
+	resp := issues.ListResponse{Issues: list}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	if !resp.CorrelationTruncated {
+		t.Fatal("correlation_truncated must be set when issues exceed the shared cap")
+	}
+	marked := 0
+	for _, iss := range resp.Issues {
+		if iss.NoRecentChanges != nil || len(iss.CorrelatedChanges) > 0 {
+			marked++
+			if iss.Severity == issuesapi.SeverityWarning && marked > correlationIssueCap {
+				t.Fatalf("warning %s marked past the cap", iss.Name)
+			}
+		}
+	}
+	if marked != correlationIssueCap {
+		t.Fatalf("marked = %d, want exactly the cap (%d)", marked, correlationIssueCap)
+	}
+	for _, iss := range resp.Issues {
+		if iss.Severity == issuesapi.SeverityCritical && iss.NoRecentChanges == nil && len(iss.CorrelatedChanges) == 0 {
+			t.Fatalf("critical %s lost its slot to an earlier-listed warning", iss.Name)
+		}
+	}
+}
+
+// A warning-only response truncates on the same shared cap.
+func TestAttachIssueChangeCorrelation_WarningOnlyTruncation(t *testing.T) {
+	initCorrelationStore(t)
+
+	var list []issuesapi.Issue
+	for i := 0; i < correlationIssueCap+2; i++ {
+		list = append(list, warningIssue("Deployment", fmt.Sprintf("warn-%d", i)))
+	}
+	resp := issues.ListResponse{Issues: list}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	if !resp.CorrelationTruncated {
+		t.Fatal("correlation_truncated must be set for warning-only overflow")
+	}
+	marked := 0
+	for _, iss := range resp.Issues {
+		if iss.NoRecentChanges != nil || len(iss.CorrelatedChanges) > 0 {
+			marked++
+		}
+	}
+	if marked != correlationIssueCap {
+		t.Fatalf("marked = %d, want exactly the cap (%d)", marked, correlationIssueCap)
+	}
+}
+
+// Worst-case correlation payload (cap × changes × field diffs, with realistic
+// field values) stays bounded — a guard against unnoticed schema growth now
+// that warnings are eligible too.
+func TestIssueCorrelation_WorstCasePayloadBounded(t *testing.T) {
+	var iss []issuesapi.Issue
+	for i := 0; i < correlationIssueCap; i++ {
+		issue := criticalIssue("Deployment", fmt.Sprintf("dep-%d", i))
+		for c := 0; c < correlationChangeCap; c++ {
+			change := issuesapi.RecentChange{
+				Source: "informer", Kind: "Deployment", Namespace: "shop",
+				Name:           fmt.Sprintf("dep-%d", i),
+				ChangeType:     "update",
+				ChangeCategory: issuesapi.ChangeCategorySpecConfig,
+				Summary:        "spec changed: containers[app].image, containers[app].resources, replicas, strategy, template.metadata.labels",
+			}
+			for f := 0; f < correlationFieldLimit; f++ {
+				change.Fields = append(change.Fields, issuesapi.ChangeField{
+					Path:     fmt.Sprintf("spec.template.spec.containers[app].env[FEATURE_FLAG_%d].value", f),
+					OldValue: "a-realistically-long-previous-configuration-value-1234567890",
+					NewValue: "a-realistically-long-updated-configuration-value-0987654321",
+				})
+			}
+			issue.CorrelatedChanges = append(issue.CorrelatedChanges, change)
+		}
+		iss = append(iss, issue)
+	}
+	data, err := json.Marshal(issuesapi.Response{Issues: iss, Total: len(iss)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const maxBytes = 128 * 1024
+	if len(data) > maxBytes {
+		t.Fatalf("worst-case correlation payload = %d bytes, exceeds %d — correlation caps no longer bound the response", len(data), maxBytes)
+	}
+	t.Logf("worst-case correlation payload: %d bytes", len(data))
 }

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -377,51 +377,6 @@ func TestAttachIssueChangeCorrelation_GroupCollisionNotCorrelated(t *testing.T) 
 	}
 }
 
-// Every kind the feed tracks must have a group entry — a kind added to
-// specKinds/configKinds without one silently stops correlating.
-func TestTrackedKindGroups_CoversAllTrackedKinds(t *testing.T) {
-	for _, kind := range []string{
-		"ConfigMap", "Secret",
-		"Deployment", "StatefulSet", "DaemonSet", "Service", "Ingress",
-		"HorizontalPodAutoscaler", "Application", "Kustomization", "HelmRelease",
-		"GitRepository", "OCIRepository", "HelmRepository",
-		"ResourceQuota", "LimitRange",
-		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
-	} {
-		if !meaningfulchanges.TrackedKindForGroup(kind, "") {
-			t.Errorf("tracked kind %q has no group entry — correlation silently disabled for it", kind)
-		}
-	}
-}
-
-// Changes that postdate the issue's onset are annotated after_issue_onset
-// and ordered after pre-onset changes, so the cap never drops a possible
-// cause in favor of a post-onset edit.
-func TestAnnotateOnsetOrder(t *testing.T) {
-	now := time.Now()
-	firstSeen := now.Add(-30 * time.Minute)
-	pre := issuesapi.RecentChange{Name: "pre", Timestamp: now.Add(-45 * time.Minute).Format(time.RFC3339)}
-	post := issuesapi.RecentChange{Name: "post", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339)}
-	within := issuesapi.RecentChange{Name: "within-slop", Timestamp: firstSeen.Add(time.Minute).Format(time.RFC3339)}
-	bad := issuesapi.RecentChange{Name: "unparseable", Timestamp: "not-a-time"}
-
-	out := annotateOnsetOrder([]issuesapi.RecentChange{post, pre, within, bad}, firstSeen)
-	if len(out) != 4 {
-		t.Fatalf("len = %d, want 4 (annotate, never filter)", len(out))
-	}
-	if out[len(out)-1].Name != "post" || !out[len(out)-1].AfterIssueOnset {
-		t.Fatalf("post-onset change should sort last and be annotated: %+v", out)
-	}
-	for _, c := range out[:3] {
-		if c.AfterIssueOnset {
-			t.Errorf("%s wrongly annotated after_issue_onset (slop/parse rules)", c.Name)
-		}
-	}
-	if zero := annotateOnsetOrder([]issuesapi.RecentChange{post}, time.Time{}); zero[0].AfterIssueOnset {
-		t.Error("unknown onset must not annotate")
-	}
-}
-
 // Worst-case correlation payload (cap × changes × field diffs, with realistic
 // field values) stays bounded — a guard against unnoticed schema growth now
 // that warnings are eligible too.

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -377,6 +377,18 @@ func TestAttachIssueChangeCorrelation_GroupCollisionNotCorrelated(t *testing.T) 
 	}
 }
 
+// Secret issues are delete-only in the feed — updates are never recorded —
+// so they must never be marker-eligible: a no_recent_changes after a data
+// rotation the feed cannot see would be a false claim.
+func TestAttachIssueChangeCorrelation_SecretIssuesNotMarkerEligible(t *testing.T) {
+	initCorrelationStore(t)
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{warningIssue("Secret", "db-credentials")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+	if sec := resp.Issues[0]; sec.NoRecentChanges != nil || len(sec.CorrelatedChanges) != 0 {
+		t.Fatalf("Secret issue must carry no markers (updates not recorded): %+v", sec)
+	}
+}
+
 // Reverse collision direction: a CORE Service issue must not absorb a
 // same-named Knative Service's change events — candidate events are group
 // filtered, so the core subject truthfully reports no_recent_changes.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -348,8 +348,10 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
 			"subject had NO tracked changes in that window — evidence the issue is not " +
 			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
-			"values, external systems) can still have changed. For an issue with neither " +
-			"marker, correlation is unknown (not checked under the cap — see " +
+			"values, external systems) can still have changed. A correlated change with " +
+			"`after_issue_onset: true` postdates the issue's first_seen — it cannot explain " +
+			"why the issue began, though it may explain later behavior. For an issue with " +
+			"neither marker, correlation is unknown (not checked under the cap — see " +
 			"`correlation_truncated` — or the lookup failed/saturated); never read absence " +
 			"as 'no changes'. " +
 			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -348,8 +348,10 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
 			"subject had NO tracked changes in that window — evidence the issue is not " +
 			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
-			"values, external systems) can still have changed. An issue with neither marker " +
-			"was not checked (see `correlation_truncated`) — never read absence as 'no changes'. " +
+			"values, external systems) can still have changed. For an issue with neither " +
+			"marker, correlation is unknown (not checked under the cap — see " +
+			"`correlation_truncated` — or the lookup failed/saturated); never read absence " +
+			"as 'no changes'. " +
 			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +
 			"them directly). " +
 			"For raw Kubernetes Warning events use get_events; for static best-practice / " +
@@ -2654,9 +2656,10 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		}
 	}
 	// Per-issue change correlation (single-namespace responses): each
-	// critical issue carries either its correlated non-status changes or an
-	// explicit no_recent_changes marker — deterministic per-subject evidence
-	// the global recent_changes list can't bind to individual issues.
+	// critical and warning issue (criticals first under a shared cap)
+	// carries either its correlated non-status changes or an explicit
+	// no_recent_changes marker — deterministic per-subject evidence the
+	// global recent_changes list can't bind to individual issues.
 	if len(allowedNamespaces) == 1 {
 		attachIssueChangeCorrelation(ctx, &resp)
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -342,12 +342,14 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"attached it. It lists recent spec/config changes that may explain failures " +
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
-			"Single-namespace responses additionally correlate changes PER critical issue: " +
+			"Single-namespace responses additionally correlate changes PER critical and " +
+			"warning issue (criticals checked first under a shared cap): " +
 			"`correlated_changes` lists recent non-status changes on that issue's subject " +
 			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
-			"subject had NO tracked changes in that window — strong evidence the issue is " +
-			"chronic rather than change-driven. An issue with neither marker was not " +
-			"checked (see `correlation_truncated`) — never read absence as 'no changes'. " +
+			"subject had NO tracked changes in that window — evidence the issue is not " +
+			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
+			"values, external systems) can still have changed. An issue with neither marker " +
+			"was not checked (see `correlation_truncated`) — never read absence as 'no changes'. " +
 			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +
 			"them directly). " +
 			"For raw Kubernetes Warning events use get_events; for static best-practice / " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -348,10 +348,8 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
 			"subject had NO tracked changes in that window — evidence the issue is not " +
 			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
-			"values, external systems) can still have changed. A correlated change with " +
-			"`after_issue_onset: true` postdates the issue's first_seen — it cannot explain " +
-			"why the issue began, though it may explain later behavior. For an issue with " +
-			"neither marker, correlation is unknown (not checked under the cap — see " +
+			"values, external systems) can still have changed. For an issue with neither " +
+			"marker, correlation is unknown (not checked under the cap — see " +
 			"`correlation_truncated` — or the lookup failed/saturated); never read absence " +
 			"as 'no changes'. " +
 			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -343,15 +343,14 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
 			"Single-namespace responses additionally correlate changes PER critical and " +
-			"warning issue (criticals checked first under a shared cap): " +
+			"warning issue: " +
 			"`correlated_changes` lists recent non-status changes on that issue's subject " +
 			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
 			"subject had NO tracked changes in that window — evidence the issue is not " +
 			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
 			"values, external systems) can still have changed. For an issue with neither " +
-			"marker, correlation is unknown (not checked under the cap — see " +
-			"`correlation_truncated` — or the lookup failed/saturated); never read absence " +
-			"as 'no changes'. " +
+			"marker, correlation is unknown — never read absence as 'no changes' (see " +
+			"`correlation_truncated`). " +
 			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +
 			"them directly). " +
 			"For raw Kubernetes Warning events use get_events; for static best-practice / " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -342,17 +342,16 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"attached it. It lists recent spec/config changes that may explain failures " +
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
-			"Single-namespace responses additionally correlate changes PER critical and " +
-			"warning issue: " +
-			"`correlated_changes` lists recent non-status changes on that issue's subject " +
-			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
-			"subject had NO tracked changes in that window — evidence the issue is not " +
-			"driven by a tracked change on its own subject; untracked dependencies (Secret " +
-			"values, external systems) can still have changed. For an issue with neither " +
-			"marker, correlation is unknown — never read absence as 'no changes' (see " +
-			"`correlation_truncated`). " +
-			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +
-			"them directly). " +
+			"Single-namespace responses may add per-issue change evidence to eligible " +
+			"critical and warning issues: `correlated_changes` lists recent non-status " +
+			"changes on the issue subject (and, for workloads, its directly referenced " +
+			"ConfigMaps); `no_recent_changes.window_seconds` means Radar observed no such " +
+			"tracked change in that window. Treat that as evidence against, not disproof " +
+			"of, a recent tracked-change cause — Secret values and external dependencies " +
+			"may still have changed. If neither field is present, correlation is unknown, " +
+			"not 'no changes'. " +
+			"When present on a ConfigMap change, `consumed_by` identifies workloads that " +
+			"directly reference it. " +
 			"For raw Kubernetes Warning events use get_events; for static best-practice / " +
 			"security-posture findings (runAsRoot, missing PDB, no probes, missing resource " +
 			"limits) use get_cluster_audit — a separate axis that must never be conflated (a " +

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -434,6 +434,40 @@ func TrackedKind(kind string) bool {
 	return isConfigKind(kind) || isSpecKind(kind)
 }
 
+// trackedKindGroups maps each tracked (canonical) kind to the API group the
+// feed actually records it from. Kind strings collide across groups — a
+// Knative Service (serving.knative.dev) is not the core Service whose
+// changes the feed tracks.
+var trackedKindGroups = map[string]string{
+	"ConfigMap": "", "Service": "", "ResourceQuota": "", "LimitRange": "", "Secret": "",
+	"Deployment": "apps", "StatefulSet": "apps", "DaemonSet": "apps",
+	"Ingress":                        "networking.k8s.io",
+	"HorizontalPodAutoscaler":        "autoscaling",
+	"Application":                    "argoproj.io",
+	"Kustomization":                  "kustomize.toolkit.fluxcd.io",
+	"HelmRelease":                    "helm.toolkit.fluxcd.io",
+	"GitRepository":                  "source.toolkit.fluxcd.io",
+	"OCIRepository":                  "source.toolkit.fluxcd.io",
+	"HelmRepository":                 "source.toolkit.fluxcd.io",
+	"MutatingWebhookConfiguration":   "admissionregistration.k8s.io",
+	"ValidatingWebhookConfiguration": "admissionregistration.k8s.io",
+}
+
+// TrackedKindForGroup is TrackedKind with kind-collision protection: when
+// the caller KNOWS the subject's API group and it differs from the group the
+// feed records for that kind, the subject is NOT tracked — correlating a
+// Knative Service against the same-named core Service's changes would
+// attach another resource's history to the issue. An empty group is
+// permissive (unknown ⇒ current behavior).
+func TrackedKindForGroup(kind, group string) bool {
+	kind = canonicalKind(kind)
+	expected, ok := trackedKindGroups[kind]
+	if !ok {
+		return false
+	}
+	return group == "" || group == expected
+}
+
 func RankAndCap(changes *[]issuesapi.RecentChange, limit int) {
 	if changes == nil {
 		return

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -302,7 +302,8 @@ func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q 
 		IncludeManaged:   false,
 		IncludeK8sEvents: false,
 	}
-	return store.Query(ctx, opts)
+	events, err := store.Query(ctx, opts)
+	return filterTrackedGroupEvents(events), err
 }
 
 func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string, limit int) ([]timeline.TimelineEvent, error) {
@@ -320,7 +321,38 @@ func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, ki
 		IncludeManaged:   false,
 		IncludeK8sEvents: false,
 	}
-	return store.Query(ctx, opts)
+	events, err := store.Query(ctx, opts)
+	return filterTrackedGroupEvents(events), err
+}
+
+// filterTrackedGroupEvents drops candidate events recorded from a different
+// API group than the one the feed tracks for that kind — kind strings are
+// queried by name, so without this a Knative Service event would enter a
+// core Service's candidate set (and vice versa). Events with no recorded
+// apiVersion are kept: unknown, not mismatched.
+func filterTrackedGroupEvents(events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	out := events[:0]
+	for _, e := range events {
+		if eventGroupMatchesTracked(e.Kind, e.APIVersion) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func eventGroupMatchesTracked(kind, apiVersion string) bool {
+	if apiVersion == "" {
+		return true // emitter did not record it — unknown, not mismatched
+	}
+	expected, ok := trackedKindGroups[canonicalKind(kind)]
+	if !ok {
+		return true
+	}
+	group := "" // bare "v1" = core group
+	if idx := strings.IndexByte(apiVersion, '/'); idx > 0 {
+		group = apiVersion[:idx]
+	}
+	return group == expected
 }
 
 func rankedChanges(events []timeline.TimelineEvent, name string, limit, fieldLimit int) ([]issuesapi.RecentChange, bool, error) {

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -477,8 +477,13 @@ func TrackedKind(kind string) bool {
 // feed actually records it from. Kind strings collide across groups — a
 // Knative Service (serving.knative.dev) is not the core Service whose
 // changes the feed tracks.
+// NOTE: this map must cover exactly TrackedKind's set (configKinds +
+// specKinds) — no lifecycleOnlyKinds. Secret is delete-only in the feed
+// (updates are never recorded), so making Secret issues marker-eligible
+// would emit a false no_recent_changes after a data rotation the feed
+// cannot see. The drift-guard test pins both directions.
 var trackedKindGroups = map[string]string{
-	"ConfigMap": "", "Service": "", "ResourceQuota": "", "LimitRange": "", "Secret": "",
+	"ConfigMap": "", "Service": "", "ResourceQuota": "", "LimitRange": "",
 	"Deployment": "apps", "StatefulSet": "apps", "DaemonSet": "apps",
 	"Ingress":                        "networking.k8s.io",
 	"HorizontalPodAutoscaler":        "autoscaling",

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -78,7 +78,7 @@ func recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, bool,
 
 	if len(q.Kinds) > 0 || q.Name != "" {
 		queryLimit := candidateLimit(q.Limit, q.Name != "")
-		events, err := queryCandidates(ctx, store, q, q.Kinds, queryLimit)
+		events, rawEvents, err := queryCandidates(ctx, store, q, q.Kinds, queryLimit)
 		if err != nil {
 			return nil, false, false, err
 		}
@@ -86,33 +86,33 @@ func recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, bool,
 		// update churn can't push them out of the newest-N candidate window
 		// before ranking ever sees them. Ranking scores deletes above status
 		// churn, but it can only rank what the fetch returns.
-		lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, q.Kinds)
+		lifecycleEvents, rawLifecycle, err := queryLifecycleCandidates(ctx, store, q, q.Kinds)
 		if err != nil {
 			return nil, false, false, err
 		}
 		changes, capped, err := rankedChanges(coalesceRecreatePairs(dedupeEvents(append(events, lifecycleEvents...))), q.Name, q.Limit, q.FieldLimit)
-		saturated := len(events) >= queryLimit || len(lifecycleEvents) >= lifecycleCandidateLimit
+		saturated := rawEvents >= queryLimit || rawLifecycle >= lifecycleCandidateLimit
 		return changes, capped, saturated, err
 	}
 
 	perQueryLimit := candidateLimit(q.Limit, false)
-	configEvents, err := queryCandidates(ctx, store, q, configKinds, perQueryLimit)
+	configEvents, rawConfig, err := queryCandidates(ctx, store, q, configKinds, perQueryLimit)
 	if err != nil {
 		return nil, false, false, err
 	}
-	specEvents, err := queryCandidates(ctx, store, q, specKinds, perQueryLimit)
+	specEvents, rawSpec, err := queryCandidates(ctx, store, q, specKinds, perQueryLimit)
 	if err != nil {
 		return nil, false, false, err
 	}
 	lifecycleKinds := append(append([]string{}, configKinds...), specKinds...)
 	lifecycleKinds = append(lifecycleKinds, lifecycleOnlyKinds...)
-	lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, lifecycleKinds)
+	lifecycleEvents, rawLifecycle, err := queryLifecycleCandidates(ctx, store, q, lifecycleKinds)
 	if err != nil {
 		return nil, false, false, err
 	}
 	merged := coalesceRecreatePairs(dedupeEvents(append(append(configEvents, specEvents...), lifecycleEvents...)))
 	changes, capped, err := rankedChanges(merged, "", q.Limit, q.FieldLimit)
-	saturated := len(configEvents) >= perQueryLimit || len(specEvents) >= perQueryLimit || len(lifecycleEvents) >= lifecycleCandidateLimit
+	saturated := rawConfig >= perQueryLimit || rawSpec >= perQueryLimit || rawLifecycle >= lifecycleCandidateLimit
 	return changes, capped, saturated, err
 }
 
@@ -289,7 +289,12 @@ const lifecycleCandidateLimit = 50
 
 // queryLifecycleCandidates fetches add/delete events for the given kinds in a
 // query of their own, immune to crowding by update events.
-func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string) ([]timeline.TimelineEvent, error) {
+// queryLifecycleCandidates returns group-filtered events plus the RAW
+// pre-filter count — saturation must key on how many events the bounded
+// query consumed, not how many survived filtering, or mismatched-group
+// events crowding the window would turn "unknown" into a false "no
+// changes".
+func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string) ([]timeline.TimelineEvent, int, error) {
 	opts := timeline.QueryOptions{
 		Namespaces:       q.Namespaces,
 		Kinds:            compactKinds(kinds),
@@ -303,10 +308,12 @@ func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q 
 		IncludeK8sEvents: false,
 	}
 	events, err := store.Query(ctx, opts)
-	return filterTrackedGroupEvents(events), err
+	return filterTrackedGroupEvents(events), len(events), err
 }
 
-func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string, limit int) ([]timeline.TimelineEvent, error) {
+// queryCandidates returns group-filtered events plus the RAW pre-filter
+// count (see queryLifecycleCandidates for why saturation needs it).
+func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string, limit int) ([]timeline.TimelineEvent, int, error) {
 	opts := timeline.QueryOptions{
 		Namespaces: q.Namespaces,
 		Kinds:      compactKinds(kinds),
@@ -322,7 +329,7 @@ func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, ki
 		IncludeK8sEvents: false,
 	}
 	events, err := store.Query(ctx, opts)
-	return filterTrackedGroupEvents(events), err
+	return filterTrackedGroupEvents(events), len(events), err
 }
 
 // filterTrackedGroupEvents drops candidate events recorded from a different

--- a/internal/meaningfulchanges/tracked_groups_test.go
+++ b/internal/meaningfulchanges/tracked_groups_test.go
@@ -1,0 +1,19 @@
+package meaningfulchanges
+
+import "testing"
+
+// Every kind the feed tracks must have a trackedKindGroups entry — a kind
+// added to configKinds/specKinds/lifecycleOnlyKinds without one would
+// silently stop correlating (TrackedKindForGroup returns false for it).
+// White-box on purpose: iterates the real slices so new kinds fail here.
+func TestTrackedKindGroups_CoversAllTrackedKinds(t *testing.T) {
+	var all []string
+	all = append(all, configKinds...)
+	all = append(all, specKinds...)
+	all = append(all, lifecycleOnlyKinds...)
+	for _, kind := range all {
+		if _, ok := trackedKindGroups[canonicalKind(kind)]; !ok {
+			t.Errorf("tracked kind %q has no trackedKindGroups entry — correlation silently disabled for it", kind)
+		}
+	}
+}

--- a/internal/meaningfulchanges/tracked_groups_test.go
+++ b/internal/meaningfulchanges/tracked_groups_test.go
@@ -2,18 +2,24 @@ package meaningfulchanges
 
 import "testing"
 
-// Every kind the feed tracks must have a trackedKindGroups entry — a kind
-// added to configKinds/specKinds/lifecycleOnlyKinds without one would
-// silently stop correlating (TrackedKindForGroup returns false for it).
-// White-box on purpose: iterates the real slices so new kinds fail here.
-func TestTrackedKindGroups_CoversAllTrackedKinds(t *testing.T) {
-	var all []string
-	all = append(all, configKinds...)
-	all = append(all, specKinds...)
-	all = append(all, lifecycleOnlyKinds...)
-	for _, kind := range all {
+// trackedKindGroups must cover EXACTLY TrackedKind's set (configKinds +
+// specKinds): a kind added there without a group entry silently stops
+// correlating, and a kind present here beyond that set becomes
+// marker-eligible without its updates being recorded — Secret
+// (lifecycleOnlyKinds, delete-only) would emit false no_recent_changes
+// after a data rotation the feed cannot see. White-box on purpose:
+// iterates the real slices so drift fails here.
+func TestTrackedKindGroups_MatchesTrackedKindSet(t *testing.T) {
+	tracked := map[string]bool{}
+	for _, kind := range append(append([]string{}, configKinds...), specKinds...) {
+		tracked[canonicalKind(kind)] = true
 		if _, ok := trackedKindGroups[canonicalKind(kind)]; !ok {
 			t.Errorf("tracked kind %q has no trackedKindGroups entry — correlation silently disabled for it", kind)
+		}
+	}
+	for kind := range trackedKindGroups {
+		if !tracked[kind] {
+			t.Errorf("%q is in trackedKindGroups but not tracked by the feed — marker-eligible without recorded updates (false no_recent_changes)", kind)
 		}
 	}
 }

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -407,12 +407,14 @@ type Issue struct {
 	// Deterministic evidence, not a causal claim — the consumer weighs
 	// whether the change explains the issue.
 	CorrelatedChanges []RecentChange `json:"correlated_changes,omitempty"`
-	// NoRecentChanges states the lookback window contained no non-status
-	// changes for this issue's subject — evidence the issue is NOT
-	// change-driven within that window. Omitted when correlation was not
-	// attempted (cap reached, lookup failed) or when the candidate fetch
-	// saturated and may have missed changes; absence must never be read as
-	// "no changes".
+	// NoRecentChanges states the lookback window contained no TRACKED
+	// non-status changes for this issue's subject (and, for workloads, its
+	// directly referenced ConfigMaps). It is scoped evidence, not proof the
+	// incident is chronic — untracked dependencies (Secret values, resources
+	// outside the tracked kind set, external systems) can still have changed.
+	// Omitted when correlation was not attempted (cap reached, lookup failed)
+	// or when the candidate fetch saturated and may have missed changes;
+	// absence must never be read as "no changes".
 	NoRecentChanges *NoRecentChangesMarker `json:"no_recent_changes,omitempty"`
 }
 
@@ -435,8 +437,9 @@ type Response struct {
 	RecentChanges       []RecentChange  `json:"recent_changes,omitempty"`
 	RecentChangesReason string          `json:"recent_changes_reason,omitempty"`
 	// CorrelationTruncated is set when per-issue change correlation skipped
-	// some critical issues (cap reached). Under truncation, an issue without
-	// correlation markers means "not checked", not "no changes".
+	// some critical or warning issues (shared cap reached; criticals are
+	// checked first). Under truncation, an issue without correlation markers
+	// means "not checked", not "no changes".
 	CorrelationTruncated bool `json:"correlation_truncated,omitempty"`
 }
 

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -307,12 +307,6 @@ type RecentChange struct {
 	// only — runtime consumers reading through an intermediary service are
 	// not captured.
 	ConsumedBy []string `json:"consumed_by,omitempty"`
-	// AfterIssueOnset marks a per-issue correlated change whose timestamp
-	// postdates the issue's first_seen (plus a small detection-lag margin):
-	// it cannot explain why the issue began, though it may explain later
-	// behavior. Deterministic causal-direction evidence, not a filter —
-	// only set on correlated_changes where the issue's onset is known.
-	AfterIssueOnset bool `json:"after_issue_onset,omitempty"`
 }
 
 type ClusterContext struct {

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -307,6 +307,12 @@ type RecentChange struct {
 	// only — runtime consumers reading through an intermediary service are
 	// not captured.
 	ConsumedBy []string `json:"consumed_by,omitempty"`
+	// AfterIssueOnset marks a per-issue correlated change whose timestamp
+	// postdates the issue's first_seen (plus a small detection-lag margin):
+	// it cannot explain why the issue began, though it may explain later
+	// behavior. Deterministic causal-direction evidence, not a filter —
+	// only set on correlated_changes where the issue's onset is known.
+	AfterIssueOnset bool `json:"after_issue_onset,omitempty"`
 }
 
 type ClusterContext struct {


### PR DESCRIPTION
## Why

In degraded-not-down incidents the active fault often manifests at **warning** severity — e.g. a Service selector matching no pods right after a selector change. Per-issue change correlation previously skipped everything below critical (`attachIssueChangeCorrelation`), so the actual fault arrived with no `correlated_changes` evidence while chronic criticals carried explicit markers. In SREGym benchmark transcripts this evidence asymmetry repeatedly steered agents toward the loudest chronic critical (or an unrelated entry in the global `recent_changes` feed) instead of the changed warning-severity subject.

## What

- Correlation runs **two passes sharing the existing cap (10)**: all criticals first, then warnings. Cap priority is independent of response sort order — a warning can never cost a critical its lookup slot.
- **Group-aware correlation, both directions**: the eligibility gate (`TrackedKindForGroup`) treats a CRD issue whose kind collides with a tracked kind (Knative Service vs core Service) as untracked, and candidate queries drop timeline events recorded from a different API group than the one the feed tracks for that kind — so neither side of a same-name kind collision can absorb the other's changes. A drift-guard test pins the kind→group map to exactly the feed's tracked set in both directions (Secret stays out: its updates are delete-only in the feed, so marker-eligibility would produce false claims).
- **Truthful saturation under crowding**: saturation keys on the raw pre-filter candidate count, so mismatched-group events filling the bounded query window read as "unknown", never as a false `no_recent_changes`.
- Same subject-scoped, deterministic, non-causal machinery as before: no demotion, no reordering, no new heuristics; the existing truthful-window semantics apply unchanged. Contract docs updated throughout (`CorrelationTruncated`, `no_recent_changes` covers tracked changes on the subject only, `issues` tool description).

## Tests

Warning correlation + unchanged-warning markers; criticals-priority-under-cap; warning-only truncation; both group-collision directions (Knative issue vs core events, core issue vs CRD events); CRD-crowding saturation; Secret non-eligibility; worst-case payload bound (~43KB measured, 128KB guard). Full `make test` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes triage evidence agents rely on (correlation markers and saturation semantics) and adds group filtering on timeline queries; behavior is heavily tested but wrong group mapping could silently disable correlation for a kind.
> 
> **Overview**
> **Per-issue change correlation** on single-namespace `issues` responses now covers **warning** as well as **critical** issues, using the same 10-issue cap with **criticals always processed first** so response ordering cannot starve critical lookups. Logic is refactored into `correlateIssue`; MCP/API docs clarify that `no_recent_changes` is scoped to **tracked** subject changes, not proof of a chronic incident.
> 
> **Group-aware correctness** replaces plain `TrackedKind`: `TrackedKindForGroup` skips CRD issues whose kind collides with a tracked core kind (e.g. Knative vs core `Service`), and timeline candidate queries **filter events by API group** so same-named resources cannot share history. **Saturation** now uses the **raw pre-filter** candidate count so mismatched-group churn cannot yield a false `no_recent_changes`. A `trackedKindGroups` map (drift-tested) keeps marker eligibility aligned with what the feed actually records—**Secret** issues stay ineligible because updates are not tracked.
> 
> Tests cover warning markers, cap priority, group collisions both ways, CRD crowding → unknown, Secret non-eligibility, and a worst-case JSON payload bound (~128KB).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88aaa45277d31fe1cbceb858c3b413b04f93aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->