### PR TITLE
feat(diagnose): let embedding hosts override the consent card's trust copy

### DIFF
--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -40,7 +40,10 @@ import type { ClusterLoadState } from "./types/clusterLoadState";
 import { TimelineSourceProvider } from "./context/TimelineSource";
 import type { TimelineSourceConfig } from "./api/timelineSource";
 import { DiagnoseCustomizationProvider } from "./context/DiagnoseCustomization";
-import type { RenderDiagnoseAction } from "./context/DiagnoseCustomization";
+import type {
+  RenderDiagnoseAction,
+  DiagnoseConsentCopy,
+} from "./context/DiagnoseCustomization";
 import { defaultDiagnoseAction } from "./components/diagnose/LocalDiagnoseAction";
 import { DiagnoseProvider } from "./components/diagnose/DiagnoseContext";
 
@@ -110,6 +113,15 @@ export interface RadarAppProps {
    * agent-free. See ./context/DiagnoseCustomization for the render-prop shape.
    */
   renderDiagnoseAction?: RenderDiagnoseAction;
+  /**
+   * Replaces the first-run consent card's trust copy. REQUIRED of any host whose
+   * backend runs the agent somewhere other than the user's own machine — the
+   * default copy states the agent runs locally, under the user's own model
+   * account, with transcripts kept on their disk, and none of that is true of a
+   * hosted runner. Radar keeps the card's chrome and the Approve/Cancel flow; a
+   * host only supplies the claims. See ./context/DiagnoseCustomization.
+   */
+  diagnoseConsent?: DiagnoseConsentCopy;
   /**
    * Initial route for `router: 'memory'` (ignored for 'browser'). Lets a host
    * deep-link a specific view (e.g. '/topology') without owning the URL bar —
@@ -184,6 +196,7 @@ export function RadarApp({
   manageDocumentTitle = false,
   documentTitleSuffix,
   renderDiagnoseAction,
+  diagnoseConsent,
   initialPath,
   onClusterLoadStateChange,
   timelineSource,
@@ -213,6 +226,7 @@ export function RadarApp({
               <TimelineSourceProvider config={timelineSource}>
                 <DiagnoseCustomizationProvider
                   value={renderDiagnoseAction ?? defaultDiagnoseAction}
+                  consentCopy={diagnoseConsent}
                 >
                   <DiagnoseProvider>
                     <App

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -23,6 +23,7 @@ import {
   agentLabelFor,
   openDiagnoseSettings,
 } from "./DiagnoseContext";
+import { useDiagnoseConsentCopy } from "../../context/DiagnoseCustomization";
 import { InvestigationView } from "./InvestigationView";
 import { RecentList } from "./Home";
 import { ConsentCard } from "./parts";
@@ -136,6 +137,7 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
 // Helm drawers, so it no longer floats viewport-fixed or DOM-measures the chrome.
 export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
   const d = useDiagnose();
+  const consentCopy = useDiagnoseConsentCopy();
   const {
     maximized,
     setMaximized,
@@ -203,6 +205,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           agentName={d.agentLabel}
           agent={d.selectedAgent}
           isolated={d.isolated}
+          copy={consentCopy}
           onOpenSettings={openDiagnoseSettings}
           onApprove={d.approveConsent}
           onCancel={d.cancelConsent}

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -22,6 +22,7 @@ import { stringify as toYaml } from "yaml";
 import { codeToHtml } from "shiki";
 import { DialogPortal } from "@skyhook-io/k8s-ui/components/ui/DialogPortal";
 import { useTheme } from "../../context/ThemeContext";
+import { type DiagnoseConsentCopy } from "../../context/DiagnoseCustomization";
 import {
   type Diagnosis,
   type DiagnoseStep,
@@ -581,95 +582,51 @@ export function RunContextCard({ run }: { run: RunSummary }) {
   );
 }
 
-// The first-run consent + trust card. Its copy is the OSS BYO-local trust story
-// ("your own agent, on your machine, nothing to Radar").
-// TODO(cloud): this copy must become embedder-overridable for Radar Cloud, where
-//   the agent runs in the cloud (the company's self-hosted instance + their key /
-//   local LLM, OR our SaaS) — a different, honestly-different trust story ("runs in
-//   your Radar Cloud, audited, managed key"). Plumb an override through the
-//   DiagnoseCustomization seam (same place Hub overrides the entry button) before
-//   the k8s-ui lift, so OSS and Cloud don't ship the same claim over different data
-//   flows. This is also a natural "upgrade to Cloud" surface.
-export function ConsentCard({
-  agentName,
-  agent,
-  isolated = true,
+// ConsentCardShell owns the card chrome (icon, layout, settings link, Approve/
+// Cancel) so every copy tier — the OSS default, the hosted fallback, and a host
+// override — feeds the same frame instead of duplicating it.
+function ConsentCardShell({
+  title,
+  body,
+  bullets,
+  settingsLabel,
+  approveLabel = "Approve & investigate",
   onOpenSettings,
   onApprove,
   onCancel,
-}: {
-  agentName: string;
-  agent?: string;
-  isolated?: boolean;
+}: DiagnoseConsentCopy & {
   onOpenSettings?: () => void;
   onApprove: () => void;
   onCancel: () => void;
 }) {
-  // Cursor can't be isolated (no flag suppresses its global MCP servers), so it
-  // gets its own honest framing rather than the isolated/my-setup pair.
-  const isCursor = agent === "cursor-agent";
+  // `settingsLabel: null` hides the link outright — a host with one fixed agent
+  // has nothing behind it. `undefined` keeps the OSS default label.
+  const resolvedSettingsLabel =
+    settingsLabel === undefined
+      ? "Change the agent and how it runs in Settings"
+      : settingsLabel;
   return (
     <div className="rounded-lg border border-theme-border bg-theme-elevated p-4">
       <div className="mb-2 flex items-center gap-2">
         <ShieldCheck className="h-4 w-4 text-accent" />
         <div className="text-sm font-medium text-theme-text-primary">
-          {isolated && !isCursor
-            ? "Run a read-only AI investigation?"
-            : "Run an AI investigation?"}
+          {title}
         </div>
       </div>
-      <p className="text-sm leading-relaxed text-theme-text-secondary">
-        This runs{" "}
-        <span className="font-medium text-theme-text-primary">
-          your own {agentName}
-        </span>{" "}
-        on your machine — no Radar cloud, no API key, no account. Radar sends
-        this resource&apos;s spec, recent events, and pod logs to it (and on to
-        its model provider under your account, not to Radar). Transcripts are
-        kept in your local Radar history on this machine until cleared.
-        {isolated && !isCursor && (
-          <>
-            {" "}
-            Through Radar the agent can only{" "}
-            <span className="font-medium">read</span> — it cannot change your
-            cluster.
-          </>
-        )}
-      </p>
-      <ul className="mt-2 space-y-1 text-xs text-theme-text-tertiary">
-        {isCursor ? (
-          <li>
-            • Through Radar the agent only <span className="font-medium">reads</span>{" "}
-            your cluster. But Cursor also loads your own global MCP servers and
-            Radar can&apos;t exclude them (unlike Claude or Codex), so if any of
-            those can make changes, Cursor could use them.
-          </li>
-        ) : isolated ? (
-          <li>
-            • Isolated: only Radar&apos;s read-only investigation tools — your
-            other CLI config and MCP servers are excluded.
-            {agent === "codex" && (
-              <>
-                {" "}
-                Codex&apos;s sandboxed shell can still <em>read</em> files on
-                your machine (it cannot write or reach the network).
-              </>
-            )}
-          </li>
-        ) : (
-          <li>
-            • &ldquo;My setup&rdquo;: the agent also runs with your own CLI
-            config + MCP servers and can read local files. Only Radar&apos;s own
-            tools are read-only.
-          </li>
-        )}
-      </ul>
-      {onOpenSettings && (
+      <div className="text-sm leading-relaxed text-theme-text-secondary">{body}</div>
+      {bullets && bullets.length > 0 && (
+        <ul className="mt-2 space-y-1 text-xs text-theme-text-tertiary">
+          {bullets.map((b, i) => (
+            <li key={i}>• {b}</li>
+          ))}
+        </ul>
+      )}
+      {onOpenSettings && resolvedSettingsLabel && (
         <button
           onClick={onOpenSettings}
           className="mt-3 text-xs text-accent hover:underline"
         >
-          Change the agent and how it runs in Settings
+          {resolvedSettingsLabel}
         </button>
       )}
       <div className="mt-4 flex gap-2">
@@ -683,10 +640,107 @@ export function ConsentCard({
           onClick={onApprove}
           className="flex-1 rounded-lg btn-brand py-1.5 text-sm"
         >
-          Approve &amp; investigate
+          {approveLabel}
         </button>
       </div>
     </div>
+  );
+}
+
+// The first-run consent + trust card. The copy is checkable fact about a data
+// flow — not marketing — and the wrong claim is a lie, not a typo. It resolves
+// in two tiers:
+//
+//   1. `copy` — the embedding host tells its own trust story. Only the host
+//      knows where its agent runs, whose key pays, and where transcripts live,
+//      so any host that runs the agent somewhere other than the OSS local CLI
+//      MUST override rather than let Radar assert the local story over its flow.
+//   2. No `copy` — the OSS bring-your-own-local-CLI default, the only tier where
+//      "on your machine / no Radar cloud / your account" actually holds.
+export function ConsentCard({
+  agentName,
+  agent,
+  isolated = true,
+  copy,
+  onOpenSettings,
+  onApprove,
+  onCancel,
+}: {
+  agentName: string;
+  agent?: string;
+  isolated?: boolean;
+  copy?: DiagnoseConsentCopy;
+  onOpenSettings?: () => void;
+  onApprove: () => void;
+  onCancel: () => void;
+}) {
+  const chrome = { onOpenSettings, onApprove, onCancel };
+
+  // Tier 1: a host (e.g. radar-hub-web) supplied its own copy — use it verbatim.
+  if (copy) return <ConsentCardShell {...copy} {...chrome} />;
+
+  // Tier 2: OSS BYO-local default. Cursor can't be isolated (no flag suppresses
+  // its global MCP servers), so it gets its own honest framing rather than the
+  // isolated/my-setup pair.
+  const isCursor = agent === "cursor-agent";
+  return (
+    <ConsentCardShell
+      {...chrome}
+      title={
+        isolated && !isCursor
+          ? "Run a read-only AI investigation?"
+          : "Run an AI investigation?"
+      }
+      body={
+        <>
+          This runs{" "}
+          <span className="font-medium text-theme-text-primary">
+            your own {agentName}
+          </span>{" "}
+          on your machine — no Radar cloud, no API key, no account. Radar sends
+          this resource&apos;s spec, recent events, and pod logs to it (and on to
+          its model provider under your account, not to Radar). Transcripts are
+          kept in your local Radar history on this machine until cleared.
+          {isolated && !isCursor && (
+            <>
+              {" "}
+              Through Radar the agent can only{" "}
+              <span className="font-medium">read</span> — it cannot change your
+              cluster.
+            </>
+          )}
+        </>
+      }
+      bullets={[
+        isCursor ? (
+          <>
+            Through Radar the agent only{" "}
+            <span className="font-medium">reads</span> your cluster. But Cursor
+            also loads your own global MCP servers and Radar can&apos;t exclude
+            them (unlike Claude or Codex), so if any of those can make changes,
+            Cursor could use them.
+          </>
+        ) : isolated ? (
+          <>
+            Isolated: only Radar&apos;s read-only investigation tools — your
+            other CLI config and MCP servers are excluded.
+            {agent === "codex" && (
+              <>
+                {" "}
+                Codex&apos;s sandboxed shell can still <em>read</em> files on
+                your machine (it cannot write or reach the network).
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            &ldquo;My setup&rdquo;: the agent also runs with your own CLI config
+            + MCP servers and can read local files. Only Radar&apos;s own tools
+            are read-only.
+          </>
+        ),
+      ]}
+    />
   );
 }
 

--- a/web/src/context/DiagnoseCustomization.tsx
+++ b/web/src/context/DiagnoseCustomization.tsx
@@ -1,4 +1,5 @@
-// Slot-based injection of a resource-level "Diagnose" action.
+// Slot-based injection of a resource-level "Diagnose" action, and of the
+// consent card's trust copy.
 //
 // Lets an embedding host (e.g. Radar Hub) inject a "Diagnose with AI" button
 // into every resource detail action bar — without forking WorkloadView or the
@@ -21,22 +22,55 @@ export type RenderDiagnoseAction = (ctx: {
   health?: "problem" | "healthy" | "unknown";
 }) => ReactNode;
 
+/**
+ * Trust copy for the first-run consent card.
+ *
+ * The card makes concrete, checkable claims about *where* the agent runs,
+ * *whose* model account it bills, and *where* the transcript is stored. Those
+ * claims are only true of OSS's bring-your-own-local-CLI agent. A host that
+ * runs the agent anywhere else (Radar Cloud runs it as a sandboxed Job under a
+ * managed key) MUST supply its own copy — shipping OSS's over a different data
+ * flow states the opposite of what happens.
+ *
+ * Radar owns the card's chrome (icon, layout, Approve/Cancel) either way; a
+ * host only replaces the claims.
+ */
+export type DiagnoseConsentCopy = {
+  title: string;
+  body: ReactNode;
+  /** Detail list under the body; each entry is rendered as its own "•" row. */
+  bullets?: ReactNode[];
+  /** Label for the settings link. `null` hides it — for hosts with one fixed
+   *  agent and no isolation choice, where it would open an empty dialog. */
+  settingsLabel?: string | null;
+  approveLabel?: string;
+};
+
 const DiagnoseCustomizationContext = createContext<RenderDiagnoseAction | undefined>(undefined);
+const DiagnoseConsentCopyContext = createContext<DiagnoseConsentCopy | undefined>(undefined);
 
 export function DiagnoseCustomizationProvider({
   value,
+  consentCopy,
   children,
 }: {
   value: RenderDiagnoseAction | undefined;
+  consentCopy?: DiagnoseConsentCopy;
   children: ReactNode;
 }) {
   return (
     <DiagnoseCustomizationContext.Provider value={value}>
-      {children}
+      <DiagnoseConsentCopyContext.Provider value={consentCopy}>
+        {children}
+      </DiagnoseConsentCopyContext.Provider>
     </DiagnoseCustomizationContext.Provider>
   );
 }
 
 export function useDiagnoseCustomization(): RenderDiagnoseAction | undefined {
   return useContext(DiagnoseCustomizationContext);
+}
+
+export function useDiagnoseConsentCopy(): DiagnoseConsentCopy | undefined {
+  return useContext(DiagnoseConsentCopyContext);
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -26,7 +26,10 @@ export type {
   TimelineCoverageSpan,
   TimelineOverviewResult,
 } from './api/timelineSource';
-export type { RenderDiagnoseAction } from './context/DiagnoseCustomization';
+export type {
+  RenderDiagnoseAction,
+  DiagnoseConsentCopy,
+} from './context/DiagnoseCustomization';
 export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';
 
 // Shared cluster-switcher primitive — re-exported from @skyhook-io/k8s-ui so


### PR DESCRIPTION
## Description

## What

  Makes the first-run "Run an AI investigation?" consent card's trust copy overridable by an embedding host.

  ## Why

  The consent card states, as fact, *where* the agent runs, *whose* model account pays, and *where* transcripts live: "your own agent, on your machine — no Radar cloud, no API key, no account. Transcripts kept in your local Radar history on this machine."

  That is only true of OSS's bring-your-own-local-CLI agent. A host that runs the agent anywhere else would be asserting the exact opposite of its real data flow. The wrong claim here is a lie, not a typo, so hosts need a seam to tell their own story.

  Previously this was a `TODO(cloud)` in `ConsentCard`; this PR implements it on the existing `DiagnoseCustomization` seam (the same place a host overrides the Diagnose entry button).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional embedder API; OSS default consent path is preserved. Main concern is embedders forgetting to override copy for non-local agents—a documentation/integration obligation, not a regression in this repo.
> 
> **Overview**
> Embedding hosts can now supply **honest first-run Diagnose consent copy** via a new `diagnoseConsent` prop on `RadarApp` (and `DiagnoseConsentCopy` on the public package API), wired through the existing `DiagnoseCustomization` seam alongside `renderDiagnoseAction`.
> 
> **`ConsentCard`** is refactored into shared **`ConsentCardShell`** (layout, Approve/Cancel, optional settings link). When the host passes copy, that text is used verbatim; otherwise the unchanged OSS default still describes local BYO-agent behavior (including Cursor/isolation variants). Hosts can hide the settings link with `settingsLabel: null` when agent choice is fixed.
> 
> **`DiagnoseSurface`** reads consent from context and passes it into the card. Standalone OSS behavior is unchanged when `diagnoseConsent` is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c0e56eb7781dca82488ec0aeebc71a575d5495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->