### PR TITLE
Secure the local listener and clarify startup posture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,10 @@ COPY --from=backend-builder /radar /radar
 
 EXPOSE 9280
 USER nonroot:nonroot
-ENTRYPOINT ["/radar"]
-CMD ["--no-browser", "--listen-address=0.0.0.0"]
+# Keep the container networking invariant in ENTRYPOINT so docker run arguments
+# and Compose command overrides cannot silently replace the shared listener.
+ENTRYPOINT ["/radar", "--listen-address=0.0.0.0"]
+CMD ["--no-browser"]
 
 # =============================================================================
 # Stage 3b: Release build - uses pre-built binaries from goreleaser
@@ -92,5 +94,7 @@ COPY radar-${TARGETARCH} /radar
 
 EXPOSE 9280
 USER nonroot:nonroot
-ENTRYPOINT ["/radar"]
-CMD ["--no-browser", "--listen-address=0.0.0.0"]
+# Keep the container networking invariant in ENTRYPOINT so docker run arguments
+# and Compose command overrides cannot silently replace the shared listener.
+ENTRYPOINT ["/radar", "--listen-address=0.0.0.0"]
+CMD ["--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY --from=backend-builder /radar /radar
 EXPOSE 9280
 USER nonroot:nonroot
 ENTRYPOINT ["/radar"]
-CMD ["--no-browser"]
+CMD ["--no-browser", "--listen-address=0.0.0.0"]
 
 # =============================================================================
 # Stage 3b: Release build - uses pre-built binaries from goreleaser
@@ -93,4 +93,4 @@ COPY radar-${TARGETARCH} /radar
 EXPOSE 9280
 USER nonroot:nonroot
 ENTRYPOINT ["/radar"]
-CMD ["--no-browser"]
+CMD ["--no-browser", "--listen-address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ radar
 | `--namespaces` | (all) | Initial namespace filters as a comma-separated list, e.g. `--namespaces ns1,ns2,ns3`. Use this when your identity can list resources in specific namespaces but cannot list namespaces cluster-wide. |
 | `--namespace-scope` | `false` | Pin namespaced informer caches to a **single** namespace for large clusters (scoping to multiple namespaces is not supported yet). Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
+| `--listen-address` | `127.0.0.1` | HTTP listen address. Use `127.0.0.1` or `localhost` for local-only access; use `0.0.0.0` explicitly for containers, VMs, WSL, or remote/shared access, together with authentication and network controls. |
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -122,6 +122,7 @@ func main() {
 		Namespace:                resolvedNamespace,
 		Namespaces:               resolvedNamespaces,
 		Port:                     fileCfg.PortOr(0), // Configured port, or random to avoid conflicts with CLI
+		ListenAddress:            "127.0.0.1",
 		DevMode:                  false,
 		HistoryLimit:             *historyLimit,
 		DebugEvents:              *debugEvents,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -69,6 +69,7 @@ func main() {
 	namespace := flag.String("namespace", fileCfg.Namespace, "Initial namespace filter (empty = all namespaces)")
 	namespaces := flag.String("namespaces", fileCfg.NamespacesFlag(), "Initial namespace filters as a comma-separated list (e.g. ns1,ns2,ns3). Use this when you can list resources in specific namespaces but cannot list namespaces cluster-wide.")
 	port := flag.Int("port", fileCfg.PortOr(9280), "Server port")
+	listenAddress := flag.String("listen-address", server.DefaultListenAddress, "HTTP listen address: 127.0.0.1 or localhost for local-only access; 0.0.0.0 for remote/shared access")
 	noBrowser := flag.Bool("no-browser", fileCfg.NoBrowser, "Don't auto-open browser")
 	browser := flag.String("browser", fileCfg.Browser, "Browser to use when opening the UI (default: OS default browser; macOS app names supported)")
 	devMode := flag.Bool("dev", false, "Development mode (serve frontend from filesystem)")
@@ -193,6 +194,10 @@ func main() {
 	if *kubeconfig != "" && *kubeconfigDir != "" {
 		log.Fatalf("--kubeconfig and --kubeconfig-dir are mutually exclusive")
 	}
+	normalizedListenAddress, err := server.NormalizeListenAddress(*listenAddress)
+	if err != nil {
+		log.Fatalf("Invalid --listen-address %q: %v", *listenAddress, err)
+	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {
 		log.Fatalf("Invalid --timeline-max-size %q: %v", *timelineMaxSize, err)
@@ -245,6 +250,7 @@ func main() {
 		Namespace:                resolvedNamespace,
 		Namespaces:               resolvedNamespaces,
 		Port:                     *port,
+		ListenAddress:            normalizedListenAddress,
 		NoBrowser:                *noBrowser,
 		Browser:                  *browser,
 		DevMode:                  *devMode,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -150,9 +150,9 @@ func main() {
 	// give every Cloud user full SA permissions).
 	// Read once via the cloud package so we use the same normalized
 	// parser (strconv.ParseBool — accepts true/1/T/TRUE etc.) as every
-	// other site that reads RADAR_CLOUD_MODE. cloud.LogStartupMode
-	// emits the resolved value below regardless of true/false so the
-	// deployment topology is obvious in startup logs.
+	// other site that reads RADAR_CLOUD_MODE. The resolved mode is included
+	// in both the preflight line (so early failures retain it) and the startup
+	// summary after the HTTP listener binds.
 	cloudMode := cloud.Mode()
 	if cloudMode {
 		if *authMode != "none" && *authMode != "proxy" {
@@ -165,11 +165,6 @@ func main() {
 		*authGroupsHeader = "X-Forwarded-Groups"
 		log.Printf("[cloud] RADAR_CLOUD_MODE=true: auth-mode forced to proxy, trusting tunnel-supplied identity headers")
 	}
-	// Always log the resolved cloud mode (true OR false) so deployment
-	// topology is visible in chart-install logs even when an operator
-	// expected Cloud mode but typo'd the env var.
-	cloud.LogStartupMode()
-
 	if *showVersion {
 		fmt.Printf("radar %s\n", version)
 		os.Exit(0)
@@ -182,7 +177,11 @@ func main() {
 	_ = flag.Set("alsologtostderr", "false")
 	klog.SetOutput(os.Stderr)
 
-	log.Printf("Radar %s starting...", version)
+	startupMode := "local"
+	if cloudMode {
+		startupMode = "Radar Cloud"
+	}
+	log.Printf("Radar %s starting (mode=%s, auth=%s)...", version, startupMode, *authMode)
 
 	// Validate flags
 	switch *authMode {
@@ -251,6 +250,7 @@ func main() {
 		Namespaces:               resolvedNamespaces,
 		Port:                     *port,
 		ListenAddress:            normalizedListenAddress,
+		ShowRemoteAccessHint:     true,
 		NoBrowser:                *noBrowser,
 		Browser:                  *browser,
 		DevMode:                  *devMode,

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -206,6 +206,7 @@ func main() {
 
 	srv := server.New(server.Config{
 		Port:            *port,
+		ListenAddress:   server.DefaultListenAddress,
 		StaticFS:        static.FS,
 		StaticRoot:      "dist",
 		EffectiveConfig: effectiveCfg,

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --port={{ .Values.service.port }}
+            - --listen-address=0.0.0.0
             - --no-browser
             - --timeline-storage={{ .Values.timeline.storage }}
             {{- if eq .Values.timeline.storage "sqlite" }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,28 @@
 
 This document covers Radar's cluster connection behavior. For CLI flags and basic usage, see the [README](../README.md#usage).
 
+## HTTP Listener
+
+Radar listens on `127.0.0.1:9280` by default, so an unauthenticated local
+instance is reachable only from the same network namespace. `localhost` is
+accepted as an equivalent spelling.
+
+To reach Radar through a VM, WSL, dev container, jump host, or another machine,
+opt into a shared listener explicitly:
+
+```bash
+radar --listen-address=0.0.0.0
+```
+
+An all-interface listener can be reached by non-browser clients; CORS is not an
+authentication boundary. Enable Radar authentication and restrict network
+access whenever using `0.0.0.0`.
+
+The Docker image and Helm chart set `0.0.0.0` explicitly because their HTTP
+listener must be reachable through a published container port or Kubernetes
+Service. Desktop Radar and temporary `radar diagnose` servers remain
+loopback-only.
+
 ## Persistent Configuration
 
 Radar stores configuration in two files under `~/.radar/`:

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -265,6 +265,11 @@ auth:
 
 When deploying Radar in-cluster:
 
+The Helm chart explicitly sets `--listen-address=0.0.0.0` so its ClusterIP
+Service can reach the pod. Unlike the native CLI's loopback-only default, this
+makes Radar reachable on the pod network; the following controls are therefore
+part of the deployment boundary.
+
 1. **Authentication**: Always enable authentication when exposing via ingress. Use [built-in auth](authentication.md) (proxy or OIDC mode) or basic auth (shown above) at minimum.
 
 2. **RBAC scope**: The default ClusterRole grants cluster-wide read access. For namespace-restricted access, set `rbac.create: false` and create a custom Role/RoleBinding. Radar will gracefully adapt to the available permissions.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -38,6 +38,7 @@ type AppConfig struct {
 	Namespaces               []string
 	Port                     int
 	ListenAddress            string
+	ShowRemoteAccessHint     bool
 	NoBrowser                bool
 	Browser                  string
 	DevMode                  bool
@@ -118,14 +119,6 @@ func InitializeK8s(cfg AppConfig) error {
 		if err := validateNamespaceScopeTarget(k8s.GetNamespaceScopeTarget()); err != nil {
 			return err
 		}
-	}
-
-	if len(cfg.KubeconfigDirs) > 0 {
-		log.Printf("Using kubeconfigs from directories: %v", cfg.KubeconfigDirs)
-	} else if kubepath := k8s.GetKubeconfigPath(); kubepath != "" {
-		log.Printf("Using kubeconfig: %s", kubepath)
-	} else {
-		log.Printf("Using in-cluster config")
 	}
 
 	k8s.SetConnectionStatus(k8s.ConnectionStatus{
@@ -273,12 +266,14 @@ func CreateServer(cfg AppConfig) *server.Server {
 	}
 
 	serverCfg := server.Config{
-		Port:            cfg.Port,
-		ListenAddress:   cfg.ListenAddress,
-		DevMode:         cfg.DevMode,
-		StaticFS:        static.FS,
-		StaticRoot:      "dist",
-		EffectiveConfig: effectiveCfg,
+		Port:             cfg.Port,
+		ListenAddress:    cfg.ListenAddress,
+		StartupLog:       true,
+		RemoteAccessHint: cfg.ShowRemoteAccessHint,
+		DevMode:          cfg.DevMode,
+		StaticFS:         static.FS,
+		StaticRoot:       "dist",
+		EffectiveConfig:  effectiveCfg,
 		DiagConfig: &server.DiagConfig{
 			Port:                 cfg.Port,
 			DevMode:              cfg.DevMode,
@@ -308,7 +303,6 @@ func CreateServer(cfg AppConfig) *server.Server {
 	if cfg.MCPEnabled {
 		serverCfg.MCPHandler = mcppkg.NewHandler()
 		serverCfg.MCPReadOnlyHandler = mcppkg.NewReadOnlyHandler()
-		log.Printf("MCP server enabled on the HTTP listener at /mcp")
 	}
 
 	return server.New(serverCfg)
@@ -322,12 +316,13 @@ func CreateServer(cfg AppConfig) *server.Server {
 // (RBAC checks + informer sync) so neither blocks the other. If the
 // connectivity check fails, subsystem init is canceled immediately.
 func InitializeCluster() {
+	log.Printf("── Kubernetes initialization · %s ─────────────────────────", k8s.GetContextName())
+
 	// Cancel any in-flight API calls from previous attempts (e.g., browser
 	// polling /api/capabilities with RBAC checks through a broken exec plugin).
 	k8s.CancelOngoingOperations()
 
 	clusterStart := time.Now()
-	log.Printf("[ops] InitializeCluster START (context=%s)", k8s.GetContextName())
 
 	k8s.SetConnectionStatus(k8s.ConnectionStatus{
 		State:       k8s.StateConnecting,
@@ -470,7 +465,6 @@ func WriteMCPPortFile(port int) {
 		log.Printf("[mcp] Failed to write port file: %v", err)
 		return
 	}
-	log.Printf("[mcp] Port file written: %s (port %d)", path, port)
 }
 
 // RemoveMCPPortFile removes the port discovery file on shutdown.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -316,7 +316,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 // (RBAC checks + informer sync) so neither blocks the other. If the
 // connectivity check fails, subsystem init is canceled immediately.
 func InitializeCluster() {
-	log.Printf("── Kubernetes initialization · %s ─────────────────────────", k8s.GetContextName())
+	log.Printf("── Kubernetes initialization · %s ─────────────────────────", k8s.SanitizeForLog(k8s.GetContextName()))
 
 	// Cancel any in-flight API calls from previous attempts (e.g., browser
 	// polling /api/capabilities with RBAC checks through a broken exec plugin).

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -37,6 +37,7 @@ type AppConfig struct {
 	Namespace                string
 	Namespaces               []string
 	Port                     int
+	ListenAddress            string
 	NoBrowser                bool
 	Browser                  string
 	DevMode                  bool
@@ -273,6 +274,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 
 	serverCfg := server.Config{
 		Port:            cfg.Port,
+		ListenAddress:   cfg.ListenAddress,
 		DevMode:         cfg.DevMode,
 		StaticFS:        static.FS,
 		StaticRoot:      "dist",
@@ -306,11 +308,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 	if cfg.MCPEnabled {
 		serverCfg.MCPHandler = mcppkg.NewHandler()
 		serverCfg.MCPReadOnlyHandler = mcppkg.NewReadOnlyHandler()
-		if cfg.Port != 0 {
-			log.Printf("MCP server enabled at http://localhost:%d/mcp", cfg.Port)
-		} else {
-			log.Printf("MCP server enabled (port will be assigned at startup)")
-		}
+		log.Printf("MCP server enabled on the HTTP listener at /mcp")
 	}
 
 	return server.New(serverCfg)

--- a/internal/cloud/mode.go
+++ b/internal/cloud/mode.go
@@ -47,12 +47,3 @@ func Mode() bool {
 	}
 	return parsed
 }
-
-// LogStartupMode logs the resolved cloud-mode value once at process
-// start. Call from main after flag parsing. Logging both true and false
-// makes the deployment topology obvious in startup logs and aids
-// support-debugging when a Cloud install accidentally boots in OSS
-// mode.
-func LogStartupMode() {
-	log.Printf("[cloud] cloud mode: %t (%s=%q)", Mode(), cloudModeEnvVar, os.Getenv(cloudModeEnvVar))
-}

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -48,6 +48,7 @@ func bootEphemeral(kubeconfig string) (base string, shutdown func(), err error) 
 	cfg := app.AppConfig{
 		Kubeconfig:      kubeconfig,
 		Port:            0, // random free port
+		ListenAddress:   "127.0.0.1",
 		NoBrowser:       true,
 		HistoryLimit:    1000, // in-memory timeline floor; this instance lives minutes
 		MCPEnabled:      true,

--- a/internal/images/inspector.go
+++ b/internal/images/inspector.go
@@ -57,7 +57,6 @@ func NewInspector() *Inspector {
 	// Start background cleanup goroutine
 	go i.cleanupLoop()
 
-	log.Printf("Image layer cache initialized at: %s", cacheDir)
 	return i
 }
 
@@ -72,7 +71,6 @@ func (i *Inspector) cleanCacheDir() {
 	if err := os.MkdirAll(i.cacheDir, 0755); err != nil {
 		log.Printf("Warning: failed to create cache directory: %v", err)
 	}
-	log.Printf("Cleaned image layer cache directory")
 }
 
 // cleanupLoop periodically removes expired entries from the cache

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -266,15 +266,6 @@ func doInit(opts InitOptions) error {
 					}
 				}
 			}
-			fileCount := len(kubeconfigPaths)
-			if fileCount == 0 && kubeconfigPath != "" {
-				fileCount = 1
-			}
-			// Total contexts across all files (pre-#519 this was the post-merge
-			// count, which silently hid colliding user/cluster definitions;
-			// now every file's contexts are individually reachable).
-			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d, exec-plugins=%d",
-				kubeconfigMode, fileCount, totalContextCount, len(execPluginCommands))
 		}
 
 		config, err = kubeConfig.ClientConfig()

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -112,7 +112,6 @@ func init() {
 func CancelOngoingOperations() {
 	operationMu.Lock()
 	defer operationMu.Unlock()
-	log.Printf("[ops] Canceling ongoing operations (previous API calls will be interrupted)")
 	operationCancel()
 	operationCtx, operationCancel = context.WithCancel(context.Background())
 	operationGen++

--- a/internal/server/listen_address.go
+++ b/internal/server/listen_address.go
@@ -1,6 +1,10 @@
 package server
 
-import "fmt"
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
 
 const (
 	DefaultListenAddress = "127.0.0.1"
@@ -21,4 +25,15 @@ func NormalizeListenAddress(address string) (string, error) {
 	default:
 		return "", fmt.Errorf("listen address must be %q, %q, or %q", DefaultListenAddress, "localhost", AllInterfacesAddress)
 	}
+}
+
+// socketAddress preserves the explicit 0.0.0.0 operator-facing opt-in while
+// using Go's empty-host wildcard for the actual listener. The latter retains
+// the previous dual-stack behavior on hosts where IPv6 is available.
+func socketAddress(listenAddress string, port int) string {
+	bindHost := listenAddress
+	if bindHost == AllInterfacesAddress {
+		bindHost = ""
+	}
+	return net.JoinHostPort(bindHost, strconv.Itoa(port))
 }

--- a/internal/server/listen_address.go
+++ b/internal/server/listen_address.go
@@ -1,0 +1,24 @@
+package server
+
+import "fmt"
+
+const (
+	DefaultListenAddress = "127.0.0.1"
+	AllInterfacesAddress = "0.0.0.0"
+)
+
+// NormalizeListenAddress validates the supported listener intents and returns
+// a concrete address suitable for net.Listen. Radar's local clients always
+// dial localhost, so arbitrary interface addresses are intentionally rejected.
+func NormalizeListenAddress(address string) (string, error) {
+	switch address {
+	case "", DefaultListenAddress:
+		return DefaultListenAddress, nil
+	case "localhost":
+		return DefaultListenAddress, nil
+	case AllInterfacesAddress:
+		return AllInterfacesAddress, nil
+	default:
+		return "", fmt.Errorf("listen address must be %q, %q, or %q", DefaultListenAddress, "localhost", AllInterfacesAddress)
+	}
+}

--- a/internal/server/listen_address_test.go
+++ b/internal/server/listen_address_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestNormalizeListenAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "zero value", want: DefaultListenAddress},
+		{name: "ipv4 loopback", input: DefaultListenAddress, want: DefaultListenAddress},
+		{name: "localhost", input: "localhost", want: DefaultListenAddress},
+		{name: "all interfaces", input: AllInterfacesAddress, want: AllInterfacesAddress},
+		{name: "arbitrary address", input: "192.0.2.10", wantErr: true},
+		{name: "arbitrary hostname", input: "radar.internal", wantErr: true},
+		{name: "whitespace", input: " 127.0.0.1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeListenAddress(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NormalizeListenAddress(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeListenAddress(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerListenAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		listenAddress string
+		wantLoopback  bool
+		wantAny       bool
+	}{
+		{name: "zero value is loopback", wantLoopback: true},
+		{name: "explicit loopback", listenAddress: DefaultListenAddress, wantLoopback: true},
+		{name: "explicit all interfaces", listenAddress: AllInterfacesAddress, wantAny: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := New(Config{Port: 0, ListenAddress: tt.listenAddress})
+			ready := make(chan struct{})
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- srv.StartWithReady(ready)
+			}()
+
+			select {
+			case <-ready:
+			case <-time.After(5 * time.Second):
+				t.Fatal("server did not become ready")
+			}
+
+			gotIP := srv.listener.Addr().(*net.TCPAddr).IP
+			if gotIP.IsLoopback() != tt.wantLoopback {
+				t.Errorf("listener IP %q loopback = %v, want %v", gotIP, gotIP.IsLoopback(), tt.wantLoopback)
+			}
+			if gotIP.IsUnspecified() != tt.wantAny {
+				t.Errorf("listener IP %q unspecified = %v, want %v", gotIP, gotIP.IsUnspecified(), tt.wantAny)
+			}
+			if got := srv.ActualAddr(); got != net.JoinHostPort("localhost", strconv.Itoa(srv.ActualPort())) {
+				t.Errorf("ActualAddr() = %q; want dialable localhost address", got)
+			}
+
+			srv.Stop()
+			select {
+			case err := <-errCh:
+				if err != nil && !errors.Is(err, net.ErrClosed) {
+					t.Fatalf("server shutdown error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("server did not stop")
+			}
+		})
+	}
+}
+
+func TestServerRejectsInvalidListenAddress(t *testing.T) {
+	srv := New(Config{Port: 0, ListenAddress: "192.0.2.10"})
+
+	if err := srv.StartWithReady(nil); err == nil {
+		t.Fatal("StartWithReady() error = nil, want invalid listen address error")
+	}
+	if srv.listener != nil {
+		t.Fatalf("StartWithReady() listener = %v, want nil after validation failure", srv.listener)
+	}
+}
+
+func TestShouldWarnUnauthenticatedListener(t *testing.T) {
+	tests := []struct {
+		name          string
+		listenAddress string
+		authEnabled   bool
+		want          bool
+	}{
+		{name: "unauthenticated all interfaces", listenAddress: AllInterfacesAddress, want: true},
+		{name: "unauthenticated loopback", listenAddress: DefaultListenAddress},
+		{name: "unauthenticated localhost", listenAddress: "localhost"},
+		{name: "authenticated all interfaces", listenAddress: AllInterfacesAddress, authEnabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldWarnUnauthenticatedListener(tt.listenAddress, tt.authEnabled); got != tt.want {
+				t.Fatalf("shouldWarnUnauthenticatedListener(%q, %v) = %v, want %v", tt.listenAddress, tt.authEnabled, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/listen_address_test.go
+++ b/internal/server/listen_address_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -93,9 +94,33 @@ func TestServerRejectsInvalidListenAddress(t *testing.T) {
 
 	if err := srv.StartWithReady(nil); err == nil {
 		t.Fatal("StartWithReady() error = nil, want invalid listen address error")
+	} else if !strings.Contains(err.Error(), `invalid listen address "192.0.2.10"`) {
+		t.Fatalf("StartWithReady() error = %q, want rejected address", err)
 	}
 	if srv.listener != nil {
 		t.Fatalf("StartWithReady() listener = %v, want nil after validation failure", srv.listener)
+	}
+}
+
+func TestServerBindFailureIncludesAddress(t *testing.T) {
+	blocked, err := net.Listen("tcp", net.JoinHostPort(DefaultListenAddress, "0"))
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer blocked.Close()
+
+	port := blocked.Addr().(*net.TCPAddr).Port
+	srv := New(Config{Port: port, ListenAddress: DefaultListenAddress})
+	err = srv.StartWithReady(nil)
+	if err == nil {
+		t.Fatal("StartWithReady() error = nil, want bind failure")
+	}
+	wantAddress := net.JoinHostPort(DefaultListenAddress, strconv.Itoa(port))
+	if !strings.Contains(err.Error(), "listen on "+wantAddress) {
+		t.Fatalf("StartWithReady() error = %q, want address %q", err, wantAddress)
+	}
+	if srv.listener != nil {
+		t.Fatalf("StartWithReady() listener = %v, want nil after bind failure", srv.listener)
 	}
 }
 

--- a/internal/server/listen_address_test.go
+++ b/internal/server/listen_address_test.go
@@ -38,6 +38,25 @@ func TestNormalizeListenAddress(t *testing.T) {
 	}
 }
 
+func TestSocketAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		listenAddress string
+		want          string
+	}{
+		{name: "loopback", listenAddress: DefaultListenAddress, want: "127.0.0.1:9280"},
+		{name: "all interfaces uses dual-stack wildcard", listenAddress: AllInterfacesAddress, want: ":9280"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := socketAddress(tt.listenAddress, 9280); got != tt.want {
+				t.Fatalf("socketAddress(%q, 9280) = %q, want %q", tt.listenAddress, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestServerListenAddress(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/server/portforward.go
+++ b/internal/server/portforward.go
@@ -185,18 +185,10 @@ func (s *Server) handleStartPortForward(w http.ResponseWriter, r *http.Request) 
 		localPort = port
 	}
 
-	// Set default listen address
-	listenAddr := req.ListenAddress
-	if listenAddr == "" {
-		listenAddr = "127.0.0.1"
-	}
-	// Validate listen address
-	if listenAddr != "127.0.0.1" && listenAddr != "0.0.0.0" && listenAddr != "localhost" {
-		s.writeError(w, http.StatusBadRequest, "listenAddress must be '127.0.0.1', '0.0.0.0', or 'localhost'")
+	listenAddr, err := NormalizeListenAddress(req.ListenAddress)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
-	}
-	if listenAddr == "localhost" {
-		listenAddr = "127.0.0.1"
 	}
 
 	// Create session

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,8 @@ type Server struct {
 	vitalsMetrics      vitalsMetricsMemo
 	port               int
 	listenAddress      string
+	startupLog         bool
+	remoteAccessHint   bool
 	devMode            bool
 	staticFS           fs.FS
 	startTime          time.Time
@@ -134,6 +136,8 @@ type Server struct {
 type Config struct {
 	Port               int
 	ListenAddress      string         // 127.0.0.1/localhost for local-only; 0.0.0.0 for shared access
+	StartupLog         bool           // Emit the operator-facing startup block after a successful bind
+	RemoteAccessHint   bool           // Explain the explicit shared-listener opt-in (native CLI only)
 	DevMode            bool           // Serve frontend from filesystem instead of embedded
 	StaticFS           embed.FS       // Embedded frontend files
 	StaticRoot         string         // Path within StaticFS
@@ -154,6 +158,8 @@ func New(cfg Config) *Server {
 		broadcaster:        NewSSEBroadcaster(),
 		port:               cfg.Port,
 		listenAddress:      cfg.ListenAddress,
+		startupLog:         cfg.StartupLog,
+		remoteAccessHint:   cfg.RemoteAccessHint,
 		devMode:            cfg.DevMode,
 		startTime:          time.Now(),
 		mcpHandler:         cfg.MCPHandler,
@@ -197,7 +203,6 @@ func New(cfg Config) *Server {
 				// history won't survive a restart, not just a log line.
 				s.aiRuns.MarkHistoryUnavailable(cfg.AIHistoryDB)
 			}
-			log.Printf("[ai] diagnose enabled (default agent: %s)", d.DefaultAgent())
 		}
 	}
 
@@ -265,10 +270,6 @@ func New(cfg Config) *Server {
 			s.oidcHandler = oidcHandler
 		}
 
-		if s.authConfig.Mode == "proxy" {
-			log.Printf("WARNING: Auth mode is 'proxy'. Ensure your ingress strips %s and %s headers from external requests to prevent spoofing.",
-				s.authConfig.UserHeader, s.authConfig.GroupsHeader)
-		}
 	}
 
 	// Set up static file system
@@ -724,9 +725,10 @@ func (s *Server) Start() error {
 // StartWithReady starts the server and signals on the ready channel once it
 // is accepting connections. If port is 0, an OS-assigned port is used.
 func (s *Server) StartWithReady(ready chan<- struct{}) error {
-	listenAddress, err := NormalizeListenAddress(s.listenAddress)
+	configuredListenAddress := s.listenAddress
+	listenAddress, err := NormalizeListenAddress(configuredListenAddress)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid listen address %q: %w", configuredListenAddress, err)
 	}
 	s.listenAddress = listenAddress
 	addr := net.JoinHostPort(listenAddress, strconv.Itoa(s.port))
@@ -735,14 +737,20 @@ func (s *Server) StartWithReady(ready chan<- struct{}) error {
 		return fmt.Errorf("listen on %s: %w", addr, err)
 	}
 	s.listener = ln
-	s.broadcaster.Start()
-
-	log.Printf("Starting Explorer server on http://%s", net.JoinHostPort(listenAddress, strconv.Itoa(s.ActualPort())))
-	if cloud.IsLoopbackHostname(listenAddress) {
-		log.Printf("Radar is listening on loopback only; use --listen-address=%s with authentication and network controls to allow remote, VM, or LAN access", AllInterfacesAddress)
-	} else if shouldWarnUnauthenticatedListener(listenAddress, s.authConfig.Enabled()) {
-		log.Printf("WARNING: Radar's HTTP listener is unauthenticated and reachable on %s; enable Radar authentication, restrict network access, or use --listen-address=%s", listenAddress, DefaultListenAddress)
+	if s.startupLog {
+		s.logStartupSummaryBlock()
+	} else {
+		// Keep the security warnings fail-safe for any direct Server caller that
+		// opts out of the full CLI/desktop startup block.
+		if shouldWarnUnauthenticatedListener(listenAddress, s.authConfig.Enabled()) && !cloud.Mode() {
+			log.Printf("WARNING: Radar's HTTP listener is unauthenticated and reachable on %s", listenAddress)
+		}
+		if s.authConfig.Mode == "proxy" && !cloud.Mode() {
+			log.Printf("WARNING: Proxy auth trusts %s and %s; ensure the ingress strips client-supplied identity headers",
+				s.authConfig.UserHeader, s.authConfig.GroupsHeader)
+		}
 	}
+	s.broadcaster.Start()
 
 	if ready != nil {
 		close(ready)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -731,10 +731,11 @@ func (s *Server) StartWithReady(ready chan<- struct{}) error {
 		return fmt.Errorf("invalid listen address %q: %w", configuredListenAddress, err)
 	}
 	s.listenAddress = listenAddress
-	addr := net.JoinHostPort(listenAddress, strconv.Itoa(s.port))
-	ln, err := net.Listen("tcp", addr)
+	bindAddr := socketAddress(listenAddress, s.port)
+	ln, err := net.Listen("tcp", bindAddr)
 	if err != nil {
-		return fmt.Errorf("listen on %s: %w", addr, err)
+		displayAddr := net.JoinHostPort(listenAddress, strconv.Itoa(s.port))
+		return fmt.Errorf("listen on %s: %w", displayAddr, err)
 	}
 	s.listener = ln
 	if s.startupLog {
@@ -747,7 +748,7 @@ func (s *Server) StartWithReady(ready chan<- struct{}) error {
 		}
 		if s.authConfig.Mode == "proxy" && !cloud.Mode() {
 			log.Printf("WARNING: Proxy auth trusts %s and %s; ensure the ingress strips client-supplied identity headers",
-				s.authConfig.UserHeader, s.authConfig.GroupsHeader)
+				sanitizeForLog(s.authConfig.UserHeader), sanitizeForLog(s.authConfig.GroupsHeader))
 		}
 	}
 	s.broadcaster.Start()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,6 +65,7 @@ type Server struct {
 	broadcaster        *SSEBroadcaster
 	vitalsMetrics      vitalsMetricsMemo
 	port               int
+	listenAddress      string
 	devMode            bool
 	staticFS           fs.FS
 	startTime          time.Time
@@ -132,6 +133,7 @@ type Server struct {
 // Config holds server configuration
 type Config struct {
 	Port               int
+	ListenAddress      string         // 127.0.0.1/localhost for local-only; 0.0.0.0 for shared access
 	DevMode            bool           // Serve frontend from filesystem instead of embedded
 	StaticFS           embed.FS       // Embedded frontend files
 	StaticRoot         string         // Path within StaticFS
@@ -151,6 +153,7 @@ func New(cfg Config) *Server {
 		router:             chi.NewRouter(),
 		broadcaster:        NewSSEBroadcaster(),
 		port:               cfg.Port,
+		listenAddress:      cfg.ListenAddress,
 		devMode:            cfg.DevMode,
 		startTime:          time.Now(),
 		mcpHandler:         cfg.MCPHandler,
@@ -721,22 +724,35 @@ func (s *Server) Start() error {
 // StartWithReady starts the server and signals on the ready channel once it
 // is accepting connections. If port is 0, an OS-assigned port is used.
 func (s *Server) StartWithReady(ready chan<- struct{}) error {
-	s.broadcaster.Start()
-
-	addr := fmt.Sprintf(":%d", s.port)
+	listenAddress, err := NormalizeListenAddress(s.listenAddress)
+	if err != nil {
+		return err
+	}
+	s.listenAddress = listenAddress
+	addr := net.JoinHostPort(listenAddress, strconv.Itoa(s.port))
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", addr, err)
 	}
 	s.listener = ln
+	s.broadcaster.Start()
 
-	log.Printf("Starting Explorer server on http://localhost:%d", s.ActualPort())
+	log.Printf("Starting Explorer server on http://%s", net.JoinHostPort(listenAddress, strconv.Itoa(s.ActualPort())))
+	if cloud.IsLoopbackHostname(listenAddress) {
+		log.Printf("Radar is listening on loopback only; use --listen-address=%s with authentication and network controls to allow remote, VM, or LAN access", AllInterfacesAddress)
+	} else if shouldWarnUnauthenticatedListener(listenAddress, s.authConfig.Enabled()) {
+		log.Printf("WARNING: Radar's HTTP listener is unauthenticated and reachable on %s; enable Radar authentication, restrict network access, or use --listen-address=%s", listenAddress, DefaultListenAddress)
+	}
 
 	if ready != nil {
 		close(ready)
 	}
 
 	return http.Serve(ln, localTCPHandler(s.router))
+}
+
+func shouldWarnUnauthenticatedListener(listenAddress string, authEnabled bool) bool {
+	return !authEnabled && !cloud.IsLoopbackHostname(listenAddress)
 }
 
 // localTCPHandler is the handler exposed on Radar's ordinary pod/host listener.

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -434,7 +434,6 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		// Cache not ready yet — wait for connection to be established
-		log.Println("SSE broadcaster: cache not ready, waiting for connection...")
 		ch := make(chan struct{}, 1)
 		k8s.OnConnectionChange(func(status k8s.ConnectionStatus) {
 			// Check if this watcher was replaced by a context switch.
@@ -466,7 +465,6 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 				log.Println("Warning: Resource cache still nil after connection")
 				return
 			}
-			log.Println("SSE broadcaster: cache ready, starting resource change watcher")
 		case <-b.stopCh:
 			return
 		case <-watchStop:

--- a/internal/server/startup_log.go
+++ b/internal/server/startup_log.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/skyhook-io/radar/internal/cloud"
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+const (
+	startupANSIReset     = "\x1b[0m"
+	startupANSIBold      = "\x1b[1m"
+	startupANSICyan      = "\x1b[36m"
+	startupANSIAmberBold = "\x1b[1;33m"
+)
+
+type startupLogSummary struct {
+	listenAddress        string
+	port                 int
+	authMode             string
+	proxyUserHeader      string
+	proxyGroupsHeader    string
+	mcpEnabled           bool
+	aiAgent              string
+	cloudMode            bool
+	showRemoteAccessHint bool
+	contextName          string
+	kubeconfigPath       string
+	kubeconfig           k8s.KubeconfigSummary
+}
+
+func (s *Server) logStartupSummaryBlock() {
+	aiAgent := ""
+	if s.aiDiagnoser != nil {
+		aiAgent = s.aiDiagnoser.DefaultAgent()
+	}
+
+	summary := startupLogSummary{
+		listenAddress:        s.listenAddress,
+		port:                 s.ActualPort(),
+		authMode:             s.authConfig.Mode,
+		proxyUserHeader:      s.authConfig.UserHeader,
+		proxyGroupsHeader:    s.authConfig.GroupsHeader,
+		mcpEnabled:           s.mcpHandler != nil,
+		aiAgent:              aiAgent,
+		cloudMode:            cloud.Mode(),
+		showRemoteAccessHint: s.remoteAccessHint,
+		contextName:          k8s.GetContextName(),
+		kubeconfigPath:       k8s.GetKubeconfigPath(),
+		kubeconfig:           k8s.GetKubeconfigSummary(),
+	}
+
+	color := startupLogColorEnabled(log.Writer())
+	for _, line := range formatStartupLogSummary(summary, color) {
+		log.Print(line)
+	}
+}
+
+func formatStartupLogSummary(summary startupLogSummary, color bool) []string {
+	paint := func(code, value string) string {
+		if !color {
+			return value
+		}
+		return code + value + startupANSIReset
+	}
+	row := func(label, value string) string {
+		return fmt.Sprintf("%-13s%s", label+":", value)
+	}
+
+	lines := []string{paint(startupANSIBold, "── Radar startup ─────────────────────────────────────────")}
+	if summary.cloudMode {
+		lines = append(lines, row("Mode", "Radar Cloud"))
+	} else {
+		lines = append(lines, row("Mode", "local"))
+	}
+
+	loopback := cloud.IsLoopbackHostname(summary.listenAddress)
+	if loopback {
+		lines = append(lines,
+			row("URL", fmt.Sprintf("http://localhost:%d", summary.port)),
+			row("Access", paint(startupANSICyan, "LOCAL ONLY")+" ("+summary.listenAddress+")"),
+		)
+	} else {
+		lines = append(lines, row("Listener", fmt.Sprintf("%s:%d", summary.listenAddress, summary.port)))
+		if summary.cloudMode {
+			lines = append(lines, row("Access", paint(startupANSICyan, "HEALTH CHECK ONLY")+" (application traffic uses the Cloud tunnel)"))
+		} else {
+			lines = append(lines, row("Access", paint(startupANSIAmberBold, "NETWORK-EXPOSED")+" ("+summary.listenAddress+")"))
+		}
+	}
+
+	authMode := strings.ToLower(summary.authMode)
+	if authMode == "" || authMode == "none" {
+		authValue := "disabled"
+		if !loopback && !summary.cloudMode {
+			authValue = paint(startupANSIAmberBold, "DISABLED")
+		}
+		lines = append(lines, row("Auth", authValue))
+	} else if summary.cloudMode && authMode == "proxy" {
+		lines = append(lines, row("Auth", "proxy (Cloud tunnel identity)"))
+	} else if authMode == "oidc" {
+		lines = append(lines, row("Auth", "OIDC"))
+	} else {
+		lines = append(lines, row("Auth", authMode))
+	}
+
+	if summary.contextName != "" {
+		lines = append(lines, row("Cluster", summary.contextName))
+	}
+	if kubeconfig := formatStartupKubeconfig(summary.kubeconfigPath, summary.kubeconfig); kubeconfig != "" {
+		lines = append(lines, row("Kubeconfig", kubeconfig))
+	}
+
+	if summary.mcpEnabled {
+		lines = append(lines, row("MCP", "enabled at /mcp"))
+	} else {
+		lines = append(lines, row("MCP", "disabled"))
+	}
+	if summary.aiAgent != "" {
+		lines = append(lines, row("AI diagnose", "enabled via "+summary.aiAgent))
+	}
+
+	if loopback && summary.showRemoteAccessHint {
+		lines = append(lines, row("Remote", "use --listen-address=0.0.0.0 with authentication and network controls"))
+	}
+	if shouldWarnUnauthenticatedListener(summary.listenAddress, authMode != "" && authMode != "none") && !summary.cloudMode {
+		lines = append(lines, paint(startupANSIAmberBold, "WARNING: Remote clients can access Radar without authentication."))
+	}
+	if authMode == "proxy" && !summary.cloudMode {
+		lines = append(lines, paint(startupANSIAmberBold, fmt.Sprintf(
+			"WARNING: Proxy auth trusts %s and %s; ensure the ingress strips client-supplied identity headers.",
+			summary.proxyUserHeader, summary.proxyGroupsHeader)))
+	}
+
+	return append(lines, "──────────────────────────────────────────────────────────")
+}
+
+func formatStartupKubeconfig(path string, summary k8s.KubeconfigSummary) string {
+	if summary.Mode == "" {
+		return ""
+	}
+	if summary.Mode == "in-cluster" {
+		return "in-cluster service account"
+	}
+
+	source := path
+	if source == "" {
+		switch summary.Mode {
+		case "multi-env":
+			source = "KUBECONFIG"
+		case "multi-dir":
+			source = "configured directories"
+		default:
+			source = summary.Mode
+		}
+	}
+
+	parts := []string{source}
+	if summary.FileCount > 1 {
+		parts = append(parts, fmt.Sprintf("%d files", summary.FileCount))
+	}
+	if summary.ContextCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d contexts", summary.ContextCount))
+	}
+	execPlugins := len(summary.ExecPluginsPresent) + len(summary.ExecPluginsMissing)
+	if execPlugins > 0 {
+		parts = append(parts, fmt.Sprintf("%d exec plugins", execPlugins))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func startupLogColorEnabled(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	file, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(file.Fd()))
+}

--- a/internal/server/startup_log.go
+++ b/internal/server/startup_log.go
@@ -138,7 +138,11 @@ func formatStartupLogSummary(summary startupLogSummary, color bool) []string {
 			summary.proxyUserHeader, summary.proxyGroupsHeader)))
 	}
 
-	return append(lines, "──────────────────────────────────────────────────────────")
+	lines = append(lines, "──────────────────────────────────────────────────────────")
+	for i := range lines {
+		lines[i] = sanitizeForLog(lines[i])
+	}
+	return lines
 }
 
 func formatStartupKubeconfig(path string, summary k8s.KubeconfigSummary) string {

--- a/internal/server/startup_log_test.go
+++ b/internal/server/startup_log_test.go
@@ -108,6 +108,32 @@ func TestFormatStartupLogSummaryProxyWarning(t *testing.T) {
 	}
 }
 
+func TestFormatStartupLogSummarySanitizesLogFields(t *testing.T) {
+	got := strings.Join(formatStartupLogSummary(startupLogSummary{
+		listenAddress:     AllInterfacesAddress,
+		port:              9280,
+		authMode:          "proxy",
+		proxyUserHeader:   "X-User\nFORGED user log",
+		proxyGroupsHeader: "X-Groups\rFORGED groups log",
+		aiAgent:           "agent\nFORGED agent log",
+		contextName:       "cluster\nFORGED context log",
+		kubeconfigPath:    "/tmp/config\rFORGED path log",
+		kubeconfig:        k8s.KubeconfigSummary{Mode: "single"},
+	}, false), "\n")
+
+	for _, forged := range []string{
+		"\nFORGED user log",
+		"\rFORGED groups log",
+		"\nFORGED agent log",
+		"\nFORGED context log",
+		"\rFORGED path log",
+	} {
+		if strings.Contains(got, forged) {
+			t.Fatalf("startup summary contains unsanitized log field %q:\n%s", forged, got)
+		}
+	}
+}
+
 func TestStartupLogColorDisabledForNonTerminal(t *testing.T) {
 	if startupLogColorEnabled(&bytes.Buffer{}) {
 		t.Fatal("startupLogColorEnabled(buffer) = true, want false")

--- a/internal/server/startup_log_test.go
+++ b/internal/server/startup_log_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func TestFormatStartupLogSummaryLoopback(t *testing.T) {
+	lines := formatStartupLogSummary(startupLogSummary{
+		listenAddress:        DefaultListenAddress,
+		port:                 9280,
+		mcpEnabled:           true,
+		aiAgent:              "claude",
+		showRemoteAccessHint: true,
+		contextName:          "kind-radar",
+		kubeconfigPath:       "/tmp/kubeconfig",
+		kubeconfig: k8s.KubeconfigSummary{
+			Mode:               "single",
+			FileCount:          1,
+			ContextCount:       24,
+			ExecPluginsPresent: []string{"aws", "gke-gcloud-auth-plugin", "kubelogin"},
+		},
+	}, false)
+	got := strings.Join(lines, "\n")
+
+	for _, want := range []string{
+		"Mode:        local",
+		"URL:         http://localhost:9280",
+		"Access:      LOCAL ONLY (127.0.0.1)",
+		"Auth:        disabled",
+		"Cluster:     kind-radar",
+		"Kubeconfig:  /tmp/kubeconfig · 24 contexts · 3 exec plugins",
+		"MCP:         enabled at /mcp",
+		"AI diagnose: enabled via claude",
+		"Remote:      use --listen-address=0.0.0.0 with authentication and network controls",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup summary missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\x1b[") {
+		t.Fatalf("non-color summary contains ANSI escapes:\n%q", got)
+	}
+}
+
+func TestFormatStartupLogSummaryUnauthenticatedWildcard(t *testing.T) {
+	got := strings.Join(formatStartupLogSummary(startupLogSummary{
+		listenAddress: AllInterfacesAddress,
+		port:          9280,
+	}, true), "\n")
+
+	for _, want := range []string{
+		"Listener:    0.0.0.0:9280",
+		"NETWORK-EXPOSED",
+		"DISABLED",
+		"WARNING: Remote clients can access Radar without authentication.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup summary missing %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, startupANSIAmberBold) {
+		t.Fatalf("color summary does not highlight the exposed unauthenticated state:\n%q", got)
+	}
+}
+
+func TestFormatStartupLogSummaryCloudListener(t *testing.T) {
+	got := strings.Join(formatStartupLogSummary(startupLogSummary{
+		listenAddress: AllInterfacesAddress,
+		port:          9280,
+		authMode:      "proxy",
+		cloudMode:     true,
+		kubeconfig:    k8s.KubeconfigSummary{Mode: "in-cluster"},
+	}, false), "\n")
+
+	for _, want := range []string{
+		"Mode:        Radar Cloud",
+		"Access:      HEALTH CHECK ONLY (application traffic uses the Cloud tunnel)",
+		"Auth:        proxy (Cloud tunnel identity)",
+		"Kubeconfig:  in-cluster service account",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup summary missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Remote clients can access Radar") || strings.Contains(got, "ensure the ingress strips") {
+		t.Fatalf("Cloud health listener emitted an inapplicable warning:\n%s", got)
+	}
+}
+
+func TestFormatStartupLogSummaryProxyWarning(t *testing.T) {
+	got := strings.Join(formatStartupLogSummary(startupLogSummary{
+		listenAddress:     AllInterfacesAddress,
+		port:              9280,
+		authMode:          "proxy",
+		proxyUserHeader:   "X-Forwarded-User",
+		proxyGroupsHeader: "X-Forwarded-Groups",
+	}, false), "\n")
+
+	if strings.Contains(got, "without authentication") {
+		t.Fatalf("authenticated proxy listener emitted unauthenticated warning:\n%s", got)
+	}
+	if !strings.Contains(got, "ensure the ingress strips client-supplied identity headers") {
+		t.Fatalf("proxy trust warning missing:\n%s", got)
+	}
+}
+
+func TestStartupLogColorDisabledForNonTerminal(t *testing.T) {
+	if startupLogColorEnabled(&bytes.Buffer{}) {
+		t.Fatal("startupLogColorEnabled(buffer) = true, want false")
+	}
+}

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -49,6 +49,7 @@ echo "Running chart template tests against $CHART_DIR"
 echo
 
 render "defaults — no self-upgrade footprint"
+assert_contains '--listen-address=0.0.0.0'          "shared listener explicitly enabled"
 assert_not_contains '^kind: Role$'                  "no namespaced Role"
 assert_not_contains '^kind: RoleBinding$'           "no namespaced RoleBinding"
 assert_not_contains 'MY_POD_NAMESPACE'              "no downward-API env var"


### PR DESCRIPTION
## Summary

Radar previously advertised a localhost URL while its native HTTP server listened on every interface. This changes the native default to loopback-only, so an unauthenticated local instance is not unintentionally reachable from a LAN, VM network, or other host interface.

It also replaces scattered startup success messages with a compact security-oriented summary before informer initialization begins. Remote and container access remain available through an explicit all-interface opt-in paired with authentication and network controls.

## What changed

- Add a validated listen-address setting supporting `127.0.0.1`, `localhost`, and `0.0.0.0`.
- Default the native CLI and zero-value server configuration to `127.0.0.1`, and reject invalid addresses before creating a listener or starting background server work.
- Preserve Docker and Helm connectivity by explicitly selecting `0.0.0.0`, with a chart assertion covering the deployment argument.
- Keep desktop, standalone diagnose, and test-server listeners explicitly local.
- Add an aligned startup block covering mode, listener exposure, authentication, cluster/kubeconfig, MCP, AI diagnose, and remote-access guidance.
- Highlight exposed or unauthenticated states with restrained TTY-only color; honor `NO_COLOR`, `TERM=dumb`, and non-terminal log destinations.
- Keep an always-on preflight line and detailed invalid-address, bind, kubeconfig, auth, cache, and MCP errors so early startup failures retain actionable diagnostics.
- Retain security warnings for direct server callers that opt out of the full startup block.
- Remove redundant success-only cache, kubeconfig, MCP, and broadcaster messages, then introduce a clear Kubernetes-initialization phase marker before informer logs.
- Reuse the listener normalizer for port-forward addresses and document that CORS is not an authentication boundary.

## Testing

- `make tsc`
- `make test`
- `make build`
- `make test-chart`
- `go test ./...`
- `go vet ./internal/server ./internal/app ./internal/k8s ./internal/images ./internal/cloud ./cmd/explorer`
- `git diff --check`
- Runtime smoke: verified loopback startup, explicit unauthenticated `0.0.0.0`, TTY color, `NO_COLOR` behavior, dynamic port reporting, invalid-address failure output, and clean shutdown.
- Visual test skipped because there is no UI change.

## Notes

Native installations that intentionally accept remote connections must now pass `--listen-address=0.0.0.0` and should enable Radar authentication plus appropriate network controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default network exposure for local installs (breaking for workflows that relied on implicit all-interface binding) and touches HTTP bind behavior for Docker, Helm, and port-forward; mitigated by explicit chart/image args and clear warnings.
> 
> **Overview**
> **Native Radar now binds to loopback by default** (`127.0.0.1` / `localhost` only). A new `--listen-address` flag validates intent before bind; arbitrary IPs are rejected. **Docker and Helm** pin `0.0.0.0` in **ENTRYPOINT** / chart args so `docker run` or Compose cannot accidentally drop shared access. Desktop, diagnose, and test-server stay explicitly local.
> 
> **After a successful bind**, the CLI emits a structured **startup block** (mode, URL vs network exposure, auth, cluster/kubeconfig, MCP/AI, remote-access hint) with TTY-only highlights and warnings for unauthenticated `0.0.0.0` or proxy header trust. A preflight line still logs mode/auth before bind; redundant kubeconfig/MCP/SSE chatter is trimmed, with a clearer **Kubernetes initialization** marker before informer work.
> 
> Port-forward listen addresses reuse the same normalizer. Docs/README describe the listener model and that **CORS is not auth**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491130e8991eadcd17e734f118ccf5d40bfd85f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->