### PR TITLE
Make Cloud status recovery actionable

### DIFF
--- a/cmd/explorer/cloud_status.go
+++ b/cmd/explorer/cloud_status.go
@@ -36,6 +36,9 @@ type hubTunnelResult struct {
 	lastConnectedAt *time.Time
 	detail          string
 	next            string
+	openURL         string
+	reinstall       bool
+	openClusters    bool
 }
 
 type agentStatusGetter interface {
@@ -411,6 +414,9 @@ func printHubTunnelStatusWithStyle(out io.Writer, target cloudinstall.RadarTarge
 	if result.detail != "" {
 		fmt.Fprintf(out, "%s %s\n", style.Dim("Details:"), result.detail)
 	}
+	if result.openURL != "" {
+		fmt.Fprintf(out, "%s %s\n", style.Bold("Open:"), result.openURL)
+	}
 	if result.next != "" {
 		fmt.Fprintf(out, "%s %s\n", style.Bold("Next:"), result.next)
 	}
@@ -460,7 +466,24 @@ func checkHubTunnelStatus(ctx context.Context, kc kubernetes.Interface, target c
 			next:    "correct the Hub URL, then run this command again.",
 		}
 	}
-	return checkHubTunnelStatusWithClient(ctx, kc, target, client)
+	result := checkHubTunnelStatusWithClient(ctx, kc, target, client)
+	if ctx.Err() == nil && (result.verdict == hubTunnelHealthy || result.openClusters) {
+		if frontendURL, ferr := client.GetFrontendURL(ctx); ferr == nil {
+			result = addHubFrontendLinks(result, frontendURL)
+		}
+	}
+	return result
+}
+
+func addHubFrontendLinks(result hubTunnelResult, frontendURL string) hubTunnelResult {
+	result.openURL = strings.TrimRight(frontendURL, "/") + "/clusters"
+	if result.verdict == hubTunnelHealthy && result.hubClusterID != "" {
+		result.openURL = cloudClusterURL(frontendURL, result.hubClusterID)
+	}
+	if result.reinstall {
+		result.next = "in the Clusters page above, choose the matching cluster, select Reinstall, ensure “Already running Radar” is selected, and run the generated command in this Kubernetes context. Then rerun this status command."
+	}
+	return result
 }
 
 func checkHubTunnelStatusWithClient(ctx context.Context, kc kubernetes.Interface, target cloudinstall.RadarTarget, client agentStatusGetter) hubTunnelResult {
@@ -477,15 +500,17 @@ func checkHubTunnelStatusWithClient(ctx context.Context, kc kubernetes.Interface
 		return hubTunnelResult{
 			summary: "not checked — Kubernetes denied access to the connection Secret",
 			detail:  fmt.Sprintf("Secret %q", secretRef),
-			next:    "run this command with an account that can read the Secret, or verify the connection in the Hub.",
+			next:    "run this command with an account that can read the Secret.",
 		}
 	}
 	if apierrors.IsNotFound(err) {
 		return hubTunnelResult{
-			verdict: hubTunnelUnhealthy,
-			summary: "failed — the connection Secret was not found",
-			detail:  fmt.Sprintf("Secret %q", secretRef),
-			next:    "restore the Secret or correct cloud.existingSecret, then run this command again.",
+			verdict:      hubTunnelUnhealthy,
+			summary:      "failed — the connection Secret was not found",
+			detail:       fmt.Sprintf("Secret %q", secretRef),
+			next:         "ask a Radar organization owner to generate a Reinstall command for this cluster, run it in this Kubernetes context, then rerun this status command.",
+			reinstall:    true,
+			openClusters: true,
 		}
 	}
 	if err != nil {
@@ -498,17 +523,21 @@ func checkHubTunnelStatusWithClient(ctx context.Context, kc kubernetes.Interface
 	token := string(secret.Data[runtime.CloudTokenSecretKey])
 	if token == "" {
 		return hubTunnelResult{
-			verdict: hubTunnelUnhealthy,
-			summary: "failed — the connection Secret has no usable token",
-			detail:  fmt.Sprintf("Secret %q, key %q", secretRef, runtime.CloudTokenSecretKey),
-			next:    "restore the token key, then restart the Radar agent.",
+			verdict:      hubTunnelUnhealthy,
+			summary:      "failed — the connection Secret has no usable token",
+			detail:       fmt.Sprintf("Secret %q, key %q", secretRef, runtime.CloudTokenSecretKey),
+			next:         "ask a Radar organization owner to generate a Reinstall command for this cluster, run it in this Kubernetes context, then rerun this status command.",
+			reinstall:    true,
+			openClusters: true,
 		}
 	}
 	status, err := client.Get(ctx, token)
 	result := evaluateHubTunnelStatus(status, err)
 	if errors.Is(err, cloud.ErrAgentStatusUnauthorized) {
 		result.detail = fmt.Sprintf("Kubernetes Secret %q, key %q", secretRef, runtime.CloudTokenSecretKey)
-		result.next = "generate a new cluster token in the Hub, update this Secret, then restart the Radar agent."
+		result.next = "ask a Radar organization owner to generate a Reinstall command for this cluster, run it in this Kubernetes context, then rerun this status command."
+		result.reinstall = true
+		result.openClusters = true
 	}
 	return result
 }
@@ -521,7 +550,7 @@ func evaluateHubTunnelStatus(status *cloud.AgentStatusResponse, err error) hubTu
 		return hubTunnelResult{
 			summary: "not checked — the Hub status endpoint was not found",
 			detail:  "GET /api/agent/status returned HTTP 404",
-			next:    "verify the connection in the Hub's cluster list; if this is a self-hosted Hub, upgrade it to a version that supports live connection status.",
+			next:    "if this is a self-hosted Hub, upgrade it to a version that supports live connection status.",
 		}
 	}
 	if err != nil {
@@ -539,12 +568,12 @@ func evaluateHubTunnelStatus(status *cloud.AgentStatusResponse, err error) hubTu
 	case "disconnected":
 		return hubTunnelResult{
 			verdict: hubTunnelUnhealthy, summary: "disconnected", hubClusterID: status.ClusterID, lastConnectedAt: status.LastConnectedAt,
-			next: "check the Radar agent state above and its Cloud connection logs.",
+			next: "check the Radar agent state above and its Cloud connection logs.", openClusters: true,
 		}
 	case "never_connected":
 		return hubTunnelResult{
 			verdict: hubTunnelUnhealthy, summary: hubTunnelNeverConnectedSummary, hubClusterID: status.ClusterID,
-			next: "check the Radar agent state above and its Cloud connection logs.",
+			next: "check the Radar agent state above and its Cloud connection logs.", openClusters: true,
 		}
 	default:
 		return hubTunnelResult{

--- a/cmd/explorer/cloud_status_test.go
+++ b/cmd/explorer/cloud_status_test.go
@@ -159,14 +159,15 @@ func TestCheckHubTunnelStatusFailsForBrokenSecretReference(t *testing.T) {
 func TestEvaluateHubTunnelStatusHealthContract(t *testing.T) {
 	connectedAt := time.Date(2026, time.July, 18, 7, 30, 0, 0, time.UTC)
 	for _, tc := range []struct {
-		name    string
-		status  *cloud.AgentStatusResponse
-		err     error
-		verdict hubTunnelVerdict
-		want    string
+		name         string
+		status       *cloud.AgentStatusResponse
+		err          error
+		verdict      hubTunnelVerdict
+		want         string
+		openClusters bool
 	}{
-		{name: "disconnected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "disconnected", LastConnectedAt: &connectedAt}, verdict: hubTunnelUnhealthy, want: "disconnected"},
-		{name: "never connected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "never_connected"}, verdict: hubTunnelUnhealthy, want: "never connected"},
+		{name: "disconnected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "disconnected", LastConnectedAt: &connectedAt}, verdict: hubTunnelUnhealthy, want: "disconnected", openClusters: true},
+		{name: "never connected", status: &cloud.AgentStatusResponse{ClusterID: "clus_123", Status: "never_connected"}, verdict: hubTunnelUnhealthy, want: "never connected", openClusters: true},
 		{name: "rejected", err: cloud.ErrAgentStatusUnauthorized, verdict: hubTunnelUnhealthy, want: "rejected the connection token"},
 		{name: "status endpoint not found", err: cloud.ErrAgentStatusEndpointNotFound, verdict: hubTunnelUnavailable, want: "status endpoint was not found"},
 		{name: "network unavailable", err: errors.New("dial timeout"), verdict: hubTunnelUnavailable, want: "Hub status request failed"},
@@ -176,6 +177,9 @@ func TestEvaluateHubTunnelStatusHealthContract(t *testing.T) {
 			actual := strings.Join([]string{got.summary, got.detail, got.next}, "\n")
 			if got.verdict != tc.verdict || !strings.Contains(actual, tc.want) {
 				t.Fatalf("result = %#v", got)
+			}
+			if got.openClusters != tc.openClusters {
+				t.Fatalf("openClusters = %v, want %v: %#v", got.openClusters, tc.openClusters, got)
 			}
 			if tc.name == "disconnected" && (got.lastConnectedAt == nil || !got.lastConnectedAt.Equal(connectedAt)) {
 				t.Fatalf("disconnected timestamp = %#v", got.lastConnectedAt)
@@ -334,8 +338,41 @@ func TestCheckHubTunnelStatusRejectedTokenNamesCredentialAndRecovery(t *testing.
 	got := checkHubTunnelStatusWithClient(context.Background(), kc, target, client)
 	if got.verdict != hubTunnelUnhealthy || !strings.Contains(got.summary, "rejected the connection token") ||
 		!strings.Contains(got.detail, `Kubernetes Secret "radar/radar-cloud-config", key "token"`) ||
-		!strings.Contains(got.next, "generate a new cluster token in the Hub") {
+		!strings.Contains(got.next, "organization owner") || !got.reinstall {
 		t.Fatalf("result = %#v", got)
+	}
+}
+
+func TestAddHubFrontendLinksUsesExactClusterAndRecoveryDestinations(t *testing.T) {
+	connected := addHubFrontendLinks(hubTunnelResult{verdict: hubTunnelHealthy, hubClusterID: "clus/a b"}, "https://app.radarhq.io/")
+	if connected.openURL != "https://app.radarhq.io/c/clus%2Fa%20b" {
+		t.Fatalf("connected open URL = %q", connected.openURL)
+	}
+
+	recovery := addHubFrontendLinks(hubTunnelResult{reinstall: true}, "https://app.radarhq.io/")
+	if recovery.openURL != "https://app.radarhq.io/clusters" ||
+		!strings.Contains(recovery.next, "select Reinstall") ||
+		!strings.Contains(recovery.next, "ensure “Already running Radar” is selected") {
+		t.Fatalf("recovery = %#v", recovery)
+	}
+
+	disconnected := addHubFrontendLinks(hubTunnelResult{verdict: hubTunnelUnhealthy, hubClusterID: "clus_123", openClusters: true}, "https://app.radarhq.io/")
+	if disconnected.openURL != "https://app.radarhq.io/clusters" {
+		t.Fatalf("disconnected open URL = %q", disconnected.openURL)
+	}
+}
+
+func TestPrintHubTunnelStatusPrintsActionableURL(t *testing.T) {
+	var out bytes.Buffer
+	printHubTunnelStatus(&out, cloudinstall.RadarTarget{}, hubTunnelResult{
+		verdict: hubTunnelUnhealthy,
+		summary: "failed — the Hub rejected the connection token",
+		openURL: "https://app.radarhq.io/clusters",
+		next:    "choose Reinstall.",
+	})
+	got := out.String()
+	if !strings.Contains(got, "Open: https://app.radarhq.io/clusters") || !strings.Contains(got, "Next: choose Reinstall.") {
+		t.Fatalf("output = %q", got)
 	}
 }
 

--- a/internal/cloud/agent_status.go
+++ b/internal/cloud/agent_status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -24,6 +25,10 @@ type AgentStatusResponse struct {
 	ClusterID       string     `json:"cluster_id"`
 	Status          string     `json:"status"`
 	LastConnectedAt *time.Time `json:"last_connected_at,omitempty"`
+}
+
+type hubPublicConfig struct {
+	FrontendURL string `json:"frontend_url"`
 }
 
 // AgentStatusClient reuses the Hub client's validation and no-redirect
@@ -83,4 +88,44 @@ func (c *AgentStatusClient) Get(ctx context.Context, token string) (*AgentStatus
 		return nil, errors.New("decode Hub agent status: cluster_id and status are required")
 	}
 	return &status, nil
+}
+
+// GetFrontendURL returns the Hub's canonical browser origin from its public
+// runtime configuration. It is intentionally independent of the cluster token
+// so status can still print an actionable link when that token was rejected.
+func (c *AgentStatusClient) GetFrontendURL(ctx context.Context) (string, error) {
+	if err := c.validateHubOrigin(); err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.HubBase+"/api/config", nil)
+	if err != nil {
+		return "", fmt.Errorf("build Hub config request: %w", err)
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("query Hub config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("query Hub config: Hub returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAgentStatusBodyBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read Hub config: %w", err)
+	}
+	if len(body) > maxAgentStatusBodyBytes {
+		return "", errors.New("read Hub config: response is too large")
+	}
+	var cfg hubPublicConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return "", fmt.Errorf("decode Hub config: %w", err)
+	}
+	cfg.FrontendURL = strings.TrimRight(strings.TrimSpace(cfg.FrontendURL), "/")
+	if cfg.FrontendURL == "" {
+		return "", errors.New("decode Hub config: frontend_url is required")
+	}
+	if err := ValidateHubOrigin(cfg.FrontendURL); err != nil {
+		return "", fmt.Errorf("decode Hub config: invalid frontend_url: %w", err)
+	}
+	return cfg.FrontendURL, nil
 }

--- a/internal/cloud/agent_status_test.go
+++ b/internal/cloud/agent_status_test.go
@@ -61,6 +61,86 @@ func TestAgentStatusClientRejectsUnauthorizedWithoutResponseBodyLeak(t *testing.
 	}
 }
 
+func TestAgentStatusClientGetsCanonicalFrontendURLWithoutClusterToken(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://api.radar.acme.example/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://api.radar.acme.example/api/config" {
+			t.Fatalf("URL = %q", r.URL.String())
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("unexpected Authorization header %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"frontend_url":"https://radar.acme.example/"}`)),
+		}, nil
+	})}
+
+	got, err := c.GetFrontendURL(context.Background())
+	if err != nil {
+		t.Fatalf("GetFrontendURL: %v", err)
+	}
+	if got != "https://radar.acme.example" {
+		t.Fatalf("frontend URL = %q", got)
+	}
+}
+
+func TestAgentStatusClientRejectsInvalidFrontendURL(t *testing.T) {
+	c, err := NewAgentStatusClient("wss://api.radarhq.io/agent")
+	if err != nil {
+		t.Fatalf("NewAgentStatusClient: %v", err)
+	}
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"frontend_url":"javascript:alert(1)"}`)),
+		}, nil
+	})}
+
+	if _, err := c.GetFrontendURL(context.Background()); err == nil || !strings.Contains(err.Error(), "invalid frontend_url") {
+		t.Fatalf("GetFrontendURL error = %v", err)
+	}
+}
+
+func TestAgentStatusClientHandlesOlderHubConfigShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		status     string
+		body       string
+		want       string
+	}{
+		{name: "frontend URL omitted", statusCode: http.StatusOK, status: "200 OK", body: `{"mode":"cloud"}`, want: "frontend_url is required"},
+		{name: "config endpoint unavailable", statusCode: http.StatusNotFound, status: "404 Not Found", body: "not found", want: "Hub returned 404 Not Found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewAgentStatusClient("wss://api.radarhq.io/agent")
+			if err != nil {
+				t.Fatalf("NewAgentStatusClient: %v", err)
+			}
+			c.HTTP = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tc.statusCode,
+					Status:     tc.status,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(tc.body)),
+				}, nil
+			})}
+
+			if _, err := c.GetFrontendURL(context.Background()); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("GetFrontendURL error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestAgentStatusClientRecognizesMissingStatusEndpoint(t *testing.T) {
 	c, err := NewAgentStatusClient("wss://acme.radarhq.io/agent")
 	if err != nil {

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -493,7 +493,7 @@ func streamRun(base, id string, out *renderer) (json.RawMessage, bool) {
 			return nil, false
 		}
 	}
-	fmt.Fprintln(os.Stderr, "stream ended unexpectedly — the run keeps going; watch it in the Radar UI")
+	fmt.Fprintf(os.Stderr, "stream ended unexpectedly — the run keeps going; watch it at %s/?ai-run=%s\n", base, id)
 	return nil, false
 }
 


### PR DESCRIPTION
## Summary

- Link healthy installations directly to their Cloud cluster.
- Link disconnected and credential-error states to the canonical Clusters page.
- Give concrete Reinstall recovery steps for missing, empty, or rejected tokens.
- Preserve graceful behavior against older Hubs that do not expose a frontend URL.
- Repeat the exact diagnose run URL if streaming is interrupted.

## Safety

This is read-only recovery guidance. The CLI does not rotate tokens, reconnect clusters, or change authentication or authorization behavior.

## Dependencies

- skyhook-dev/radar-hub#110 enables canonical links.
- skyhook-dev/radar-hub-web#200 improves the Reinstall command path.

## Verification

- `make tsc`
- `make test`
- `make build`
- `go test ./cmd/explorer ./internal/cloud ./internal/diagnosecli`
- `go build ./cmd/explorer`