### PR TITLE
Polish CLI recovery destinations

### DIFF
--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -302,7 +302,7 @@ func cloudInstall(args []string) {
 		}
 	}
 	if err != nil {
-		if !printFreshInstallConflict(os.Stderr, err, commandTarget) && !printTokenSecretConflict(os.Stderr, err) {
+		if !printFreshInstallConflict(os.Stderr, err, commandTarget) && !printTokenSecretConflict(os.Stderr, err, plan.Release, commandTarget) {
 			fmt.Fprintf(os.Stderr, "installation preparation failed: %v\n", err)
 		}
 		fmt.Fprintln(os.Stderr, "No Hub request or cluster was created.")
@@ -375,7 +375,7 @@ func cloudInstall(args []string) {
 
 	pr, err := client.PollUntilApproved(ctx, cr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\n%s connect failed: %v\n", stderrStyle.Marker(cliui.Failure), err)
+		printConnectFailure(os.Stderr, err, cloudClustersURL(cr.ConnectURL))
 		os.Exit(1)
 	}
 	if ctx.Err() != nil && plan.Mode != cloudInstallGitOps {
@@ -422,7 +422,7 @@ func cloudInstall(args []string) {
 	fmt.Printf("\n  %s Kubernetes provisioning complete.\n", stdoutStyle.Marker(cliui.Success))
 	fmt.Printf("  %s Waiting up to %s for the in-cluster agent to connect…\n", stdoutStyle.Marker(cliui.Progress), cloudTunnelConfirmationTimeout)
 	if err := client.WaitUntilConsumed(ctx, cr, cloudTunnelConfirmationTimeout); err != nil {
-		printTunnelConfirmationFailure(os.Stderr, err, pr.ClusterID, pr.WSSURL, prepared.Deployment(), commandTarget)
+		printTunnelConfirmationFailure(os.Stderr, err, pr.ClusterID, pr.WSSURL, cloudClusterURL(cr.ConnectURL, pr.ClusterID), prepared.Deployment(), commandTarget)
 		os.Exit(1)
 	}
 
@@ -470,9 +470,21 @@ func resolveCloudInstallClusterName(explicit, contextName string) string {
 }
 
 func cloudClusterURL(connectURL, clusterID string) string {
+	return cloudFrontendOrigin(connectURL) + "/c/" + url.PathEscape(clusterID)
+}
+
+func cloudClustersURL(connectURL string) string {
+	return cloudFrontendOrigin(connectURL) + "/clusters"
+}
+
+func cloudFrontendOrigin(connectURL string) string {
 	u, _ := url.Parse(connectURL)
-	origin := (&url.URL{Scheme: u.Scheme, Host: u.Host}).String()
-	return origin + "/c/" + url.PathEscape(clusterID)
+	return (&url.URL{Scheme: u.Scheme, Host: u.Host}).String()
+}
+
+func printConnectFailure(w io.Writer, err error, clustersURL string) {
+	fmt.Fprintf(w, "\n%s connect failed: %v\n", cliui.New(w).Marker(cliui.Failure), err)
+	fmt.Fprintf(w, "Open: %s\n", clustersURL)
 }
 
 func printInstallSuccess(w io.Writer, clusterName, clusterURL string, deployment helm.DeploymentRef, target cloudCommandTarget) {
@@ -514,13 +526,15 @@ func printFreshInstallConflict(w io.Writer, err error, target cloudCommandTarget
 	return false
 }
 
-func printTokenSecretConflict(w io.Writer, err error) bool {
+func printTokenSecretConflict(w io.Writer, err error, releaseName string, target cloudCommandTarget) bool {
 	var secret *cloudinstall.TokenSecretExistsError
 	if !errors.As(err, &secret) {
 		return false
 	}
 	fmt.Fprintf(w, "Cloud token Secret %q already exists in namespace %q; Radar will not overwrite it.\n", secret.Name, secret.Namespace)
-	fmt.Fprintln(w, "Inspect the existing Helm release and Secret, and recover that installation if it belongs to an earlier approval.")
+	fmt.Fprintln(w, "Inspect the existing installation and its Cloud pairing:")
+	fmt.Fprintf(w, "  %s\n", target.cloudStatus(secret.Namespace, releaseName))
+	fmt.Fprintln(w, "Recover that installation if it belongs to an earlier approval.")
 	fmt.Fprintln(w, "If it was abandoned, clean up its Helm release and Secret and delete the corresponding Hub cluster before starting a fresh flow.")
 	return true
 }
@@ -592,7 +606,7 @@ func printPostApprovalRecoveryGuidance(w io.Writer, clusterID, clusterURL string
 	fmt.Fprintln(w, "If the token Secret remains, recover the partial install with this Hub cluster. If the Secret was cleaned up, the token is no longer recoverable: clean up any partial Helm release, then delete this Hub cluster before starting a fresh flow.")
 }
 
-func printTunnelConfirmationFailure(w io.Writer, err error, clusterID, cloudURL string, deployment helm.DeploymentRef, target cloudCommandTarget) {
+func printTunnelConfirmationFailure(w io.Writer, err error, clusterID, cloudURL, clusterURL string, deployment helm.DeploymentRef, target cloudCommandTarget) {
 	reason := err.Error()
 	switch {
 	case errors.Is(err, cloud.ErrConnectConsumptionTimeout):
@@ -604,6 +618,7 @@ func printTunnelConfirmationFailure(w io.Writer, err error, clusterID, cloudURL 
 	}
 
 	fmt.Fprintf(w, "\n%s Radar was provisioned and Hub cluster %q already exists, but its tunnel could not be confirmed: %s.\n", cliui.New(w).Marker(cliui.Attention), clusterID, reason)
+	fmt.Fprintf(w, "Open: %s\n", clusterURL)
 	fmt.Fprintln(w, "Do not rerun the installer or delete the cluster by default; the existing agent can still connect after you resolve its startup or egress issue.")
 	fmt.Fprintln(w, "Inspect:")
 	fmt.Fprintf(w, "  %s -n %s rollout status deployment/%s\n", target.kubectl(), deployment.Namespace, deployment.Name)

--- a/cmd/explorer/cloud_cmd_test.go
+++ b/cmd/explorer/cloud_cmd_test.go
@@ -381,15 +381,34 @@ func TestCloudClusterURLUsesConnectOriginAndEscapesClusterID(t *testing.T) {
 	if want := "https://app.radarhq.io/c/clus%2Fa%20b"; got != want {
 		t.Fatalf("cloudClusterURL() = %q, want %q", got, want)
 	}
+	if got := cloudClustersURL("https://app.radarhq.io/connect/req_123?from=cli#approval"); got != "https://app.radarhq.io/clusters" {
+		t.Fatalf("cloudClustersURL() = %q", got)
+	}
+}
+
+func TestPrintConnectFailurePointsToClusterRecovery(t *testing.T) {
+	var out bytes.Buffer
+	printConnectFailure(&out, cloud.ErrConnectRecoveryTimeout, "https://app.radarhq.io/clusters")
+	got := out.String()
+	for _, want := range []string{"connect failed", cloud.ErrConnectRecoveryTimeout.Error(), "Open: https://app.radarhq.io/clusters"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("connect failure missing %q:\n%s", want, got)
+		}
+	}
 }
 
 func TestPrintTokenSecretConflict(t *testing.T) {
 	var out bytes.Buffer
 	err := fmt.Errorf("wrapped: %w", &cloudinstall.TokenSecretExistsError{Name: "radar-cloud-config", Namespace: "ops"})
-	if !printTokenSecretConflict(&out, err) {
+	if !printTokenSecretConflict(&out, err, "radar", cloudCommandTarget{Context: "prod context"}) {
 		t.Fatal("typed Secret conflict was not classified")
 	}
-	for _, want := range []string{"will not overwrite", "recover that installation", "corresponding Hub cluster"} {
+	for _, want := range []string{
+		"will not overwrite",
+		"radar cloud status --context 'prod context' --namespace 'ops' --release 'radar'",
+		"Recover that installation",
+		"corresponding Hub cluster",
+	} {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("guidance missing %q:\n%s", want, out.String())
 		}
@@ -398,13 +417,14 @@ func TestPrintTokenSecretConflict(t *testing.T) {
 
 func TestTunnelConfirmationFailurePreservesExistingInstall(t *testing.T) {
 	var out bytes.Buffer
-	printTunnelConfirmationFailure(&out, cloud.ErrConnectConsumptionTimeout, "clus_existing", "wss://api.example/agent", helm.DeploymentRef{
+	printTunnelConfirmationFailure(&out, cloud.ErrConnectConsumptionTimeout, "clus_existing", "wss://api.example/agent", "https://app.example/c/clus_existing", helm.DeploymentRef{
 		Name: "prod-radar", Namespace: "radar-prod",
 	}, cloudCommandTarget{})
 	got := out.String()
 	for _, want := range []string{
 		"Radar was provisioned", "clus_existing", "five-minute confirmation window",
 		"Do not rerun", "deployment/prod-radar", "logs deployment/prod-radar",
+		"Open: https://app.example/c/clus_existing",
 		"outbound WSS/HTTPS access to wss://api.example/agent", "Only if you deliberately abandon",
 	} {
 		if !strings.Contains(got, want) {
@@ -416,7 +436,7 @@ func TestTunnelConfirmationFailurePreservesExistingInstall(t *testing.T) {
 func TestTunnelConfirmationPickupExpiryDoesNotRepeatDeleteAdvice(t *testing.T) {
 	var out bytes.Buffer
 	err := fmt.Errorf("%w: delete pending cluster", cloud.ErrConnectPickupExpired)
-	printTunnelConfirmationFailure(&out, err, "clus_existing", "wss://api.example/agent", helm.DeploymentRef{Name: "radar", Namespace: "radar"}, cloudCommandTarget{})
+	printTunnelConfirmationFailure(&out, err, "clus_existing", "wss://api.example/agent", "https://app.example/c/clus_existing", helm.DeploymentRef{Name: "radar", Namespace: "radar"}, cloudCommandTarget{})
 	got := out.String()
 	if strings.Contains(got, "delete pending cluster") {
 		t.Fatalf("post-install guidance repeated pre-install deletion advice:\n%s", got)

--- a/cmd/explorer/cloud_install_output.go
+++ b/cmd/explorer/cloud_install_output.go
@@ -43,6 +43,14 @@ func (t cloudCommandTarget) helm() string {
 	return command
 }
 
+func (t cloudCommandTarget) cloudStatus(namespace, release string) string {
+	command := "radar cloud status"
+	if t.Context != "" {
+		command += " --context " + shellArgument(t.Context)
+	}
+	return command + " --namespace " + shellArgument(namespace) + " --release " + shellArgument(release)
+}
+
 func shellArgument(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -47,6 +47,25 @@ func TestRendererVerdictShapes(t *testing.T) {
 	}
 }
 
+func TestRendererVerdictRepeatsWatchURL(t *testing.T) {
+	tmp, err := createTempFile(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &renderer{w: tmp, color: false}
+	r.header(runSummary{ID: "run-123", Kind: "Pod", Name: "checkout", Agent: "codex"}, "http://localhost:9280")
+	r.verdict(diagnosis{Healthy: true})
+	if _, err := tmp.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 8192)
+	n, _ := tmp.Read(buf)
+	got := string(buf[:n])
+	if url := "http://localhost:9280/?ai-run=run-123"; strings.Count(got, url) != 2 {
+		t.Fatalf("watch URL should appear in the header and final footer:\n%s", got)
+	}
+}
+
 func captureVerdict(t *testing.T, d diagnosis) string {
 	t.Helper()
 	tmp, err := createTempFile(t)

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -42,6 +42,7 @@ type renderer struct {
 	lastEvent   time.Time // last real output, for the quiet-gap threshold
 	activeTool  string    // tool currently running (the spinner speaks its activity verb)
 	sawAnything bool      // false until the agent's first output ("starting investigation…")
+	watchURL    string
 	stopSpin    chan struct{}
 	spinStopped bool
 }
@@ -152,13 +153,14 @@ func (r *renderer) toolStarted(tool string) {
 }
 
 func (r *renderer) header(run runSummary, base string) {
+	r.watchURL = fmt.Sprintf("%s/?ai-run=%s", base, run.ID)
 	target := run.Kind + " "
 	if run.Namespace != "" {
 		target += run.Namespace + "/"
 	}
 	target += run.Name
 	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), r.c(cBold, r.c(cCyan, target)))
-	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("%s · via %s · watch: %s/?ai-run=%s", run.ID, ai.AgentLabel(run.Agent), base, run.ID)))
+	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("%s · via %s · watch: %s", run.ID, ai.AgentLabel(run.Agent), r.watchURL)))
 	// Radar's read at start — the concrete issue rows the server captured, shown
 	// before the agent produces anything (its boot is the longest silent gap).
 	if h := run.Health; h != nil {
@@ -339,7 +341,11 @@ func (r *renderer) verdict(d diagnosis) {
 			fmt.Fprintln(r.w, "The investigation finished without a clear result.")
 		}
 	}
-	fmt.Fprintf(r.w, "\n%s\n", r.c(cDim, "AI-generated — review before applying. Continue in the Radar UI or your own agent."))
+	footer := "AI-generated — review before applying. Continue in the Radar UI or your own agent."
+	if r.watchURL != "" {
+		footer = "AI-generated — review before applying. Continue in Radar: " + r.watchURL + " — or in your own agent."
+	}
+	fmt.Fprintf(r.w, "\n%s\n", r.c(cDim, footer))
 }
 
 func confidenceLabel(c float64) string {


### PR DESCRIPTION
## Summary

- Point connect-flow failures to the canonical Clusters page.
- Repeat the exact cluster URL when tunnel confirmation fails.
- Give existing token-Secret conflicts a context-pinned, read-only `radar cloud status` command.
- Repeat the exact Diagnose investigation URL in the final footer.

## Safety

This changes CLI guidance only. It does not mutate credentials or change authentication, authorization, tokens, or connection behavior.

## Verification

- `go test ./cmd/explorer ./internal/diagnosecli`
- `make test`
- `make tsc`
- `make build`
- visual-test: skipped (no rendered UI delta)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing CLI messages and URL formatting; no auth, provisioning, or connection behavior changes.
> 
> **Overview**
> Improves **CLI recovery copy** so operators get copy-pasteable destinations when cloud install or diagnose flows fail or finish.
> 
> **`radar cloud install`:** Connect approval failures now go through `printConnectFailure` and suggest the canonical **`/clusters`** page (derived from the connect URL via `cloudFrontendOrigin`). Tunnel confirmation failures add an **`Open:`** line with the per-cluster UI URL. Existing cloud token Secret conflicts print a context-pinned **`radar cloud status`** command (`cloudCommandTarget.cloudStatus`) instead of generic Helm/Secret advice.
> 
> **`radar diagnose`:** The investigation watch URL is stored on the renderer and repeated in the **verdict footer** (in addition to the header), so users can continue in Radar without re-copying from the top of the output.
> 
> Tests cover URL helpers, connect failure output, token-secret guidance, tunnel failure copy, and the diagnose footer URL appearing twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bccaba61d0bf63ec315240bb27987d3bbe41f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->