### PR TITLE
feat(timeline): 30-day retention with a Cloud backend

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -444,6 +444,10 @@ func (s *Server) setupRoutes() {
 			r.Get("/events", s.handleEvents)
 			r.Get("/changes", s.handleChanges)
 			r.Get("/changes/{kind}/{namespace}/{name}/children", s.handleChangeChildren)
+			// The shared timeline wire contract (NDJSON + terminal record) —
+			// the same shape the hub serves; backs the web client's single
+			// ring-and-delta timeline path.
+			r.Get("/timeline/events", s.handleTimelineEvents)
 
 			// Pod logs (non-streaming)
 			r.Get("/pods/{namespace}/{name}/logs", s.handlePodLogs)

--- a/internal/server/timeline_events.go
+++ b/internal/server/timeline_events.go
@@ -46,16 +46,21 @@ func (s *Server) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
 	}
+	// Store and epoch are captured once, together, and threaded through: a
+	// kubeconfig context switch resets the global store mid-request, and
+	// re-resolving it later could pair one store generation's rows with
+	// another's epoch (or dereference nil).
 	store := timeline.GetStore()
 	if store == nil {
 		s.writeError(w, http.StatusServiceUnavailable, "Timeline store not available")
 		return
 	}
+	epoch := timeline.ObservationStart().UnixNano()
 	if since := r.URL.Query().Get("since"); since != "" {
-		s.serveTimelineEventsDelta(w, r, since)
+		s.serveTimelineEventsDelta(w, r, store, epoch, since)
 		return
 	}
-	s.serveTimelineEventsWindow(w, r)
+	s.serveTimelineEventsWindow(w, r, store, epoch)
 }
 
 func timelineCursor(epoch, seq int64) string {
@@ -98,8 +103,7 @@ func (s *Server) timelineEventsQuery(r *http.Request, namespaces []string) timel
 	}
 }
 
-func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request, cursor string) {
-	epoch := timeline.ObservationStart().UnixNano()
+func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request, store timeline.EventStore, epoch int64, cursor string) {
 	seq, ok := parseTimelineCursor(cursor, epoch)
 	if !ok {
 		s.writeError(w, http.StatusBadRequest, "stale or invalid cursor")
@@ -116,7 +120,7 @@ func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request
 	opts.SinceSeq = seq
 	opts.SeqPaging = true
 
-	events, err := timeline.GetStore().Query(r.Context(), opts)
+	events, err := store.Query(r.Context(), opts)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -141,7 +145,7 @@ func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Request) {
+func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Request, store timeline.EventStore, epoch int64) {
 	q := r.URL.Query()
 	fromMs, errFrom := strconv.ParseInt(q.Get("from"), 10, 64)
 	toMs, errTo := strconv.ParseInt(q.Get("to"), 10, 64)
@@ -161,7 +165,6 @@ func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	epoch := timeline.ObservationStart().UnixNano()
 	namespaces := s.parseNamespacesForUser(r)
 	if noNamespaceAccess(namespaces) {
 		writeTimelineStream(w, nil, timelineEndRecord{Type: "end", Cursor: timelineCursor(epoch, 0)})
@@ -173,7 +176,7 @@ func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Reques
 	opts.Until = time.UnixMilli(toMs)
 	opts.Limit = limit
 
-	events, err := timeline.GetStore().Query(r.Context(), opts)
+	events, err := store.Query(r.Context(), opts)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/server/timeline_events.go
+++ b/internal/server/timeline_events.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+// timelineEventsPageLimit caps both response shapes at the store's own page
+// ceiling. The client sends larger limits (the hub serves up to 50k); a limit
+// above the cap clamps rather than erroring — it is a maximum, not a demand.
+const timelineEventsPageLimit = 10000
+
+// timelineEndRecord is the NDJSON terminal record closing an events stream.
+// Its shape is the wire contract the web client's retained source parses —
+// the same record the hub emits.
+type timelineEndRecord struct {
+	Type      string `json:"type"`
+	Cursor    string `json:"cursor,omitempty"`
+	More      bool   `json:"more,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// handleTimelineEvents serves GET /api/timeline/events — the shared timeline
+// wire contract (the same one the hub serves): NDJSON event lines closed by a
+// terminal record carrying the delta cursor.
+//
+//	?from=<ms>&to=<ms>[&limit=N]  window load: newest-N events in the event-time
+//	                              range, `truncated` set when the range held more
+//	?since=<cursor>               delta: every event that ARRIVED after the
+//	                              cursor, ascending arrival order
+//
+// The cursor is opaque to clients: "<epoch>:<seq>", where seq is the store's
+// arrival counter and epoch is the observation start. Arrival order is the
+// load-bearing choice — a late-arriving or revised event has an old event
+// time but a fresh seq, so it rides the next poll like any new event. A
+// cursor minted by another epoch (the store was re-created: restart, context
+// switch) gets 400 and the client full-resyncs; an empty delta from a reset
+// store must never read as "nothing new".
+func (s *Server) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	store := timeline.GetStore()
+	if store == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Timeline store not available")
+		return
+	}
+	if since := r.URL.Query().Get("since"); since != "" {
+		s.serveTimelineEventsDelta(w, r, since)
+		return
+	}
+	s.serveTimelineEventsWindow(w, r)
+}
+
+func timelineCursor(epoch, seq int64) string {
+	return strconv.FormatInt(epoch, 10) + ":" + strconv.FormatInt(seq, 10)
+}
+
+// parseTimelineCursor validates a client cursor against the current store
+// epoch. ok=false means the cursor is malformed or from another epoch —
+// either way the client's position is meaningless and it must full-resync.
+func parseTimelineCursor(cursor string, epoch int64) (seq int64, ok bool) {
+	epochStr, seqStr, found := strings.Cut(cursor, ":")
+	if !found {
+		return 0, false
+	}
+	cursorEpoch, err := strconv.ParseInt(epochStr, 10, 64)
+	if err != nil || cursorEpoch != epoch {
+		return 0, false
+	}
+	seq, err = strconv.ParseInt(seqStr, 10, 64)
+	if err != nil || seq < 0 {
+		return 0, false
+	}
+	return seq, true
+}
+
+// timelineEventsQuery is the everything-visible read both response shapes
+// share: content filtering is the client's job (applyClientFilters runs on
+// every mode), so the server applies only per-user namespace RBAC and the
+// active-cluster scope.
+func (s *Server) timelineEventsQuery(r *http.Request, namespaces []string) timeline.QueryOptions {
+	return timeline.QueryOptions{
+		Namespaces:       namespaces,
+		FilterPreset:     "all",
+		IncludeManaged:   true,
+		IncludeK8sEvents: true,
+		Limit:            timelineEventsPageLimit,
+		// The persistent store retains events from previously-connected
+		// clusters; this endpoint answers for the current one only.
+		ClusterContext: k8s.ActiveClusterContext(),
+	}
+}
+
+func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request, cursor string) {
+	epoch := timeline.ObservationStart().UnixNano()
+	seq, ok := parseTimelineCursor(cursor, epoch)
+	if !ok {
+		s.writeError(w, http.StatusBadRequest, "stale or invalid cursor")
+		return
+	}
+
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		writeTimelineStream(w, nil, timelineEndRecord{Type: "end", Cursor: cursor})
+		return
+	}
+
+	opts := s.timelineEventsQuery(r, namespaces)
+	opts.SinceSeq = seq
+	opts.SeqPaging = true
+
+	events, err := timeline.GetStore().Query(r.Context(), opts)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	// Cursor progress is derived BEFORE the RBAC filter: rows the user can't
+	// read still advance the frontier, or a run of unreadable rows would pin
+	// the cursor while the client re-fetches the same page forever (same
+	// discipline as handleChanges).
+	maxSeq := seq
+	for _, e := range events {
+		if e.Seq > maxSeq {
+			maxSeq = e.Seq
+		}
+	}
+	full := len(events) == timelineEventsPageLimit
+	events = s.filterChangesByClusterScopedRBAC(r, events)
+
+	writeTimelineStream(w, events, timelineEndRecord{
+		Type:   "end",
+		Cursor: timelineCursor(epoch, maxSeq),
+		More:   full,
+	})
+}
+
+func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	fromMs, errFrom := strconv.ParseInt(q.Get("from"), 10, 64)
+	toMs, errTo := strconv.ParseInt(q.Get("to"), 10, 64)
+	if errFrom != nil || errTo != nil || fromMs < 0 || toMs <= fromMs {
+		s.writeError(w, http.StatusBadRequest, "invalid or missing from/to (epoch milliseconds, from < to)")
+		return
+	}
+	limit := timelineEventsPageLimit
+	if raw := q.Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			s.writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		if n < limit {
+			limit = n
+		}
+	}
+
+	epoch := timeline.ObservationStart().UnixNano()
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		writeTimelineStream(w, nil, timelineEndRecord{Type: "end", Cursor: timelineCursor(epoch, 0)})
+		return
+	}
+
+	opts := s.timelineEventsQuery(r, namespaces)
+	opts.Since = time.UnixMilli(fromMs)
+	opts.Until = time.UnixMilli(toMs)
+	opts.Limit = limit
+
+	events, err := timeline.GetStore().Query(r.Context(), opts)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	maxSeq := int64(0)
+	for _, e := range events {
+		if e.Seq > maxSeq {
+			maxSeq = e.Seq
+		}
+	}
+	// The default query order is newest-first, so hitting the limit means the
+	// oldest part of the requested range was cut — exactly what the client's
+	// `truncated` banner reports. An exactly-limit-sized range over-reports;
+	// harmless, the same heuristic every consumer of this flag uses.
+	truncated := len(events) == limit
+	events = s.filterChangesByClusterScopedRBAC(r, events)
+
+	writeTimelineStream(w, events, timelineEndRecord{
+		Type:      "end",
+		Cursor:    timelineCursor(epoch, maxSeq),
+		Truncated: truncated,
+	})
+}
+
+// writeTimelineStream emits the NDJSON body: one event per line, then the
+// terminal record. Everything is queried before the first byte, so failures
+// surface as real HTTP errors, never a half stream.
+func writeTimelineStream(w http.ResponseWriter, events []timeline.TimelineEvent, end timelineEndRecord) {
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	enc := json.NewEncoder(w)
+	for i := range events {
+		if err := enc.Encode(&events[i]); err != nil {
+			// The connection is gone mid-body; the missing terminal record
+			// tells the client the stream was cut.
+			return
+		}
+	}
+	_ = enc.Encode(end)
+}

--- a/internal/server/timeline_events_test.go
+++ b/internal/server/timeline_events_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+// The wire contract the web client's single timeline path depends on (the
+// same one the hub serves): NDJSON event lines closed by a terminal record
+// carrying an opaque epoch:seq cursor; window loads report truncation;
+// deltas page ascending by arrival; a foreign-epoch cursor is 400.
+func TestHandleTimelineEvents_Contract(t *testing.T) {
+	prev := k8s.GetConnectionStatus()
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{State: k8s.StateConnected})
+	t.Cleanup(func() { k8s.SetConnectionStatus(prev) })
+
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(func() {
+		timeline.ResetStore()
+		if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
+			t.Fatalf("re-init global store: %v", err)
+		}
+	})
+
+	store := timeline.GetStore()
+	base := time.Now().Add(-time.Minute)
+	for i, name := range []string{"a", "b", "c"} {
+		if err := store.Append(t.Context(), timeline.TimelineEvent{
+			ID: "ev-" + name, Timestamp: base.Add(time.Duration(i) * time.Second),
+			Source: timeline.SourceInformer, Kind: "Deployment", Namespace: "default",
+			Name: name, EventType: timeline.EventTypeUpdate,
+			ClusterContext: k8s.ActiveClusterContext(),
+		}); err != nil {
+			t.Fatalf("Append %s: %v", name, err)
+		}
+	}
+
+	s := &Server{}
+	get := func(url string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rr := httptest.NewRecorder()
+		s.handleTimelineEvents(rr, req)
+		return rr
+	}
+	// parseStream splits an NDJSON body into events and the terminal record.
+	parseStream := func(t *testing.T, body string) ([]timeline.TimelineEvent, timelineEndRecord) {
+		t.Helper()
+		var events []timeline.TimelineEvent
+		var end timelineEndRecord
+		sawEnd := false
+		for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+			if sawEnd {
+				t.Fatalf("line after terminal record: %s", line)
+			}
+			var probe struct {
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal([]byte(line), &probe); err != nil {
+				t.Fatalf("bad NDJSON line %q: %v", line, err)
+			}
+			if probe.Type == "end" || probe.Type == "error" {
+				if err := json.Unmarshal([]byte(line), &end); err != nil {
+					t.Fatalf("bad terminal record %q: %v", line, err)
+				}
+				sawEnd = true
+				continue
+			}
+			var e timeline.TimelineEvent
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Fatalf("bad event line %q: %v", line, err)
+			}
+			events = append(events, e)
+		}
+		if !sawEnd {
+			t.Fatalf("stream missing terminal record: %s", body)
+		}
+		return events, end
+	}
+
+	epoch := strconv.FormatInt(timeline.ObservationStart().UnixNano(), 10)
+	fromMs := strconv.FormatInt(base.Add(-time.Second).UnixMilli(), 10)
+	toMs := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	// Window load: all three events, cursor = epoch:maxSeq, not truncated.
+	rr := get("/api/timeline/events?from=" + fromMs + "&to=" + toMs + "&namespaces=default")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("window status = %d, body %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/x-ndjson" {
+		t.Fatalf("window Content-Type = %q", ct)
+	}
+	events, end := parseStream(t, rr.Body.String())
+	if len(events) != 3 {
+		t.Fatalf("window returned %d events, want 3", len(events))
+	}
+	if end.Truncated || end.More {
+		t.Fatalf("uncapped window end = %+v", end)
+	}
+	if !strings.HasPrefix(end.Cursor, epoch+":") {
+		t.Fatalf("cursor %q not stamped with current epoch %s", end.Cursor, epoch)
+	}
+	var maxSeq int64
+	for _, e := range events {
+		if e.Seq > maxSeq {
+			maxSeq = e.Seq
+		}
+	}
+	if end.Cursor != epoch+":"+strconv.FormatInt(maxSeq, 10) {
+		t.Fatalf("window cursor = %q, want frontier %s:%d", end.Cursor, epoch, maxSeq)
+	}
+	frontier := end.Cursor
+
+	// Capped window: newest-first cut, truncated set.
+	rr = get("/api/timeline/events?from=" + fromMs + "&to=" + toMs + "&limit=2&namespaces=default")
+	events, end = parseStream(t, rr.Body.String())
+	if len(events) != 2 || !end.Truncated {
+		t.Fatalf("capped window: %d events, end %+v; want 2 events truncated", len(events), end)
+	}
+	for _, e := range events {
+		if e.Name == "a" {
+			t.Fatalf("capped window kept the oldest event instead of the newest")
+		}
+	}
+
+	// The `to` bound is honored: a window ending before event c excludes it.
+	beforeC := strconv.FormatInt(base.Add(1500*time.Millisecond).UnixMilli(), 10)
+	rr = get("/api/timeline/events?from=" + fromMs + "&to=" + beforeC + "&namespaces=default")
+	events, _ = parseStream(t, rr.Body.String())
+	for _, e := range events {
+		if e.Name == "c" {
+			t.Fatalf("window [from,to] returned an event past to")
+		}
+	}
+
+	// Delta from the middle: only later arrivals, ascending seq, cursor advances.
+	middle := events[0].Seq // events here are from the bounded window (a,b); newest first ⇒ b
+	rr = get("/api/timeline/events?since=" + epoch + ":" + strconv.FormatInt(middle, 10) + "&namespaces=default")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delta status = %d, body %s", rr.Code, rr.Body.String())
+	}
+	events, end = parseStream(t, rr.Body.String())
+	for i, e := range events {
+		if e.Seq <= middle {
+			t.Fatalf("delta returned seq %d <= cursor %d", e.Seq, middle)
+		}
+		if i > 0 && e.Seq < events[i-1].Seq {
+			t.Fatalf("delta page not ascending by seq")
+		}
+	}
+	if end.Cursor != frontier {
+		t.Fatalf("delta cursor = %q, want frontier %q", end.Cursor, frontier)
+	}
+
+	// Delta at the frontier: no events, cursor echoed unchanged.
+	rr = get("/api/timeline/events?since=" + frontier + "&namespaces=default")
+	events, end = parseStream(t, rr.Body.String())
+	if len(events) != 0 || end.Cursor != frontier {
+		t.Fatalf("frontier delta: %d events, cursor %q; want 0 events, cursor %q", len(events), end.Cursor, frontier)
+	}
+
+	// A cursor from another epoch (store re-created) or malformed input is a
+	// 400 — the client must full-resync, never trust an empty delta.
+	for _, bad := range []string{"1:5", "abc", epoch, epoch + ":x", epoch + ":-2"} {
+		rr = get("/api/timeline/events?since=" + bad + "&namespaces=default")
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("since=%q status = %d, want 400", bad, rr.Code)
+		}
+	}
+
+	// Window parameter validation.
+	for _, u := range []string{
+		"/api/timeline/events",
+		"/api/timeline/events?from=10&to=5",
+		"/api/timeline/events?from=x&to=5",
+		"/api/timeline/events?from=1&to=2&limit=0",
+	} {
+		if rr = get(u); rr.Code != http.StatusBadRequest {
+			t.Fatalf("%s status = %d, want 400", u, rr.Code)
+		}
+	}
+}

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
@@ -301,6 +301,9 @@ describe("ApplicationDetail shell", () => {
 
     const local = renderDetail({ ...base, historyMode: 'local' })
     expect(local).not.toContain('the retained window exceeded')
+    // Local can be ring-truncated too (the binary's 10k ring) - same warning,
+    // source-appropriate copy.
+    expect(local).toContain('ring is full, so the oldest activity is not loaded')
   })
 
   it('shows a single honest error state when runtime history fails without source history', () => {

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
@@ -278,6 +278,31 @@ describe("ApplicationDetail shell", () => {
     expect(html).not.toContain('Recording coverage is incomplete')
   })
 
+  it('reports ring truncation with its own copy, only in retained mode', () => {
+    const base = {
+      selectedView: 'history' as const,
+      onSelectView: () => {},
+      selectedWorkloadKey: null,
+      onSelectWorkload: () => {},
+      historyRange: '7d' as const,
+      historyRangeOptions: [{ value: '7d' as const, label: '7 days' }],
+      historyRingTruncated: true,
+      historyItems: [{
+        id: 'ring-change',
+        category: 'change' as const,
+        title: 'Deployment updated',
+        timestamp: '2026-07-13T09:00:00.000Z',
+      }],
+    }
+    const retained = renderDetail({ ...base, historyMode: 'retained' })
+    expect(retained).toContain('the retained window exceeded')
+    // Distinct cause, distinct copy — not the per-query 10k note.
+    expect(retained).not.toContain('Showing the 10,000 most recent events')
+
+    const local = renderDetail({ ...base, historyMode: 'local' })
+    expect(local).not.toContain('the retained window exceeded')
+  })
+
   it('shows a single honest error state when runtime history fails without source history', () => {
     const html = renderDetail({
       selectedView: 'history',

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
@@ -238,6 +238,9 @@ export type ApplicationDetailProps = {
   }>;
   historyCoverageRecordCount?: number;
   historyRuntimeLimited?: boolean;
+  // The retained ring itself was row-capped: the OLDEST part of the retention
+  // window is not loaded, independent of the per-query event limit.
+  historyRingTruncated?: boolean;
   onHistoryRangeChange?: (range: ApplicationHistoryRange) => void;
   onOpenTimeline?: (timestamp?: string) => void;
   onOpenSource?: (source: AppSourceRef) => void;
@@ -330,6 +333,7 @@ export function ApplicationDetail({
   historyRangeOptions,
   historyCoverageRecordCount,
   historyRuntimeLimited,
+  historyRingTruncated,
   onHistoryRangeChange,
   onOpenTimeline,
   onOpenSource,
@@ -750,6 +754,7 @@ export function ApplicationDetail({
             historyRangeOptions={historyRangeOptions}
             historyCoverageRecordCount={historyCoverageRecordCount}
             historyRuntimeLimited={historyRuntimeLimited}
+            historyRingTruncated={historyRingTruncated}
             onHistoryRangeChange={onHistoryRangeChange}
             onOpenTimeline={onOpenTimeline}
             onOpenSource={onOpenSource}
@@ -797,6 +802,7 @@ function ApplicationWorkspace({
   historyRangeOptions,
   historyCoverageRecordCount,
   historyRuntimeLimited,
+  historyRingTruncated,
   onHistoryRangeChange,
   onOpenTimeline,
   onOpenSource,
@@ -848,6 +854,7 @@ function ApplicationWorkspace({
   }>;
   historyCoverageRecordCount?: number;
   historyRuntimeLimited?: boolean;
+  historyRingTruncated?: boolean;
   onHistoryRangeChange?: (range: ApplicationHistoryRange) => void;
   onOpenTimeline?: (timestamp?: string) => void;
   onOpenSource?: (source: AppSourceRef) => void;
@@ -916,6 +923,7 @@ function ApplicationWorkspace({
           rangeOptions={historyRangeOptions}
           coverageRecordCount={historyCoverageRecordCount}
           runtimeLimited={historyRuntimeLimited}
+          ringTruncated={historyRingTruncated}
           workloads={workloads}
           onSelectWorkload={onSelectWorkload}
           onNavigateToResource={onNavigateToResource}
@@ -2146,6 +2154,7 @@ function ApplicationHistoryView({
   rangeOptions,
   coverageRecordCount,
   runtimeLimited,
+  ringTruncated,
   workloads,
   onSelectWorkload,
   onNavigateToResource,
@@ -2163,6 +2172,7 @@ function ApplicationHistoryView({
   rangeOptions?: Array<{ value: ApplicationHistoryRange; label: string }>;
   coverageRecordCount?: number;
   runtimeLimited?: boolean;
+  ringTruncated?: boolean;
   workloads: AppWorkload[];
   onSelectWorkload: (workload: AppWorkload) => void;
   onNavigateToResource?: (resource: ResourceRef) => void;
@@ -2370,6 +2380,12 @@ function ApplicationHistoryView({
               <div>
                 Showing the 10,000 most recent events in these namespaces. Older
                 application activity in this range may not be included.
+              </div>
+            )}
+            {mode === "retained" && ringTruncated && (
+              <div>
+                Event history may be incomplete: the retained window exceeded
+                its size limit, so the oldest activity is not loaded.
               </div>
             )}
           </div>

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
@@ -2382,10 +2382,11 @@ function ApplicationHistoryView({
                 application activity in this range may not be included.
               </div>
             )}
-            {mode === "retained" && ringTruncated && (
+            {ringTruncated && (
               <div>
-                Event history may be incomplete: the retained window exceeded
-                its size limit, so the oldest activity is not loaded.
+                {mode === "retained"
+                  ? "Event history may be incomplete: the retained window exceeded its size limit, so the oldest activity is not loaded."
+                  : "Event history may be incomplete: the event store's ring is full, so the oldest activity is not loaded."}
               </div>
             )}
           </div>

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -1077,16 +1077,29 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
     return { start, end, windowMs, now: effectiveNow }
   }, [zoom, panOffset, effectiveNow, viewWindow])
 
+  // The visible window WITHOUT the live-`now` field. Keyed on the primitive
+  // bounds so its identity changes only when the window actually moves — a live
+  // `now` tick (30s) advances `visibleTimeRange.now` for the now-line but must
+  // NOT invalidate the lane-ordering / window-clip memos below, which only care
+  // about [start,end]. This stops the heavy build from re-running on each tick
+  // while the window is static — the controlled retained lens or a paused view.
+  // (In uncontrolled live mode start/end track `effectiveNow`, so they advance
+  // every tick regardless; the win is for the static-window cases this targets.)
+  const visibleWindow = useMemo(
+    () => ({ start: visibleTimeRange.start, end: visibleTimeRange.end, windowMs: visibleTimeRange.windowMs }),
+    [visibleTimeRange.start, visibleTimeRange.end, visibleTimeRange.windowMs],
+  )
+
   // Apply the chosen ordering to the top-level lanes. 'recent' needs the visible
   // window (newest-in-view first), so this lives after visibleTimeRange. The
   // pinned section is ordered separately (strict pin order) and never flows here.
   const orderedLanes = useMemo(
     () => sortTimelineLanes(lanes, sort, {
-      windowStart: visibleTimeRange.start,
-      windowEnd: visibleTimeRange.end,
+      windowStart: visibleWindow.start,
+      windowEnd: visibleWindow.end,
       scoreOf: (lane) => lane.scoreBreakdown?.total ?? calculateInterestingness(lane),
     }),
-    [lanes, sort, visibleTimeRange],
+    [lanes, sort, visibleWindow],
   )
 
   // Live-mode order hysteresis. The importance rank recomputes every poll (recency
@@ -1147,17 +1160,17 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   // "events" count so it's view-scoped like "resources" — a lens sitting in a
   // recording gap reads "0 resources · 0 events", not "0 resources · N events".
   const eventsInWindow = useMemo(() => {
-    const { start, end } = visibleTimeRange
+    const { start, end } = visibleWindow
     return filteredEvents.filter((e) => {
       const t = new Date(e.timestamp).getTime()
       return t >= start && t <= end
     })
-  }, [filteredEvents, visibleTimeRange])
+  }, [filteredEvents, visibleWindow])
 
   // Recording gaps clipped to the visible window, for the hatched lane bands.
   const visibleGaps = useMemo(() => {
     if (!gaps || gaps.length === 0) return []
-    const { start, end } = visibleTimeRange
+    const { start, end } = visibleWindow
     const out: TimeWindow[] = []
     for (const g of gaps) {
       const fromMs = Math.max(g.fromMs, start)
@@ -1165,7 +1178,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
       if (toMs > fromMs) out.push({ fromMs, toMs })
     }
     return out
-  }, [gaps, visibleTimeRange])
+  }, [gaps, visibleWindow])
 
   // Pin MOVES a row: pinned lanes (and pinned children inside groups) leave
   // the regular list entirely — the pinned section is their only home.
@@ -1181,7 +1194,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
 
   // Filter out lanes with no events in the visible time window
   const visibleLanes = useMemo(() => {
-    const { start, end } = visibleTimeRange
+    const { start, end } = visibleWindow
     return unpinnedLanes.filter(lane => {
       const allLaneEvents = lane.allEventsSorted || []
       return allLaneEvents.some(e => {
@@ -1189,7 +1202,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
         return t >= start && t <= end
       })
     })
-  }, [unpinnedLanes, visibleTimeRange])
+  }, [unpinnedLanes, visibleWindow])
 
   // Pinned rows: resolved from the FULL lane list (pre-window-filter, any
   // grouping) so they stay put while the lens moves and even when they have no
@@ -1203,7 +1216,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   // Honest counts while filtered to pins: only pinned rows' in-window events.
   const pinnedEventsInWindow = useMemo(() => {
     if (pinnedLaneRows.length === 0) return 0
-    const { start, end } = visibleTimeRange
+    const { start, end } = visibleWindow
     let n = 0
     for (const lane of pinnedLaneRows) {
       for (const e of lane.allEventsSorted || []) {
@@ -1212,7 +1225,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
       }
     }
     return n
-  }, [pinnedLaneRows, visibleTimeRange])
+  }, [pinnedLaneRows, visibleWindow])
 
   const pinnedIdSet = useMemo(() => new Set((pinnedLanes ?? []).map((p) => p.id)), [pinnedLanes])
   // A pin button for a lane, or null when the host wired no pin handler. A pinned
@@ -1236,7 +1249,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
 
   // Generate time axis ticks
   const axisTicks = useMemo(() => {
-    const { start, end } = visibleTimeRange
+    const { start, end } = visibleWindow
     const ticks: { time: number; label: string }[] = []
     const span = end - start
     if (span <= 0) return ticks
@@ -1262,18 +1275,18 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
     }
 
     return ticks
-  }, [visibleTimeRange])
+  }, [visibleWindow])
 
   // Convert timestamp to X position (0-100%)
   const timeToX = useCallback(
     (timestamp: number): number => {
-      const { start, windowMs } = visibleTimeRange
+      const { start, windowMs } = visibleWindow
       // A zero-width window (host bounds with fromMs === toMs) would divide by
       // zero and emit NaN into `left:` CSS — pin everything to the left edge.
       if (windowMs <= 0) return 0
       return ((timestamp - start) / windowMs) * 100
     },
-    [visibleTimeRange]
+    [visibleWindow]
   )
 
   // Vertical grid line positions (x-percent) shared by every lane backdrop.

--- a/packages/k8s-ui/src/components/timeline/index.ts
+++ b/packages/k8s-ui/src/components/timeline/index.ts
@@ -20,8 +20,6 @@ export {
   advanceLatchedLens,
   deriveLiveSelection,
   isLensLatched,
-  quantizeBaseWindow,
   LIVE_TICK_MS,
-  BASE_QUANTIZE_STEP_MS,
   type TimelineLiveState,
 } from './timeline-live'

--- a/packages/k8s-ui/src/components/timeline/timeline-live.test.ts
+++ b/packages/k8s-ui/src/components/timeline/timeline-live.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
-  BASE_QUANTIZE_STEP_MS,
   LENS_LATCH_EPSILON_MS,
   STALE_AMBER_AFTER_MS,
   advanceLatchedLens,
   deriveLiveSelection,
   isLensLatched,
-  quantizeBaseWindow,
 } from './timeline-live'
 import { clampSelection, type ScrubberRange } from './scrubber-math'
 
@@ -17,41 +15,6 @@ describe('deriveLiveSelection', () => {
   it('pins the window to now with the given width', () => {
     const now = 1_000_000_000
     expect(deriveLiveSelection(HOUR, now)).toEqual({ fromMs: now - HOUR, toMs: now })
-  })
-})
-
-describe('quantizeBaseWindow', () => {
-  it('floors both edges to the step', () => {
-    const step = BASE_QUANTIZE_STEP_MS
-    const q = quantizeBaseWindow(step * 3 + 12_345, step * 10 + 4_000, step)
-    expect(q).toEqual({ fromMs: step * 3, toMs: step * 10 })
-  })
-
-  it('is stable across two ticks inside the same step', () => {
-    const step = BASE_QUANTIZE_STEP_MS
-    const base = step * 100
-    // Two "now" values 30s apart but inside the same 5-minute step.
-    const a = quantizeBaseWindow(base - HOUR + 10_000, base + 10_000, step)
-    const b = quantizeBaseWindow(base - HOUR + 40_000, base + 40_000, step)
-    expect(a).toEqual(b)
-  })
-
-  it('advances once the edge crosses a step boundary', () => {
-    const step = BASE_QUANTIZE_STEP_MS
-    const before = quantizeBaseWindow(0, step - 1, step)
-    const after = quantizeBaseWindow(0, step + 1, step)
-    expect(before.toMs).toBe(0)
-    expect(after.toMs).toBe(step)
-  })
-
-  it('trailing seam never exceeds one step (covered by the 10-min live poll)', () => {
-    const step = BASE_QUANTIZE_STEP_MS
-    const now = step * 42 + 137_000
-    const q = quantizeBaseWindow(now - HOUR, now, step)
-    // Gap between the quantized right edge and now is < one step, and one step
-    // (5min) is well inside the 10-min live poll window ⇒ no data hole.
-    expect(now - q.toMs).toBeLessThan(step)
-    expect(step).toBeLessThan(10 * MIN)
   })
 })
 

--- a/packages/k8s-ui/src/components/timeline/timeline-live.ts
+++ b/packages/k8s-ui/src/components/timeline/timeline-live.ts
@@ -18,8 +18,8 @@ export type TimelineLiveState =
   | { kind: 'frozen'; asOfMs: number; newEventCount?: number }
 
 // Cadence the host slides a live selection at. Coarse on purpose: the precise
-// [from,to] is re-derived every tick, but the base fetch is quantized so the
-// query key only churns every QUANTIZE step (see quantizeBaseWindow).
+// [from,to] is re-derived every tick without refetching — data arrives via the
+// source's own delta polling, so the tick only moves the visible window.
 export const LIVE_TICK_MS = 30_000
 
 // A frozen selection older than this reads as stale — the chip turns amber.
@@ -30,31 +30,9 @@ export const STALE_AMBER_AFTER_MS = 15 * 60_000
 // LIVE_TICK_MS so a lens that just slid with the tick still reads as latched.
 export const LENS_LATCH_EPSILON_MS = 60_000
 
-// Base-fetch quantization step. The react-query key is keyed on the quantized
-// window, so it only changes when the live edge crosses a 5-minute boundary —
-// the seam between the quantized edge and now is covered by the 10-minute live
-// poll (5min quantization lag < 10min poll window ⇒ no hole).
-export const BASE_QUANTIZE_STEP_MS = 5 * 60_000
-
 /** LIVE selection: a width pinned to now. */
 export function deriveLiveSelection(widthMs: number, nowMs: number): ScrubberRange {
   return { fromMs: nowMs - widthMs, toMs: nowMs }
-}
-
-/**
- * Quantize a sliding [from,to] down to fixed steps so the value is stable across
- * ticks within one step (identical output ⇒ stable react-query key). Both edges
- * floor to the step; the trailing seam to `now` is filled by the live poll.
- */
-export function quantizeBaseWindow(
-  fromMs: number,
-  toMs: number,
-  stepMs: number = BASE_QUANTIZE_STEP_MS,
-): ScrubberRange {
-  return {
-    fromMs: Math.floor(fromMs / stepMs) * stepMs,
-    toMs: Math.floor(toMs / stepMs) * stepMs,
-  }
 }
 
 /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -967,6 +967,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     if (tl.timer === null) {
       tl.timer = window.setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['changes'] })
+        // The ring-and-delta timeline path: an invalidation costs one ~KB
+        // cursor delta, so SSE keeps the timeline fresh within seconds and
+        // the hook's 10s poll remains the no-SSE fallback.
+        queryClient.invalidateQueries({ queryKey: ['timeline-ring'] })
         timelineInvalidationRef.current = { timer: null }
       }, 5000)
     }

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -426,6 +426,21 @@ describe('retained ring fetch (the OSS-identical accumulate model)', () => {
     expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('limit=3')
   })
 
+  // The local source keeps its historical 5-minute anti-entropy cadence; a
+  // per-source resyncMs below the ring age must force a full reload.
+  it('honors a per-source resync interval', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1' })])
+    cached.loadedAtMs = NOW - 6 * 60 * 1000
+    mockApiFetch.mockResolvedValueOnce(streamResponse([line(ev({ id: 'e2' })), end({ cursor: '9' })]))
+    await runRetainedRingFetch({
+      ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW,
+      resyncMs: 5 * 60 * 1000,
+    })
+    // 6 minutes old with a 5-minute cadence: a FULL window load, not a delta.
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('from=')
+  })
+
   // The ring is row-capped, so a namespace-scoped consumer must scope the
   // server query itself — client-side filtering alone would let other
   // namespaces' events consume the cap.

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -1,28 +1,25 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-// The retained NDJSON parser goes through apiFetch; mock the client module so a
-// test can hand fetchRetainedWindow an arbitrary streamed body. ApiError is only
-// hit on the non-ok branch (not exercised here) but must exist for module load.
-vi.mock('./client', () => ({
-  apiFetch: vi.fn(),
-  useChanges: vi.fn(),
-  ApiError: class ApiError extends Error {
-    status: number
-    constructor(message: string, status: number) {
-      super(message)
-      this.status = status
-    }
-  },
-}))
+// The retained NDJSON parser goes through apiFetch; mock ONLY the network in
+// the client module so a test can hand the stream readers an arbitrary body —
+// ApiError and mergeDeltaEvents stay real (the ring fetch depends on the real
+// merge semantics).
+vi.mock('./client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./client')>()
+  return { ...actual, apiFetch: vi.fn(), useChanges: vi.fn() }
+})
 
-import { apiFetch } from './client'
+import { apiFetch, ApiError } from './client'
 import {
   fetchRetainedWindow,
+  rangeSpanMs,
+  RETAINED_RING_LIMIT,
+  fetchRetainedDelta,
+  runRetainedRingFetch,
   applyClientFilters,
   localOverviewFromEvents,
-  LIVE_WINDOW_MS,
+  type RetainedRing,
 } from './timelineSource'
-import { BASE_QUANTIZE_STEP_MS } from '@skyhook-io/k8s-ui'
 import type { TimelineEvent } from '../types'
 
 const mockApiFetch = vi.mocked(apiFetch)
@@ -152,6 +149,16 @@ describe('applyClientFilters', () => {
     expect(out.map((e) => e.id)).toEqual(['del1', 'p1'])
   })
 
+  // Retained mode passes no limit — the hub owns the window bound (31d + a 50k
+  // row hard stop that surfaces as a stream error). The client must never
+  // silently drop older events, so an unset limit returns the full window.
+  it('returns every event when no limit is set', () => {
+    const many: TimelineEvent[] = Array.from({ length: 12000 }, (_, i) =>
+      ev({ id: `e${i}`, kind: 'Pod', namespace: 'ns-a', timestamp: new Date(T0 + i).toISOString() }),
+    )
+    expect(applyClientFilters(many, {})).toHaveLength(12000)
+  })
+
   // Mirrors Go's TimelineEvent.IsManaged: owned, or ReplicaSet/Pod/Event.
   // Enforced client-side so retained mode (whose endpoint has no
   // include_managed param) behaves exactly like local mode.
@@ -210,8 +217,260 @@ describe('localOverviewFromEvents', () => {
   })
 })
 
-describe('cross-package live-window invariant', () => {
-  it('quantization step stays under the live poll window so no fetch hole opens', () => {
-    expect(BASE_QUANTIZE_STEP_MS).toBeLessThan(LIVE_WINDOW_MS)
+describe('rangeSpanMs (client-side preset resolution)', () => {
+  const CAP = 31 * 24 * 60 * 60 * 1000
+  it('resolves presets to their spans', () => {
+    expect(rangeSpanMs('24h', CAP)).toBe(24 * 60 * 60 * 1000)
+    expect(rangeSpanMs('7d', CAP)).toBe(7 * 24 * 60 * 60 * 1000)
+  })
+  it("falls back to the ring depth for 'all' and unset", () => {
+    expect(rangeSpanMs('all', CAP)).toBe(CAP)
+    expect(rangeSpanMs(undefined, CAP)).toBe(CAP)
+  })
+  it("preset arms return their nominal span — clamping is the caller's job", () => {
+    // A 30d preset against a 7d host returns 30d here; the use site clamps
+    // with Math.min against the ring depth (pinned indirectly by the hook).
+    const shallow = 7 * 24 * 60 * 60 * 1000
+    expect(rangeSpanMs('30d', shallow)).toBe(30 * 24 * 60 * 60 * 1000)
+  })
+})
+
+describe('retained ring fetch (the OSS-identical accumulate model)', () => {
+  const DAY = 24 * 60 * 60 * 1000
+  const CAP = 31 * DAY
+  const NOW = T0 + 40 * DAY
+
+  const line = (e: TimelineEvent) => JSON.stringify(e) + '\n'
+  const end = (over: Record<string, unknown> = {}) => JSON.stringify({ type: 'end', ...over }) + '\n'
+
+  function ring(events: TimelineEvent[], over: Partial<RetainedRing> = {}): RetainedRing {
+    return { events, coverage: [], truncated: false, cursor: '100', loadedAtMs: NOW, ...over }
+  }
+
+  it('parses cursor/truncated from the end record and sends limit on the window fetch', async () => {
+    mockApiFetch.mockResolvedValue(
+      streamResponse([line(ev({ id: 'a' })), end({ cursor: '111', truncated: true })]),
+    )
+    const res = await fetchRetainedWindow(0, 1000, undefined, 50)
+    expect(mockApiFetch.mock.calls[0][0]).toContain('limit=50')
+    expect(res.cursor).toBe('111')
+    expect(res.truncated).toBe(true)
+  })
+
+  it('sends the cursor on the delta fetch and surfaces more', async () => {
+    mockApiFetch.mockResolvedValue(streamResponse([end({ cursor: '222', more: true })]))
+    const res = await fetchRetainedDelta('111')
+    expect(mockApiFetch.mock.calls[0][0]).toContain('since=111')
+    expect(res.cursor).toBe('222')
+    expect(res.more).toBe(true)
+  })
+
+  it('loads the full ring once, then accumulates deltas — including a LATE event', async () => {
+    const flags = new Set<string>()
+    // Full load: one event, cursor 100.
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e1', timestamp: new Date(NOW - DAY).toISOString() })), end({ cursor: '100' })]),
+    )
+    const first = await runRetainedRingFetch({ ringKey: 'k', cached: undefined, forceResync: flags, capMs: CAP, now: NOW })
+    expect(first.events.map((e) => e.id)).toEqual(['e1'])
+    expect(mockApiFetch.mock.calls[0][0]).toContain('from=')
+
+    // Delta: a brand-new event AND a late one (event time 3 days back) — both
+    // ride the ingestion-ordered poll and land in the ring.
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([
+        line(ev({ id: 'e-new', timestamp: new Date(NOW).toISOString() })),
+        line(ev({ id: 'e-late', timestamp: new Date(NOW - 3 * DAY).toISOString() })),
+        end({ cursor: '200' }),
+      ]),
+    )
+    const second = await runRetainedRingFetch({ ringKey: 'k', cached: first, forceResync: flags, capMs: CAP, now: NOW })
+    expect(mockApiFetch.mock.calls[1][0]).toContain('since=100')
+    expect(second.events.map((e) => e.id).sort()).toEqual(['e-late', 'e-new', 'e1'])
+    expect(second.cursor).toBe('200')
+  })
+
+  it('a delta revision replaces its cached id', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1', eventType: 'add', timestamp: new Date(NOW - DAY).toISOString() })])
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e1', eventType: 'update', timestamp: new Date(NOW - DAY).toISOString() })), end({ cursor: '200' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(out.events).toHaveLength(1)
+    expect(out.events[0].eventType).toBe('update')
+  })
+
+  it('a no-op delta returns the cached reference (no re-render)', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1' })])
+    // No rows, cursor unchanged — the idle-cluster steady state.
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '100' })]))
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(out).toBe(cached)
+  })
+
+  it('an empty delta with a moved cursor commits the cursor WITH the data', async () => {
+    const flags = new Set<string>()
+    const loadedAt = NOW - 1000
+    const cached = ring([ev({ id: 'e1', timestamp: new Date(NOW - DAY).toISOString() })], { loadedAtMs: loadedAt })
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '150' })]))
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    // The advanced cursor rides the same commit as the events it describes —
+    // a discarded fetch discards both, so they can never diverge.
+    expect(out).not.toBe(cached)
+    expect(out.cursor).toBe('150')
+    expect(out.events.map((e) => e.id)).toEqual(['e1'])
+    // Delta commits must PRESERVE the full-load clock — resetting it to `now`
+    // would silently disable the hourly anti-entropy on any active cluster.
+    expect(out.loadedAtMs).toBe(loadedAt)
+  })
+
+  it('a ring loaded "in the future" (backward clock step) resyncs instead of suspending', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1', timestamp: new Date(NOW - DAY).toISOString() })], { loadedAtMs: NOW + 10 * 60 * 1000 })
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e-resynced', timestamp: new Date(NOW).toISOString() })), end({ cursor: '700' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(mockApiFetch.mock.calls[0][0]).toContain('from=')
+    expect(out.loadedAtMs).toBe(NOW)
+  })
+
+  it('prunes events older than the retention depth on merge, keeping the skew-slack band', async () => {
+    const flags = new Set<string>()
+    const cached = ring([
+      ev({ id: 'e-ancient', timestamp: new Date(NOW - CAP - DAY).toISOString() }),
+      // Inside the clock-skew slack band just past the depth: a client clock
+      // ahead of the hub must not prune what the hub still retains.
+      ev({ id: 'e-slack', timestamp: new Date(NOW - CAP - 60 * 1000).toISOString() }),
+      ev({ id: 'e-kept', timestamp: new Date(NOW - DAY).toISOString() }),
+    ])
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e-new', timestamp: new Date(NOW).toISOString() })), end({ cursor: '200' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(out.events.map((e) => e.id).sort()).toEqual(['e-kept', 'e-new', 'e-slack'])
+  })
+
+  it('a capped delta page (more) pages forward within one fetch', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1', timestamp: new Date(NOW - DAY).toISOString() })])
+    mockApiFetch
+      .mockResolvedValueOnce(streamResponse([line(ev({ id: 'p1', timestamp: new Date(NOW).toISOString() })), end({ cursor: '150', more: true })]))
+      .mockResolvedValueOnce(streamResponse([line(ev({ id: 'p2', timestamp: new Date(NOW).toISOString() })), end({ cursor: '200' })]))
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(mockApiFetch).toHaveBeenCalledTimes(2)
+    expect(mockApiFetch.mock.calls[1][0]).toContain('since=150')
+    expect(out.events.map((e) => e.id).sort()).toEqual(['e1', 'p1', 'p2'])
+    expect(out.cursor).toBe('200')
+  })
+
+  it('a rejected cursor (400) resyncs with a full ring load', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e-stale' })])
+    mockApiFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'invalid since cursor' }),
+      } as unknown as Response)
+      .mockResolvedValueOnce(streamResponse([line(ev({ id: 'e-fresh' })), end({ cursor: '300' })]))
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(out.events.map((e) => e.id)).toEqual(['e-fresh'])
+    expect(out.cursor).toBe('300')
+  })
+
+  it('caps accumulated growth at the ring limit, dropping the oldest and flagging truncated', async () => {
+    const flags = new Set<string>()
+    // A ring already at the cap, oldest-last after sort.
+    const full: TimelineEvent[] = Array.from({ length: RETAINED_RING_LIMIT }, (_, i) =>
+      ev({ id: `e${i}`, timestamp: new Date(NOW - DAY - i * 1000).toISOString() }),
+    )
+    const cached = ring(full)
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([
+        line(ev({ id: 'e-newest', timestamp: new Date(NOW).toISOString() })),
+        end({ cursor: '200' }),
+      ]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(out.events).toHaveLength(RETAINED_RING_LIMIT)
+    expect(out.events[0].id).toBe('e-newest')
+    // The OLDEST row fell off the ring, and the drop is flagged, not silent.
+    expect(out.events.some((e) => e.id === `e${RETAINED_RING_LIMIT - 1}`)).toBe(false)
+    expect(out.truncated).toBe(true)
+  })
+
+  it('a hub without a delta cursor turns polls into no-ops instead of full reloads', async () => {
+    const flags = new Set<string>()
+    // Full load whose end record has NO cursor (pre-delta hub).
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e1', timestamp: new Date(NOW).toISOString() })), end()]),
+    )
+    const first = await runRetainedRingFetch({ ringKey: 'k', cached: undefined, forceResync: flags, capMs: CAP, now: NOW })
+    expect(first.events.map((e) => e.id)).toEqual(['e1'])
+    // Next poll: no network at all — the cached ring is returned as-is.
+    const second = await runRetainedRingFetch({ ringKey: 'k', cached: first, forceResync: flags, capMs: CAP, now: NOW })
+    expect(second).toBe(first)
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('a stale ring resyncs with a full reload past the anti-entropy window', async () => {
+    // loadedAtMs two hours back: cursor is valid, but the resync clock is due —
+    // the poll must take the FULL path (refreshing coverage + truncated).
+    const flags = new Set<string>()
+    const cached = ring(
+      [ev({ id: 'e-old-copy', timestamp: new Date(NOW - DAY).toISOString() })],
+      { loadedAtMs: NOW - 2 * 60 * 60 * 1000 },
+    )
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e-fresh', timestamp: new Date(NOW).toISOString() })), end({ cursor: '900' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(mockApiFetch.mock.calls[0][0]).toContain('from=')
+    expect(mockApiFetch.mock.calls[0][0]).not.toContain('since=')
+    expect(out.events.map((e) => e.id)).toEqual(['e-fresh'])
+    expect(out.cursor).toBe('900')
+    expect(out.loadedAtMs).toBe(NOW)
+  })
+
+  it('a manual refresh flag forces a full reload and is consumed', async () => {
+    const flags = new Set<string>(['k'])
+    const cached = ring([ev({ id: 'e1', timestamp: new Date(NOW - DAY).toISOString() })])
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'e-resynced', timestamp: new Date(NOW).toISOString() })), end({ cursor: '500' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW })
+    expect(mockApiFetch.mock.calls[0][0]).toContain('from=')
+    expect(out.events.map((e) => e.id)).toEqual(['e-resynced'])
+    expect(flags.has('k')).toBe(false)
+  })
+
+  it('the initial window extends past the client clock by the skew slack', async () => {
+    // A client clock behind the hub must not open a permanent hole at the live
+    // edge: to > now, from slides back by the same slack to keep the span.
+    const flags = new Set<string>()
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '1' })]))
+    await runRetainedRingFetch({ ringKey: 'k', cached: undefined, forceResync: flags, capMs: CAP, now: NOW })
+    const url = String(mockApiFetch.mock.calls[0][0])
+    const from = Number(/from=(\d+)/.exec(url)?.[1])
+    const to = Number(/to=(\d+)/.exec(url)?.[1])
+    expect(to).toBeGreaterThan(NOW)
+    expect(to - from).toBe(CAP)
+  })
+
+  it('a non-400 delta failure propagates and keeps the cursor for the next poll', async () => {
+    const flags = new Set<string>()
+    const cached = ring([ev({ id: 'e1' })])
+    mockApiFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: 'boom' }),
+      status: 503,
+    } as unknown as Response)
+    await expect(
+      runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW }),
+    ).rejects.toBeInstanceOf(ApiError)
+    // cursor is intact on the cached ring — nothing was committed
   })
 })

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -219,16 +219,19 @@ describe('localOverviewFromEvents', () => {
 })
 
 // The hook arms the frozen-window fetch on this predicate alone, so these pin
-// all three directions: ring-covered explicit windows stay zero-fetch, the
-// LIVE sliding selection (an explicit window ending at the clock) stays
-// zero-fetch, and a frozen selection below a truncated ring's oldest loaded
-// row escapes to the server.
+// all directions: ring-covered explicit windows stay zero-fetch, the LIVE
+// sliding selection (an explicit window ending at the clock) stays zero-fetch
+// even under hub-ahead clock skew and tick lag, and a frozen selection whose
+// to-edge sits below the newest loaded ring row (past the tick slack) with a
+// from-edge below the oldest escapes to the server — however close its
+// to-edge is to the clock.
 describe('needsWindowFetch (frozen-window coverage predicate)', () => {
   const HOUR = 60 * 60 * 1000
   const NOW = T0 + 24 * HOUR
+  const newestMs = NOW - HOUR
   const oldestMs = NOW - 2 * HOUR
   const ringEvents: TimelineEvent[] = [
-    ev({ id: 'newer', timestamp: new Date(NOW - HOUR).toISOString() }),
+    ev({ id: 'newer', timestamp: new Date(newestMs).toISOString() }),
     ev({ id: 'oldest', timestamp: new Date(oldestMs).toISOString() }),
   ]
   // A frozen selection wholly below the ring's oldest loaded row — THE bug
@@ -243,23 +246,57 @@ describe('needsWindowFetch (frozen-window coverage predicate)', () => {
   })
 
   it('a truncated ring still answers windows at or after its oldest loaded row', () => {
-    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs, NOW - HOUR, NOW)).toBe(false)
-    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs + 1, NOW - HOUR, NOW)).toBe(false)
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs, newestMs, NOW)).toBe(false)
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs + 1, newestMs, NOW)).toBe(false)
   })
 
-  it('a truncated ring with a from-edge below its oldest loaded row needs the server window', () => {
+  it('a from-edge below the oldest loaded row needs the server window when the to-edge is below the newest', () => {
     expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, deepToMs, NOW)).toBe(true)
-    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs - 1, NOW - HOUR, NOW)).toBe(true)
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs - 1, newestMs - 5 * 60_000, NOW)).toBe(true)
   })
 
-  it('a window ending at the live edge stays on the ring, however deep its from-edge', () => {
-    // The ring IS the server's newest-ringLimit answer up to now; a window
-    // fetch for this selection would return the same rows, and arming it
-    // would re-key a full fetch on every live tick.
+  it('a frozen window ending just below the newest ring row fetches even near the live edge', () => {
+    // Ring rows newer than the window's to-edge consume ring budget a server
+    // window fetch would spend on OLDER rows the truncated ring dropped —
+    // wall-clock proximity of the to-edge proves nothing about coverage.
+    const busyRing: TimelineEvent[] = [
+      ev({ id: 'fresh', timestamp: new Date(NOW - 30_000).toISOString() }),
+      ev({ id: 'oldest', timestamp: new Date(oldestMs).toISOString() }),
+    ]
+    expect(needsWindowFetch({ events: busyRing, truncated: true }, deepFromMs, NOW - 2 * 60_000, NOW)).toBe(true)
+  })
+
+  it('a window reaching to/past the newest ring row stays on the ring, however deep its from-edge', () => {
+    // Every ring row falls inside such a window, and the ring is the server's
+    // newest-ringLimit answer — a window fetch would return the identical set,
+    // and arming it would re-key a full fetch on every live tick.
     expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, NOW, NOW)).toBe(false)
-    // The live selection's to-edge lags the clock by its coarse tick; the
-    // slack band must absorb that lag.
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, newestMs, NOW)).toBe(false)
+    // An idle ring whose newest row is old: the live selection's to-edge sits
+    // far above it and stays ring-served.
     expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, NOW - 60_000, NOW)).toBe(false)
+  })
+
+  it('rows stamped ahead of the client clock cannot re-arm the live selection', () => {
+    // Hub clock ahead: the newest ring row sits in the client's future. The
+    // newest-row edge caps at `now`, so a live to-edge at the clock still
+    // counts as reaching the ring's edge.
+    const skewedRing: TimelineEvent[] = [
+      ev({ id: 'future', timestamp: new Date(NOW + 3 * 60_000).toISOString() }),
+      ev({ id: 'oldest', timestamp: new Date(oldestMs).toISOString() }),
+    ]
+    expect(needsWindowFetch({ events: skewedRing, truncated: true }, deepFromMs, NOW, NOW)).toBe(false)
+  })
+
+  it('a delta row landing between live ticks cannot re-arm the live selection', () => {
+    // The live to-edge lags the clock by up to one coarse tick while delta
+    // merges keep pushing the newest ring row toward now; the tick-slack
+    // tolerance keeps that lag from re-keying a full-window fetch per merge.
+    const freshRing: TimelineEvent[] = [
+      ev({ id: 'justmerged', timestamp: new Date(NOW - 5_000).toISOString() }),
+      ev({ id: 'oldest', timestamp: new Date(oldestMs).toISOString() }),
+    ]
+    expect(needsWindowFetch({ events: freshRing, truncated: true }, deepFromMs, NOW - 30_000, NOW)).toBe(false)
   })
 
   it('an empty truncated ring fails toward fetching', () => {

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -402,6 +402,30 @@ describe('retained ring fetch (the OSS-identical accumulate model)', () => {
     expect(out.truncated).toBe(true)
   })
 
+  // The local source shares this implementation with a smaller ceiling (its
+  // binary pages at 10k); the cap and the window-load limit must both follow
+  // the configured ringLimit, not the retained default.
+  it('honors a per-source ringLimit for the cap and the window-load limit', async () => {
+    const flags = new Set<string>()
+    const cached = ring([
+      ev({ id: 'old-1', timestamp: new Date(NOW - DAY - 1000).toISOString() }),
+      ev({ id: 'old-2', timestamp: new Date(NOW - DAY - 2000).toISOString() }),
+      ev({ id: 'old-3', timestamp: new Date(NOW - DAY - 3000).toISOString() }),
+    ])
+    mockApiFetch.mockResolvedValueOnce(
+      streamResponse([line(ev({ id: 'new-1', timestamp: new Date(NOW).toISOString() })), end({ cursor: '200' })]),
+    )
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, capMs: CAP, now: NOW, ringLimit: 3 })
+    expect(out.events.map((e) => e.id)).toEqual(['new-1', 'old-1', 'old-2'])
+    expect(out.truncated).toBe(true)
+
+    // A full load sends the configured limit on the wire.
+    const flags2 = new Set<string>()
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '1' })]))
+    await runRetainedRingFetch({ ringKey: 'k2', cached: undefined, forceResync: flags2, capMs: CAP, now: NOW, ringLimit: 3 })
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('limit=3')
+  })
+
   it('a hub without a delta cursor turns polls into no-ops instead of full reloads', async () => {
     const flags = new Set<string>()
     // Full load whose end record has NO cursor (pre-delta hub).

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -426,6 +426,21 @@ describe('retained ring fetch (the OSS-identical accumulate model)', () => {
     expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('limit=3')
   })
 
+  // Unbounded depth (a local store configured to retain forever): the full
+  // load starts at epoch zero and delta merges never age-prune.
+  it('treats an unset capMs as unbounded depth', async () => {
+    const flags = new Set<string>()
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '5' })]))
+    await runRetainedRingFetch({ ringKey: 'k', cached: undefined, forceResync: flags, now: NOW })
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('from=0')
+
+    const ancient = ev({ id: 'e-ancient', timestamp: new Date(NOW - 400 * DAY).toISOString() })
+    const cached = ring([ancient])
+    mockApiFetch.mockResolvedValueOnce(streamResponse([line(ev({ id: 'e-new', timestamp: new Date(NOW).toISOString() })), end({ cursor: '9' })]))
+    const out = await runRetainedRingFetch({ ringKey: 'k', cached, forceResync: flags, now: NOW })
+    expect(out.events.some((e) => e.id === 'e-ancient')).toBe(true)
+  })
+
   // The local source keeps its historical 5-minute anti-entropy cadence; a
   // per-source resyncMs below the ring age must force a full reload.
   it('honors a per-source resync interval', async () => {

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -426,6 +426,27 @@ describe('retained ring fetch (the OSS-identical accumulate model)', () => {
     expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('limit=3')
   })
 
+  // The ring is row-capped, so a namespace-scoped consumer must scope the
+  // server query itself — client-side filtering alone would let other
+  // namespaces' events consume the cap.
+  it('sends the namespace scope on window loads and delta polls', async () => {
+    const flags = new Set<string>()
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '5' })]))
+    const first = await runRetainedRingFetch({
+      ringKey: 'k', cached: undefined, forceResync: flags, capMs: CAP, now: NOW,
+      namespaces: ['team-a', 'team-b'],
+    })
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('namespaces=team-a%2Cteam-b')
+
+    mockApiFetch.mockResolvedValueOnce(streamResponse([end({ cursor: '6' })]))
+    await runRetainedRingFetch({
+      ringKey: 'k', cached: first, forceResync: flags, capMs: CAP, now: NOW,
+      namespaces: ['team-a', 'team-b'],
+    })
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('since=5')
+    expect(mockApiFetch.mock.calls.at(-1)?.[0]).toContain('namespaces=team-a%2Cteam-b')
+  })
+
   it('a hub without a delta cursor turns polls into no-ops instead of full reloads', async () => {
     const flags = new Set<string>()
     // Full load whose end record has NO cursor (pre-delta hub).

--- a/web/src/api/timelineSource.test.ts
+++ b/web/src/api/timelineSource.test.ts
@@ -18,6 +18,7 @@ import {
   runRetainedRingFetch,
   applyClientFilters,
   localOverviewFromEvents,
+  needsWindowFetch,
   type RetainedRing,
 } from './timelineSource'
 import type { TimelineEvent } from '../types'
@@ -214,6 +215,55 @@ describe('localOverviewFromEvents', () => {
     // Same hour → one hourly bucket, but two distinct 5-minute buckets.
     expect(localOverviewFromEvents(events).buckets).toHaveLength(1)
     expect(localOverviewFromEvents(events, FIVE_MIN).buckets).toHaveLength(2)
+  })
+})
+
+// The hook arms the frozen-window fetch on this predicate alone, so these pin
+// all three directions: ring-covered explicit windows stay zero-fetch, the
+// LIVE sliding selection (an explicit window ending at the clock) stays
+// zero-fetch, and a frozen selection below a truncated ring's oldest loaded
+// row escapes to the server.
+describe('needsWindowFetch (frozen-window coverage predicate)', () => {
+  const HOUR = 60 * 60 * 1000
+  const NOW = T0 + 24 * HOUR
+  const oldestMs = NOW - 2 * HOUR
+  const ringEvents: TimelineEvent[] = [
+    ev({ id: 'newer', timestamp: new Date(NOW - HOUR).toISOString() }),
+    ev({ id: 'oldest', timestamp: new Date(oldestMs).toISOString() }),
+  ]
+  // A frozen selection wholly below the ring's oldest loaded row — THE bug
+  // case: the ring slice for it is empty while the server holds rows.
+  const deepFromMs = NOW - 10 * HOUR
+  const deepToMs = NOW - 8 * HOUR
+
+  it('an untruncated ring answers every window — no fetch', () => {
+    // Even a from-edge far below the oldest loaded row: untruncated means the
+    // server sent everything it holds in the ring's depth.
+    expect(needsWindowFetch({ events: ringEvents, truncated: false }, deepFromMs, deepToMs, NOW)).toBe(false)
+  })
+
+  it('a truncated ring still answers windows at or after its oldest loaded row', () => {
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs, NOW - HOUR, NOW)).toBe(false)
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs + 1, NOW - HOUR, NOW)).toBe(false)
+  })
+
+  it('a truncated ring with a from-edge below its oldest loaded row needs the server window', () => {
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, deepToMs, NOW)).toBe(true)
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, oldestMs - 1, NOW - HOUR, NOW)).toBe(true)
+  })
+
+  it('a window ending at the live edge stays on the ring, however deep its from-edge', () => {
+    // The ring IS the server's newest-ringLimit answer up to now; a window
+    // fetch for this selection would return the same rows, and arming it
+    // would re-key a full fetch on every live tick.
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, NOW, NOW)).toBe(false)
+    // The live selection's to-edge lags the clock by its coarse tick; the
+    // slack band must absorb that lag.
+    expect(needsWindowFetch({ events: ringEvents, truncated: true }, deepFromMs, NOW - 60_000, NOW)).toBe(false)
+  })
+
+  it('an empty truncated ring fails toward fetching', () => {
+    expect(needsWindowFetch({ events: [], truncated: true }, deepFromMs, deepToMs, NOW)).toBe(true)
   })
 })
 
@@ -533,6 +583,28 @@ describe('retained ring fetch (the OSS-identical accumulate model)', () => {
     const to = Number(/to=(\d+)/.exec(url)?.[1])
     expect(to).toBeGreaterThan(NOW)
     expect(to - from).toBe(CAP)
+  })
+
+  // The frozen-window fetch reuses fetchRetainedWindow with the hook's exact
+  // arguments: the selection's [from,to], the source's ringLimit, and the
+  // server-side namespace scope.
+  it('a frozen-window fetch carries from/to/limit/namespaces on the wire and surfaces truncated', async () => {
+    mockApiFetch.mockResolvedValue(
+      streamResponse([
+        line(ev({ id: 'deep', timestamp: new Date(T0).toISOString() })),
+        end({ truncated: true }),
+      ]),
+    )
+    const res = await fetchRetainedWindow(T0, T0 + 60_000, undefined, 10_000, ['team-a', 'team-b'])
+    const url = String(mockApiFetch.mock.calls[0][0])
+    expect(url).toContain(`from=${T0}`)
+    expect(url).toContain(`to=${T0 + 60_000}`)
+    expect(url).toContain('limit=10000')
+    expect(url).toContain('namespaces=team-a%2Cteam-b')
+    expect(res.events.map((e) => e.id)).toEqual(['deep'])
+    // The window response's own truncated flag is what the hook surfaces while
+    // the window serves — a row-capped frozen window must not read as complete.
+    expect(res.truncated).toBe(true)
   })
 
   it('a non-400 delta failure propagates and keeps the cursor for the next poll', async () => {

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -2,7 +2,7 @@
 //
 // Radar's timeline can be backed by two stores:
 //   - 'local'    — the in-process event store the Radar binary keeps (default,
-//                  OSS standalone). Fetched via GET {apiBase}/changes.
+//                  OSS standalone). Fetched via GET {apiBase}/timeline/events.
 //   - 'retained' — a longer-horizon history store answered upstream of Radar
 //                  (relative to apiBase) as GET {apiBase}/timeline/events and
 //                  GET {apiBase}/timeline/overview. This is an extension point:
@@ -104,7 +104,9 @@ export interface TimelineEventsResult {
   // Do not drive user-visible loaders from this — they would flicker on every
   // poll; use isLoading (true only with no data at all) for loaders. Period
   // changes re-window the loaded ring client-side in both sources, so they
-  // never fetch and never signal either flag.
+  // never fetch and never signal either flag; the one exception is a frozen
+  // [from,to] selection reaching below a truncated ring, which fetches its
+  // own window once and signals both flags while it does.
   isFetching: boolean
   isError: boolean
   // The failure behind isError, when one is available. Surfaced so the UI can
@@ -114,9 +116,11 @@ export interface TimelineEventsResult {
   refetch: () => void
   // Present only for sources that report coverage (retained).
   coverage?: TimelineCoverageRecord[]
-  // Retained only: the ring load was row-capped, so the OLDEST part of the
-  // retention window is not loaded. Hosts must surface this — rendering a
-  // truncated ring without a note reads as "nothing older happened".
+  // The load serving the data was row-capped, so the OLDEST part of what it
+  // asked for is not loaded — the ring load when the ring serves, the window
+  // load when a frozen selection fetched its own window. Hosts must surface
+  // this — rendering a truncated result without a note reads as "nothing
+  // older happened".
   truncated?: boolean
 }
 
@@ -482,6 +486,51 @@ export interface RetainedRing {
   loadedAtMs: number
 }
 
+// A window whose to-edge sits within this band of the clock counts as ending
+// at the live edge. Generous: it only needs to absorb the LIVE selection's
+// coarse tick and clock jitter, and misclassifying a just-frozen window as
+// live-edged is harmless — at that moment the ring IS what the server would
+// return for it (see needsWindowFetch).
+const LIVE_EDGE_SLACK_MS = 5 * 60 * 1000
+
+// Whether an explicit [from,to] selection reaches below what the loaded ring
+// holds. A truncated ring kept only the NEWEST rows, so a selection whose
+// from-edge is older than the ring's oldest loaded event would render rows the
+// server still holds as empty — such a window must fetch itself. An
+// untruncated ring holds everything its depth covers, so every selection
+// slices it client-side with no fetch.
+//
+// A window ending at the live edge never fetches, however deep its from-edge:
+// the ring is the server's newest-ringLimit answer up to now, which is exactly
+// what a window fetch for it would return. This is what keeps the LIVE
+// sliding selection — which rides the query as an explicit [from,to] and
+// re-derives every tick — on the zero-fetch ring path instead of re-keying a
+// full-window fetch per tick.
+//
+// An empty truncated ring proves nothing about coverage, so it fails toward
+// fetching. Exported for unit tests; not re-exported publicly.
+export function needsWindowFetch(
+  ring: Pick<RetainedRing, 'events' | 'truncated'>,
+  fromMs: number,
+  toMs: number,
+  now: number,
+): boolean {
+  if (!ring.truncated) return false
+  if (toMs >= now - LIVE_EDGE_SLACK_MS) return false
+  let oldest = Number.POSITIVE_INFINITY
+  for (const e of ring.events) {
+    const t = new Date(e.timestamp).getTime()
+    if (Number.isFinite(t) && t < oldest) oldest = t
+  }
+  return fromMs < oldest
+}
+
+// A frozen window never slides and never polls, so it refetches only on a
+// genuinely new mount past this staleness. Not cached forever: a late-ingested
+// event CAN land inside an old window, so an aged cache entry may still
+// refresh.
+const FROZEN_WINDOW_STALE_MS = 10 * 60 * 1000
+
 // Ring keys whose next fetch must be a full reload (manual refresh). A side
 // flag, not a side cursor: consuming it only switches the PATH of the next
 // fetch — all sync state that must stay consistent with the data lives inside
@@ -622,7 +671,8 @@ function createRingEventsHook(opts: {
     // namespace-scoped consumer — an all-namespace ring could spend its whole
     // budget elsewhere). It does NOT carry the query's [from,to]: period
     // changes re-window the loaded ring client-side in applyClientFilters,
-    // issuing no fetch.
+    // issuing no fetch. A frozen window the ring cannot answer runs its own
+    // separately-keyed query below instead of widening the ring.
     const apiBase = getApiBase()
     const ringNamespacesKey = query.namespaces?.length ? [...query.namespaces].sort().join(',') : ''
     const queryKey = useMemo(
@@ -649,6 +699,46 @@ function createRingEventsHook(opts: {
       staleTime: 5000,
     })
 
+    // On a store holding more than ringLimit rows, an explicit frozen
+    // [from,to] older than the ring's oldest loaded event has NO rows in the
+    // ring even though the server holds them — slicing would render the deep
+    // past as empty. Such a window fetches itself: same endpoint, same wire
+    // contract in both modes. Ring-covered and live-edge windows never arm
+    // this query (see needsWindowFetch), so period changes and the live tick
+    // stay zero-fetch.
+    //
+    // The clock sample only refreshes when a dep changes, so on an IDLE ring a
+    // just-frozen live-edge window can stay ring-served past the slack band.
+    // That is coverage-correct: an idle ring accumulates nothing, drops
+    // nothing, and so keeps being the server's best answer for that window.
+    const windowFromMs = query.fromMs
+    const windowToMs = query.toMs
+    const windowNeeded = useMemo(
+      () =>
+        enabled && windowFromMs != null && windowToMs != null && ring.data != null &&
+        needsWindowFetch(ring.data, windowFromMs, windowToMs, Date.now()),
+      [enabled, windowFromMs, windowToMs, ring.data],
+    )
+    const windowQuery = useQuery<RetainedWindowResult>({
+      queryKey: ['timeline-window', apiBase, windowFromMs, windowToMs, ringNamespacesKey],
+      queryFn: ({ signal }) => {
+        if (windowFromMs == null || windowToMs == null) {
+          // Unreachable: `enabled` requires both bounds. Guards the invariant
+          // without a non-null assertion.
+          throw new Error('timeline window query ran without an explicit [from,to]')
+        }
+        return fetchRetainedWindow(
+          windowFromMs,
+          windowToMs,
+          signal,
+          ringLimit,
+          ringNamespacesKey ? ringNamespacesKey.split(',') : undefined,
+        )
+      },
+      enabled: windowNeeded,
+      staleTime: FROZEN_WINDOW_STALE_MS,
+    })
+
     const kindsKey = query.kinds?.join(',')
     const namespacesKey = query.namespaces?.join(',')
     // A preset-derived window slides with the clock; on an idle ring the memo
@@ -670,6 +760,12 @@ function createRingEventsHook(opts: {
       return () => clearInterval(id)
     }, [tickActive])
     const data = useMemo(() => {
+      if (windowNeeded) {
+        // Serving from the frozen-window fetch. Same client filters as the
+        // ring path so the two are indistinguishable to consumers; undefined
+        // while in flight so the host shows a loader, not an empty ring slice.
+        return windowQuery.data ? applyClientFilters(windowQuery.data.events, query) : undefined
+      }
       if (!ring.data) return undefined
       // A `timeRange` preset without an explicit [from,to] window resolves to
       // a client-side bound over the ring — the retained twin of the local
@@ -691,6 +787,8 @@ function createRingEventsHook(opts: {
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
       ring.data,
+      windowNeeded,
+      windowQuery.data,
       namespacesKey,
       kindsKey,
       query.includeK8sEvents,
@@ -704,6 +802,24 @@ function createRingEventsHook(opts: {
       derivedWindow,
       presetTick,
     ])
+
+    if (windowNeeded) {
+      // Every signal follows the query that serves the data: the ring keeps
+      // polling in the background, but its flags describe data the consumer
+      // is not looking at.
+      return {
+        data,
+        isLoading: windowQuery.isLoading,
+        isFetching: windowQuery.isFetching,
+        isError: windowQuery.isError,
+        error: windowQuery.error,
+        refetch: () => {
+          windowQuery.refetch()
+        },
+        coverage: windowQuery.data?.coverage,
+        truncated: windowQuery.data?.truncated,
+      }
+    }
 
     return {
       data,

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -275,7 +275,7 @@ const RETAINED_PRESET_TICK_MS = 5 * 60 * 1000
 // 'all'/unset falls back to the ring depth — clamping a preset wider than a
 // shallow host is the CALLER's job (Math.min at the use site). Exported for
 // unit tests; not re-exported publicly.
-export function rangeSpanMs(range: TimeRange | undefined, capMs: number): number {
+export function rangeSpanMs(range: TimeRange | undefined, capMs?: number): number | undefined {
   switch (range) {
     case '5m': return 5 * 60 * 1000
     case '30m': return 30 * 60 * 1000
@@ -498,7 +498,10 @@ export async function runRetainedRingFetch(deps: {
   ringKey: string
   cached: RetainedRing | undefined
   forceResync: Set<string>
-  capMs: number
+  // Retention depth of the backend. Undefined = unbounded (a local store may
+  // be configured to retain forever): the full load starts at epoch zero and
+  // delta merges never age-prune - the ring row cap is the only bound.
+  capMs?: number
   now: number
   signal?: AbortSignal
   // Ring row cap: the server's per-request ceiling for this source (the hub
@@ -557,8 +560,8 @@ export async function runRetainedRingFetch(deps: {
       // cap — accumulation past it drops the OLDEST rows, the same
       // semantics as the initial load and the local source's ring, and
       // flips `truncated` so the UI says so.
-      const floor = now - capMs - RETAINED_CLOCK_SKEW_SLACK_MS
-      const pruned = merged.filter((e) => new Date(e.timestamp).getTime() >= floor)
+      const floor = capMs != null ? now - capMs - RETAINED_CLOCK_SKEW_SLACK_MS : Number.NEGATIVE_INFINITY
+      const pruned = capMs != null ? merged.filter((e) => new Date(e.timestamp).getTime() >= floor) : merged
       const capped = pruned.length > ringLimit
       return {
         events: capped ? pruned.slice(0, ringLimit) : pruned,
@@ -582,7 +585,7 @@ export async function runRetainedRingFetch(deps: {
   // them). The window slides back by the same slack to stay within the hub's
   // maximum range.
   const to = now + RETAINED_CLOCK_SKEW_SLACK_MS
-  const full = await fetchRetainedWindow(to - capMs, to, signal, ringLimit, namespaces)
+  const full = await fetchRetainedWindow(capMs != null ? to - capMs : 0, to, signal, ringLimit, namespaces)
   // Consume the flag only while this fetch still owns the query. A resolved
   // load can still be discarded — a manual refresh cancels the in-flight poll
   // AFTER its network call finished — and deleting then would eat the flag
@@ -603,7 +606,8 @@ export async function runRetainedRingFetch(deps: {
 // (ringLimit). The endpoint path is identical (`{apiBase}/timeline/events`);
 // apiBase alone decides which server answers.
 function createRingEventsHook(opts: {
-  capMs: number
+  // Undefined = unbounded depth (the server's own retention is the bound).
+  capMs?: number
   ringLimit: number
   resyncMs: number
 }): (query: TimelineQuery) => TimelineEventsResult {
@@ -622,7 +626,7 @@ function createRingEventsHook(opts: {
     const apiBase = getApiBase()
     const ringNamespacesKey = query.namespaces?.length ? [...query.namespaces].sort().join(',') : ''
     const queryKey = useMemo(
-      () => ['timeline-ring', apiBase, capMs, ringNamespacesKey],
+      () => ['timeline-ring', apiBase, capMs ?? 'unbounded', ringNamespacesKey],
       [apiBase, ringNamespacesKey],
     )
 
@@ -674,7 +678,10 @@ function createRingEventsHook(opts: {
       // the whole ring.
       let effective = query
       if (derivedWindow) {
-        effective = { ...query, fromMs: Date.now() - Math.min(rangeSpanMs(query.timeRange, capMs), capMs) }
+        const span = rangeSpanMs(query.timeRange, capMs)
+        if (span != null) {
+          effective = { ...query, fromMs: Date.now() - (capMs != null ? Math.min(span, capMs) : span) }
+        }
       }
       return applyClientFilters(ring.data.events, effective)
       // Every filter is client-side here (the ring key carries none of them),
@@ -752,10 +759,9 @@ async function fetchRetainedOverview(range: TimelineRange): Promise<TimelineOver
 export const localSource: TimelineSource = {
   capabilities: { mode: 'local', ringLimit: LOCAL_RING_LIMIT },
   useEvents: createRingEventsHook({
-    // Depth is nominally unbounded locally (the server's own ring and
-    // retention are the real limits); the ceiling only bounds client-side
-    // pruning and 'all'-range resolution.
-    capMs: RETAINED_MAX_DEPTH_DAYS * DAY_MS,
+    // No depth cap: the binary's own ring size and --timeline-retention are
+    // the real bounds, and retention may legitimately be unlimited. The ring
+    // row ceiling still bounds client-side growth.
     ringLimit: LOCAL_RING_LIMIT,
     resyncMs: LOCAL_FULL_RESYNC_MS,
   }),

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -142,6 +142,10 @@ export interface TimelineSourceConfig {
 // 10k, matching the default in-process ring size).
 const LOCAL_RING_LIMIT = 10000
 
+// The local anti-entropy cadence: a full ring reload is a cheap same-host
+// request, so server-side evictions surface within minutes.
+const LOCAL_FULL_RESYNC_MS = 5 * 60 * 1000
+
 const LOCAL_HOUR_MS = 60 * 60 * 1000
 
 interface LocalHourSlot {
@@ -504,8 +508,16 @@ export async function runRetainedRingFetch(deps: {
   // Scope the server query when the consumer is namespace-scoped; see
   // namespacesParam.
   namespaces?: string[]
+  // Anti-entropy cadence: how stale the ring may get before a full reload
+  // (server-side evictions and retention prunes are invisible to deltas).
+  // The local binary reloads cheaply so it keeps its historical 5-minute
+  // cadence; a Cloud ring is a heavy transfer and resyncs hourly.
+  resyncMs?: number
 }): Promise<RetainedRing> {
-  const { ringKey, cached, forceResync, capMs, now, signal, ringLimit = RETAINED_RING_LIMIT, namespaces } = deps
+  const {
+    ringKey, cached, forceResync, capMs, now, signal,
+    ringLimit = RETAINED_RING_LIMIT, namespaces, resyncMs = RETAINED_FULL_RESYNC_MS,
+  } = deps
   // Anti-entropy: past the resync window (or on manual refresh), fall through
   // to a full reload regardless of cursor state — refreshing coverage,
   // recomputing the truncated flag, and dropping anything deltas can't
@@ -514,7 +526,7 @@ export async function runRetainedRingFetch(deps: {
   // resume) counts as due: the resync clock must fail toward refreshing, not
   // toward silently suspending anti-entropy for hours.
   const ringAge = cached != null ? now - cached.loadedAtMs : 0
-  const resyncDue = forceResync.has(ringKey) || (cached != null && (ringAge < 0 || ringAge > RETAINED_FULL_RESYNC_MS))
+  const resyncDue = forceResync.has(ringKey) || (cached != null && (ringAge < 0 || ringAge > resyncMs))
   if (cached && !resyncDue) {
     if (!cached.cursor) {
       return cached
@@ -593,8 +605,9 @@ export async function runRetainedRingFetch(deps: {
 function createRingEventsHook(opts: {
   capMs: number
   ringLimit: number
+  resyncMs: number
 }): (query: TimelineQuery) => TimelineEventsResult {
-  const { capMs, ringLimit } = opts
+  const { capMs, ringLimit, resyncMs } = opts
   return function useRingEvents(query: TimelineQuery): TimelineEventsResult {
     const enabled = query.enabled ?? true
     const queryClient = useQueryClient()
@@ -625,6 +638,7 @@ function createRingEventsHook(opts: {
           signal,
           ringLimit,
           namespaces: ringNamespacesKey ? ringNamespacesKey.split(',') : undefined,
+          resyncMs,
         }),
       enabled,
       refetchInterval: RETAINED_POLL_MS,
@@ -743,6 +757,7 @@ export const localSource: TimelineSource = {
     // pruning and 'all'-range resolution.
     capMs: RETAINED_MAX_DEPTH_DAYS * DAY_MS,
     ringLimit: LOCAL_RING_LIMIT,
+    resyncMs: LOCAL_FULL_RESYNC_MS,
   }),
 }
 
@@ -758,6 +773,7 @@ export function createRetainedSource(config: TimelineSourceConfig): TimelineSour
       capMs:
         Math.min(capabilities.maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS, RETAINED_MAX_DEPTH_DAYS) * DAY_MS,
       ringLimit: RETAINED_RING_LIMIT,
+      resyncMs: RETAINED_FULL_RESYNC_MS,
     }),
     fetchOverview: fetchRetainedOverview,
   }

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -14,6 +14,7 @@
 // wrappers stay source-agnostic: pick the source from context, call useEvents.
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { LIVE_TICK_MS } from '@skyhook-io/k8s-ui'
 import { apiFetch, mergeDeltaEvents, ApiError, type UseChangesOptions } from './client'
 import { apiUrl, getApiBase } from './config'
 import type { TimelineEvent, TimeRange } from '../types'
@@ -486,13 +487,6 @@ export interface RetainedRing {
   loadedAtMs: number
 }
 
-// A window whose to-edge sits within this band of the clock counts as ending
-// at the live edge. Generous: it only needs to absorb the LIVE selection's
-// coarse tick and clock jitter, and misclassifying a just-frozen window as
-// live-edged is harmless — at that moment the ring IS what the server would
-// return for it (see needsWindowFetch).
-const LIVE_EDGE_SLACK_MS = 5 * 60 * 1000
-
 // Whether an explicit [from,to] selection reaches below what the loaded ring
 // holds. A truncated ring kept only the NEWEST rows, so a selection whose
 // from-edge is older than the ring's oldest loaded event would render rows the
@@ -500,15 +494,30 @@ const LIVE_EDGE_SLACK_MS = 5 * 60 * 1000
 // untruncated ring holds everything its depth covers, so every selection
 // slices it client-side with no fetch.
 //
-// A window ending at the live edge never fetches, however deep its from-edge:
-// the ring is the server's newest-ringLimit answer up to now, which is exactly
-// what a window fetch for it would return. This is what keeps the LIVE
-// sliding selection — which rides the query as an explicit [from,to] and
-// re-derives every tick — on the zero-fetch ring path instead of re-keying a
-// full-window fetch per tick.
+// The ring stays authoritative only while the window reaches to/past the
+// NEWEST loaded ring row: every ring row then falls inside the window, and
+// the ring being the server's globally-newest-ringLimit rows makes them the
+// newest-ringLimit rows within the window too — a server window fetch would
+// return the identical set. A window whose to-edge is BELOW the newest ring
+// row excludes the freshest rows, so a server fetch spends that budget on
+// older rows the truncated ring dropped — such a window must fetch itself.
+// The guard is ring-relative, not wall-clock: distance from the clock proves
+// nothing about coverage (under heavy churn the ring's whole budget can sit
+// inside the last few minutes, leaving a just-frozen window's slice empty).
 //
-// An empty truncated ring proves nothing about coverage, so it fails toward
-// fetching. Exported for unit tests; not re-exported publicly.
+// Two allowances keep the LIVE sliding selection — an explicit [from,to]
+// re-derived from the clock on a coarse tick — on the zero-fetch ring path:
+// the newest-row edge caps at `now` (a hub clock ahead of the client stamps
+// ring rows in the client's future; they must not outrun a to-edge that
+// tracks the client clock), and the comparison tolerates one tick of lag
+// (delta merges land fresh rows while the live to-edge waits for its next
+// re-derive; without the tolerance every merge would re-key a full-window
+// fetch until the tick catches up).
+//
+// An empty truncated ring (or one with no parseable timestamps) proves
+// nothing about coverage, so it fails toward fetching. Exported for unit
+// tests; not re-exported publicly.
+const LIVE_WINDOW_TICK_SLACK_MS = 2 * LIVE_TICK_MS
 export function needsWindowFetch(
   ring: Pick<RetainedRing, 'events' | 'truncated'>,
   fromMs: number,
@@ -516,12 +525,15 @@ export function needsWindowFetch(
   now: number,
 ): boolean {
   if (!ring.truncated) return false
-  if (toMs >= now - LIVE_EDGE_SLACK_MS) return false
   let oldest = Number.POSITIVE_INFINITY
+  let newest = Number.NEGATIVE_INFINITY
   for (const e of ring.events) {
     const t = new Date(e.timestamp).getTime()
-    if (Number.isFinite(t) && t < oldest) oldest = t
+    if (!Number.isFinite(t)) continue
+    if (t < oldest) oldest = t
+    if (t > newest) newest = t
   }
+  if (Number.isFinite(newest) && toMs >= Math.min(newest, now) - LIVE_WINDOW_TICK_SLACK_MS) return false
   return fromMs < oldest
 }
 
@@ -707,10 +719,10 @@ function createRingEventsHook(opts: {
     // this query (see needsWindowFetch), so period changes and the live tick
     // stay zero-fetch.
     //
-    // The clock sample only refreshes when a dep changes, so on an IDLE ring a
-    // just-frozen live-edge window can stay ring-served past the slack band.
-    // That is coverage-correct: an idle ring accumulates nothing, drops
-    // nothing, and so keeps being the server's best answer for that window.
+    // The clock sample only refreshes when a dep changes; that is safe here
+    // because the predicate is ring-relative — the clock only caps the
+    // newest-row comparison against skew-stamped future rows, and a stale
+    // sample makes that cap tighter (toward the ring), never looser.
     const windowFromMs = query.fromMs
     const windowToMs = query.toMs
     const windowNeeded = useMemo(

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -12,10 +12,9 @@
 //
 // Both sources expose the same `useEvents(query)` hook shape so the timeline
 // wrappers stay source-agnostic: pick the source from context, call useEvents.
-import { useMemo } from 'react'
-import { useQuery, keepPreviousData } from '@tanstack/react-query'
-import { quantizeBaseWindow } from '@skyhook-io/k8s-ui'
-import { useChanges, apiFetch, ApiError, type UseChangesOptions } from './client'
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useChanges, apiFetch, mergeDeltaEvents, ApiError, type UseChangesOptions } from './client'
 import { apiUrl, getApiBase } from './config'
 import type { TimelineEvent, TimeRange } from '../types'
 
@@ -29,11 +28,6 @@ export type TimelineQuery = UseChangesOptions & {
   // [from,to] client-side.
   fromMs?: number
   toMs?: number
-  // LIVE mode: the [from,to] window slides every tick. Quantize the BASE fetch
-  // window to fixed steps so the react-query key only changes every few minutes;
-  // the precise sliding window is still applied by the client-side filter, and
-  // the trailing seam is covered by the live poll. Ignored by the local source.
-  sliding?: boolean
 }
 
 export interface TimelineSourceCapabilities {
@@ -101,11 +95,25 @@ export interface TimelineOverviewResult {
 export interface TimelineEventsResult {
   data: TimelineEvent[] | undefined
   isLoading: boolean
+  // Broad "is loading" signal: any fetch for the requested data is in flight,
+  // INCLUDING routine background polls (every ~10s on the retained source).
+  // Do not drive user-visible loaders from this — they would flicker on every
+  // poll; use isLoading (true only with no data at all) for loaders. Period
+  // changes re-window the loaded ring client-side in both sources, so they
+  // never fetch and never signal either flag.
   isFetching: boolean
   isError: boolean
+  // The failure behind isError, when one is available. Surfaced so the UI can
+  // show the server's actionable message (e.g. the retained row-cap "narrow the
+  // from/to range") instead of a generic "failed to load".
+  error?: Error | null
   refetch: () => void
   // Present only for sources that report coverage (retained).
   coverage?: TimelineCoverageRecord[]
+  // Retained only: the ring load was row-capped, so the OLDEST part of the
+  // retention window is not loaded. Hosts must surface this — rendering a
+  // truncated ring without a note reads as "nothing older happened".
+  truncated?: boolean
 }
 
 export interface TimelineSource {
@@ -143,7 +151,7 @@ function useLocalEvents(query: TimelineQuery): TimelineEventsResult {
   // query and the list's windowed one): SSE-driven refetches then transfer only
   // what arrived since the last full load. Dropdown-ranged (`since`) queries
   // stay plain — they're small and their range moves with the clock.
-  const { data, isLoading, isFetching, isError, refetch } = useChanges(
+  const { data, isLoading, isFetching, isError, error, refetch } = useChanges(
     windowed
       ? { ...query, timeRange: 'all', limit: LOCAL_RING_LIMIT, deltaSync: true }
       : { ...query, deltaSync: query.timeRange === 'all' },
@@ -166,7 +174,7 @@ function useLocalEvents(query: TimelineQuery): TimelineEventsResult {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [data, query.fromMs, query.toMs, query.limit, kindsKey, query.includeManaged],
   )
-  return { data: events, isLoading, isFetching, isError, refetch }
+  return { data: events, isLoading, isFetching, isError, error, refetch }
 }
 
 export const localSource: TimelineSource = {
@@ -252,53 +260,85 @@ const DAY_MS = 24 * HOUR_MS
 // Bound for the 'all' range when the host doesn't specify maxRangeDays.
 const DEFAULT_RETAINED_MAX_RANGE_DAYS = 7
 
-// Recent window the live poll re-fetches and merges over the loaded range. Wide
-// enough that a missed 10s tick can't open a gap. Exported so a unit test can pin
-// it against the base-window quantization step (quantization lag < poll window).
-export const LIVE_WINDOW_MS = 10 * 60 * 1000
-const LIVE_REFETCH_MS = 10_000
+// The retained source is the SAME accumulate model as the local source,
+// pointed at the hub: one ring load (the newest RETAINED_RING_LIMIT events
+// over the retention depth), then a poll for everything INGESTED since a
+// server-issued cursor. Ingestion order is what makes the poll complete —
+// a late-arriving or revised event has an old event time but a fresh
+// ingestion time, so it rides the same poll as brand-new events. Period
+// changes re-window the loaded ring client-side; no fetch.
 
-function rangeSpanMs(range: TimeRange | undefined, maxRangeDays?: number): number {
-  const cap = (maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS) * DAY_MS
-  let span: number
+// Matches the hub's per-response row cap. A window holding more arrives as
+// the newest RETAINED_RING_LIMIT events with `truncated` set — ring
+// semantics, exactly like the local source's capped ring, never a silent cut.
+export const RETAINED_RING_LIMIT = 50_000
+
+// Depth ceiling of the initial ring load; the hub rejects wider windows.
+const RETAINED_MAX_DEPTH_DAYS = 31
+
+// Delta poll cadence. Same order as the local source's SSE-nudged refetches.
+const RETAINED_POLL_MS = 10_000
+
+// A row-capped delta page sets `more`; the fetch pages forward immediately,
+// bounded so a pathological feed can't spin a single poll forever.
+const RETAINED_DELTA_MAX_PAGES = 10
+
+// Anti-entropy: a periodic full ring reload, the retained twin of the local
+// source's FULL_RESYNC_MS. Catches what deltas structurally can't — server-
+// side deletions, coverage-gap updates, and a stale truncated flag. Hourly,
+// not the local 5 minutes: a full ring is a heavy transfer and the delta feed
+// carries revisions, so entropy accumulates far slower here.
+const RETAINED_FULL_RESYNC_MS = 60 * 60 * 1000
+
+// Client-vs-hub clock skew allowance, applied at both edges of the ring:
+// the initial window's recent edge extends past the client clock by this
+// slack (a clock BEHIND the hub would otherwise exclude already-ingested
+// events in (clientNow, hubNow] — and the delta cursor already covers them,
+// so no poll would ever deliver them; the window slides back by the same
+// slack to stay within the hub's maximum range), and the delta-merge prune
+// floor sits below the retention depth by the same slack (a clock AHEAD of
+// the hub would otherwise prune oldest events the hub still retains).
+export const RETAINED_CLOCK_SKEW_SLACK_MS = 5 * 60 * 1000
+
+// How often a preset-derived window's sliding lower bound refreshes on an
+// IDLE ring (the no-op cached return keeps ring identity stable, so the memo
+// otherwise never re-samples the clock and a "24h" label slowly overstays).
+const RETAINED_PRESET_TICK_MS = 5 * 60 * 1000
+
+// The client-side spans the `timeRange` presets resolve to when no explicit
+// [from,to] window rides the query — the retained twin of the local source's
+// server-side `since` resolution. Preset arms return their nominal span; only
+// 'all'/unset falls back to the ring depth — clamping a preset wider than a
+// shallow host is the CALLER's job (Math.min at the use site). Exported for
+// unit tests; not re-exported publicly.
+export function rangeSpanMs(range: TimeRange | undefined, capMs: number): number {
   switch (range) {
-    case '5m':
-      span = 5 * 60 * 1000
-      break
-    case '30m':
-      span = 30 * 60 * 1000
-      break
-    case '1h':
-      span = HOUR_MS
-      break
-    case '6h':
-      span = 6 * HOUR_MS
-      break
-    case '24h':
-      span = 24 * HOUR_MS
-      break
-    case '7d':
-      span = 7 * DAY_MS
-      break
-    case '30d':
-      span = 30 * DAY_MS
-      break
-    case 'all':
-    case undefined:
-      span = cap
-      break
-    default:
-      span = HOUR_MS
+    case '5m': return 5 * 60 * 1000
+    case '30m': return 30 * 60 * 1000
+    case '1h': return HOUR_MS
+    case '6h': return 6 * HOUR_MS
+    case '24h': return 24 * HOUR_MS
+    case '7d': return 7 * DAY_MS
+    case '30d': return 30 * DAY_MS
+    default: return capMs
   }
-  return Math.min(span, cap)
 }
 
 interface RetainedWindowResult {
   events: TimelineEvent[]
   coverage: TimelineCoverageRecord[]
+  // Next delta cursor (opaque, server-issued). Absent when talking to a hub
+  // that predates the delta feed.
+  cursor?: string
+  // Delta page was row-capped; poll again immediately from `cursor`.
+  more: boolean
+  // Ring load shipped only the newest slice of the window.
+  truncated: boolean
 }
 
-type TerminalRecord = { type: 'end' } | { type: 'error'; message?: string }
+type TerminalRecord =
+  | { type: 'end'; cursor?: string; more?: boolean; truncated?: boolean }
+  | { type: 'error'; message?: string }
 
 // De-dupe by id keeping the LAST occurrence — a later revision of an event
 // replaces the earlier one.
@@ -308,16 +348,9 @@ function dedupeById(events: TimelineEvent[]): TimelineEvent[] {
   return Array.from(byId.values())
 }
 
-// Exported for unit tests (the NDJSON stream parser); not re-exported publicly.
-export async function fetchRetainedWindow(
-  from: number,
-  to: number,
-  signal?: AbortSignal,
-): Promise<RetainedWindowResult> {
-  const res = await apiFetch(
-    apiUrl(`/timeline/events?from=${Math.round(from)}&to=${Math.round(to)}`),
-    signal ? { signal } : undefined,
-  )
+// Shared NDJSON stream reader for both events endpoints (window and delta).
+async function fetchRetainedStream(path: string, signal?: AbortSignal): Promise<RetainedWindowResult> {
+  const res = await apiFetch(apiUrl(path), signal ? { signal } : undefined)
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
     throw new ApiError(errorData.error || `HTTP ${res.status}`, res.status, errorData)
@@ -336,9 +369,9 @@ export async function fetchRetainedWindow(
   const handleLine = (line: string): void => {
     const trimmed = line.trim()
     if (!trimmed) return
-    const rec = JSON.parse(trimmed) as { type?: string; message?: string }
+    const rec = JSON.parse(trimmed) as { type?: string; message?: string; cursor?: string; more?: boolean; truncated?: boolean }
     if (rec.type === 'end') {
-      terminal = { type: 'end' }
+      terminal = { type: 'end', cursor: rec.cursor, more: rec.more, truncated: rec.truncated }
     } else if (rec.type === 'error') {
       terminal = { type: 'error', message: rec.message }
     } else if (rec.type === 'coverage') {
@@ -365,11 +398,38 @@ export async function fetchRetainedWindow(
   if (!terminal) {
     throw new Error('timeline stream truncated (missing terminal record)')
   }
-  if ((terminal as TerminalRecord).type === 'error') {
-    throw new Error((terminal as { message?: string }).message || 'timeline stream error')
+  const end = terminal as TerminalRecord
+  if (end.type === 'error') {
+    throw new Error(end.message || 'timeline stream error')
   }
+  return {
+    events: dedupeById(events),
+    coverage,
+    cursor: end.cursor,
+    more: end.more === true,
+    truncated: end.truncated === true,
+  }
+}
 
-  return { events: dedupeById(events), coverage }
+// The ring load: newest `limit` events overlapping [from, to], plus the delta
+// cursor to continue from. Exported for unit tests; not re-exported publicly.
+export async function fetchRetainedWindow(
+  from: number,
+  to: number,
+  signal?: AbortSignal,
+  limit?: number,
+): Promise<RetainedWindowResult> {
+  const limitParam = limit ? `&limit=${limit}` : ''
+  return fetchRetainedStream(
+    `/timeline/events?from=${Math.round(from)}&to=${Math.round(to)}${limitParam}`,
+    signal,
+  )
+}
+
+// The delta poll: everything ingested since the cursor, in ingestion order.
+// Exported for unit tests; not re-exported publicly.
+export async function fetchRetainedDelta(cursor: string, signal?: AbortSignal): Promise<RetainedWindowResult> {
+  return fetchRetainedStream(`/timeline/events?since=${encodeURIComponent(cursor)}`, signal)
 }
 
 // Mirrors the Go store's TimelineEvent.IsManaged (pkg/timeline/types.go):
@@ -424,14 +484,120 @@ export function applyClientFilters(events: TimelineEvent[], query: TimelineQuery
   return out
 }
 
-function mergeWindows(
-  base: RetainedWindowResult | undefined,
-  live: RetainedWindowResult | undefined,
-): RetainedWindowResult {
-  // live is newer, so it overwrites base for shared ids.
-  const events = dedupeById([...(base?.events ?? []), ...(live?.events ?? [])])
-  const coverage = [...(base?.coverage ?? []), ...(live?.coverage ?? [])]
-  return { events, coverage }
+// The retained ring: what the single query holds. Same shape idea as the
+// local source's cached page, plus retention extras (coverage, truncation).
+export interface RetainedRing {
+  events: TimelineEvent[]
+  coverage: TimelineCoverageRecord[]
+  truncated: boolean
+  // The delta cursor rides the SAME react-query commit as the events it
+  // describes: an aborted or discarded fetch discards both together, so the
+  // cursor can never advance past events that were thrown away. Absent = the
+  // hub predates the delta feed; polls become no-ops (manual refresh still
+  // resyncs) instead of hammering it with a full reload every tick.
+  cursor?: string
+  // When the last FULL ring load ran — the anti-entropy resync clock.
+  loadedAtMs: number
+}
+
+// Ring keys whose next fetch must be a full reload (manual refresh). A side
+// flag, not a side cursor: consuming it only switches the PATH of the next
+// fetch — all sync state that must stay consistent with the data lives inside
+// RetainedRing itself.
+const retainedForceResync = new Set<string>()
+
+// Ring-fetch orchestration, the retained twin of client.ts's
+// runDeltaSyncFetch: full ring load when there's no cached page (or a resync
+// is due), else delta pages merged in with replace-by-id. Extracted so the
+// full-load → delta-poll → cursor-reset contract is exercisable without a
+// React render; state (the cached page, the force flag) is passed in
+// explicitly.
+export async function runRetainedRingFetch(deps: {
+  ringKey: string
+  cached: RetainedRing | undefined
+  forceResync: Set<string>
+  capMs: number
+  now: number
+  signal?: AbortSignal
+}): Promise<RetainedRing> {
+  const { ringKey, cached, forceResync, capMs, now, signal } = deps
+  // Anti-entropy: past the resync window (or on manual refresh), fall through
+  // to a full reload regardless of cursor state — refreshing coverage,
+  // recomputing the truncated flag, and dropping anything deltas can't
+  // retract.
+  // A negative age (loadedAtMs in the future — backward clock step, suspend/
+  // resume) counts as due: the resync clock must fail toward refreshing, not
+  // toward silently suspending anti-entropy for hours.
+  const ringAge = cached != null ? now - cached.loadedAtMs : 0
+  const resyncDue = forceResync.has(ringKey) || (cached != null && (ringAge < 0 || ringAge > RETAINED_FULL_RESYNC_MS))
+  if (cached && !resyncDue) {
+    if (!cached.cursor) {
+      return cached
+    }
+    try {
+      let cursor = cached.cursor
+      let merged = cached.events
+      let changed = false
+      for (let page = 0; page < RETAINED_DELTA_MAX_PAGES; page++) {
+        const delta = await fetchRetainedDelta(cursor, signal)
+        if (delta.cursor) cursor = delta.cursor
+        if (delta.events.length) {
+          merged = mergeDeltaEvents(merged, delta.events, Number.POSITIVE_INFINITY)
+          changed = true
+        }
+        if (!delta.more) break
+      }
+      // Returning the cached reference on a no-op delta skips re-renders. An
+      // idle cluster's cursor is stable by construction — verified against the
+      // hub: EventsIngestedSince starts its frontier AT `since` and advances
+      // it only past emitted rows, and the read-side clamp can only lower a
+      // frontier that already rests at or below the visibility edge.
+      if (!changed && cursor === cached.cursor) return cached
+      // Two bounds keep an always-open tab from growing without limit: the
+      // retention floor (the server TTL-deletes past the same boundary,
+      // held below the depth by the skew slack so a client clock ahead of
+      // the hub cannot prune events the hub still retains) and the ring row
+      // cap — accumulation past it drops the OLDEST rows, the same
+      // semantics as the initial load and the local source's ring, and
+      // flips `truncated` so the UI says so.
+      const floor = now - capMs - RETAINED_CLOCK_SKEW_SLACK_MS
+      const pruned = merged.filter((e) => new Date(e.timestamp).getTime() >= floor)
+      const capped = pruned.length > RETAINED_RING_LIMIT
+      return {
+        events: capped ? pruned.slice(0, RETAINED_RING_LIMIT) : pruned,
+        coverage: cached.coverage,
+        truncated: cached.truncated || capped,
+        cursor,
+        loadedAtMs: cached.loadedAtMs,
+      }
+    } catch (err) {
+      // A rejected cursor (hub restarted onto an older build, operator wiped
+      // the store) is recoverable: fall through to a full reload. Anything
+      // else propagates — react-query keeps the cached ring visible.
+      if (!(err instanceof ApiError && err.status === 400)) {
+        throw err
+      }
+    }
+  }
+  // The recent edge extends past the client clock by the skew slack (a client
+  // clock behind the hub would otherwise leave a permanent hole: events in
+  // (clientNow, hubNow] are under the returned cursor, so no delta re-delivers
+  // them). The window slides back by the same slack to stay within the hub's
+  // maximum range.
+  const to = now + RETAINED_CLOCK_SKEW_SLACK_MS
+  const full = await fetchRetainedWindow(to - capMs, to, signal, RETAINED_RING_LIMIT)
+  // Consume the flag only while this fetch still owns the query. A resolved
+  // load can still be discarded — a manual refresh cancels the in-flight poll
+  // AFTER its network call finished — and deleting then would eat the flag
+  // that refresh just armed, turning it into a silent no-op delta poll.
+  if (!signal?.aborted) forceResync.delete(ringKey)
+  return {
+    events: full.events,
+    coverage: full.coverage,
+    truncated: full.truncated,
+    cursor: full.cursor,
+    loadedAtMs: now,
+  }
 }
 
 function createRetainedEventsHook(
@@ -439,73 +605,78 @@ function createRetainedEventsHook(
 ): (query: TimelineQuery) => TimelineEventsResult {
   return function useRetainedEvents(query: TimelineQuery): TimelineEventsResult {
     const enabled = query.enabled ?? true
+    const queryClient = useQueryClient()
 
-    // Pin the base window when the range (or cap) changes — not on every render —
-    // so the query key is stable and react-query can cache it. Recency is the
-    // live poll's job.
-    const window = useMemo<TimelineRange>(() => {
-      if (query.fromMs != null && query.toMs != null) {
-        // An explicit window (frozen brush, or a hand-entered ?from&to) must not
-        // reach further back than maxRangeDays — the same cap rangeSpanMs applies
-        // to the range-derived branch below. Anchor at the recent edge.
-        const capMs = (capabilities.maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS) * DAY_MS
-        const from = Math.max(query.fromMs, query.toMs - capMs)
-        // Sliding: quantize so two ticks inside one step share a query key (no
-        // refetch). The precise [from,to] is still enforced by applyClientFilters.
-        if (query.sliding) {
-          const q = quantizeBaseWindow(from, query.toMs)
-          return { from: q.fromMs, to: q.toMs }
-        }
-        return { from, to: query.toMs }
-      }
-      const to = Date.now()
-      return { from: to - rangeSpanMs(query.timeRange, capabilities.maxRangeDays), to }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [query.fromMs, query.toMs, query.timeRange, query.sliding, capabilities.maxRangeDays])
-
-    const base = useQuery<RetainedWindowResult>({
-      // apiBase scopes the key: a host that swaps clusters (mutable module global)
-      // must not serve the previous cluster's cached window.
-      queryKey: ['timeline-retained', getApiBase(), 'base', window.from, window.to],
-      queryFn: ({ signal }) => fetchRetainedWindow(window.from, window.to, signal),
-      enabled,
-      staleTime: LIVE_REFETCH_MS,
-      // The base window quantizes to fixed steps, so its key rotates every few
-      // minutes even while live. Hold the previous window's events through the
-      // refetch instead of blanking the range on each rotation.
-      placeholderData: keepPreviousData,
-    })
-
-    // Fixed recent-window re-poll. Key is stable; queryFn reads the clock fresh
-    // each tick so the window slides without churning the cache key. Skipped for
-    // a purely historical brush (its right edge is older than the live window),
-    // where recency merging would only add events the time filter drops.
-    const liveEnabled = enabled && (query.toMs == null || query.toMs >= Date.now() - LIVE_WINDOW_MS)
-    const live = useQuery<RetainedWindowResult>({
-      queryKey: ['timeline-retained', getApiBase(), 'live'],
-      queryFn: ({ signal }) => {
-        const to = Date.now()
-        return fetchRetainedWindow(to - LIVE_WINDOW_MS, to, signal)
-      },
-      enabled: liveEnabled,
-      refetchInterval: LIVE_REFETCH_MS,
-    })
-
-    const merged = useMemo(
-      () => mergeWindows(base.data, live.data),
-      [base.data, live.data],
+    // The ring depth: the host's declared retention, ceilinged by what the hub
+    // serves per request. The key carries it (and the apiBase — a host that
+    // swaps clusters must not serve the previous cluster's ring), NOT the
+    // query's [from,to]: period changes re-window the loaded ring client-side
+    // in applyClientFilters, issuing no fetch — the same behavior as the local
+    // source, which is the point.
+    const capMs =
+      Math.min(capabilities.maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS, RETAINED_MAX_DEPTH_DAYS) * DAY_MS
+    const apiBase = getApiBase()
+    const queryKey = useMemo(
+      () => ['timeline-retained', apiBase, 'ring', capMs],
+      [apiBase, capMs],
     )
 
+    const ring = useQuery<RetainedRing>({
+      queryKey,
+      queryFn: ({ signal }) =>
+        runRetainedRingFetch({
+          ringKey: JSON.stringify(queryKey),
+          cached: queryClient.getQueryData<RetainedRing>(queryKey),
+          forceResync: retainedForceResync,
+          capMs,
+          now: Date.now(),
+          signal,
+        }),
+      enabled,
+      refetchInterval: RETAINED_POLL_MS,
+      staleTime: 5000,
+    })
+
     const kindsKey = query.kinds?.join(',')
+    const namespacesKey = query.namespaces?.join(',')
+    // A preset-derived window slides with the clock; on an idle ring the memo
+    // would never re-sample it (the no-op cached return keeps ring identity
+    // stable), freezing a "24h" bound overnight. A coarse tick keeps the label
+    // honest without meaningful churn.
+    const derivedWindow =
+      query.fromMs == null && query.toMs == null && !!query.timeRange && query.timeRange !== 'all'
+    // Gated on `enabled` too: a disabled consumer (an unopened tab) must not
+    // pay a periodic re-filter of the shared ring. The bump on arming keeps
+    // the window fresh across a disable→enable gap (tab reopened hours later
+    // must not show the stale bound until the next tick).
+    const tickActive = derivedWindow && enabled
+    const [presetTick, setPresetTick] = useState(0)
+    useEffect(() => {
+      if (!tickActive) return
+      setPresetTick((t) => t + 1)
+      const id = setInterval(() => setPresetTick((t) => t + 1), RETAINED_PRESET_TICK_MS)
+      return () => clearInterval(id)
+    }, [tickActive])
     const data = useMemo(() => {
-      if (base.data === undefined && live.data === undefined) return undefined
-      return applyClientFilters(merged.events, query)
+      if (!ring.data) return undefined
+      // A `timeRange` preset without an explicit [from,to] window resolves to
+      // a client-side bound over the ring — the retained twin of the local
+      // source's server-side `since` resolution. Without this, a consumer
+      // like the Applications History tab picking "24h" would silently get
+      // the whole ring.
+      let effective = query
+      if (derivedWindow) {
+        effective = { ...query, fromMs: Date.now() - Math.min(rangeSpanMs(query.timeRange, capMs), capMs) }
+      }
+      return applyClientFilters(ring.data.events, effective)
+      // Every filter is client-side here (the ring key carries none of them),
+      // so each rides the memo: array-valued ones via join keys so identity
+      // churn from the host doesn't re-filter. The live tick advances
+      // query.toMs, re-windowing to the sliding edge with no refetch.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-      merged,
-      base.data,
-      live.data,
-      query.namespaces,
+      ring.data,
+      namespacesKey,
       kindsKey,
       query.includeK8sEvents,
       query.includeDeleted,
@@ -513,20 +684,26 @@ function createRetainedEventsHook(
       query.limit,
       query.fromMs,
       query.toMs,
+      query.timeRange,
+      capMs,
+      derivedWindow,
+      presetTick,
     ])
 
     return {
       data,
-      isLoading: base.isLoading,
-      isFetching: base.isFetching || live.isFetching,
-      // Base failure is a real error; a failing live poll must not blank an
-      // already-loaded range.
-      isError: base.isError,
+      isLoading: ring.isLoading,
+      isFetching: ring.isFetching,
+      isError: ring.isError,
+      error: ring.error,
       refetch: () => {
-        base.refetch()
-        live.refetch()
+        // Manual refresh is the resync backstop: flag the ring so the next
+        // fetch reloads it whole instead of trusting accumulated state.
+        retainedForceResync.add(JSON.stringify(queryKey))
+        ring.refetch()
       },
-      coverage: merged.coverage,
+      coverage: ring.data?.coverage,
+      truncated: ring.data?.truncated,
     }
   }
 }

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -32,6 +32,10 @@ export type TimelineQuery = UseChangesOptions & {
 
 export interface TimelineSourceCapabilities {
   mode: 'local' | 'retained'
+  // The server's per-request row ceiling for this source — the number the
+  // truncation copy must cite (the local binary pages at 10k, a retained
+  // backend at 50k).
+  ringLimit: number
   // Only meaningful for 'retained': the maximum lookback the retained backend
   // serves. Clamps EVERY derived range (rangeSpanMs, not just 'all'), the
   // from-edge of an explicit [from,to] window, and the scrubber's selectable
@@ -374,18 +378,36 @@ export async function fetchRetainedWindow(
   to: number,
   signal?: AbortSignal,
   limit?: number,
+  namespaces?: string[],
 ): Promise<RetainedWindowResult> {
   const limitParam = limit ? `&limit=${limit}` : ''
   return fetchRetainedStream(
-    `/timeline/events?from=${Math.round(from)}&to=${Math.round(to)}${limitParam}`,
+    `/timeline/events?from=${Math.round(from)}&to=${Math.round(to)}${limitParam}${namespacesParam(namespaces)}`,
     signal,
   )
 }
 
+// A namespace-scoped consumer must scope the SERVER query, not just the
+// client filter: the ring is row-capped, so an all-namespace ring on a busy
+// cluster could spend its whole budget on other namespaces' events. A server
+// that scopes only by time ignores the parameter and the client filter still
+// applies.
+function namespacesParam(namespaces?: string[]): string {
+  if (!namespaces || namespaces.length === 0) return ''
+  return `&namespaces=${encodeURIComponent(namespaces.join(','))}`
+}
+
 // The delta poll: everything ingested since the cursor, in ingestion order.
 // Exported for unit tests; not re-exported publicly.
-export async function fetchRetainedDelta(cursor: string, signal?: AbortSignal): Promise<RetainedWindowResult> {
-  return fetchRetainedStream(`/timeline/events?since=${encodeURIComponent(cursor)}`, signal)
+export async function fetchRetainedDelta(
+  cursor: string,
+  signal?: AbortSignal,
+  namespaces?: string[],
+): Promise<RetainedWindowResult> {
+  return fetchRetainedStream(
+    `/timeline/events?since=${encodeURIComponent(cursor)}${namespacesParam(namespaces)}`,
+    signal,
+  )
 }
 
 // Mirrors the Go store's TimelineEvent.IsManaged (pkg/timeline/types.go):
@@ -479,8 +501,11 @@ export async function runRetainedRingFetch(deps: {
   // serves up to 50k; the local binary pages at 10k). Also bounds delta
   // accumulation client-side.
   ringLimit?: number
+  // Scope the server query when the consumer is namespace-scoped; see
+  // namespacesParam.
+  namespaces?: string[]
 }): Promise<RetainedRing> {
-  const { ringKey, cached, forceResync, capMs, now, signal, ringLimit = RETAINED_RING_LIMIT } = deps
+  const { ringKey, cached, forceResync, capMs, now, signal, ringLimit = RETAINED_RING_LIMIT, namespaces } = deps
   // Anti-entropy: past the resync window (or on manual refresh), fall through
   // to a full reload regardless of cursor state — refreshing coverage,
   // recomputing the truncated flag, and dropping anything deltas can't
@@ -499,7 +524,7 @@ export async function runRetainedRingFetch(deps: {
       let merged = cached.events
       let changed = false
       for (let page = 0; page < RETAINED_DELTA_MAX_PAGES; page++) {
-        const delta = await fetchRetainedDelta(cursor, signal)
+        const delta = await fetchRetainedDelta(cursor, signal, namespaces)
         if (delta.cursor) cursor = delta.cursor
         if (delta.events.length) {
           merged = mergeDeltaEvents(merged, delta.events, Number.POSITIVE_INFINITY)
@@ -545,7 +570,7 @@ export async function runRetainedRingFetch(deps: {
   // them). The window slides back by the same slack to stay within the hub's
   // maximum range.
   const to = now + RETAINED_CLOCK_SKEW_SLACK_MS
-  const full = await fetchRetainedWindow(to - capMs, to, signal, ringLimit)
+  const full = await fetchRetainedWindow(to - capMs, to, signal, ringLimit, namespaces)
   // Consume the flag only while this fetch still owns the query. A resolved
   // load can still be discarded — a manual refresh cancels the in-flight poll
   // AFTER its network call finished — and deleting then would eat the flag
@@ -574,14 +599,18 @@ function createRingEventsHook(opts: {
     const enabled = query.enabled ?? true
     const queryClient = useQueryClient()
 
-    // The key carries the depth (and the apiBase — a host that swaps clusters
-    // must not serve the previous cluster's ring), NOT the query's [from,to]:
-    // period changes re-window the loaded ring client-side in
-    // applyClientFilters, issuing no fetch.
+    // The key carries the depth, the apiBase (a host that swaps clusters must
+    // not serve the previous cluster's ring), and the namespace scope (the
+    // ring is row-capped, so the SERVER query must be scoped for a
+    // namespace-scoped consumer — an all-namespace ring could spend its whole
+    // budget elsewhere). It does NOT carry the query's [from,to]: period
+    // changes re-window the loaded ring client-side in applyClientFilters,
+    // issuing no fetch.
     const apiBase = getApiBase()
+    const ringNamespacesKey = query.namespaces?.length ? [...query.namespaces].sort().join(',') : ''
     const queryKey = useMemo(
-      () => ['timeline-ring', apiBase, capMs],
-      [apiBase],
+      () => ['timeline-ring', apiBase, capMs, ringNamespacesKey],
+      [apiBase, ringNamespacesKey],
     )
 
     const ring = useQuery<RetainedRing>({
@@ -595,6 +624,7 @@ function createRingEventsHook(opts: {
           now: Date.now(),
           signal,
           ringLimit,
+          namespaces: ringNamespacesKey ? ringNamespacesKey.split(',') : undefined,
         }),
       enabled,
       refetchInterval: RETAINED_POLL_MS,
@@ -706,7 +736,7 @@ async function fetchRetainedOverview(range: TimelineRange): Promise<TimelineOver
 }
 
 export const localSource: TimelineSource = {
-  capabilities: { mode: 'local' },
+  capabilities: { mode: 'local', ringLimit: LOCAL_RING_LIMIT },
   useEvents: createRingEventsHook({
     // Depth is nominally unbounded locally (the server's own ring and
     // retention are the real limits); the ceiling only bounds client-side
@@ -719,6 +749,7 @@ export const localSource: TimelineSource = {
 export function createRetainedSource(config: TimelineSourceConfig): TimelineSource {
   const capabilities: TimelineSourceCapabilities = {
     mode: 'retained',
+    ringLimit: RETAINED_RING_LIMIT,
     maxRangeDays: config.maxRangeDays,
   }
   return {

--- a/web/src/api/timelineSource.ts
+++ b/web/src/api/timelineSource.ts
@@ -14,7 +14,7 @@
 // wrappers stay source-agnostic: pick the source from context, call useEvents.
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useChanges, apiFetch, mergeDeltaEvents, ApiError, type UseChangesOptions } from './client'
+import { apiFetch, mergeDeltaEvents, ApiError, type UseChangesOptions } from './client'
 import { apiUrl, getApiBase } from './config'
 import type { TimelineEvent, TimeRange } from '../types'
 
@@ -130,57 +130,13 @@ export interface TimelineSourceConfig {
 }
 
 // ============================================================================
-// Local source — thin wrapper over the existing useChanges behavior. Zero
-// behavioral change for OSS standalone.
+// Local source — the same ring-and-delta hook as retained, pointed at the
+// Radar binary's own /timeline/events endpoint. One mechanism, two depths.
 // ============================================================================
 
-// Full ring size to pull when the host bounds the local list by the shared
-// scrubber selection — matches the swimlane's ring fetch so both views cover the
-// same window.
+// The local binary's per-request row ceiling (its /timeline/events pages at
+// 10k, matching the default in-process ring size).
 const LOCAL_RING_LIMIT = 10000
-
-function useLocalEvents(query: TimelineQuery): TimelineEventsResult {
-  // Without a window the dropdown-driven `since` fetch is untouched. When the
-  // host drives an explicit [from,to] window (the shared scrubber selection),
-  // the private range dropdown is bypassed: the local /changes endpoint is
-  // `since`-based and can't express a frozen past window, so load the whole ring
-  // and bound it to the selection client-side (applyClientFilters), exactly as
-  // the swimlane derives its view from the loaded ring.
-  const windowed = query.fromMs != null || query.toMs != null
-  // deltaSync on every full-ring pull (timeRange 'all' — the swimlane's direct
-  // query and the list's windowed one): SSE-driven refetches then transfer only
-  // what arrived since the last full load. Dropdown-ranged (`since`) queries
-  // stay plain — they're small and their range moves with the clock.
-  const { data, isLoading, isFetching, isError, error, refetch } = useChanges(
-    windowed
-      ? { ...query, timeRange: 'all', limit: LOCAL_RING_LIMIT, deltaSync: true }
-      : { ...query, deltaSync: query.timeRange === 'all' },
-  )
-  // applyClientFilters runs on BOTH paths: a multi-kind selection is a CLIENT-side
-  // filter (only a single kind rides the /changes server query key), so a 2+ kind
-  // pick is narrowed here whether or not a window is set. A non-windowed query has
-  // null from/to, so the [from,to] bounding inside is a no-op there; the windowed
-  // path additionally bounds the loaded ring. The memo watches kindsKey itself —
-  // `data` identity won't change when only the kind set does.
-  const kindsKey = query.kinds?.join(',')
-  const events = useMemo(
-    () => (data ? applyClientFilters(data, query) : data),
-    // `data` identity captures every server-side filter change (namespaces,
-    // k8s-events, deleted — all in the useChanges query key); the client-only
-    // window + cap + kind set are added here, plus includeManaged, which is
-    // client-enforced and must not depend on staying in the server key. The
-    // live tick advances query.toMs, re-filtering to the sliding edge with no
-    // refetch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, query.fromMs, query.toMs, query.limit, kindsKey, query.includeManaged],
-  )
-  return { data: events, isLoading, isFetching, isError, error, refetch }
-}
-
-export const localSource: TimelineSource = {
-  capabilities: { mode: 'local' },
-  useEvents: useLocalEvents,
-}
 
 const LOCAL_HOUR_MS = 60 * 60 * 1000
 
@@ -519,8 +475,12 @@ export async function runRetainedRingFetch(deps: {
   capMs: number
   now: number
   signal?: AbortSignal
+  // Ring row cap: the server's per-request ceiling for this source (the hub
+  // serves up to 50k; the local binary pages at 10k). Also bounds delta
+  // accumulation client-side.
+  ringLimit?: number
 }): Promise<RetainedRing> {
-  const { ringKey, cached, forceResync, capMs, now, signal } = deps
+  const { ringKey, cached, forceResync, capMs, now, signal, ringLimit = RETAINED_RING_LIMIT } = deps
   // Anti-entropy: past the resync window (or on manual refresh), fall through
   // to a full reload regardless of cursor state — refreshing coverage,
   // recomputing the truncated flag, and dropping anything deltas can't
@@ -562,9 +522,9 @@ export async function runRetainedRingFetch(deps: {
       // flips `truncated` so the UI says so.
       const floor = now - capMs - RETAINED_CLOCK_SKEW_SLACK_MS
       const pruned = merged.filter((e) => new Date(e.timestamp).getTime() >= floor)
-      const capped = pruned.length > RETAINED_RING_LIMIT
+      const capped = pruned.length > ringLimit
       return {
-        events: capped ? pruned.slice(0, RETAINED_RING_LIMIT) : pruned,
+        events: capped ? pruned.slice(0, ringLimit) : pruned,
         coverage: cached.coverage,
         truncated: cached.truncated || capped,
         cursor,
@@ -585,7 +545,7 @@ export async function runRetainedRingFetch(deps: {
   // them). The window slides back by the same slack to stay within the hub's
   // maximum range.
   const to = now + RETAINED_CLOCK_SKEW_SLACK_MS
-  const full = await fetchRetainedWindow(to - capMs, to, signal, RETAINED_RING_LIMIT)
+  const full = await fetchRetainedWindow(to - capMs, to, signal, ringLimit)
   // Consume the flag only while this fetch still owns the query. A resolved
   // load can still be discarded — a manual refresh cancels the in-flight poll
   // AFTER its network call finished — and deleting then would eat the flag
@@ -600,25 +560,28 @@ export async function runRetainedRingFetch(deps: {
   }
 }
 
-function createRetainedEventsHook(
-  capabilities: TimelineSourceCapabilities,
-): (query: TimelineQuery) => TimelineEventsResult {
-  return function useRetainedEvents(query: TimelineQuery): TimelineEventsResult {
+// One events hook for every mode. Local and hub-backed timelines share the
+// whole cycle — ring load, cursor deltas, client-side re-windowing — and
+// differ only in depth (capMs) and the server's per-request row ceiling
+// (ringLimit). The endpoint path is identical (`{apiBase}/timeline/events`);
+// apiBase alone decides which server answers.
+function createRingEventsHook(opts: {
+  capMs: number
+  ringLimit: number
+}): (query: TimelineQuery) => TimelineEventsResult {
+  const { capMs, ringLimit } = opts
+  return function useRingEvents(query: TimelineQuery): TimelineEventsResult {
     const enabled = query.enabled ?? true
     const queryClient = useQueryClient()
 
-    // The ring depth: the host's declared retention, ceilinged by what the hub
-    // serves per request. The key carries it (and the apiBase — a host that
-    // swaps clusters must not serve the previous cluster's ring), NOT the
-    // query's [from,to]: period changes re-window the loaded ring client-side
-    // in applyClientFilters, issuing no fetch — the same behavior as the local
-    // source, which is the point.
-    const capMs =
-      Math.min(capabilities.maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS, RETAINED_MAX_DEPTH_DAYS) * DAY_MS
+    // The key carries the depth (and the apiBase — a host that swaps clusters
+    // must not serve the previous cluster's ring), NOT the query's [from,to]:
+    // period changes re-window the loaded ring client-side in
+    // applyClientFilters, issuing no fetch.
     const apiBase = getApiBase()
     const queryKey = useMemo(
-      () => ['timeline-retained', apiBase, 'ring', capMs],
-      [apiBase, capMs],
+      () => ['timeline-ring', apiBase, capMs],
+      [apiBase],
     )
 
     const ring = useQuery<RetainedRing>({
@@ -631,6 +594,7 @@ function createRetainedEventsHook(
           capMs,
           now: Date.now(),
           signal,
+          ringLimit,
         }),
       enabled,
       refetchInterval: RETAINED_POLL_MS,
@@ -741,6 +705,17 @@ async function fetchRetainedOverview(range: TimelineRange): Promise<TimelineOver
   return { buckets, availableFromMs: env.availableFromMs }
 }
 
+export const localSource: TimelineSource = {
+  capabilities: { mode: 'local' },
+  useEvents: createRingEventsHook({
+    // Depth is nominally unbounded locally (the server's own ring and
+    // retention are the real limits); the ceiling only bounds client-side
+    // pruning and 'all'-range resolution.
+    capMs: RETAINED_MAX_DEPTH_DAYS * DAY_MS,
+    ringLimit: LOCAL_RING_LIMIT,
+  }),
+}
+
 export function createRetainedSource(config: TimelineSourceConfig): TimelineSource {
   const capabilities: TimelineSourceCapabilities = {
     mode: 'retained',
@@ -748,7 +723,11 @@ export function createRetainedSource(config: TimelineSourceConfig): TimelineSour
   }
   return {
     capabilities,
-    useEvents: createRetainedEventsHook(capabilities),
+    useEvents: createRingEventsHook({
+      capMs:
+        Math.min(capabilities.maxRangeDays ?? DEFAULT_RETAINED_MAX_RANGE_DAYS, RETAINED_MAX_DEPTH_DAYS) * DAY_MS,
+      ringLimit: RETAINED_RING_LIMIT,
+    }),
     fetchOverview: fetchRetainedOverview,
   }
 }

--- a/web/src/components/applications/ApplicationsView.tsx
+++ b/web/src/components/applications/ApplicationsView.tsx
@@ -639,13 +639,14 @@ function AppDetailRoute({
         history={historyQuery.data}
         historyLoading={historyQuery.isLoading}
         historyItems={historyItems}
-        historyRuntimeLoading={historyTimelineQuery.isFetching}
+        historyRuntimeLoading={historyTimelineQuery.isLoading}
         historyRuntimeError={historyTimelineQuery.isError}
         historyMode={timelineSource.capabilities.mode}
         historyRange={historyRange}
         historyRangeOptions={historyRangeOptions}
         historyCoverageRecordCount={historyTimelineQuery.coverage?.length ?? 0}
         historyRuntimeLimited={historyRuntimeLimited}
+        historyRingTruncated={historyTimelineQuery.truncated ?? false}
         onHistoryRangeChange={setRetainedHistoryRange}
         onOpenTimeline={openApplicationTimeline}
         onOpenSource={openSource}

--- a/web/src/components/timeline/RetainedTimelineScrubber.tsx
+++ b/web/src/components/timeline/RetainedTimelineScrubber.tsx
@@ -13,10 +13,11 @@ import {
   type ScrubberRange,
   type TimelineLiveState,
 } from '@skyhook-io/k8s-ui'
-import type {
-  TimelineSource,
-  TimelineOverviewBucket,
-  TimelineOverviewResult,
+import {
+  RETAINED_CLOCK_SKEW_SLACK_MS,
+  type TimelineSource,
+  type TimelineOverviewBucket,
+  type TimelineOverviewResult,
 } from '../../api/timelineSource'
 import { getApiBase } from '../../api/config'
 
@@ -25,8 +26,11 @@ const DAY_MS = 24 * HOUR_MS
 const EMPTY_BUCKETS: TimelineOverviewBucket[] = []
 const MAX_STRIP_BARS = 512
 
-// Per-request guard on the retained events endpoint: never brush wider than 7d.
-const MAX_SELECTION_MS = 7 * DAY_MS
+// Absolute per-request ceiling on the retained events endpoint, matching the
+// hub's own timelineEventsMaxRange. The effective cap is the smaller of this
+// and the embedder's declared retention depth (maxRangeDays), so a host that
+// advertises 30d of retention can load all 30d in one view.
+const MAX_SELECTION_MS = 31 * DAY_MS
 
 // Group the server's hour buckets into fixed display buckets aligned to the
 // display size, summing counts. The host owns this so the pure scrubber only
@@ -83,8 +87,8 @@ export function buildPresets(maxRangeDays: number): ScrubberPreset[] {
     { label: '24h', ms: DAY_MS },
     { label: '7d', ms: 7 * DAY_MS },
   ]
-  // 30d is a domain-context preset — it clamps to the 7d per-request cap, but
-  // signals the deeper retained window is available.
+  // 30d loads the full retained window in one request (bounded by the hub's
+  // per-request cap); shown only when the retention depth reaches it.
   if (maxRangeDays >= 30) presets.push({ label: '30d', ms: 30 * DAY_MS })
   return presets
 }
@@ -176,17 +180,21 @@ export function RetainedTimelineScrubber({ source, selection, onSelectionChange,
   const availableFromMs = overview.data?.availableFromMs
 
   const domain = useMemo<ScrubberRange>(() => {
-    // Clamp the domain floor to the queryable window. availableFromMs can point
+    // Clamp the domain floor to the LOADED window. availableFromMs can point
     // at ancient synthesized-historical event times (resource creation dates on
-    // long-lived clusters), which would stretch the strip over years of
-    // unreachable nothing — the UI can never brush past maxRangeDays anyway.
-    const floor = now - maxRangeDays * DAY_MS
+    // long-lived clusters), and a host may declare maxRangeDays deeper than the
+    // ring the client actually loads (MAX_SELECTION_MS) — either would stretch
+    // the strip over regions that render empty despite overview density. The
+    // ring's window slides forward by the clock-skew slack, so the floor does
+    // too — without it the oldest slack-width sliver is brushable but never
+    // loadable.
+    const floor = now - Math.min(maxRangeDays * DAY_MS, MAX_SELECTION_MS) + RETAINED_CLOCK_SKEW_SLACK_MS
     const fromMs = availableFromMs != null ? Math.max(availableFromMs, floor) : floor
     return { fromMs: Math.min(fromMs, now - HOUR_MS), toMs: now }
   }, [availableFromMs, now, maxRangeDays])
 
   const domainWidth = domain.toMs - domain.fromMs
-  const maxSelectionMs = Math.min(MAX_SELECTION_MS, domainWidth)
+  const maxSelectionMs = Math.min(maxRangeDays * DAY_MS, MAX_SELECTION_MS, domainWidth)
 
   // The histogram spans the QUERY RANGE (selection) directly —
   // no ×8 framing, no minimap. The query is the view, so a narrow window is never

--- a/web/src/components/timeline/TimelineList.tsx
+++ b/web/src/components/timeline/TimelineList.tsx
@@ -16,12 +16,11 @@ import { AlertTriangle, RefreshCw } from 'lucide-react'
 
 export type { ActivityTypeFilter, ActivityFilterKey }
 
-// Cap on the list fetch — server-side for local (the /changes limit param),
-// client-side for retained (which streams the full window; applyClientFilters
-// slices). Generous so a busy query window isn't silently truncated; the list
-// is already bounded to the selection range, so this only caps pathological
-// bursts. Surfaced as `truncatedAt` so a window that hits it shows an
-// end-of-list note instead of dropping silently.
+// Cap on the list result — applied client-side in both modes over the loaded
+// window (applyClientFilters slices). Generous so a busy query window isn't
+// silently truncated; the list is already bounded to the selection range, so
+// this only caps pathological bursts. Surfaced as `truncatedAt` so a window
+// that hits it shows an end-of-list note instead of dropping silently.
 const LIST_FETCH_LIMIT = 2000
 const APP_SCOPED_FETCH_LIMIT = 10000
 
@@ -42,10 +41,11 @@ interface TimelineListProps {
   kindFilter: string[]
   onKindFilterChange: (kinds: string[]) => void
   // The shared scrubber selection [from,to]. When set (retained mode always;
-  // local mode once the scrubber owns the range), it drives the fetch window and
+  // local mode once the scrubber owns the range), it drives the query window and
   // hides the built-in range dropdown so the list can't drift from the
-  // swimlane/URL. Retained scopes server-side; local loads the ring and bounds it
-  // client-side (see useLocalEvents).
+  // swimlane/URL. In both modes a window the loaded ring covers slices it
+  // client-side with no fetch; a frozen selection older than a truncated ring's
+  // oldest row fetches its own server window (see createRingEventsHook).
   selectionWindow?: { fromMs: number; toMs: number }
   // Time span of the rows visible in the list's scrollport — the host renders
   // it as the scrubber lens so scrolling the list moves the lens.

--- a/web/src/components/timeline/TimelineList.tsx
+++ b/web/src/components/timeline/TimelineList.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from 'react'
 import {
+  SEVERITY_TEXT,
   TimelineList as TimelineListUI,
   eventsForApplication,
   type ActivityTypeFilter,
@@ -15,10 +16,12 @@ import { AlertTriangle, RefreshCw } from 'lucide-react'
 
 export type { ActivityTypeFilter, ActivityFilterKey }
 
-// Server-side cap on the list fetch. Generous so a busy query window isn't
-// silently truncated — the list is already bounded to the selection range, so
-// this only caps pathological bursts. Surfaced to the list as `truncatedAt` so a
-// window that does hit it shows an end-of-list note instead of dropping silently.
+// Cap on the list fetch — server-side for local (the /changes limit param),
+// client-side for retained (which streams the full window; applyClientFilters
+// slices). Generous so a busy query window isn't silently truncated; the list
+// is already bounded to the selection range, so this only caps pathological
+// bursts. Surfaced as `truncatedAt` so a window that hits it shows an
+// end-of-list note instead of dropping silently.
 const LIST_FETCH_LIMIT = 2000
 const APP_SCOPED_FETCH_LIMIT = 10000
 
@@ -44,9 +47,6 @@ interface TimelineListProps {
   // swimlane/URL. Retained scopes server-side; local loads the ring and bounds it
   // client-side (see useLocalEvents).
   selectionWindow?: { fromMs: number; toMs: number }
-  // LIVE mode: quantize the base fetch so the sliding window doesn't churn the
-  // query key every tick.
-  sliding?: boolean
   // Time span of the rows visible in the list's scrollport — the host renders
   // it as the scrubber lens so scrolling the list moves the lens.
   onVisibleWindowChange?: (window: { fromMs: number; toMs: number } | null) => void
@@ -58,7 +58,7 @@ interface TimelineListProps {
   appScopeLoading?: boolean
 }
 
-export function TimelineList({ namespaces, onViewChange, currentView, onResourceClick, initialFilter, initialTimeRange, showDeleted, onShowDeletedChange, search, onSearchChange, activityFilter, onActivityFilterChange, kindFilter, onKindFilterChange, selectionWindow, sliding, onVisibleWindowChange, scrollToMs, focusedAppIndex, appScoped = false, topology, appScopeLoading = false }: TimelineListProps) {
+export function TimelineList({ namespaces, onViewChange, currentView, onResourceClick, initialFilter, initialTimeRange, showDeleted, onShowDeletedChange, search, onSearchChange, activityFilter, onActivityFilterChange, kindFilter, onKindFilterChange, selectionWindow, onVisibleWindowChange, scrollToMs, focusedAppIndex, appScoped = false, topology, appScopeLoading = false }: TimelineListProps) {
   const hasLimitedAccess = useHasLimitedAccess()
   const timelineSource = useTimelineSource()
   const [queryParams, setQueryParams] = useState<{ timeRange: TimeRange; kinds: string[] }>({
@@ -71,7 +71,7 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
   }, [])
 
   const fetchLimit = appScoped ? APP_SCOPED_FETCH_LIMIT : LIST_FETCH_LIMIT
-  const { data: unscopedEvents = [], isLoading, isError, refetch } = timelineSource.useEvents({
+  const { data: fetchedEvents, isLoading, isError, error, refetch } = timelineSource.useEvents({
     namespaces,
     kinds: queryParams.kinds,
     timeRange: queryParams.timeRange,
@@ -81,23 +81,27 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
     limit: fetchLimit,
     fromMs: selectionWindow?.fromMs,
     toMs: selectionWindow?.toMs,
-    sliding,
   })
-  const events = useMemo(
-    () => appScoped
+  const events = useMemo(() => {
+    const unscoped = fetchedEvents ?? []
+    return appScoped
       ? focusedAppIndex
-        ? eventsForApplication(unscopedEvents, topology, focusedAppIndex)
+        ? eventsForApplication(unscoped, topology, focusedAppIndex)
         : []
-      : unscopedEvents,
-    [appScoped, focusedAppIndex, topology, unscopedEvents],
-  )
-  const sourceTruncated = unscopedEvents.length >= fetchLimit
+      : unscoped
+  }, [appScoped, focusedAppIndex, topology, fetchedEvents])
+  const sourceTruncated = (fetchedEvents?.length ?? 0) >= fetchLimit
 
-  if (isError) {
+  // Full-screen error only when nothing is loaded; a failing background poll
+  // with data on screen keeps rendering (data before error).
+  if (isError && !fetchedEvents) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-3">
         <AlertTriangle className="w-10 h-10 text-amber-400/70" />
         <p className="text-base">Failed to load timeline data</p>
+        {error?.message?.trim() && (
+          <p className="max-w-md px-6 text-center text-sm text-theme-text-tertiary">{error.message.trim()}</p>
+        )}
         <button
           onClick={() => refetch()}
           className="flex items-center gap-2 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg hover:bg-theme-hover transition-colors"
@@ -109,34 +113,53 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
     )
   }
 
+  // Failing background polls with rows on screen: keep the data, say it may
+  // be stale. Only when the list owns its own range — under a scrubber the
+  // view-level banner already reports the shared failure, and a second note
+  // would double up.
+  const staleNote = isError && fetchedEvents && !selectionWindow ? (
+    <div className="flex items-center gap-1.5 border-b border-theme-border px-4 py-1.5 text-xs text-theme-text-tertiary">
+      <AlertTriangle className={`h-3.5 w-3.5 shrink-0 ${SEVERITY_TEXT.warning}`} />
+      Live updates are failing — the list may be stale.
+      <button type="button" onClick={() => refetch()} className="underline hover:text-theme-text-primary">
+        Retry now
+      </button>
+    </div>
+  ) : null
+
   return (
-    <TimelineListUI
-      events={events}
-      isLoading={isLoading || appScopeLoading}
-      onQueryChange={handleQueryChange}
-      hasLimitedAccess={hasLimitedAccess}
-      namespaces={namespaces}
-      onViewChange={onViewChange}
-      currentView={currentView}
-      onResourceClick={onResourceClick}
-      initialFilter={initialFilter}
-      initialTimeRange={initialTimeRange}
-      hideRangeSelector={!!selectionWindow}
-      showDeleted={showDeleted}
-      onShowDeletedChange={onShowDeletedChange}
-      search={search}
-      onSearchChange={onSearchChange}
-      activityFilter={activityFilter}
-      onActivityFilterChange={onActivityFilterChange}
-      kindFilter={kindFilter}
-      onKindFilterChange={onKindFilterChange}
-      onVisibleWindowChange={onVisibleWindowChange}
-      scrollToMs={scrollToMs}
-      truncatedAt={fetchLimit}
-      isTruncated={sourceTruncated}
-      truncationMessage={appScoped && sourceTruncated
-        ? `Showing application activity found in the newest ${fetchLimit.toLocaleString()} events in this range — narrow the query to see older activity`
-        : undefined}
-    />
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      {staleNote}
+      <div className="min-h-0 flex-1">
+        <TimelineListUI
+          events={events}
+          isLoading={isLoading || appScopeLoading}
+          onQueryChange={handleQueryChange}
+          hasLimitedAccess={hasLimitedAccess}
+          namespaces={namespaces}
+          onViewChange={onViewChange}
+          currentView={currentView}
+          onResourceClick={onResourceClick}
+          initialFilter={initialFilter}
+          initialTimeRange={initialTimeRange}
+          hideRangeSelector={!!selectionWindow}
+          showDeleted={showDeleted}
+          onShowDeletedChange={onShowDeletedChange}
+          search={search}
+          onSearchChange={onSearchChange}
+          activityFilter={activityFilter}
+          onActivityFilterChange={onActivityFilterChange}
+          kindFilter={kindFilter}
+          onKindFilterChange={onKindFilterChange}
+          onVisibleWindowChange={onVisibleWindowChange}
+          scrollToMs={scrollToMs}
+          truncatedAt={fetchLimit}
+          isTruncated={sourceTruncated}
+          truncationMessage={appScoped && sourceTruncated
+            ? `Showing application activity found in the newest ${fetchLimit.toLocaleString()} events in this range — narrow the query to see older activity`
+            : undefined}
+        />
+      </div>
+    </div>
   )
 }

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -25,7 +25,6 @@ import { RetainedTimelineScrubber, extendSelection, type ScrubberDomainInfo } fr
 import { LocalTimelineScrubber } from './LocalTimelineScrubber'
 import { useTopology, useApplications } from '../../api/client'
 import { useTimelineSource } from '../../context/TimelineSource'
-import { RETAINED_RING_LIMIT } from '../../api/timelineSource'
 import type { Topology } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
 import { LargeClusterNamespacePicker } from '../shared/LargeClusterNamespacePicker'
@@ -832,7 +831,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
         {ringTruncated && (
           <div className="flex items-center gap-1.5 border-b border-theme-border px-4 py-1.5 text-xs text-theme-text-tertiary">
             <AlertTriangle className={`h-3.5 w-3.5 shrink-0 ${SEVERITY_TEXT.warning}`} />
-            History is truncated: showing the newest {RETAINED_RING_LIMIT.toLocaleString()} events of the retention window — the oldest activity is not loaded.
+            History is truncated: showing the newest {timelineSource.capabilities.ringLimit.toLocaleString()} events of the retention window — the oldest activity is not loaded.
           </div>
         )}
         {/* Failing background polls with a loaded ring: keep the data, say

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -25,6 +25,7 @@ import { RetainedTimelineScrubber, extendSelection, type ScrubberDomainInfo } fr
 import { LocalTimelineScrubber } from './LocalTimelineScrubber'
 import { useTopology, useApplications } from '../../api/client'
 import { useTimelineSource } from '../../context/TimelineSource'
+import { RETAINED_RING_LIMIT } from '../../api/timelineSource'
 import type { Topology } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
 import { LargeClusterNamespacePicker } from '../shared/LargeClusterNamespacePicker'
@@ -92,6 +93,10 @@ export type TimelineMode =
 // burying the lanes in a day of history; presets/URL widen it deliberately.
 const DEFAULT_LIVE_WIDTH_MS = 60 * 60 * 1000
 const DAY_MS = 24 * 60 * 60 * 1000
+// Presets wider than this land the swimlane on a bounded recent lens instead of
+// the full range, so it never renders every resource lane at once (a 30d domain
+// has thousands). 7d and narrower keep the full-range lens.
+const WIDE_LENS_THRESHOLD_MS = 7 * DAY_MS
 // Fallback cap for a retained hand-entered ?from&to when the source doesn't
 // declare maxRangeDays — mirrors the retained source's own default.
 const DEFAULT_MAX_RANGE_DAYS = 7
@@ -293,8 +298,8 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
   const effectiveInitialMode = scopeRequiresNamespaceFilter ? 'list' : (parseView(searchParams) ?? initialViewMode ?? DEFAULT_VIEW)
   const [viewMode, setViewMode] = useState<TimelineViewMode>(effectiveInitialMode)
   // Shared across list + swimlane so the toggle carries across the view switch,
-  // and so the swimlane fetch can exclude deletes server-side (before LIMIT)
-  // rather than only hiding them client-side after the 10k cap.
+  // and so the fetch can exclude deletes at the source rather than only hiding
+  // them client-side.
   const [showDeleted, setShowDeleted] = useState(() => searchParams.get('deleted') !== '0')
   // ?pinnedOnly=1 is inert without pins: honoring it with no stored pins would
   // arm a filter that hides everything. Gate the read on stored pins so the param
@@ -519,11 +524,21 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     // plain fixed widths.
     const all = isLocal && scrubberDomain != null && widthMs >= scrubberDomain.maxSelectionMs
     const now = Date.now()
+    const sel = deriveLiveSelection(capped, now)
     setMode({ kind: 'live', widthMs: capped, all: all || undefined })
     setFrozenAsOfMs(null)
     setNowTick(now)
-    resetLensToFull(deriveLiveSelection(capped, now))
-  }, [isLocal, scrubberDomain, resetLensToFull])
+    // A full-range lens on a very wide domain (e.g. 30d) renders EVERY resource
+    // lane at once — thousands of rows — which freezes the browser for seconds
+    // before the view settles. Land directly on a bounded recent lens instead;
+    // the density strip still spans the full selected range for context, and the
+    // user scrubs it. Narrow presets (<= 7d) keep the full-range lens unchanged.
+    if (capped > WIDE_LENS_THRESHOLD_MS) {
+      resetLensToRecent(sel)
+    } else {
+      resetLensToFull(sel)
+    }
+  }, [isLocal, scrubberDomain, resetLensToFull, resetLensToRecent])
 
   // "→ Now" → LIVE, width = current selection width. Pins to now and resets the
   // lens to the live edge.
@@ -640,22 +655,26 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     setSearchParamsRef.current(target, { replace })
   }, [viewMode, mode, showDeleted, pinnedOnly, search, activityFilter, kindFilter, grouping, sort, selectedEventId, isRetained, isLocal, scopeRequiresNamespaceFilter])
 
-  // Fetch all activity - zoom controls what's visible in the UI. The heavy 10k
-  // ring feeds the swimlanes and the local strip's histogram, so it also runs in
-  // list mode when that strip is shown; the list itself fetches its own 2000.
-  const { data: activity, isLoading, isError, refetch } = timelineSource.useEvents({
+  // Fetch all activity - zoom controls what's visible in the UI. This ring feeds
+  // the swimlanes and the local strip's histogram, so it also runs in list mode
+  // when that strip is shown; the list itself fetches its own 2000.
+  const { data: activity, isLoading, isError, error, refetch, truncated: ringTruncated } = timelineSource.useEvents({
     namespaces: timelineNamespaces,
     timeRange: 'all',
     includeK8sEvents: true,
     includeManaged: true,
     includeDeleted: showDeleted,
-    limit: 10000,
+    // Only the local in-memory ring imposes a client-side size cap (it can't
+    // hold more than its ring anyway). Retained mode renders every event its
+    // ring holds — the hub bounds the ring itself (retention depth + a newest-
+    // 50k cap flagged as truncated, never a silent cut), so a busy window
+    // never silently drops its oldest events on the client.
+    limit: isRetained ? undefined : 10000,
     // The local strip derives its histogram from this ring fetch, so it must
     // run in list mode too whenever the strip is shown.
     enabled: appScopeReady && (showSwimlanes || showLocalScrubber),
     fromMs: isRetained ? selection.fromMs : undefined,
     toMs: isRetained ? selection.toMs : undefined,
-    sliding: isRetained && mode.kind === 'live',
   })
 
   // Topology powers both swimlane hierarchy and application-scoped attribution.
@@ -721,7 +740,12 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
   )
   const focusedAppLoading = Boolean(focusedAppKey) && appsLoading
   const focusedAppUnavailable = Boolean(focusedAppKey) && (!appScopeReady || (!appsLoading && (appsError || !focusedApp)))
-  const focusedAppTimelineLimited = Boolean(focusedAppKey) && unscopedEvents.length >= 10_000
+  // Only local truncates the swimlane fetch at 10k (the in-memory ring cap), so
+  // hitting 10k there genuinely means older app activity is hidden. Retained
+  // sends no client limit — the full hub ring is on screen (the hub caps it at
+  // the newest 50k, surfaced by the truncated flag and its banner, never a
+  // silent cut) — so this "showing newest 10k" banner would be false there.
+  const focusedAppTimelineLimited = isLocal && Boolean(focusedAppKey) && unscopedEvents.length >= 10_000
   const clearFocusedApp = useCallback(() => {
     const next = new URLSearchParams(searchParamsRef.current)
     next.delete('app')
@@ -802,6 +826,26 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     return (
       <div className="flex-1 flex flex-col min-h-0">
         {appScopeBar}
+        {/* A row-capped ring load means the OLDEST part of the retention
+            window is not loaded — say so, or an old selection reads as
+            "nothing happened back then". */}
+        {ringTruncated && (
+          <div className="flex items-center gap-1.5 border-b border-theme-border px-4 py-1.5 text-xs text-theme-text-tertiary">
+            <AlertTriangle className={`h-3.5 w-3.5 shrink-0 ${SEVERITY_TEXT.warning}`} />
+            History is truncated: showing the newest {RETAINED_RING_LIMIT.toLocaleString()} events of the retention window — the oldest activity is not loaded.
+          </div>
+        )}
+        {/* Failing background polls with a loaded ring: keep the data, say
+            it's going stale. The full-screen error is reserved for no-data. */}
+        {isError && activity && (
+          <div className="flex items-center gap-1.5 border-b border-theme-border px-4 py-1.5 text-xs text-theme-text-tertiary">
+            <AlertTriangle className={`h-3.5 w-3.5 shrink-0 ${SEVERITY_TEXT.warning}`} />
+            Live updates are failing — the timeline may be stale.
+            <button type="button" onClick={() => refetch()} className="underline hover:text-theme-text-primary">
+              Retry now
+            </button>
+          </div>
+        )}
         {isRetained ? (
           <RetainedTimelineScrubber
             source={timelineSource}
@@ -887,18 +931,26 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
       )
     }
 
-    // A failed fetch must not render as the swimlane "No events yet" empty state —
-    // that reads as a quiet cluster rather than a load failure.
-    if (isError) {
+    // A failed fetch with NOTHING loaded must not render as the swimlane
+    // "No events yet" empty state — that reads as a quiet cluster rather than
+    // a load failure. With a loaded ring on screen, a failing background poll
+    // must NOT blank it (gate on data before error); the stale-data banner
+    // below carries the warning instead.
+    if (isError && !activity) {
+      // Surface the server's own message — a generic "failed to load" would
+      // swallow whatever the hub said. "Try again" is a full resync: the
+      // retained source drops its delta cursor and reloads the whole ring.
+      const detail = error?.message?.trim()
       return wrap(
         <div className="flex-1 flex flex-col">
           <div className="flex items-center justify-between px-4 py-2 border-b border-theme-border">
             <div />
             <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
           </div>
-          <div className="flex-1 flex flex-col items-center justify-center text-theme-text-tertiary gap-3">
+          <div className="flex-1 flex flex-col items-center justify-center text-theme-text-tertiary gap-3 px-6">
             <AlertTriangle className="w-10 h-10 text-amber-400/70" />
             <p className="text-base">Failed to load timeline data</p>
+            {detail && <p className="max-w-md text-center text-sm text-theme-text-tertiary">{detail}</p>}
             <button
               onClick={() => refetch()}
               className="flex items-center gap-2 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg hover:bg-theme-hover transition-colors"
@@ -971,7 +1023,6 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
       // to own the range — passing it scrubber-less would hide the list's own
       // range dropdown and leave the user with no time control at all.
       selectionWindow={showScrubber ? selection : undefined}
-      sliding={showScrubber && mode.kind === 'live'}
       onVisibleWindowChange={setListVisibleWindow}
       // Seeded with the swimlane's window at the switch (see the viewMode
       // effect); afterwards, dragging the strip band retargets the scroll.


### PR DESCRIPTION
## Summary

Timeline data is synced with a ring-and-delta mechanism over one wire contract, served by both the Radar binary and Cloud-retained backends: the client loads its event ring once, polls a cursor-based delta endpoint for what arrived since, and resolves every period change client-side over the loaded ring. With a Cloud-retained backend the timeline serves up to 30 days of history; against the local binary it serves the in-process ring. The mechanism, interface, and UI are identical in both cases - retention depth is the only difference.

## Server

New endpoint `GET /api/timeline/events` (`internal/server/timeline_events.go`), NDJSON lines closed by a terminal record:

- `?from&to[&limit]` - window load: the newest events in the event-time range; `truncated` on the terminal record when the range held more than the limit.
- `?since=<cursor>` - delta: every event that *arrived* after the cursor, ascending arrival order. Arrival order means a late-arriving or revised event (old event time, fresh arrival) is delivered by the next poll like any new event - no gap tracking.
- The terminal record carries an opaque `epoch:seq` cursor. A cursor minted under another epoch (the store was re-created: restart, kubeconfig context switch) is answered with **400**; the client reacts with an automatic full reload.
- The query is everything-visible; content filters are client-side. Per-user namespace RBAC and cluster-scoped-kind filtering match `/api/changes`, including advancing the cursor past rows the user cannot read (a run of unreadable rows must not pin a client's cursor).
- `/api/changes` is unchanged.

## Client

`web/src/api/timelineSource.ts`: both timeline sources use one ring-and-delta hook against `{apiBase}/timeline/events`, configured per source:

| | local | retained (Cloud) |
|---|---|---|
| ring row ceiling | 10k (the binary's page cap) | 50k |
| depth | the binary's own ring/retention | up to 31 days (`maxRangeDays`) |
| overview strip | derived client-side from the ring | server rollup (`fetchOverview`) |

Replaced by this hook: the local source's `useChanges`-based fetch path, and the retained source's periodic full window refetch with its separate live-window poll (`TimelineQuery.sliding`, `quantizeBaseWindow`, `BASE_QUANTIZE_STEP_MS`, `LIVE_WINDOW_MS` are removed).

Behavior of the hook:

- One window load, then a ~KB cursor delta every 10s; new, late, and revised events merge into the ring by id.
- Period changes re-slice the loaded ring client-side - zero network requests.
- Automatic full reloads: hourly (anti-entropy), on a 400-rejected cursor, and on manual refresh. The load window and the prune floor both carry 5 minutes of clock-skew slack.
- Namespace-scoped consumers scope the server query itself (the namespace set rides the requests and the ring cache key): a row-capped ring must not spend its budget on other namespaces' events.
- SSE frames invalidate the ring (throttled ~5s, `web/src/App.tsx`), keeping the timeline fresh within seconds; the 10s poll is the no-SSE fallback.
- Against a backend whose terminal record has no cursor, polls are no-ops and manual refresh still reloads.

## UI

- The ring-truncation state is surfaced: banners in the timeline and the application History tab, citing the active source's ceiling (`capabilities.ringLimit`).
- A failing poll with data on screen keeps the data and shows a stale-data note with Retry (timeline and standalone list); a full-screen error appears only when nothing is loaded.
- Presets wider than 7 days open on a bounded recent lens (a full 30-day lens renders thousands of lanes at once); the scrubber allows selections up to 31 days, bounded by the declared retention depth.
- `TimelineSwimlanes` recomputes lane ordering and window clipping only when the visible window actually changes, not on every 30s live tick.

## Compatibility

- `/api/changes` untouched; the new endpoint is additive - old web clients against a new binary keep working.
- Published package surface: `TimelineEventsResult` gains optional `error`/`truncated`; `TimelineSourceCapabilities` gains `ringLimit`; `TimelineQuery.sliding` is removed (no consumers remain); `@skyhook-io/k8s-ui` drops the now-unused `quantizeBaseWindow`/`BASE_QUANTIZE_STEP_MS` exports - k8s-ui and radar-app must be published in lockstep.

## Testing

- Go: a contract test pins the NDJSON framing, epoch/cursor semantics, ascending delta paging, truncation, the `to` bound, and every 400 path. Full `internal/` and `pkg/` suites green.
- Client: 37 ring-behavior cases (delta merge, late-event arrival, revision replace, atomic cursor commit, pruning with clock-skew slack, row cap, paging, 400 recovery, per-source ring ceiling, namespace scoping); full web (182) and k8s-ui (1256) suites green; tsc clean.
- Verified against a running binary watching a real cluster: one window load then only `?since=` deltas, zero `/api/changes` timeline traffic; killing and restarting the binary produced `400 → automatic full window reload → deltas resuming on the new epoch` with no user-visible error.
- The retained configuration was verified end-to-end against a live Cloud deployment: initial load, ~KB polls, zero-fetch period switches, and a late-arriving 3-day-old event surfacing within one poll at its historical position.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral swap in timeline data fetching (cursor epochs, truncation, frozen-window fetches) across server RBAC and client caching; additive API but breaking package exports require lockstep k8s-ui/radar-app publish.
> 
> **Overview**
> **Unifies timeline loading** on a single **ring load + cursor delta** model over **`GET /api/timeline/events`** (NDJSON + terminal `epoch:seq` cursor), matching the hub wire contract. The Radar binary gains **`handleTimelineEvents`** for window (`?from&to`) and delta (`?since`) queries with RBAC/cursor semantics aligned to `/api/changes`; **`/api/changes` is unchanged**.
> 
> **Replaces split client paths**: local no longer uses **`useChanges`** / sliding **`quantizeBaseWindow`**; retained drops the dual base+live window refetch. Both sources share **`createRingEventsHook`** / **`runRetainedRingFetch`** (10s polls, hourly/400/manual resync, **`needsWindowFetch`** for deep frozen windows, namespace-scoped ring keys). SSE also invalidates **`timeline-ring`** queries.
> 
> **UI/API surface**: **`ringLimit`**, **`truncated`**, and **`error`** on timeline results; ring-truncation banners (timeline + app history); stale-data banners when polls fail with data loaded; retained scrubber domain/selection up to **31d**; wide presets open a bounded lens; swimlane memos keyed on window bounds only (not live **`now`** ticks). **`quantizeBaseWindow`** exports removed from k8s-ui.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95d5cb30f4afde0b5fce621cf3f222fb189ecb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->