### PR TITLE
Collapse repeated timestamped log lines

### DIFF
--- a/pkg/ai/context/logs.go
+++ b/pkg/ai/context/logs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // FilteredLogs contains selected, bounded log lines.
@@ -14,7 +15,22 @@ type FilteredLogs struct {
 	Fallback     bool     `json:"fallback"` // true if no error patterns matched, using last N raw lines
 }
 
-var errorPatterns = regexp.MustCompile(`(?i)(\bERROR\b|\bFATAL\b|\bWARN(?:ING)?\b|\bException\b|\bpanic:\b|\bTraceback\b|\bCRITICAL\b|"level"\s*:\s*"(?:error|fatal|warn)")`)
+type logTimestampPattern struct {
+	re     *regexp.Regexp
+	layout string
+}
+
+var (
+	errorPatterns        = regexp.MustCompile(`(?i)(\bERROR\b|\bFATAL\b|\bWARN(?:ING)?\b|\bException\b|\bpanic:\b|\bTraceback\b|\bCRITICAL\b|"level"\s*:\s*"(?:error|fatal|warn)")`)
+	rfc3339LogPrefix     = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})) (.*)$`)
+	bracketedLogPrefix   = regexp.MustCompile(`^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\] (.*)$`)
+	spaceDateLogPrefix   = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) (.*)$`)
+	logTimestampPatterns = []logTimestampPattern{
+		{rfc3339LogPrefix, time.RFC3339Nano},
+		{bracketedLogPrefix, time.RFC3339Nano},
+		{spaceDateLogPrefix, "2006/01/02 15:04:05"},
+	}
+)
 
 const (
 	maxFilteredLines = 50
@@ -61,15 +77,30 @@ func FilterLogs(rawLogs string) FilteredLogs {
 
 func formatMatchedLogs(totalLines int, matched []string) FilteredLogs {
 	matchedLines := len(matched)
-	if len(matched) > maxFilteredLines {
+	runs := deduplicateLogRuns(matched, true)
+	formatted := make([]string, 0, len(runs))
+	if len(runs) > maxFilteredLines {
+		omittedLines := 0
+		for _, run := range runs[headLines : len(runs)-tailLines] {
+			omittedLines += run.occurrences
+		}
 		truncated := make([]string, 0, maxFilteredLines+1)
-		truncated = append(truncated, matched[:headLines]...)
-		truncated = append(truncated, fmt.Sprintf("... (%d lines omitted) ...", len(matched)-maxFilteredLines))
-		truncated = append(truncated, matched[len(matched)-tailLines:]...)
-		matched = truncated
+		for _, run := range runs[:headLines] {
+			truncated = append(truncated, run.text)
+		}
+		truncated = append(truncated, fmt.Sprintf("... (%d lines omitted) ...", omittedLines))
+		for _, run := range runs[len(runs)-tailLines:] {
+			truncated = append(truncated, run.text)
+		}
+		formatted = truncated
+	} else {
+		for _, run := range runs {
+			formatted = append(formatted, run.text)
+		}
 	}
 
-	lines := deduplicateStackTraces(matched)
+	// The pre-pass deliberately leaves raw duplicates for the legacy post-cap collapse.
+	lines := deduplicateStackTraces(formatted)
 	return FilteredLogs{
 		Lines:        redactLogLines(lines),
 		TotalLines:   totalLines,
@@ -104,36 +135,81 @@ func splitLogLines(rawLogs string) []string {
 	return strings.Split(strings.TrimSuffix(rawLogs, "\n"), "\n")
 }
 
-// deduplicateStackTraces collapses identical consecutive lines with a repeat count.
-func deduplicateStackTraces(lines []string) []string {
-	if len(lines) == 0 {
-		return lines
-	}
+type normalizedLogLine struct {
+	raw          string
+	key          string
+	timestamp    time.Time
+	hasTimestamp bool
+}
 
-	var result []string
-	prev := lines[0]
-	count := 1
+type deduplicatedLogRun struct {
+	text        string
+	occurrences int
+}
 
-	for i := 1; i < len(lines); i++ {
-		if lines[i] == prev {
-			count++
-		} else {
-			if count > 1 {
-				result = append(result, fmt.Sprintf("%s (repeated x%d)", prev, count))
-			} else {
-				result = append(result, prev)
-			}
-			prev = lines[i]
-			count = 1
+func normalizeLogLine(line string) normalizedLogLine {
+	for _, pattern := range logTimestampPatterns {
+		match := pattern.re.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		timestamp, err := time.Parse(pattern.layout, match[1])
+		if err == nil {
+			return normalizedLogLine{raw: line, key: match[2], timestamp: timestamp, hasTimestamp: true}
 		}
 	}
-	// Flush last
-	if count > 1 {
-		result = append(result, fmt.Sprintf("%s (repeated x%d)", prev, count))
-	} else {
-		result = append(result, prev)
+	return normalizedLogLine{raw: line, key: line}
+}
+
+func deduplicateLogRuns(lines []string, timestampedOnly bool) []deduplicatedLogRun {
+	if len(lines) == 0 {
+		return nil
 	}
 
+	result := make([]deduplicatedLogRun, 0, len(lines))
+	first := normalizeLogLine(lines[0])
+	last := first
+	count := 1
+
+	flush := func() {
+		text := first.raw
+		if count > 1 {
+			if first.hasTimestamp {
+				text = fmt.Sprintf("%s (repeated ×%d, %s→%s)", first.raw, count, first.timestamp.Format("15:04:05"), last.timestamp.Format("15:04:05"))
+			} else {
+				text = fmt.Sprintf("%s (repeated x%d)", first.raw, count)
+			}
+		}
+		result = append(result, deduplicatedLogRun{text: text, occurrences: count})
+	}
+
+	for _, line := range lines[1:] {
+		current := normalizeLogLine(line)
+		sameRun := current.key == last.key && current.hasTimestamp == last.hasTimestamp
+		if timestampedOnly {
+			sameRun = sameRun && current.hasTimestamp
+		}
+		if sameRun {
+			last = current
+			count++
+			continue
+		}
+		flush()
+		first = current
+		last = current
+		count = 1
+	}
+	flush()
+	return result
+}
+
+// deduplicateStackTraces strips only validated timestamp prefixes before comparison.
+func deduplicateStackTraces(lines []string) []string {
+	runs := deduplicateLogRuns(lines, false)
+	result := make([]string, 0, len(runs))
+	for _, run := range runs {
+		result = append(result, run.text)
+	}
 	return result
 }
 

--- a/pkg/ai/context/logs_test.go
+++ b/pkg/ai/context/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFilterLogs_ErrorLines(t *testing.T) {
@@ -141,6 +142,126 @@ func TestFilterLogs_DeduplicatesIdenticalLines(t *testing.T) {
 	}
 	if !strings.Contains(result.Lines[0], "repeated x10") {
 		t.Errorf("Expected repeat count, got: %s", result.Lines[0])
+	}
+}
+
+func TestFilterLogs_DeduplicatesTimestampedRunBeforeTruncation(t *testing.T) {
+	const count = 89
+	start := time.Date(2026, 7, 21, 2, 26, 44, 0, time.UTC)
+	span := 4*time.Minute + 26*time.Second
+	lines := make([]string, count)
+	for i := range lines {
+		timestamp := start.Add(span * time.Duration(i) / (count - 1)).Format(time.RFC3339Nano)
+		lines[i] = timestamp + " ERROR reconciliation failed: HTTP 403 Forbidden"
+	}
+
+	result := FilterLogs(strings.Join(lines, "\n"))
+	want := "2026-07-21T02:26:44Z ERROR reconciliation failed: HTTP 403 Forbidden (repeated ×89, 02:26:44→02:31:10)"
+	if result.MatchedLines != count || !reflect.DeepEqual(result.Lines, []string{want}) {
+		t.Fatalf("Unexpected timestamp-aware dedup result: %#v", result)
+	}
+}
+
+func TestDeduplicateStackTraces_TimestampFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{
+			name: "space-separated application timestamp",
+			lines: []string{
+				"2026/07/20 21:32:22 lookup prometheus.monitoring.svc: no such host",
+				"2026/07/20 21:33:05 lookup prometheus.monitoring.svc: no such host",
+			},
+			want: "2026/07/20 21:32:22 lookup prometheus.monitoring.svc: no such host (repeated ×2, 21:32:22→21:33:05)",
+		},
+		{
+			name: "bracketed RFC3339 timestamp",
+			lines: []string{
+				"[2026-07-20T21:32:22.587Z] WARN retrying",
+				"[2026-07-20T21:33:05.123Z] WARN retrying",
+			},
+			want: "[2026-07-20T21:32:22.587Z] WARN retrying (repeated ×2, 21:32:22→21:33:05)",
+		},
+		{
+			name: "offset and mixed fractional precision",
+			lines: []string{
+				"2026-07-20T21:32:22+02:00 ERROR retrying",
+				"2026-07-20T21:33:05.123456789+02:00 ERROR retrying",
+			},
+			want: "2026-07-20T21:32:22+02:00 ERROR retrying (repeated ×2, 21:32:22→21:33:05)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deduplicateStackTraces(tt.lines); !reflect.DeepEqual(got, []string{tt.want}) {
+				t.Fatalf("deduplicateStackTraces() = %#v, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateStackTraces_ConservativeGrouping(t *testing.T) {
+	t.Run("different bodies", func(t *testing.T) {
+		lines := []string{
+			"2026-07-21T02:26:44Z ERROR forbidden for namespace team-a",
+			"2026-07-21T02:26:45Z ERROR forbidden for namespace team-b",
+		}
+		if got := deduplicateStackTraces(lines); !reflect.DeepEqual(got, lines) {
+			t.Fatalf("different bodies were merged: %#v", got)
+		}
+	})
+
+	t.Run("invalid timestamp-like prefix", func(t *testing.T) {
+		lines := []string{
+			"2026-99-21T02:26:44Z ERROR retrying",
+			"2026-99-21T02:26:45Z ERROR retrying",
+		}
+		if got := deduplicateStackTraces(lines); !reflect.DeepEqual(got, lines) {
+			t.Fatalf("invalid timestamp prefixes were stripped: %#v", got)
+		}
+	})
+
+	t.Run("timestamped and raw body", func(t *testing.T) {
+		lines := []string{
+			"ERROR retrying",
+			"2026-07-21T02:26:45Z ERROR retrying",
+		}
+		if got := deduplicateStackTraces(lines); !reflect.DeepEqual(got, lines) {
+			t.Fatalf("timestamped line merged with raw body: %#v", got)
+		}
+	})
+
+	t.Run("non-consecutive runs", func(t *testing.T) {
+		lines := []string{
+			"2026-07-21T02:26:44Z ERROR A",
+			"2026-07-21T02:26:45Z ERROR A",
+			"2026-07-21T02:26:46Z ERROR B",
+			"2026-07-21T02:26:47Z ERROR A",
+			"2026-07-21T02:26:48Z ERROR A",
+		}
+		want := []string{
+			"2026-07-21T02:26:44Z ERROR A (repeated ×2, 02:26:44→02:26:45)",
+			"2026-07-21T02:26:46Z ERROR B",
+			"2026-07-21T02:26:47Z ERROR A (repeated ×2, 02:26:47→02:26:48)",
+		}
+		if got := deduplicateStackTraces(lines); !reflect.DeepEqual(got, want) {
+			t.Fatalf("non-consecutive runs merged globally: %#v", got)
+		}
+	})
+}
+
+func TestFilterLogs_DeduplicatesTimestampedFallback(t *testing.T) {
+	input := strings.Join([]string{
+		"2026-07-21T02:26:44Z retry scheduled",
+		"2026-07-21T02:26:45Z retry scheduled",
+	}, "\n")
+	result := FilterLogs(input)
+	want := []string{"2026-07-21T02:26:44Z retry scheduled (repeated ×2, 02:26:44→02:26:45)"}
+	if !result.Fallback || !reflect.DeepEqual(result.Lines, want) {
+		t.Fatalf("Unexpected fallback result: %#v", result)
 	}
 }
 
@@ -307,6 +428,80 @@ func TestFilterLogsByPattern_DeduplicatesAfterTruncation(t *testing.T) {
 	}
 	if result.MatchedLines != 60 || !reflect.DeepEqual(result.Lines, want) {
 		t.Fatalf("Unexpected result: %#v", result)
+	}
+}
+
+func TestFilterLogsByPattern_DeduplicatesTimestampedMatches(t *testing.T) {
+	input := strings.Join([]string{
+		"2026-07-21T02:26:44Z lookup prometheus: no such host",
+		"2026-07-21T02:26:45Z lookup prometheus: no such host",
+	}, "\n")
+	result, err := FilterLogsByPattern(input, "no such host")
+	if err != nil {
+		t.Fatalf("FilterLogsByPattern returned error: %v", err)
+	}
+	want := []string{"2026-07-21T02:26:44Z lookup prometheus: no such host (repeated ×2, 02:26:44→02:26:45)"}
+	if result.MatchedLines != 2 || !reflect.DeepEqual(result.Lines, want) {
+		t.Fatalf("Unexpected grep result: %#v", result)
+	}
+}
+
+func TestFilterLogsByPattern_DeduplicatesSpaceDateMatches(t *testing.T) {
+	input := strings.Join([]string{
+		"2026/07/20 21:32:22 lookup prometheus: no such host",
+		"2026/07/20 21:33:05 lookup prometheus: no such host",
+	}, "\n")
+	result, err := FilterLogsByPattern(input, "no such host")
+	if err != nil {
+		t.Fatalf("FilterLogsByPattern returned error: %v", err)
+	}
+	want := []string{"2026/07/20 21:32:22 lookup prometheus: no such host (repeated ×2, 21:32:22→21:33:05)"}
+	if result.MatchedLines != 2 || !reflect.DeepEqual(result.Lines, want) {
+		t.Fatalf("Unexpected space-date grep result: %#v", result)
+	}
+}
+
+func TestFilterLogsByPattern_MixedTimestampedAndRawRuns(t *testing.T) {
+	input := strings.Join([]string{
+		"ERROR raw retry",
+		"ERROR raw retry",
+		"2026-07-21T02:26:44Z ERROR timestamped retry",
+		"2026-07-21T02:26:45Z ERROR timestamped retry",
+	}, "\n")
+	result, err := FilterLogsByPattern(input, "ERROR")
+	if err != nil {
+		t.Fatalf("FilterLogsByPattern returned error: %v", err)
+	}
+	want := []string{
+		"ERROR raw retry (repeated x2)",
+		"2026-07-21T02:26:44Z ERROR timestamped retry (repeated ×2, 02:26:44→02:26:45)",
+	}
+	if !reflect.DeepEqual(result.Lines, want) {
+		t.Fatalf("Unexpected mixed dedup result: %#v", result)
+	}
+}
+
+func TestFilterLogsByPattern_CountsRawOmittedTimestampedLines(t *testing.T) {
+	lines := make([]string, 0, 56)
+	for i := 0; i < 30; i++ {
+		lines = append(lines, fmt.Sprintf("2026-07-21T02:26:%02dZ ERROR head %d", i, i))
+	}
+	for i := 0; i < 3; i++ {
+		lines = append(lines, fmt.Sprintf("2026-07-21T02:27:%02dZ ERROR middle A", i))
+	}
+	for i := 0; i < 3; i++ {
+		lines = append(lines, fmt.Sprintf("2026-07-21T02:28:%02dZ ERROR middle B", i))
+	}
+	for i := 0; i < 20; i++ {
+		lines = append(lines, fmt.Sprintf("2026-07-21T02:29:%02dZ ERROR tail %d", i, i))
+	}
+
+	result, err := FilterLogsByPattern(strings.Join(lines, "\n"), "ERROR")
+	if err != nil {
+		t.Fatalf("FilterLogsByPattern returned error: %v", err)
+	}
+	if result.MatchedLines != 56 || result.Lines[30] != "... (6 lines omitted) ..." {
+		t.Fatalf("Unexpected raw line accounting: %#v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

Repeated Kubernetes failures often differ only by a timestamp prefix, so Radar's exact-line deduplication leaves retry storms intact and consumes diagnostic context with duplicate signal. This change recognizes a narrow set of validated timestamp prefixes and presents consecutive, byte-identical message bodies as one occurrence with a count and observed time span.

## What changed

- Recognize RFC3339/RFC3339Nano prefixes (including offsets), bracketed RFC3339 prefixes, and `YYYY/MM/DD HH:MM:SS` application prefixes. Regex matches are anchored and candidates must parse successfully before their prefix can be ignored.
- Collapse only consecutive lines whose full post-timestamp bodies are identical. The first complete line remains the representative and timestamped runs render as `(repeated ×N, HH:MM:SS→HH:MM:SS)`.
- Collapse timestamped runs before the matched-log cap so large retry bursts retain their complete count and span. Raw occurrence counts still drive `MatchedLines` and omission markers.
- Preserve legacy non-timestamp behavior, including the `(repeated xN)` suffix and head/omission/tail truncation shape.

## Testing

- `cd pkg && go build ./... && go test ./ai/context/...`
- `go build ./...`
- `make backend`
- `make test`
- `make tsc`
- `make build`
- Visual testing skipped: this is a Go-only change to machine-facing diagnostic output with no rendered UI delta.

Tests cover an 89-line RFC3339Nano failure burst, all supported timestamp shapes, timezone offsets, invalid timestamp-like prefixes, body mismatches, timestamped/raw boundaries, non-consecutive runs, fallback and explicit-pattern paths, raw omission accounting, and legacy exact-line behavior.

## Notes

The parser intentionally degrades to exact-line comparison for unrecognized or invalid timestamp prefixes. The main residual risk is missed deduplication for unsupported application-specific formats; conservative failure to collapse is preferred over merging different log bodies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to log formatting for AI context; conservative parsing avoids merging different bodies, with broad test coverage.
> 
> **Overview**
> **Radar log filtering** now treats consecutive lines with the same message body (after a validated timestamp prefix) as one run, instead of requiring byte-identical lines.
> 
> Supported prefixes are RFC3339/RFC3339Nano (plain and bracketed) and `YYYY/MM/DD HH:MM:SS`; only successfully parsed prefixes are stripped for comparison. Timestamped runs render as `(repeated ×N, HH:MM:SS→HH:MM:SS)`; lines without a valid timestamp still use `(repeated xN)`.
> 
> **`formatMatchedLogs`** deduplicates timestamped runs *before* the 50-line cap, and omission counts use raw line occurrences so large retry bursts keep accurate `MatchedLines` and span. Fallback and `FilterLogsByPattern` share the same path via `deduplicateLogRuns` / `deduplicateStackTraces`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df719a5afeff4f10cb35b5d8710a568646814407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->