### PR TITLE
Warn agents when crash logs are unavailable

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1824,6 +1824,8 @@ func handleGetPodLogs(ctx context.Context, req *mcp.CallToolRequest, input podLo
 //     pass previous=true, the current container's logs are likely the
 //     next-crash in progress; the error that killed the last container is in
 //     previous.
+//   - when that previous log is empty, its absence isn't evidence of health
+//     and must not be used to infer a cause.
 //
 // Best-effort — if the pod can't be fetched, return no warnings rather than
 // failing the logs call (the caller already has whatever logs we returned).
@@ -1850,12 +1852,12 @@ func computePodLogsWarnings(namespace, name, container string, previous bool, ra
 		))
 	}
 
-	if !previous {
-		statuses := pod.Status.ContainerStatuses
-		if container != "" {
-			statuses = filterContainerStatuses(statuses, container)
-		}
-		if cs := pickCrashIndicator(statuses); cs != nil {
+	statuses := pod.Status.ContainerStatuses
+	if container != "" {
+		statuses = filterContainerStatuses(statuses, container)
+	}
+	if cs := pickCrashIndicator(statuses); cs != nil {
+		if !previous {
 			reason := cs.LastTerminationState.Terminated.Reason
 			if reason == "" {
 				reason = "(reason unset)"
@@ -1868,6 +1870,8 @@ func computePodLogsWarnings(namespace, name, container string, previous bool, ra
 				cs.LastTerminationState.Terminated.ExitCode,
 				crashloopSuffix(rawLines),
 			))
+		} else if rawLines == 0 {
+			out = append(out, emptyCrashLogWarning(cs))
 		}
 	}
 
@@ -1898,6 +1902,19 @@ func filterContainerStatuses(statuses []corev1.ContainerStatus, name string) []c
 		}
 	}
 	return nil
+}
+
+func emptyCrashLogWarning(cs *corev1.ContainerStatus) string {
+	reason := cs.LastTerminationState.Terminated.Reason
+	if reason == "" {
+		reason = "(reason unset)"
+	}
+	return fmt.Sprintf(
+		"No crash log was captured for the previous instance of container `%s`; the last recorded termination was `%s` (exit code %d). This is an absence of evidence, not evidence of health — do NOT infer a root cause from the empty log. Inspect `get_events`, `diagnose` (recent spec changes), and pod conditions instead.",
+		cs.Name,
+		reason,
+		cs.LastTerminationState.Terminated.ExitCode,
+	)
 }
 
 func crashloopSuffix(rawLines int) string {

--- a/internal/mcp/tools_logs_warnings_test.go
+++ b/internal/mcp/tools_logs_warnings_test.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const emptyCrashLogMarker = "do NOT infer a root cause from the empty log"
+
+func TestComputePodLogsWarnings_EmptyCrashLog(t *testing.T) {
+	tests := []struct {
+		name             string
+		previous         bool
+		rawLines         int
+		crashed          bool
+		wantMarker       bool
+		wantPreviousHint bool
+	}{
+		{name: "empty previous crash log", previous: true, crashed: true, wantMarker: true},
+		{name: "empty previous healthy log", previous: true},
+		{name: "empty current crash log", crashed: true, wantPreviousHint: true},
+		{name: "non-empty raw previous crash log including grep-empty response", previous: true, rawLines: 3, crashed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := logWarningTestPod("pod-a", tt.crashed)
+			if err := k8s.InitTestResourceCache(fake.NewSimpleClientset(pod)); err != nil {
+				t.Fatalf("InitTestResourceCache: %v", err)
+			}
+			defer k8s.ResetTestState()
+
+			warnings := computePodLogsWarnings("default", pod.Name, "app", tt.previous, tt.rawLines)
+			if got := warningsContain(warnings, emptyCrashLogMarker); got != tt.wantMarker {
+				t.Errorf("empty crash-log marker present = %v, want %v; warnings: %v", got, tt.wantMarker, warnings)
+			}
+			if tt.wantMarker {
+				for _, detail := range []string{"container `app`", "last recorded termination was `Error`", "exit code 42"} {
+					if !warningsContain(warnings, detail) {
+						t.Errorf("marker missing %q: %v", detail, warnings)
+					}
+				}
+			}
+			if got := warningsContain(warnings, "call again with `previous: true`"); got != tt.wantPreviousHint {
+				t.Errorf("previous-log hint present = %v, want %v; warnings: %v", got, tt.wantPreviousHint, warnings)
+			}
+		})
+	}
+}
+
+func TestComputeWorkloadLogsWarnings_EmptyCrashLog(t *testing.T) {
+	crashed := logWarningTestPod("pod-a", true)
+	healthy := logWarningTestPod("pod-b", false)
+
+	tests := []struct {
+		name             string
+		pods             []*corev1.Pod
+		logs             []podLogEntry
+		previous         bool
+		wantMarker       bool
+		wantPreviousHint bool
+	}{
+		{
+			name:       "empty previous crash log",
+			pods:       []*corev1.Pod{crashed},
+			logs:       []podLogEntry{{Pod: "pod-a", Container: "app"}},
+			previous:   true,
+			wantMarker: true,
+		},
+		{
+			name:     "empty previous healthy log",
+			pods:     []*corev1.Pod{healthy},
+			logs:     []podLogEntry{{Pod: "pod-b", Container: "app"}},
+			previous: true,
+		},
+		{
+			name:             "empty current crash log",
+			pods:             []*corev1.Pod{crashed},
+			logs:             []podLogEntry{{Pod: "pod-a", Container: "app"}},
+			wantPreviousHint: true,
+		},
+		{
+			name:     "non-empty raw previous crash log including grep-empty response",
+			pods:     []*corev1.Pod{crashed},
+			logs:     []podLogEntry{{Pod: "pod-a", Container: "app", RawLines: 3}},
+			previous: true,
+		},
+		{
+			name:     "failed previous crash-log fetch",
+			pods:     []*corev1.Pod{crashed},
+			logs:     []podLogEntry{{Pod: "pod-a", Container: "app", Error: "fetch failed"}},
+			previous: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := computeWorkloadLogsWarnings(tt.pods, tt.logs, tt.previous)
+			if got := warningsContain(warnings, emptyCrashLogMarker); got != tt.wantMarker {
+				t.Errorf("empty crash-log marker present = %v, want %v; warnings: %v", got, tt.wantMarker, warnings)
+			}
+			if tt.wantMarker {
+				for _, detail := range []string{"1 previous pod/container instance(s)", "`pod-a/app`", "last recorded termination: `Error`", "exit code 42"} {
+					if !warningsContain(warnings, detail) {
+						t.Errorf("marker missing %q: %v", detail, warnings)
+					}
+				}
+			}
+			if got := warningsContain(warnings, "call again with `previous: true`"); got != tt.wantPreviousHint {
+				t.Errorf("previous-log hint present = %v, want %v; warnings: %v", got, tt.wantPreviousHint, warnings)
+			}
+		})
+	}
+}
+
+func TestComputeWorkloadLogsWarnings_AggregatesEmptyCrashLogs(t *testing.T) {
+	podA := logWarningTestPod("pod-a", true)
+	podB := logWarningTestPod("pod-b", true)
+	warnings := computeWorkloadLogsWarnings(
+		[]*corev1.Pod{podA, podB},
+		[]podLogEntry{
+			{Pod: "pod-a", Container: "app"},
+			{Pod: "pod-b", Container: "app"},
+		},
+		true,
+	)
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one aggregate warning", warnings)
+	}
+	if !warningsContain(warnings, "2 previous pod/container instance(s)") || !warningsContain(warnings, "`pod-a/app`") {
+		t.Fatalf("aggregate warning missing count or example: %v", warnings)
+	}
+}
+
+func TestComputeWorkloadLogsWarnings_MatchesEmptyLogToContainer(t *testing.T) {
+	pod := logWarningTestPod("pod-a", true)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "sidecar"})
+	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{Name: "sidecar"})
+
+	warnings := computeWorkloadLogsWarnings(
+		[]*corev1.Pod{pod},
+		[]podLogEntry{{Pod: "pod-a", Container: "sidecar"}},
+		true,
+	)
+	if warningsContain(warnings, emptyCrashLogMarker) {
+		t.Fatalf("healthy sidecar inherited app crash marker: %v", warnings)
+	}
+}
+
+func logWarningTestPod(name string, crashed bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "app"}},
+		},
+	}
+	if crashed {
+		pod.Status.ContainerStatuses[0].RestartCount = 2
+		pod.Status.ContainerStatuses[0].LastTerminationState.Terminated = &corev1.ContainerStateTerminated{
+			Reason:   "Error",
+			ExitCode: 42,
+		}
+	}
+	return pod
+}
+
+func warningsContain(warnings []string, substring string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, substring) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -278,7 +278,7 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 			break
 		}
 	}
-	if w := computeWorkloadLogsWarnings(pods, input.Previous); len(w) > 0 {
+	if w := computeWorkloadLogsWarnings(pods, allLogs, input.Previous); len(w) > 0 {
 		resp["warnings"] = w
 	}
 	return toJSONResult(resp)
@@ -449,11 +449,13 @@ func schedulingBlockerWarnings(kind, namespace, name string) []string {
 	)}
 }
 
-// computeWorkloadLogsWarnings aggregates the not-Running and crashloop logs
-// hints that get_pod_logs surfaces, summarized across all pods of the workload.
-func computeWorkloadLogsWarnings(pods []*corev1.Pod, previous bool) []string {
+// computeWorkloadLogsWarnings aggregates the not-Running, crashloop, and empty
+// previous-log hints that get_pod_logs surfaces across the workload.
+func computeWorkloadLogsWarnings(pods []*corev1.Pod, logs []podLogEntry, previous bool) []string {
 	var notRunning, crashloop int
+	podsByName := make(map[string]*corev1.Pod, len(pods))
 	for _, p := range pods {
+		podsByName[p.Name] = p
 		if p.Status.Phase != corev1.PodRunning && p.Status.Phase != corev1.PodSucceeded {
 			notRunning++
 		}
@@ -473,6 +475,42 @@ func computeWorkloadLogsWarnings(pods []*corev1.Pod, previous bool) []string {
 			"%d of %d pod(s) have container restarts on record; the error(s) that killed prior containers are in the previous instance's logs — call again with `previous: true` to see them.",
 			crashloop, len(pods),
 		))
+	}
+	if previous {
+		var emptyCrashLogs int
+		var examplePod string
+		var exampleStatus *corev1.ContainerStatus
+		for _, entry := range logs {
+			if entry.RawLines != 0 || entry.Error != "" {
+				continue
+			}
+			pod := podsByName[entry.Pod]
+			if pod == nil {
+				continue
+			}
+			statuses := filterContainerStatuses(pod.Status.ContainerStatuses, entry.Container)
+			if cs := pickCrashIndicator(statuses); cs != nil {
+				emptyCrashLogs++
+				if exampleStatus == nil {
+					examplePod = entry.Pod
+					exampleStatus = cs
+				}
+			}
+		}
+		if emptyCrashLogs > 0 {
+			reason := exampleStatus.LastTerminationState.Terminated.Reason
+			if reason == "" {
+				reason = "(reason unset)"
+			}
+			out = append(out, fmt.Sprintf(
+				"No crash log was captured for %d previous pod/container instance(s) (for example, `%s/%s`; last recorded termination: `%s`, exit code %d). This is an absence of evidence, not evidence of health — do NOT infer a root cause from the empty log. Inspect `get_events`, `diagnose` (recent spec changes), and pod conditions instead.",
+				emptyCrashLogs,
+				examplePod,
+				exampleStatus.Name,
+				reason,
+				exampleStatus.LastTerminationState.Terminated.ExitCode,
+			))
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Empty previous-container logs can leave diagnostic agents without evidence and invite an invented root cause. This change makes that state explicit: when Kubernetes reports a prior crash but captured no previous-instance output, Radar warns that the empty log is an absence of evidence and directs the agent to events, recent spec changes, and pod conditions.

## What changed

- `get_pod_logs` emits the warning only for `previous: true`, a successful zero-line fetch, and an existing crash indicator. Healthy empty logs, current logs, and non-empty previous logs keep their existing behavior.
- `get_workload_logs` carries each fetched entry’s pre-filter line count into warning computation, excludes fetch/read/filter errors, and matches the exact pod/container status before classifying an empty crash log. Multiple affected workload entries produce one aggregate warning with a count and representative pod/container.
- Termination details are described as the last recorded termination so the warning does not over-attribute status during a fast restart loop.

## Testing

- `go test ./internal/mcp/... -run TestCompute`
- `go test ./internal/mcp/...`
- `go build ./...`
- `make tsc`
- `make test`
- `make build`
- Visual testing skipped: this is a Go-only MCP response change with no rendered UI delta.

The change is additive to MCP warnings and leaves log content, crash detection, issue ranking, and severity unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive MCP response warnings only; log fetching, crash detection, and RBAC behavior are unchanged.
> 
> **Overview**
> Adds MCP **warnings** so diagnostic agents do not treat an empty `previous: true` log as proof of health when Kubernetes still reports a prior container crash.
> 
> For **`get_pod_logs`**, when the fetch succeeds with zero raw lines, `previous` is set, and the target container has a crash indicator, the response includes a message that the missing log is *absence of evidence* (with last recorded termination reason/exit code) and points to `get_events`, `diagnose`, and pod conditions. The existing “use `previous: true`” hint for current logs is unchanged.
> 
> **`get_workload_logs`** now passes per-entry `RawLines` into warning computation and applies the same rule per pod/container (skipping fetch errors and non-empty streams). Multiple matches produce one aggregate warning with a count and an example pod/container.
> 
> New unit tests cover pod and workload warning paths, aggregation, and container-scoped matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f45bcc4843a779083f9bee5920f3b763a13b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->