### PR TITLE
Dashboard warningGroups: full dedup window with lastSeen + involved objects, recency-ordered

### DIFF
--- a/internal/mcp/dashboard_warnings_test.go
+++ b/internal/mcp/dashboard_warnings_test.go
@@ -2,11 +2,13 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -25,11 +27,12 @@ func warningEvent(name, reason, message string, count int32, last time.Time, obj
 	}
 }
 
-// topWarnings must order by recency (not lifetime count) and carry the facts
-// a consumer needs to judge each row: lastSeen and the involved objects. The
-// old count-first ordering promoted a long-stale high-count group over the
-// live incident, and the old shape gave no way to tell the two apart.
-func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
+// warningGroups must order by recency (not lifetime count) and carry the
+// facts a consumer needs to judge each row: lastSeen and the involved
+// objects. The old count-first ordering promoted a long-stale high-count
+// group over the live incident, and the old shape gave no way to tell the
+// two apart.
+func TestBuildDashboard_WarningGroups_RecencyAndObjects(t *testing.T) {
 	defer k8s.ResetTestState()
 
 	ns := "shop"
@@ -52,18 +55,18 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		dashboard = buildDashboard(context.Background(), cache, ns, false, false)
-		if len(dashboard.TopWarnings) >= 2 {
+		if len(dashboard.WarningGroups) >= 2 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if len(dashboard.TopWarnings) < 2 {
-		t.Fatalf("topWarnings never populated: %+v", dashboard.TopWarnings)
+	if len(dashboard.WarningGroups) < 2 {
+		t.Fatalf("warningGroups never populated: %+v", dashboard.WarningGroups)
 	}
 
-	live := dashboard.TopWarnings[0]
+	live := dashboard.WarningGroups[0]
 	if live.Reason != "BackOff" {
-		t.Fatalf("topWarnings[0] = %+v, want the RECENT BackOff group first despite the stale group's higher count", dashboard.TopWarnings)
+		t.Fatalf("warningGroups[0] = %+v, want the RECENT BackOff group first despite the stale group's higher count", dashboard.WarningGroups)
 	}
 	if live.Count != 3 {
 		t.Errorf("live count = %d, want 3 (aggregated across both pods)", live.Count)
@@ -78,54 +81,65 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 		t.Errorf("objects[0] = %+v, want most-recent pod %+v", live.Objects[0], want)
 	}
 
-	stale := dashboard.TopWarnings[1]
+	stale := dashboard.WarningGroups[1]
 	if stale.Reason != "FailedMount" {
-		t.Fatalf("topWarnings[1] = %+v, want the stale FailedMount group", stale)
+		t.Fatalf("warningGroups[1] = %+v, want the stale FailedMount group", stale)
 	}
 	if stale.LastSeen.IsZero() || now.Sub(stale.LastSeen) < time.Hour {
 		t.Errorf("stale lastSeen = %v — without an old lastSeen a consumer cannot tell this group is stale", stale.LastSeen)
 	}
 }
 
-// Row selection is a union: the newest groups must not evict an actively
-// repeating storm whose latest event record is merely minutes older than a
-// burst of one-off churn — and vice versa, a stale storm must not hide fresh
-// incidents (observed in benchmark transcripts, where a resolved storm
-// outranked the live incident under count-first ordering). Six groups:
-// five fresh one-offs (count 1)
-// plus a 4-minute-old storm (count 400). Recency-only would emit the five
-// one-offs; count-only would lead with the storm. The union keeps the three
-// newest AND the storm.
-func TestSelectTopWarningGroups_UnionKeepsStormAndFresh(t *testing.T) {
+// The dashboard emits the FULL dedup window with no row selection: any
+// pick-N heuristic creates unrecoverable omissions (a live incident or an
+// active storm not making the cut — both observed in benchmark transcripts).
+// Seven distinct groups must yield seven rows, recency-ordered, with the
+// high-count storm present even though it is the oldest.
+func TestBuildDashboard_WarningGroups_FullWindowNoSelection(t *testing.T) {
+	defer k8s.ResetTestState()
+
+	ns := "shop"
 	now := time.Now()
-	mk := func(reason string, count int, last time.Time) aicontext.DeduplicatedEventGroup {
-		return aicontext.DeduplicatedEventGroup{DeduplicatedEvent: aicontext.DeduplicatedEvent{
-			Reason: reason, Message: "m", Type: "Warning", Count: count, LastTimestamp: last,
-		}}
+
+	objs := make([]runtime.Object, 0, 7)
+	for i := 0; i < 6; i++ {
+		objs = append(objs, warningEvent(
+			fmt.Sprintf("ev-fresh-%d", i), fmt.Sprintf("FreshReason%d", i),
+			fmt.Sprintf("distinct message %d", i), 1,
+			now.Add(-time.Duration(i+1)*time.Minute), "Pod", ns, fmt.Sprintf("pod-%d", i)))
 	}
-	groups := []aicontext.DeduplicatedEventGroup{ // dedup order: most recent first
-		mk("Fresh1", 1, now.Add(-10*time.Second)),
-		mk("Fresh2", 1, now.Add(-20*time.Second)),
-		mk("Fresh3", 1, now.Add(-30*time.Second)),
-		mk("Fresh4", 1, now.Add(-40*time.Second)),
-		mk("Fresh5", 1, now.Add(-50*time.Second)),
-		mk("Storm", 400, now.Add(-4*time.Minute)),
+	// Oldest group in the window, but an active storm by count — a 5-row
+	// selection under pure recency would have dropped it.
+	objs = append(objs, warningEvent("ev-storm", "StormReason", "storm message", 400,
+		now.Add(-10*time.Minute), "Pod", ns, "storm-pod"))
+
+	client := fake.NewSimpleClientset(objs...)
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
 	}
-	selected := selectTopWarningGroups(groups, topWarningRecentSlots, topWarningRows)
-	if len(selected) != topWarningRows {
-		t.Fatalf("selected %d rows, want %d", len(selected), topWarningRows)
+	cache := k8s.GetResourceCache()
+
+	var dashboard mcpDashboard
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dashboard = buildDashboard(context.Background(), cache, ns, false, false)
+		if len(dashboard.WarningGroups) >= 7 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
-	reasons := make(map[string]bool)
-	for _, g := range selected {
-		reasons[g.Reason] = true
+	if len(dashboard.WarningGroups) != 7 {
+		t.Fatalf("warningGroups = %d rows, want all 7 groups (no selection layer): %+v",
+			len(dashboard.WarningGroups), dashboard.WarningGroups)
 	}
-	for _, want := range []string{"Fresh1", "Fresh2", "Fresh3", "Storm"} {
-		if !reasons[want] {
-			t.Errorf("selection %v missing %s", reasons, want)
+	for i := 1; i < len(dashboard.WarningGroups); i++ {
+		if dashboard.WarningGroups[i].LastSeen.After(dashboard.WarningGroups[i-1].LastSeen) {
+			t.Errorf("rows not recency-ordered at %d: %v after %v",
+				i, dashboard.WarningGroups[i].LastSeen, dashboard.WarningGroups[i-1].LastSeen)
 		}
 	}
-	if selected[len(selected)-1].Reason != "Storm" {
-		t.Errorf("rows should stay in recency order with the storm last, got %v", reasons)
+	if last := dashboard.WarningGroups[6]; last.Reason != "StormReason" || last.Count != 400 {
+		t.Errorf("oldest row = %+v, want the storm group present with count 400", last)
 	}
 }
 

--- a/internal/mcp/dashboard_warnings_test.go
+++ b/internal/mcp/dashboard_warnings_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func warningEvent(name, reason, message string, count int32, last time.Time, objKind, objNS, objName string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: name, Namespace: objNS},
+		Reason:         reason,
+		Message:        message,
+		Type:           "Warning",
+		Count:          count,
+		LastTimestamp:  metav1.Time{Time: last},
+		InvolvedObject: corev1.ObjectReference{Kind: objKind, Namespace: objNS, Name: objName},
+	}
+}
+
+// topWarnings must order by recency (not lifetime count) and carry the facts
+// a consumer needs to judge each row: lastSeen and the involved objects. The
+// old count-first ordering promoted a long-stale high-count group over the
+// live incident, and the old shape gave no way to tell the two apart.
+func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
+	defer k8s.ResetTestState()
+
+	ns := "shop"
+	now := time.Now()
+
+	client := fake.NewSimpleClientset(
+		// Stale but noisy: a mount failure that stopped 2h ago, count 500.
+		warningEvent("ev-noisy", "FailedMount", "MountVolume.SetUp failed for volume data", 500, now.Add(-2*time.Hour), "Pod", ns, "legacy-worker-0"),
+		// Live incident: two pods of one workload, same normalized message,
+		// most recent occurrences.
+		warningEvent("ev-live-a", "BackOff", "Back-off restarting failed container in pod cart-5d4f7c9b8-aaaaa", 2, now.Add(-2*time.Minute), "Pod", ns, "cart-5d4f7c9b8-aaaaa"),
+		warningEvent("ev-live-b", "BackOff", "Back-off restarting failed container in pod cart-5d4f7c9b8-bbbbb", 1, now.Add(-1*time.Minute), "Pod", ns, "cart-5d4f7c9b8-bbbbb"),
+	)
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := k8s.GetResourceCache()
+
+	var dashboard mcpDashboard
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dashboard = buildDashboard(context.Background(), cache, ns, false, false)
+		if len(dashboard.TopWarnings) >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(dashboard.TopWarnings) < 2 {
+		t.Fatalf("topWarnings never populated: %+v", dashboard.TopWarnings)
+	}
+
+	live := dashboard.TopWarnings[0]
+	if live.Reason != "BackOff" {
+		t.Fatalf("topWarnings[0] = %+v, want the RECENT BackOff group first despite the stale group's higher count", dashboard.TopWarnings)
+	}
+	if live.Count != 3 {
+		t.Errorf("live count = %d, want 3 (aggregated across both pods)", live.Count)
+	}
+	if live.LastSeen.IsZero() || now.Sub(live.LastSeen) > 5*time.Minute {
+		t.Errorf("live lastSeen = %v, want ~1m ago", live.LastSeen)
+	}
+	if live.ObjectCount != 2 || len(live.Objects) != 2 {
+		t.Fatalf("live objects = %+v (count %d), want both pods", live.Objects, live.ObjectCount)
+	}
+	if live.Objects[0] != "Pod/shop/cart-5d4f7c9b8-bbbbb" {
+		t.Errorf("objects[0] = %q, want most-recent pod as Kind/namespace/name", live.Objects[0])
+	}
+
+	stale := dashboard.TopWarnings[1]
+	if stale.Reason != "FailedMount" {
+		t.Fatalf("topWarnings[1] = %+v, want the stale FailedMount group", stale)
+	}
+	if stale.LastSeen.IsZero() || now.Sub(stale.LastSeen) < time.Hour {
+		t.Errorf("stale lastSeen = %v — without an old lastSeen a consumer cannot tell this group is stale", stale.LastSeen)
+	}
+}

--- a/internal/mcp/dashboard_warnings_test.go
+++ b/internal/mcp/dashboard_warnings_test.go
@@ -87,6 +87,46 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 	}
 }
 
+// Row selection is a union: the newest groups must not evict an actively
+// repeating storm whose latest event record is merely minutes older than a
+// burst of one-off churn — and vice versa, a stale storm must not hide fresh
+// incidents (the batch7 failure). Six groups: five fresh one-offs (count 1)
+// plus a 4-minute-old storm (count 400). Recency-only would emit the five
+// one-offs; count-only would lead with the storm. The union keeps the three
+// newest AND the storm.
+func TestSelectTopWarningGroups_UnionKeepsStormAndFresh(t *testing.T) {
+	now := time.Now()
+	mk := func(reason string, count int, last time.Time) aicontext.DeduplicatedEventGroup {
+		return aicontext.DeduplicatedEventGroup{DeduplicatedEvent: aicontext.DeduplicatedEvent{
+			Reason: reason, Message: "m", Type: "Warning", Count: count, LastTimestamp: last,
+		}}
+	}
+	groups := []aicontext.DeduplicatedEventGroup{ // dedup order: most recent first
+		mk("Fresh1", 1, now.Add(-10*time.Second)),
+		mk("Fresh2", 1, now.Add(-20*time.Second)),
+		mk("Fresh3", 1, now.Add(-30*time.Second)),
+		mk("Fresh4", 1, now.Add(-40*time.Second)),
+		mk("Fresh5", 1, now.Add(-50*time.Second)),
+		mk("Storm", 400, now.Add(-4*time.Minute)),
+	}
+	selected := selectTopWarningGroups(groups, topWarningRecentSlots, topWarningRows)
+	if len(selected) != topWarningRows {
+		t.Fatalf("selected %d rows, want %d", len(selected), topWarningRows)
+	}
+	reasons := make(map[string]bool)
+	for _, g := range selected {
+		reasons[g.Reason] = true
+	}
+	for _, want := range []string{"Fresh1", "Fresh2", "Fresh3", "Storm"} {
+		if !reasons[want] {
+			t.Errorf("selection %v missing %s", reasons, want)
+		}
+	}
+	if selected[len(selected)-1].Reason != "Storm" {
+		t.Errorf("rows should stay in recency order with the storm last, got %v", reasons)
+	}
+}
+
 // The emitted object ref derives the API group from apiVersion so agents can
 // disambiguate colliding kinds when feeding it into get_resource.
 func TestWarningObjectFromRef_GroupDerivation(t *testing.T) {

--- a/internal/mcp/dashboard_warnings_test.go
+++ b/internal/mcp/dashboard_warnings_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 )
 
 func warningEvent(name, reason, message string, count int32, last time.Time, objKind, objNS, objName string) *corev1.Event {
@@ -73,8 +74,8 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 	if live.ObjectCount != 2 || len(live.Objects) != 2 {
 		t.Fatalf("live objects = %+v (count %d), want both pods", live.Objects, live.ObjectCount)
 	}
-	if live.Objects[0] != "Pod/shop/cart-5d4f7c9b8-bbbbb" {
-		t.Errorf("objects[0] = %q, want most-recent pod as Kind/namespace/name", live.Objects[0])
+	if want := (mcpWarningObject{Kind: "Pod", Namespace: "shop", Name: "cart-5d4f7c9b8-bbbbb"}); live.Objects[0] != want {
+		t.Errorf("objects[0] = %+v, want most-recent pod %+v", live.Objects[0], want)
 	}
 
 	stale := dashboard.TopWarnings[1]
@@ -83,5 +84,25 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 	}
 	if stale.LastSeen.IsZero() || now.Sub(stale.LastSeen) < time.Hour {
 		t.Errorf("stale lastSeen = %v — without an old lastSeen a consumer cannot tell this group is stale", stale.LastSeen)
+	}
+}
+
+// The emitted object ref derives the API group from apiVersion so agents can
+// disambiguate colliding kinds when feeding it into get_resource.
+func TestWarningObjectFromRef_GroupDerivation(t *testing.T) {
+	cases := []struct {
+		apiVersion string
+		wantGroup  string
+	}{
+		{"apps/v1", "apps"},
+		{"v1", ""},
+		{"", ""},
+		{"serving.knative.dev/v1", "serving.knative.dev"},
+	}
+	for _, tt := range cases {
+		got := warningObjectFromRef(aicontext.EventObjectRef{Kind: "Service", APIVersion: tt.apiVersion, Namespace: "ns", Name: "x"})
+		if got.Group != tt.wantGroup {
+			t.Errorf("apiVersion %q: group = %q, want %q", tt.apiVersion, got.Group, tt.wantGroup)
+		}
 	}
 }

--- a/internal/mcp/dashboard_warnings_test.go
+++ b/internal/mcp/dashboard_warnings_test.go
@@ -90,7 +90,9 @@ func TestBuildDashboard_TopWarnings_RecencyAndObjects(t *testing.T) {
 // Row selection is a union: the newest groups must not evict an actively
 // repeating storm whose latest event record is merely minutes older than a
 // burst of one-off churn — and vice versa, a stale storm must not hide fresh
-// incidents (the batch7 failure). Six groups: five fresh one-offs (count 1)
+// incidents (observed in benchmark transcripts, where a resolved storm
+// outranked the live incident under count-first ordering). Six groups:
+// five fresh one-offs (count 1)
 // plus a 4-minute-old storm (count 400). Recency-only would emit the five
 // one-offs; count-only would lead with the storm. The union keeps the three
 // newest AND the storm.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -62,9 +62,10 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 		Description: "Use for inventory-style cluster or namespace health triage, like " +
 			"`kubectl get all` plus detected problems and warning events in one call. " +
 			"Returns resource counts, failing pods, unhealthy workloads, Warning-event " +
-			"groups (topWarnings mixes the newest and highest-count groups; use each " +
-			"row's lastSeen for recency, and treat objects as a capped sample — " +
-			"objectCount/objectsTruncated show whether the group is broader), " +
+			"groups (warningGroups: up to 20, ordered by lastSeen descending; use " +
+			"lastSeen for liveness, count for cumulative occurrence volume, and " +
+			"objectCount for breadth — objects is a capped sample of up to 3 involved " +
+			"resources, objectsTruncated flags more), " +
 			"and Helm release status so you can rank likely suspects before " +
 			"calling get_resource or logs. Routing: unknown broken thing -> issues; " +
 			"content/name search -> search; service routing/dependencies -> get_topology " +
@@ -1939,7 +1940,7 @@ type mcpDashboard struct {
 	ProblemsBySeverity map[string]int         `json:"problemsBySeverity,omitempty"` // critical/high/medium/warning counts across the full set
 	RecentChanges      []mcpChange            `json:"recentChanges,omitempty"`
 	WarningEvents      int                    `json:"warningEvents"`
-	TopWarnings        []mcpWarning           `json:"topWarnings"`
+	WarningGroups      []mcpWarning           `json:"warningGroups"`
 	HelmReleases       mcpHelmSummary         `json:"helmReleases"`
 	Metrics            *mcpMetrics            `json:"metrics,omitempty"`
 	TopologyNodes      int                    `json:"topologyNodes"`
@@ -2041,52 +2042,11 @@ func countBySeverity(problems []mcpProblem) map[string]int {
 	return out
 }
 
-// topWarningObjectCap bounds involved-object refs per topWarnings row. The
+// warningObjectCap bounds involved-object refs per warningGroups row. The
 // grouping is systemic (reason + normalized message), so one row can span
 // many objects; three named subjects plus objectCount conveys both "who"
 // and "how widespread" without bloating the dashboard.
-const topWarningObjectCap = 3
-
-// topWarnings row selection: topWarningRecentSlots newest groups, remaining
-// rows filled by highest count among the rest of the dedup window.
-const (
-	topWarningRows        = 5
-	topWarningRecentSlots = 3
-)
-
-// selectTopWarningGroups picks up to total rows: the first recentSlots
-// groups in dedup (recency) order, then the highest-count remaining groups
-// (ties broken by recency order, which is itself deterministic). Emitted in
-// recency order.
-func selectTopWarningGroups(groups []aicontext.DeduplicatedEventGroup, recentSlots, total int) []aicontext.DeduplicatedEventGroup {
-	if len(groups) <= total {
-		return groups
-	}
-	picked := make(map[int]bool, total)
-	for i := 0; i < recentSlots; i++ {
-		picked[i] = true
-	}
-	rest := make([]int, 0, len(groups)-recentSlots)
-	for i := recentSlots; i < len(groups); i++ {
-		rest = append(rest, i)
-	}
-	sort.SliceStable(rest, func(a, b int) bool {
-		return groups[rest[a]].Count > groups[rest[b]].Count
-	})
-	for _, i := range rest {
-		if len(picked) >= total {
-			break
-		}
-		picked[i] = true
-	}
-	out := make([]aicontext.DeduplicatedEventGroup, 0, total)
-	for i := range groups {
-		if picked[i] {
-			out = append(out, groups[i])
-		}
-	}
-	return out
-}
+const warningObjectCap = 3
 
 type mcpWarning struct {
 	Reason  string `json:"reason"`
@@ -2096,14 +2056,14 @@ type mcpWarning struct {
 	// a consumer cannot tell a stale warning from a live one, and a
 	// long-resolved BackOff reads as current behavior.
 	LastSeen time.Time `json:"lastSeen"`
-	// Objects lists up to topWarningObjectCap distinct involved objects
+	// Objects lists up to warningObjectCap distinct involved objects
 	// (most recent first); ObjectCount is the uncapped distinct total.
 	Objects          []mcpWarningObject `json:"objects,omitempty"`
 	ObjectCount      int                `json:"objectCount,omitempty"`
 	ObjectsTruncated bool               `json:"objectsTruncated,omitempty"`
 }
 
-// mcpWarningObject is one involved object behind a topWarnings row, shaped
+// mcpWarningObject is one involved object behind a warningGroups row, shaped
 // to feed straight into get_resource/diagnose (kind + group + namespace +
 // name). Group is included because bare kinds collide (core Service vs
 // Knative Service); empty means the core API group — or unknown, when no
@@ -2399,18 +2359,17 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		// Deduplicate keeping involved objects. Dedup returns groups
 		// most-recent first with deterministic tie-breakers (recency,
 		// count, reason, message, type — applied before its group cap).
-		deduplicated := aicontext.DeduplicateEventsWithObjects(warningValues, topWarningObjectCap)
-
-		// Row selection is a bounded union of both signals: the newest
-		// groups ("what just happened") plus the highest-count groups
-		// among the recent ones ("what keeps happening"). Pure count-first
-		// let a long-stale noisy group hide a live incident; pure
-		// recency-first lets a burst of one-off deploy churn hide an
-		// actively repeating storm whose last event record is minutes old.
-		// The union keeps both without a brittle time threshold; rows are
-		// emitted in recency order regardless of which rule selected them.
-		selected := selectTopWarningGroups(deduplicated, topWarningRecentSlots, topWarningRows)
-		for _, e := range selected {
+		//
+		// Emit the FULL dedup window — no row selection. Any pick-N-of-20
+		// heuristic pre-judges what the consumer needs and creates
+		// unrecoverable omissions (an agent can underweight a returned
+		// row; it cannot recover an absent one); lastSeen makes stale
+		// rows self-labeling, so extra rows are skimmable rather than
+		// misleading. Row count is bounded by the dedup helper's 20-group
+		// window (maxDeduplicatedEvents) — if that cap is ever raised for
+		// other consumers, give the dashboard its own cap here.
+		deduplicated := aicontext.DeduplicateEventsWithObjects(warningValues, warningObjectCap)
+		for _, e := range deduplicated {
 			w := mcpWarning{
 				Reason:           e.Reason,
 				Message:          k8s.Truncate(e.Message, 200),
@@ -2422,7 +2381,7 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 			for _, o := range e.Objects {
 				w.Objects = append(w.Objects, warningObjectFromRef(o))
 			}
-			d.TopWarnings = append(d.TopWarnings, w)
+			d.WarningGroups = append(d.WarningGroups, w)
 		}
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -62,7 +62,9 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 		Description: "Use for inventory-style cluster or namespace health triage, like " +
 			"`kubectl get all` plus detected problems and warning events in one call. " +
 			"Returns resource counts, failing pods, unhealthy workloads, recent Warning " +
-			"events, and Helm release status so you can rank likely suspects before " +
+			"events (topWarnings, most-recent first — each row carries lastSeen and the " +
+			"involved objects, so check lastSeen before treating a warning as live), " +
+			"and Helm release status so you can rank likely suspects before " +
 			"calling get_resource or logs. Routing: unknown broken thing -> issues; " +
 			"content/name search -> search; service routing/dependencies -> get_topology " +
 			"or get_neighborhood; inventory/counts/Helm/events overview -> get_dashboard. " +
@@ -2038,10 +2040,36 @@ func countBySeverity(problems []mcpProblem) map[string]int {
 	return out
 }
 
+// topWarningObjectCap bounds involved-object refs per topWarnings row. The
+// grouping is systemic (reason + normalized message), so one row can span
+// many objects; three named subjects plus objectCount conveys both "who"
+// and "how widespread" without bloating the dashboard.
+const topWarningObjectCap = 3
+
 type mcpWarning struct {
 	Reason  string `json:"reason"`
 	Message string `json:"message"`
 	Count   int    `json:"count"`
+	// LastSeen is the most recent occurrence across the group — without it
+	// a consumer cannot tell a stale warning from a live one, and a
+	// long-resolved BackOff reads as current behavior.
+	LastSeen time.Time `json:"lastSeen"`
+	// Objects lists up to topWarningObjectCap distinct involved objects
+	// (most recent first) as Kind/namespace/name; ObjectCount is the
+	// uncapped distinct total.
+	Objects          []string `json:"objects,omitempty"`
+	ObjectCount      int      `json:"objectCount,omitempty"`
+	ObjectsTruncated bool     `json:"objectsTruncated,omitempty"`
+}
+
+// formatEventObjectRef renders an involved object as Kind/namespace/name
+// (Kind/name for cluster-scoped objects) — the same compact ref shape agents
+// can feed straight into get_resource/diagnose.
+func formatEventObjectRef(ref aicontext.EventObjectRef) string {
+	if ref.Namespace == "" {
+		return ref.Kind + "/" + ref.Name
+	}
+	return ref.Kind + "/" + ref.Namespace + "/" + ref.Name
 }
 
 type mcpHelmSummary struct {
@@ -2314,19 +2342,28 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		}
 		d.WarningEvents = len(warningValues)
 
-		// Deduplicate and sort by count descending to surface systemic issues
-		deduplicated := aicontext.DeduplicateEvents(warningValues)
-		sort.Slice(deduplicated, func(i, j int) bool {
-			return deduplicated[i].Count > deduplicated[j].Count
-		})
+		// Deduplicate keeping involved objects. Rows arrive most-recent
+		// first with deterministic tie-breakers (recency, count, reason,
+		// message — applied inside dedup, before its group cap): a triage
+		// dashboard answers "what's happening now", and the old count-first
+		// ordering promoted stale noisy groups over the live incident.
+		// Count still rides along to convey chronicity.
+		deduplicated := aicontext.DeduplicateEventsWithObjects(warningValues, topWarningObjectCap)
 
 		limit := min(len(deduplicated), 5)
 		for _, e := range deduplicated[:limit] {
-			d.TopWarnings = append(d.TopWarnings, mcpWarning{
-				Reason:  e.Reason,
-				Message: k8s.Truncate(e.Message, 200),
-				Count:   e.Count,
-			})
+			w := mcpWarning{
+				Reason:           e.Reason,
+				Message:          k8s.Truncate(e.Message, 200),
+				Count:            e.Count,
+				LastSeen:         e.LastTimestamp,
+				ObjectCount:      e.ObjectCount,
+				ObjectsTruncated: e.ObjectsTruncated,
+			}
+			for _, o := range e.Objects {
+				w.Objects = append(w.Objects, formatEventObjectRef(o))
+			}
+			d.TopWarnings = append(d.TopWarnings, w)
 		}
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2075,11 +2075,12 @@ type mcpWarningObject struct {
 // warningObjectFromRef converts an event's involved-object ref, deriving the
 // API group from apiVersion ("apps/v1" → "apps"; "v1" → core/empty).
 func warningObjectFromRef(ref aicontext.EventObjectRef) mcpWarningObject {
-	group := ""
-	if idx := strings.IndexByte(ref.APIVersion, '/'); idx > 0 {
-		group = ref.APIVersion[:idx]
+	return mcpWarningObject{
+		Kind:      ref.Kind,
+		Group:     aicontext.GroupOfAPIVersion(ref.APIVersion),
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
 	}
-	return mcpWarningObject{Kind: ref.Kind, Group: group, Namespace: ref.Namespace, Name: ref.Name}
 }
 
 type mcpHelmSummary struct {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2055,21 +2055,31 @@ type mcpWarning struct {
 	// long-resolved BackOff reads as current behavior.
 	LastSeen time.Time `json:"lastSeen"`
 	// Objects lists up to topWarningObjectCap distinct involved objects
-	// (most recent first) as Kind/namespace/name; ObjectCount is the
-	// uncapped distinct total.
-	Objects          []string `json:"objects,omitempty"`
-	ObjectCount      int      `json:"objectCount,omitempty"`
-	ObjectsTruncated bool     `json:"objectsTruncated,omitempty"`
+	// (most recent first); ObjectCount is the uncapped distinct total.
+	Objects          []mcpWarningObject `json:"objects,omitempty"`
+	ObjectCount      int                `json:"objectCount,omitempty"`
+	ObjectsTruncated bool               `json:"objectsTruncated,omitempty"`
 }
 
-// formatEventObjectRef renders an involved object as Kind/namespace/name
-// (Kind/name for cluster-scoped objects) — the same compact ref shape agents
-// can feed straight into get_resource/diagnose.
-func formatEventObjectRef(ref aicontext.EventObjectRef) string {
-	if ref.Namespace == "" {
-		return ref.Kind + "/" + ref.Name
+// mcpWarningObject is one involved object behind a topWarnings row, shaped
+// to feed straight into get_resource/diagnose (kind + group + namespace +
+// name). Group is included because bare kinds collide (core Service vs
+// Knative Service); empty means the core API group.
+type mcpWarningObject struct {
+	Kind      string `json:"kind"`
+	Group     string `json:"group,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+// warningObjectFromRef converts an event's involved-object ref, deriving the
+// API group from apiVersion ("apps/v1" → "apps"; "v1" → core/empty).
+func warningObjectFromRef(ref aicontext.EventObjectRef) mcpWarningObject {
+	group := ""
+	if idx := strings.IndexByte(ref.APIVersion, '/'); idx > 0 {
+		group = ref.APIVersion[:idx]
 	}
-	return ref.Kind + "/" + ref.Namespace + "/" + ref.Name
+	return mcpWarningObject{Kind: ref.Kind, Group: group, Namespace: ref.Namespace, Name: ref.Name}
 }
 
 type mcpHelmSummary struct {
@@ -2361,7 +2371,7 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 				ObjectsTruncated: e.ObjectsTruncated,
 			}
 			for _, o := range e.Objects {
-				w.Objects = append(w.Objects, formatEventObjectRef(o))
+				w.Objects = append(w.Objects, warningObjectFromRef(o))
 			}
 			d.TopWarnings = append(d.TopWarnings, w)
 		}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2046,6 +2046,47 @@ func countBySeverity(problems []mcpProblem) map[string]int {
 // and "how widespread" without bloating the dashboard.
 const topWarningObjectCap = 3
 
+// topWarnings row selection: topWarningRecentSlots newest groups, remaining
+// rows filled by highest count among the rest of the dedup window.
+const (
+	topWarningRows        = 5
+	topWarningRecentSlots = 3
+)
+
+// selectTopWarningGroups picks up to total rows: the first recentSlots
+// groups in dedup (recency) order, then the highest-count remaining groups
+// (ties broken by recency order, which is itself deterministic). Emitted in
+// recency order.
+func selectTopWarningGroups(groups []aicontext.DeduplicatedEventGroup, recentSlots, total int) []aicontext.DeduplicatedEventGroup {
+	if len(groups) <= total {
+		return groups
+	}
+	picked := make(map[int]bool, total)
+	for i := 0; i < recentSlots; i++ {
+		picked[i] = true
+	}
+	rest := make([]int, 0, len(groups)-recentSlots)
+	for i := recentSlots; i < len(groups); i++ {
+		rest = append(rest, i)
+	}
+	sort.SliceStable(rest, func(a, b int) bool {
+		return groups[rest[a]].Count > groups[rest[b]].Count
+	})
+	for _, i := range rest {
+		if len(picked) >= total {
+			break
+		}
+		picked[i] = true
+	}
+	out := make([]aicontext.DeduplicatedEventGroup, 0, total)
+	for i := range groups {
+		if picked[i] {
+			out = append(out, groups[i])
+		}
+	}
+	return out
+}
+
 type mcpWarning struct {
 	Reason  string `json:"reason"`
 	Message string `json:"message"`
@@ -2064,7 +2105,8 @@ type mcpWarning struct {
 // mcpWarningObject is one involved object behind a topWarnings row, shaped
 // to feed straight into get_resource/diagnose (kind + group + namespace +
 // name). Group is included because bare kinds collide (core Service vs
-// Knative Service); empty means the core API group.
+// Knative Service); empty means the core API group — or unknown, when no
+// sighting of the object carried an apiVersion.
 type mcpWarningObject struct {
 	Kind      string `json:"kind"`
 	Group     string `json:"group,omitempty"`
@@ -2353,16 +2395,21 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		}
 		d.WarningEvents = len(warningValues)
 
-		// Deduplicate keeping involved objects. Rows arrive most-recent
-		// first with deterministic tie-breakers (recency, count, reason,
-		// message — applied inside dedup, before its group cap): a triage
-		// dashboard answers "what's happening now", and the old count-first
-		// ordering promoted stale noisy groups over the live incident.
-		// Count still rides along to convey chronicity.
+		// Deduplicate keeping involved objects. Dedup returns groups
+		// most-recent first with deterministic tie-breakers (recency,
+		// count, reason, message, type — applied before its group cap).
 		deduplicated := aicontext.DeduplicateEventsWithObjects(warningValues, topWarningObjectCap)
 
-		limit := min(len(deduplicated), 5)
-		for _, e := range deduplicated[:limit] {
+		// Row selection is a bounded union of both signals: the newest
+		// groups ("what just happened") plus the highest-count groups
+		// among the recent ones ("what keeps happening"). Pure count-first
+		// let a long-stale noisy group hide a live incident; pure
+		// recency-first lets a burst of one-off deploy churn hide an
+		// actively repeating storm whose last event record is minutes old.
+		// The union keeps both without a brittle time threshold; rows are
+		// emitted in recency order regardless of which rule selected them.
+		selected := selectTopWarningGroups(deduplicated, topWarningRecentSlots, topWarningRows)
+		for _, e := range selected {
 			w := mcpWarning{
 				Reason:           e.Reason,
 				Message:          k8s.Truncate(e.Message, 200),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -62,8 +62,9 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 		Description: "Use for inventory-style cluster or namespace health triage, like " +
 			"`kubectl get all` plus detected problems and warning events in one call. " +
 			"Returns resource counts, failing pods, unhealthy workloads, recent Warning " +
-			"events (topWarnings, most-recent first — each row carries lastSeen and the " +
-			"involved objects, so check lastSeen before treating a warning as live), " +
+			"events (topWarnings mixes the newest and most-frequent recent warning " +
+			"groups; check each row's lastSeen before treating it as live — objects " +
+			"lists the affected resources), " +
 			"and Helm release status so you can rank likely suspects before " +
 			"calling get_resource or logs. Routing: unknown broken thing -> issues; " +
 			"content/name search -> search; service routing/dependencies -> get_topology " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -61,10 +61,10 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 		Name: "get_dashboard",
 		Description: "Use for inventory-style cluster or namespace health triage, like " +
 			"`kubectl get all` plus detected problems and warning events in one call. " +
-			"Returns resource counts, failing pods, unhealthy workloads, recent Warning " +
-			"events (topWarnings mixes the newest and most-frequent recent warning " +
-			"groups; check each row's lastSeen before treating it as live — objects " +
-			"lists the affected resources), " +
+			"Returns resource counts, failing pods, unhealthy workloads, Warning-event " +
+			"groups (topWarnings mixes the newest and highest-count groups; use each " +
+			"row's lastSeen for recency, and treat objects as a capped sample — " +
+			"objectCount/objectsTruncated show whether the group is broader), " +
 			"and Helm release status so you can rank likely suspects before " +
 			"calling get_resource or logs. Routing: unknown broken thing -> issues; " +
 			"content/name search -> search; service routing/dependencies -> get_topology " +

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -56,11 +56,14 @@ type eventKey struct {
 }
 
 // EventObjectRef identifies one involved object that contributed to a
-// deduplicated event group.
+// deduplicated event group. APIVersion is carried so consumers can
+// disambiguate colliding kinds (core Service vs Knative Service) when
+// feeding the ref into resource lookups.
 type EventObjectRef struct {
-	Kind      string `json:"kind"`
-	Namespace string `json:"namespace,omitempty"`
-	Name      string `json:"name"`
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
 }
 
 // DeduplicatedEventGroup is a DeduplicatedEvent plus the distinct involved
@@ -142,11 +145,15 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 			order = append(order, key)
 		}
 
-		if objectCap > 0 && (ev.InvolvedObject.Kind != "" || ev.InvolvedObject.Name != "") {
+		// Both kind AND name required — legacy Event validation doesn't
+		// reliably enforce either, and a partial ref ("Pod/shop/" or
+		// "/shop/foo") is not a usable identity.
+		if objectCap > 0 && ev.InvolvedObject.Kind != "" && ev.InvolvedObject.Name != "" {
 			ref := EventObjectRef{
-				Kind:      ev.InvolvedObject.Kind,
-				Namespace: ev.InvolvedObject.Namespace,
-				Name:      ev.InvolvedObject.Name,
+				Kind:       ev.InvolvedObject.Kind,
+				APIVersion: ev.InvolvedObject.APIVersion,
+				Namespace:  ev.InvolvedObject.Namespace,
+				Name:       ev.InvolvedObject.Name,
 			}
 			seen := objects[key]
 			if seen == nil {
@@ -170,7 +177,9 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 
 	// Most recent first, with full deterministic tie-breakers BEFORE the
 	// cap — otherwise which equal-timestamp groups survive the cut depends
-	// on informer map iteration order.
+	// on informer map iteration order. Type is a comparator key because it
+	// is a grouping key: Normal and Warning groups can tie on everything
+	// else.
 	sort.Slice(result, func(i, j int) bool {
 		a, b := result[i], result[j]
 		if !a.LastTimestamp.Equal(b.LastTimestamp) {
@@ -182,7 +191,10 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 		if a.Reason != b.Reason {
 			return a.Reason < b.Reason
 		}
-		return a.Message < b.Message
+		if a.Message != b.Message {
+			return a.Message < b.Message
+		}
+		return a.Type < b.Type
 	})
 
 	if len(result) > maxDeduplicatedEvents {
@@ -215,7 +227,10 @@ func selectGroupObjects(seen map[EventObjectRef]time.Time, limit int) ([]EventOb
 		if a.Namespace != b.Namespace {
 			return a.Namespace < b.Namespace
 		}
-		return a.Name < b.Name
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.APIVersion < b.APIVersion
 	})
 	total := len(refs)
 	if total > limit {

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -55,14 +55,61 @@ type eventKey struct {
 	Type              string
 }
 
+// EventObjectRef identifies one involved object that contributed to a
+// deduplicated event group.
+type EventObjectRef struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+// DeduplicatedEventGroup is a DeduplicatedEvent plus the distinct involved
+// objects behind it. Produced only by DeduplicateEventsWithObjects — the
+// systemic grouping key stays (Reason, normalizedMessage, Type), so one
+// group can span several objects; Objects makes that visible instead of
+// leaving an aggregated Count with no subject.
+type DeduplicatedEventGroup struct {
+	DeduplicatedEvent
+	// Objects lists distinct involved objects, most recent contribution
+	// first (ties broken by kind/namespace/name), capped by the caller;
+	// ObjectCount is the uncapped distinct total.
+	Objects          []EventObjectRef `json:"objects,omitempty"`
+	ObjectCount      int              `json:"objectCount,omitempty"`
+	ObjectsTruncated bool             `json:"objectsTruncated,omitempty"`
+}
+
 // DeduplicateEvents groups similar K8s events by (Reason, normalizedMessage),
 // collapses repeats with counts, sorts by last timestamp descending, and caps at 20.
 func DeduplicateEvents(events []corev1.Event) []DeduplicatedEvent {
+	groups := deduplicateEventGroups(events, 0)
+	if len(groups) == 0 {
+		return nil
+	}
+	result := make([]DeduplicatedEvent, len(groups))
+	for i := range groups {
+		result[i] = groups[i].DeduplicatedEvent
+	}
+	return result
+}
+
+// DeduplicateEventsWithObjects is DeduplicateEvents plus per-group involved
+// objects, for surfaces (like the dashboard) where an aggregated count
+// without a subject would be misleading. objectCap bounds Objects per group;
+// ObjectCount always carries the uncapped distinct total.
+func DeduplicateEventsWithObjects(events []corev1.Event, objectCap int) []DeduplicatedEventGroup {
+	if objectCap <= 0 {
+		objectCap = 1
+	}
+	return deduplicateEventGroups(events, objectCap)
+}
+
+func deduplicateEventGroups(events []corev1.Event, objectCap int) []DeduplicatedEventGroup {
 	if len(events) == 0 {
 		return nil
 	}
 
-	groups := make(map[eventKey]*DeduplicatedEvent)
+	groups := make(map[eventKey]*DeduplicatedEventGroup)
+	objects := make(map[eventKey]map[EventObjectRef]time.Time)
 	order := make([]eventKey, 0)
 
 	for i := range events {
@@ -74,34 +121,68 @@ func DeduplicateEvents(events []corev1.Event) []DeduplicatedEvent {
 		}
 
 		last := eventLastTimestamp(ev)
-		evCount := max(int(ev.Count), 1)
+		evCount := eventOccurrenceCount(ev)
 
 		if existing, ok := groups[key]; ok {
 			existing.Count += evCount
 			if last.After(existing.LastTimestamp) {
 				existing.LastTimestamp = last
 				existing.Message = ev.Message // keep the most recent actual message
+			} else if last.Equal(existing.LastTimestamp) && ev.Message < existing.Message {
+				existing.Message = ev.Message // deterministic representative on exact ties
 			}
 		} else {
-			groups[key] = &DeduplicatedEvent{
+			groups[key] = &DeduplicatedEventGroup{DeduplicatedEvent: DeduplicatedEvent{
 				Reason:        ev.Reason,
 				Message:       ev.Message,
 				Type:          ev.Type,
 				Count:         evCount,
 				LastTimestamp: last,
-			}
+			}}
 			order = append(order, key)
+		}
+
+		if objectCap > 0 && (ev.InvolvedObject.Kind != "" || ev.InvolvedObject.Name != "") {
+			ref := EventObjectRef{
+				Kind:      ev.InvolvedObject.Kind,
+				Namespace: ev.InvolvedObject.Namespace,
+				Name:      ev.InvolvedObject.Name,
+			}
+			seen := objects[key]
+			if seen == nil {
+				seen = make(map[EventObjectRef]time.Time)
+				objects[key] = seen
+			}
+			if prev, ok := seen[ref]; !ok || last.After(prev) {
+				seen[ref] = last
+			}
 		}
 	}
 
-	result := make([]DeduplicatedEvent, 0, len(groups))
+	result := make([]DeduplicatedEventGroup, 0, len(groups))
 	for _, key := range order {
-		result = append(result, *groups[key])
+		g := *groups[key]
+		if objectCap > 0 {
+			g.Objects, g.ObjectCount, g.ObjectsTruncated = selectGroupObjects(objects[key], objectCap)
+		}
+		result = append(result, g)
 	}
 
-	// Sort by last timestamp descending (most recent first)
+	// Most recent first, with full deterministic tie-breakers BEFORE the
+	// cap — otherwise which equal-timestamp groups survive the cut depends
+	// on informer map iteration order.
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].LastTimestamp.After(result[j].LastTimestamp)
+		a, b := result[i], result[j]
+		if !a.LastTimestamp.Equal(b.LastTimestamp) {
+			return a.LastTimestamp.After(b.LastTimestamp)
+		}
+		if a.Count != b.Count {
+			return a.Count > b.Count
+		}
+		if a.Reason != b.Reason {
+			return a.Reason < b.Reason
+		}
+		return a.Message < b.Message
 	})
 
 	if len(result) > maxDeduplicatedEvents {
@@ -109,6 +190,38 @@ func DeduplicateEvents(events []corev1.Event) []DeduplicatedEvent {
 	}
 
 	return result
+}
+
+// selectGroupObjects orders a group's distinct involved objects by most
+// recent contribution (ties broken by kind/namespace/name for determinism)
+// and caps the emitted list, counting distinct identities before the cap.
+func selectGroupObjects(seen map[EventObjectRef]time.Time, limit int) ([]EventObjectRef, int, bool) {
+	if len(seen) == 0 {
+		return nil, 0, false
+	}
+	refs := make([]EventObjectRef, 0, len(seen))
+	for ref := range seen {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		a, b := refs[i], refs[j]
+		at, bt := seen[a], seen[b]
+		if !at.Equal(bt) {
+			return at.After(bt)
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		return a.Name < b.Name
+	})
+	total := len(refs)
+	if total > limit {
+		return refs[:limit], total, true
+	}
+	return refs, total, false
 }
 
 // FormatEvents renders deduplicated events as a string for LLM context.
@@ -125,6 +238,13 @@ func FormatEvents(events []DeduplicatedEvent) string {
 }
 
 func eventLastTimestamp(ev *corev1.Event) time.Time {
+	// Series-style events (events.k8s.io emitters mirrored into core/v1)
+	// carry their latest occurrence in Series.LastObservedTime — legacy
+	// LastTimestamp stays zero and EventTime is the FIRST occurrence, so
+	// without this an actively repeating warning reads as stale.
+	if ev.Series != nil && !ev.Series.LastObservedTime.IsZero() {
+		return ev.Series.LastObservedTime.Time
+	}
 	if !ev.LastTimestamp.IsZero() {
 		return ev.LastTimestamp.Time
 	}
@@ -132,4 +252,13 @@ func eventLastTimestamp(ev *corev1.Event) time.Time {
 		return ev.CreationTimestamp.Time
 	}
 	return ev.EventTime.Time
+}
+
+// eventOccurrenceCount reads the aggregate occurrence count: series-style
+// events carry it in Series.Count (legacy Count stays zero for them).
+func eventOccurrenceCount(ev *corev1.Event) int {
+	if ev.Series != nil && ev.Series.Count > 0 {
+		return int(ev.Series.Count)
+	}
+	return max(int(ev.Count), 1)
 }

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -262,12 +262,35 @@ func GroupOfAPIVersion(apiVersion string) string {
 // selectGroupObjects orders a group's distinct involved objects by most
 // recent contribution (ties broken by kind/namespace/name for determinism)
 // and caps the emitted list, counting distinct identities before the cap.
+// Distinct means distinct EMITTED identity (kind/group/namespace/name):
+// UID keying during collection can hold several incarnations of one name
+// (a StatefulSet pod deleted and recreated while old events linger), and
+// for a lookup-oriented surface those are one subject, not duplicates.
 func selectGroupObjects(seen map[eventObjectIdentity]objectSighting, limit int) ([]EventObjectRef, int, bool) {
 	if len(seen) == 0 {
 		return nil, 0, false
 	}
-	sightings := make([]objectSighting, 0, len(seen))
+	merged := make(map[eventObjectIdentity]objectSighting, len(seen))
 	for _, s := range seen {
+		id := eventObjectIdentity{
+			Kind:      s.Ref.Kind,
+			Group:     GroupOfAPIVersion(s.Ref.APIVersion),
+			Namespace: s.Ref.Namespace,
+			Name:      s.Ref.Name,
+		}
+		prev, existed := merged[id]
+		if !existed || s.Last.After(prev.Last) {
+			if existed && s.Ref.APIVersion == "" && prev.Ref.APIVersion != "" {
+				s.Ref.APIVersion = prev.Ref.APIVersion
+			}
+			merged[id] = s
+		} else if prev.Ref.APIVersion == "" && s.Ref.APIVersion != "" {
+			prev.Ref.APIVersion = s.Ref.APIVersion
+			merged[id] = prev
+		}
+	}
+	sightings := make([]objectSighting, 0, len(merged))
+	for _, s := range merged {
 		sightings = append(sightings, s)
 	}
 	// Sort by the emitted ref, not the identity key — UID-keyed identities

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -112,7 +112,7 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 	}
 
 	groups := make(map[eventKey]*DeduplicatedEventGroup)
-	objects := make(map[eventKey]map[EventObjectRef]time.Time)
+	objects := make(map[eventKey]map[eventObjectIdentity]objectSighting)
 	order := make([]eventKey, 0)
 
 	for i := range events {
@@ -155,13 +155,24 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 				Namespace:  ev.InvolvedObject.Namespace,
 				Name:       ev.InvolvedObject.Name,
 			}
+			// Identity keys on the API GROUP, not the raw apiVersion:
+			// emitters are inconsistent about populating involvedObject
+			// apiVersion ("" vs "v1" vs "apps/v1"), and version-within-group
+			// never distinguishes objects — keying on the raw string would
+			// double-count one object seen through two emitters.
+			id := eventObjectIdentity{
+				Kind:      ref.Kind,
+				Group:     GroupOfAPIVersion(ref.APIVersion),
+				Namespace: ref.Namespace,
+				Name:      ref.Name,
+			}
 			seen := objects[key]
 			if seen == nil {
-				seen = make(map[EventObjectRef]time.Time)
+				seen = make(map[eventObjectIdentity]objectSighting)
 				objects[key] = seen
 			}
-			if prev, ok := seen[ref]; !ok || last.After(prev) {
-				seen[ref] = last
+			if prev, ok := seen[id]; !ok || last.After(prev.Last) {
+				seen[id] = objectSighting{Ref: ref, Last: last}
 			}
 		}
 	}
@@ -204,20 +215,46 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 	return result
 }
 
+// eventObjectIdentity is the dedup key for involved objects: kind + API
+// group + namespace + name. Version-within-group is deliberately excluded —
+// it never distinguishes objects, and emitters populate apiVersion
+// inconsistently.
+type eventObjectIdentity struct {
+	Kind      string
+	Group     string
+	Namespace string
+	Name      string
+}
+
+// objectSighting keeps the most recent full ref observed for one identity.
+type objectSighting struct {
+	Ref  EventObjectRef
+	Last time.Time
+}
+
+// GroupOfAPIVersion returns the API group portion of an apiVersion string
+// ("apps/v1" → "apps"; "v1" or "" → "" for the core group).
+func GroupOfAPIVersion(apiVersion string) string {
+	if idx := strings.IndexByte(apiVersion, '/'); idx > 0 {
+		return apiVersion[:idx]
+	}
+	return ""
+}
+
 // selectGroupObjects orders a group's distinct involved objects by most
 // recent contribution (ties broken by kind/namespace/name for determinism)
 // and caps the emitted list, counting distinct identities before the cap.
-func selectGroupObjects(seen map[EventObjectRef]time.Time, limit int) ([]EventObjectRef, int, bool) {
+func selectGroupObjects(seen map[eventObjectIdentity]objectSighting, limit int) ([]EventObjectRef, int, bool) {
 	if len(seen) == 0 {
 		return nil, 0, false
 	}
-	refs := make([]EventObjectRef, 0, len(seen))
-	for ref := range seen {
-		refs = append(refs, ref)
+	ids := make([]eventObjectIdentity, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
 	}
-	sort.Slice(refs, func(i, j int) bool {
-		a, b := refs[i], refs[j]
-		at, bt := seen[a], seen[b]
+	sort.Slice(ids, func(i, j int) bool {
+		a, b := ids[i], ids[j]
+		at, bt := seen[a].Last, seen[b].Last
 		if !at.Equal(bt) {
 			return at.After(bt)
 		}
@@ -230,13 +267,18 @@ func selectGroupObjects(seen map[EventObjectRef]time.Time, limit int) ([]EventOb
 		if a.Name != b.Name {
 			return a.Name < b.Name
 		}
-		return a.APIVersion < b.APIVersion
+		return a.Group < b.Group
 	})
-	total := len(refs)
-	if total > limit {
-		return refs[:limit], total, true
+	total := len(ids)
+	truncated := total > limit
+	if truncated {
+		ids = ids[:limit]
 	}
-	return refs, total, false
+	refs := make([]EventObjectRef, len(ids))
+	for i, id := range ids {
+		refs[i] = seen[id].Ref
+	}
+	return refs, total, truncated
 }
 
 // FormatEvents renders deduplicated events as a string for LLM context.

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -155,24 +155,24 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 				Namespace:  ev.InvolvedObject.Namespace,
 				Name:       ev.InvolvedObject.Name,
 			}
-			// Identity keys on the API GROUP, not the raw apiVersion:
-			// emitters are inconsistent about populating involvedObject
-			// apiVersion ("" vs "v1" vs "apps/v1"), and version-within-group
-			// never distinguishes objects — keying on the raw string would
-			// double-count one object seen through two emitters.
-			id := eventObjectIdentity{
-				Kind:      ref.Kind,
-				Group:     GroupOfAPIVersion(ref.APIVersion),
-				Namespace: ref.Namespace,
-				Name:      ref.Name,
-			}
+			id := identityForInvolvedObject(&ev.InvolvedObject)
 			seen := objects[key]
 			if seen == nil {
 				seen = make(map[eventObjectIdentity]objectSighting)
 				objects[key] = seen
 			}
-			if prev, ok := seen[id]; !ok || last.After(prev.Last) {
+			prev, existed := seen[id]
+			if !existed || last.After(prev.Last) {
+				// Carry a known apiVersion across sightings — emitters are
+				// inconsistent about populating it, and losing it would
+				// mislabel the object's API group downstream.
+				if existed && ref.APIVersion == "" && prev.Ref.APIVersion != "" {
+					ref.APIVersion = prev.Ref.APIVersion
+				}
 				seen[id] = objectSighting{Ref: ref, Last: last}
+			} else if existed && prev.Ref.APIVersion == "" && ref.APIVersion != "" {
+				prev.Ref.APIVersion = ref.APIVersion
+				seen[id] = prev
 			}
 		}
 	}
@@ -215,15 +215,33 @@ func deduplicateEventGroups(events []corev1.Event, objectCap int) []Deduplicated
 	return result
 }
 
-// eventObjectIdentity is the dedup key for involved objects: kind + API
+// eventObjectIdentity is the dedup key for involved objects. UID is the
+// primary identity when the emitter populated it; otherwise kind + API
 // group + namespace + name. Version-within-group is deliberately excluded —
 // it never distinguishes objects, and emitters populate apiVersion
-// inconsistently.
+// inconsistently (which also means the group fallback can split one
+// non-core object seen with and without apiVersion; UID avoids that
+// whenever it is available).
 type eventObjectIdentity struct {
+	UID       string
 	Kind      string
 	Group     string
 	Namespace string
 	Name      string
+}
+
+// identityForInvolvedObject builds the dedup key: UID alone when present,
+// else the kind/group/namespace/name fallback.
+func identityForInvolvedObject(obj *corev1.ObjectReference) eventObjectIdentity {
+	if obj.UID != "" {
+		return eventObjectIdentity{UID: string(obj.UID)}
+	}
+	return eventObjectIdentity{
+		Kind:      obj.Kind,
+		Group:     GroupOfAPIVersion(obj.APIVersion),
+		Namespace: obj.Namespace,
+		Name:      obj.Name,
+	}
 }
 
 // objectSighting keeps the most recent full ref observed for one identity.
@@ -248,35 +266,36 @@ func selectGroupObjects(seen map[eventObjectIdentity]objectSighting, limit int) 
 	if len(seen) == 0 {
 		return nil, 0, false
 	}
-	ids := make([]eventObjectIdentity, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
+	sightings := make([]objectSighting, 0, len(seen))
+	for _, s := range seen {
+		sightings = append(sightings, s)
 	}
-	sort.Slice(ids, func(i, j int) bool {
-		a, b := ids[i], ids[j]
-		at, bt := seen[a].Last, seen[b].Last
-		if !at.Equal(bt) {
-			return at.After(bt)
+	// Sort by the emitted ref, not the identity key — UID-keyed identities
+	// carry no name fields.
+	sort.Slice(sightings, func(i, j int) bool {
+		a, b := sightings[i], sightings[j]
+		if !a.Last.Equal(b.Last) {
+			return a.Last.After(b.Last)
 		}
-		if a.Kind != b.Kind {
-			return a.Kind < b.Kind
+		if a.Ref.Kind != b.Ref.Kind {
+			return a.Ref.Kind < b.Ref.Kind
 		}
-		if a.Namespace != b.Namespace {
-			return a.Namespace < b.Namespace
+		if a.Ref.Namespace != b.Ref.Namespace {
+			return a.Ref.Namespace < b.Ref.Namespace
 		}
-		if a.Name != b.Name {
-			return a.Name < b.Name
+		if a.Ref.Name != b.Ref.Name {
+			return a.Ref.Name < b.Ref.Name
 		}
-		return a.Group < b.Group
+		return a.Ref.APIVersion < b.Ref.APIVersion
 	})
-	total := len(ids)
+	total := len(sightings)
 	truncated := total > limit
 	if truncated {
-		ids = ids[:limit]
+		sightings = sightings[:limit]
 	}
-	refs := make([]EventObjectRef, len(ids))
-	for i, id := range ids {
-		refs[i] = seen[id].Ref
+	refs := make([]EventObjectRef, len(sightings))
+	for i, s := range sightings {
+		refs[i] = s.Ref
 	}
 	return refs, total, truncated
 }

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -236,6 +236,31 @@ func TestDeduplicateEventsWithObjects_APIVersionVariantsAreOneIdentity(t *testin
 	}
 }
 
+// A NON-core object seen with and without apiVersion is still one identity
+// when the emitter set UID (the group fallback alone cannot merge "" with
+// "apps/v1"), and the known apiVersion is carried onto the kept ref even
+// when the most recent sighting lacked it.
+func TestDeduplicateEventsWithObjects_UIDMergesAcrossMissingAPIVersion(t *testing.T) {
+	now := time.Now()
+	withVersion := makeEventForObject("ScalingReplicaSet", "scaled down", "Warning", 1, now.Add(-time.Minute), "Deployment", "shop", "web")
+	withVersion.InvolvedObject.APIVersion = "apps/v1"
+	withVersion.InvolvedObject.UID = "uid-web-1"
+	versionless := makeEventForObject("ScalingReplicaSet", "scaled down", "Warning", 1, now, "Deployment", "shop", "web")
+	versionless.InvolvedObject.UID = "uid-web-1"
+
+	result := DeduplicateEventsWithObjects([]corev1.Event{withVersion, versionless}, 3)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(result))
+	}
+	g := result[0]
+	if g.ObjectCount != 1 || len(g.Objects) != 1 {
+		t.Fatalf("objects = %+v (count %d), want ONE identity via UID", g.Objects, g.ObjectCount)
+	}
+	if g.Objects[0].APIVersion != "apps/v1" {
+		t.Errorf("kept ref apiVersion = %q, want \"apps/v1\" carried from the earlier sighting", g.Objects[0].APIVersion)
+	}
+}
+
 // The plain DeduplicateEvents wire shape is unchanged by the objects path —
 // its consumers (get_events, diagnose, resource includes) group across pods
 // on purpose and must not grow new fields.

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -261,6 +261,32 @@ func TestDeduplicateEventsWithObjects_UIDMergesAcrossMissingAPIVersion(t *testin
 	}
 }
 
+// Two UIDs behind one name are successive incarnations (a StatefulSet pod
+// deleted and recreated while its old events linger), not two objects: the
+// emitted list must not repeat an identical kind/group/namespace/name ref,
+// and objectCount must not inflate past what a consumer can act on.
+func TestDeduplicateEventsWithObjects_RecreatedObjectIsOneRef(t *testing.T) {
+	now := time.Now()
+	oldIncarnation := makeEventForObject("BackOff", "restarting", "Warning", 3, now.Add(-time.Minute), "Pod", "shop", "db-0")
+	oldIncarnation.InvolvedObject.UID = "uid-old"
+	newIncarnation := makeEventForObject("BackOff", "restarting", "Warning", 1, now, "Pod", "shop", "db-0")
+	newIncarnation.InvolvedObject.UID = "uid-new"
+	newIncarnation.InvolvedObject.APIVersion = "v1"
+
+	result := DeduplicateEventsWithObjects([]corev1.Event{oldIncarnation, newIncarnation}, 3)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(result))
+	}
+	g := result[0]
+	if g.ObjectCount != 1 || len(g.Objects) != 1 || g.ObjectsTruncated {
+		t.Fatalf("objects = %+v (count %d, truncated %v), want ONE ref across incarnations", g.Objects, g.ObjectCount, g.ObjectsTruncated)
+	}
+	want := EventObjectRef{Kind: "Pod", APIVersion: "v1", Namespace: "shop", Name: "db-0"}
+	if g.Objects[0] != want {
+		t.Errorf("objects[0] = %+v, want most-recent incarnation's ref %+v", g.Objects[0], want)
+	}
+}
+
 // The plain DeduplicateEvents wire shape is unchanged by the objects path —
 // its consumers (get_events, diagnose, resource includes) group across pods
 // on purpose and must not grow new fields.

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -164,6 +164,56 @@ func TestDeduplicateEvents_DeterministicUnderCapTies(t *testing.T) {
 	}
 }
 
+// Type is a grouping key, so it must also be a comparator key: a Normal and
+// a Warning group identical on every other field must not swap which one
+// survives the 20-group cap based on input order.
+func TestDeduplicateEvents_TypeTieDeterministicAtCap(t *testing.T) {
+	now := time.Now()
+	events := make([]corev1.Event, 0, 21)
+	for i := 0; i < 19; i++ {
+		events = append(events, makeEvent(fmt.Sprintf("A%02d", i), "m", "Warning", 1, now))
+	}
+	events = append(events,
+		makeEvent("Z", "same", "Normal", 1, now),
+		makeEvent("Z", "same", "Warning", 1, now),
+	)
+	reversed := make([]corev1.Event, len(events))
+	for i := range events {
+		reversed[len(events)-1-i] = events[i]
+	}
+	a, b := DeduplicateEvents(events), DeduplicateEvents(reversed)
+	if len(a) != maxDeduplicatedEvents || len(b) != maxDeduplicatedEvents {
+		t.Fatalf("lens = %d/%d, want both capped", len(a), len(b))
+	}
+	if a[len(a)-1] != b[len(b)-1] {
+		t.Fatalf("cap survivor depends on input order: %+v vs %+v", a[len(a)-1], b[len(b)-1])
+	}
+}
+
+// Partial involved-object refs (kind without name, or name without kind) are
+// not a usable identity and must be dropped, not emitted malformed. APIVersion
+// is carried through for kind disambiguation.
+func TestDeduplicateEventsWithObjects_RefValidityAndAPIVersion(t *testing.T) {
+	now := time.Now()
+	full := makeEventForObject("BackOff", "restarting", "Warning", 1, now, "Pod", "shop", "pod-a")
+	full.InvolvedObject.APIVersion = "v1"
+	kindless := makeEventForObject("BackOff", "restarting", "Warning", 1, now, "", "shop", "orphan")
+	nameless := makeEventForObject("BackOff", "restarting", "Warning", 1, now, "Pod", "shop", "")
+
+	result := DeduplicateEventsWithObjects([]corev1.Event{full, kindless, nameless}, 3)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(result))
+	}
+	g := result[0]
+	if g.ObjectCount != 1 || len(g.Objects) != 1 {
+		t.Fatalf("objects = %+v (count %d), want only the fully-identified ref", g.Objects, g.ObjectCount)
+	}
+	want := EventObjectRef{Kind: "Pod", APIVersion: "v1", Namespace: "shop", Name: "pod-a"}
+	if g.Objects[0] != want {
+		t.Errorf("objects[0] = %+v, want %+v", g.Objects[0], want)
+	}
+}
+
 // The plain DeduplicateEvents wire shape is unchanged by the objects path —
 // its consumers (get_events, diagnose, resource includes) group across pods
 // on purpose and must not grow new fields.

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -1,7 +1,9 @@
 package context
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +42,148 @@ func TestDeduplicateEvents_CollapseIdentical(t *testing.T) {
 	}
 	if result[0].Reason != "BackOff" {
 		t.Errorf("Expected reason=BackOff, got %s", result[0].Reason)
+	}
+}
+
+func makeEventForObject(reason, message, eventType string, count int32, lastTime time.Time, kind, namespace, name string) corev1.Event {
+	ev := makeEvent(reason, message, eventType, count, lastTime)
+	ev.InvolvedObject = corev1.ObjectReference{Kind: kind, Namespace: namespace, Name: name}
+	return ev
+}
+
+// The systemic grouping key spans objects: two pods emitting the same
+// normalized warning collapse into ONE group whose count aggregates both —
+// Objects must name each contributor instead of leaving the count subjectless.
+func TestDeduplicateEventsWithObjects_CollectsDistinctObjects(t *testing.T) {
+	now := time.Now()
+	events := []corev1.Event{
+		makeEventForObject("BackOff", "Back-off restarting failed container in pod cart-5d4f7c9b8-aaaaa", "Warning", 3, now.Add(-10*time.Minute), "Pod", "shop", "cart-5d4f7c9b8-aaaaa"),
+		makeEventForObject("BackOff", "Back-off restarting failed container in pod cart-5d4f7c9b8-bbbbb", "Warning", 2, now.Add(-1*time.Minute), "Pod", "shop", "cart-5d4f7c9b8-bbbbb"),
+	}
+
+	result := DeduplicateEventsWithObjects(events, 3)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group (pod-hash normalization), got %d: %+v", len(result), result)
+	}
+	g := result[0]
+	if g.Count != 5 {
+		t.Errorf("count = %d, want 5 (aggregated across objects)", g.Count)
+	}
+	if g.ObjectCount != 2 || g.ObjectsTruncated {
+		t.Errorf("objectCount = %d truncated=%v, want 2/false", g.ObjectCount, g.ObjectsTruncated)
+	}
+	if len(g.Objects) != 2 {
+		t.Fatalf("objects = %+v, want both pods", g.Objects)
+	}
+	// Most recent contributor first.
+	if g.Objects[0].Name != "cart-5d4f7c9b8-bbbbb" || g.Objects[1].Name != "cart-5d4f7c9b8-aaaaa" {
+		t.Errorf("objects order = %+v, want most-recent first", g.Objects)
+	}
+}
+
+// Distinct identities are counted before the cap, and equal timestamps fall
+// back to name order so the emitted subset is deterministic.
+func TestDeduplicateEventsWithObjects_CapsDeterministically(t *testing.T) {
+	now := time.Now()
+	var events []corev1.Event
+	for _, name := range []string{"pod-d", "pod-b", "pod-c", "pod-a", "pod-e"} {
+		events = append(events, makeEventForObject("BackOff", "Back-off restarting failed container", "Warning", 1, now, "Pod", "shop", name))
+	}
+
+	result := DeduplicateEventsWithObjects(events, 3)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(result))
+	}
+	g := result[0]
+	if g.ObjectCount != 5 || !g.ObjectsTruncated {
+		t.Errorf("objectCount = %d truncated=%v, want 5/true (distinct counted before cap)", g.ObjectCount, g.ObjectsTruncated)
+	}
+	if len(g.Objects) != 3 {
+		t.Fatalf("objects = %+v, want capped at 3", g.Objects)
+	}
+	for i, want := range []string{"pod-a", "pod-b", "pod-c"} {
+		if g.Objects[i].Name != want {
+			t.Errorf("objects[%d] = %s, want %s (name order on equal timestamps)", i, g.Objects[i].Name, want)
+		}
+	}
+}
+
+// Series-style events (events.k8s.io mirrored into core/v1) carry recency
+// and count in Series, not the legacy fields — an actively repeating warning
+// must not read as a stale count-1 one-off.
+func TestDeduplicateEvents_HonorsEventSeries(t *testing.T) {
+	now := time.Now()
+	ev := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "series-ev", Namespace: "default"},
+		Reason:     "Unhealthy", Message: "Readiness probe failed", Type: "Warning",
+		// Legacy fields as a series emitter leaves them: Count zero,
+		// LastTimestamp zero, EventTime = FIRST occurrence (an hour ago).
+		EventTime: metav1.MicroTime{Time: now.Add(-1 * time.Hour)},
+		Series: &corev1.EventSeries{
+			Count:            42,
+			LastObservedTime: metav1.MicroTime{Time: now.Add(-30 * time.Second)},
+		},
+	}
+
+	result := DeduplicateEvents([]corev1.Event{ev})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result))
+	}
+	if result[0].Count != 42 {
+		t.Errorf("count = %d, want 42 (Series.Count)", result[0].Count)
+	}
+	if got := result[0].LastTimestamp; now.Sub(got) > time.Minute {
+		t.Errorf("lastTimestamp = %v, want Series.LastObservedTime (~30s ago), not first-occurrence EventTime", got)
+	}
+}
+
+// Which equal-timestamp groups survive the 20-group cap must not depend on
+// input (informer map) order: same events, two orders, same output.
+func TestDeduplicateEvents_DeterministicUnderCapTies(t *testing.T) {
+	now := time.Now()
+	var events []corev1.Event
+	for i := 0; i < 30; i++ {
+		events = append(events, makeEvent(fmt.Sprintf("Reason%02d", i), fmt.Sprintf("message %02d", i), "Warning", 1, now))
+	}
+	reversed := make([]corev1.Event, len(events))
+	for i := range events {
+		reversed[len(events)-1-i] = events[i]
+	}
+
+	a := DeduplicateEvents(events)
+	b := DeduplicateEvents(reversed)
+	if len(a) != maxDeduplicatedEvents || len(b) != maxDeduplicatedEvents {
+		t.Fatalf("lens = %d/%d, want both capped at %d", len(a), len(b), maxDeduplicatedEvents)
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("order diverged at %d under equal timestamps: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+// The plain DeduplicateEvents wire shape is unchanged by the objects path —
+// its consumers (get_events, diagnose, resource includes) group across pods
+// on purpose and must not grow new fields.
+func TestDeduplicateEvents_ShapeUnchanged(t *testing.T) {
+	now := time.Now()
+	events := []corev1.Event{
+		makeEventForObject("BackOff", "Back-off restarting", "Warning", 1, now, "Pod", "shop", "pod-a"),
+	}
+	result := DeduplicateEvents(events)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result))
+	}
+	data, err := json.Marshal(result[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, forbidden := range []string{"objects", "objectCount", "objectsTruncated"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Errorf("DeduplicatedEvent JSON grew %q: %s", forbidden, data)
+		}
 	}
 }
 

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -214,6 +214,28 @@ func TestDeduplicateEventsWithObjects_RefValidityAndAPIVersion(t *testing.T) {
 	}
 }
 
+// One object seen through emitters that populate apiVersion inconsistently
+// ("" vs "v1") is ONE object — identity keys on the API group, never the raw
+// apiVersion string.
+func TestDeduplicateEventsWithObjects_APIVersionVariantsAreOneIdentity(t *testing.T) {
+	now := time.Now()
+	older := makeEventForObject("BackOff", "restarting", "Warning", 1, now.Add(-time.Minute), "Pod", "shop", "pod-a")
+	newer := makeEventForObject("BackOff", "restarting", "Warning", 1, now, "Pod", "shop", "pod-a")
+	newer.InvolvedObject.APIVersion = "v1"
+
+	result := DeduplicateEventsWithObjects([]corev1.Event{older, newer}, 3)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(result))
+	}
+	g := result[0]
+	if g.ObjectCount != 1 || len(g.Objects) != 1 {
+		t.Fatalf("objects = %+v (count %d), want ONE identity across apiVersion variants", g.Objects, g.ObjectCount)
+	}
+	if g.Objects[0].APIVersion != "v1" {
+		t.Errorf("kept ref apiVersion = %q, want the most recent sighting's (\"v1\")", g.Objects[0].APIVersion)
+	}
+}
+
 // The plain DeduplicateEvents wire shape is unchanged by the objects path —
 // its consumers (get_events, diagnose, resource includes) group across pods
 // on purpose and must not grow new fields.


### PR DESCRIPTION
## Why

`get_dashboard`'s `topWarnings` rows carried only `{reason, message, count}`, sorted by lifetime count. Two observed failure modes (SREGym benchmark transcripts):

1. A noisy-but-resolved warning group dominated the list over the live incident (count-first ordering).
2. A consumer had **no way to tell a stale warning from a current one** — a long-recovered BackOff read as live crash behavior, costing an otherwise-correct diagnosis.

## What

- Each row now carries `lastSeen` plus the distinct involved objects as structured refs `{kind, group, namespace, name}` (capped at 3, most recent first, with `objectCount`/`objectsTruncated` for the uncapped distinct total, counted before the cap) — the ref shape feeds directly into `get_resource`'s inputs, with API group included because bare kinds collide (core vs Knative Service).
- **No row selection — the full dedup window is emitted** (up to 20 groups, recency-ordered), and the field is renamed `topWarnings` → `warningGroups` since nothing is "top" anymore. An earlier revision selected 5 rows (3 newest + 2 highest-count union); design consult concluded any pick-N-of-20 heuristic creates unrecoverable omissions — an agent can underweight a returned row but cannot recover an absent one, and both observed failures were selection failures. With `lastSeen` on every row, stale rows are self-labeling and skimmable rather than misleading. Worst-case cost is ~20 rows only on clusters that actually have 20 distinct warning groups.
- **Deterministic ordering end to end**: the full comparator (recency, count, reason, message, type — type is a grouping key so it must be a comparator key) applies inside dedup before its 20-group cap, so equal-timestamp survival no longer depends on informer iteration order; representative message on exact ties is deterministic.
- **Object identity keys on `InvolvedObject.UID`** when present (falling back to kind/group/namespace/name), with a known apiVersion carried across merged sightings — emitters populate apiVersion inconsistently, and raw-string keying double-counted one object seen through two emitters. Emitted refs then collapse successive incarnations (same kind/group/namespace/name across different UIDs, e.g. a recreated StatefulSet pod) into one subject, so objectCount never counts two UIDs a consumer cannot tell apart.
- **Event recency/count honor events.k8s.io `Series` fields** (`Series.LastObservedTime`/`Series.Count`) with legacy fallback — previously an actively repeating series warning read as a stale count-1 one-off. Benefits all `DeduplicateEvents` consumers.
- Object collection is a **dashboard-scoped opt-in** (`DeduplicateEventsWithObjects`); the shared `DeduplicateEvents` wire shape is byte-identical for its other consumers (get_events, diagnose, resource includes), pinned by a shape test.
- `get_dashboard` tool description separates the three signals: `lastSeen` for liveness, `count` for cumulative occurrence volume, `objectCount` for breadth (`objects` is a capped sample of 3).

## Tests

Dashboard-level recency+objects assertions; full-window emission (7 groups → 7 rows, recency-ordered, oldest high-count storm present); distinct-object collection across pod-hash-normalized groups; UID merge across missing apiVersion; ref-validity guard (kind+name required); Series honor; cap-boundary determinism under shuffled input incl. type-only ties; group derivation; unchanged legacy wire shape. Full `make test` green.

Known pre-existing issue deliberately not expanded here (tracked as follow-up): the shared dedup helper's internal 20-group cap conflicts with `get_events`' documented limit=100 and `cluster://events`' cap=50.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking MCP JSON field rename (`topWarnings` → `warningGroups`) and shared event dedup behavior changes (Series timestamps, sort order) affect every `DeduplicateEvents` consumer, though the legacy wire shape is explicitly preserved.
> 
> **Overview**
> **`get_dashboard`** replaces **`topWarnings`** with **`warningGroups`**: each row adds **`lastSeen`**, involved-resource refs (**`objects`**, up to 3, most recent first), **`objectCount`**, and **`objectsTruncated`**, with **`group`** derived from **`apiVersion`** for **`get_resource`**. Groups are ordered by **recency** (not lifetime **`count`**), and the dashboard emits the **full dedup window** (up to 20 groups) instead of a top-5 count-first slice.
> 
> Event dedup in **`pkg/ai/context`** is refactored behind **`deduplicateEventGroups`**. **`DeduplicateEventsWithObjects`** is dashboard-only; plain **`DeduplicateEvents`** keeps the same JSON shape. All dedup consumers get **`Series.LastObservedTime`** / **`Series.Count`**, deterministic tie-break sorting before the 20-group cap, and richer involved-object identity (UID, API group, incarnation collapse).
> 
> Tests cover dashboard ordering, full-window emission, and dedup/object edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2552711e4618ea94fe122945d95c26f50187c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


