### PR TITLE
Detect duplicate environment variables in workloads

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -149,6 +149,8 @@ func classifyProblem(in classifyInput) issuesapi.Category {
 	switch in.Reason {
 	case "CoreDNS NXDOMAIN override", "CoreDNS service DNS rewrite":
 		return issuesapi.CategoryDNSFailure
+	case "DuplicateEnvVar":
+		return issuesapi.CategoryInvalidConfiguration
 	case "Missing referenced Service":
 		return issuesapi.CategoryMissingConfigRef
 	case "Service port mismatch":

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -30,6 +30,9 @@ func TestClassify(t *testing.T) {
 		{"coredns service rewrite", classifyInput{Source: SourceProblem, Kind: "ConfigMap", Reason: "CoreDNS service DNS rewrite"}, issuesapi.CategoryDNSFailure},
 		{"env missing service", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "Missing referenced Service"}, issuesapi.CategoryMissingConfigRef},
 		{"env service port mismatch", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "Service port mismatch"}, issuesapi.CategoryMissingConfigRef},
+		{"deployment duplicate env", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
+		{"job duplicate env is not job failure", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
+		{"cronjob duplicate env", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
 
 		// problem / Pod
 		{"image pull backoff", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ImagePullBackOff"}, issuesapi.CategoryImagePullFailed},

--- a/internal/k8s/detect_config.go
+++ b/internal/k8s/detect_config.go
@@ -31,6 +31,7 @@ func detectConfigProblems(cache *ResourceCache, namespace string, now time.Time)
 		out = append(out, detectSuspiciousCoreDNS(cache, now)...)
 	}
 	out = append(out, detectEnvServiceRefs(cache, namespace, now)...)
+	out = append(out, detectDuplicateEnvVars(cache, namespace, now)...)
 	return out
 }
 
@@ -131,6 +132,124 @@ type EnvServiceRefCheck struct {
 	ServicePorts     []string
 	Message          string
 	AgeSeconds       int64
+}
+
+type DuplicateEnvVarOccurrence struct {
+	Position int
+	Value    string
+}
+
+type DuplicateEnvVarCheck struct {
+	WorkloadGroup     string
+	WorkloadKind      string
+	Namespace         string
+	WorkloadName      string
+	Container         string
+	EnvName           string
+	Occurrences       []DuplicateEnvVarOccurrence
+	LastDeclaredValue string
+	Message           string
+	AgeSeconds        int64
+}
+
+const maxDuplicateEnvVarMessageOccurrences = 5
+
+func detectDuplicateEnvVars(cache *ResourceCache, namespace string, now time.Time) []Detection {
+	checks := findDuplicateEnvVarChecks(envServiceWorkloads(cache, namespace), now)
+	out := make([]Detection, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, Detection{
+			Kind:        check.WorkloadKind,
+			Group:       check.WorkloadGroup,
+			Namespace:   check.Namespace,
+			Name:        check.WorkloadName,
+			Severity:    "warning",
+			Reason:      "DuplicateEnvVar",
+			Message:     check.Message,
+			Age:         FormatAge(time.Duration(check.AgeSeconds) * time.Second),
+			AgeSeconds:  check.AgeSeconds,
+			Fingerprint: fmt.Sprintf("dup-env:%s:%s:%s:%s", check.Namespace, check.WorkloadName, check.Container, check.EnvName),
+		})
+	}
+	return out
+}
+
+// FindDuplicateEnvVarsForObject returns duplicate environment-variable facts
+// for a single workload object.
+func FindDuplicateEnvVarsForObject(obj runtime.Object) []DuplicateEnvVarCheck {
+	wl, ok := envServiceWorkloadForObject(obj)
+	if !ok {
+		return nil
+	}
+	return findDuplicateEnvVarChecks([]envServiceWorkload{wl}, time.Now())
+}
+
+func findDuplicateEnvVarChecks(workloads []envServiceWorkload, now time.Time) []DuplicateEnvVarCheck {
+	var out []DuplicateEnvVarCheck
+	for _, wl := range workloads {
+		containers := make([]corev1.Container, 0, len(wl.spec.InitContainers)+len(wl.spec.Containers))
+		containers = append(containers, wl.spec.InitContainers...)
+		containers = append(containers, wl.spec.Containers...)
+		for _, container := range containers {
+			byName := make(map[string][]DuplicateEnvVarOccurrence, len(container.Env))
+			for i, env := range container.Env {
+				byName[env.Name] = append(byName[env.Name], DuplicateEnvVarOccurrence{
+					Position: i + 1,
+					Value:    envVarDisplayValue(env),
+				})
+			}
+			for envName, occurrences := range byName {
+				if len(occurrences) < 2 {
+					continue
+				}
+				last := occurrences[len(occurrences)-1]
+				out = append(out, DuplicateEnvVarCheck{
+					WorkloadGroup:     wl.group,
+					WorkloadKind:      wl.kind,
+					Namespace:         wl.namespace,
+					WorkloadName:      wl.name,
+					Container:         container.Name,
+					EnvName:           envName,
+					Occurrences:       occurrences,
+					LastDeclaredValue: last.Value,
+					Message:           duplicateEnvVarMessage(container.Name, envName, occurrences),
+					AgeSeconds:        ageSeconds(now, wl.created),
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		if out[i].WorkloadKind != out[j].WorkloadKind {
+			return out[i].WorkloadKind < out[j].WorkloadKind
+		}
+		if out[i].WorkloadName != out[j].WorkloadName {
+			return out[i].WorkloadName < out[j].WorkloadName
+		}
+		if out[i].Container != out[j].Container {
+			return out[i].Container < out[j].Container
+		}
+		return out[i].EnvName < out[j].EnvName
+	})
+	return out
+}
+
+func duplicateEnvVarMessage(container, envName string, occurrences []DuplicateEnvVarOccurrence) string {
+	displayed := occurrences
+	if len(displayed) > maxDuplicateEnvVarMessageOccurrences {
+		displayed = displayed[:maxDuplicateEnvVarMessageOccurrences]
+	}
+	values := make([]string, 0, len(displayed)+1)
+	for _, occurrence := range displayed {
+		values = append(values, fmt.Sprintf("%d=%q", occurrence.Position, occurrence.Value))
+	}
+	if omitted := len(occurrences) - len(displayed); omitted > 0 {
+		values = append(values, fmt.Sprintf("... and %d more", omitted))
+	}
+	last := occurrences[len(occurrences)-1]
+	return fmt.Sprintf("Container %s defines env %s %d times at positions/values %s; the last definition %q typically takes effect.", container, envName, len(occurrences), strings.Join(values, ", "), last.Value)
 }
 
 func detectEnvServiceRefs(cache *ResourceCache, namespace string, now time.Time) []Detection {

--- a/internal/k8s/detect_config_test.go
+++ b/internal/k8s/detect_config_test.go
@@ -1,0 +1,196 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFindDuplicateEnvVarsForObject(t *testing.T) {
+	t.Run("motivating duplicate reports positions values and final declaration", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{
+			Name: "app",
+			Env: []corev1.EnvVar{
+				{Name: "APP_HOST", Value: "api"},
+				{Name: "LOG_LEVEL", Value: "info"},
+				{Name: "APP_HOST", Value: "localhost"},
+			},
+		}}, nil)
+
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 {
+			t.Fatalf("got %d checks, want 1: %+v", len(got), got)
+		}
+		check := got[0]
+		if check.Container != "app" || check.EnvName != "APP_HOST" || check.LastDeclaredValue != "localhost" {
+			t.Fatalf("unexpected check: %+v", check)
+		}
+		if len(check.Occurrences) != 2 || check.Occurrences[0].Position != 1 || check.Occurrences[0].Value != "api" || check.Occurrences[1].Position != 3 || check.Occurrences[1].Value != "localhost" {
+			t.Fatalf("unexpected occurrences: %+v", check.Occurrences)
+		}
+		for _, want := range []string{"app", "APP_HOST", "2 times", `1="api"`, `3="localhost"`, "typically takes effect"} {
+			if !strings.Contains(check.Message, want) {
+				t.Errorf("message %q does not contain %q", check.Message, want)
+			}
+		}
+	})
+
+	t.Run("no duplicates", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{
+			Name: "app",
+			Env:  []corev1.EnvVar{{Name: "APP_HOST", Value: "api"}, {Name: "LOG_LEVEL", Value: "info"}},
+		}}, nil)
+		if got := FindDuplicateEnvVarsForObject(deployment); len(got) != 0 {
+			t.Fatalf("got duplicate checks for unique env vars: %+v", got)
+		}
+	})
+
+	t.Run("init container", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment(nil, []corev1.Container{{
+			Name: "migrate",
+			Env:  []corev1.EnvVar{{Name: "DB_HOST", Value: "old"}, {Name: "DB_HOST", Value: "new"}},
+		}})
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 || got[0].Container != "migrate" || got[0].LastDeclaredValue != "new" {
+			t.Fatalf("unexpected init-container checks: %+v", got)
+		}
+	})
+
+	t.Run("three declarations emit once", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{
+			Name: "app",
+			Env:  []corev1.EnvVar{{Name: "MODE", Value: "one"}, {Name: "MODE", Value: "two"}, {Name: "MODE", Value: "three"}},
+		}}, nil)
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 || len(got[0].Occurrences) != 3 || got[0].LastDeclaredValue != "three" {
+			t.Fatalf("unexpected three-way duplicate: %+v", got)
+		}
+	})
+
+	t.Run("containers are independent", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{
+			{Name: "app", Env: []corev1.EnvVar{{Name: "PORT", Value: "8080"}, {Name: "PORT", Value: "8081"}}},
+			{Name: "sidecar", Env: []corev1.EnvVar{{Name: "PORT", Value: "9090"}, {Name: "PORT", Value: "9091"}}},
+			{Name: "metrics", Env: []corev1.EnvVar{{Name: "PORT", Value: "9100"}}},
+		}, nil)
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 2 || got[0].Container != "app" || got[1].Container != "sidecar" {
+			t.Fatalf("unexpected per-container checks: %+v", got)
+		}
+
+		deployment = duplicateEnvTestDeployment([]corev1.Container{
+			{Name: "app", Env: []corev1.EnvVar{{Name: "SHARED", Value: "one"}}},
+			{Name: "sidecar", Env: []corev1.EnvVar{{Name: "SHARED", Value: "two"}}},
+		}, nil)
+		if got := FindDuplicateEnvVarsForObject(deployment); len(got) != 0 {
+			t.Fatalf("same name in separate containers must not be flagged: %+v", got)
+		}
+	})
+
+	t.Run("identical values still duplicate and names are case sensitive", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{
+			Name: "app",
+			Env: []corev1.EnvVar{
+				{Name: "MODE", Value: "prod"},
+				{Name: "mode", Value: "lowercase"},
+				{Name: "MODE", Value: "prod"},
+			},
+		}}, nil)
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 || got[0].EnvName != "MODE" || len(got[0].Occurrences) != 2 {
+			t.Fatalf("unexpected exact-name duplicate result: %+v", got)
+		}
+	})
+
+	t.Run("secret values are redacted in live message", func(t *testing.T) {
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{
+			Name: "app",
+			Env: []corev1.EnvVar{
+				{Name: "API_TOKEN", Value: "first-super-secret-token"},
+				{Name: "API_TOKEN", Value: "second-super-secret-token"},
+			},
+		}}, nil)
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 {
+			t.Fatalf("got %d checks, want 1: %+v", len(got), got)
+		}
+		check := got[0]
+		if check.LastDeclaredValue != "[REDACTED]" || check.Occurrences[0].Value != "[REDACTED]" || check.Occurrences[1].Value != "[REDACTED]" {
+			t.Fatalf("secret values were not redacted: %+v", check)
+		}
+		if strings.Contains(check.Message, "first-super-secret-token") || strings.Contains(check.Message, "second-super-secret-token") || !strings.Contains(check.Message, "[REDACTED]") {
+			t.Fatalf("live detection message is not safely redacted: %q", check.Message)
+		}
+	})
+
+	t.Run("pathological duplicates bound message detail", func(t *testing.T) {
+		env := make([]corev1.EnvVar, 0, 7)
+		for _, value := range []string{"one", "two", "three", "four", "five", "six", "seven"} {
+			env = append(env, corev1.EnvVar{Name: "MODE", Value: value})
+		}
+		deployment := duplicateEnvTestDeployment([]corev1.Container{{Name: "app", Env: env}}, nil)
+
+		got := FindDuplicateEnvVarsForObject(deployment)
+		if len(got) != 1 || len(got[0].Occurrences) != 7 || got[0].LastDeclaredValue != "seven" {
+			t.Fatalf("unexpected bounded duplicate check: %+v", got)
+		}
+		for _, want := range []string{"7 times", `5="five"`, "... and 2 more", `last definition "seven"`} {
+			if !strings.Contains(got[0].Message, want) {
+				t.Errorf("message %q does not contain %q", got[0].Message, want)
+			}
+		}
+		if strings.Contains(got[0].Message, `6="six"`) || strings.Contains(got[0].Message, `7="seven"`) {
+			t.Fatalf("message contains unbounded occurrence detail: %q", got[0].Message)
+		}
+	})
+}
+
+func TestDetectConfigProblemsIncludesDuplicateEnvVars(t *testing.T) {
+	now := time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC)
+	deployment := duplicateEnvTestDeployment([]corev1.Container{{
+		Name: "app",
+		Env:  []corev1.EnvVar{{Name: "APP_HOST", Value: "api"}, {Name: "APP_HOST", Value: "localhost"}},
+	}}, nil)
+	deployment.CreationTimestamp = metav1.NewTime(now.Add(-2 * time.Hour))
+
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client:        fake.NewClientset(deployment),
+		ResourceTypes: map[string]bool{k8score.Deployments: true},
+		DeferredTypes: map[string]bool{},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	cache := &ResourceCache{ResourceCache: core}
+
+	got := detectConfigProblems(cache, "prod", now)
+	if len(got) != 1 {
+		t.Fatalf("got %d config problems, want 1: %+v", len(got), got)
+	}
+	detection := got[0]
+	if detection.Kind != "Deployment" || detection.Group != "apps" || detection.Namespace != "prod" || detection.Name != "web" {
+		t.Fatalf("unexpected subject: %+v", detection)
+	}
+	if detection.Severity != "warning" || detection.Reason != "DuplicateEnvVar" {
+		t.Fatalf("unexpected severity/reason: %+v", detection)
+	}
+	if detection.Fingerprint != "dup-env:prod:web:app:APP_HOST" || detection.AgeSeconds != 7200 {
+		t.Fatalf("unexpected identity/age: %+v", detection)
+	}
+}
+
+func duplicateEnvTestDeployment(containers, initContainers []corev1.Container) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod", CreationTimestamp: metav1.Now()},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: containers, InitContainers: initContainers}},
+		},
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1107,11 +1107,14 @@ func buildMCPResourceContext(ctx context.Context, obj runtime.Object, kind, name
 	auditSum := computeMCPAuditSummary(cache, canonicalGroup, canonicalKind, namespace, name)
 
 	opts := resourcecontext.Options{
-		Tier:            tier,
-		AccessChecker:   newMCPRequestScopedChecker(ctx),
-		IssueSummary:    issueSum,
-		AuditSummary:    auditSum,
-		AppReferences:   resourcecontextrefs.AppReferencesFromEnvServiceChecks(k8s.FindEnvServiceRefChecksForObject(cache, obj)),
+		Tier:          tier,
+		AccessChecker: newMCPRequestScopedChecker(ctx),
+		IssueSummary:  issueSum,
+		AuditSummary:  auditSum,
+		AppReferences: resourcecontextrefs.AppReferencesFromEnvChecks(
+			k8s.FindEnvServiceRefChecksForObject(cache, obj),
+			k8s.FindDuplicateEnvVarsForObject(obj),
+		),
 		ServiceBackends: mcpServiceBackendLookup{cache: cache},
 	}
 

--- a/internal/resourcecontextrefs/app_references.go
+++ b/internal/resourcecontextrefs/app_references.go
@@ -6,13 +6,18 @@ import (
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 )
 
-func AppReferencesFromEnvServiceChecks(checks []k8s.EnvServiceRefCheck) *resourcecontext.AppReferences {
-	if len(checks) == 0 {
+const maxDuplicateEnvVarContextOccurrences = 5
+
+func AppReferencesFromEnvChecks(serviceChecks []k8s.EnvServiceRefCheck, duplicateChecks []k8s.DuplicateEnvVarCheck) *resourcecontext.AppReferences {
+	if len(serviceChecks) == 0 && len(duplicateChecks) == 0 {
 		return nil
 	}
-	out := make([]resourcecontext.ServiceEnvReference, 0, len(checks))
-	for _, check := range checks {
-		out = append(out, resourcecontext.ServiceEnvReference{
+	out := &resourcecontext.AppReferences{
+		ServiceEnv:   make([]resourcecontext.ServiceEnvReference, 0, len(serviceChecks)),
+		DuplicateEnv: make([]resourcecontext.DuplicateEnvVarReference, 0, len(duplicateChecks)),
+	}
+	for _, check := range serviceChecks {
+		out.ServiceEnv = append(out.ServiceEnv, resourcecontext.ServiceEnvReference{
 			Status:         check.Status,
 			Container:      check.Container,
 			Env:            check.EnvName,
@@ -23,5 +28,26 @@ func AppReferencesFromEnvServiceChecks(checks []k8s.EnvServiceRefCheck) *resourc
 			Message:        aicontext.RedactSecrets(check.Message),
 		})
 	}
-	return &resourcecontext.AppReferences{ServiceEnv: out}
+	for _, check := range duplicateChecks {
+		displayed := check.Occurrences
+		if len(displayed) > maxDuplicateEnvVarContextOccurrences {
+			displayed = displayed[:maxDuplicateEnvVarContextOccurrences]
+		}
+		occurrences := make([]resourcecontext.DuplicateEnvVarOccurrence, 0, len(displayed))
+		for _, occurrence := range displayed {
+			occurrences = append(occurrences, resourcecontext.DuplicateEnvVarOccurrence{
+				Position: occurrence.Position,
+				Value:    aicontext.RedactSecrets(occurrence.Value),
+			})
+		}
+		out.DuplicateEnv = append(out.DuplicateEnv, resourcecontext.DuplicateEnvVarReference{
+			Container:         check.Container,
+			Env:               check.EnvName,
+			Count:             len(check.Occurrences),
+			Occurrences:       occurrences,
+			LastDeclaredValue: aicontext.RedactSecrets(check.LastDeclaredValue),
+			Message:           aicontext.RedactSecrets(check.Message),
+		})
+	}
+	return out
 }

--- a/internal/resourcecontextrefs/app_references_test.go
+++ b/internal/resourcecontextrefs/app_references_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/skyhook-io/radar/internal/k8s"
 )
 
-func TestAppReferencesFromEnvServiceChecks(t *testing.T) {
-	if got := AppReferencesFromEnvServiceChecks(nil); got != nil {
+func TestAppReferencesFromEnvChecks(t *testing.T) {
+	if got := AppReferencesFromEnvChecks(nil, nil); got != nil {
 		t.Fatalf("empty checks should return nil, got %+v", got)
 	}
 
-	got := AppReferencesFromEnvServiceChecks([]k8s.EnvServiceRefCheck{{
+	got := AppReferencesFromEnvChecks([]k8s.EnvServiceRefCheck{{
 		Status:           "port_mismatch",
 		Container:        "app",
 		EnvName:          "PAYMENTS_URL",
@@ -21,7 +21,7 @@ func TestAppReferencesFromEnvServiceChecks(t *testing.T) {
 		ReferencedPort:   8080,
 		ServicePorts:     []string{"80/TCP"},
 		Message:          "env var references Service port 8080 with password=supersecret, but Service exposes 80/TCP",
-	}})
+	}}, nil)
 	if got == nil || len(got.ServiceEnv) != 1 {
 		t.Fatalf("expected one service env reference, got %+v", got)
 	}
@@ -37,5 +37,52 @@ func TestAppReferencesFromEnvServiceChecks(t *testing.T) {
 	}
 	if ref.ReferencedPort != 8080 || len(ref.ServicePorts) != 1 || ref.ServicePorts[0] != "80/TCP" || ref.Message == "" {
 		t.Fatalf("detail fields not mapped correctly: %+v", ref)
+	}
+}
+
+func TestAppReferencesFromEnvChecks_DuplicateEnv(t *testing.T) {
+	got := AppReferencesFromEnvChecks(nil, []k8s.DuplicateEnvVarCheck{{
+		Container:         "app",
+		EnvName:           "API_TOKEN",
+		LastDeclaredValue: "password=second-secret",
+		Occurrences: []k8s.DuplicateEnvVarOccurrence{
+			{Position: 1, Value: "password=first-secret"},
+			{Position: 3, Value: "password=second-secret"},
+		},
+		Message: "API_TOKEN appears twice: password=first-secret then password=second-secret",
+	}})
+	if got == nil || len(got.DuplicateEnv) != 1 {
+		t.Fatalf("expected one duplicate env reference, got %+v", got)
+	}
+	ref := got.DuplicateEnv[0]
+	if ref.Container != "app" || ref.Env != "API_TOKEN" || ref.Count != 2 {
+		t.Fatalf("basic fields not mapped correctly: %+v", ref)
+	}
+	if len(ref.Occurrences) != 2 || ref.Occurrences[0].Position != 1 || ref.Occurrences[1].Position != 3 {
+		t.Fatalf("occurrences not mapped correctly: %+v", ref.Occurrences)
+	}
+	if ref.Occurrences[0].Value == "password=first-secret" || ref.Occurrences[1].Value == "password=second-secret" || ref.LastDeclaredValue == "password=second-secret" || ref.Message == "API_TOKEN appears twice: password=first-secret then password=second-secret" {
+		t.Fatalf("duplicate env values/message were not redacted: %+v", ref)
+	}
+}
+
+func TestAppReferencesFromEnvChecks_BoundsDuplicateOccurrences(t *testing.T) {
+	checks := []k8s.DuplicateEnvVarCheck{{
+		Container:         "app",
+		EnvName:           "MODE",
+		LastDeclaredValue: "seven",
+		Message:           "7 declarations; ... and 2 more; last definition seven",
+	}}
+	for i, value := range []string{"one", "two", "three", "four", "five", "six", "seven"} {
+		checks[0].Occurrences = append(checks[0].Occurrences, k8s.DuplicateEnvVarOccurrence{Position: i + 1, Value: value})
+	}
+
+	got := AppReferencesFromEnvChecks(nil, checks)
+	if got == nil || len(got.DuplicateEnv) != 1 {
+		t.Fatalf("expected one duplicate env reference, got %+v", got)
+	}
+	ref := got.DuplicateEnv[0]
+	if ref.Count != 7 || len(ref.Occurrences) != 5 || ref.Occurrences[4].Position != 5 || ref.LastDeclaredValue != "seven" {
+		t.Fatalf("unexpected bounded duplicate reference: %+v", ref)
 	}
 }

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -426,11 +426,14 @@ func (s *Server) buildAIResourceContext(r *http.Request, obj runtime.Object, kin
 	auditSum := computeAuditSummaryForResource(cache, canonicalGroup, canonicalKind, namespace, name)
 
 	opts := resourcecontext.Options{
-		Tier:            resourcecontext.TierBasic,
-		AccessChecker:   s.newRequestScopedChecker(r),
-		IssueSummary:    issueSum,
-		AuditSummary:    auditSum,
-		AppReferences:   resourcecontextrefs.AppReferencesFromEnvServiceChecks(k8s.FindEnvServiceRefChecksForObject(cache, obj)),
+		Tier:          resourcecontext.TierBasic,
+		AccessChecker: s.newRequestScopedChecker(r),
+		IssueSummary:  issueSum,
+		AuditSummary:  auditSum,
+		AppReferences: resourcecontextrefs.AppReferencesFromEnvChecks(
+			k8s.FindEnvServiceRefChecksForObject(cache, obj),
+			k8s.FindDuplicateEnvVarsForObject(obj),
+		),
 		ServiceBackends: serviceBackendLookup{cache: cache},
 	}
 

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -59,7 +59,7 @@ var catalogOrder = []Category{
 	CategoryCrashLoop, CategoryOOMKilled, CategoryLivenessProbeFail, CategoryReadinessFailed,
 	CategoryWorkloadDegraded, CategoryHighRestart, CategoryJobFailed, CategoryCronJobFailed,
 	// Configuration
-	CategoryMissingConfigRef, CategoryPDBBlocksEvictions, CategorySecretSyncFailed,
+	CategoryMissingConfigRef, CategoryInvalidConfiguration, CategoryPDBBlocksEvictions, CategorySecretSyncFailed,
 	// Networking
 	CategoryServiceNoEndpoints, CategoryIngressBackendMissing, CategoryLoadBalancerPending,
 	CategoryGatewayNotReady, CategoryGatewayRouteInvalid, CategoryDNSFailure,
@@ -108,9 +108,10 @@ var categoryDescription = map[Category]string{
 	CategoryJobFailed:         "A Job failed — it exhausted its retries (backoffLimit) or hit its deadline — or has been running too long with no completions.",
 	CategoryCronJobFailed:     "A CronJob's recent runs are failing, or its schedule isn't producing successful jobs.",
 	// Configuration
-	CategoryMissingConfigRef:   "A pod references a ConfigMap, Secret, or volume that doesn't exist, so it can't start.",
-	CategoryPDBBlocksEvictions: "A PodDisruptionBudget is blocking evictions — node drains and upgrades can't make progress.",
-	CategorySecretSyncFailed:   "An external secret sync (e.g. External Secrets Operator) failed to materialize a Secret.",
+	CategoryMissingConfigRef:     "A pod references a ConfigMap, Secret, or volume that doesn't exist, so it can't start.",
+	CategoryInvalidConfiguration: "A workload contains contradictory or redundant configuration that can make the application behave differently from its manifest's apparent intent.",
+	CategoryPDBBlocksEvictions:   "A PodDisruptionBudget is blocking evictions — node drains and upgrades can't make progress.",
+	CategorySecretSyncFailed:     "An external secret sync (e.g. External Secrets Operator) failed to materialize a Secret.",
 	// Networking
 	CategoryServiceNoEndpoints:    "A Service has no ready endpoints — its selector matches no ready pods, so traffic to it fails.",
 	CategoryIngressBackendMissing: "An Ingress points at a Service that doesn't exist — incoming requests get 503s.",

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -51,6 +51,7 @@ const (
 	CategoryCronJobFailed     Category = "cronjob_failed"
 
 	CategoryMissingConfigRef         Category = "missing_config_ref"
+	CategoryInvalidConfiguration     Category = "invalid_configuration"
 	CategoryPDBBlocksEvictions       Category = "pdb_blocks_evictions"
 	CategorySecretSyncFailed         Category = "secret_sync_failed"
 	CategoryServiceNoEndpoints       Category = "service_no_endpoints"
@@ -125,6 +126,7 @@ var categoryGroup = map[Category]CategoryGroup{
 	CategoryJobFailed:                GroupRuntime,
 	CategoryCronJobFailed:            GroupRuntime,
 	CategoryMissingConfigRef:         GroupConfiguration,
+	CategoryInvalidConfiguration:     GroupConfiguration,
 	CategoryPDBBlocksEvictions:       GroupConfiguration,
 	CategorySecretSyncFailed:         GroupConfiguration,
 	CategoryServiceNoEndpoints:       GroupNetworking,

--- a/pkg/resourcecontext/build.go
+++ b/pkg/resourcecontext/build.go
@@ -1410,7 +1410,7 @@ func filterAppReferences(ctx context.Context, refs *AppReferences, ac RefAccessC
 	if refs == nil {
 		return nil
 	}
-	out := &AppReferences{}
+	out := &AppReferences{DuplicateEnv: append([]DuplicateEnvVarReference(nil), refs.DuplicateEnv...)}
 	deniedAny := false
 	for _, ref := range refs.ServiceEnv {
 		if !checkRef(ctx, ac, &ref.Service) {
@@ -1422,7 +1422,7 @@ func filterAppReferences(ctx context.Context, refs *AppReferences, ac RefAccessC
 	if deniedAny {
 		omitted.add("appReferences.serviceEnv", OmittedRBACDenied)
 	}
-	if len(out.ServiceEnv) == 0 {
+	if len(out.ServiceEnv) == 0 && len(out.DuplicateEnv) == 0 {
 		return nil
 	}
 	return out

--- a/pkg/resourcecontext/build_test.go
+++ b/pkg/resourcecontext/build_test.go
@@ -786,6 +786,44 @@ func TestBuild_RBACDenied_AppReferences(t *testing.T) {
 	}
 }
 
+func TestBuild_RBACDenied_ServiceReferencePreservesDuplicateEnv(t *testing.T) {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "frontend", Namespace: "prod"},
+	}
+	rc := Build(context.Background(), dep, Options{
+		Tier:          TierBasic,
+		AccessChecker: denyChecker{group: "", kind: "Service", namespace: "shared"},
+		AppReferences: &AppReferences{
+			ServiceEnv: []ServiceEnvReference{{
+				Status:  "port_mismatch",
+				Service: ContextRef{Kind: "Service", Namespace: "shared", Name: "product-catalog"},
+			}},
+			DuplicateEnv: []DuplicateEnvVarReference{{
+				Container:         "app",
+				Env:               "PRODUCT_CATALOG_URL",
+				Count:             2,
+				LastDeclaredValue: "http://localhost:8080",
+			}},
+		},
+	})
+	if rc.AppReferences == nil || len(rc.AppReferences.DuplicateEnv) != 1 {
+		t.Fatalf("duplicate env facts should survive Service RBAC deny; got %+v", rc.AppReferences)
+	}
+	if len(rc.AppReferences.ServiceEnv) != 0 {
+		t.Fatalf("Service env references should be removed after deny; got %+v", rc.AppReferences.ServiceEnv)
+	}
+	gotOmitted := false
+	for _, o := range rc.Omitted {
+		if o.Field == "appReferences.serviceEnv" && o.Reason == OmittedRBACDenied {
+			gotOmitted = true
+			break
+		}
+	}
+	if !gotOmitted {
+		t.Fatalf("expected omitted [appReferences.serviceEnv, rbac_denied]; got %+v", rc.Omitted)
+	}
+}
+
 func TestBuild_NilObj(t *testing.T) {
 	if rc := Build(context.Background(), nil, Options{}); rc != nil {
 		t.Errorf("Build(nil) = %+v, want nil", rc)

--- a/pkg/resourcecontext/types.go
+++ b/pkg/resourcecontext/types.go
@@ -109,7 +109,8 @@ type UsesBlock struct {
 }
 
 type AppReferences struct {
-	ServiceEnv []ServiceEnvReference `json:"serviceEnv,omitempty"`
+	ServiceEnv   []ServiceEnvReference      `json:"serviceEnv,omitempty"`
+	DuplicateEnv []DuplicateEnvVarReference `json:"duplicateEnv,omitempty"`
 }
 
 type ServiceEnvReference struct {
@@ -121,6 +122,20 @@ type ServiceEnvReference struct {
 	ReferencedPort int32      `json:"referencedPort,omitempty"`
 	ServicePorts   []string   `json:"servicePorts,omitempty"`
 	Message        string     `json:"message,omitempty"`
+}
+
+type DuplicateEnvVarReference struct {
+	Container         string                      `json:"container"`
+	Env               string                      `json:"env"`
+	Count             int                         `json:"count"`
+	Occurrences       []DuplicateEnvVarOccurrence `json:"occurrences"`
+	LastDeclaredValue string                      `json:"lastDeclaredValue"`
+	Message           string                      `json:"message,omitempty"`
+}
+
+type DuplicateEnvVarOccurrence struct {
+	Position int    `json:"position"`
+	Value    string `json:"value"`
 }
 
 // ReferencedBy lists workload specs that directly reference the subject


### PR DESCRIPTION
## Summary

Kubernetes accepts duplicate environment-variable declarations within a container and resolves them by declaration order, which can silently leave operators with an unexpected effective value. This change detects those ambiguous declarations as configuration issues and includes the same evidence in REST and MCP resource context.

## What changed

- Scan inline environment variables in every regular and init container covered by the existing workload configuration checks. Matching is exact and scoped to a single container, so declarations in separate containers remain independent.
- Emit one DuplicateEnvVar warning per duplicated name with a stable fingerprint, deterministic ordering, declaration positions and redacted display values, plus the final declared value that typically takes effect.
- Bound rendered issue and AI-context occurrence details to five entries while retaining the true duplicate count and final value.
- Add Invalid Configuration to the issue taxonomy and classify DuplicateEnvVar by reason before workload-specific categories, including Jobs and CronJobs.
- Extend application references with an additive duplicateEnv section and wire it consistently through REST and MCP. Because these facts come from the workload already being viewed, they remain available even when referenced Service data is filtered by RBAC.
- Cover ordinary and init-container duplicates, independent containers, three-way duplicates, identical values, case sensitivity, secret redaction, deterministic fingerprints, bounded pathological inputs, resource-context mapping, RBAC filtering, and taxonomy classification.

## Testing

Automated verification:

- go test ./internal/k8s/...
- go build ./...
- make backend
- make tsc
- make test
- make build
- git diff --check

Live smoke verification against the nonprod GKE cluster:

- Started the branch build namespace-scoped against an isolated, zero-replica Deployment fixture.
- Confirmed the Kubernetes API preserved three APP_MODE, two API_PASSWORD, and two init-container INIT_MODE declarations.
- Confirmed cluster info, flat issues, resource issues, and AI resource-context endpoints returned HTTP 200.
- Verified exactly three DuplicateEnvVar warnings: APP_MODE reported count 3 and final value final; INIT_MODE reported count 2 and final value ready; API_PASSWORD reported count 2 with every value redacted.
- Verified the Overview page rendered all three Invalid configuration rows with zero browser console errors.
- Deleted the isolated fixture namespace and stopped the local Radar instance after verification.

## Notes

The detector intentionally evaluates explicit env entries only. Expanding envFrom references would require permission-dependent ConfigMap and Secret reads and could create misleading partial results or expose sensitive data.