### PR TITLE
Let MCP search accept structured namespace scope

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -392,7 +392,8 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"metadata, but data values won't appear in snippets to avoid leaking " +
 			"secret material through search results. " +
 			"Examples: `readinessProbe user-service`, `image:flagd`, `kind:Pod label:app=cart error`. " +
-			"Modifiers such as kind:Pod, ns:foo, label:app=bar, and image:redis narrow a " +
+			"Use the namespace parameter for structured namespace scoping. Modifiers such as " +
+			"kind:Pod, ns:foo, label:app=bar, and image:redis narrow a " +
 			"term match; modifier-only queries are enumeration, so use list_resources when " +
 			"you already know the kind/namespace. Returns ranked hits with snippets and " +
 			"summaryContext. Use CEL filter for structural predicates. Searches typed kinds " +
@@ -615,11 +616,12 @@ type podLogsInput struct {
 }
 
 type searchInput struct {
-	Query   string `json:"query" jsonschema:"search query for unknown resources or broad content scans. Free tokens AND'd. Matches identity plus searchable object content. Examples: adServiceFailure, kind:NetworkChaos delay, kind:ConfigMap flagd, image:flagd. Modifiers: kind:Pod, kind:NetworkChaos, ns:foo, label:k=v, image:redis"`
-	Limit   int    `json:"limit,omitempty" jsonschema:"max hits returned (default 50, max 500)"`
-	Include string `json:"include,omitempty" jsonschema:"per-hit detail: summary (default), raw, or none"`
-	Filter  string `json:"filter,omitempty" jsonschema:"optional CEL boolean expression run against each candidate K8s object. Bindings: kind, apiVersion, metadata, spec, status, labels, annotations. Use has(x.y) before optional fields. Examples: 'kind == \"Pod\" && status.phase == \"Failed\"', 'labels[\"app\"] == \"cart\"', 'has(status.readyReplicas) && status.readyReplicas == 0'"`
-	Context string `json:"context,omitempty" jsonschema:"per-hit context: default attaches summaryContext (managedBy + health + issueCount) for suspect ranking; 'none' returns bare hits"`
+	Query     string `json:"query" jsonschema:"search query for unknown resources or broad content scans. Free tokens AND'd. Matches identity plus searchable object content. Examples: adServiceFailure, kind:NetworkChaos delay, kind:ConfigMap flagd, image:flagd. Modifiers: kind:Pod, kind:NetworkChaos, ns:foo, label:k=v, image:redis"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"optional namespace to scope the search; equivalent to an inline ns: modifier. When set, overrides all inline namespace modifiers"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"max hits returned (default 50, max 500)"`
+	Include   string `json:"include,omitempty" jsonschema:"per-hit detail: summary (default), raw, or none"`
+	Filter    string `json:"filter,omitempty" jsonschema:"optional CEL boolean expression run against each candidate K8s object. Bindings: kind, apiVersion, metadata, spec, status, labels, annotations. Use has(x.y) before optional fields. Examples: 'kind == \"Pod\" && status.phase == \"Failed\"', 'labels[\"app\"] == \"cart\"', 'has(status.readyReplicas) && status.readyReplicas == 0'"`
+	Context   string `json:"context,omitempty" jsonschema:"per-hit context: default attaches summaryContext (managedBy + health + issueCount) for suspect ranking; 'none' returns bare hits"`
 }
 
 type issuesInput struct {
@@ -2971,6 +2973,9 @@ func handleSearch(ctx context.Context, req *mcp.CallToolRequest, input searchInp
 		return nil, nil, fmt.Errorf("query is required")
 	}
 	parsed := search.Parse(query)
+	if input.Namespace != "" {
+		parsed.NSFilter = []string{input.Namespace}
+	}
 	allowed := filterNamespacesForUser(ctx, nil)
 	if allowed != nil && len(allowed) == 0 {
 		return toJSONResult(search.Result{Hits: []search.Hit{}})

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"regexp"
 	"sort"
@@ -66,6 +67,33 @@ func TestSetupDialogCoversAllTools(t *testing.T) {
 	if len(staleInDialog) > 0 {
 		t.Errorf("setup dialog catalog (%s) lists tools that are not registered — remove them: %s",
 			setupDialogCatalogPath, strings.Join(staleInDialog, ", "))
+	}
+}
+
+func TestSearchToolSchemaIncludesNamespace(t *testing.T) {
+	var searchTool *mcpsdk.Tool
+	for _, tool := range listRegisteredTools(t) {
+		if tool.Name == "search" {
+			searchTool = tool
+			break
+		}
+	}
+	if searchTool == nil {
+		t.Fatal("search tool is not registered")
+	}
+
+	raw, err := json.Marshal(searchTool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal search input schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal search input schema: %v", err)
+	}
+	if _, ok := schema.Properties["namespace"]; !ok {
+		t.Fatalf("search input schema does not accept namespace: %s", raw)
 	}
 }
 

--- a/internal/mcp/tools_filter_test.go
+++ b/internal/mcp/tools_filter_test.go
@@ -661,6 +661,63 @@ func TestHandleSearch_Secrets_PerNamespaceFanout(t *testing.T) {
 	}
 }
 
+func TestHandleSearch_NamespaceParameter(t *testing.T) {
+	setupFakeCacheForFilterTests(t)
+
+	t.Run("matches inline scope", func(t *testing.T) {
+		structured, _, err := handleSearch(context.Background(), nil, searchInput{Query: "kind:Pod", Namespace: "alpha"})
+		if err != nil {
+			t.Fatalf("structured namespace: %v", err)
+		}
+		inline, _, err := handleSearch(context.Background(), nil, searchInput{Query: "kind:Pod ns:alpha"})
+		if err != nil {
+			t.Fatalf("inline namespace: %v", err)
+		}
+		if got, want := extractText(t, structured), extractText(t, inline); got != want {
+			t.Errorf("structured namespace result differs from inline scope\nstructured: %s\ninline: %s", got, want)
+		}
+	})
+
+	t.Run("omitted remains cluster wide", func(t *testing.T) {
+		result, _, err := handleSearch(context.Background(), nil, searchInput{Query: "kind:Pod"})
+		if err != nil {
+			t.Fatalf("handleSearch: %v", err)
+		}
+		body := extractText(t, result)
+		for _, want := range []string{"alpha-pod", "beta-pod", "gamma-pod"} {
+			if !containsName(body, want) {
+				t.Errorf("cluster-wide search missing %s: %s", want, body)
+			}
+		}
+	})
+
+	t.Run("denied namespace returns no hits", func(t *testing.T) {
+		ctx := withRestrictedUser(t, "namespace-search-user", []string{"alpha"})
+		result, _, err := handleSearch(ctx, nil, searchInput{Query: "kind:Pod", Namespace: "beta"})
+		if err != nil {
+			t.Fatalf("handleSearch: %v", err)
+		}
+		body := extractText(t, result)
+		if containsName(body, "alpha-pod") || containsName(body, "beta-pod") || containsName(body, "gamma-pod") {
+			t.Errorf("denied namespace search returned pod hits: %s", body)
+		}
+	})
+
+	t.Run("top level overrides inline namespace modifiers", func(t *testing.T) {
+		result, _, err := handleSearch(context.Background(), nil, searchInput{Query: "kind:Pod namespace:beta", Namespace: "alpha"})
+		if err != nil {
+			t.Fatalf("handleSearch: %v", err)
+		}
+		body := extractText(t, result)
+		if !containsName(body, "alpha-pod") {
+			t.Errorf("top-level namespace result missing alpha-pod: %s", body)
+		}
+		if containsName(body, "beta-pod") || containsName(body, "gamma-pod") {
+			t.Errorf("inline namespace was not overridden: %s", body)
+		}
+	})
+}
+
 func TestHandleSearch_Secrets_ClusterWideShape_NsFilter(t *testing.T) {
 	// Regression for the bug where AllowedNamespaces==nil (cluster-wide
 	// namespace sentinel) plus a concrete `ns:` filter took the cluster-
@@ -689,6 +746,18 @@ func TestHandleSearch_Secrets_ClusterWideShape_NsFilter(t *testing.T) {
 	}
 	if containsName(body, "beta-secret") {
 		t.Errorf("beta-secret leaked despite ns:alpha filter + per-ns RBAC: %s", body)
+	}
+
+	result, _, err = handleSearch(ctx, nil, searchInput{Query: "kind:Secret", Namespace: "alpha"})
+	if err != nil {
+		t.Fatalf("handleSearch with structured namespace: %v", err)
+	}
+	body = extractText(t, result)
+	if !containsName(body, "alpha-secret") {
+		t.Errorf("structured namespace did not reach per-namespace secret RBAC: %s", body)
+	}
+	if containsName(body, "beta-secret") {
+		t.Errorf("beta-secret leaked despite structured namespace + per-ns RBAC: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

MCP agents can now scope search calls with the same structured namespace argument used by adjacent Radar tools. This removes the strict-schema rejection that forced agents to retry with an inline namespace query modifier.

## What changed

- Adds an optional namespace property to the generated search tool schema and documents it in the tool description.
- Routes structured namespace values into the existing parsed namespace filter before user-access intersection, lister scoping, and per-namespace Secret authorization.
- Defines deterministic mixed-input behavior: a non-empty top-level namespace overrides all inline namespace modifiers. Omitted namespace keeps the existing cluster-wide behavior.
- Covers generated-schema exposure, structured-versus-inline equivalence, cluster-wide defaults, denied namespace access, mixed-input precedence, and Secret authorization fanout.

## Testing

- go test ./internal/mcp/... -count=1
- make tsc
- make test
- go build ./...
- make backend
- make build
- Visual test skipped because this is an MCP and Go-only change with no rendered UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive MCP API change with tests; namespace scoping reuses existing RBAC and search paths rather than new authorization logic.
> 
> **Overview**
> Adds an optional **`namespace`** parameter to the MCP **`search`** tool so agents can scope searches with structured JSON instead of only inline `ns:` / `namespace:` query modifiers—aligning with other Radar MCP tools and avoiding strict-schema rejections.
> 
> **`handleSearch`** sets `parsed.NSFilter` from `input.Namespace` after parsing the query; a non-empty top-level value **replaces** any inline namespace modifiers. Omitted `namespace` keeps cluster-wide search. Scope still flows through user namespace allow-lists, Secret per-namespace SAR fanout, and the rest of the existing search pipeline.
> 
> The **`search`** tool description and **`searchInput`** jsonschema document the new field. Tests assert the generated input schema exposes `namespace`, equivalence with `ns:alpha`, cluster-wide default, denied-namespace empty results, override precedence, and structured namespace for Secret RBAC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927f9636c4ad849f015376e1715103555343b512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->