### PR TITLE
feat(traffic): add Grafana Beyla as a traffic source (#1205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,14 +399,15 @@ See the [GitOps guide](docs/gitops.md) for the full feature matrix, RBAC require
 
 ### Traffic
 
-Visualize live network traffic between services using Hubble or Caretta.
+Visualize live network traffic between services using Hubble, Caretta, Istio, or Beyla.
 
 <p align="center">
   <img src="docs/screenshots/traffic-view.png" alt="Traffic View" width="800">
   <br><em>Traffic View — See how services communicate in real-time</em>
 </p>
 
-- Auto-detects Hubble (Cilium), Caretta, or Istio as traffic data sources
+- Auto-detects Hubble (Cilium), Istio, Caretta, or Grafana Beyla as traffic data sources
+- Beyla (standalone or via Grafana Alloy) provides eBPF L4 + HTTP visibility with no service mesh, read from Prometheus
 - Animated flow graph showing requests per second between services
 - Filter by namespace, protocol, or status code
 - Setup wizard to install a traffic source if none is detected

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -139,6 +139,7 @@ func main() {
 	flag.Var(promHeaders, "prometheus-header", "HTTP header to send with Prometheus requests, e.g. 'Authorization=Bearer <token>' (repeatable). Required for auth-protected backends.")
 	promHeadersFromEnv := newHeaderFromEnvFlag(fileCfg.PrometheusHeadersFromEnv)
 	flag.Var(promHeadersFromEnv, "prometheus-header-from-env", "HTTP header to send with Prometheus requests, sourced from an env var, e.g. 'Authorization=PROMETHEUS_TOKEN' (repeatable).")
+	beylaJobSelector := flag.String("beyla-job-selector", "", `PromQL job-label matcher fragment Beyla traffic queries use to scope Prometheus series, e.g. 'job=~"my-beyla.*"' (empty = built-in default matching *beyla* or *alloy* job names)`)
 	// MCP server
 	noMCP := flag.Bool("no-mcp", !fileCfg.MCPEnabledOr(true), "Disable MCP (Model Context Protocol) server for AI tools")
 	mcpCatalogStdio := flag.Bool("mcp-catalog-stdio", false, "Start only the MCP catalog over stdio for registry/inspector introspection; skips Kubernetes initialization")
@@ -350,6 +351,7 @@ func main() {
 		PrometheusURL:            *prometheusURL,
 		PrometheusHeaders:        resolvedPrometheusHeaders,
 		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),
+		BeylaJobSelector:         *beylaJobSelector,
 		MCPEnabled:               mcpEnabled,
 		AIHistory:                *aiHistory,
 		AIHistoryDBPath:          fileCfg.AIHistoryDBPath,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -61,6 +61,7 @@ type AppConfig struct {
 	PrometheusURL            string
 	PrometheusHeaders        map[string]string
 	PrometheusHeadersFromEnv map[string]string
+	BeylaJobSelector         string
 	Version                  string
 	MCPEnabled               bool
 	AIHistory                bool   // persist AI investigations across restarts
@@ -241,6 +242,9 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 	if len(cfg.PrometheusHeaders) > 0 {
 		traffic.SetMetricsHeaders(cfg.PrometheusHeaders)
 		prometheuspkg.SetHeaders(cfg.PrometheusHeaders)
+	}
+	if cfg.BeylaJobSelector != "" {
+		traffic.SetBeylaJobSelector(cfg.BeylaJobSelector)
 	}
 
 	k8s.RegisterTrafficFuncs(traffic.Reset, func() error {

--- a/internal/traffic/beyla.go
+++ b/internal/traffic/beyla.go
@@ -1,0 +1,543 @@
+package traffic
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/skyhook-io/radar/internal/portforward"
+	promclient "github.com/skyhook-io/radar/internal/prometheus"
+	"github.com/skyhook-io/radar/pkg/prom"
+)
+
+const (
+	// defaultBeylaJobSelector is used unless overridden via SetBeylaJobSelector
+	// (wired to --beyla-job-selector) for clusters running Alloy/Beyla under a
+	// non-default Prometheus job name.
+	defaultBeylaJobSelector = `job=~".*beyla.*|.*alloy.*"`
+	// Rate window in the PromQL queries; used to turn per-second rates back
+	// into absolute counts for the window.
+	beylaRateWindowSeconds = 300
+)
+
+// beylaJobSelector returns the PromQL job-label matcher fragment (e.g.
+// `job=~".*beyla.*"`) used to scope Beyla queries, honoring any operator
+// override.
+func beylaJobSelector() string {
+	if selector := BeylaJobSelector(); selector != "" {
+		return selector
+	}
+	return defaultBeylaJobSelector
+}
+
+type promQueryFunc func(ctx context.Context, query string) (*prom.QueryResult, error)
+
+// BeylaSource implements TrafficSource for Grafana Beyla via Prometheus metrics.
+type BeylaSource struct {
+	k8sClient kubernetes.Interface
+	queryFn   promQueryFunc
+}
+
+// NewBeylaSource creates a new Beyla traffic source wired to the shared Prometheus client.
+func NewBeylaSource(client kubernetes.Interface) *BeylaSource {
+	s := &BeylaSource{k8sClient: client}
+	s.queryFn = s.defaultQuery
+	return s
+}
+
+func (s *BeylaSource) Name() string { return "beyla" }
+
+func (s *BeylaSource) defaultQuery(ctx context.Context, query string) (*prom.QueryResult, error) {
+	client := promclient.GetClient()
+	if client == nil {
+		return nil, fmt.Errorf("prometheus client not initialized")
+	}
+	return client.Query(ctx, query)
+}
+
+func (s *BeylaSource) query(ctx context.Context, query string) (*prom.QueryResult, error) {
+	return s.queryFn(ctx, query)
+}
+
+// Connect delegates to the shared Prometheus client's EnsureConnected.
+func (s *BeylaSource) Connect(ctx context.Context, contextName string) (*portforward.ConnectionInfo, error) {
+	client := promclient.GetClient()
+	if client == nil {
+		return &portforward.ConnectionInfo{Connected: false, Error: "Prometheus client not initialized"}, nil
+	}
+	_, _, err := client.EnsureConnected(ctx)
+	if err != nil {
+		return &portforward.ConnectionInfo{Connected: false, Error: fmt.Sprintf("Failed to connect to Prometheus: %v", err)}, nil
+	}
+	status := client.GetStatus()
+	info := &portforward.ConnectionInfo{Connected: true, Address: status.Address, ContextName: contextName}
+	if status.Service != nil {
+		info.Namespace = status.Service.Namespace
+		info.ServiceName = status.Service.Name
+	}
+	return info, nil
+}
+
+func (s *BeylaSource) Close() error { return nil }
+
+func (s *BeylaSource) Detect(ctx context.Context) (*DetectionResult, error) {
+	result := &DetectionResult{Available: false}
+
+	// Phase 1: metric probe via Prometheus. Scoped to the same jobs the flow
+	// queries read, so detection can't succeed on metrics GetFlows won't see.
+	qr, err := s.query(ctx, fmt.Sprintf(`count(beyla_network_flow_bytes_total{%s})`, beylaJobSelector()))
+	if err == nil && qr != nil && len(qr.Series) > 0 {
+		result.Available = true
+		result.Native = false
+		result.Message = "Beyla detected via Prometheus metrics"
+		result.Version = s.detectVersion(ctx)
+		return result, nil
+	}
+
+	// Phase 2: pod label fallback
+	if pods := s.countBeylaPods(ctx); pods > 0 {
+		result.Available = true
+		result.Native = false
+		result.Message = fmt.Sprintf("Beyla detected via %d running pod(s) (Alloy or standalone)", pods)
+		return result, nil
+	}
+
+	result.Message = "Beyla not detected. Install Alloy + Beyla for L7 traffic visibility."
+	return result, nil
+}
+
+func (s *BeylaSource) detectVersion(ctx context.Context) string {
+	qr, err := s.query(ctx, `beyla_build_info`)
+	if err != nil {
+		return ""
+	}
+	for _, series := range qr.Series {
+		if v := series.Labels["version"]; v != "" {
+			return v
+		}
+		if v := series.Labels["beyla_version"]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func (s *BeylaSource) countBeylaPods(ctx context.Context) int {
+	count := 0
+	for _, label := range []string{"app.kubernetes.io/name=alloy", "app.kubernetes.io/name=beyla"} {
+		pods, err := s.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: label})
+		if err != nil {
+			log.Printf("[beyla] Failed to list pods matching %s: %v", label, err)
+			continue
+		}
+		for i := range pods.Items {
+			if pods.Items[i].Status.Phase == corev1.PodRunning {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// l4Key uniquely identifies an L4 flow for dedup. Must include every label
+// beylaL4GroupBy groups by (dst_port, transport) — otherwise distinct series
+// (e.g. TCP and UDP to the same endpoint/port) collide and one is dropped.
+type l4Key struct {
+	srcNs, srcName string
+	dstNs, dstName string
+	dstPort        int
+	protocol       string
+}
+
+// dstKey identifies a destination workload only. Beyla's HTTP server-duration
+// metric is recorded server-side and carries no source labels at all — it
+// can't be paired by (src, dst) the way the network-flow metric can — so L7
+// results are matched onto L4 flows by destination alone.
+type dstKey struct {
+	dstNs, dstName string
+}
+
+func (s *BeylaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsResponse, error) {
+	flows, err := s.getFlowsInternal(ctx, opts)
+	if err != nil {
+		log.Printf("[beyla] Error fetching flows: %v", err)
+		return &FlowsResponse{Source: "beyla", Timestamp: time.Now(), Flows: []Flow{},
+			Warning: fmt.Sprintf("Failed to query Beyla metrics: %v", err)}, nil
+	}
+	return &FlowsResponse{Source: "beyla", Timestamp: time.Now(), Flows: flows}, nil
+}
+
+func (s *BeylaSource) getFlowsInternal(ctx context.Context, opts FlowOptions) ([]Flow, error) {
+	l4Flows, dstPorts, err := s.queryL4(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("L4 query: %w", err)
+	}
+
+	l7Flows, err := s.queryL7(ctx, opts)
+	if err != nil {
+		log.Printf("[beyla] L7 query failed (continuing with L4 only): %v", err)
+		l7Flows = nil
+	}
+
+	l4Map := make(map[l4Key]*Flow, len(l4Flows))
+	byDst := make(map[dstKey][]*Flow, len(l4Flows))
+	for i := range l4Flows {
+		f := &l4Flows[i]
+		l4Map[l4FlowKey(f)] = f
+		dst := dstKey{f.Destination.Namespace, f.Destination.Name}
+		byDst[dst] = append(byDst[dst], f)
+	}
+
+	// Merge L7 into L4 by destination only: the HTTP server-duration metric is
+	// recorded on the serving side and has no source labels, so there's no way
+	// to attribute a request to a particular caller. A destination may have
+	// several L4 edges (different callers/ports); each gets a share of the
+	// destination's total HTTP metadata. L7 series with no matching L4
+	// destination are dropped — without a source there's no edge to draw.
+	for _, l7 := range busiestL7PerDst(l7Flows) {
+		dst := dstKey{l7.Destination.Namespace, l7.Destination.Name}
+		existing, ok := byDst[dst]
+		if !ok {
+			continue
+		}
+		// The HTTP metric has no port label, so if this destination fans out
+		// over more than one distinct L4 port there's no way to tell which one
+		// is actually HTTP (e.g. an app port alongside a raw-TCP DB port) —
+		// skip rather than mislabel every port as HTTP. Checked against
+		// dstPorts (every port Beyla reported for this destination) rather
+		// than len(existing): a port can be dropped from existing/l4Map for
+		// having an unresolved (e.g. external) source name while still being
+		// the real HTTP port, and existing's remaining single port would
+		// otherwise look unambiguous.
+		if len(dstPorts[dst]) != 1 {
+			continue
+		}
+		// l7.RequestRate describes the whole destination, so it must be split
+		// across its L4 edges rather than copied onto each one — otherwise
+		// aggregation overcounts by the number of edges. Weight the split by
+		// each edge's L4 byte volume as the best available proxy for its share
+		// of the destination's request traffic.
+		var totalBytes int64
+		for _, f := range existing {
+			totalBytes += f.BytesSent + f.BytesRecv
+		}
+		for _, f := range existing {
+			f.L7Protocol = l7.L7Protocol
+			f.HTTPMethod = l7.HTTPMethod
+			f.HTTPPath = l7.HTTPPath
+			f.HTTPStatus = l7.HTTPStatus
+			if totalBytes > 0 {
+				share := float64(f.BytesSent+f.BytesRecv) / float64(totalBytes)
+				f.RequestRate = l7.RequestRate * share
+			} else {
+				f.RequestRate = l7.RequestRate / float64(len(existing))
+			}
+		}
+	}
+
+	result := make([]Flow, 0, len(l4Map))
+	for _, f := range l4Map {
+		result = append(result, *f)
+	}
+	return result, nil
+}
+
+func busiestL7PerDst(l7Flows []Flow) []Flow {
+	best := make(map[dstKey]Flow, len(l7Flows))
+	topRate := make(map[dstKey]float64, len(l7Flows))
+	for _, f := range l7Flows {
+		dst := dstKey{f.Destination.Namespace, f.Destination.Name}
+		cur, ok := best[dst]
+		if !ok {
+			best[dst], topRate[dst] = f, f.RequestRate
+			continue
+		}
+		// Rates cover the whole destination; the route/method/status shown is
+		// the busiest single series.
+		if f.RequestRate > topRate[dst] {
+			topRate[dst] = f.RequestRate
+			cur.HTTPMethod, cur.HTTPPath, cur.HTTPStatus = f.HTTPMethod, f.HTTPPath, f.HTTPStatus
+		}
+		cur.RequestRate += f.RequestRate
+		best[dst] = cur
+	}
+	out := make([]Flow, 0, len(best))
+	for _, f := range best {
+		out = append(out, f)
+	}
+	return out
+}
+
+func l4FlowKey(f *Flow) l4Key {
+	return l4Key{
+		srcNs: f.Source.Namespace, srcName: f.Source.Name,
+		dstNs: f.Destination.Namespace, dstName: f.Destination.Name,
+		dstPort: f.Port, protocol: f.Protocol,
+	}
+}
+
+const (
+	beylaL4GroupBy = `k8s_src_owner_name, k8s_src_namespace, k8s_src_owner_type, k8s_dst_owner_name, k8s_dst_namespace, k8s_dst_owner_type, dst_port, transport`
+	// beylaL7Metric is Beyla's OTel-aligned HTTP server histogram; there is no
+	// millisecond variant, and it carries no source-side labels at all (see
+	// beylaL7GroupBy below).
+	beylaL7Metric = "http_server_request_duration_seconds_count"
+	// beylaL7GroupBy labels come from http_server_request_duration_seconds,
+	// which is recorded server-side only. k8s_owner_name is Beyla's own
+	// resolved owner (Deployment/ReplicaSet/StatefulSet/DaemonSet, whichever
+	// applies) — the same concept as k8s_dst_owner_name on the L4 metric, so
+	// destinations from both metrics line up. No caller/source labels exist
+	// on this metric at all, unlike beyla_network_flow_bytes_total.
+	beylaL7GroupBy = `k8s_namespace_name, k8s_owner_name, k8s_pod_name, http_request_method, http_route, http_response_status_code`
+)
+
+// beylaRateQuery builds `sum by (groupBy) (rate(metric{job=~...}[5m]))`. A
+// namespace filter has to become two OR'd selectors: PromQL cannot express
+// "src OR dst namespace matches" inside a single label selector.
+func beylaRateQuery(groupBy, metric, namespace string) string {
+	sum := func(extra string) string {
+		return fmt.Sprintf(`sum by (%s) (rate(%s{%s%s}[5m]))`, groupBy, metric, beylaJobSelector(), extra)
+	}
+	if namespace == "" {
+		return sum("")
+	}
+	return sum(fmt.Sprintf(`, k8s_src_namespace=%q`, namespace)) + " or " +
+		sum(fmt.Sprintf(`, k8s_dst_namespace=%q`, namespace))
+}
+
+// beylaL7RateQuery builds the L7 query. Unlike beylaRateQuery, there's only
+// one namespace label to filter on (k8s_namespace_name) since the metric has
+// no source side.
+func beylaL7RateQuery(namespace string) string {
+	extra := ""
+	if namespace != "" {
+		extra = fmt.Sprintf(`, k8s_namespace_name=%q`, namespace)
+	}
+	return fmt.Sprintf(`sum by (%s) (rate(%s{%s%s}[5m]))`, beylaL7GroupBy, beylaL7Metric, beylaJobSelector(), extra)
+}
+
+func (s *BeylaSource) queryL4(ctx context.Context, opts FlowOptions) ([]Flow, map[dstKey]map[int]struct{}, error) {
+	query := beylaRateQuery(beylaL4GroupBy, "beyla_network_flow_bytes_total", opts.Namespace)
+	result, err := s.query(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	flows, dstPorts := s.parseL4Flows(result)
+	return flows, dstPorts, nil
+}
+
+func (s *BeylaSource) queryL7(ctx context.Context, opts FlowOptions) ([]Flow, error) {
+	query := beylaL7RateQuery(opts.Namespace)
+	result, err := s.query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return s.parseL7Flows(result), nil
+}
+
+// parseL4Flows returns the L4 flows plus, separately, every distinct
+// destination port Beyla reported traffic on for each destination —
+// including ports whose flow got dropped below for an unresolved source
+// name. Callers that need to know whether a destination is unambiguously
+// single-port (e.g. before trusting L7 HTTP metadata has the right target)
+// must use the latter, not the port set of the returned flows: a real HTTP
+// port can be the one that gets dropped (external caller, no owner name),
+// leaving a surviving non-HTTP port that would otherwise look unambiguous.
+func (s *BeylaSource) parseL4Flows(result *prom.QueryResult) ([]Flow, map[dstKey]map[int]struct{}) {
+	if result == nil {
+		return nil, nil
+	}
+	flows := make([]Flow, 0, len(result.Series))
+	dstPorts := make(map[dstKey]map[int]struct{})
+	for _, series := range result.Series {
+		labels := series.Labels
+		if len(series.DataPoints) == 0 {
+			continue
+		}
+		val := series.DataPoints[0].Value
+		if val <= 0 {
+			continue
+		}
+
+		srcName := pickLabel(labels, "k8s_src_owner_name", "k8s_src_name")
+		srcNs := labels["k8s_src_namespace"]
+		srcType := pickLabel(labels, "k8s_src_owner_type", "k8s_src_type")
+		dstName := pickLabel(labels, "k8s_dst_owner_name", "k8s_dst_name")
+		dstNs := labels["k8s_dst_namespace"]
+		dstType := pickLabel(labels, "k8s_dst_owner_type", "k8s_dst_type")
+		port := parseIntLabel(labels["dst_port"])
+
+		if dstName != "" {
+			dst := dstKey{dstNs, dstName}
+			if dstPorts[dst] == nil {
+				dstPorts[dst] = make(map[int]struct{})
+			}
+			dstPorts[dst][port] = struct{}{}
+		}
+
+		// A nameless endpoint renders as an anonymous node the UI can't resolve
+		// or navigate to, so drop the series rather than emit a phantom.
+		if srcName == "" || dstName == "" {
+			continue
+		}
+
+		flow := Flow{
+			Source:      Endpoint{Name: srcName, Namespace: srcNs, Kind: mapBeylaKind(srcType), Workload: srcName},
+			Destination: Endpoint{Name: dstName, Namespace: dstNs, Kind: mapBeylaKind(dstType), Workload: dstName, Port: port},
+			Protocol:    mapBeylaTransport(labels["transport"]),
+			Port:        port,
+			Verdict:     "forwarded",
+			LastSeen:    time.Now(),
+			BytesSent:   int64(val * beylaRateWindowSeconds),
+			Connections: 1,
+		}
+
+		if flow.Source.Namespace == "" && flow.Source.Name != "" {
+			flow.Source.Kind = "External"
+		}
+		if flow.Destination.Namespace == "" && flow.Destination.Name != "" {
+			flow.Destination.Kind = "External"
+		}
+
+		flows = append(flows, flow)
+	}
+	return flows, dstPorts
+}
+
+// parseL7Flows reads http_server_request_duration_seconds_count series. The
+// metric is server-side only, so Source is left empty here — getFlowsInternal
+// attaches the caller identity from the matching L4 flow(s) instead.
+func (s *BeylaSource) parseL7Flows(result *prom.QueryResult) []Flow {
+	if result == nil {
+		return nil
+	}
+	flows := make([]Flow, 0, len(result.Series))
+	for _, series := range result.Series {
+		labels := series.Labels
+		if len(series.DataPoints) == 0 {
+			continue
+		}
+		val := series.DataPoints[0].Value
+		if val <= 0 {
+			continue
+		}
+
+		dstNs := labels["k8s_namespace_name"]
+		dstName, dstKind := pickBeylaOwner(labels)
+		if dstName == "" {
+			continue
+		}
+
+		flow := Flow{
+			Destination: Endpoint{Name: dstName, Namespace: dstNs, Kind: dstKind, Workload: dstName},
+			L7Protocol:  "HTTP",
+			HTTPMethod:  labels["http_request_method"],
+			HTTPPath:    labels["http_route"],
+			HTTPStatus:  parseIntLabel(labels["http_response_status_code"]),
+			Verdict:     "forwarded",
+			LastSeen:    time.Now(),
+			// val is a per-second request rate over a 5m window, not a
+			// connection count; Connections here is only a non-zero weight for
+			// downstream aggregation.
+			RequestRate: val,
+			Connections: max(int64(val*beylaRateWindowSeconds), 1),
+		}
+
+		flows = append(flows, flow)
+	}
+	return flows
+}
+
+// pickBeylaOwner resolves the destination workload name Beyla attached to an
+// HTTP server-duration series. k8s_owner_name is Beyla's own resolved owner —
+// the same value beyla_network_flow_bytes_total exposes as k8s_dst_owner_name
+// — so L7 results line up with L4 destinations for the same workload; a bare
+// Pod (no owner) falls back to its pod name.
+func pickBeylaOwner(labels map[string]string) (name, kind string) {
+	switch {
+	case labels["k8s_owner_name"] != "":
+		return labels["k8s_owner_name"], "Workload"
+	case labels["k8s_pod_name"] != "":
+		return labels["k8s_pod_name"], "Pod"
+	default:
+		return "", ""
+	}
+}
+
+func pickLabel(labels map[string]string, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := labels[k]; ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func parseIntLabel(s string) int {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func mapBeylaKind(beylaType string) string {
+	switch strings.ToLower(beylaType) {
+	case "pod":
+		return "Pod"
+	case "deployment", "replicaset", "statefulset", "daemonset":
+		return "Workload"
+	case "service":
+		return "Service"
+	default:
+		return "Pod"
+	}
+}
+
+func mapBeylaTransport(transport string) string {
+	switch strings.ToUpper(transport) {
+	case "TCP":
+		return "tcp"
+	case "UDP":
+		return "udp"
+	default:
+		return "tcp"
+	}
+}
+
+func (s *BeylaSource) StreamFlows(ctx context.Context, opts FlowOptions) (<-chan Flow, error) {
+	flowCh := make(chan Flow, 100)
+	go func() {
+		defer close(flowCh)
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				response, err := s.GetFlows(ctx, opts)
+				if err != nil {
+					log.Printf("[beyla] Error fetching flows: %v", err)
+					continue
+				}
+				for _, flow := range response.Flows {
+					select {
+					case flowCh <- flow:
+					case <-ctx.Done():
+						return
+					default:
+					}
+				}
+			}
+		}
+	}()
+	return flowCh, nil
+}

--- a/internal/traffic/beyla_test.go
+++ b/internal/traffic/beyla_test.go
@@ -1,0 +1,470 @@
+package traffic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/pkg/prom"
+)
+
+func TestBeylaSource_Detect_MetricProbe(t *testing.T) {
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector", promSeries(map[string]string{}, 42)), nil
+		}
+		if strings.Contains(query, "beyla_build_info") {
+			return promResult("vector", promSeries(map[string]string{"version": "1.0.0"}, 1)), nil
+		}
+		return emptyResult(), nil
+	}
+
+	result, err := src.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Available {
+		t.Fatal("expected available=true")
+	}
+	if result.Native {
+		t.Error("expected Native=false")
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", result.Version, "1.0.0")
+	}
+}
+
+func TestBeylaSource_Detect_LabelFallback_Alloy(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alloy-abc",
+			Namespace: "monitoring",
+			Labels:    map[string]string{"app.kubernetes.io/name": "alloy"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset(pod)}
+	src.queryFn = func(_ context.Context, _ string) (*prom.QueryResult, error) {
+		return nil, fmt.Errorf("prometheus not available")
+	}
+
+	result, err := src.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Available {
+		t.Fatal("expected available=true via label fallback")
+	}
+}
+
+func TestBeylaSource_Detect_LabelFallback_Beyla(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "beyla-xyz",
+			Namespace: "default",
+			Labels:    map[string]string{"app.kubernetes.io/name": "beyla"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset(pod)}
+	src.queryFn = func(_ context.Context, _ string) (*prom.QueryResult, error) {
+		return nil, fmt.Errorf("prometheus not available")
+	}
+
+	result, err := src.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Available {
+		t.Fatal("expected available=true via standalone beyla label fallback")
+	}
+}
+
+func TestBeylaSource_Detect_NotAvailable(t *testing.T) {
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, _ string) (*prom.QueryResult, error) {
+		return nil, fmt.Errorf("prometheus not available")
+	}
+
+	result, err := src.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Available {
+		t.Fatal("expected available=false")
+	}
+}
+
+func TestBeylaSource_GetFlows_OwnerLevel(t *testing.T) {
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector", promSeries(map[string]string{
+				"k8s_src_owner_name": "frontend", "k8s_src_namespace": "web",
+				"k8s_src_owner_type": "Deployment",
+				"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+				"k8s_dst_owner_type": "Deployment",
+				"dst_port":           "8080", "transport": "TCP",
+			}, 15.5)), nil
+		}
+		return emptyResult(), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 1 {
+		t.Fatalf("expected 1 flow, got %d", len(resp.Flows))
+	}
+	f := resp.Flows[0]
+	assertEq(t, "source name", f.Source.Name, "frontend")
+	assertEq(t, "source namespace", f.Source.Namespace, "web")
+	assertEq(t, "source kind", f.Source.Kind, "Workload")
+	assertEq(t, "dest name", f.Destination.Name, "backend")
+	assertEq(t, "dest kind", f.Destination.Kind, "Workload")
+	assertEq(t, "port", fmt.Sprintf("%d", f.Port), "8080")
+	assertEq(t, "protocol", f.Protocol, "tcp")
+	assertEq(t, "verdict", f.Verdict, "forwarded")
+	if f.Connections == 0 {
+		t.Error("expected non-zero connections")
+	}
+}
+
+func TestBeylaSource_GetFlows_L7OnlyDroppedWithoutL4Match(t *testing.T) {
+	// http_server_request_duration_seconds has no source labels, so an L7
+	// series with no matching L4 destination can't be drawn as an edge and
+	// must be dropped rather than emitted as a sourceless flow.
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return emptyResult(), nil
+		}
+		return promResult("vector", promSeries(map[string]string{
+			"k8s_namespace_name": "api", "k8s_owner_name": "backend",
+			"http_request_method": "GET", "http_route": "/api/users", "http_response_status_code": "200",
+		}, 8.0)), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 0 {
+		t.Fatalf("expected 0 flows (no L4 match to attach HTTP metadata to), got %d", len(resp.Flows))
+	}
+}
+
+func TestBeylaSource_GetFlows_L4PlusL7(t *testing.T) {
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector", promSeries(map[string]string{
+				"k8s_src_owner_name": "frontend", "k8s_src_namespace": "web",
+				"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+				"dst_port": "8080", "transport": "TCP",
+			}, 10.0)), nil
+		}
+		return promResult("vector", promSeries(map[string]string{
+			"k8s_namespace_name": "api", "k8s_owner_name": "backend",
+			"http_request_method": "POST", "http_route": "/api/orders", "http_response_status_code": "201",
+		}, 5.0)), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 1 {
+		t.Fatalf("expected 1 merged flow, got %d", len(resp.Flows))
+	}
+	f := resp.Flows[0]
+	assertEq(t, "httpMethod", f.HTTPMethod, "POST")
+	assertEq(t, "httpPath", f.HTTPPath, "/api/orders")
+	assertEq(t, "httpStatus", fmt.Sprintf("%d", f.HTTPStatus), "201")
+	assertEq(t, "l7Protocol", f.L7Protocol, "HTTP")
+	assertEq(t, "port", fmt.Sprintf("%d", f.Port), "8080")
+	assertEq(t, "source name", f.Source.Name, "frontend")
+}
+
+func TestBeylaSource_GetFlows_L7SkippedWhenDestinationHasMultiplePorts(t *testing.T) {
+	// http_server_request_duration_seconds carries no port label, so a
+	// destination fanning out over 2 L4 ports (e.g. an app port plus a raw-TCP
+	// DB port) can't be safely tagged with HTTP metadata on either edge.
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector",
+				promSeries(map[string]string{
+					"k8s_src_owner_name": "frontend", "k8s_src_namespace": "web",
+					"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+					"dst_port": "8080", "transport": "TCP",
+				}, 10.0),
+				promSeries(map[string]string{
+					"k8s_src_owner_name": "frontend", "k8s_src_namespace": "web",
+					"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+					"dst_port": "5432", "transport": "TCP",
+				}, 3.0),
+			), nil
+		}
+		return promResult("vector", promSeries(map[string]string{
+			"k8s_namespace_name": "api", "k8s_owner_name": "backend",
+			"http_request_method": "POST", "http_route": "/api/orders", "http_response_status_code": "201",
+		}, 5.0)), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 2 {
+		t.Fatalf("expected 2 L4-only flows, got %d", len(resp.Flows))
+	}
+	for _, f := range resp.Flows {
+		if f.L7Protocol != "" {
+			t.Errorf("port %d: expected no HTTP metadata attached, got L7Protocol=%q", f.Port, f.L7Protocol)
+		}
+	}
+}
+
+func TestBeylaSource_GetFlows_TCPAndUDPSameEndpointBothSurvive(t *testing.T) {
+	// Same src/dst/port but different transport (e.g. DNS on 53) must not
+	// collide in l4Map — l4Key needs transport in addition to port.
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector",
+				promSeries(map[string]string{
+					"k8s_src_owner_name": "app", "k8s_src_namespace": "web",
+					"k8s_dst_owner_name": "coredns", "k8s_dst_namespace": "kube-system",
+					"dst_port": "53", "transport": "TCP",
+				}, 4.0),
+				promSeries(map[string]string{
+					"k8s_src_owner_name": "app", "k8s_src_namespace": "web",
+					"k8s_dst_owner_name": "coredns", "k8s_dst_namespace": "kube-system",
+					"dst_port": "53", "transport": "UDP",
+				}, 20.0),
+			), nil
+		}
+		return emptyResult(), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 2 {
+		t.Fatalf("expected 2 flows (TCP and UDP both surviving), got %d", len(resp.Flows))
+	}
+	protocols := map[string]bool{}
+	for _, f := range resp.Flows {
+		protocols[f.Protocol] = true
+	}
+	if !protocols["tcp"] || !protocols["udp"] {
+		t.Errorf("expected both tcp and udp flows to survive, got %v", protocols)
+	}
+}
+
+func TestBeylaSource_GetFlows_L7SkippedWhenRealHTTPPortDroppedForUnnamedSource(t *testing.T) {
+	// The destination has HTTP traffic on 8080 from an external caller Beyla
+	// can't name (dropped from l4Map/byDst), plus unrelated in-cluster TCP
+	// traffic on 5432. Only port 5432 survives into byDst, but the port-count
+	// guard must still see 2 real ports for this destination and skip
+	// attaching HTTP metadata to the surviving non-HTTP port.
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector",
+				promSeries(map[string]string{
+					// no k8s_src_owner_name/k8s_src_name: unresolved external caller
+					"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+					"dst_port": "8080", "transport": "TCP",
+				}, 10.0),
+				promSeries(map[string]string{
+					"k8s_src_owner_name": "worker", "k8s_src_namespace": "jobs",
+					"k8s_dst_owner_name": "backend", "k8s_dst_namespace": "api",
+					"dst_port": "5432", "transport": "TCP",
+				}, 3.0),
+			), nil
+		}
+		return promResult("vector", promSeries(map[string]string{
+			"k8s_namespace_name": "api", "k8s_owner_name": "backend",
+			"http_request_method": "GET", "http_route": "/health", "http_response_status_code": "200",
+		}, 5.0)), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 1 {
+		t.Fatalf("expected 1 flow (only port 5432 survives naming), got %d", len(resp.Flows))
+	}
+	if resp.Flows[0].L7Protocol != "" {
+		t.Errorf("port %d: expected no HTTP metadata attached to the non-HTTP port, got L7Protocol=%q",
+			resp.Flows[0].Port, resp.Flows[0].L7Protocol)
+	}
+}
+
+func TestBeylaSource_ParseL7Flows_OwnerFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		wantName string
+		wantKind string
+	}{
+		{"owner name", map[string]string{"k8s_owner_name": "backend"}, "backend", "Workload"},
+		{"pod fallback", map[string]string{"k8s_pod_name": "backend-abc123"}, "backend-abc123", "Pod"},
+	}
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := map[string]string{
+				"k8s_namespace_name": "api", "http_request_method": "GET",
+				"http_route": "/x", "http_response_status_code": "200",
+			}
+			for k, v := range tt.labels {
+				labels[k] = v
+			}
+			flows := src.parseL7Flows(promResult("vector", promSeries(labels, 1.0)))
+			if len(flows) != 1 {
+				t.Fatalf("expected 1 flow, got %d", len(flows))
+			}
+			assertEq(t, "dest name", flows[0].Destination.Name, tt.wantName)
+			assertEq(t, "dest kind", flows[0].Destination.Kind, tt.wantKind)
+		})
+	}
+}
+
+func TestBeylaSource_GetFlows_NamespaceFilter(t *testing.T) {
+	var capturedQuery string
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		capturedQuery = query
+		return emptyResult(), nil
+	}
+
+	_, err := src.GetFlows(context.Background(), FlowOptions{Namespace: "test-ns"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedQuery, "test-ns") {
+		t.Errorf("expected namespace filter in query, got: %s", capturedQuery)
+	}
+}
+
+func TestBeylaSource_GetFlows_FallbackToOwner(t *testing.T) {
+	src := &BeylaSource{k8sClient: fake.NewSimpleClientset()}
+	src.queryFn = func(_ context.Context, query string) (*prom.QueryResult, error) {
+		if strings.Contains(query, "beyla_network_flow_bytes_total") {
+			return promResult("vector", promSeries(map[string]string{
+				"k8s_src_owner_name": "api", "k8s_src_namespace": "backend",
+				"k8s_dst_owner_name": "db", "k8s_dst_namespace": "data",
+				"k8s_src_owner_type": "Deployment", "k8s_dst_owner_type": "StatefulSet",
+				"dst_port": "5432", "transport": "TCP",
+			}, 3.0)), nil
+		}
+		return emptyResult(), nil
+	}
+
+	resp, err := src.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Flows) != 1 {
+		t.Fatalf("expected 1 flow, got %d", len(resp.Flows))
+	}
+	f := resp.Flows[0]
+	assertEq(t, "source kind", f.Source.Kind, "Workload")
+	assertEq(t, "dest kind", f.Destination.Kind, "Workload")
+	assertEq(t, "port", fmt.Sprintf("%d", f.Port), "5432")
+}
+
+func TestBeylaSource_MapBeylaKind(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"Pod", "Pod"}, {"Deployment", "Workload"}, {"ReplicaSet", "Workload"},
+		{"StatefulSet", "Workload"}, {"DaemonSet", "Workload"}, {"Service", "Service"},
+		{"Unknown", "Pod"}, {"pod", "Pod"}, {"deployment", "Workload"},
+	}
+	for _, tt := range tests {
+		if got := mapBeylaKind(tt.input); got != tt.want {
+			t.Errorf("mapBeylaKind(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBeylaSource_MapBeylaTransport(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"TCP", "tcp"}, {"UDP", "udp"}, {"tcp", "tcp"}, {"Tcp", "tcp"}, {"", "tcp"},
+	}
+	for _, tt := range tests {
+		if got := mapBeylaTransport(tt.input); got != tt.want {
+			t.Errorf("mapBeylaTransport(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestManager_DetectSources_IncludesBeyla(t *testing.T) {
+	m := &Manager{sources: make(map[string]TrafficSource)}
+	m.sources["beyla"] = NewBeylaSource(fake.NewSimpleClientset())
+	if _, ok := m.sources["beyla"]; !ok {
+		t.Fatal("expected 'beyla' in sources map")
+	}
+}
+
+func TestBeylaSource_QueryL4_NamespaceFilterIsValidPromQL(t *testing.T) {
+	q := beylaRateQuery(beylaL4GroupBy, "beyla_network_flow_bytes_total", "test-ns")
+	if !strings.Contains(q, `k8s_src_namespace="test-ns"}`) || !strings.Contains(q, `k8s_dst_namespace="test-ns"}`) {
+		t.Errorf("namespace matchers must live inside the label selector, got: %s", q)
+	}
+	if strings.Contains(q, " and (") {
+		t.Errorf("bare label matchers after `and` are not valid PromQL, got: %s", q)
+	}
+}
+
+func TestBeylaSource_QueryL7_UsesCorrectMetricAndLabels(t *testing.T) {
+	q := beylaL7RateQuery("test-ns")
+	if !strings.Contains(q, "http_server_request_duration_seconds_count") {
+		t.Errorf("expected the OTel-aligned Beyla HTTP server metric, got: %s", q)
+	}
+	if !strings.Contains(q, `k8s_namespace_name="test-ns"}`) {
+		t.Errorf("expected a single k8s_namespace_name matcher inside the label selector, got: %s", q)
+	}
+	if strings.Contains(q, "k8s_src_owner_name") || strings.Contains(q, "k8s_dst_owner_name") {
+		t.Errorf("L7 query must not reference network-flow-only owner labels, got: %s", q)
+	}
+}
+
+// --- test helpers ---
+
+func promResult(resultType string, series ...prom.Series) *prom.QueryResult {
+	return &prom.QueryResult{ResultType: resultType, Series: series}
+}
+
+func promSeries(labels map[string]string, value float64) prom.Series {
+	return prom.Series{
+		Labels:     labels,
+		DataPoints: []prom.DataPoint{{Value: value}},
+	}
+}
+
+func emptyResult() *prom.QueryResult {
+	return &prom.QueryResult{ResultType: "vector", Series: []prom.Series{}}
+}
+
+func assertEq(t *testing.T, label, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %q, want %q", label, got, want)
+	}
+}

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -44,6 +44,9 @@ var (
 	// configuredMetricsHeaders are sent with every Prometheus query — required
 	// for auth-protected backends. Also persists across context switches.
 	configuredMetricsHeaders map[string]string
+	// configuredBeylaJobSelector overrides the default `job` label matcher used
+	// to scope Beyla's Prometheus queries; empty means use the built-in default.
+	configuredBeylaJobSelector string
 )
 
 // SetMetricsURL sets a manual Prometheus/VictoriaMetrics URL, bypassing auto-discovery.
@@ -65,6 +68,24 @@ func SetMetricsHeaders(h map[string]string) {
 	out := make(map[string]string, len(h))
 	maps.Copy(out, h)
 	configuredMetricsHeaders = out
+}
+
+// SetBeylaJobSelector overrides the `job` label matcher fragment (e.g.
+// `job=~".*beyla.*"`) Beyla queries use to scope which Prometheus series they
+// read — for a cluster where Alloy or Beyla runs under a non-default job
+// name. Pass "" to restore the default.
+func SetBeylaJobSelector(selector string) {
+	metricsConfigMu.Lock()
+	defer metricsConfigMu.Unlock()
+	configuredBeylaJobSelector = selector
+}
+
+// BeylaJobSelector returns the configured Beyla job-label matcher fragment,
+// or "" if unset.
+func BeylaJobSelector() string {
+	metricsConfigMu.RLock()
+	defer metricsConfigMu.RUnlock()
+	return configuredBeylaJobSelector
 }
 
 // metricsConfig returns the configured URL + headers under the read lock.
@@ -98,6 +119,7 @@ func InitializeWithConfig(client kubernetes.Interface, config *rest.Config, cont
 		caretta.headers = metricsHeaders
 		manager.sources["caretta"] = caretta
 		manager.sources["istio"] = NewIstioSource(client)
+		manager.sources["beyla"] = NewBeylaSource(client)
 
 		// Set K8s clients for port-forward functionality
 		if config != nil {
@@ -132,8 +154,8 @@ func (m *Manager) DetectSources(ctx context.Context) (*SourcesResponse, error) {
 	}
 
 	// Check each registered source in deterministic priority order
-	// (hubble has deepest visibility, istio has L7 metrics, caretta is fallback)
-	sourceOrder := []string{"hubble", "istio", "caretta"}
+	// (hubble has deepest visibility, istio has L7 metrics, caretta is fallback, beyla is external eBPF)
+	sourceOrder := []string{"hubble", "istio", "caretta", "beyla"}
 	for _, name := range sourceOrder {
 		source, ok := m.sources[name]
 		if !ok {
@@ -541,6 +563,8 @@ func (m *Manager) Connect(ctx context.Context) (*portforward.ConnectionInfo, err
 	case *HubbleSource:
 		return s.Connect(ctx, contextName)
 	case *IstioSource:
+		return s.Connect(ctx, contextName)
+	case *BeylaSource:
 		return s.Connect(ctx, contextName)
 	default:
 		// For sources without Connect support, just report connected.


### PR DESCRIPTION
## Description

Adds **Grafana Beyla** as a fourth traffic source, alongside Hubble, Istio and Caretta.

Beyla derives network flows from eBPF without requiring a service mesh or CNI-level
integration, which makes it the first traffic source that works on a plain cluster.
Radar reads its metrics from any Prometheus-compatible endpoint - Prometheus, Mimir,
or whatever Alloy remote-writes to - rather than talking to Beyla directly.

## Implementation

- `BeylaSource` implementing the `TrafficSource` interface: `Connect`, `Detect`,
  `GetFlows`, `StreamFlows`, `Close`
- Detection probes `beyla_network_flow_bytes_total`, with a pod-label fallback that
  recognises both Alloy-embedded and standalone Beyla deployments
- **L4** flows built from `beyla_network_flow_bytes_total`, keyed on owner-level
  attributes (`k8s_src_owner_name` / `k8s_dst_owner_name`) so edges land on
  Deployments rather than individual pods
- **L7** enrichment (HTTP method/route/status) comes from
  `http_server_request_duration_seconds`, matched onto L4 flows by **destination
  only**. That metric is recorded server-side and carries no source-side labels at
  all, so pairing by (src, dst) the way L4 does isn't possible. The destination
  workload is resolved from Beyla's own `k8s_owner_name` label - the same value the
  L4 metric exposes as `k8s_dst_owner_name` - rather than a hand-built
  Deployment/ReplicaSet/StatefulSet/DaemonSet fallback chain, so both metrics agree
  on the same destination identity.
- A destination's `RequestRate` is split across its L4 edges weighted by byte share
  (an even split when no bytes are available), rather than copied onto each edge
  verbatim - copying it would overcount by the number of edges.
- Enrichment is skipped when a destination has more than one distinct port, since
  the L7 metric has no port label to say which one is actually HTTP (e.g. an app
  port alongside a raw-TCP DB port on the same workload). The port count is taken
  from *every* port Beyla reported for that destination, not just the ports that
  survived into the result - an L4 series with an unresolved source name (e.g. an
  external caller Beyla can't name) is dropped from the output but still counted
  here, so a destination whose real HTTP port drops out doesn't look falsely
  single-port and get HTTP metadata attached to an unrelated surviving port.
- `--beyla-job-selector` flag overrides the default PromQL `job` label matcher
  (`job=~".*beyla.*|.*alloy.*"`) for clusters running Alloy/Beyla under a
  non-standard job name
- Manager wiring: registration and priority ordering - Beyla is tried last, so an
  existing Hubble or Istio install still wins

## Notes for reviewers

- Namespace filtering on the **L4** query is emitted as two OR'd selectors
  (`sum(...{src="ns"}) or sum(...{dst="ns"})`). PromQL cannot express "src OR dst
  namespace" inside a single selector - a bare matcher after `and` is a parse
  error, not just a stylistic issue. This matches the idiom already used in
  `istio.go`. The **L7** query doesn't need this: since the metric has no source
  side, it filters on a single `k8s_namespace_name` matcher.
- `l4Key` includes `transport` in addition to `dst_port` - two series to the same
  (src, dst, port) but different transport (e.g. DNS on port 53, TCP vs UDP) would
  otherwise collide in `l4Map` and one would silently overwrite the other.
- `Connections` is used downstream in `pkg/traffic/aggregation.go` as an
  aggregation weight (`agg.Connections`, and the weight for L7-protocol voting), so
  it's kept explicitly non-zero on every flow. It's not the same thing as
  `RequestRate`: `BytesSent` (L4) and `Connections` (both) are derived from the
  Prometheus rate by multiplying back up by the 5m window; `RequestRate` (L7) is
  kept as the rate itself and used as-is downstream.
- Series with an empty source or destination name are dropped rather than emitted
  as anonymous nodes the UI cannot resolve or navigate to.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

Purely additive - the source is only used when detected, and detection is
last in priority order, so existing Hubble/Istio/Caretta users see no change.

## How has this been tested?

- [x] Tested locally with minikube/kind (and deployed Grafana-Beyla as Daemonset)
- [x] Added/updated unit tests

<img width="3831" height="2029" alt="radar_with_beyla" src="https://github.com/user-attachments/assets/579cb736-de2f-4188-9f0a-799d2d08e0a7" />
<img width="3820" height="2046" alt="radar_with_beyla_2" src="https://github.com/user-attachments/assets/08f7c7da-9827-4723-84c2-46e1829b1f70" />

#### Unit tests

18 test functions covering metric-probe and pod-label detection, owner-level and
extended-label flows, the L4+L7 merge (destination-only matching, the multi-port
skip guard, TCP/UDP key collision, and HTTP metadata misattachment when the real
HTTP port has an unresolved source name), namespace filtering, kind/transport
mapping, and PromQL shape assertions for both L4 and L7 queries.

#### Live validation - L4 (original testing session)

Validated end-to-end on a `kind` cluster running Beyla (DaemonSet, `hostPID` +
`hostNetwork`), Alloy scraping via ServiceMonitor, and Mimir as the query backend:

| Check | Result |
|---|---|
| `Detect` | `available=true`, "Beyla detected via Prometheus metrics" |
| `GetFlows` | 418 flows |
| Namespace filter | `demo-backend` → 24, `demo-frontend` → 223, no cross-namespace leakage |

Representative flows:

```
demo-frontend/frontend (Workload) -> demo-backend/backend (Workload)  port=80 tcp  bytes=1649148
demo-frontend/frontend (Workload) -> kube-system/coredns  (Workload)  port=53 udp  bytes=784348
demo-frontend/frontend (Workload) -> kube-system/kube-dns (Service)   port=53 udp  bytes=587614
```

At this point the L7 path was still unvalidated: Beyla's application-level probes
failed to load on the test kernel (WSL2) with `BPF program is too large. Processed
1000001 insn`, so no HTTP metrics existed to exercise the merge against, and the
metric name (`http_request_duration_milliseconds_count`, guessed rather than
confirmed) turned out to be wrong - see below.

A build-tagged live test (`//go:build livebeyla`) is included so this is
reproducible; it is excluded from normal builds and CI.

#### Live validation - L7 (follow-up session, different cluster)

The wrong metric name was caught in review and confirmed against Beyla's own
`docs/sources/metrics.md`: Beyla exports `http_server_request_duration_seconds`
(OTel-aligned, seconds not ms), with `http_request_method` / `http_route` /
`http_response_status_code` / `k8s_owner_name` labels - not the network-flow-style
labels this PR originally queried. The L7 merge was redesigned around
destination-only matching to fit the metric's actual shape (see Implementation).

Re-ran the `livebeyla` suite against a live Mimir + Beyla v3.28.0 install (a
different cluster than the one above, kernel not affected by the WSL2 BPF-size
issue): `demo-frontend/frontend -> demo-backend/backend` came back correctly
enriched with `l7=HTTP GET /missing`, and the live metric/label names matched
exactly what the code now queries. `Detect`, `GetFlows`, and namespace filtering
all passed against real data.

One live-only finding: this cluster's Beyla config deliberately drops `dst.port`
from `beyla_network_flow_bytes`'s attribute selection (ephemeral UDP ports were
blowing past Mimir's per-series cardinality limit) - a legitimate, common
operational trade-off. Under that config every L4 flow reports `port=0`, so the
multi-port skip guard can never trigger there - every destination looks trivially
single-port. This degrades gracefully (no crash, no wrong data on *this* cluster),
but it does mean clusters that disable per-port cardinality on L4 lose the guard's
protection: if a destination genuinely serves both an HTTP port and a non-HTTP
port, there's no signal left to tell them apart. Querying the live metric directly
did show a `server_port` label on `http_server_request_duration_seconds_count`
itself, so a future fix could match L7 to L4 by exact port when both metrics carry
one - that's not implemented here, filed as a known limitation rather than
blocking.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Part-Of and Closes #1205


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive traffic integration with last-priority selection; existing Hubble/Istio/Caretta behavior is unchanged unless Beyla is the only detected source.
> 
> **Overview**
> Adds **Grafana Beyla** (standalone or via Alloy) as a fourth Traffic view source, reading eBPF network and HTTP metrics from Prometheus instead of talking to Beyla directly.
> 
> A new `BeylaSource` implements the existing `TrafficSource` contract: detection probes `beyla_network_flow_bytes_total` (with Alloy/Beyla pod-label fallback), builds L4 edges from owner-level labels, and enriches them from `http_server_request_duration_seconds_count` matched by **destination only** (the HTTP metric has no caller labels). L7 metadata is skipped when a workload exposes more than one L4 port, and request rates are split across edges by byte share to avoid overcounting.
> 
> Wiring includes manager registration, detection order **Hubble → Istio → Caretta → Beyla** (Beyla only wins when nothing else is available), Prometheus `Connect` handling, and **`--beyla-job-selector`** to override the default `job=~".*beyla.*|.*alloy.*"` PromQL scope. README Traffic docs are updated accordingly; unit tests cover detection, merge edge cases, and PromQL shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0d03555eaf43f0b1b25fb661d634bc4db89d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

