### PR TITLE
Detect stuck terminating ConfigMaps and Secrets

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -139,6 +139,35 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 			}
 		}
 	}
+
+	if cmLister := cache.ConfigMaps(); cmLister != nil {
+		var configMaps []*corev1.ConfigMap
+		if namespace != "" {
+			configMaps, _ = cmLister.ConfigMaps(namespace).List(labels.Everything())
+		} else {
+			configMaps, _ = cmLister.List(labels.Everything())
+		}
+		for _, cm := range configMaps {
+			if det, ok := terminatingProblem("ConfigMap", "", cm, now); ok {
+				problems = append(problems, det)
+			}
+		}
+	}
+
+	if secretLister := cache.Secrets(); secretLister != nil {
+		var secrets []*corev1.Secret
+		if namespace != "" {
+			secrets, _ = secretLister.Secrets(namespace).List(labels.Everything())
+		} else {
+			secrets, _ = secretLister.List(labels.Everything())
+		}
+		for _, secret := range secrets {
+			if det, ok := terminatingProblem("Secret", "", secret, now); ok {
+				problems = append(problems, det)
+			}
+		}
+	}
+
 	podsByNamespace := listPodsByNamespace(cache, namespace)
 
 	// Deployment problems: unavailableReplicas > 0

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1840,8 +1841,47 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 	oldCreated := metav1.NewTime(now.Add(-2 * time.Hour))
 	oldDelete := metav1.NewTime(now.Add(-35 * time.Minute))
 	recentDelete := metav1.NewTime(now.Add(-2 * time.Minute))
+	const secretValue = "must-not-appear-in-detection"
 
 	client := fake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "config-stuck",
+				Namespace:         "prod",
+				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &oldDelete,
+				Finalizers:        []string{"example.com/config-finalizer"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "secret-stuck",
+				Namespace:         "prod",
+				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &oldDelete,
+				Finalizers:        []string{"example.com/secret-finalizer"},
+			},
+			Data: map[string][]byte{"token": []byte(secretValue)},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "config-recent",
+				Namespace:         "prod",
+				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &recentDelete,
+			},
+		},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "config-normal", Namespace: "prod", CreationTimestamp: oldCreated}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret-normal", Namespace: "prod", CreationTimestamp: oldCreated}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "config-other-namespace",
+				Namespace:         "staging",
+				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &oldDelete,
+				Finalizers:        []string{"example.com/finalizer"},
+			},
+		},
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "pod-stuck",
@@ -1884,7 +1924,9 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 	for time.Now().Before(deadline) {
 		problems = DetectProblems(cache, "prod")
 		if hasProblem(problems, "Pod", "pod-stuck", "Terminating stuck") &&
-			hasProblem(problems, "Deployment", "deploy-stuck", "Terminating stuck") {
+			hasProblem(problems, "Deployment", "deploy-stuck", "Terminating stuck") &&
+			hasProblem(problems, "ConfigMap", "config-stuck", "Terminating stuck") &&
+			hasProblem(problems, "Secret", "secret-stuck", "Terminating stuck") {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -1895,6 +1937,31 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 		t.Fatalf("terminating pod problem = %+v, want finalizer context", p)
 	}
 	assertProblem(t, problems, "Deployment", "deploy-stuck", "Terminating stuck", "critical")
+	assertProblem(t, problems, "ConfigMap", "config-stuck", "Terminating stuck", "critical")
+	if p, ok := lookupProblem(problems, "ConfigMap", "config-stuck", "Terminating stuck"); !ok || !strings.Contains(p.Message, "example.com/config-finalizer") {
+		t.Fatalf("terminating ConfigMap problem = %+v, want finalizer context", p)
+	}
+	assertProblem(t, problems, "Secret", "secret-stuck", "Terminating stuck", "critical")
+	if p, ok := lookupProblem(problems, "Secret", "secret-stuck", "Terminating stuck"); !ok {
+		t.Fatal("terminating Secret problem not found")
+	} else if !strings.Contains(p.Message, "example.com/secret-finalizer") {
+		t.Fatalf("terminating Secret problem = %+v, want finalizer context", p)
+	} else if strings.Contains(fmt.Sprintf("%+v", p), secretValue) {
+		t.Fatalf("terminating Secret problem leaked secret data: %+v", p)
+	}
+	if hasProblem(problems, "ConfigMap", "config-recent", "Terminating stuck") {
+		t.Fatalf("recently deleting ConfigMap should not be flagged: %+v", problems)
+	}
+	if hasProblem(problems, "ConfigMap", "config-normal", "Terminating stuck") ||
+		hasProblem(problems, "Secret", "secret-normal", "Terminating stuck") {
+		t.Fatalf("normal ConfigMap and Secret should not be flagged: %+v", problems)
+	}
+	if hasProblem(problems, "ConfigMap", "config-other-namespace", "Terminating stuck") {
+		t.Fatalf("ConfigMap outside the requested namespace should not be flagged: %+v", problems)
+	}
+	if allProblems := DetectProblems(cache, ""); !hasProblem(allProblems, "ConfigMap", "config-other-namespace", "Terminating stuck") {
+		t.Fatalf("all-namespace scan should include terminating ConfigMap from staging: %+v", allProblems)
+	}
 	if hasProblem(problems, "Service", "svc-recent", "Terminating stuck") {
 		t.Fatalf("recently deleting Service should not be flagged: %+v", problems)
 	}


### PR DESCRIPTION
## Summary

Radar can now surface ConfigMaps and Secrets that remain in Terminating because a finalizer is wedged. This closes a diagnostic blind spot where the cluster contained direct lifecycle evidence but the problems and issue pipelines had no ranked signal for it.

## What changed

- Scan the existing cached ConfigMap and Secret listers in both namespace-filtered and all-namespace problem detection.
- Feed each object through the existing terminating detector with the same 10-minute warning and 30-minute critical thresholds used by other Kubernetes resources.
- Preserve the cache's conservative behavior: detection is skipped until the deferred lister is ready, and when Radar lacks list access for that kind.
- Keep Secret handling metadata-only. The lifecycle helper receives metav1.Object and reads deletion timestamp, finalizers, identity, and creation time; Secret data is never accessed or emitted.
- Cover stuck, recent deletion, normal-resource, namespace-filtering, all-namespace, finalizer-context, and Secret non-disclosure scenarios in the detector integration test.

## Testing

- go test ./internal/k8s/... -run Terminating -count=1
- go test ./internal/k8s/... -count=1
- go build ./...
- make backend
- make tsc
- make test
- make build
- Visual testing skipped because there is no UI delta.

## Notes

The added work is one cached list pass for each newly covered kind, matching the existing detector pattern. Secret detection remains best-effort when cluster RBAC does not allow Radar to list Secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive detector pass on existing cache/listers; Secret paths use metadata only and are covered by non-disclosure tests.
> 
> **Overview**
> **Problem detection** now includes **ConfigMaps** and **Secrets** that stay in **Terminating** too long, using the same cached listers and **`terminatingProblem`** thresholds (10m warning / 30m critical) as other resources.
> 
> Scans respect namespace filtering vs all-namespace mode, skip when listers are unavailable, and Secret handling stays **metadata-only** (no `Secret.data` in detections).
> 
> **Tests** extend the terminating-resources integration case for stuck CM/Secret, recent delete, healthy objects, namespace scope, finalizer messages, and asserting secret values never appear in problem output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b6d5e9309779e2ac1a38ffc4fa66a99bec16e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->