### PR TITLE
Activity type rollup, compact window header, and demoted evidence provenance

### DIFF
--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -46,6 +46,8 @@ Evaluations cover Karpenter NodePools only: `blocked` means no NodePool can take
 
 A bounded evidence timeline of provisioning, disruption, interruption, termination, and NodePool config-change **episodes**, correlated from resource lifecycle transitions and Karpenter's exact event vocabulary. Every episode carries its evidence with per-item confidence — heuristic matches are labeled `inferred`, never presented as fact.
 
+A **type rollup strip** summarizes the whole filtered window ("Provision · 28 · 3 failed"), so a provisioning storm reads as a shape, not a page of rows. The rollup comes with the first page and stays stable while the type pills narrow the list (mirroring the Demand state pills); when timeline coverage is partial or bounded, every count renders as a `≥` lower bound. Evidence tables lead with when/source/raw/references; the normalized reason code, relationship, and confidence columns sit behind a per-episode "Show provenance" toggle.
+
 ## Entry points
 
 Operators rarely start at the nav. Capacity meets them where they are:
@@ -104,7 +106,7 @@ All read-only, all behind the NodePool RBAC gate:
 - `GET /api/capacity` — overview: KPIs, scheduling aggregate, signals, pool summaries
 - `GET /api/capacity/pools` (+ `/{name}`, `/{name}/members`) — inventory, detail, paginated members
 - `GET /api/capacity/demand` — groups with `?state=`, `?pool=`, `?owner=ns/Kind/name` filters
-- `GET /api/capacity/activity` — episode timeline with keyset cursors
+- `GET /api/capacity/activity` — episode timeline with keyset cursors; `?type=` narrows to one episode type, and first-page responses carry an `aggregate` rollup of the whole filtered window that the type filter deliberately does not narrow
 
 ## Limitations
 

--- a/internal/capacity/activity.go
+++ b/internal/capacity/activity.go
@@ -55,6 +55,21 @@ func inferredActivity(activityType capacityapi.ActivityType, state capacityapi.A
 	}
 }
 
+func AggregateActivityRecords(records []ActivityRecord) capacityapi.ActivityAggregate {
+	aggregate := capacityapi.NewActivityAggregate()
+	for _, record := range records {
+		aggregate.Total++
+		counts := aggregate.ByType[record.Episode.Type]
+		counts.Total++
+		if counts.ByState == nil {
+			counts.ByState = map[capacityapi.ActivityState]int{}
+		}
+		counts.ByState[record.Episode.State]++
+		aggregate.ByType[record.Episode.Type] = counts
+	}
+	return aggregate
+}
+
 func BuildActivityRecords(events []timeline.TimelineEvent) []ActivityRecord {
 	orderedEvents := append([]timeline.TimelineEvent{}, events...)
 	sort.Slice(orderedEvents, func(i, j int) bool {

--- a/internal/capacity/activity_test.go
+++ b/internal/capacity/activity_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/skyhook-io/radar/pkg/timeline"
 )
 
+func TestAggregateActivityRecordsCountsByTypeAndState(t *testing.T) {
+	records := []ActivityRecord{
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityProvision, State: capacityapi.ActivityCompleted}},
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityProvision, State: capacityapi.ActivityFailed}},
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityProvision, State: capacityapi.ActivityOpen}},
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityDisruption, State: capacityapi.ActivityBlocked}},
+	}
+	aggregate := AggregateActivityRecords(records)
+	if aggregate.Total != 4 {
+		t.Fatalf("total = %d, want 4", aggregate.Total)
+	}
+	provision := aggregate.ByType[capacityapi.ActivityProvision]
+	if provision.Total != 3 || provision.ByState[capacityapi.ActivityCompleted] != 1 ||
+		provision.ByState[capacityapi.ActivityFailed] != 1 || provision.ByState[capacityapi.ActivityOpen] != 1 {
+		t.Fatalf("provision counts = %+v", provision)
+	}
+	disruption := aggregate.ByType[capacityapi.ActivityDisruption]
+	if disruption.Total != 1 || disruption.ByState[capacityapi.ActivityBlocked] != 1 {
+		t.Fatalf("disruption counts = %+v", disruption)
+	}
+
+	empty := AggregateActivityRecords(nil)
+	if empty.Total != 0 || empty.ByType == nil {
+		t.Fatalf("empty aggregate = %+v, want zero total with a non-null byType map", empty)
+	}
+}
+
 func TestBuildActivityRecordsCorrelatesAndClosesProvisionEpisode(t *testing.T) {
 	start := time.Date(2026, time.July, 13, 10, 0, 0, 0, time.UTC)
 	events := []timeline.TimelineEvent{

--- a/internal/server/capacity_activity.go
+++ b/internal/server/capacity_activity.go
@@ -40,6 +40,7 @@ type capacityActivityRequest struct {
 	cursor            *capacityActivityCursor
 	filterFingerprint string
 	filters           url.Values
+	typeFilter        capacityapi.ActivityType
 	since             time.Time
 	sinceProvided     bool
 }
@@ -178,6 +179,16 @@ func (s *Server) handleCapacityActivity(w http.ResponseWriter, r *http.Request) 
 
 	records := capacitymodel.BuildActivityRecords(events)
 	records = filterCapacityActivityRecords(records, request.filters)
+	// The aggregate summarizes the whole filtered window, so it is computed
+	// before the type filter (type pills stay stable while the list narrows,
+	// mirroring the demand-state rollup) and only on first-page requests —
+	// cursor pages see a window bounded near the cursor, and an aggregate
+	// over that slice would misread as the whole window.
+	if request.cursor == nil {
+		aggregate := capacitymodel.AggregateActivityRecords(records)
+		response.Aggregate = &aggregate
+	}
+	records = filterCapacityActivityRecordsByType(records, request.typeFilter)
 	if request.cursor == nil {
 		reverseActivityRecords(records)
 	} else {
@@ -429,6 +440,26 @@ func parseCapacityActivityRequest(query url.Values) (capacityActivityRequest, er
 		request.sinceProvided = true
 		filters.Set("since", request.since.UTC().Format(time.RFC3339Nano))
 	}
+	if values := query["type"]; len(values) > 1 {
+		return capacityActivityRequest{}, fmt.Errorf("type must be specified at most once")
+	} else if len(values) == 1 && strings.TrimSpace(values[0]) != "" {
+		activityType := capacityapi.ActivityType(strings.TrimSpace(values[0]))
+		valid := map[capacityapi.ActivityType]bool{
+			capacityapi.ActivityProvision:             true,
+			capacityapi.ActivityLaunchFailure:         true,
+			capacityapi.ActivityRegistrationFailure:   true,
+			capacityapi.ActivityInitializationFailure: true,
+			capacityapi.ActivityDisruption:            true,
+			capacityapi.ActivityInterruption:          true,
+			capacityapi.ActivityTermination:           true,
+			capacityapi.ActivityConfigChange:          true,
+		}
+		if !valid[activityType] {
+			return capacityActivityRequest{}, fmt.Errorf("invalid activity type %q", activityType)
+		}
+		request.typeFilter = activityType
+		filters.Set("type", string(activityType))
+	}
 	request.filterFingerprint = capacityFilterFingerprint(filters)
 	if values := query["cursor"]; len(values) > 1 {
 		return capacityActivityRequest{}, newCapacityCursorInvalidError("cursor must be specified at most once")
@@ -564,6 +595,19 @@ func filterCapacityActivityRecords(records []capacitymodel.ActivityRecord, filte
 		result = append(result, record)
 	}
 	return result
+}
+
+func filterCapacityActivityRecordsByType(records []capacitymodel.ActivityRecord, activityType capacityapi.ActivityType) []capacitymodel.ActivityRecord {
+	if activityType == "" {
+		return records
+	}
+	kept := records[:0]
+	for _, record := range records {
+		if record.Episode.Type == activityType {
+			kept = append(kept, record)
+		}
+	}
+	return kept
 }
 
 func episodeHasReason(episode capacityapi.ActivityEpisode, reason string) bool {

--- a/internal/server/capacity_activity_test.go
+++ b/internal/server/capacity_activity_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	capacitymodel "github.com/skyhook-io/radar/internal/capacity"
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/capacityapi"
 	"github.com/skyhook-io/radar/pkg/timeline"
 )
 
@@ -102,12 +104,44 @@ func TestCapacityActivityCursorRejectsMalformedPayload(t *testing.T) {
 	}
 }
 
+func TestCapacityActivityTypeFilterBindsFingerprintAndNarrowsRecords(t *testing.T) {
+	base, err := parseCapacityActivityRequest(url.Values{})
+	if err != nil {
+		t.Fatalf("parse base request: %v", err)
+	}
+	typed, err := parseCapacityActivityRequest(url.Values{"type": {"provision"}})
+	if err != nil {
+		t.Fatalf("parse typed request: %v", err)
+	}
+	if typed.typeFilter != capacityapi.ActivityProvision {
+		t.Fatalf("typeFilter = %q, want provision", typed.typeFilter)
+	}
+	if typed.filterFingerprint == base.filterFingerprint {
+		t.Fatal("type filter must participate in the cursor filter fingerprint")
+	}
+
+	records := []capacitymodel.ActivityRecord{
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityProvision}},
+		{Episode: capacityapi.ActivityEpisode{Type: capacityapi.ActivityDisruption}},
+	}
+	all := filterCapacityActivityRecordsByType(append([]capacitymodel.ActivityRecord{}, records...), "")
+	if len(all) != 2 {
+		t.Fatalf("unfiltered records = %d, want 2", len(all))
+	}
+	kept := filterCapacityActivityRecordsByType(records, capacityapi.ActivityDisruption)
+	if len(kept) != 1 || kept[0].Episode.Type != capacityapi.ActivityDisruption {
+		t.Fatalf("type-filtered records = %#v", kept)
+	}
+}
+
 func TestCapacityActivityRequestValidatesFiltersAndSince(t *testing.T) {
 	for name, query := range map[string]url.Values{
 		"repeated filter": {"pool": {"a", "b"}},
 		"invalid since":   {"since": {"yesterday"}},
 		"repeated since":  {"since": {"2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z"}},
 		"workload filter": {"workload": {"api"}},
+		"invalid type":    {"type": {"resize"}},
+		"repeated type":   {"type": {"provision", "termination"}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := parseCapacityActivityRequest(query); err == nil {

--- a/packages/k8s-ui/src/types/capacity.ts
+++ b/packages/k8s-ui/src/types/capacity.ts
@@ -587,6 +587,16 @@ export interface CapacityObservationWindow {
   gaps: CapacityObservationGap[];
 }
 
+export interface CapacityActivityTypeCounts {
+  total: number;
+  byState: Partial<Record<CapacityActivityState, number>>;
+}
+
+export interface CapacityActivityAggregate {
+  total: number;
+  byType: Partial<Record<CapacityActivityType, CapacityActivityTypeCounts>>;
+}
+
 export interface CapacityActivityResponse extends CapacityResponseMeta {
   state: CapacityIntegrationState;
   items: CapacityActivityEpisode[];
@@ -594,4 +604,6 @@ export interface CapacityActivityResponse extends CapacityResponseMeta {
   cursorStatus: CapacityCursorStatus;
   cursorGap?: CapacityObservationGap;
   observation: CapacityObservationWindow;
+  /** Whole-window rollup; present only on first-page responses and never narrowed by the type filter. */
+  aggregate?: CapacityActivityAggregate;
 }

--- a/pkg/capacityapi/activity.go
+++ b/pkg/capacityapi/activity.go
@@ -81,6 +81,20 @@ func NewActivityEpisode() ActivityEpisode {
 	return ActivityEpisode{State: ActivityUnknown, Evidence: []ActivityEvidence{}}
 }
 
+type ActivityTypeCounts struct {
+	Total   int                   `json:"total"`
+	ByState map[ActivityState]int `json:"byState"`
+}
+
+type ActivityAggregate struct {
+	Total  int                                 `json:"total"`
+	ByType map[ActivityType]ActivityTypeCounts `json:"byType"`
+}
+
+func NewActivityAggregate() ActivityAggregate {
+	return ActivityAggregate{ByType: map[ActivityType]ActivityTypeCounts{}}
+}
+
 type CursorStatus string
 
 const (

--- a/pkg/capacityapi/responses.go
+++ b/pkg/capacityapi/responses.go
@@ -121,6 +121,9 @@ type ActivityResponse struct {
 	CursorStatus CursorStatus      `json:"cursorStatus"`
 	CursorGap    *ObservationGap   `json:"cursorGap,omitempty"`
 	Observation  ObservationWindow `json:"observation"`
+	// Aggregate summarizes the whole filtered window and is present only on
+	// first-page responses; the type filter deliberately does not narrow it.
+	Aggregate *ActivityAggregate `json:"aggregate,omitempty"`
 }
 
 func NewActivityResponse(generatedAt time.Time) ActivityResponse {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1236,6 +1236,7 @@ export interface CapacityActivityQueryOptions extends CapacityPageQueryOptions {
   claim?: string;
   node?: string;
   reason?: string;
+  type?: string;
 }
 
 export function useCapacityActivity(options?: CapacityActivityQueryOptions) {
@@ -1248,6 +1249,7 @@ export function useCapacityActivity(options?: CapacityActivityQueryOptions) {
   if (options?.claim) params.set("claim", options.claim);
   if (options?.node) params.set("node", options.node);
   if (options?.reason) params.set("reason", options.reason);
+  if (options?.type) params.set("type", options.type);
   const query = params.toString();
   const queryKey = [
     "capacity",
@@ -1259,6 +1261,7 @@ export function useCapacityActivity(options?: CapacityActivityQueryOptions) {
     options?.claim,
     options?.node,
     options?.reason,
+    options?.type,
   ];
   return useQuery<CapacityActivityResponse>({
     queryKey,

--- a/web/src/components/capacity/CapacityActivity.tsx
+++ b/web/src/components/capacity/CapacityActivity.tsx
@@ -19,14 +19,12 @@ import {
   ActivityStateBadge,
   CapacityFreshness,
   InlineEmpty,
-  KeyValueRows,
   LinkButton,
   Notice,
   PageControls,
   ROW_HOVER,
   ScopeBadges,
   ScrollableContent,
-  SectionCard,
   TABLE_HEAD,
   TABLE_WRAP,
   TBODY,
@@ -55,6 +53,17 @@ const WINDOW_PILLS: [number | undefined, string][] = [
   [24, "Last 24 hours"],
 ];
 
+const TYPE_PILL_ORDER: CapacityActivityEpisode["type"][] = [
+  "provision",
+  "launch_failure",
+  "registration_failure",
+  "initialization_failure",
+  "disruption",
+  "interruption",
+  "termination",
+  "config_change",
+];
+
 export function CapacityActivity({
   connectionState,
   onOpenPool,
@@ -73,6 +82,7 @@ export function CapacityActivity({
   const claimFilter = search.get("claim") || undefined;
   const nodeFilter = search.get("node") || undefined;
   const reasonFilter = search.get("reason") || undefined;
+  const typeFilter = search.get("type") || undefined;
   const sinceFilter = search.get("since") || undefined;
   const invalidSinceFilter = Boolean(
     sinceFilter && !Number.isFinite(Date.parse(sinceFilter)),
@@ -116,6 +126,7 @@ export function CapacityActivity({
     claim: claimFilter,
     node: nodeFilter,
     reason: reasonFilter,
+    type: typeFilter,
     since: requestSinceFilter,
   });
   const recoveringCursor = useCapacityCursorRecovery(
@@ -155,10 +166,23 @@ export function CapacityActivity({
     event.preventDefault();
     updateFilters(poolDraft, reasonDraft, sinceFilter);
   };
+  const changeTypeFilter = (type?: CapacityActivityEpisode["type"]) => {
+    const params = new URLSearchParams(location.search);
+    params.delete("workload");
+    if (type) params.set("type", type);
+    else params.delete("type");
+    navigate(
+      {
+        pathname: location.pathname,
+        search: params.toString() ? `?${params.toString()}` : "",
+      },
+      { replace: true },
+    );
+  };
   const clearFilters = () => {
     const params = new URLSearchParams(location.search);
-    ["pool", "claim", "node", "workload", "reason", "since"].forEach((key) =>
-      params.delete(key),
+    ["pool", "claim", "node", "workload", "reason", "since", "type"].forEach(
+      (key) => params.delete(key),
     );
     navigate(
       {
@@ -189,8 +213,19 @@ export function CapacityActivity({
   };
 
   const hasActiveFilters = Boolean(
-    poolFilter || claimFilter || nodeFilter || reasonFilter || sinceFilter,
+    poolFilter ||
+    claimFilter ||
+    nodeFilter ||
+    reasonFilter ||
+    sinceFilter ||
+    typeFilter,
   );
+  const aggregate = response.aggregate;
+  const aggregateIsLowerBound = coverageIsLowerBound(
+    response.coverage.timeline,
+  );
+  const formatAggregateCount = (count: number) =>
+    `${aggregateIsLowerBound ? "≥" : ""}${count}`;
 
   return (
     <ScrollableContent>
@@ -213,6 +248,23 @@ export function CapacityActivity({
               source="karpenterObjectEvents"
             />
           </div>
+          {coverageHasObservations(response.coverage.timeline) && (
+            <p className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-xs text-theme-text-tertiary">
+              <span>
+                Window {formatTimestamp(response.observation.startedAt)} →{" "}
+                {formatTimestamp(response.observation.endedAt)}
+              </span>
+              {response.observation.sources.length > 0 && (
+                <span>· {response.observation.sources.join(" · ")}</span>
+              )}
+              <span>· {retentionLabel(response.observation.retention)}</span>
+              <WithTooltip
+                tip={`An observation window, not a durable audit log. ${coverageMessage(response.coverage.timeline, "Retained activity")}`}
+              >
+                <span aria-label="About the observation window">ⓘ</span>
+              </WithTooltip>
+            </p>
+          )}
         </div>
         <div className="flex items-center gap-2">
           {pagination.cursor && (
@@ -281,38 +333,6 @@ export function CapacityActivity({
           . Episodes may omit events outside this user’s authorized namespaces.
         </Notice>
       )}
-
-      <SectionCard
-        title="Observation window"
-        subtitle="an observation window, not a durable audit log"
-        bodyClassName="px-4 py-3"
-      >
-        {coverageHasObservations(response.coverage.timeline) ? (
-          <KeyValueRows
-            rows={[
-              [
-                "Window",
-                `${formatTimestamp(response.observation.startedAt)} → ${formatTimestamp(response.observation.endedAt)}`,
-              ],
-              [
-                "Sources",
-                response.observation.sources.length > 0
-                  ? response.observation.sources.join(" · ")
-                  : "No evidence sources observed",
-              ],
-              ["Retention", retentionLabel(response.observation.retention)],
-              [
-                "Coverage",
-                coverageMessage(response.coverage.timeline, "Retained activity"),
-              ],
-            ]}
-          />
-        ) : (
-          <p className="text-sm text-theme-text-secondary">
-            {coverageMessage(response.coverage.timeline, "Retained activity")}
-          </p>
-        )}
-      </SectionCard>
 
       <form
         className="flex flex-wrap items-end gap-2 rounded-xl border border-theme-border bg-theme-surface px-4 py-3 shadow-theme-sm"
@@ -395,6 +415,61 @@ export function CapacityActivity({
         )}
       </form>
 
+      {(aggregate !== undefined || typeFilter !== undefined) && (
+        <div
+          className="flex flex-wrap gap-1.5"
+          aria-label="Filter activity by type"
+        >
+          {/* Counts come from the whole-window rollup (stable across the active
+            type filter), not the current page. Pills without a rollup (cursor
+            pages) never show a fabricated count. */}
+          <button
+            type="button"
+            aria-pressed={typeFilter === undefined}
+            className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+              typeFilter === undefined
+                ? "selection border-theme-border text-theme-text-primary"
+                : "border-theme-border text-theme-text-secondary hover:bg-theme-hover"
+            }`}
+            onClick={() => changeTypeFilter(undefined)}
+          >
+            {aggregate
+              ? `All · ${formatAggregateCount(aggregate.total)}`
+              : "All"}
+          </button>
+          {TYPE_PILL_ORDER.filter(
+            (type) =>
+              (aggregate?.byType[type]?.total ?? 0) > 0 || type === typeFilter,
+          ).map((type) => {
+            const counts = aggregate?.byType[type];
+            const failed = counts?.byState?.failed ?? 0;
+            return (
+              <button
+                key={type}
+                type="button"
+                aria-pressed={typeFilter === type}
+                className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  typeFilter === type
+                    ? "selection border-theme-border text-theme-text-primary"
+                    : "border-theme-border text-theme-text-secondary hover:bg-theme-hover"
+                }`}
+                onClick={() =>
+                  changeTypeFilter(typeFilter === type ? undefined : type)
+                }
+              >
+                {counts
+                  ? `${activityTypeLabel(type)} · ${formatAggregateCount(counts.total)}${
+                      failed > 0
+                        ? ` · ${formatAggregateCount(failed)} failed`
+                        : ""
+                    }`
+                  : activityTypeLabel(type)}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {response.items.length > 0 ? (
         <div className="space-y-3">
           {response.items.map((episode, index) => (
@@ -474,12 +549,9 @@ function ActivityEpisodeCard({
   onOpenResource: (resource: SelectedResource) => void;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
-  const subjects = [
-    episode.pool,
-    episode.claim,
-    episode.node,
-  ].filter((identity): identity is CapacityResourceIdentity =>
-    Boolean(identity),
+  const [showProvenance, setShowProvenance] = useState(false);
+  const subjects = [episode.pool, episode.claim, episode.node].filter(
+    (identity): identity is CapacityResourceIdentity => Boolean(identity),
   );
   const duration =
     episode.durationSeconds !== undefined
@@ -504,7 +576,9 @@ function ActivityEpisodeCard({
               {activityTypeLabel(episode.type)}
             </Badge>
             <ActivityStateBadge state={episode.state} />
-            {!episode.evidence.some((item) => item.relationship === "direct") && (
+            {!episode.evidence.some(
+              (item) => item.relationship === "direct",
+            ) && (
               <WithTooltip tip="No controller-recorded cause — this episode was inferred by correlating event text. Expand for the raw evidence.">
                 <Badge severity="neutral" size="sm">
                   inferred
@@ -564,15 +638,22 @@ function ActivityEpisodeCard({
         <div className="border-t border-theme-border">
           {episode.evidence.length > 0 ? (
             <div className={TABLE_WRAP}>
+              <div className="flex justify-end px-4 pt-2">
+                <LinkButton
+                  onClick={() => setShowProvenance((current) => !current)}
+                >
+                  {showProvenance ? "Hide provenance ▴" : "Show provenance ▾"}
+                </LinkButton>
+              </div>
               <table className="w-full text-left">
                 <thead className={TABLE_HEAD}>
                   <tr>
                     <th className={TH}>When</th>
                     <th className={TH}>Source</th>
-                    <th className={TH}>Normalized</th>
+                    {showProvenance && <th className={TH}>Normalized</th>}
                     <th className={TH}>Raw</th>
-                    <th className={TH}>Relationship</th>
-                    <th className={TH}>Confidence</th>
+                    {showProvenance && <th className={TH}>Relationship</th>}
+                    {showProvenance && <th className={TH}>Confidence</th>}
                     <th className={TH}>References</th>
                   </tr>
                 </thead>
@@ -582,7 +663,9 @@ function ActivityEpisodeCard({
                       key={`${evidence.at}-${evidence.reasonCode}-${index}`}
                       className={ROW_HOVER}
                     >
-                      <td className={`${TD} whitespace-nowrap font-mono text-theme-text-tertiary`}>
+                      <td
+                        className={`${TD} whitespace-nowrap font-mono text-theme-text-tertiary`}
+                      >
                         {relativeTime(evidence.at)}
                       </td>
                       <td className={TD}>
@@ -590,25 +673,35 @@ function ActivityEpisodeCard({
                           {evidence.source.replace("_", " ")}
                         </Badge>
                       </td>
-                      <td className={`${TD} font-mono`}>{evidence.reasonCode}</td>
+                      {showProvenance && (
+                        <td className={`${TD} font-mono`}>
+                          {evidence.reasonCode}
+                        </td>
+                      )}
                       <td className={`${TD} text-theme-text-secondary`}>
                         {evidence.rawReason || evidence.rawMessage ? (
                           <>
-                            {evidence.rawReason ? `${evidence.rawReason}: ` : ""}
+                            {evidence.rawReason
+                              ? `${evidence.rawReason}: `
+                              : ""}
                             {evidence.rawMessage}
                           </>
                         ) : (
                           "—"
                         )}
                       </td>
-                      <td className={`${TD} text-theme-text-secondary`}>
-                        {evidence.relationship}
-                      </td>
-                      <td className={TD}>
-                        <Badge tone="structural" size="sm">
-                          {evidence.confidence}
-                        </Badge>
-                      </td>
+                      {showProvenance && (
+                        <td className={`${TD} text-theme-text-secondary`}>
+                          {evidence.relationship}
+                        </td>
+                      )}
+                      {showProvenance && (
+                        <td className={TD}>
+                          <Badge tone="structural" size="sm">
+                            {evidence.confidence}
+                          </Badge>
+                        </td>
+                      )}
                       <td className={TD}>
                         {evidence.refs.length > 0 ? (
                           <div className="flex flex-wrap gap-1">

--- a/web/src/components/capacity/CapacityView.test.tsx
+++ b/web/src/components/capacity/CapacityView.test.tsx
@@ -462,6 +462,13 @@ function activityResponse(): CapacityActivityResponse {
       },
       gaps: [],
     },
+    aggregate: {
+      total: 3,
+      byType: {
+        provision: { total: 2, byState: { completed: 1, failed: 1 } },
+        disruption: { total: 1, byState: { blocked: 1 } },
+      },
+    },
   };
 }
 
@@ -951,7 +958,7 @@ describe("CapacityView demand", () => {
 });
 
 describe("CapacityView activity", () => {
-  it("renders the bounded observation window and episodes", () => {
+  it("renders the window line, type rollup pills, and demoted provenance", () => {
     const html = renderCapacity("/capacity/activity", (client) =>
       client.setQueryData(
         [
@@ -964,15 +971,24 @@ describe("CapacityView activity", () => {
           undefined,
           undefined,
           undefined,
+          undefined,
         ],
         activityResponse(),
       ),
     );
     expect(html).toContain("Activity");
     expect(html).toContain("Recent Karpenter capacity events");
-    expect(html).toContain("Observation window");
+    // The observation-window card collapsed into a single header line.
+    expect(html).not.toContain("Observation window");
+    expect(html).toContain("Window ");
     expect(html).toContain("Provisioned a node for pending pods");
-    // First episode is expanded by default → its evidence table renders.
-    expect(html).toContain("Relationship");
+    // Type pills carry whole-window rollup counts, failures called out.
+    expect(html).toContain("All · 3");
+    expect(html).toContain("Provision · 2 · 1 failed");
+    expect(html).toContain("Disruption · 1");
+    // Provenance columns hide behind the toggle; the raw evidence leads.
+    expect(html).toContain("Show provenance");
+    expect(html).not.toContain("Relationship");
+    expect(html).toContain("Raw");
   });
 });


### PR DESCRIPTION
Stacked on #1156 — merge after it (GitHub will retarget to main when the base merges).

## Summary

On busy clusters the Activity timeline reads as an undifferentiated page of episodes: a 40-minute provisioning storm with three failures looks the same as routine churn until you page through it. This adds a whole-window rollup so the shape of activity is visible at a glance, and reshapes the episode presentation for triage-first reading.

## What changed

**Type rollup strip.** First-page `/api/capacity/activity` responses carry an `aggregate`: episode counts by type and state over the entire filtered window. The UI renders it as filter pills — `All · 31`, `Provision · 28 · 3 failed` — in the same pattern as the Demand state pills:

- Pills stay stable while the new `?type=` filter narrows the episode list (the aggregate is deliberately computed before the type filter, mirroring how the demand summary ignores the state filter).
- When timeline coverage is partial or the window query hit its bound, every count renders as a `≥` lower bound — bounded is never presented as exact.
- Cursor pages omit the aggregate entirely: a window bounded near the cursor must not masquerade as the whole retained window. Pills on deep pages show labels without fabricated counts.
- `?type=` is validated against the episode-type vocabulary and participates in the cursor filter fingerprint, so stale cursors cannot silently cross filters.

**Compact window header.** The observation-window card (which pushed actual episodes below the fold) collapses into one header line — `Window <start> → <end> · sources · retention` — with the "observation window, not a durable audit log" framing and coverage detail in a tooltip.

**Demoted provenance.** Evidence tables lead with When / Source / Raw / References. The pipeline-facing columns — normalized reason code, relationship, confidence — sit behind a per-episode "Show provenance" toggle.

Wire changes are additive only: a new optional `aggregate` response field and a new optional `type` query parameter.

## Testing

- `make test` (Go, both modules) and `make tsc` green.
- New tests: aggregate counting by type/state (never-null `byType`), `?type=` validation + fingerprint binding + record narrowing, and an SSR test pinning the pills text, the collapsed header, and provenance columns hidden by default.
- Visual test: not run in this change; the strip renders from the same SSR-tested markup, and a full visual pass is planned against a live Karpenter cluster before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only Capacity activity API and UI; additive fields and query param with validation and tests, no auth or mutation paths.
> 
> **Overview**
> Adds a **whole-window activity rollup** and **type filtering** on Capacity Activity so operators can see provisioning storms and failure counts without paging every episode.
> 
> **API:** First-page `GET /api/capacity/activity` responses include an optional `aggregate` (totals by episode type and state). A validated `?type=` query narrows the episode list; it is included in the cursor filter fingerprint. The aggregate is computed **before** the type filter (counts stay stable when a type pill is selected, like Demand state pills) and is **omitted on cursor pages** so deep pagination cannot fake whole-window totals.
> 
> **UI:** Type pills (`All · N`, `Provision · N · M failed`) use the rollup when present; partial/bounded timeline coverage prefixes counts with `≥`. The observation-window card becomes a single header line with tooltip context. Episode evidence tables default to When/Source/Raw/References; normalized reason, relationship, and confidence columns sit behind **Show provenance**.
> 
> Wire changes are additive (`aggregate` field, `type` query param) plus docs updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d502396064daea8c8d14e148be3b56a74845daa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->