### PR TITLE
Event dedup: normalize long numeric IDs so serial incarnations group

### DIFF
--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -39,15 +39,28 @@ var (
 	uuidPattern    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	tsPattern      = regexp.MustCompile(`\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}`)
 	ipPattern      = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?`)
-	// Hyphen-anchored runs of >=6 digits are generated NAME SEGMENTS (epoch
-	// suffixes in Argo cron workflow names, CronJob pod names, controller
-	// child-node IDs). podHashPattern's {5,10} bound only partially consumes
-	// them, leaving distinct digit tails that split one chronic failure into
-	// a new group per incarnation. The leading hyphen restricts this to
-	// identifier context: freestanding quantities (eviction thresholds,
-	// byte counts — "using 123456789") stay distinct, and the >=6 floor
-	// additionally preserves ports, HTTP status codes, and exit codes.
-	longNumPattern = regexp.MustCompile(`-\d{6,}`)
+	// Runs of >=6 digits attached to a NAME (\b requires a word character
+	// before the hyphen without consuming it, so adjacent segments like
+	// name-{epoch}-{childID} both match) are generated name segments: epoch
+	// suffixes in Argo cron workflow and CronJob pod names, controller
+	// child-node IDs, cert-manager Order/Challenge FNV suffixes.
+	// podHashPattern's {5,10} bound only partially consumes them, leaving
+	// distinct digit tails that split one chronic failure into a new group
+	// per incarnation. The word-boundary anchor restricts this to identifier
+	// context: freestanding quantities (eviction thresholds, byte counts —
+	// "using 123456789") and negative values ("value: -123456789") stay
+	// distinct, and the >=6 floor additionally preserves ports, HTTP status
+	// codes, and exit codes.
+	longNumPattern = regexp.MustCompile(`\b-\d{6,}`)
+	// CronJob MissSchedule emits RFC1123Z ("Sun, 19 Jul 2026 12:30:00
+	// +0000"), repeatedly for a chronically missing schedule — the ISO
+	// tsPattern doesn't touch it, so each emission formed a new group.
+	rfc1123ZPattern = regexp.MustCompile(`\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}`)
+	// Kubelet SystemOOM ("victim process: X, pid: 1234567") embeds the
+	// ephemeral PID — identity, never magnitude — so repeated OOMs split
+	// per kill. All widths normalized: a 5-digit PID is no more meaningful
+	// than a 7-digit one.
+	pidPattern = regexp.MustCompile(`\bpid: \d+\b`)
 )
 
 func normalizeMessage(msg string) string {
@@ -63,7 +76,9 @@ func normalizeMessage(msg string) string {
 	// per-incarnation splitting this pattern exists to fix.
 	s := uuidPattern.ReplaceAllString(msg, "<uuid>")
 	s = tsPattern.ReplaceAllString(s, "<timestamp>")
+	s = rfc1123ZPattern.ReplaceAllString(s, "<timestamp>")
 	s = ipPattern.ReplaceAllString(s, "<ip>")
+	s = pidPattern.ReplaceAllString(s, "pid: <pid>")
 	s = longNumPattern.ReplaceAllString(s, "-nnnnnn")
 	s = podHashPattern.ReplaceAllString(s, "<pod>")
 	return s

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -53,10 +53,16 @@ func normalizeMessage(msg string) string {
 	// segment or IP would otherwise be eaten before uuidPattern/ipPattern
 	// can recognize it — and BEFORE podHashPattern, whose {5,10} bound is
 	// what leaves the digit tails.
+	//
+	// Its placeholder must stay inside [a-z0-9]: CronJob pod names are
+	// {name}-{unixMinutes}-{rand5}, and an out-of-class token (e.g. "<n>")
+	// in the middle would stop podHashPattern from consuming the whole
+	// name, splitting same-shaped events on the rand5 tail — the exact
+	// per-incarnation splitting this pattern exists to fix.
 	s := uuidPattern.ReplaceAllString(msg, "<uuid>")
 	s = tsPattern.ReplaceAllString(s, "<timestamp>")
 	s = ipPattern.ReplaceAllString(s, "<ip>")
-	s = longNumPattern.ReplaceAllString(s, "<n>")
+	s = longNumPattern.ReplaceAllString(s, "nnnnnn")
 	s = podHashPattern.ReplaceAllString(s, "<pod>")
 	return s
 }

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -39,13 +39,15 @@ var (
 	uuidPattern    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	tsPattern      = regexp.MustCompile(`\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}`)
 	ipPattern      = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?`)
-	// Runs of >=6 digits are generated identifiers (epoch suffixes in Argo
-	// cron workflow names, controller child-node IDs), not meaningful
-	// message text. podHashPattern's {5,10} bound only partially consumes
-	// them, leaving distinct digit tails that split one chronic failure
-	// into a new group per incarnation. The >=6 floor preserves ports
-	// (4-5 digits), HTTP status codes, and exit codes.
-	longNumPattern = regexp.MustCompile(`\d{6,}`)
+	// Hyphen-anchored runs of >=6 digits are generated NAME SEGMENTS (epoch
+	// suffixes in Argo cron workflow names, CronJob pod names, controller
+	// child-node IDs). podHashPattern's {5,10} bound only partially consumes
+	// them, leaving distinct digit tails that split one chronic failure into
+	// a new group per incarnation. The leading hyphen restricts this to
+	// identifier context: freestanding quantities (eviction thresholds,
+	// byte counts — "using 123456789") stay distinct, and the >=6 floor
+	// additionally preserves ports, HTTP status codes, and exit codes.
+	longNumPattern = regexp.MustCompile(`-\d{6,}`)
 )
 
 func normalizeMessage(msg string) string {
@@ -62,7 +64,7 @@ func normalizeMessage(msg string) string {
 	s := uuidPattern.ReplaceAllString(msg, "<uuid>")
 	s = tsPattern.ReplaceAllString(s, "<timestamp>")
 	s = ipPattern.ReplaceAllString(s, "<ip>")
-	s = longNumPattern.ReplaceAllString(s, "nnnnnn")
+	s = longNumPattern.ReplaceAllString(s, "-nnnnnn")
 	s = podHashPattern.ReplaceAllString(s, "<pod>")
 	return s
 }

--- a/pkg/ai/context/events.go
+++ b/pkg/ai/context/events.go
@@ -39,12 +39,24 @@ var (
 	uuidPattern    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	tsPattern      = regexp.MustCompile(`\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}`)
 	ipPattern      = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?`)
+	// Runs of >=6 digits are generated identifiers (epoch suffixes in Argo
+	// cron workflow names, controller child-node IDs), not meaningful
+	// message text. podHashPattern's {5,10} bound only partially consumes
+	// them, leaving distinct digit tails that split one chronic failure
+	// into a new group per incarnation. The >=6 floor preserves ports
+	// (4-5 digits), HTTP status codes, and exit codes.
+	longNumPattern = regexp.MustCompile(`\d{6,}`)
 )
 
 func normalizeMessage(msg string) string {
+	// longNumPattern runs AFTER the specific patterns — a digit-heavy UUID
+	// segment or IP would otherwise be eaten before uuidPattern/ipPattern
+	// can recognize it — and BEFORE podHashPattern, whose {5,10} bound is
+	// what leaves the digit tails.
 	s := uuidPattern.ReplaceAllString(msg, "<uuid>")
 	s = tsPattern.ReplaceAllString(s, "<timestamp>")
 	s = ipPattern.ReplaceAllString(s, "<ip>")
+	s = longNumPattern.ReplaceAllString(s, "<n>")
 	s = podHashPattern.ReplaceAllString(s, "<pod>")
 	return s
 }

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -40,6 +40,25 @@ func TestNormalizeMessage_CollapsesSerialNumericIncarnations(t *testing.T) {
 			"child 'radar-batch-cronworkflow-1784443200-1321105865' failed",
 			"child 'radar-batch-cronworkflow-1784442000-1354049248' failed",
 		},
+		// cert-manager Order/Challenge names carry decimal FNV suffixes
+		// (<=10 digits; a 5-digit render falls to podHashPattern instead).
+		{
+			"Created Order resource shop/example-cert-4082662562",
+			"Created Order resource shop/example-cert-1193317457",
+		},
+		// Kubelet SystemOOM embeds the ephemeral PID — identity, never
+		// magnitude — so repeated kills of one process are one story.
+		{
+			"System OOM encountered, victim process: java, pid: 1234567",
+			"System OOM encountered, victim process: java, pid: 7654321",
+		},
+		// CronJob MissSchedule emits RFC1123Z timestamps, repeatedly for a
+		// chronically missing schedule; the ISO tsPattern never matched
+		// these, so each emission formed a new group.
+		{
+			"Missed scheduled time to start a job: Sun, 19 Jul 2026 12:30:00 +0000",
+			"Missed scheduled time to start a job: Sat, 18 Jul 2026 09:10:00 +0000",
+		},
 	}
 	for _, p := range pairs {
 		a, b := normalizeMessage(p[0]), normalizeMessage(p[1])
@@ -62,9 +81,14 @@ func TestNormalizeMessage_PreservesMeaningfulSmallNumbers(t *testing.T) {
 		{"Error (exit code 64): task failed", "Error (exit code 137): task failed"},
 		{"0/9 nodes are available", "0/3 nodes are available"},
 		// Freestanding large quantities are diagnostic values, not name
-		// segments — the hyphen anchor keeps them distinct.
+		// segments — the word-boundary anchor keeps them distinct.
 		{"Container was using 123456789, request is 100000000", "Container was using 987654321, request is 100000000"},
 		{"attempting to reclaim 512000000 bytes of ephemeral-storage", "attempting to reclaim 128000000 bytes of ephemeral-storage"},
+		// A hyphen NOT preceded by a word character is a sign or a flag,
+		// not a name segment (\b anchor): negative metric values and
+		// --flag-style tokens stay distinct.
+		{"current metric value: -123456789", "current metric value: -987654321"},
+		{"unknown flag: --123456", "unknown flag: --654321"},
 	}
 	for _, p := range distinct {
 		a, b := normalizeMessage(p[0]), normalizeMessage(p[1])

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -61,6 +61,10 @@ func TestNormalizeMessage_PreservesMeaningfulSmallNumbers(t *testing.T) {
 		{"Readiness probe failed: HTTP probe failed with statuscode: 500", "Readiness probe failed: HTTP probe failed with statuscode: 503"},
 		{"Error (exit code 64): task failed", "Error (exit code 137): task failed"},
 		{"0/9 nodes are available", "0/3 nodes are available"},
+		// Freestanding large quantities are diagnostic values, not name
+		// segments — the hyphen anchor keeps them distinct.
+		{"Container was using 123456789, request is 100000000", "Container was using 987654321, request is 100000000"},
+		{"attempting to reclaim 512000000 bytes of ephemeral-storage", "attempting to reclaim 128000000 bytes of ephemeral-storage"},
 	}
 	for _, p := range distinct {
 		a, b := normalizeMessage(p[0]), normalizeMessage(p[1])

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -25,6 +25,78 @@ func makeEvent(reason, message, eventType string, count int32, lastTime time.Tim
 	}
 }
 
+// Serial incarnations of one chronic failure must be ONE group. Messages
+// verbatim from a live cluster: an Argo cron workflow fails every tick, and
+// each run's epoch-suffixed name plus child-node ID used to survive
+// normalization as distinct digit tails ("<pod>05865" vs "<pod>0114"),
+// filling 11 of 20 dashboard rows with one failure.
+func TestNormalizeMessage_CollapsesSerialNumericIncarnations(t *testing.T) {
+	pairs := [][2]string{
+		{
+			"Failed node radar-batch-cronworkflow-1784443200: child 'radar-batch-cronworkflow-1784443200-1321105865' failed",
+			"Failed node radar-batch-cronworkflow-1784442600: child 'radar-batch-cronworkflow-1784442600-331300114' failed",
+		},
+		{
+			"child 'radar-batch-cronworkflow-1784443200-1321105865' failed",
+			"child 'radar-batch-cronworkflow-1784442000-1354049248' failed",
+		},
+	}
+	for _, p := range pairs {
+		a, b := normalizeMessage(p[0]), normalizeMessage(p[1])
+		if a != b {
+			t.Errorf("incarnations did not collapse:\n  %q -> %q\n  %q -> %q", p[0], a, p[1], b)
+		}
+	}
+}
+
+// The >=6-digit floor must NOT merge messages whose small numbers are
+// meaningful: ports, HTTP status codes, exit codes, replica fractions.
+func TestNormalizeMessage_PreservesMeaningfulSmallNumbers(t *testing.T) {
+	distinct := [][2]string{
+		// Same-shaped probe failures on different ports are different probes.
+		{
+			`Liveness probe failed: Get "http://svc:9440/healthz": context deadline exceeded`,
+			`Liveness probe failed: Get "http://svc:8082/healthz": context deadline exceeded`,
+		},
+		{"Readiness probe failed: HTTP probe failed with statuscode: 500", "Readiness probe failed: HTTP probe failed with statuscode: 503"},
+		{"Error (exit code 64): task failed", "Error (exit code 137): task failed"},
+		{"0/9 nodes are available", "0/3 nodes are available"},
+	}
+	for _, p := range distinct {
+		a, b := normalizeMessage(p[0]), normalizeMessage(p[1])
+		if a == b {
+			t.Errorf("meaningful numbers were merged: %q and %q both -> %q", p[0], p[1], a)
+		}
+	}
+}
+
+// Pattern-order pins. A digit-heavy UUID must still normalize as <uuid> —
+// longNumPattern running first would mangle it into "<n>-1234-…" and split
+// same-shaped messages by UUID composition. IPs keep their <ip> placeholder.
+func TestNormalizeMessage_SpecificPatternsWinOverLongNum(t *testing.T) {
+	a := normalizeMessage("volume 12345678-1234-1234-1234-123456789012 mount failed")
+	b := normalizeMessage("volume a1b2c3d4-e5f6-7890-abcd-ef1234567890 mount failed")
+	if a != b {
+		t.Errorf("UUID normalization diverged by digit composition: %q vs %q", a, b)
+	}
+	if got := normalizeMessage("dial tcp 10.192.5.18:8081: connect: connection refused"); !strings.Contains(got, "<ip>") {
+		t.Errorf("IP not normalized as <ip>: %q", got)
+	}
+}
+
+// Documented, accepted debt (pre-existing, NOT introduced by longNumPattern):
+// podHashPattern's shape also matches ordinary hyphenated word pairs, so
+// same-shaped messages differing only in such a pair over-merge. Real
+// mis-grouping additionally requires identical reason and type. This test
+// pins the behavior so a future podHashPattern redesign notices it.
+func TestNormalizeMessage_KnownHyphenatedPhraseOverMerge(t *testing.T) {
+	a := normalizeMessage("error: connection-refused by peer")
+	b := normalizeMessage("error: connection-timeout by peer")
+	if a != b {
+		t.Errorf("hyphenated-phrase over-merge no longer occurs (%q vs %q) — podHashPattern changed; update this documented-debt test and audit grouping", a, b)
+	}
+}
+
 func TestDeduplicateEvents_CollapseIdentical(t *testing.T) {
 	now := time.Now()
 	events := make([]corev1.Event, 50)

--- a/pkg/ai/context/events_test.go
+++ b/pkg/ai/context/events_test.go
@@ -70,6 +70,18 @@ func TestNormalizeMessage_PreservesMeaningfulSmallNumbers(t *testing.T) {
 	}
 }
 
+// CronJob/Job pod names are {name}-{unixMinutes}-{rand5}. The long-number
+// placeholder must stay inside [a-z0-9] so podHashPattern still consumes the
+// whole name — an out-of-class token would leave the rand5 tail and split
+// same-shaped events per incarnation (the regression this pins).
+func TestNormalizeMessage_CronJobPodNamesStillCollapse(t *testing.T) {
+	a := normalizeMessage("Back-off restarting failed container in pod mycron-29184720-abcde")
+	b := normalizeMessage("Back-off restarting failed container in pod mycron-29184721-fghij")
+	if a != b {
+		t.Errorf("CronJob pod incarnations split: %q vs %q", a, b)
+	}
+}
+
 // Pattern-order pins. A digit-heavy UUID must still normalize as <uuid> —
 // longNumPattern running first would mangle it into "<n>-1234-…" and split
 // same-shaped messages by UUID composition. IPs keep their <ip> placeholder.


### PR DESCRIPTION
## Why

Runs of ≥6 digits (epoch suffixes in Argo cron workflow names, controller child-node IDs) survive message normalization as distinct digit tails — `podHashPattern`'s `{5,10}` bound only partially consumes them (`<pod>05865` vs `<pod>0114`) — so one chronic failure forms a new dedup group per incarnation. Observed live on GKE nonprod: **11 of 20 `get_dashboard` warningGroups rows were one Argo cron failure**, filling the 20-group dedup window and silently hiding everything beyond it. Benefits all `DeduplicateEvents` consumers (get_dashboard, get_events, diagnose, resource includes, cluster://events).

## What

- `longNumPattern = \d{6,}` → `<n>` in `normalizeMessage`, ordered **after** uuid/timestamp/ip (a digit-heavy UUID must still normalize as `<uuid>`; ordering is pinned by test) and **before** podHash (whose bound creates the tails). The ≥6 floor preserves ports (4–5 digits), HTTP status codes, and exit codes.
- Grouping-only: representative messages stay raw.

## Verification

- Corpus tests from live nonprod messages: incarnations collapse; ports/status codes/exit codes/replica fractions stay distinct; UUID-ordering pin; documented pre-existing pod-hash hyphenated-phrase over-merge pinned as known debt.
- Equivalence-class inspection on the captured nonprod dashboard corpus: 20 rows → 13 groups, every merged class a true positive (the three workflow-failure shapes, each merging only across cron incarnations).
- `go test` green in both modules.

First leg of the event-dedup-fidelity follow-up to #1202 (cap parameterization, truncation signals, and get_events Warning-only fix are separate, gated items).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all `DeduplicateEvents` consumers group warnings (dashboard, diagnose, get_events); behavior is heavily tested but could merge or split groups differently than before in edge cases.
> 
> **Overview**
> **Event dedup grouping** now treats repeated failures with changing generated IDs as one group instead of filling the 20-group cap with near-duplicates (e.g. Argo cron workflow epoch/child-node suffixes).
> 
> `normalizeMessage` gains **`longNumPattern`** (`\b-\d{6,}` → `-nnnnnn`), **`rfc1123ZPattern`** (CronJob MissSchedule dates → `<timestamp>`), and **`pidPattern`** (OOM `pid:` → `pid: <pid>`), with a fixed apply order: UUID/ISO timestamp/RFC1123Z/IP first, then PID and long numeric name segments, then existing `podHashPattern`. Placeholders stay `[a-z0-9]`-compatible so CronJob pod names still collapse as a single `<pod>`.
> 
> Representative event **messages shown to users stay raw**; only the grouping key changes. New tests cover live-style incarnations, preservation of ports/status/exit codes and freestanding byte counts, UUID/IP ordering, CronJob pod collapse, and a pinned pre-existing hyphenated-phrase over-merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03d02c7e9ec0e441eb4378ceac0681466f3df90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->