### PR TITLE
Cap aggregate multi-pod log bundles

### DIFF
--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -11,13 +11,113 @@ import (
 // always with an explicit warning — silent truncation would read as "that's
 // the whole value".
 const (
-	configMapGuardTotalBytes = 16 * 1024
-	configMapGuardValueBytes = 8 * 1024
+	configMapGuardTotalBytes  = 16 * 1024
+	configMapGuardValueBytes  = 8 * 1024
+	maxMultiPodLogBundleBytes = 32 * 1024
 	// configMapGuardValueFloor bounds how far the per-value cap tightens when
 	// many medium values blow the total budget — below this, values stop
 	// being readable at all.
 	configMapGuardValueFloor = 512
 )
+
+type multiPodLogBundleCap struct {
+	Truncated       bool
+	ShownLines      int
+	TotalLines      int
+	ShownPods       int
+	TotalPods       int
+	FirstOmittedPod string
+}
+
+// capMultiPodLogBundles keeps aggregate log responses from consuming the
+// agent's context window. Whole lines are selected breadth-first across
+// pod/container streams so one noisy pod cannot monopolize the budget.
+func capMultiPodLogBundles(bundles ...[]podLogEntry) ([][]podLogEntry, multiPodLogBundleCap) {
+	stats := multiPodLogBundleCap{}
+	totalBytes := 0
+	totalPods := map[string]struct{}{}
+	for _, bundle := range bundles {
+		for _, entry := range bundle {
+			if len(entry.Logs.Lines) > 0 {
+				totalPods[entry.Pod] = struct{}{}
+			}
+			for _, line := range entry.Logs.Lines {
+				stats.TotalLines++
+				totalBytes += len(line) + 1
+			}
+		}
+	}
+	stats.TotalPods = len(totalPods)
+	if totalBytes <= maxMultiPodLogBundleBytes {
+		stats.ShownLines = stats.TotalLines
+		stats.ShownPods = stats.TotalPods
+		return bundles, stats
+	}
+
+	capped := make([][]podLogEntry, len(bundles))
+	blocked := make([][]bool, len(bundles))
+	for bundleIndex, bundle := range bundles {
+		capped[bundleIndex] = make([]podLogEntry, len(bundle))
+		blocked[bundleIndex] = make([]bool, len(bundle))
+		copy(capped[bundleIndex], bundle)
+		for entryIndex := range capped[bundleIndex] {
+			if len(bundle[entryIndex].Logs.Lines) > 0 {
+				capped[bundleIndex][entryIndex].Logs.Lines = make([]string, 0, len(bundle[entryIndex].Logs.Lines))
+			}
+		}
+	}
+
+	usedBytes := 0
+	shownPods := map[string]struct{}{}
+	for lineIndex := 0; ; lineIndex++ {
+		found := false
+		for bundleIndex, bundle := range bundles {
+			for entryIndex, entry := range bundle {
+				if blocked[bundleIndex][entryIndex] || lineIndex >= len(entry.Logs.Lines) {
+					continue
+				}
+				found = true
+				line := entry.Logs.Lines[lineIndex]
+				lineBytes := len(line) + 1
+				if usedBytes+lineBytes > maxMultiPodLogBundleBytes {
+					blocked[bundleIndex][entryIndex] = true
+					if stats.FirstOmittedPod == "" {
+						stats.FirstOmittedPod = entry.Pod
+					}
+					continue
+				}
+				capped[bundleIndex][entryIndex].Logs.Lines = append(capped[bundleIndex][entryIndex].Logs.Lines, line)
+				usedBytes += lineBytes
+				stats.ShownLines++
+				shownPods[entry.Pod] = struct{}{}
+			}
+		}
+		if !found {
+			break
+		}
+	}
+
+	stats.Truncated = stats.ShownLines < stats.TotalLines
+	stats.ShownPods = len(shownPods)
+	return capped, stats
+}
+
+func multiPodLogBundleNarrowHint(namespace string, stats multiPodLogBundleCap) string {
+	scope := fmt.Sprintf(
+		"showing logs from %d of %d pods / %d of %d lines",
+		stats.ShownPods, stats.TotalPods, stats.ShownLines, stats.TotalLines,
+	)
+	if stats.ShownPods == stats.TotalPods {
+		scope = fmt.Sprintf(
+			"showing %d of %d lines across %d pods",
+			stats.ShownLines, stats.TotalLines, stats.TotalPods,
+		)
+	}
+	return fmt.Sprintf(
+		"log bundle truncated: %s (%d KiB aggregate log-content cap reached) — use `get_pod_logs namespace=%q name=%q` for the full log of a specific pod, or narrow with since=, grep=, or container=",
+		scope, maxMultiPodLogBundleBytes/1024, namespace, stats.FirstOmittedPod,
+	)
+}
 
 // truncateLargeConfigMapData truncates oversized values in a minified
 // ConfigMap payload (map[string]any with "data" / "binaryData" sections),

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -118,7 +118,7 @@ func multiPodLogBundleNarrowHint(namespace string, stats multiPodLogBundleCap, p
 		)
 	}
 	return fmt.Sprintf(
-		"log bundle truncated: %s (%d KiB aggregate log-content cap reached) — use `get_pod_logs namespace=%q name=%q container=%q previous=%t` for the full omitted stream, or narrow with since= or grep=",
+		"log bundle truncated: %s (%d KiB aggregate log-content cap reached) — use `get_pod_logs namespace=%q name=%q container=%q previous=%t` to inspect the omitted stream, or narrow with since= or grep=",
 		scope, maxMultiPodLogBundleBytes/1024, namespace, stats.FirstOmittedPod, stats.FirstOmittedContainer, previous,
 	)
 }

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -21,19 +21,21 @@ const (
 )
 
 type multiPodLogBundleCap struct {
-	Truncated       bool
-	ShownLines      int
-	TotalLines      int
-	ShownPods       int
-	TotalPods       int
-	FirstOmittedPod string
+	Truncated             bool
+	ShownLines            int
+	TotalLines            int
+	ShownPods             int
+	TotalPods             int
+	FirstOmittedPod       string
+	FirstOmittedContainer string
+	FirstOmittedBundle    int
 }
 
 // capMultiPodLogBundles keeps aggregate log responses from consuming the
 // agent's context window. Whole lines are selected breadth-first across
 // pod/container streams so one noisy pod cannot monopolize the budget.
 func capMultiPodLogBundles(bundles ...[]podLogEntry) ([][]podLogEntry, multiPodLogBundleCap) {
-	stats := multiPodLogBundleCap{}
+	stats := multiPodLogBundleCap{FirstOmittedBundle: -1}
 	totalBytes := 0
 	totalPods := map[string]struct{}{}
 	for _, bundle := range bundles {
@@ -81,8 +83,10 @@ func capMultiPodLogBundles(bundles ...[]podLogEntry) ([][]podLogEntry, multiPodL
 				lineBytes := len(line) + 1
 				if usedBytes+lineBytes > maxMultiPodLogBundleBytes {
 					blocked[bundleIndex][entryIndex] = true
-					if stats.FirstOmittedPod == "" {
+					if stats.FirstOmittedBundle < 0 {
 						stats.FirstOmittedPod = entry.Pod
+						stats.FirstOmittedContainer = entry.Container
+						stats.FirstOmittedBundle = bundleIndex
 					}
 					continue
 				}
@@ -102,7 +106,7 @@ func capMultiPodLogBundles(bundles ...[]podLogEntry) ([][]podLogEntry, multiPodL
 	return capped, stats
 }
 
-func multiPodLogBundleNarrowHint(namespace string, stats multiPodLogBundleCap) string {
+func multiPodLogBundleNarrowHint(namespace string, stats multiPodLogBundleCap, previous bool) string {
 	scope := fmt.Sprintf(
 		"showing logs from %d of %d pods / %d of %d lines",
 		stats.ShownPods, stats.TotalPods, stats.ShownLines, stats.TotalLines,
@@ -114,8 +118,8 @@ func multiPodLogBundleNarrowHint(namespace string, stats multiPodLogBundleCap) s
 		)
 	}
 	return fmt.Sprintf(
-		"log bundle truncated: %s (%d KiB aggregate log-content cap reached) — use `get_pod_logs namespace=%q name=%q` for the full log of a specific pod, or narrow with since=, grep=, or container=",
-		scope, maxMultiPodLogBundleBytes/1024, namespace, stats.FirstOmittedPod,
+		"log bundle truncated: %s (%d KiB aggregate log-content cap reached) — use `get_pod_logs namespace=%q name=%q container=%q previous=%t` for the full omitted stream, or narrow with since= or grep=",
+		scope, maxMultiPodLogBundleBytes/1024, namespace, stats.FirstOmittedPod, stats.FirstOmittedContainer, previous,
 	)
 }
 

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -78,8 +78,8 @@ func TestCapMultiPodLogBundles_BreadthFirstAcrossDiagnoseStreams(t *testing.T) {
 		t.Fatalf("returned line payload is %d bytes, cap is %d", shownBytes, maxMultiPodLogBundleBytes)
 	}
 
-	hint := multiPodLogBundleNarrowHint("prod", stats)
-	for _, want := range []string{"truncated", "showing 8 of 12 lines across 3 pods", "32 KiB", "aggregate log-content cap", "get_pod_logs", `namespace="prod"`, `name="api-2"`, "since=", "grep=", "container="} {
+	hint := multiPodLogBundleNarrowHint("prod", stats, stats.FirstOmittedBundle == 1)
+	for _, want := range []string{"truncated", "showing 8 of 12 lines across 3 pods", "32 KiB", "aggregate log-content cap", "get_pod_logs", `namespace="prod"`, `name="api-2"`, `container="app"`, "previous=true", "since=", "grep="} {
 		if !strings.Contains(hint, want) {
 			t.Errorf("hint %q missing %q", hint, want)
 		}
@@ -102,9 +102,11 @@ func TestCapMultiPodLogBundles_LongLineDoesNotStarveOtherPods(t *testing.T) {
 	if !reflect.DeepEqual(got[0][1].Logs.Lines, logs[1].Logs.Lines) {
 		t.Fatalf("shorter pod lines were starved: %#v", got[0][1].Logs.Lines)
 	}
-	hint := multiPodLogBundleNarrowHint("prod", stats)
-	if !strings.Contains(hint, "showing logs from 1 of 2 pods") {
-		t.Fatalf("hint must report omitted pod coverage: %q", hint)
+	hint := multiPodLogBundleNarrowHint("prod", stats, false)
+	for _, want := range []string{"showing logs from 1 of 2 pods", `container="app"`, "previous=false"} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint %q missing %q", hint, want)
+		}
 	}
 }
 

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,7 +12,101 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 )
+
+func TestCapMultiPodLogBundles_UnderBudgetUnchanged(t *testing.T) {
+	current := []podLogEntry{{
+		Pod:       "api-0",
+		Container: "api",
+		Logs:      aicontext.FilteredLogs{Lines: []string{"ERROR small failure"}, TotalLines: 1, MatchedLines: 1},
+	}}
+	previous := []podLogEntry{{Pod: "api-0", Container: "api", Error: "previous terminated container not found"}}
+
+	got, stats := capMultiPodLogBundles(current, previous)
+	if stats.Truncated {
+		t.Fatal("small bundles must not be marked truncated")
+	}
+	if !reflect.DeepEqual(got, [][]podLogEntry{current, previous}) {
+		t.Fatalf("small bundles changed: %#v", got)
+	}
+}
+
+func TestCapMultiPodLogBundles_BreadthFirstAcrossDiagnoseStreams(t *testing.T) {
+	line := strings.Repeat("x", 4095)
+	entry := func(pod string) podLogEntry {
+		return podLogEntry{
+			Pod:       pod,
+			Container: "app",
+			Logs:      aicontext.FilteredLogs{Lines: []string{line, line, line, line}, TotalLines: 4, MatchedLines: 4},
+		}
+	}
+
+	got, stats := capMultiPodLogBundles(
+		[]podLogEntry{entry("api-0"), entry("api-1")},
+		[]podLogEntry{entry("api-2")},
+	)
+	if !stats.Truncated {
+		t.Fatal("oversized diagnose current+previous bundle must be truncated")
+	}
+	if stats.TotalPods != 3 || stats.ShownPods != 3 {
+		t.Fatalf("breadth lost: shown %d of %d pods", stats.ShownPods, stats.TotalPods)
+	}
+	if stats.ShownLines != 8 || stats.TotalLines != 12 {
+		t.Fatalf("lines = %d of %d, want 8 of 12", stats.ShownLines, stats.TotalLines)
+	}
+	for bundleIndex, bundle := range got {
+		for _, logEntry := range bundle {
+			if len(logEntry.Logs.Lines) < 2 {
+				t.Fatalf("bundle %d pod %s received only %d lines", bundleIndex, logEntry.Pod, len(logEntry.Logs.Lines))
+			}
+		}
+	}
+	if got[0][0].Logs.Lines[0] != line || got[1][0].Logs.Lines[0] != line {
+		t.Fatal("returned log content changed")
+	}
+
+	shownBytes := 0
+	for _, bundle := range got {
+		for _, logEntry := range bundle {
+			for _, returnedLine := range logEntry.Logs.Lines {
+				shownBytes += len(returnedLine) + 1
+			}
+		}
+	}
+	if shownBytes > maxMultiPodLogBundleBytes {
+		t.Fatalf("returned line payload is %d bytes, cap is %d", shownBytes, maxMultiPodLogBundleBytes)
+	}
+
+	hint := multiPodLogBundleNarrowHint("prod", stats)
+	for _, want := range []string{"truncated", "showing 8 of 12 lines across 3 pods", "32 KiB", "aggregate log-content cap", "get_pod_logs", `namespace="prod"`, `name="api-2"`, "since=", "grep=", "container="} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint %q missing %q", hint, want)
+		}
+	}
+}
+
+func TestCapMultiPodLogBundles_LongLineDoesNotStarveOtherPods(t *testing.T) {
+	logs := []podLogEntry{
+		{Pod: "oversized", Container: "app", Logs: aicontext.FilteredLogs{Lines: []string{strings.Repeat("x", maxMultiPodLogBundleBytes+1)}}},
+		{Pod: "useful", Container: "app", Logs: aicontext.FilteredLogs{Lines: []string{"ERROR connection refused", "WARN retrying"}}},
+	}
+
+	got, stats := capMultiPodLogBundles(logs)
+	if !stats.Truncated || stats.FirstOmittedPod != "oversized" {
+		t.Fatalf("stats = %+v, want oversized pod reported as omitted", stats)
+	}
+	if len(got[0][0].Logs.Lines) != 0 {
+		t.Fatalf("over-cap line must be omitted whole, got %d lines", len(got[0][0].Logs.Lines))
+	}
+	if !reflect.DeepEqual(got[0][1].Logs.Lines, logs[1].Logs.Lines) {
+		t.Fatalf("shorter pod lines were starved: %#v", got[0][1].Logs.Lines)
+	}
+	hint := multiPodLogBundleNarrowHint("prod", stats)
+	if !strings.Contains(hint, "showing logs from 1 of 2 pods") {
+		t.Fatalf("hint must report omitted pod coverage: %q", hint)
+	}
+}
 
 func TestTruncateLargeConfigMapData(t *testing.T) {
 	small := map[string]any{"data": map[string]any{"k": "v"}}

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -79,7 +79,7 @@ func TestCapMultiPodLogBundles_BreadthFirstAcrossDiagnoseStreams(t *testing.T) {
 	}
 
 	hint := multiPodLogBundleNarrowHint("prod", stats, stats.FirstOmittedBundle == 1)
-	for _, want := range []string{"truncated", "showing 8 of 12 lines across 3 pods", "32 KiB", "aggregate log-content cap", "get_pod_logs", `namespace="prod"`, `name="api-2"`, `container="app"`, "previous=true", "since=", "grep="} {
+	for _, want := range []string{"truncated", "showing 8 of 12 lines across 3 pods", "32 KiB", "aggregate log-content cap", "get_pod_logs", `namespace="prod"`, `name="api-2"`, `container="app"`, "previous=true", "inspect the omitted stream", "since=", "grep="} {
 		if !strings.Contains(hint, want) {
 			t.Errorf("hint %q missing %q", hint, want)
 		}

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -301,6 +301,20 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 	}
 	resp.DNSContext = dnsContextForDiagnose(ctx, cache, obj, pods, resp.LogsCurrent, resp.LogsPrevious, resp.Events)
 	resp.Warnings = k8score.EnrichRuntimeObjectWarnings(obj)
+	capped, capStats := capMultiPodLogBundles(resp.LogsCurrent, resp.LogsPrevious)
+	resp.LogsCurrent = capped[0]
+	resp.LogsPrevious = capped[1]
+	if capStats.Truncated {
+		capHint := multiPodLogBundleNarrowHint(input.Namespace, capStats)
+		if logsTruncated {
+			resp.NarrowHint = fmt.Sprintf(
+				"workload has %d pods; sampled top %d by restart count for logs; %s",
+				len(pods), len(logPods), capHint,
+			)
+		} else {
+			resp.NarrowHint = capHint
+		}
+	}
 	return toJSONResult(resp)
 }
 

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -305,10 +305,10 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 	resp.LogsCurrent = capped[0]
 	resp.LogsPrevious = capped[1]
 	if capStats.Truncated {
-		capHint := multiPodLogBundleNarrowHint(input.Namespace, capStats)
+		capHint := multiPodLogBundleNarrowHint(input.Namespace, capStats, capStats.FirstOmittedBundle == 1)
 		if logsTruncated {
 			resp.NarrowHint = fmt.Sprintf(
-				"workload has %d pods; sampled top %d by restart count for logs; %s",
+				"workload has %d pods; sampled top %d by restart count for logs — for a pod outside the sample, call diagnose with kind=pod and its name; %s",
 				len(pods), len(logPods), capHint,
 			)
 		} else {

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -278,7 +278,7 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 	if capStats.Truncated {
 		// Raising tail_lines cannot recover aggregate-truncated output, so the
 		// bundle-cap guidance supersedes the per-stream tail hint.
-		narrowHint = multiPodLogBundleNarrowHint(input.Namespace, capStats)
+		narrowHint = multiPodLogBundleNarrowHint(input.Namespace, capStats, input.Previous)
 	}
 
 	resp := map[string]any{

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -260,23 +260,34 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 	}
 
 	allLogs := fetchPodLogs(ctx, pods, input.Namespace, input.Container, input.Grep, tailLines, sinceSeconds, input.Previous)
+	var narrowHint string
+	// Steering hint when any pod's stream hit its tail cap. Compare against
+	// RawLines (pre-grep) so grep-filtered streams still surface the hint.
+	// Heuristic mirrors handleGetPodLogs.
+	for _, e := range allLogs {
+		if int64(e.RawLines) >= tailLines {
+			narrowHint = fmt.Sprintf(
+				"at least one pod's log stream tailed to %d lines (cap reached) — narrow with since= (e.g. 10m), grep= regex, container=, or raise tail_lines",
+				tailLines,
+			)
+			break
+		}
+	}
+	capped, capStats := capMultiPodLogBundles(allLogs)
+	allLogs = capped[0]
+	if capStats.Truncated {
+		// Raising tail_lines cannot recover aggregate-truncated output, so the
+		// bundle-cap guidance supersedes the per-stream tail hint.
+		narrowHint = multiPodLogBundleNarrowHint(input.Namespace, capStats)
+	}
 
 	resp := map[string]any{
 		"workload": fmt.Sprintf("%s/%s/%s", kind, input.Namespace, input.Name),
 		"pods":     len(pods),
 		"logs":     allLogs,
 	}
-	// Steering hint when any pod's stream hit its tail cap. Compare against
-	// RawLines (pre-grep) so grep-filtered streams still surface the hint.
-	// Heuristic mirrors handleGetPodLogs.
-	for _, e := range allLogs {
-		if int64(e.RawLines) >= tailLines {
-			resp["narrowHint"] = fmt.Sprintf(
-				"at least one pod's log stream tailed to %d lines (cap reached) — narrow with since= (e.g. 10m), grep= regex, container=, or raise tail_lines",
-				tailLines,
-			)
-			break
-		}
+	if narrowHint != "" {
+		resp["narrowHint"] = narrowHint
 	}
 	if w := computeWorkloadLogsWarnings(pods, input.Previous); len(w) > 0 {
 		resp["warnings"] = w


### PR DESCRIPTION
## Summary

Bound aggregate multi-pod log responses so noisy workloads cannot consume an agent's context window while preserving normal small responses unchanged.

## What changed

- Cap log content returned by `diagnose` and `get_workload_logs` at 32 KiB across all included pod/container streams.
- Select whole log lines breadth-first so one noisy pod cannot monopolize the response; one shared budget covers current and previous diagnose logs.
- Preserve full logs for internal DNS diagnosis before response truncation.
- Emit an explicit narrowing hint with a concrete `get_pod_logs` call and supported `since`, `grep`, and `container` filters.
- Leave the focused single-pod `get_pod_logs` path unchanged.

## Testing

- `go test ./internal/mcp/...`
- `make tsc`
- `make test`
- `make build`
- `make backend`
- `git diff --check`

### Live smoke test

- Built commit `58ff5dab` and ran Radar against a live GKE cluster.
- An under-budget nine-pod workload returned 23,178 log bytes unchanged and emitted no truncation hint.
- An over-budget nine-pod workload was reduced from 459 source lines to 164 whole lines / 32,599 log bytes while retaining output from every pod.
- The emitted recovery hint identified the correct pod, container, and `previous=false`; executing its exact `get_pod_logs` call succeeded.
- The frontend loaded normally with no console errors or warnings, and observed API requests returned 200.

Visual testing was skipped because this changes only MCP response shaping and has no rendered UI delta.

## Risk

The cap counts aggregate log-line content, leaving JSON metadata outside the 32 KiB budget. Under-budget responses are returned unchanged, overflow keeps whole lines in source order, and truncation is always disclosed with recovery guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MCP response shaping only; under-budget behavior is unchanged and truncation is always disclosed with recovery hints.
> 
> **Overview**
> **Bounds multi-pod log payloads** returned by `diagnose` and `get_workload_logs` so large workloads cannot flood the agent context. Responses under **32 KiB** of log-line content are unchanged; over that budget, **`capMultiPodLogBundles`** keeps whole lines in **breadth-first** order across pod/container streams (and across diagnose’s current + previous bundles on one shared budget) so one noisy pod cannot take the entire cap.
> 
> **`diagnose`** still builds DNS context from the **full** logs, then truncates `logsCurrent` / `logsPrevious` for the JSON response. When truncation fires, **`narrowHint`** points at a concrete **`get_pod_logs`** call (plus `since=` / `grep=`), and can be merged with the existing pod-sampling hint when both apply. **`get_workload_logs`** applies the same cap and lets the bundle-cap hint **override** the per-stream `tail_lines` hint when aggregate truncation occurs.
> 
> **`get_pod_logs`** (single pod) is untouched. Tests cover under-budget passthrough, breadth-first behavior, and long-line starvation cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684cbdc6e41083760cd49b952f2989f8d8c31b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

