### PR TITLE
fix: aggregate duplicate env issues and redact secrets

### DIFF
--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -177,8 +177,10 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 }
 
 // MergeExternalIssues adds already-shaped issue rows from handler-owned data
-// sources, then applies the public sort/cap. `base` must already have gone
-// through ComposeWithStats with the same filters except Limit=NoLimit.
+// sources, then applies the public filters, sort, and cap. `base` must already
+// have gone through ComposeWithStats with the same structural filters except
+// Limit=NoLimit and Filter=nil; CEL is evaluated here against the final public
+// shape after duplicate-env aggregation and external rows are merged.
 func MergeExternalIssues(base []Issue, baseStats ComposeStats, f Filters, extras []Issue) ([]Issue, ComposeStats) {
 	limit, uncapped := normalizedLimit(f.Limit)
 	f.Limit = limit
@@ -186,24 +188,16 @@ func MergeExternalIssues(base []Issue, baseStats ComposeStats, f Filters, extras
 		base = aggregateDuplicateEnvIssues(base)
 	}
 
-	if len(extras) == 0 {
-		baseStats.TotalMatched = len(base)
-		if !uncapped && len(base) > f.Limit {
-			base = base[:f.Limit]
-		}
-		return base, baseStats
-	}
-
-	filteredExtras, extraStats := filterShapedIssues(append([]Issue(nil), extras...), f)
-	out := make([]Issue, 0, len(base)+len(filteredExtras))
+	out := make([]Issue, 0, len(base)+len(extras))
 	out = append(out, base...)
-	out = append(out, filteredExtras...)
+	out = append(out, extras...)
+	out, mergedStats := filterShapedIssues(out, f)
 	sort.SliceStable(out, func(i, j int) bool { return lessIssue(out[i], out[j]) })
 
 	stats := baseStats
-	stats.FilterErrors += extraStats.FilterErrors
+	stats.FilterErrors += mergedStats.FilterErrors
 	if stats.FilterErrorSample == "" {
-		stats.FilterErrorSample = extraStats.FilterErrorSample
+		stats.FilterErrorSample = mergedStats.FilterErrorSample
 	}
 	stats.TotalMatched = len(out)
 	if !uncapped && len(out) > f.Limit {

--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -182,6 +182,9 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 func MergeExternalIssues(base []Issue, baseStats ComposeStats, f Filters, extras []Issue) ([]Issue, ComposeStats) {
 	limit, uncapped := normalizedLimit(f.Limit)
 	f.Limit = limit
+	if f.Grouped {
+		base = aggregateDuplicateEnvIssues(base)
+	}
 
 	if len(extras) == 0 {
 		baseStats.TotalMatched = len(base)

--- a/internal/issues/duplicate_env_aggregation.go
+++ b/internal/issues/duplicate_env_aggregation.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
@@ -96,11 +97,11 @@ func newDuplicateEnvAggregate(members []Issue) Issue {
 func duplicateEnvAggregateMessage(members []Issue) string {
 	detailSet := make(map[string]bool, len(members))
 	for _, member := range members {
-		parts := strings.SplitN(member.Fingerprint, ":", 5)
-		if len(parts) != 5 || parts[0] != "dup-env" {
+		fingerprint, ok := k8s.ParseDuplicateEnvVarFingerprint(member.Fingerprint)
+		if !ok {
 			continue
 		}
-		detailSet[fmt.Sprintf("%s (%s)", parts[4], parts[3])] = true
+		detailSet[fmt.Sprintf("%s (%s)", fingerprint.EnvName, fingerprint.Container)] = true
 	}
 	details := make([]string, 0, len(detailSet))
 	for detail := range detailSet {

--- a/internal/issues/duplicate_env_aggregation.go
+++ b/internal/issues/duplicate_env_aggregation.go
@@ -1,0 +1,91 @@
+package issues
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
+
+const duplicateEnvAggregateFingerprint = "duplicate-env-workload-aggregate"
+
+func aggregateDuplicateEnvIssues(in []Issue) []Issue {
+	buckets := make(map[string][]Issue)
+	for _, issue := range in {
+		key, ok := duplicateEnvAggregationKey(issue)
+		if !ok {
+			continue
+		}
+		buckets[key] = append(buckets[key], issue)
+	}
+
+	if len(buckets) == 0 {
+		return in
+	}
+
+	out := make([]Issue, 0, len(in))
+	emitted := make(map[string]bool, len(buckets))
+	for _, issue := range in {
+		key, ok := duplicateEnvAggregationKey(issue)
+		if !ok {
+			out = append(out, issue)
+			continue
+		}
+		members := buckets[key]
+		if len(members) < 2 {
+			out = append(out, issue)
+			continue
+		}
+		if emitted[key] {
+			continue
+		}
+		emitted[key] = true
+		out = append(out, newDuplicateEnvAggregate(members))
+	}
+
+	sort.SliceStable(out, func(i, j int) bool { return lessIssue(out[i], out[j]) })
+	return out
+}
+
+func duplicateEnvAggregationKey(issue Issue) (string, bool) {
+	if issue.Reason != "DuplicateEnvVar" || issue.Category != issuesapi.CategoryInvalidConfiguration {
+		return "", false
+	}
+	group := resolveGroup(issue.Group, issue.Kind)
+	return resourceKey(group, issue.Kind, issue.Namespace, issue.Name), true
+}
+
+func newDuplicateEnvAggregate(members []Issue) Issue {
+	first := members[0]
+	severity := first.Severity
+	firstSeen := first.FirstSeen
+	lastSeen := first.LastSeen
+	for _, member := range members[1:] {
+		if SeverityRank(member.Severity) > SeverityRank(severity) {
+			severity = member.Severity
+		}
+		if !member.FirstSeen.IsZero() && (firstSeen.IsZero() || member.FirstSeen.Before(firstSeen)) {
+			firstSeen = member.FirstSeen
+		}
+		if member.LastSeen.After(lastSeen) {
+			lastSeen = member.LastSeen
+		}
+	}
+
+	issue := Issue{
+		Severity:    severity,
+		Source:      SourceProblem,
+		Kind:        first.Kind,
+		Group:       resolveGroup(first.Group, first.Kind),
+		Namespace:   first.Namespace,
+		Name:        first.Name,
+		Reason:      "DuplicateEnvVar",
+		Message:     fmt.Sprintf("This workload has duplicate environment variable definitions in %d places across its containers. Later declarations hide earlier ones, and apply/patch may drop hidden entries.", len(members)),
+		Fingerprint: duplicateEnvAggregateFingerprint,
+		FirstSeen:   firstSeen,
+		LastSeen:    lastSeen,
+	}
+	classifyIssue(&issue)
+	enrichIdentity(&issue)
+	return issue
+}

--- a/internal/issues/duplicate_env_aggregation.go
+++ b/internal/issues/duplicate_env_aggregation.go
@@ -3,11 +3,13 @@ package issues
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 const duplicateEnvAggregateFingerprint = "duplicate-env-workload-aggregate"
+const maxDuplicateEnvAggregateDetails = 5
 
 func aggregateDuplicateEnvIssues(in []Issue) []Issue {
 	buckets := make(map[string][]Issue)
@@ -80,7 +82,8 @@ func newDuplicateEnvAggregate(members []Issue) Issue {
 		Namespace:   first.Namespace,
 		Name:        first.Name,
 		Reason:      "DuplicateEnvVar",
-		Message:     fmt.Sprintf("This workload has duplicate environment variable definitions in %d places across its containers. Later declarations hide earlier ones, and apply/patch may drop hidden entries.", len(members)),
+		Message:     duplicateEnvAggregateMessage(members),
+		Action:      "Remove duplicate entries from the workload manifest or chart so each environment variable is declared once per container, then redeploy through the normal delivery path.",
 		Fingerprint: duplicateEnvAggregateFingerprint,
 		FirstSeen:   firstSeen,
 		LastSeen:    lastSeen,
@@ -88,4 +91,30 @@ func newDuplicateEnvAggregate(members []Issue) Issue {
 	classifyIssue(&issue)
 	enrichIdentity(&issue)
 	return issue
+}
+
+func duplicateEnvAggregateMessage(members []Issue) string {
+	detailSet := make(map[string]bool, len(members))
+	for _, member := range members {
+		parts := strings.SplitN(member.Fingerprint, ":", 5)
+		if len(parts) != 5 || parts[0] != "dup-env" {
+			continue
+		}
+		detailSet[fmt.Sprintf("%s (%s)", parts[4], parts[3])] = true
+	}
+	details := make([]string, 0, len(detailSet))
+	for detail := range detailSet {
+		details = append(details, detail)
+	}
+	sort.Strings(details)
+	if len(details) > maxDuplicateEnvAggregateDetails {
+		omitted := len(details) - maxDuplicateEnvAggregateDetails
+		details = append(details[:maxDuplicateEnvAggregateDetails], fmt.Sprintf("+%d more", omitted))
+	}
+
+	summary := "Duplicate environment variables are declared more than once"
+	if len(details) > 0 {
+		summary = "Duplicate environment variables: " + strings.Join(details, ", ")
+	}
+	return summary + ". This is a configuration risk: the workload may be running normally, but later declarations shadow earlier ones and apply/patch can drop shadowed entries."
 }

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -1,8 +1,12 @@
 package issues
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 func TestMergeExternalIssuesFiltersSortsAndCaps(t *testing.T) {
@@ -31,6 +35,102 @@ func TestMergeExternalIssuesFiltersSortsAndCaps(t *testing.T) {
 	}
 }
 
+func TestMergeExternalIssuesAggregatesDuplicateEnvWithoutExtras(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	members := []Issue{
+		duplicateEnvIssueForMerge("apps", "web", "app", "APP_MODE", now.Add(-10*time.Minute), now),
+		duplicateEnvIssueForMerge("apps", "web", "app", "API_PASSWORD", now.Add(-30*time.Minute), now.Add(time.Minute)),
+		duplicateEnvIssueForMerge("apps", "web", "init", "INIT_MODE", now.Add(-20*time.Minute), now.Add(2*time.Minute)),
+	}
+	members[0].Cause = "member-only cause"
+	members[0].Action = "member-only action"
+	members[0].DiagnosticContext = &issuesapi.DiagnosticContext{Role: issuesapi.DiagnosticRoleCandidate}
+	members[0].ChangeContext = &issuesapi.ChangeContext{}
+	members[0].IssueTiming = "started_at_resource_creation"
+	unrelated := testIssueForMerge("Deployment", "apps", "web", SeverityCritical, now.Add(-time.Hour))
+
+	got, stats := MergeExternalIssues(append(append([]Issue(nil), members...), unrelated), ComposeStats{}, Filters{
+		Grouped: true,
+		Limit:   NoLimit,
+	}, nil)
+
+	if stats.TotalMatched != 2 || len(got) != 2 {
+		t.Fatalf("got %d rows and TotalMatched=%d, want 2", len(got), stats.TotalMatched)
+	}
+	var aggregate *Issue
+	for i := range got {
+		if got[i].Reason == "DuplicateEnvVar" {
+			aggregate = &got[i]
+		}
+	}
+	if aggregate == nil {
+		t.Fatal("duplicate-env aggregate missing")
+	}
+	wantMessage := "This workload has duplicate environment variable definitions in 3 places across its containers. Later declarations hide earlier ones, and apply/patch may drop hidden entries."
+	if aggregate.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", aggregate.Message, wantMessage)
+	}
+	if !aggregate.FirstSeen.Equal(now.Add(-30*time.Minute)) || !aggregate.LastSeen.Equal(now.Add(2*time.Minute)) {
+		t.Fatalf("aggregate timestamps = %s..%s", aggregate.FirstSeen, aggregate.LastSeen)
+	}
+	if aggregate.Count != 0 || aggregate.Cause != "" || aggregate.Action != "" || aggregate.DiagnosticContext != nil || aggregate.ChangeContext != nil || aggregate.IssueTiming != "" {
+		t.Fatalf("aggregate inherited member-only fields: %+v", *aggregate)
+	}
+	for _, member := range members {
+		if aggregate.ID == member.ID {
+			t.Fatalf("aggregate ID %q collides with member", aggregate.ID)
+		}
+	}
+	capped, cappedStats := MergeExternalIssues(append(append([]Issue(nil), members...), unrelated), ComposeStats{}, Filters{Grouped: true, Limit: 1}, nil)
+	if len(capped) != 1 || cappedStats.TotalMatched != 2 || capped[0].ID != unrelated.ID {
+		t.Fatalf("post-aggregation cap = %+v, TotalMatched=%d", capped, cappedStats.TotalMatched)
+	}
+
+	reversed := []Issue{members[2], unrelated, members[1], members[0]}
+	again, _ := MergeExternalIssues(reversed, ComposeStats{}, Filters{Grouped: true, Limit: NoLimit}, nil)
+	for i := range again {
+		if again[i].Reason == "DuplicateEnvVar" && again[i].ID != aggregate.ID {
+			t.Fatalf("aggregate ID changed under permutation: %q != %q", again[i].ID, aggregate.ID)
+		}
+	}
+	if !reflect.DeepEqual(got[0], unrelated) {
+		t.Fatalf("unrelated issue changed:\n got: %+v\nwant: %+v", got[0], unrelated)
+	}
+}
+
+func TestMergeExternalIssuesDuplicateEnvPresentationBoundaries(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	web := []Issue{
+		duplicateEnvIssueForMerge("apps", "web", "app", "APP_MODE", now, now),
+		duplicateEnvIssueForMerge("apps", "web", "init", "APP_MODE", now, now),
+	}
+	worker := duplicateEnvIssueForMerge("apps", "worker", "app", "APP_MODE", now, now)
+	extra := testIssueForMerge("HelmRelease", "apps", "cart", SeverityCritical, now)
+
+	grouped, stats := MergeExternalIssues(append(web, worker), ComposeStats{}, Filters{Grouped: true, Limit: NoLimit}, []Issue{extra})
+	if len(grouped) != 3 || stats.TotalMatched != 3 {
+		t.Fatalf("grouped rows=%d TotalMatched=%d, want 3", len(grouped), stats.TotalMatched)
+	}
+	for _, issue := range grouped {
+		if issue.Name == "worker" && issue.Message != worker.Message {
+			t.Fatalf("single duplicate changed from detailed message %q to %q", worker.Message, issue.Message)
+		}
+	}
+	flat, _ := MergeExternalIssues(append(web, worker), ComposeStats{}, Filters{Grouped: false, Limit: NoLimit}, nil)
+	if len(flat) != 3 {
+		t.Fatalf("flat rows=%d, want 3 detailed findings", len(flat))
+	}
+
+	p := &fakeProvider{problems: []k8s.Detection{
+		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in app", Fingerprint: "dup-env:apps:web:app:APP_MODE"},
+		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in init", Fingerprint: "dup-env:apps:web:init:APP_MODE"},
+	}}
+	related := RelatedIssues(p, nil, "apps", "Deployment", "apps", "web")
+	if len(related) != 2 {
+		t.Fatalf("RelatedIssues rows=%d, want 2 detailed findings", len(related))
+	}
+}
+
 func testIssueForMerge(kind, namespace, name string, severity Severity, firstSeen time.Time) Issue {
 	iss := Issue{
 		Severity:  severity,
@@ -42,6 +142,25 @@ func testIssueForMerge(kind, namespace, name string, severity Severity, firstSee
 		Reason:    "TestReason",
 		FirstSeen: firstSeen,
 		LastSeen:  firstSeen,
+	}
+	classifyIssue(&iss)
+	enrichIdentity(&iss)
+	return iss
+}
+
+func duplicateEnvIssueForMerge(namespace, name, container, envName string, firstSeen, lastSeen time.Time) Issue {
+	iss := Issue{
+		Severity:    SeverityWarning,
+		Source:      SourceProblem,
+		Kind:        "Deployment",
+		Group:       "apps",
+		Namespace:   namespace,
+		Name:        name,
+		Reason:      "DuplicateEnvVar",
+		Message:     envName + " in " + container,
+		Fingerprint: "dup-env:" + namespace + ":" + name + ":" + container + ":" + envName,
+		FirstSeen:   firstSeen,
+		LastSeen:    lastSeen,
 	}
 	classifyIssue(&iss)
 	enrichIdentity(&iss)

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -133,8 +133,8 @@ func TestMergeExternalIssuesDuplicateEnvPresentationBoundaries(t *testing.T) {
 	}
 
 	p := &fakeProvider{problems: []k8s.Detection{
-		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in app", Fingerprint: "dup-env:apps:web:app:APP_MODE"},
-		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in init", Fingerprint: "dup-env:apps:web:init:APP_MODE"},
+		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in app", Fingerprint: k8s.FormatDuplicateEnvVarFingerprint("apps", "web", "app", "APP_MODE")},
+		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in init", Fingerprint: k8s.FormatDuplicateEnvVarFingerprint("apps", "web", "init", "APP_MODE")},
 	}}
 	base, baseStats := ComposeWithStats(p, Filters{Grouped: true, Limit: NoLimit})
 	composed, composedStats := MergeExternalIssues(base, baseStats, Filters{Grouped: true, Limit: NoLimit}, nil)
@@ -216,7 +216,7 @@ func duplicateEnvIssueForMerge(namespace, name, container, envName string, first
 		Name:        name,
 		Reason:      "DuplicateEnvVar",
 		Message:     envName + " in " + container,
-		Fingerprint: "dup-env:" + namespace + ":" + name + ":" + container + ":" + envName,
+		Fingerprint: k8s.FormatDuplicateEnvVarFingerprint(namespace, name, container, envName),
 		FirstSeen:   firstSeen,
 		LastSeen:    lastSeen,
 	}

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -104,6 +104,14 @@ func TestMergeExternalIssuesAggregatesDuplicateEnvWithoutExtras(t *testing.T) {
 			t.Fatalf("aggregate ID changed under permutation: %q != %q", again[i].ID, aggregate.ID)
 		}
 	}
+	workerMembers := []Issue{
+		duplicateEnvIssueForMerge("apps", "worker", "app", "APP_MODE", now, now),
+		duplicateEnvIssueForMerge("apps", "worker", "app", "API_PASSWORD", now, now),
+	}
+	workerAggregate := newDuplicateEnvAggregate(workerMembers)
+	if workerAggregate.ID == aggregate.ID {
+		t.Fatalf("aggregate ID %q collides across workloads", aggregate.ID)
+	}
 	if !reflect.DeepEqual(got[0], unrelated) {
 		t.Fatalf("unrelated issue changed:\n got: %+v\nwant: %+v", got[0], unrelated)
 	}

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -1,7 +1,9 @@
 package issues
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,6 +50,7 @@ func TestMergeExternalIssuesAggregatesDuplicateEnvWithoutExtras(t *testing.T) {
 	members[0].DiagnosticContext = &issuesapi.DiagnosticContext{Role: issuesapi.DiagnosticRoleCandidate}
 	members[0].ChangeContext = &issuesapi.ChangeContext{}
 	members[0].IssueTiming = "started_at_resource_creation"
+	members[1].Message = `Container app defines env API_PASSWORD at 1="secret-one", 2="secret-two"`
 	unrelated := testIssueForMerge("Deployment", "apps", "web", SeverityCritical, now.Add(-time.Hour))
 
 	got, stats := MergeExternalIssues(append(append([]Issue(nil), members...), unrelated), ComposeStats{}, Filters{
@@ -67,14 +70,21 @@ func TestMergeExternalIssuesAggregatesDuplicateEnvWithoutExtras(t *testing.T) {
 	if aggregate == nil {
 		t.Fatal("duplicate-env aggregate missing")
 	}
-	wantMessage := "This workload has duplicate environment variable definitions in 3 places across its containers. Later declarations hide earlier ones, and apply/patch may drop hidden entries."
+	wantMessage := "Duplicate environment variables: API_PASSWORD (app), APP_MODE (app), INIT_MODE (init). This is a configuration risk: the workload may be running normally, but later declarations shadow earlier ones and apply/patch can drop shadowed entries."
 	if aggregate.Message != wantMessage {
 		t.Fatalf("message = %q, want %q", aggregate.Message, wantMessage)
+	}
+	if strings.Contains(aggregate.Message, "secret-one") || strings.Contains(aggregate.Message, "secret-two") {
+		t.Fatalf("aggregate message leaked member values: %q", aggregate.Message)
+	}
+	wantAction := "Remove duplicate entries from the workload manifest or chart so each environment variable is declared once per container, then redeploy through the normal delivery path."
+	if aggregate.Action != wantAction {
+		t.Fatalf("action = %q, want %q", aggregate.Action, wantAction)
 	}
 	if !aggregate.FirstSeen.Equal(now.Add(-30*time.Minute)) || !aggregate.LastSeen.Equal(now.Add(2*time.Minute)) {
 		t.Fatalf("aggregate timestamps = %s..%s", aggregate.FirstSeen, aggregate.LastSeen)
 	}
-	if aggregate.Count != 0 || aggregate.Cause != "" || aggregate.Action != "" || aggregate.DiagnosticContext != nil || aggregate.ChangeContext != nil || aggregate.IssueTiming != "" {
+	if aggregate.Count != 0 || aggregate.Cause != "" || aggregate.DiagnosticContext != nil || aggregate.ChangeContext != nil || aggregate.IssueTiming != "" {
 		t.Fatalf("aggregate inherited member-only fields: %+v", *aggregate)
 	}
 	for _, member := range members {
@@ -139,7 +149,7 @@ func TestMergeExternalIssuesFiltersDuplicateEnvAggregatePublicShape(t *testing.T
 		duplicateEnvIssueForMerge("apps", "web", "init", "API_PASSWORD", now, now),
 	}
 
-	memberFilter, err := filter.CompileIssueFilter(`message.contains("APP_MODE")`)
+	memberFilter, err := filter.CompileIssueFilter(`message.contains("APP_MODE in app")`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,13 +158,29 @@ func TestMergeExternalIssuesFiltersDuplicateEnvAggregatePublicShape(t *testing.T
 		t.Fatalf("member-only filter matched rewritten aggregate: %+v, TotalMatched=%d", got, stats.TotalMatched)
 	}
 
-	aggregateFilter, err := filter.CompileIssueFilter(`message.contains("definitions in 2 places")`)
+	aggregateFilter, err := filter.CompileIssueFilter(`message.contains("API_PASSWORD (init)")`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	got, stats = MergeExternalIssues(members, ComposeStats{}, Filters{Grouped: true, Limit: NoLimit, Filter: aggregateFilter}, nil)
 	if len(got) != 1 || stats.TotalMatched != 1 || got[0].Fingerprint != duplicateEnvAggregateFingerprint {
 		t.Fatalf("aggregate filter result = %+v, TotalMatched=%d", got, stats.TotalMatched)
+	}
+}
+
+func TestDuplicateEnvAggregateBoundsEvidenceSummary(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	members := make([]Issue, 0, 7)
+	for i := range 7 {
+		members = append(members, duplicateEnvIssueForMerge("apps", "web", "app", fmt.Sprintf("VAR_%d", i), now, now))
+	}
+
+	aggregate := newDuplicateEnvAggregate(members)
+	if !strings.Contains(aggregate.Message, "VAR_0 (app), VAR_1 (app), VAR_2 (app), VAR_3 (app), VAR_4 (app), +2 more") {
+		t.Fatalf("bounded aggregate message = %q", aggregate.Message)
+	}
+	if strings.Contains(aggregate.Message, "VAR_5") || strings.Contains(aggregate.Message, "VAR_6") {
+		t.Fatalf("aggregate message exceeded detail cap: %q", aggregate.Message)
 	}
 }
 

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -136,6 +136,11 @@ func TestMergeExternalIssuesDuplicateEnvPresentationBoundaries(t *testing.T) {
 		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in app", Fingerprint: "dup-env:apps:web:app:APP_MODE"},
 		{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web", Severity: "warning", Reason: "DuplicateEnvVar", Message: "APP_MODE in init", Fingerprint: "dup-env:apps:web:init:APP_MODE"},
 	}}
+	base, baseStats := ComposeWithStats(p, Filters{Grouped: true, Limit: NoLimit})
+	composed, composedStats := MergeExternalIssues(base, baseStats, Filters{Grouped: true, Limit: NoLimit}, nil)
+	if len(composed) != 1 || composedStats.TotalMatched != 1 || !strings.Contains(composed[0].Message, "APP_MODE (app), APP_MODE (init)") {
+		t.Fatalf("composed aggregate lost env evidence: %+v, TotalMatched=%d", composed, composedStats.TotalMatched)
+	}
 	related := RelatedIssues(p, nil, "apps", "Deployment", "apps", "web")
 	if len(related) != 2 {
 		t.Fatalf("RelatedIssues rows=%d, want 2 detailed findings", len(related))

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skyhook-io/radar/internal/filter"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
@@ -128,6 +129,32 @@ func TestMergeExternalIssuesDuplicateEnvPresentationBoundaries(t *testing.T) {
 	related := RelatedIssues(p, nil, "apps", "Deployment", "apps", "web")
 	if len(related) != 2 {
 		t.Fatalf("RelatedIssues rows=%d, want 2 detailed findings", len(related))
+	}
+}
+
+func TestMergeExternalIssuesFiltersDuplicateEnvAggregatePublicShape(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	members := []Issue{
+		duplicateEnvIssueForMerge("apps", "web", "app", "APP_MODE", now, now),
+		duplicateEnvIssueForMerge("apps", "web", "init", "API_PASSWORD", now, now),
+	}
+
+	memberFilter, err := filter.CompileIssueFilter(`message.contains("APP_MODE")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, stats := MergeExternalIssues(members, ComposeStats{}, Filters{Grouped: true, Limit: NoLimit, Filter: memberFilter}, nil)
+	if len(got) != 0 || stats.TotalMatched != 0 {
+		t.Fatalf("member-only filter matched rewritten aggregate: %+v, TotalMatched=%d", got, stats.TotalMatched)
+	}
+
+	aggregateFilter, err := filter.CompileIssueFilter(`message.contains("definitions in 2 places")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, stats = MergeExternalIssues(members, ComposeStats{}, Filters{Grouped: true, Limit: NoLimit, Filter: aggregateFilter}, nil)
+	if len(got) != 1 || stats.TotalMatched != 1 || got[0].Fingerprint != duplicateEnvAggregateFingerprint {
+		t.Fatalf("aggregate filter result = %+v, TotalMatched=%d", got, stats.TotalMatched)
 	}
 }
 

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -126,6 +126,7 @@ func foldGroup(members []Issue) Issue {
 		Reason:               rep.Reason,
 		Message:              rep.Message,
 		RawMessage:           rep.RawMessage,
+		Fingerprint:          rep.Fingerprint,
 		RestartCount:         rep.RestartCount,
 		LastTerminatedReason: rep.LastTerminatedReason,
 		FirstSeen:            rep.FirstSeen,

--- a/internal/k8s/detect_config.go
+++ b/internal/k8s/detect_config.go
@@ -168,7 +168,7 @@ func detectDuplicateEnvVars(cache *ResourceCache, namespace string, now time.Tim
 			Message:     check.Message,
 			Age:         FormatAge(time.Duration(check.AgeSeconds) * time.Second),
 			AgeSeconds:  check.AgeSeconds,
-			Fingerprint: fmt.Sprintf("dup-env:%s:%s:%s:%s", check.Namespace, check.WorkloadName, check.Container, check.EnvName),
+			Fingerprint: FormatDuplicateEnvVarFingerprint(check.Namespace, check.WorkloadName, check.Container, check.EnvName),
 		})
 	}
 	return out

--- a/internal/k8s/detect_config_test.go
+++ b/internal/k8s/detect_config_test.go
@@ -181,7 +181,7 @@ func TestDetectConfigProblemsIncludesDuplicateEnvVars(t *testing.T) {
 	if detection.Severity != "warning" || detection.Reason != "DuplicateEnvVar" {
 		t.Fatalf("unexpected severity/reason: %+v", detection)
 	}
-	if detection.Fingerprint != "dup-env:prod:web:app:APP_HOST" || detection.AgeSeconds != 7200 {
+	if detection.Fingerprint != FormatDuplicateEnvVarFingerprint("prod", "web", "app", "APP_HOST") || detection.AgeSeconds != 7200 {
 		t.Fatalf("unexpected identity/age: %+v", detection)
 	}
 }

--- a/internal/k8s/duplicate_env_fingerprint.go
+++ b/internal/k8s/duplicate_env_fingerprint.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+)
+
+const duplicateEnvVarFingerprintPrefix = "dup-env"
+
+type DuplicateEnvVarFingerprint struct {
+	Namespace    string
+	WorkloadName string
+	Container    string
+	EnvName      string
+}
+
+func FormatDuplicateEnvVarFingerprint(namespace, workloadName, container, envName string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s", duplicateEnvVarFingerprintPrefix, namespace, workloadName, container, envName)
+}
+
+func ParseDuplicateEnvVarFingerprint(fingerprint string) (DuplicateEnvVarFingerprint, bool) {
+	parts := strings.SplitN(fingerprint, ":", 5)
+	if len(parts) != 5 || parts[0] != duplicateEnvVarFingerprintPrefix {
+		return DuplicateEnvVarFingerprint{}, false
+	}
+	return DuplicateEnvVarFingerprint{
+		Namespace:    parts[1],
+		WorkloadName: parts[2],
+		Container:    parts[3],
+		EnvName:      parts[4],
+	}, true
+}

--- a/internal/k8s/duplicate_env_fingerprint_test.go
+++ b/internal/k8s/duplicate_env_fingerprint_test.go
@@ -1,0 +1,33 @@
+package k8s
+
+import "testing"
+
+func TestDuplicateEnvVarFingerprintRoundTrip(t *testing.T) {
+	want := DuplicateEnvVarFingerprint{
+		Namespace:    "prod",
+		WorkloadName: "web",
+		Container:    "app",
+		EnvName:      "APP:MODE",
+	}
+
+	encoded := FormatDuplicateEnvVarFingerprint(want.Namespace, want.WorkloadName, want.Container, want.EnvName)
+	if encoded != "dup-env:prod:web:app:APP:MODE" {
+		t.Fatalf("FormatDuplicateEnvVarFingerprint() = %q", encoded)
+	}
+	got, ok := ParseDuplicateEnvVarFingerprint(encoded)
+	if !ok || got != want {
+		t.Fatalf("ParseDuplicateEnvVarFingerprint(%q) = %+v, %t; want %+v, true", encoded, got, ok, want)
+	}
+}
+
+func TestParseDuplicateEnvVarFingerprintRejectsOtherShapes(t *testing.T) {
+	for _, fingerprint := range []string{
+		"",
+		"other:prod:web:app:APP_MODE",
+		"dup-env:prod:web:APP_MODE",
+	} {
+		if got, ok := ParseDuplicateEnvVarFingerprint(fingerprint); ok {
+			t.Fatalf("ParseDuplicateEnvVarFingerprint(%q) = %+v, true; want false", fingerprint, got)
+		}
+	}
+}

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -1324,28 +1324,15 @@ func sanitizeConfigValue(path string, value any) any {
 }
 
 func sensitivePath(path string) bool {
-	if sensitivePathSegment(strings.ToLower(path)) {
+	if aicontext.IsSensitiveEnvName(path) {
 		return true
 	}
 	for _, part := range strings.FieldsFunc(path, func(r rune) bool { return r == '.' || r == '[' || r == ']' || r == '/' || r == '-' || r == '_' }) {
-		if sensitivePathSegment(part) {
+		if aicontext.IsSensitiveEnvName(part) {
 			return true
 		}
 	}
 	return false
-}
-
-func sensitivePathSegment(segment string) bool {
-	segment = strings.ToLower(segment)
-	compact := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(segment)
-	return strings.Contains(segment, "password") || strings.Contains(segment, "passwd") ||
-		strings.Contains(segment, "token") || strings.Contains(segment, "secret") ||
-		strings.Contains(segment, "credential") ||
-		strings.Contains(segment, "api_key") || strings.Contains(segment, "apikey") ||
-		strings.Contains(segment, "accesskey") || strings.Contains(segment, "privatekey") ||
-		strings.Contains(segment, "private_key") ||
-		strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") ||
-		strings.Contains(compact, "privatekey") || strings.Contains(compact, "clientsecret")
 }
 
 func truncateConfigScalar(value string, max int) string {
@@ -3184,7 +3171,7 @@ func commandArgNameLooksSecret(value string) bool {
 	if name == "key" {
 		return true
 	}
-	return sensitivePathSegment(name)
+	return aicontext.IsSensitiveEnvName(name)
 }
 
 func getTotalRestarts(statuses []corev1.ContainerStatus) int32 {

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -3138,7 +3138,7 @@ func valueOrNil(v string, ok bool) any {
 }
 
 func envNameLooksSecret(name string) bool {
-	return sensitivePathSegment(name)
+	return aicontext.IsSensitiveEnvName(name)
 }
 
 func commandArgDisplayValues(values []string) []string {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2748,6 +2748,7 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 	}
 	composeFilters := filters
 	composeFilters.Limit = issues.NoLimit
+	composeFilters.Filter = nil
 	out, stats := issues.ComposeWithStats(provider, composeFilters)
 	out, stats = issues.MergeExternalIssues(out, stats, filters, nativeHelmIssuesForContext(ctx, allowedNamespaces, filters))
 	// Shared base response shape (issues.ListResponse), then MCP-specific

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -98,6 +98,7 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 
 	composeFilters := filters
 	composeFilters.Limit = issues.NoLimit
+	composeFilters.Filter = nil
 	out, stats := issues.ComposeWithStats(provider, composeFilters)
 	out, stats = issues.MergeExternalIssues(out, stats, filters, s.nativeHelmIssuesForRequest(r, namespaces, filters))
 	// Shared base response shape (issues.ListResponse); surfaces add their

--- a/pkg/ai/context/compact.go
+++ b/pkg/ai/context/compact.go
@@ -61,6 +61,7 @@ func pruneMapCompact(m map[string]any) {
 // unconditional key drops ride the shared profiles' Drop + ElementDrops.
 func pruneSpecElementsCompact(m map[string]any) {
 	forEachContainer(m, pruneContainerConditionalCompact)
+	sanitizeSpecEnvLists(m, true)
 }
 
 func minifySecretCompact(secret *corev1.Secret) map[string]any {

--- a/pkg/ai/context/detail.go
+++ b/pkg/ai/context/detail.go
@@ -70,6 +70,7 @@ func pruneMapDetail(m map[string]any) {
 // detailBaseProfile's Drop + ElementDrops).
 func pruneSpecElements(m map[string]any) {
 	forEachContainer(m, pruneContainerConditional)
+	sanitizeSpecEnvLists(m, false)
 }
 
 func minifySecretDetail(secret *corev1.Secret) map[string]any {

--- a/pkg/ai/context/minify_test.go
+++ b/pkg/ai/context/minify_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -282,6 +283,120 @@ func TestMinify_Detail_EnvValueRedaction(t *testing.T) {
 	}
 	if !contains(output, "production") {
 		t.Errorf("Safe env value should be preserved at detail level: %s", output)
+	}
+}
+
+func TestMinify_Detail_RedactsSensitiveEnvNamesAcrossPodContainerTypes(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-redaction", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Env: []corev1.EnvVar{
+					{Name: "API_PASSWORD", Value: "secret-one"},
+					{Name: "APP_MODE", Value: "production"},
+					{Name: "EMPTY_VALUE"},
+					{Name: "CONFIG_FROM", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "app-credentials"},
+						Key:                  "password",
+					}}},
+				},
+			}},
+			InitContainers: []corev1.Container{{
+				Name: "init",
+				Env:  []corev1.EnvVar{{Name: "CLIENT_SECRET", Value: "opaque"}},
+			}},
+			EphemeralContainers: []corev1.EphemeralContainer{{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: "debug",
+					Env:  []corev1.EnvVar{{Name: "AUTH_TOKEN", Value: "short"}},
+				},
+			}},
+		},
+	}
+
+	raw, err := Minify(pod, LevelDetail)
+	if err != nil {
+		t.Fatalf("Minify failed: %v", err)
+	}
+	data, _ := json.Marshal(raw)
+	output := string(data)
+	for _, leaked := range []string{"secret-one", "opaque", "short"} {
+		if contains(output, leaked) {
+			t.Errorf("sensitive env value %q leaked: %s", leaked, output)
+		}
+	}
+	for _, preserved := range []string{"production", "app-credentials", `"key":"password"`} {
+		if !contains(output, preserved) {
+			t.Errorf("expected safe/reference value %q to survive: %s", preserved, output)
+		}
+	}
+	compactRaw, err := Minify(pod, LevelCompact)
+	if err != nil {
+		t.Fatalf("Minify Compact failed: %v", err)
+	}
+	compactData, _ := json.Marshal(compactRaw)
+	if !contains(string(compactData), "EMPTY_VALUE") || contains(string(compactData), `"name":"EMPTY_VALUE"`) {
+		t.Fatalf("empty literal env was not reduced to its name: %s", compactData)
+	}
+}
+
+func TestMinify_EnvSanitizationCoversCronJobAndNestedUnstructured(t *testing.T) {
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "report", Namespace: "default"},
+		Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{Name: "report", Env: []corev1.EnvVar{
+				{Name: "DB_PASSWORD", Value: "cron-secret"},
+				{Name: "REPORT_MODE", Value: "daily"},
+			}}},
+		}}}}},
+	}
+
+	for _, level := range []VerbosityLevel{LevelDetail, LevelCompact} {
+		raw, err := Minify(cronJob, level)
+		if err != nil {
+			t.Fatalf("Minify CronJob level=%d failed: %v", level, err)
+		}
+		data, _ := json.Marshal(raw)
+		output := string(data)
+		if contains(output, "cron-secret") {
+			t.Fatalf("CronJob password leaked at level=%d: %s", level, output)
+		}
+		if !contains(output, "DB_PASSWORD") || !contains(output, "REPORT_MODE") {
+			t.Fatalf("CronJob env names missing at level=%d: %s", level, output)
+		}
+		if level == LevelDetail && !contains(output, "daily") {
+			t.Fatalf("safe CronJob env value missing at Detail: %s", output)
+		}
+		if level == LevelCompact && contains(output, "daily") {
+			t.Fatalf("CronJob env value survived Compact: %s", output)
+		}
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Worker",
+		"metadata":   map[string]any{"name": "nested", "namespace": "default"},
+		"spec": map[string]any{"controller": map[string]any{"template": map[string]any{"env": []any{
+			map[string]any{"name": "API_PASSWORD", "value": "nested-secret"},
+			map[string]any{"name": "APP_MODE", "value": "staging"},
+			map[string]any{"name": "CONFIG_FROM", "valueFrom": map[string]any{"secretKeyRef": map[string]any{"name": "worker-credentials", "key": "password"}}},
+			map[string]any{"name": "MALFORMED"},
+			map[string]any{"value": "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo5MDEyMzQ1Njc4OUFCQ0RFRg=="},
+			"QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo5MDEyMzQ1Njc4OUFCQ0RFRg==",
+		}}}},
+	}}
+
+	detailData, _ := json.Marshal(MinifyUnstructured(obj, LevelDetail))
+	detail := string(detailData)
+	if contains(detail, "nested-secret") || contains(detail, "QUJDREVGR0hJ") || !contains(detail, "staging") || !contains(detail, "worker-credentials") {
+		t.Fatalf("unexpected nested Detail env sanitization: %s", detail)
+	}
+	compactData, _ := json.Marshal(MinifyUnstructured(obj, LevelCompact))
+	compact := string(compactData)
+	if contains(compact, "nested-secret") || contains(compact, "QUJDREVGR0hJ") || contains(compact, "staging") || !contains(compact, "API_PASSWORD") || !contains(compact, "APP_MODE") {
+		t.Fatalf("unexpected nested Compact env sanitization: %s", compact)
 	}
 }
 

--- a/pkg/ai/context/minify_test.go
+++ b/pkg/ai/context/minify_test.go
@@ -400,6 +400,31 @@ func TestMinify_EnvSanitizationCoversCronJobAndNestedUnstructured(t *testing.T) 
 	}
 }
 
+func TestMinifyUnstructured_EnvSanitizationPreservesNonEnvVarListsAndFailsClosed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Worker",
+		"metadata":   map[string]any{"name": "worker"},
+		"spec": map[string]any{
+			"env": []any{"prod", "staging"},
+			"template": map[string]any{"env": []any{
+				map[string]any{"name": "API_TOKEN", "value": map[string]any{"opaque": "short-secret"}},
+			}},
+		},
+	}}
+
+	for _, level := range []VerbosityLevel{LevelDetail, LevelCompact} {
+		data, _ := json.Marshal(MinifyUnstructured(obj.DeepCopy(), level))
+		output := string(data)
+		if !contains(output, `"env":["prod","staging"]`) {
+			t.Fatalf("non-EnvVar env list changed at level=%d: %s", level, output)
+		}
+		if contains(output, "short-secret") {
+			t.Fatalf("sensitive non-string env value leaked at level=%d: %s", level, output)
+		}
+	}
+}
+
 func TestMinifyUnstructured_Compact(t *testing.T) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{

--- a/pkg/ai/context/prune.go
+++ b/pkg/ai/context/prune.go
@@ -126,8 +126,6 @@ func pruneContainerConditional(container map[string]any) {
 	if policy, ok := container["imagePullPolicy"].(string); ok && policy != "Never" {
 		delete(container, "imagePullPolicy")
 	}
-	// Redact inline env values
-	redactEnvValues(container)
 }
 
 // pruneContainersCompact applies the CONDITIONAL per-container pruning at
@@ -139,9 +137,8 @@ func pruneContainerConditionalCompact(container map[string]any) {
 	if policy, ok := container["imagePullPolicy"].(string); ok && policy != "Never" {
 		delete(container, "imagePullPolicy")
 	}
-	// Simplify volumeMounts + env: keep names only (strip values for tokens)
+	// Simplify volumeMounts; env lists are handled recursively under spec.
 	simplifyVolumeMounts(container)
-	simplifyEnvToNames(container)
 }
 
 func simplifyVolumeMounts(container map[string]any) {
@@ -160,34 +157,91 @@ func simplifyVolumeMounts(container map[string]any) {
 	container["volumeMounts"] = names
 }
 
-func simplifyEnvToNames(container map[string]any) {
-	envList, ok := container["env"].([]any)
+func sanitizeSpecEnvLists(m map[string]any, compact bool) {
+	spec, ok := m["spec"]
 	if !ok {
 		return
 	}
-	names := make([]string, 0, len(envList))
-	for _, e := range envList {
-		if env, ok := e.(map[string]any); ok {
-			if name, ok := env["name"].(string); ok {
-				names = append(names, name)
-			}
-		}
-	}
-	container["env"] = names
+	sanitizeEnvLists(spec, compact)
 }
 
-func redactEnvValues(container map[string]any) {
-	envList, ok := container["env"].([]any)
-	if !ok {
-		return
-	}
-	for _, e := range envList {
-		if env, ok := e.(map[string]any); ok {
-			if val, ok := env["value"].(string); ok {
-				env["value"] = RedactSecrets(val)
+func sanitizeEnvLists(node any, compact bool) {
+	switch value := node.(type) {
+	case map[string]any:
+		for key, child := range value {
+			if key == "env" {
+				if envList, ok := child.([]any); ok {
+					value[key] = sanitizeEnvEntries(envList, compact)
+					continue
+				}
 			}
+			sanitizeEnvLists(child, compact)
+		}
+	case []any:
+		for _, child := range value {
+			sanitizeEnvLists(child, compact)
 		}
 	}
+}
+
+func sanitizeEnvEntries(envList []any, compact bool) any {
+	out := make([]any, 0, len(envList))
+	names := make([]string, 0, len(envList))
+	allRecognized := true
+	for _, item := range envList {
+		env, ok := item.(map[string]any)
+		if !ok {
+			allRecognized = false
+			if compact {
+				continue
+			}
+			if literal, ok := item.(string); ok {
+				out = append(out, RedactSecrets(literal))
+			} else {
+				out = append(out, item)
+			}
+			continue
+		}
+		name, hasName := env["name"].(string)
+		_, hasValue := env["value"]
+		_, hasValueFrom := env["valueFrom"]
+		emptyLiteral := hasName && len(env) == 1
+		if !hasName || (!hasValue && !hasValueFrom && !emptyLiteral) {
+			allRecognized = false
+			if literal, ok := env["value"].(string); ok {
+				if compact {
+					delete(env, "value")
+				} else {
+					env["value"] = RedactSecrets(literal)
+				}
+			}
+			if compact {
+				delete(env, "valueFrom")
+			}
+			sanitizeEnvLists(env, compact)
+			if len(env) > 0 {
+				out = append(out, env)
+			}
+			continue
+		}
+		if compact {
+			names = append(names, name)
+			out = append(out, name)
+			continue
+		}
+		if literal, ok := env["value"].(string); ok {
+			if IsSensitiveEnvName(name) {
+				env["value"] = "[REDACTED]"
+			} else {
+				env["value"] = RedactSecrets(literal)
+			}
+		}
+		out = append(out, env)
+	}
+	if compact && allRecognized {
+		return names
+	}
+	return out
 }
 
 // The flat drop tables above are POLICY; the tree surgery executing them is

--- a/pkg/ai/context/prune.go
+++ b/pkg/ai/context/prune.go
@@ -170,7 +170,7 @@ func sanitizeEnvLists(node any, compact bool) {
 	case map[string]any:
 		for key, child := range value {
 			if key == "env" {
-				if envList, ok := child.([]any); ok {
+				if envList, ok := child.([]any); ok && containsEnvEntry(envList) {
 					value[key] = sanitizeEnvEntries(envList, compact)
 					continue
 				}
@@ -182,6 +182,24 @@ func sanitizeEnvLists(node any, compact bool) {
 			sanitizeEnvLists(child, compact)
 		}
 	}
+}
+
+func containsEnvEntry(items []any) bool {
+	for _, item := range items {
+		env, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := env["name"].(string); !ok {
+			continue
+		}
+		_, hasValue := env["value"]
+		_, hasValueFrom := env["valueFrom"]
+		if hasValue || hasValueFrom || len(env) == 1 {
+			return true
+		}
+	}
+	return false
 }
 
 func sanitizeEnvEntries(envList []any, compact bool) any {
@@ -229,10 +247,10 @@ func sanitizeEnvEntries(envList []any, compact bool) any {
 			out = append(out, name)
 			continue
 		}
-		if literal, ok := env["value"].(string); ok {
+		if literal, ok := env["value"]; ok {
 			if IsSensitiveEnvName(name) {
 				env["value"] = "[REDACTED]"
-			} else {
+			} else if literal, ok := literal.(string); ok {
 				env["value"] = RedactSecrets(literal)
 			}
 		}

--- a/pkg/ai/context/redact.go
+++ b/pkg/ai/context/redact.go
@@ -53,6 +53,19 @@ func isSensitiveKey(key string) bool {
 	return sensitiveValueKeys[norm]
 }
 
+func IsSensitiveEnvName(name string) bool {
+	lower := strings.ToLower(name)
+	compact := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(lower)
+	return strings.Contains(lower, "password") || strings.Contains(lower, "passwd") ||
+		strings.Contains(lower, "token") || strings.Contains(lower, "secret") ||
+		strings.Contains(lower, "credential") ||
+		strings.Contains(lower, "api_key") || strings.Contains(lower, "apikey") ||
+		strings.Contains(lower, "accesskey") || strings.Contains(lower, "privatekey") ||
+		strings.Contains(lower, "private_key") ||
+		strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") ||
+		strings.Contains(compact, "privatekey") || strings.Contains(compact, "clientsecret")
+}
+
 func applyPatterns(text string, patterns []*regexp.Regexp) string {
 	result := text
 	for _, pattern := range patterns {

--- a/pkg/ai/context/redact_test.go
+++ b/pkg/ai/context/redact_test.go
@@ -78,6 +78,22 @@ func TestRedactSecrets_EmptyString(t *testing.T) {
 	}
 }
 
+func TestIsSensitiveEnvName(t *testing.T) {
+	for _, name := range []string{
+		"API_PASSWORD", "database-passwd", "AUTH_TOKEN", "client.secret",
+		"cloud_credential", "API_KEY", "AccessKey", "PRIVATE_KEY",
+	} {
+		if !IsSensitiveEnvName(name) {
+			t.Errorf("IsSensitiveEnvName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"APP_MODE", "LOG_LEVEL", "BUILD_SHA"} {
+		if IsSensitiveEnvName(name) {
+			t.Errorf("IsSensitiveEnvName(%q) = true, want false", name)
+		}
+	}
+}
+
 func TestRedactSecrets_GitHubAppToken(t *testing.T) {
 	input := "token: ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
 	result := RedactSecrets(input)


### PR DESCRIPTION
## Description

Follow-up to #1222 that makes duplicate environment-variable findings actionable without turning a latent configuration risk into alert noise, and closes AI-context redaction gaps.

- Collapse two or more `DuplicateEnvVar` findings for one workload into one warning in grouped Overview/MCP responses. The message lists up to five sorted `ENV_KEY (container)` pairs, omits values, and explains that the workload may be running normally while later declarations shadow earlier ones.
- Keep single findings and flat/resource-detail responses per variable and container so detailed evidence remains available.
- Preserve deterministic aggregate identity, maximum severity, timestamp envelope, totals, ordering, filtering, and post-aggregation limits. CEL filters run against the final public aggregate shape.
- Share the duplicate-env fingerprint formatter/parser between the detector and aggregator, with the internal fingerprint excluded from JSON.
- Redact sensitive-named literal env values in AI Detail across regular, init, ephemeral, CronJob, and nested unstructured templates. Preserve safe literals and `valueFrom` references; keep Compact output names-only.
- Reuse the sensitive-env-name policy in workload history. Fail closed for malformed sensitive-named values while preserving unrelated CRD fields that happen to be named `env`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [x] Tested against a remote cluster
- [x] Added/updated unit tests

Automated checks:

- `make tsc`
- `make test`
- `make build`
- `go test ./ai/context` from `pkg/`
- `git diff --check`

Live-tested exact head `3efeae4f` against the nonprod GKE cluster with an isolated zero-replica Deployment containing three duplicate-env findings and a temporary namespaced CRD/CR:

- Default `/api/issues`: one workload aggregate with key/container evidence
- `/api/issues?view=flat`: three detailed findings
- `/api/issues/resource/...`: three detailed findings
- MCP `issues`: one workload aggregate
- AI Detail: password-named literal values redacted; safe `APP_MODE` values preserved
- Unstructured AI Detail: non-EnvVar `spec.env: [prod, staging]` preserved; malformed sensitive-named object value redacted
- Overview: exactly one rendered issue row, with zero browser console errors

The fixture namespace, temporary CRD, and Radar process were removed after verification.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments only where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Follow-up to #1222.
