### PR TITLE
Add semantic color to Radar Cloud CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ and Cloud configuration without printing the connection token. Passing both
 `--namespace` and `--release` selects an exact installation. Live tunnel status
 is reported by Radar Cloud using the token in the referenced Kubernetes Secret.
 If the Secret or Hub is unavailable, local installation diagnostics still run.
+Interactive terminals use restrained status colors; set `NO_COLOR` (or pipe the
+output) for plain text. URLs, tokens, and suggested commands remain unstyled.
 
 **CLI Flags**
 

--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/skyhook-io/radar/internal/app"
+	"github.com/skyhook-io/radar/internal/cliui"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/cloudinstall"
 	"github.com/skyhook-io/radar/internal/config"
@@ -241,6 +242,8 @@ func cloudInstall(args []string) {
 
 	ctx, cancel := signalContext()
 	defer cancel()
+	stdoutStyle := cliui.New(os.Stdout)
+	stderrStyle := cliui.New(os.Stderr)
 
 	// Build kube + helm clients against the resolved kubecontext — the driver runs
 	// before Radar's normal boot, so we resolve these ourselves.
@@ -250,7 +253,7 @@ func cloudInstall(args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Inspecting Kubernetes context %q for an existing Radar installation…\n\n", ctxName)
+	fmt.Printf("%s Inspecting Kubernetes context %q for an existing Radar installation…\n\n", stdoutStyle.Marker(cliui.Progress), ctxName)
 	interactive := term.IsTerminal(int(os.Stdin.Fd()))
 	plan, err := inspectCloudInstallPlan(ctx, clients, *namespace, *release, cloudInstallUsesExactTarget(explicitNamespace, explicitRelease))
 	if err != nil {
@@ -332,7 +335,7 @@ func cloudInstall(args []string) {
 			})
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "permission preflight failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "%s permission preflight failed: %v\n", stderrStyle.Marker(cliui.Failure), err)
 			fmt.Fprintln(os.Stderr, "No Hub request or cluster was created.")
 			os.Exit(1)
 		}
@@ -341,15 +344,16 @@ func cloudInstall(args []string) {
 			fmt.Fprintln(os.Stderr, "No Hub request or cluster was created.")
 			os.Exit(1)
 		}
+		fmt.Printf("%s Permission preflight passed.\n", stdoutStyle.Marker(cliui.Success))
 		printCloudPermissionAdvisories(os.Stdout, pf)
 	}
 
 	// Dry-run stops before device approval and token minting.
 	if *dryRun {
 		if plan.Mode == cloudInstallGitOps {
-			fmt.Println("Dry run complete. The verified GitOps controller and exact stable target are shown above; no Hub request or live Kubernetes change was made.")
+			fmt.Printf("%s Dry run complete. The verified GitOps controller and exact stable target are shown above; no Hub request or live Kubernetes change was made.\n", stdoutStyle.Marker(cliui.Success))
 		} else {
-			fmt.Println("Dry run complete. Blocking permission checks and chart preparation passed; no Hub request or Kubernetes change was made.")
+			fmt.Printf("%s Dry run complete. Blocking permission checks and chart preparation passed; no Hub request or Kubernetes change was made.\n", stdoutStyle.Marker(cliui.Success))
 		}
 		return
 	}
@@ -360,18 +364,18 @@ func cloudInstall(args []string) {
 	client := cloud.NewConnectClient(*hubURL)
 	cr, err := client.Create(ctx, meta)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\ncouldn't start the connect flow: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\n%s couldn't start the connect flow: %v\n", stderrStyle.Marker(cliui.Failure), err)
 		os.Exit(1)
 	}
-	fmt.Printf("  Approve this connection in your browser:\n\n    %s\n\n", cr.ConnectURL)
+	fmt.Printf("  %s Approve this connection in your browser:\n\n    %s\n\n", stdoutStyle.Marker(cliui.Progress), cr.ConnectURL)
 	if !*noBrowser {
 		go app.OpenBrowser(cr.ConnectURL, *browserPref)
 	}
-	fmt.Println("  Waiting for approval… (Ctrl-C to cancel)")
+	fmt.Printf("  %s Waiting for approval… (Ctrl-C to cancel)\n", stdoutStyle.Marker(cliui.Progress))
 
 	pr, err := client.PollUntilApproved(ctx, cr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\nconnect failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\n%s connect failed: %v\n", stderrStyle.Marker(cliui.Failure), err)
 		os.Exit(1)
 	}
 	if ctx.Err() != nil && plan.Mode != cloudInstallGitOps {
@@ -384,7 +388,7 @@ func cloudInstall(args []string) {
 			printGitOpsHandoffFailure(os.Stderr, err, pr.ClusterID, cloudClusterURL(cr.ConnectURL, pr.ClusterID))
 			os.Exit(1)
 		}
-		fmt.Printf("\n  Waiting up to %s for your GitOps-managed agent to connect (you can safely leave this running)…\n", cloudTunnelConfirmationTimeout)
+		fmt.Printf("\n  %s Waiting up to %s for your GitOps-managed agent to connect (you can safely leave this running)…\n", stdoutStyle.Marker(cliui.Progress), cloudTunnelConfirmationTimeout)
 		if err := client.WaitUntilConsumed(ctx, cr, cloudTunnelConfirmationTimeout); err != nil {
 			printGitOpsPendingHandoff(os.Stderr, err, pr.ClusterID, cloudClusterURL(cr.ConnectURL, pr.ClusterID))
 			os.Exit(1)
@@ -399,7 +403,8 @@ func cloudInstall(args []string) {
 	if plan.Mode == cloudInstallAdopt {
 		action = "Upgrading and connecting"
 	}
-	fmt.Printf("\n  Approved. %s Radar in namespace %q…\n", action, prepared.Namespace())
+	fmt.Printf("\n  %s Approved.\n", stdoutStyle.Marker(cliui.Success))
+	fmt.Printf("  %s %s Radar in namespace %q…\n", stdoutStyle.Marker(cliui.Progress), action, prepared.Namespace())
 	perr := cloudinstall.ProvisionPrepared(ctx, clients.Kubernetes, prepared, cloudinstall.ProvisionConfig{
 		Namespace:    prepared.Namespace(),
 		ReleaseName:  prepared.ReleaseName(),
@@ -409,12 +414,13 @@ func cloudInstall(args []string) {
 		Token:        pr.Token,
 	})
 	if perr != nil {
-		fmt.Fprintf(os.Stderr, "\nprovisioning failed: %v\n", perr)
+		fmt.Fprintf(os.Stderr, "\n%s provisioning failed: %v\n", stderrStyle.Marker(cliui.Failure), perr)
 		printPostApprovalRecoveryGuidance(os.Stderr, pr.ClusterID, cloudClusterURL(cr.ConnectURL, pr.ClusterID), provisionRecoveryFrom(prepared), perr, commandTarget)
 		os.Exit(1)
 	}
 
-	fmt.Printf("\n  Kubernetes provisioning complete. Waiting up to %s for the in-cluster agent to connect…\n", cloudTunnelConfirmationTimeout)
+	fmt.Printf("\n  %s Kubernetes provisioning complete.\n", stdoutStyle.Marker(cliui.Success))
+	fmt.Printf("  %s Waiting up to %s for the in-cluster agent to connect…\n", stdoutStyle.Marker(cliui.Progress), cloudTunnelConfirmationTimeout)
 	if err := client.WaitUntilConsumed(ctx, cr, cloudTunnelConfirmationTimeout); err != nil {
 		printTunnelConfirmationFailure(os.Stderr, err, pr.ClusterID, pr.WSSURL, prepared.Deployment(), commandTarget)
 		os.Exit(1)
@@ -470,7 +476,7 @@ func cloudClusterURL(connectURL, clusterID string) string {
 }
 
 func printInstallSuccess(w io.Writer, clusterName, clusterURL string, deployment helm.DeploymentRef, target cloudCommandTarget) {
-	fmt.Fprintf(w, "\n  ✓ Cluster %q is connected to Radar.\n", clusterName)
+	fmt.Fprintf(w, "\n  %s Cluster %q is connected to Radar.\n", cliui.New(w).Marker(cliui.Success), clusterName)
 	fmt.Fprintf(w, "    Open: %s\n", clusterURL)
 	fmt.Fprintf(w, "    Track it: %s -n %s rollout status deployment/%s\n\n", target.kubectl(), deployment.Namespace, deployment.Name)
 }
@@ -520,7 +526,7 @@ func printTokenSecretConflict(w io.Writer, err error) bool {
 }
 
 func printCanceledAfterApproval(w io.Writer, clusterID, clusterURL string) {
-	fmt.Fprintf(w, "\nThe Hub approved cluster %q, but this command was canceled before Kubernetes provisioning began.\n", clusterID)
+	fmt.Fprintf(w, "\n%s The Hub approved cluster %q, but this command was canceled before Kubernetes provisioning began.\n", cliui.New(w).Marker(cliui.Attention), clusterID)
 	fmt.Fprintln(w, "No token Secret or Helm release was written. Rerun `radar cloud install` to try again.")
 	fmt.Fprintln(w, "The previous approval may remain as a pending cluster in Radar. An organization owner can delete it later:")
 	fmt.Fprintf(w, "  %s\n", clusterURL)
@@ -597,7 +603,7 @@ func printTunnelConfirmationFailure(w io.Writer, err error, clusterID, cloudURL 
 		reason = "confirmation was canceled"
 	}
 
-	fmt.Fprintf(w, "\nRadar was provisioned and Hub cluster %q already exists, but its tunnel could not be confirmed: %s.\n", clusterID, reason)
+	fmt.Fprintf(w, "\n%s Radar was provisioned and Hub cluster %q already exists, but its tunnel could not be confirmed: %s.\n", cliui.New(w).Marker(cliui.Attention), clusterID, reason)
 	fmt.Fprintln(w, "Do not rerun the installer or delete the cluster by default; the existing agent can still connect after you resolve its startup or egress issue.")
 	fmt.Fprintln(w, "Inspect:")
 	fmt.Fprintf(w, "  %s -n %s rollout status deployment/%s\n", target.kubectl(), deployment.Namespace, deployment.Name)

--- a/cmd/explorer/cloud_install_output.go
+++ b/cmd/explorer/cloud_install_output.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/skyhook-io/radar/internal/cliui"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/cloudinstall"
 	"github.com/skyhook-io/radar/internal/helm"
@@ -47,7 +48,7 @@ func shellArgument(value string) string {
 }
 
 func printPreparedInstallPlan(w io.Writer, prepared *cloudinstall.PreparedProvision, enableCloudFeatures, noSelfUpgrade bool) {
-	fmt.Fprintln(w, "Plan:")
+	fmt.Fprintln(w, cliui.New(w).Bold("Plan:"))
 	fmt.Fprintf(w, "  Kubernetes target: namespace %q, Helm release %q\n", prepared.Namespace(), prepared.ReleaseName())
 	if prepared.Mode() == cloudinstall.ProvisionFresh {
 		fmt.Fprintln(w, "  Action: install a new connected Radar release")
@@ -81,7 +82,7 @@ func printPreparedInstallPlan(w io.Writer, prepared *cloudinstall.PreparedProvis
 }
 
 func printGitOpsInstallPlan(w io.Writer, plan cloudInstallPlan, target helm.PreparedChartSummary, enableCloudFeatures bool) {
-	fmt.Fprintln(w, "Plan:")
+	fmt.Fprintln(w, cliui.New(w).Bold("Plan:"))
 	fmt.Fprintf(w, "  Kubernetes target: namespace %q, Helm release %q, Deployment %q\n",
 		plan.Namespace, plan.Release, plan.Target.DeploymentName)
 	fmt.Fprintln(w, "  Action: generate a source-of-truth handoff; do not mutate the live controller or workload")
@@ -111,7 +112,7 @@ func printCloudPermissionFailure(
 	prepared *cloudinstall.PreparedProvision,
 	clusterName string,
 ) {
-	fmt.Fprintln(w, "Your current Kubernetes identity cannot perform the exact planned Radar operation.")
+	fmt.Fprintf(w, "%s Your current Kubernetes identity cannot perform the exact planned Radar operation.\n", cliui.New(w).Marker(cliui.Failure))
 	fmt.Fprintln(w, "Blocked while trying to:")
 	for _, detail := range pf.Blocking {
 		fmt.Fprintf(w, "  • %s\n", detail)
@@ -126,7 +127,8 @@ func printCloudPermissionAdvisories(w io.Writer, pf cloudinstall.PreflightResult
 	if len(pf.Advisory) == 0 {
 		return
 	}
-	fmt.Fprintln(w, "Preflight notes:")
+	style := cliui.New(w)
+	fmt.Fprintf(w, "%s %s\n", style.Marker(cliui.Attention), style.Tone(cliui.Attention, "Preflight notes:"))
 	for _, detail := range pf.Advisory {
 		fmt.Fprintf(w, "  • %s\n", detail)
 	}
@@ -144,7 +146,7 @@ func printApprovedGitOpsHandoff(
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(w, "\n  Approved. No live Kubernetes resource was changed.")
+	fmt.Fprintf(w, "\n  %s Approved. No live Kubernetes resource was changed.\n", cliui.New(w).Marker(cliui.Success))
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, handoff.Guidance)
 	fmt.Fprintln(w, "\nOne-time connection token (store it through your existing secret-management workflow; never place it in Helm values or Git):")
@@ -183,7 +185,7 @@ func buildGitOpsHandoff(
 }
 
 func printGitOpsHandoffFailure(w io.Writer, err error, clusterID, clusterURL string) {
-	fmt.Fprintf(w, "\nCould not generate the source-of-truth handoff for Hub cluster %q: %v.\n", clusterID, err)
+	fmt.Fprintf(w, "\n%s Could not generate the source-of-truth handoff for Hub cluster %q: %v.\n", cliui.New(w).Marker(cliui.Failure), clusterID, err)
 	fmt.Fprintln(w, "The Hub approval already created this cluster, but no live Kubernetes resource was changed and no GitOps instructions or token Secret were generated.")
 	fmt.Fprintln(w, "Do not rerun `radar cloud install`, because that would create another pending cluster.")
 	fmt.Fprintln(w, "The credentials from this attempt were not handed off and cannot be recovered after this command exits.")
@@ -201,7 +203,7 @@ func printGitOpsPendingHandoff(w io.Writer, err error, clusterID, clusterURL str
 	case errors.Is(err, context.Canceled):
 		reason = "the local wait was canceled"
 	}
-	fmt.Fprintf(w, "\nGitOps handoff generated for Hub cluster %q, but its in-cluster connection was not confirmed: %s.\n", clusterID, reason)
+	fmt.Fprintf(w, "\n%s GitOps handoff generated for Hub cluster %q, but its in-cluster connection was not confirmed: %s.\n", cliui.New(w).Marker(cliui.Attention), clusterID, reason)
 	fmt.Fprintln(w, "The configuration handoff is ready. Commit the generated configuration and token Secret through the source of truth; the existing Hub cluster remains the one to connect.")
 	fmt.Fprintln(w, "Do not rerun `radar cloud install`, because that would create another pending cluster.")
 	fmt.Fprintf(w, "Open or recover this cluster in Radar: %s\n", clusterURL)

--- a/cmd/explorer/cloud_status.go
+++ b/cmd/explorer/cloud_status.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/skyhook-io/radar/internal/cliui"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/cloudinstall"
 	"github.com/skyhook-io/radar/internal/config"
@@ -24,6 +25,8 @@ const (
 	hubTunnelUnavailable hubTunnelVerdict = iota
 	hubTunnelHealthy
 	hubTunnelUnhealthy
+
+	hubTunnelNeverConnectedSummary = "never connected"
 )
 
 type hubTunnelResult struct {
@@ -129,13 +132,13 @@ func cloudStatus(args []string, out, errOut io.Writer) int {
 			return 1
 		}
 	}
-	fmt.Fprintf(out, "\nStatus: %s\n\n", cloudStatusHeadline(targets, result.ClusterWideError, tunnel))
+	fmt.Fprintf(out, "\n%s\n\n", formatCloudStatusHeadline(cliui.New(out), targets, result.ClusterWideError, tunnel))
 	code := printCloudDiscoveryStatus(out, errOut, targets, result.ClusterWideError, exactTarget, normalizedNamespace, normalizedRelease)
 	if len(targets) == 1 {
 		if targets[0].Runtime.AlreadyCloud {
 			printHubTunnelStatus(out, targets[0], tunnel)
 		} else if tunnel.next != "" {
-			fmt.Fprintf(out, "\nNext: %s\n", tunnel.next)
+			fmt.Fprintf(out, "\n%s %s\n", cliui.New(out).Bold("Next:"), tunnel.next)
 		}
 		if tunnel.verdict == hubTunnelUnhealthy {
 			return 1
@@ -146,7 +149,8 @@ func cloudStatus(args []string, out, errOut io.Writer) int {
 
 func printCloudDiscoveryStatus(out, errOut io.Writer, targets []cloudinstall.RadarTarget, clusterWideErr error, exactTarget bool, namespace, release string) int {
 	if clusterWideErr != nil {
-		fmt.Fprintf(errOut, "Warning: Radar could not inspect all visible namespaces: %v\n", clusterWideErr)
+		style := cliui.New(errOut)
+		fmt.Fprintf(errOut, "%s Radar could not inspect all visible namespaces: %v\n", style.Tone(cliui.Attention, "Warning:"), clusterWideErr)
 	}
 	switch len(targets) {
 	case 0:
@@ -164,7 +168,8 @@ func printCloudDiscoveryStatus(out, errOut io.Writer, targets []cloudinstall.Rad
 	case 1:
 		healthy := printCloudStatus(out, targets[0])
 		if clusterWideErr != nil {
-			fmt.Fprintln(out, "Discovery: incomplete; other Radar installations could not be ruled out")
+			style := cliui.New(out)
+			fmt.Fprintf(out, "Discovery: %s incomplete; other Radar installations could not be ruled out\n", style.Marker(cliui.Attention))
 			fmt.Fprintln(out, "Pass --namespace and --release to make the target explicit.")
 			return 1
 		}
@@ -179,6 +184,10 @@ func printCloudDiscoveryStatus(out, errOut io.Writer, targets []cloudinstall.Rad
 }
 
 func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
+	return printCloudStatusWithStyle(out, target, cliui.New(out))
+}
+
+func printCloudStatusWithStyle(out io.Writer, target cloudinstall.RadarTarget, style cliui.Styler) bool {
 	runtime := target.Runtime
 	fmt.Fprintf(out, "Radar installation: %s/%s\n", target.Namespace, target.DeploymentName)
 	fmt.Fprintf(out, "Managed by: %s\n", cloudOwnershipLabel(target))
@@ -190,10 +199,12 @@ func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
 	}
 
 	ready := cloudAgentHealthy(runtime)
+	agentTone := cloudAgentTone(runtime)
 	if runtime.DesiredReplicas == 0 {
-		fmt.Fprintln(out, "Agent: scaled to zero")
+		fmt.Fprintf(out, "Agent: %s scaled to zero\n", style.Marker(agentTone))
 	} else if !runtime.StatusObserved {
-		fmt.Fprintf(out, "Agent: rollout status pending (%d/%d replicas ready)\n", runtime.ReadyReplicas, runtime.DesiredReplicas)
+		state := fmt.Sprintf("rollout status pending (%d/%d replicas ready)", runtime.ReadyReplicas, runtime.DesiredReplicas)
+		fmt.Fprintf(out, "Agent: %s %s\n", style.Marker(agentTone), state)
 	} else if !ready {
 		oldReplicas := runtime.TotalReplicas - runtime.UpdatedReplicas
 		if oldReplicas > 0 {
@@ -201,9 +212,8 @@ func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
 			if oldReplicas != 1 {
 				noun = "replicas"
 			}
-			fmt.Fprintf(
-				out,
-				"Agent: rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available; %d old %s still running; readiness includes old replicas)\n",
+			state := fmt.Sprintf(
+				"rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available; %d old %s still running; readiness includes old replicas)",
 				runtime.UpdatedReplicas,
 				runtime.DesiredReplicas,
 				runtime.ReadyReplicas,
@@ -213,10 +223,10 @@ func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
 				oldReplicas,
 				noun,
 			)
+			fmt.Fprintf(out, "Agent: %s %s\n", style.Marker(agentTone), state)
 		} else {
-			fmt.Fprintf(
-				out,
-				"Agent: rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available)\n",
+			state := fmt.Sprintf(
+				"rollout incomplete (%d/%d updated, %d/%d ready, %d/%d available)",
 				runtime.UpdatedReplicas,
 				runtime.DesiredReplicas,
 				runtime.ReadyReplicas,
@@ -224,21 +234,24 @@ func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
 				runtime.AvailableReplicas,
 				runtime.DesiredReplicas,
 			)
+			fmt.Fprintf(out, "Agent: %s %s\n", style.Marker(agentTone), state)
 		}
 	} else {
-		fmt.Fprintf(out, "Agent: %d/%d replicas ready\n", runtime.ReadyReplicas, runtime.DesiredReplicas)
+		state := fmt.Sprintf("%d/%d replicas ready", runtime.ReadyReplicas, runtime.DesiredReplicas)
+		fmt.Fprintf(out, "Agent: %s %s\n", style.Marker(agentTone), state)
 	}
 
 	if !runtime.AlreadyCloud {
-		fmt.Fprintln(out, "Cloud configuration: not configured")
+		fmt.Fprintf(out, "Cloud configuration: %s not configured\n", style.Marker(cliui.Attention))
 		return false
 	}
 
 	missing := missingCloudConfiguration(runtime)
 	if len(missing) > 0 {
-		fmt.Fprintf(out, "Cloud configuration: incomplete (missing %s)\n", strings.Join(missing, ", "))
+		state := fmt.Sprintf("incomplete (missing %s)", strings.Join(missing, ", "))
+		fmt.Fprintf(out, "Cloud configuration: %s %s\n", style.Marker(cliui.Attention), state)
 	} else {
-		fmt.Fprintln(out, "Cloud configuration: present")
+		fmt.Fprintf(out, "Cloud configuration: %s present\n", style.Marker(cliui.Success))
 	}
 	if runtime.CloudModeUnresolved {
 		fmt.Fprintln(out, "Cloud mode: configured from a referenced value (value not inspected)")
@@ -254,6 +267,16 @@ func printCloudStatus(out io.Writer, target cloudinstall.RadarTarget) bool {
 		fmt.Fprintln(out, "Configured cluster reference: sourced from a referenced value (value not inspected)")
 	}
 	return ready && len(missing) == 0
+}
+
+func cloudAgentTone(runtime cloudinstall.DeploymentRuntime) cliui.Tone {
+	if runtime.DesiredReplicas == 0 {
+		return cliui.Failure
+	}
+	if cloudAgentHealthy(runtime) {
+		return cliui.Success
+	}
+	return cliui.Attention
 }
 
 func cloudAgentHealthy(runtime cloudinstall.DeploymentRuntime) bool {
@@ -283,6 +306,41 @@ func cloudStatusHeadline(targets []cloudinstall.RadarTarget, clusterWideErr erro
 	}
 }
 
+func formatCloudStatusHeadline(style cliui.Styler, targets []cloudinstall.RadarTarget, clusterWideErr error, tunnel hubTunnelResult) string {
+	return fmt.Sprintf("%s %s %s", style.Bold("Status:"), style.Marker(cloudStatusTone(targets, clusterWideErr, tunnel)), cloudStatusHeadline(targets, clusterWideErr, tunnel))
+}
+
+func cloudStatusTone(targets []cloudinstall.RadarTarget, clusterWideErr error, tunnel hubTunnelResult) cliui.Tone {
+	if len(targets) != 1 {
+		return cliui.Attention
+	}
+	tone := cloudTargetStatusTone(targets[0], tunnel)
+	if clusterWideErr != nil && tone == cliui.Success {
+		return cliui.Attention
+	}
+	return tone
+}
+
+func cloudTargetStatusTone(target cloudinstall.RadarTarget, tunnel hubTunnelResult) cliui.Tone {
+	agentTone := cloudAgentTone(target.Runtime)
+	if !target.Runtime.AlreadyCloud || len(missingCloudConfiguration(target.Runtime)) > 0 {
+		if agentTone == cliui.Failure {
+			return cliui.Failure
+		}
+		return cliui.Attention
+	}
+	if tunnel.verdict == hubTunnelHealthy {
+		return agentTone
+	}
+	if tunnel.verdict == hubTunnelUnhealthy && tunnel.summary != hubTunnelNeverConnectedSummary {
+		return cliui.Failure
+	}
+	if agentTone == cliui.Failure {
+		return cliui.Failure
+	}
+	return cliui.Attention
+}
+
 func cloudTargetStatusHeadline(target cloudinstall.RadarTarget, tunnel hubTunnelResult) string {
 	runtime := target.Runtime
 	agentHealthy := cloudAgentHealthy(runtime)
@@ -310,7 +368,7 @@ func cloudTargetStatusHeadline(target cloudinstall.RadarTarget, tunnel hubTunnel
 		switch tunnel.summary {
 		case "disconnected":
 			connection = "it is disconnected from the Hub"
-		case "never connected":
+		case hubTunnelNeverConnectedSummary:
 			connection = "it has never connected to the Hub"
 		case "failed — the Hub rejected the connection token":
 			connection = "the Hub rejected its connection token"
@@ -334,7 +392,12 @@ func cloudTargetStatusHeadline(target cloudinstall.RadarTarget, tunnel hubTunnel
 }
 
 func printHubTunnelStatus(out io.Writer, target cloudinstall.RadarTarget, result hubTunnelResult) {
-	fmt.Fprintf(out, "\nCloud connection: %s\n", result.summary)
+	printHubTunnelStatusWithStyle(out, target, result, cliui.New(out))
+}
+
+func printHubTunnelStatusWithStyle(out io.Writer, target cloudinstall.RadarTarget, result hubTunnelResult, style cliui.Styler) {
+	tone := hubTunnelTone(result)
+	fmt.Fprintf(out, "\nCloud connection: %s %s\n", style.Marker(tone), result.summary)
 	if result.hubClusterID != "" && result.hubClusterID != target.Runtime.ClusterName {
 		fmt.Fprintf(out, "Hub cluster ID: %s\n", result.hubClusterID)
 	}
@@ -346,10 +409,24 @@ func printHubTunnelStatus(out io.Writer, target cloudinstall.RadarTarget, result
 		fmt.Fprintf(out, "%s: %s\n", label, result.lastConnectedAt.UTC().Format(time.RFC3339))
 	}
 	if result.detail != "" {
-		fmt.Fprintf(out, "Details: %s\n", result.detail)
+		fmt.Fprintf(out, "%s %s\n", style.Dim("Details:"), result.detail)
 	}
 	if result.next != "" {
-		fmt.Fprintf(out, "Next: %s\n", result.next)
+		fmt.Fprintf(out, "%s %s\n", style.Bold("Next:"), result.next)
+	}
+}
+
+func hubTunnelTone(result hubTunnelResult) cliui.Tone {
+	switch result.verdict {
+	case hubTunnelHealthy:
+		return cliui.Success
+	case hubTunnelUnhealthy:
+		if result.summary == hubTunnelNeverConnectedSummary {
+			return cliui.Attention
+		}
+		return cliui.Failure
+	default:
+		return cliui.Attention
 	}
 }
 
@@ -466,7 +543,7 @@ func evaluateHubTunnelStatus(status *cloud.AgentStatusResponse, err error) hubTu
 		}
 	case "never_connected":
 		return hubTunnelResult{
-			verdict: hubTunnelUnhealthy, summary: "never connected", hubClusterID: status.ClusterID,
+			verdict: hubTunnelUnhealthy, summary: hubTunnelNeverConnectedSummary, hubClusterID: status.ClusterID,
 			next: "check the Radar agent state above and its Cloud connection logs.",
 		}
 	default:

--- a/cmd/explorer/cloud_status_test.go
+++ b/cmd/explorer/cloud_status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skyhook-io/radar/internal/cliui"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/cloudinstall"
 	"github.com/skyhook-io/radar/pkg/subject"
@@ -70,7 +71,7 @@ func TestPrintCloudStatusConfiguredReady(t *testing.T) {
 	}
 	got := out.String()
 	for _, want := range []string{
-		"radar/radar", `Helm release "radar"`, "1/1 replicas ready", "Cloud configuration: present",
+		"radar/radar", `Helm release "radar"`, "Agent: ✓ 1/1 replicas ready", "Cloud configuration: ✓ present",
 		"wss://api.radarhq.io/agent", "Configured cluster reference: cluster-123",
 	} {
 		if !strings.Contains(got, want) {
@@ -193,7 +194,7 @@ func TestPrintHubTunnelStatusKeepsBottomLineReadableAndExpertIdentityWhenNeeded(
 	printHubTunnelStatus(&out, target, result)
 	got := out.String()
 	for _, want := range []string{
-		"\nCloud connection: connected\n", "Hub cluster ID: clus_123", "Connected since: 2026-07-18T07:30:00Z",
+		"\nCloud connection: ✓ connected\n", "Hub cluster ID: clus_123", "Connected since: 2026-07-18T07:30:00Z",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status missing %q:\n%s", want, got)
@@ -239,6 +240,84 @@ func TestCloudStatusHeadlineSynthesizesHumanVerdict(t *testing.T) {
 				t.Fatalf("headline = %q, want substring %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCloudStatusToneDistinguishesAttentionFromConfirmedFailure(t *testing.T) {
+	healthyRuntime := cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "clus_123", CloudTokenConfigured: true,
+	}
+	attentionRuntime := healthyRuntime
+	attentionRuntime.StatusObserved = false
+	failureRuntime := healthyRuntime
+	failureRuntime.DesiredReplicas = 0
+	failureRuntime.TotalReplicas = 0
+	failureRuntime.UpdatedReplicas = 0
+	failureRuntime.ReadyReplicas = 0
+	failureRuntime.AvailableReplicas = 0
+
+	for _, tc := range []struct {
+		name    string
+		targets []cloudinstall.RadarTarget
+		err     error
+		tunnel  hubTunnelResult
+		want    cliui.Tone
+	}{
+		{name: "not installed", want: cliui.Attention},
+		{name: "healthy connected", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: cliui.Success},
+		{name: "rollout pending", targets: []cloudinstall.RadarTarget{{Runtime: attentionRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: cliui.Attention},
+		{name: "scaled to zero", targets: []cloudinstall.RadarTarget{{Runtime: failureRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: cliui.Failure},
+		{name: "never connected", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: hubTunnelNeverConnectedSummary}, want: cliui.Attention},
+		{name: "disconnected", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, tunnel: hubTunnelResult{verdict: hubTunnelUnhealthy, summary: "disconnected"}, want: cliui.Failure},
+		{name: "Hub unverified", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, want: cliui.Attention},
+		{name: "partial discovery", targets: []cloudinstall.RadarTarget{{Runtime: healthyRuntime}}, err: errors.New("forbidden"), tunnel: hubTunnelResult{verdict: hubTunnelHealthy}, want: cliui.Attention},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cloudStatusTone(tc.targets, tc.err, tc.tunnel); got != tc.want {
+				t.Fatalf("tone = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCloudStatusStylingIsSemanticAndLeavesCopyableValuesPlain(t *testing.T) {
+	runtime := cloudinstall.DeploymentRuntime{
+		DesiredReplicas: 1, TotalReplicas: 1, UpdatedReplicas: 1, ReadyReplicas: 1, AvailableReplicas: 1, StatusObserved: true,
+		AlreadyCloud: true, CloudModeConfigured: true, CloudMode: true,
+		CloudURLConfigured: true, CloudURL: "wss://api.radarhq.io/agent",
+		ClusterNameConfigured: true, ClusterName: "clus_123", CloudTokenConfigured: true,
+	}
+	target := cloudinstall.RadarTarget{Namespace: "radar", DeploymentName: "radar", Runtime: runtime}
+	style := cliui.Styler{Enabled: true}
+
+	headline := formatCloudStatusHeadline(style, []cloudinstall.RadarTarget{target}, nil, hubTunnelResult{verdict: hubTunnelHealthy})
+	if !strings.Contains(headline, cliui.Bold+"Status:"+cliui.Reset) || !strings.Contains(headline, cliui.Green+"✓"+cliui.Reset) {
+		t.Fatalf("styled headline = %q", headline)
+	}
+
+	var out bytes.Buffer
+	printCloudStatusWithStyle(&out, target, style)
+	printHubTunnelStatusWithStyle(&out, target, hubTunnelResult{verdict: hubTunnelHealthy, summary: "connected"}, style)
+	got := out.String()
+	if strings.Count(got, cliui.Green+"✓"+cliui.Reset) < 3 {
+		t.Fatalf("styled state output = %q", got)
+	}
+	for _, plain := range []string{"1/1 replicas ready", "present", "connected"} {
+		if strings.Contains(got, cliui.Green+plain) {
+			t.Fatalf("state explanation %q was colored instead of remaining readable: %q", plain, got)
+		}
+	}
+	if !strings.Contains(got, "Hub: wss://api.radarhq.io/agent\n") || strings.Contains(got, "Hub: "+cliui.Cyan) {
+		t.Fatalf("Hub URL was styled instead of remaining copyable: %q", got)
+	}
+
+	out.Reset()
+	printCloudStatus(&out, target)
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("buffered output contains ANSI sequences: %q", out.String())
 	}
 }
 
@@ -441,7 +520,7 @@ func TestPrintCloudDiscoveryStatusHealthyTargetStillFailsAfterPartialScan(t *tes
 	}}
 	var out, errOut bytes.Buffer
 	code := printCloudDiscoveryStatus(&out, &errOut, []cloudinstall.RadarTarget{target}, errors.New("forbidden"), false, "radar", "radar")
-	if code != 1 || !strings.Contains(out.String(), "Discovery: incomplete") || !strings.Contains(errOut.String(), "could not inspect all visible namespaces") {
+	if code != 1 || !strings.Contains(out.String(), "Discovery: ! incomplete") || !strings.Contains(errOut.String(), "could not inspect all visible namespaces") {
 		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, out.String(), errOut.String())
 	}
 }

--- a/internal/cliui/style.go
+++ b/internal/cliui/style.go
@@ -1,0 +1,90 @@
+package cliui
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+const (
+	Reset = "\x1b[0m"
+	Dim   = "\x1b[2m"
+	Bold  = "\x1b[1m"
+	Green = "\x1b[32m"
+	Red   = "\x1b[31m"
+	Amber = "\x1b[33m"
+	Cyan  = "\x1b[36m"
+)
+
+type Tone uint8
+
+const (
+	Neutral Tone = iota
+	Success
+	Progress
+	Attention
+	Failure
+)
+
+type Styler struct {
+	Enabled bool
+}
+
+func New(w io.Writer) Styler {
+	f, ok := w.(*os.File)
+	return Styler{Enabled: ok && ColorEnabled(f)}
+}
+
+func ColorEnabled(f *os.File) bool {
+	return colorAllowed(term.IsTerminal(int(f.Fd())), os.Getenv("NO_COLOR"), os.Getenv("TERM"))
+}
+
+func colorAllowed(tty bool, noColor, termName string) bool {
+	return tty && noColor == "" && termName != "dumb"
+}
+
+func (s Styler) Apply(code, value string) string {
+	if !s.Enabled || value == "" {
+		return value
+	}
+	return code + value + Reset
+}
+
+func (s Styler) Bold(value string) string {
+	return s.Apply(Bold, value)
+}
+
+func (s Styler) Dim(value string) string {
+	return s.Apply(Dim, value)
+}
+
+func (s Styler) Tone(tone Tone, value string) string {
+	switch tone {
+	case Success:
+		return s.Apply(Green, value)
+	case Progress:
+		return s.Apply(Cyan, value)
+	case Attention:
+		return s.Apply(Amber, value)
+	case Failure:
+		return s.Apply(Red, value)
+	default:
+		return value
+	}
+}
+
+func (s Styler) Marker(tone Tone) string {
+	marker := "○"
+	switch tone {
+	case Success:
+		marker = "✓"
+	case Progress:
+		marker = "→"
+	case Attention:
+		marker = "!"
+	case Failure:
+		marker = "✗"
+	}
+	return s.Tone(tone, marker)
+}

--- a/internal/cliui/style_test.go
+++ b/internal/cliui/style_test.go
@@ -1,0 +1,46 @@
+package cliui
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestColorAllowed(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tty     bool
+		noColor string
+		term    string
+		want    bool
+	}{
+		{name: "interactive", tty: true, term: "xterm-256color", want: true},
+		{name: "not a terminal", term: "xterm-256color"},
+		{name: "NO_COLOR", tty: true, noColor: "1", term: "xterm-256color"},
+		{name: "NO_COLOR zero still disables", tty: true, noColor: "0", term: "xterm-256color"},
+		{name: "dumb terminal", tty: true, term: "dumb"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := colorAllowed(tc.tty, tc.noColor, tc.term); got != tc.want {
+				t.Fatalf("colorAllowed() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStylerUsesSemanticMarkersWithoutChangingPlainOutput(t *testing.T) {
+	plain := New(&bytes.Buffer{})
+	if got := plain.Marker(Success) + " " + plain.Tone(Success, "connected"); got != "✓ connected" {
+		t.Fatalf("plain state = %q", got)
+	}
+
+	styled := Styler{Enabled: true}
+	if got := styled.Marker(Failure); got != Red+"✗"+Reset {
+		t.Fatalf("failure marker = %q", got)
+	}
+	if got := styled.Tone(Attention, "not checked"); got != Amber+"not checked"+Reset {
+		t.Fatalf("attention text = %q", got)
+	}
+	if got := styled.Marker(Neutral); got != "○" {
+		t.Fatalf("neutral marker = %q", got)
+	}
+}

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -10,19 +10,18 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/term"
-
 	"github.com/skyhook-io/radar/internal/ai"
+	"github.com/skyhook-io/radar/internal/cliui"
 )
 
 const (
-	cReset = "\x1b[0m"
-	cDim   = "\x1b[2m"
-	cBold  = "\x1b[1m"
-	cGreen = "\x1b[32m"
-	cRed   = "\x1b[31m"
-	cAmber = "\x1b[33m"
-	cCyan  = "\x1b[36m"
+	cReset = cliui.Reset
+	cDim   = cliui.Dim
+	cBold  = cliui.Bold
+	cGreen = cliui.Green
+	cRed   = cliui.Red
+	cAmber = cliui.Amber
+	cCyan  = cliui.Cyan
 
 	// clearLine returns the cursor to column 0 and erases the spinner line.
 	clearLine = "\r\x1b[K"
@@ -54,7 +53,7 @@ func newRenderer(jsonMode bool) *renderer {
 	}
 	return &renderer{
 		w:         w,
-		color:     term.IsTerminal(int(w.Fd())) && os.Getenv("NO_COLOR") == "",
+		color:     cliui.ColorEnabled(w),
 		lastEvent: time.Now(),
 		stopSpin:  make(chan struct{}),
 	}

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"golang.org/x/term"
 	"k8s.io/klog/v2"
 
 	"github.com/skyhook-io/radar/internal/app"
+	"github.com/skyhook-io/radar/internal/cliui"
 )
 
 // bootEphemeral starts a temporary in-process Radar for one investigation:
@@ -108,7 +108,7 @@ func bootEphemeral(kubeconfig string) (base string, shutdown func(), err error) 
 // connecting to cluster… 12s") on stderr; the renderer's own spinner takes
 // over once the investigation streams.
 func bootSpinner(stop <-chan struct{}) {
-	if os.Getenv("NO_COLOR") != "" || !term.IsTerminal(int(os.Stderr.Fd())) {
+	if !cliui.ColorEnabled(os.Stderr) {
 		return
 	}
 	start := time.Now()


### PR DESCRIPTION
## Summary

- add a small shared CLI styling helper with TTY, `NO_COLOR`, and `TERM=dumb` detection
- make `radar cloud status` glanceable with semantic markers for healthy, pending, and failed states
- add restrained progress, success, attention, and failure markers to `radar cloud install`
- keep URLs, tokens, identities, and suggested commands unstyled and preserve plain-text meaning in every environment
- reuse the shared terminal detection in `radar diagnose` and document plain-output behavior

## Design

Color is deliberately redundant with glyphs and copy: green `✓` means healthy or complete, cyan `→` means active progress, amber `!` means pending or uncertain, and red `✗` means confirmed failure. Only compact markers and labels are styled so long diagnostics remain readable and copyable values never contain ANSI sequences.

## Testing

- `make test`
- `make tsc`
- `make build`
- focused status, install-output, terminal-detection, and ANSI-leakage tests
- live `radar cloud status` against a connected nonprod cluster in a TTY
- live piped status output verified ANSI-free

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CLI output changes with tests for tone semantics and ANSI leakage; no install, auth, or cluster mutation logic changes.
> 
> **Overview**
> Adds **`internal/cliui`**, a small helper that turns color on only for interactive TTYs (respecting `NO_COLOR` and `TERM=dumb`) and exposes semantic **tones** (success, progress, attention, failure) via glyphs like `✓`, `→`, `!`, `✗`.
> 
> **`radar cloud status`** and **`radar cloud install`** now use those markers on headlines, agent/Cloud/tunnel state, and install milestones; tone logic distinguishes pending/uncertain cases (e.g. never connected, partial discovery) from confirmed failures. URLs, tokens, and suggested commands stay unstyled; buffered/piped output stays ANSI-free.
> 
> **`radar diagnose`** reuses the same color gate instead of ad-hoc checks. README documents plain-output behavior for `radar cloud status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f34505fa405c743e532e7b66b3f3f76669bd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->