### PR TITLE
Remove dead dashboard recentEvents payload

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -32,7 +32,6 @@ type DashboardResponse struct {
 	Health                 DashboardHealth                 `json:"health"`
 	Problems               []DashboardProblem              `json:"problems"`
 	ResourceCounts         DashboardResourceCounts         `json:"resourceCounts"`
-	RecentEvents           []DashboardEvent                `json:"recentEvents"`
 	RecentChanges          []DashboardChange               `json:"recentChanges"`
 	TopologySummary        DashboardTopologySummary        `json:"topologySummary"`
 	TrafficSummary         *DashboardTrafficSummary        `json:"trafficSummary"`
@@ -226,16 +225,6 @@ type DashboardCRDCount struct {
 	Count int    `json:"count"`
 }
 
-type DashboardEvent struct {
-	Type           string `json:"type"`
-	Reason         string `json:"reason"`
-	Message        string `json:"message"`
-	InvolvedObject string `json:"involvedObject"`
-	Namespace      string `json:"namespace"`
-	Timestamp      string `json:"timestamp"`
-	Count          int32  `json:"count,omitempty"`
-}
-
 type DashboardChange struct {
 	Kind       string `json:"kind"`
 	Namespace  string `json:"namespace"`
@@ -398,7 +387,6 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	t = time.Now()
 	for _, ns := range iterateNamespaces {
-		resp.RecentEvents = append(resp.RecentEvents, s.getDashboardRecentEvents(cache, ns)...)
 		resp.Health.WarningEvents += s.countWarningEvents(cache, ns)
 	}
 	k8s.LogTiming("  [dashboard] events: %v", time.Since(t))
@@ -1153,70 +1141,6 @@ func (s *Server) getDashboardResourceCounts(cache *k8s.ResourceCache, namespace 
 
 	counts.Restricted = restricted
 	return counts
-}
-
-func (s *Server) getDashboardRecentEvents(cache *k8s.ResourceCache, namespace string) []DashboardEvent {
-	eventLister := cache.Events()
-	if eventLister == nil {
-		return []DashboardEvent{}
-	}
-	var events []*corev1.Event
-	var err error
-	if namespace != "" {
-		events, err = eventLister.Events(namespace).List(labels.Everything())
-	} else {
-		events, err = eventLister.List(labels.Everything())
-	}
-	if err != nil || len(events) == 0 {
-		return []DashboardEvent{}
-	}
-
-	// Filter to Warning events only and sort by last timestamp desc
-	var warnings []*corev1.Event
-	for _, e := range events {
-		if e.Type == "Warning" {
-			warnings = append(warnings, e)
-		}
-	}
-
-	sort.Slice(warnings, func(i, j int) bool {
-		ci := max(warnings[i].Count, 1)
-		cj := max(warnings[j].Count, 1)
-		if ci != cj {
-			return ci > cj
-		}
-		ti := warnings[i].LastTimestamp.Time
-		tj := warnings[j].LastTimestamp.Time
-		if ti.IsZero() {
-			ti = warnings[i].CreationTimestamp.Time
-		}
-		if tj.IsZero() {
-			tj = warnings[j].CreationTimestamp.Time
-		}
-		return ti.After(tj)
-	})
-
-	// Take top 5
-	limit := min(len(warnings), 5)
-
-	result := make([]DashboardEvent, 0, limit)
-	for _, e := range warnings[:limit] {
-		ts := e.LastTimestamp.Time
-		if ts.IsZero() {
-			ts = e.CreationTimestamp.Time
-		}
-		result = append(result, DashboardEvent{
-			Type:           e.Type,
-			Reason:         e.Reason,
-			Message:        k8s.Truncate(e.Message, 200),
-			InvolvedObject: fmt.Sprintf("%s/%s", e.InvolvedObject.Kind, e.InvolvedObject.Name),
-			Namespace:      e.Namespace,
-			Timestamp:      ts.Format(time.RFC3339),
-			Count:          max(e.Count, 1),
-		})
-	}
-
-	return result
 }
 
 func (s *Server) getDashboardRecentChanges(ctx context.Context, namespaces []string) []DashboardChange {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -255,15 +255,6 @@ export interface DashboardResourceCounts {
   restricted?: string[] // Resource kinds the user cannot list due to RBAC
 }
 
-export interface DashboardEvent {
-  type: string
-  reason: string
-  message: string
-  involvedObject: string
-  namespace: string
-  timestamp: string
-}
-
 export interface DashboardChange {
   kind: string
   namespace: string
@@ -387,7 +378,6 @@ export interface DashboardResponse {
   health: DashboardHealth
   problems: DashboardProblem[]
   resourceCounts: DashboardResourceCounts
-  recentEvents: DashboardEvent[]
   recentChanges: DashboardChange[]
   topologySummary: DashboardTopologySummary
   trafficSummary: DashboardTrafficSummary | null


### PR DESCRIPTION
## Why

`getDashboardRecentEvents` (internal/server/dashboard.go) ran on **every dashboard build** — listing all events, filtering Warning, count-first sorting, building structs — and shipped a top-5 `recentEvents` array in the `/dashboard` response. Nothing consumed it:

- **Server-side:** the `RecentEvents` field was only *written* (never read).
- **Client-side:** `DashboardEvent` / `recentEvents` existed **only** in the API type (`client.ts`) — zero references in any `.tsx`. The `/dashboard` response is used only for cluster load-state, never to render an events list.

This came out of investigating #1214, which assumed a count-first recent-events *widget* was misleading operators. There is no widget — the data was never rendered. So rather than build a panel nobody asked for (the recent-warnings job is already covered by the issues/problems views, and `get_dashboard` warningGroups for agents), this removes the dead compute + payload.

## What

- Delete `getDashboardRecentEvents`, the `RecentEvents` struct field + its append, and the `DashboardEvent` backend struct.
- Delete the frontend `DashboardEvent` interface and `recentEvents` field.

86 lines removed, 0 added. Backend builds + `go test ./internal/server` green; frontend `tsc` clean. No behavior change — removes an unrendered field from the response.

Closes #1214.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion of an unreferenced JSON field and redundant event listing; no auth or data-path changes.
> 
> **Overview**
> Removes **dead** `recentEvents` from the `/dashboard` API: the backend no longer lists Warning events, sorts by count, or returns a top-five array, and the frontend drops the matching `DashboardEvent` / `recentEvents` types.
> 
> **`health.warningEvents`** still comes from `countWarningEvents` on each dashboard build — only the unused recent-events list and ~86 lines of `getDashboardRecentEvents` are gone. No UI ever rendered this field; warning signal stays on problems/issues paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcd9c6a84cd533397b36999c5ee33760748013e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->