### PR TITLE
Surface env history and on-demand stale Secret diagnostics

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -149,7 +149,7 @@ func classifyProblem(in classifyInput) issuesapi.Category {
 	switch in.Reason {
 	case "CoreDNS NXDOMAIN override", "CoreDNS service DNS rewrite":
 		return issuesapi.CategoryDNSFailure
-	case "DuplicateEnvVar":
+	case "DuplicateEnvVar", "StaleSecretEnv":
 		return issuesapi.CategoryInvalidConfiguration
 	case "Missing referenced Service":
 		return issuesapi.CategoryMissingConfigRef

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -33,6 +33,7 @@ func TestClassify(t *testing.T) {
 		{"deployment duplicate env", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
 		{"job duplicate env is not job failure", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
 		{"cronjob duplicate env", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "DuplicateEnvVar"}, issuesapi.CategoryInvalidConfiguration},
+		{"stale Secret env", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "StaleSecretEnv"}, issuesapi.CategoryInvalidConfiguration},
 
 		// problem / Pod
 		{"image pull backoff", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ImagePullBackOff"}, issuesapi.CategoryImagePullFailed},

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -222,6 +222,28 @@ func TestCompose_GroupsMemberPodsUnderOwner(t *testing.T) {
 	}
 }
 
+func TestCompose_StaleSecretEnvSurvivesAsStableWorkloadIssue(t *testing.T) {
+	p := &fakeProvider{problems: []k8s.Detection{{
+		Kind: "Pod", Namespace: "shop", Name: "catalog-abc-1", Severity: "warning",
+		Reason: "StaleSecretEnv", Message: "container may hold a stale Secret-backed env value",
+		OwnerGroup: "apps", OwnerKind: "Deployment", OwnerName: "catalog",
+		Fingerprint: "stale-secret-env",
+	}}}
+	filters := Filters{Grouped: true}
+	first := Compose(p, filters)
+	second := Compose(p, filters)
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("stale Secret env issue was dropped during compose: first=%+v second=%+v", first, second)
+	}
+	issue := first[0]
+	if issue.Category != issuesapi.CategoryInvalidConfiguration || issue.Group != "apps" || issue.Kind != "Deployment" || issue.Namespace != "shop" || issue.Name != "catalog" {
+		t.Fatalf("unexpected grouped stale Secret env issue: %+v", issue)
+	}
+	if issue.ID == "" || issue.ID != second[0].ID || issue.Fingerprint != "stale-secret-env" {
+		t.Fatalf("stale Secret env issue identity is not stable: first=%+v second=%+v", first, second)
+	}
+}
+
 func TestCompose_GroupedKindFilterMatchesSubject(t *testing.T) {
 	// A crashlooping Deployment is evidenced by Pod rows that fold under the
 	// Deployment subject. On the GROUPED surface, kind=Deployment must return

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -379,8 +379,11 @@ func InitResourceCache(ctx context.Context) error {
 				secretWriteTimes.capture(obj)
 			},
 
-			OnChange: func(change k8score.ResourceChange, obj, oldObj any) {
+			OnObservedChange: func(change k8score.ResourceChange, obj, _ any) {
 				secretWriteTimes.reconcile(change, obj)
+			},
+
+			OnChange: func(change k8score.ResourceChange, obj, oldObj any) {
 				if DebugEvents && change.Operation == "add" &&
 					(change.Kind == "Pod" || change.Kind == "Deployment" || change.Kind == "Service") {
 					log.Printf("[DEBUG] enqueueChange: %s add %s/%s", change.Kind, change.Namespace, change.Name)

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -118,9 +118,9 @@ type ResourceCache struct {
 	// continuously OutOfSync. Lives here so its lifecycle is the cache's:
 	// recreated per cluster, dropped on a kubeconfig context switch.
 	argoDrift *argoDriftTracker
-	// secretWriteTimes preserves one metadata-only signal that the shared
-	// informer transform intentionally strips before objects enter the cache.
-	secretWriteTimes *sync.Map
+	// secretWriteTimes preserves verified Secret data-owner write times that
+	// the shared informer transform intentionally strips before caching.
+	secretWriteTimes *secretDataManagerWriteIndex
 }
 
 type secretDataManagerWrite struct {
@@ -128,18 +128,64 @@ type secretDataManagerWrite struct {
 	at  time.Time
 }
 
+type secretDataManagerWriteVersion struct {
+	namespace       string
+	name            string
+	uid             string
+	resourceVersion string
+}
+
+type pendingSecretDataManagerWrite struct {
+	write *secretDataManagerWrite
+	helm  bool
+}
+
+type secretDataManagerWriteIndex struct {
+	mu           sync.Mutex
+	committed    map[string]secretDataManagerWrite
+	pending      map[secretDataManagerWriteVersion]pendingSecretDataManagerWrite
+	pendingLimit int
+}
+
+const maxPendingSecretDataManagerWrites = 10_000
+
+func newSecretDataManagerWriteIndex() *secretDataManagerWriteIndex {
+	return &secretDataManagerWriteIndex{
+		committed:    make(map[string]secretDataManagerWrite),
+		pending:      make(map[secretDataManagerWriteVersion]pendingSecretDataManagerWrite),
+		pendingLimit: maxPendingSecretDataManagerWrites,
+	}
+}
+
 func secretWriteKey(namespace, name string) string {
 	return namespace + "\x00" + name
 }
 
-func captureSecretDataManagerWriteTime(index *sync.Map, obj any) {
+func secretChangeWritesData(change k8score.ResourceChange) bool {
+	if change.Diff == nil {
+		return false
+	}
+	for _, field := range change.Diff.Fields {
+		if isSecretDataWritePath(field.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSecretDataWritePath(path string) bool {
+	switch path {
+	case "data (added keys)", "data (removed keys)", "data (modified keys)",
+		"stringData (added keys)", "stringData (removed keys)", "stringData (modified keys)":
+		return true
+	default:
+		return false
+	}
+}
+
+func (index *secretDataManagerWriteIndex) capture(obj any) {
 	secret, ok := obj.(*corev1.Secret)
 	if !ok || secret == nil || index == nil {
-		return
-	}
-	key := secretWriteKey(secret.Namespace, secret.Name)
-	if secret.Type == corev1.SecretType("helm.sh/release.v1") {
-		index.Delete(key)
 		return
 	}
 	var latest time.Time
@@ -165,26 +211,92 @@ func captureSecretDataManagerWriteTime(index *sync.Map, obj any) {
 			latest = entry.Time.Time
 		}
 	}
-	if latest.IsZero() {
-		index.Delete(key)
-		return
+	version := secretDataManagerWriteVersion{
+		namespace:       secret.Namespace,
+		name:            secret.Name,
+		uid:             string(secret.UID),
+		resourceVersion: secret.ResourceVersion,
 	}
-	index.Store(key, secretDataManagerWrite{uid: string(secret.UID), at: latest})
+	pending := pendingSecretDataManagerWrite{
+		helm: secret.Type == corev1.SecretType("helm.sh/release.v1"),
+	}
+	if !latest.IsZero() {
+		pending.write = &secretDataManagerWrite{uid: string(secret.UID), at: latest}
+	}
+	index.mu.Lock()
+	if _, exists := index.pending[version]; !exists && len(index.pending) >= index.pendingLimit {
+		// Transform observations are advisory. Under callback starvation,
+		// discard unmatched candidates rather than grow without bound; a
+		// missing fallback fails closed and a later object version can restage.
+		clear(index.pending)
+	}
+	index.pending[version] = pending
+	index.mu.Unlock()
 }
 
-func deleteSecretDataManagerWriteTime(index *sync.Map, change k8score.ResourceChange) {
-	if index == nil || change.Kind != "Secret" || change.Operation != k8score.OpDelete {
+func (index *secretDataManagerWriteIndex) reconcile(change k8score.ResourceChange, obj any) {
+	if index == nil || change.Kind != "Secret" {
 		return
 	}
 	key := secretWriteKey(change.Namespace, change.Name)
-	value, ok := index.Load(key)
+	index.mu.Lock()
+	defer index.mu.Unlock()
+
+	if change.Operation == k8score.OpDelete {
+		if write, ok := index.committed[key]; ok && write.uid == change.UID {
+			delete(index.committed, key)
+		}
+		for version := range index.pending {
+			if version.namespace == change.Namespace && version.name == change.Name && version.uid == change.UID {
+				delete(index.pending, version)
+			}
+		}
+		return
+	}
+
+	meta, ok := obj.(metav1.Object)
+	if !ok || meta == nil {
+		return
+	}
+	version := secretDataManagerWriteVersion{
+		namespace:       change.Namespace,
+		name:            change.Name,
+		uid:             change.UID,
+		resourceVersion: meta.GetResourceVersion(),
+	}
+	pending, ok := index.pending[version]
 	if !ok {
 		return
 	}
-	write, ok := value.(secretDataManagerWrite)
-	if ok && write.uid == change.UID {
-		index.Delete(key)
+	delete(index.pending, version)
+
+	if pending.helm {
+		if write, ok := index.committed[key]; !ok || write.uid == change.UID {
+			delete(index.committed, key)
+		}
+		return
 	}
+	if change.Operation == k8score.OpUpdate && !secretChangeWritesData(change) {
+		return
+	}
+	if write, ok := index.committed[key]; ok && write.uid != change.UID && change.Operation != k8score.OpAdd {
+		return
+	}
+	if pending.write == nil {
+		delete(index.committed, key)
+		return
+	}
+	index.committed[key] = *pending.write
+}
+
+func (index *secretDataManagerWriteIndex) load(namespace, name string) (secretDataManagerWrite, bool) {
+	if index == nil {
+		return secretDataManagerWrite{}, false
+	}
+	index.mu.Lock()
+	defer index.mu.Unlock()
+	write, ok := index.committed[secretWriteKey(namespace, name)]
+	return write, ok
 }
 
 var (
@@ -243,7 +355,7 @@ func InitResourceCache(ctx context.Context) error {
 		// wiring-time value keeps late events truthfully attributed to the
 		// cluster they came from.
 		recordClusterContext := ActiveClusterContext()
-		secretWriteTimes := &sync.Map{}
+		secretWriteTimes := newSecretDataManagerWriteIndex()
 
 		cfg := k8score.CacheConfig{
 			Client:                  k8sClient,
@@ -264,11 +376,11 @@ func InitResourceCache(ctx context.Context) error {
 			},
 
 			OnTransform: func(obj any) {
-				captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+				secretWriteTimes.capture(obj)
 			},
 
 			OnChange: func(change k8score.ResourceChange, obj, oldObj any) {
-				deleteSecretDataManagerWriteTime(secretWriteTimes, change)
+				secretWriteTimes.reconcile(change, obj)
 				if DebugEvents && change.Operation == "add" &&
 					(change.Kind == "Pod" || change.Kind == "Deployment" || change.Kind == "Service") {
 					log.Printf("[DEBUG] enqueueChange: %s add %s/%s", change.Kind, change.Namespace, change.Name)

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -116,6 +118,73 @@ type ResourceCache struct {
 	// continuously OutOfSync. Lives here so its lifecycle is the cache's:
 	// recreated per cluster, dropped on a kubeconfig context switch.
 	argoDrift *argoDriftTracker
+	// secretWriteTimes preserves one metadata-only signal that the shared
+	// informer transform intentionally strips before objects enter the cache.
+	secretWriteTimes *sync.Map
+}
+
+type secretDataManagerWrite struct {
+	uid string
+	at  time.Time
+}
+
+func secretWriteKey(namespace, name string) string {
+	return namespace + "\x00" + name
+}
+
+func captureSecretDataManagerWriteTime(index *sync.Map, obj any) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret == nil || index == nil {
+		return
+	}
+	key := secretWriteKey(secret.Namespace, secret.Name)
+	if secret.Type == corev1.SecretType("helm.sh/release.v1") {
+		index.Delete(key)
+		return
+	}
+	var latest time.Time
+	for _, entry := range secret.ManagedFields {
+		if entry.Time == nil || entry.FieldsV1 == nil ||
+			(entry.Operation != metav1.ManagedFieldsOperationApply && entry.Operation != metav1.ManagedFieldsOperationUpdate) {
+			continue
+		}
+		raw := entry.FieldsV1.Raw
+		if !bytes.Contains(raw, []byte(`"f:data"`)) && !bytes.Contains(raw, []byte(`"f:stringData"`)) {
+			continue
+		}
+		var fields map[string]json.RawMessage
+		if json.Unmarshal(raw, &fields) != nil {
+			continue
+		}
+		if _, ownsData := fields["f:data"]; !ownsData {
+			if _, ownsStringData := fields["f:stringData"]; !ownsStringData {
+				continue
+			}
+		}
+		if entry.Time.Time.After(latest) {
+			latest = entry.Time.Time
+		}
+	}
+	if latest.IsZero() {
+		index.Delete(key)
+		return
+	}
+	index.Store(key, secretDataManagerWrite{uid: string(secret.UID), at: latest})
+}
+
+func deleteSecretDataManagerWriteTime(index *sync.Map, change k8score.ResourceChange) {
+	if index == nil || change.Kind != "Secret" || change.Operation != k8score.OpDelete {
+		return
+	}
+	key := secretWriteKey(change.Namespace, change.Name)
+	value, ok := index.Load(key)
+	if !ok {
+		return
+	}
+	write, ok := value.(secretDataManagerWrite)
+	if ok && write.uid == change.UID {
+		index.Delete(key)
+	}
 }
 
 var (
@@ -174,6 +243,7 @@ func InitResourceCache(ctx context.Context) error {
 		// wiring-time value keeps late events truthfully attributed to the
 		// cluster they came from.
 		recordClusterContext := ActiveClusterContext()
+		secretWriteTimes := &sync.Map{}
 
 		cfg := k8score.CacheConfig{
 			Client:                  k8sClient,
@@ -193,7 +263,12 @@ func InitResourceCache(ctx context.Context) error {
 				timeline.IncrementReceived(kind)
 			},
 
+			OnTransform: func(obj any) {
+				captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+			},
+
 			OnChange: func(change k8score.ResourceChange, obj, oldObj any) {
+				deleteSecretDataManagerWriteTime(secretWriteTimes, change)
 				if DebugEvents && change.Operation == "add" &&
 					(change.Kind == "Pod" || change.Kind == "Deployment" || change.Kind == "Service") {
 					log.Printf("[DEBUG] enqueueChange: %s add %s/%s", change.Kind, change.Namespace, change.Name)
@@ -235,9 +310,10 @@ func InitResourceCache(ctx context.Context) error {
 		initialSyncComplete = core.IsSyncComplete()
 
 		resourceCache = &ResourceCache{
-			ResourceCache:  core,
-			secretsEnabled: scopes["secrets"].Enabled,
-			argoDrift:      newArgoDriftTracker(),
+			ResourceCache:    core,
+			secretsEnabled:   scopes["secrets"].Enabled,
+			argoDrift:        newArgoDriftTracker(),
+			secretWriteTimes: secretWriteTimes,
 		}
 	})
 	return initErr

--- a/internal/k8s/detect_config.go
+++ b/internal/k8s/detect_config.go
@@ -32,6 +32,7 @@ func detectConfigProblems(cache *ResourceCache, namespace string, now time.Time)
 	}
 	out = append(out, detectEnvServiceRefs(cache, namespace, now)...)
 	out = append(out, detectDuplicateEnvVars(cache, namespace, now)...)
+	out = append(out, detectStaleSecretEnv(cache, namespace, now)...)
 	return out
 }
 

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -1,0 +1,538 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	envHistoryLookback                  = time.Hour
+	maxStaleSecretEnvChecksPerContainer = 5
+)
+
+type RemovedServiceEnvCheck struct {
+	WorkloadGroup    string
+	WorkloadKind     string
+	Namespace        string
+	WorkloadName     string
+	Container        string
+	EnvName          string
+	OldValue         string
+	ServiceNamespace string
+	ServiceName      string
+	ReferencedPort   int32
+	RemovedAt        time.Time
+	Message          string
+}
+
+type StaleSecretEnvCheck struct {
+	Namespace           string
+	PodName             string
+	Container           string
+	EnvName             string
+	Source              string
+	Prefix              string
+	SecretName          string
+	Key                 string
+	ContainerStartedAt  time.Time
+	SecretDataChangedAt time.Time
+	Message             string
+}
+
+// FindRemovedServiceEnvChecksForObject returns recent env-removal facts for a
+// workload. It deliberately consumes only the already-redacted timeline diff;
+// sensitive env names therefore under-report instead of reaching for raw history.
+// These stay as per-object facts because an intentional removal has no cheap,
+// reliable active-failure signal that would justify a triage issue.
+func FindRemovedServiceEnvChecksForObject(ctx context.Context, cache *ResourceCache, obj runtime.Object) []RemovedServiceEnvCheck {
+	wl, ok := envServiceWorkloadForObject(obj)
+	if !ok || !supportsEnvRemovalHistory(wl.kind) {
+		return nil
+	}
+	events := queryEnvHistory(ctx, timeline.QueryOptions{
+		Namespaces:     []string{wl.namespace},
+		Kinds:          []string{wl.kind},
+		Names:          []string{wl.name},
+		Since:          time.Now().Add(-envHistoryLookback),
+		Sources:        []timeline.EventSource{timeline.SourceInformer},
+		EventTypes:     []timeline.EventType{timeline.EventTypeUpdate},
+		ClusterContext: ActiveClusterContext(),
+		Limit:          1000,
+	})
+	var uid string
+	if object, ok := obj.(metav1.Object); ok {
+		uid = string(object.GetUID())
+	}
+	return findRemovedServiceEnvChecks(cache, wl, uid, events)
+}
+
+func supportsEnvRemovalHistory(kind string) bool {
+	switch kind {
+	case "Deployment", "StatefulSet", "DaemonSet":
+		return true
+	default:
+		return false
+	}
+}
+
+func findRemovedServiceEnvChecks(cache *ResourceCache, wl envServiceWorkload, uid string, events []timeline.TimelineEvent) []RemovedServiceEnvCheck {
+	if cache == nil || cache.Services() == nil {
+		return nil
+	}
+	sortTimelineEventsNewestFirst(events)
+	seenPaths := make(map[string]bool)
+	var out []RemovedServiceEnvCheck
+	for _, event := range events {
+		if event.Kind != wl.kind || event.Namespace != wl.namespace || event.Name != wl.name ||
+			event.Source != timeline.SourceInformer || event.EventType != timeline.EventTypeUpdate || event.Diff == nil {
+			continue
+		}
+		if uid != "" && event.UID != "" && event.UID != uid {
+			continue
+		}
+		for _, change := range event.Diff.Fields {
+			container, envName, ok := parseWorkloadEnvPath(change.Path)
+			if !ok || seenPaths[change.Path] {
+				continue
+			}
+			seenPaths[change.Path] = true
+			if change.NewValue != nil {
+				continue
+			}
+			oldValue, ok := change.OldValue.(string)
+			if !ok || oldValue == "" || oldValue == "[REDACTED]" {
+				continue
+			}
+			ref, ok := parseEnvServiceRef(oldValue, wl.namespace)
+			if !ok {
+				continue
+			}
+			svc, err := cache.Services().Services(ref.namespace).Get(ref.name)
+			if err != nil || svc == nil {
+				continue
+			}
+			out = append(out, RemovedServiceEnvCheck{
+				WorkloadGroup:    wl.group,
+				WorkloadKind:     wl.kind,
+				Namespace:        wl.namespace,
+				WorkloadName:     wl.name,
+				Container:        container,
+				EnvName:          envName,
+				OldValue:         oldValue,
+				ServiceNamespace: ref.namespace,
+				ServiceName:      ref.name,
+				ReferencedPort:   ref.port,
+				RemovedAt:        event.Timestamp,
+				Message:          fmt.Sprintf("Env %s in container %s, which referenced Service/%s at %s, was removed at %s.", envName, container, ref.name, ref.display, event.Timestamp.UTC().Format(time.RFC3339)),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Container != out[j].Container {
+			return out[i].Container < out[j].Container
+		}
+		return out[i].EnvName < out[j].EnvName
+	})
+	return out
+}
+
+func parseWorkloadEnvPath(path string) (container, envName string, ok bool) {
+	const prefix = "spec.template.spec.containers["
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, "]") {
+		return "", "", false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(path, prefix), "]")
+	container, envName, ok = strings.Cut(rest, "].env[")
+	if !ok || container == "" || envName == "" {
+		return "", "", false
+	}
+	return container, envName, true
+}
+
+// FindStaleSecretEnvChecksForObject returns key-and-time metadata for a Pod's
+// Secret-backed env values. Secret data and stringData are never accessed.
+func FindStaleSecretEnvChecksForObject(ctx context.Context, cache *ResourceCache, obj runtime.Object) []StaleSecretEnvCheck {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil || !podHasSecretEnvReference(pod) {
+		return nil
+	}
+	events := querySecretDataHistory(ctx, pod.Namespace, time.Now())
+	return findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, events)
+}
+
+func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time) []Detection {
+	if cache == nil || cache.Pods() == nil || cache.Secrets() == nil {
+		return nil
+	}
+	var pods []*corev1.Pod
+	var err error
+	if namespace == "" {
+		pods, err = cache.Pods().List(labels.Everything())
+	} else {
+		pods, err = cache.Pods().Pods(namespace).List(labels.Everything())
+	}
+	if err != nil {
+		logConfigListError("Pod", namespace, err)
+		return nil
+	}
+	usesSecretEnv := false
+	for _, pod := range pods {
+		if podHasSecretEnvReference(pod) {
+			usesSecretEnv = true
+			break
+		}
+	}
+	if !usesSecretEnv {
+		return nil
+	}
+	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, now))
+	checksByPod := make(map[string][]StaleSecretEnvCheck)
+	for _, check := range checks {
+		key := check.Namespace + "\x00" + check.PodName
+		checksByPod[key] = append(checksByPod[key], check)
+	}
+	var out []Detection
+	for _, pod := range pods {
+		podChecks := checksByPod[pod.Namespace+"\x00"+pod.Name]
+		bitingChecks := staleSecretEnvBitingChecks(pod, podChecks)
+		if len(bitingChecks) == 0 {
+			continue
+		}
+		changedAt := bitingChecks[0].SecretDataChangedAt
+		for _, check := range bitingChecks[1:] {
+			if check.SecretDataChangedAt.Before(changedAt) {
+				changedAt = check.SecretDataChangedAt
+			}
+		}
+		age := ageSeconds(now, changedAt)
+		ownerGroup, ownerKind, ownerName := podOwnerKindName(cache, pod)
+		out = append(out, Detection{
+			Kind:            "Pod",
+			Namespace:       pod.Namespace,
+			Name:            pod.Name,
+			Severity:        "warning",
+			Reason:          "StaleSecretEnv",
+			Message:         staleSecretEnvDetectionMessage(bitingChecks),
+			Age:             FormatAge(time.Duration(age) * time.Second),
+			AgeSeconds:      age,
+			Duration:        FormatAge(time.Duration(age) * time.Second),
+			DurationSeconds: age,
+			OwnerGroup:      ownerGroup,
+			OwnerKind:       ownerKind,
+			OwnerName:       ownerName,
+			Fingerprint:     "stale-secret-env",
+			Cause:           "A running container loaded a Secret-backed environment value before Radar observed that Secret key change.",
+			Action:          "Restart the pod so its containers re-read Secret-backed environment variables.",
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func podHasSecretEnvReference(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				return true
+			}
+		}
+		for _, envFrom := range container.EnvFrom {
+			if envFrom.SecretRef != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func querySecretDataHistory(ctx context.Context, namespace string, now time.Time) []timeline.TimelineEvent {
+	opts := timeline.QueryOptions{
+		Kinds:          []string{"Secret"},
+		Since:          now.Add(-envHistoryLookback),
+		Sources:        []timeline.EventSource{timeline.SourceInformer},
+		EventTypes:     []timeline.EventType{timeline.EventTypeUpdate},
+		ClusterContext: ActiveClusterContext(),
+		Limit:          1000,
+	}
+	if namespace != "" {
+		opts.Namespaces = []string{namespace}
+	}
+	return queryEnvHistory(ctx, opts)
+}
+
+func queryEnvHistory(ctx context.Context, opts timeline.QueryOptions) []timeline.TimelineEvent {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	events, err := timeline.QueryEvents(ctx, opts)
+	if err != nil {
+		return nil
+	}
+	return events
+}
+
+type secretDataKey struct {
+	namespace string
+	name      string
+	key       string
+}
+
+func findStaleSecretEnvChecks(cache *ResourceCache, pods []*corev1.Pod, events []timeline.TimelineEvent) []StaleSecretEnvCheck {
+	if cache == nil || cache.Secrets() == nil {
+		return nil
+	}
+	changes := latestSecretDataChanges(events)
+	if len(changes) == 0 {
+		return nil
+	}
+	changesBySecret := secretDataChangesBySecret(changes)
+	exists := make(map[string]bool)
+	checked := make(map[string]bool)
+	var out []StaleSecretEnvCheck
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
+		for _, status := range pod.Status.ContainerStatuses {
+			statuses[status.Name] = status
+		}
+		for _, container := range pod.Spec.Containers {
+			status, ok := statuses[container.Name]
+			if !ok {
+				continue
+			}
+			startedAt, ok := latestContainerStart(status)
+			if !ok {
+				continue
+			}
+			containerChecks := 0
+			for _, env := range container.Env {
+				if containerChecks >= maxStaleSecretEnvChecksPerContainer {
+					break
+				}
+				if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+					continue
+				}
+				ref := env.ValueFrom.SecretKeyRef
+				changedAt, ok := changes[secretDataKey{namespace: pod.Namespace, name: ref.Name, key: ref.Key}]
+				if !ok || !startedAt.Before(changedAt) || !secretExists(cache, pod.Namespace, ref.Name, exists, checked) {
+					continue
+				}
+				out = append(out, newStaleSecretEnvCheck(pod, container.Name, env.Name, "secretKeyRef", "", ref.Name, ref.Key, startedAt, changedAt))
+				containerChecks++
+			}
+			for _, envFrom := range container.EnvFrom {
+				if containerChecks >= maxStaleSecretEnvChecksPerContainer {
+					break
+				}
+				if envFrom.SecretRef == nil || !secretExists(cache, pod.Namespace, envFrom.SecretRef.Name, exists, checked) {
+					continue
+				}
+				identity := pod.Namespace + "\x00" + envFrom.SecretRef.Name
+				for _, change := range changesBySecret[identity] {
+					if containerChecks >= maxStaleSecretEnvChecksPerContainer {
+						break
+					}
+					if !startedAt.Before(change.changedAt) {
+						continue
+					}
+					out = append(out, newStaleSecretEnvCheck(pod, container.Name, envFrom.Prefix+change.key, "envFrom", envFrom.Prefix, envFrom.SecretRef.Name, change.key, startedAt, change.changedAt))
+					containerChecks++
+				}
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		if out[i].PodName != out[j].PodName {
+			return out[i].PodName < out[j].PodName
+		}
+		if out[i].Container != out[j].Container {
+			return out[i].Container < out[j].Container
+		}
+		if out[i].SecretName != out[j].SecretName {
+			return out[i].SecretName < out[j].SecretName
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+type secretDataChange struct {
+	key       string
+	changedAt time.Time
+}
+
+func secretDataChangesBySecret(changes map[secretDataKey]time.Time) map[string][]secretDataChange {
+	out := make(map[string][]secretDataChange)
+	for identity, changedAt := range changes {
+		secret := identity.namespace + "\x00" + identity.name
+		out[secret] = append(out[secret], secretDataChange{key: identity.key, changedAt: changedAt})
+	}
+	for secret := range out {
+		sort.Slice(out[secret], func(i, j int) bool { return out[secret][i].key < out[secret][j].key })
+	}
+	return out
+}
+
+func newStaleSecretEnvCheck(pod *corev1.Pod, container, envName, source, prefix, secretName, key string, startedAt, changedAt time.Time) StaleSecretEnvCheck {
+	return StaleSecretEnvCheck{
+		Namespace:           pod.Namespace,
+		PodName:             pod.Name,
+		Container:           container,
+		EnvName:             envName,
+		Source:              source,
+		Prefix:              prefix,
+		SecretName:          secretName,
+		Key:                 key,
+		ContainerStartedAt:  startedAt,
+		SecretDataChangedAt: changedAt,
+		Message:             fmt.Sprintf("Container %s started at %s, before Radar observed Secret/%s key %s change at %s; env %s may hold a stale value until the container restarts.", container, startedAt.UTC().Format(time.RFC3339), secretName, key, changedAt.UTC().Format(time.RFC3339), envName),
+	}
+}
+
+func secretExists(cache *ResourceCache, namespace, name string, exists, checked map[string]bool) bool {
+	identity := namespace + "\x00" + name
+	if checked[identity] {
+		return exists[identity]
+	}
+	checked[identity] = true
+	secret, err := cache.Secrets().Secrets(namespace).Get(name)
+	exists[identity] = err == nil && secret != nil
+	return exists[identity]
+}
+
+func latestContainerStart(status corev1.ContainerStatus) (time.Time, bool) {
+	var latest time.Time
+	if status.State.Running != nil {
+		latest = status.State.Running.StartedAt.Time
+	}
+	if status.State.Terminated != nil && status.State.Terminated.StartedAt.Time.After(latest) {
+		latest = status.State.Terminated.StartedAt.Time
+	}
+	if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.StartedAt.Time.After(latest) {
+		latest = status.LastTerminationState.Terminated.StartedAt.Time
+	}
+	return latest, !latest.IsZero()
+}
+
+func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]time.Time {
+	out := make(map[secretDataKey]time.Time)
+	for _, event := range events {
+		if event.Kind != "Secret" || event.Source != timeline.SourceInformer || event.EventType != timeline.EventTypeUpdate || event.Diff == nil || event.Timestamp.IsZero() {
+			continue
+		}
+		for _, field := range event.Diff.Fields {
+			if !isSecretDataChangePath(field.Path) {
+				continue
+			}
+			keys := stringValues(field.NewValue)
+			if len(keys) == 0 {
+				keys = stringValues(field.OldValue)
+			}
+			for _, key := range keys {
+				if key == "" {
+					continue
+				}
+				identity := secretDataKey{namespace: event.Namespace, name: event.Name, key: key}
+				if event.Timestamp.After(out[identity]) {
+					out[identity] = event.Timestamp
+				}
+			}
+		}
+	}
+	return out
+}
+
+func isSecretDataChangePath(path string) bool {
+	switch path {
+	case "data (modified keys)", "data (added keys)", "stringData (modified keys)", "stringData (added keys)":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringValues(value any) []string {
+	switch values := value.(type) {
+	case []string:
+		return values
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if text, ok := value.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func sortTimelineEventsNewestFirst(events []timeline.TimelineEvent) {
+	sort.SliceStable(events, func(i, j int) bool {
+		if !events[i].Timestamp.Equal(events[j].Timestamp) {
+			return events[i].Timestamp.After(events[j].Timestamp)
+		}
+		return events[i].Seq > events[j].Seq
+	})
+}
+
+func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) []StaleSecretEnvCheck {
+	if pod == nil || pod.Status.Phase != corev1.PodRunning {
+		return nil
+	}
+	readyKnown, ready := false, false
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			readyKnown = true
+			ready = condition.Status == corev1.ConditionTrue
+			break
+		}
+	}
+	if !readyKnown || ready {
+		return nil
+	}
+	bitingContainers := make(map[string]bool)
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running != nil && !status.Ready {
+			bitingContainers[status.Name] = true
+		}
+	}
+	var out []StaleSecretEnvCheck
+	for _, check := range checks {
+		if bitingContainers[check.Container] {
+			out = append(out, check)
+		}
+	}
+	return out
+}
+
+func staleSecretEnvDetectionMessage(checks []StaleSecretEnvCheck) string {
+	if len(checks) == 1 {
+		check := checks[0]
+		return fmt.Sprintf("Container %s is not Ready and may be running a stale env value for Secret/%s key %s; restart the pod to refresh it.", check.Container, check.SecretName, check.Key)
+	}
+	return fmt.Sprintf("A not-Ready container may be running %d stale Secret-backed env values; restart the pod to refresh them.", len(checks))
+}

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -465,6 +465,7 @@ func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]
 }
 
 func isSecretDataModificationPath(path string) bool {
+	// Added keys were absent from existing envFrom environments, so they cannot make an injected value stale.
 	switch path {
 	case "data (modified keys)", "stringData (modified keys)":
 		return true

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	envHistoryLookback                  = time.Hour
+	envHistoryContextMaxLookback        = 24 * time.Hour
 	maxStaleSecretEnvChecksPerContainer = 5
 	// A mass Secret rotation coinciding with a rollout can leave many pods
 	// simultaneously not-Ready with in-window key changes; a sweep must not
@@ -42,18 +43,25 @@ type RemovedServiceEnvCheck struct {
 }
 
 type StaleSecretEnvCheck struct {
-	Namespace           string
-	PodName             string
-	Container           string
-	EnvName             string
-	Source              string
-	Prefix              string
-	SecretName          string
-	Key                 string
-	ContainerStartedAt  time.Time
-	SecretDataChangedAt time.Time
-	Message             string
+	Namespace          string
+	PodName            string
+	Container          string
+	EnvName            string
+	ReferenceKind      string
+	EvidenceSource     string
+	Prefix             string
+	SecretName         string
+	Key                string
+	AffectedPods       int
+	ContainerStartedAt time.Time
+	SecretChangedAt    time.Time
+	Message            string
 }
+
+const (
+	staleSecretEvidenceObservedChange = "observed_change"
+	staleSecretEvidenceManagedFields  = "managed_fields_mtime"
+)
 
 // FindRemovedServiceEnvChecksForObject returns recent env-removal facts for a
 // workload. It deliberately consumes only the already-redacted timeline diff;
@@ -172,8 +180,68 @@ func FindStaleSecretEnvChecksForObject(ctx context.Context, cache *ResourceCache
 	if !ok || pod == nil || !podHasSecretEnvReference(pod) {
 		return nil
 	}
-	events := querySecretDataHistory(ctx, pod.Namespace, time.Now())
-	return findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, events)
+	now := time.Now()
+	return findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, querySecretDataHistory(ctx, pod.Namespace, staleSecretEnvHistorySince([]*corev1.Pod{pod}, now)))
+}
+
+// FindStaleSecretEnvChecksForPods aggregates the Pod-level facts needed by a
+// workload diagnosis, including the managedFields fallback that is deliberately
+// confined to this diagnostic path.
+func FindStaleSecretEnvChecksForPods(ctx context.Context, cache *ResourceCache, pods []*corev1.Pod) []StaleSecretEnvCheck {
+	if cache == nil {
+		return nil
+	}
+	podsByNamespace := make(map[string][]*corev1.Pod)
+	for _, pod := range pods {
+		if pod != nil && podHasSecretEnvReference(pod) {
+			podsByNamespace[pod.Namespace] = append(podsByNamespace[pod.Namespace], pod)
+		}
+	}
+	namespaces := make([]string, 0, len(podsByNamespace))
+	for namespace := range podsByNamespace {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	var out []StaleSecretEnvCheck
+	for _, namespace := range namespaces {
+		now := time.Now()
+		events := querySecretDataHistory(ctx, namespace, staleSecretEnvHistorySince(podsByNamespace[namespace], now))
+		checks := groupStaleSecretEnvChecks(findStaleSecretEnvChecksWithManagedFields(cache, podsByNamespace[namespace], events))
+		if len(checks) > maxStaleSecretEnvDetectionsPerNamespace {
+			checks = checks[:maxStaleSecretEnvDetectionsPerNamespace]
+		}
+		out = append(out, checks...)
+	}
+	return out
+}
+
+func groupStaleSecretEnvChecks(checks []StaleSecretEnvCheck) []StaleSecretEnvCheck {
+	type group struct {
+		check StaleSecretEnvCheck
+		pods  map[string]bool
+	}
+	byKey := make(map[string]*group)
+	for _, check := range checks {
+		key := check.Namespace + "\x00" + check.Container + "\x00" + check.EnvName + "\x00" +
+			check.ReferenceKind + "\x00" + check.EvidenceSource + "\x00" + check.Prefix + "\x00" +
+			check.SecretName + "\x00" + check.Key
+		current := byKey[key]
+		if current == nil {
+			current = &group{check: check, pods: make(map[string]bool)}
+			byKey[key] = current
+		}
+		current.pods[check.PodName] = true
+		if check.PodName < current.check.PodName {
+			current.check = check
+		}
+	}
+	out := make([]StaleSecretEnvCheck, 0, len(byKey))
+	for _, current := range byKey {
+		current.check.AffectedPods = len(current.pods)
+		out = append(out, current.check)
+	}
+	sortStaleSecretEnvChecks(out)
+	return out
 }
 
 func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time) []Detection {
@@ -201,7 +269,7 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 	if !usesSecretEnv {
 		return nil
 	}
-	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, now))
+	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, now.Add(-envHistoryLookback)))
 	checksByPod := make(map[string][]StaleSecretEnvCheck)
 	for _, check := range checks {
 		key := check.Namespace + "\x00" + check.PodName
@@ -214,10 +282,10 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 		if len(bitingChecks) == 0 {
 			continue
 		}
-		changedAt := bitingChecks[0].SecretDataChangedAt
+		changedAt := bitingChecks[0].SecretChangedAt
 		for _, check := range bitingChecks[1:] {
-			if check.SecretDataChangedAt.Before(changedAt) {
-				changedAt = check.SecretDataChangedAt
+			if check.SecretChangedAt.Before(changedAt) {
+				changedAt = check.SecretChangedAt
 			}
 		}
 		age := ageSeconds(now, changedAt)
@@ -272,10 +340,10 @@ func podHasSecretEnvReference(pod *corev1.Pod) bool {
 	return false
 }
 
-func querySecretDataHistory(ctx context.Context, namespace string, now time.Time) []timeline.TimelineEvent {
+func querySecretDataHistory(ctx context.Context, namespace string, since time.Time) []timeline.TimelineEvent {
 	opts := timeline.QueryOptions{
 		Kinds:          []string{"Secret"},
-		Since:          now.Add(-envHistoryLookback),
+		Since:          since,
 		Sources:        []timeline.EventSource{timeline.SourceInformer},
 		EventTypes:     []timeline.EventType{timeline.EventTypeUpdate},
 		ClusterContext: ActiveClusterContext(),
@@ -285,6 +353,33 @@ func querySecretDataHistory(ctx context.Context, namespace string, now time.Time
 		opts.Namespaces = []string{namespace}
 	}
 	return queryEnvHistory(ctx, opts)
+}
+
+func staleSecretEnvHistorySince(pods []*corev1.Pod, now time.Time) time.Time {
+	floor := now.Add(-envHistoryContextMaxLookback)
+	var earliest time.Time
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
+				continue
+			}
+			startedAt := status.State.Running.StartedAt.Time
+			if earliest.IsZero() || startedAt.Before(earliest) {
+				earliest = startedAt
+			}
+		}
+	}
+	if earliest.IsZero() || earliest.Before(floor) {
+		return floor
+	}
+	since := earliest.Add(-time.Second)
+	if since.Before(floor) {
+		return floor
+	}
+	return since
 }
 
 func queryEnvHistory(ctx context.Context, opts timeline.QueryOptions) []timeline.TimelineEvent {
@@ -326,13 +421,10 @@ func findStaleSecretEnvChecks(cache *ResourceCache, pods []*corev1.Pod, events [
 		}
 		for _, container := range pod.Spec.Containers {
 			status, ok := statuses[container.Name]
-			if !ok {
+			if !ok || status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
 				continue
 			}
-			startedAt, ok := latestContainerStart(status)
-			if !ok {
-				continue
-			}
+			startedAt := status.State.Running.StartedAt.Time
 			containerChecks := 0
 			for _, env := range container.Env {
 				if containerChecks >= maxStaleSecretEnvChecksPerContainer {
@@ -370,7 +462,79 @@ func findStaleSecretEnvChecks(cache *ResourceCache, pods []*corev1.Pod, events [
 			}
 		}
 	}
+	sortStaleSecretEnvChecks(out)
+	return out
+}
+
+func findStaleSecretEnvChecksWithManagedFields(cache *ResourceCache, pods []*corev1.Pod, events []timeline.TimelineEvent) []StaleSecretEnvCheck {
+	out := findStaleSecretEnvChecks(cache, pods, events)
+	if cache == nil || cache.Secrets() == nil {
+		return out
+	}
+
+	observedSecrets := secretsWithObservedDataWrites(events)
+	checksPerContainer := make(map[string]int)
+	for _, check := range out {
+		checksPerContainer[check.Namespace+"\x00"+check.PodName+"\x00"+check.Container]++
+	}
+	exists := make(map[string]bool)
+	checked := make(map[string]bool)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
+		for _, status := range pod.Status.ContainerStatuses {
+			statuses[status.Name] = status
+		}
+		for _, container := range pod.Spec.Containers {
+			status, ok := statuses[container.Name]
+			if !ok || status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
+				continue
+			}
+			startedAt := status.State.Running.StartedAt.Time
+			containerIdentity := pod.Namespace + "\x00" + pod.Name + "\x00" + container.Name
+			seenSecrets := make(map[string]bool)
+			addFallback := func(referenceKind, prefix, secretName string) {
+				if checksPerContainer[containerIdentity] >= maxStaleSecretEnvChecksPerContainer || secretName == "" {
+					return
+				}
+				secretIdentity := pod.Namespace + "\x00" + secretName
+				if seenSecrets[secretIdentity] {
+					return
+				}
+				seenSecrets[secretIdentity] = true
+				if observedSecrets[secretIdentity] || !secretExists(cache, pod.Namespace, secretName, exists, checked) {
+					return
+				}
+				changedAt, ok := secretDataManagerWriteTime(cache, pod.Namespace, secretName)
+				if !ok || !startedAt.Before(changedAt) {
+					return
+				}
+				out = append(out, newManagedFieldsStaleSecretEnvCheck(pod, container.Name, referenceKind, prefix, secretName, startedAt, changedAt))
+				checksPerContainer[containerIdentity]++
+			}
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+					addFallback("secretKeyRef", "", env.ValueFrom.SecretKeyRef.Name)
+				}
+			}
+			for _, envFrom := range container.EnvFrom {
+				if envFrom.SecretRef != nil {
+					addFallback("envFrom", envFrom.Prefix, envFrom.SecretRef.Name)
+				}
+			}
+		}
+	}
+	sortStaleSecretEnvChecks(out)
+	return out
+}
+
+func sortStaleSecretEnvChecks(out []StaleSecretEnvCheck) {
 	sort.Slice(out, func(i, j int) bool {
+		if out[i].EvidenceSource != out[j].EvidenceSource {
+			return out[i].EvidenceSource == staleSecretEvidenceObservedChange
+		}
 		if out[i].Namespace != out[j].Namespace {
 			return out[i].Namespace < out[j].Namespace
 		}
@@ -385,7 +549,6 @@ func findStaleSecretEnvChecks(cache *ResourceCache, pods []*corev1.Pod, events [
 		}
 		return out[i].Key < out[j].Key
 	})
-	return out
 }
 
 type secretDataChange struct {
@@ -405,19 +568,35 @@ func secretDataChangesBySecret(changes map[secretDataKey]time.Time) map[string][
 	return out
 }
 
-func newStaleSecretEnvCheck(pod *corev1.Pod, container, envName, source, prefix, secretName, key string, startedAt, changedAt time.Time) StaleSecretEnvCheck {
+func newStaleSecretEnvCheck(pod *corev1.Pod, container, envName, referenceKind, prefix, secretName, key string, startedAt, changedAt time.Time) StaleSecretEnvCheck {
 	return StaleSecretEnvCheck{
-		Namespace:           pod.Namespace,
-		PodName:             pod.Name,
-		Container:           container,
-		EnvName:             envName,
-		Source:              source,
-		Prefix:              prefix,
-		SecretName:          secretName,
-		Key:                 key,
-		ContainerStartedAt:  startedAt,
-		SecretDataChangedAt: changedAt,
-		Message:             fmt.Sprintf("Container %s started at %s, before Radar observed Secret/%s key %s change at %s; env %s may hold a stale value until the container restarts.", container, startedAt.UTC().Format(time.RFC3339), secretName, key, changedAt.UTC().Format(time.RFC3339), envName),
+		Namespace:          pod.Namespace,
+		PodName:            pod.Name,
+		Container:          container,
+		EnvName:            envName,
+		ReferenceKind:      referenceKind,
+		EvidenceSource:     staleSecretEvidenceObservedChange,
+		Prefix:             prefix,
+		SecretName:         secretName,
+		Key:                key,
+		ContainerStartedAt: startedAt,
+		SecretChangedAt:    changedAt,
+		Message:            fmt.Sprintf("Container %s started at %s, before Radar observed Secret/%s key %s change at %s; env %s may hold a stale value until the container restarts.", container, startedAt.UTC().Format(time.RFC3339), secretName, key, changedAt.UTC().Format(time.RFC3339), envName),
+	}
+}
+
+func newManagedFieldsStaleSecretEnvCheck(pod *corev1.Pod, container, referenceKind, prefix, secretName string, startedAt, changedAt time.Time) StaleSecretEnvCheck {
+	return StaleSecretEnvCheck{
+		Namespace:          pod.Namespace,
+		PodName:            pod.Name,
+		Container:          container,
+		ReferenceKind:      referenceKind,
+		EvidenceSource:     staleSecretEvidenceManagedFields,
+		Prefix:             prefix,
+		SecretName:         secretName,
+		ContainerStartedAt: startedAt,
+		SecretChangedAt:    changedAt,
+		Message:            fmt.Sprintf("Secret/%s was modified at %s by a field manager that owns Secret data, after container %s started at %s; managedFields cannot identify which field changed, so if the write touched a consumed key the running process may hold a stale env value until restart.", secretName, changedAt.UTC().Format(time.RFC3339), container, startedAt.UTC().Format(time.RFC3339)),
 	}
 }
 
@@ -432,18 +611,40 @@ func secretExists(cache *ResourceCache, namespace, name string, exists, checked 
 	return exists[identity]
 }
 
-func latestContainerStart(status corev1.ContainerStatus) (time.Time, bool) {
-	var latest time.Time
-	if status.State.Running != nil {
-		latest = status.State.Running.StartedAt.Time
+func secretDataManagerWriteTime(cache *ResourceCache, namespace, name string) (time.Time, bool) {
+	if cache == nil || cache.secretWriteTimes == nil || cache.Secrets() == nil {
+		return time.Time{}, false
 	}
-	if status.State.Terminated != nil && status.State.Terminated.StartedAt.Time.After(latest) {
-		latest = status.State.Terminated.StartedAt.Time
+	value, ok := cache.secretWriteTimes.Load(secretWriteKey(namespace, name))
+	if !ok {
+		return time.Time{}, false
 	}
-	if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.StartedAt.Time.After(latest) {
-		latest = status.LastTerminationState.Terminated.StartedAt.Time
+	write, ok := value.(secretDataManagerWrite)
+	if !ok || write.at.IsZero() {
+		return time.Time{}, false
 	}
-	return latest, !latest.IsZero()
+	secret, err := cache.Secrets().Secrets(namespace).Get(name)
+	if err != nil || secret == nil || string(secret.UID) != write.uid {
+		return time.Time{}, false
+	}
+	return write.at, true
+}
+
+func secretsWithObservedDataWrites(events []timeline.TimelineEvent) map[string]bool {
+	out := make(map[string]bool)
+	for _, event := range events {
+		if event.Kind != "Secret" || event.Source != timeline.SourceInformer || event.EventType != timeline.EventTypeUpdate || event.Diff == nil {
+			continue
+		}
+		for _, field := range event.Diff.Fields {
+			switch field.Path {
+			case "data (added keys)", "data (removed keys)", "data (modified keys)",
+				"stringData (added keys)", "stringData (removed keys)", "stringData (modified keys)":
+				out[event.Namespace+"\x00"+event.Name] = true
+			}
+		}
+	}
+	return out
 }
 
 func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]time.Time {
@@ -536,7 +737,7 @@ func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) [
 	}
 	var out []StaleSecretEnvCheck
 	for _, check := range checks {
-		if bitingContainers[check.Container] {
+		if check.EvidenceSource == staleSecretEvidenceObservedChange && bitingContainers[check.Container] {
 			out = append(out, check)
 		}
 	}

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -161,8 +161,20 @@ func findRemovedServiceEnvChecks(cache *ResourceCache, wl envServiceWorkload, ui
 }
 
 func parseWorkloadEnvPath(path string) (container, envName string, ok bool) {
-	const prefix = "spec.template.spec.containers["
-	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, "]") {
+	const (
+		containersPrefix     = "spec.template.spec.containers["
+		initContainersPrefix = "spec.template.spec.initContainers["
+	)
+	var prefix string
+	switch {
+	case strings.HasPrefix(path, containersPrefix):
+		prefix = containersPrefix
+	case strings.HasPrefix(path, initContainersPrefix):
+		prefix = initContainersPrefix
+	default:
+		return "", "", false
+	}
+	if !strings.HasSuffix(path, "]") {
 		return "", "", false
 	}
 	rest := strings.TrimSuffix(strings.TrimPrefix(path, prefix), "]")
@@ -269,7 +281,7 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 	if !usesSecretEnv {
 		return nil
 	}
-	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, now.Add(-envHistoryLookback)))
+	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, staleSecretEnvHistorySince(pods, now)))
 	checksByPod := make(map[string][]StaleSecretEnvCheck)
 	for _, check := range checks {
 		key := check.Namespace + "\x00" + check.PodName
@@ -325,7 +337,7 @@ func podHasSecretEnvReference(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
 	}
-	for _, container := range pod.Spec.Containers {
+	for _, container := range staleSecretEnvContainers(pod) {
 		for _, env := range container.Env {
 			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 				return true
@@ -338,6 +350,57 @@ func podHasSecretEnvReference(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// staleSecretEnvContainers returns the containers whose Secret-backed env can go
+// stale until restart: all regular containers plus restartable init containers
+// (native sidecars, restartPolicy=Always), which run for the pod's lifetime.
+// Regular init containers run once to completion and re-read env on the next pod
+// start, so they can never hold a stale-until-restart value and are excluded.
+func staleSecretEnvContainers(pod *corev1.Pod) []corev1.Container {
+	out := make([]corev1.Container, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for _, container := range pod.Spec.InitContainers {
+		if isRestartableInitContainer(container) {
+			out = append(out, container)
+		}
+	}
+	return append(out, pod.Spec.Containers...)
+}
+
+// staleSecretEnvContainerStatuses indexes the statuses of the containers that
+// staleSecretEnvContainers walks: regular containers plus restartable init
+// containers. Container names are unique across a Pod's regular and init
+// containers, so merging the two status lists cannot collide, and only the
+// runtime containers above are ever looked up.
+func staleSecretEnvContainerStatuses(pod *corev1.Pod) map[string]corev1.ContainerStatus {
+	statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
+	restartable := restartableInitContainerNames(pod)
+	for _, status := range pod.Status.InitContainerStatuses {
+		if restartable[status.Name] {
+			statuses[status.Name] = status
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		statuses[status.Name] = status
+	}
+	return statuses
+}
+
+func restartableInitContainerNames(pod *corev1.Pod) map[string]bool {
+	var names map[string]bool
+	for _, container := range pod.Spec.InitContainers {
+		if isRestartableInitContainer(container) {
+			if names == nil {
+				names = make(map[string]bool)
+			}
+			names[container.Name] = true
+		}
+	}
+	return names
+}
+
+func isRestartableInitContainer(container corev1.Container) bool {
+	return container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }
 
 func querySecretDataHistory(ctx context.Context, namespace string, since time.Time) []timeline.TimelineEvent {
@@ -358,18 +421,27 @@ func querySecretDataHistory(ctx context.Context, namespace string, since time.Ti
 func staleSecretEnvHistorySince(pods []*corev1.Pod, now time.Time) time.Time {
 	floor := now.Add(-envHistoryContextMaxLookback)
 	var earliest time.Time
+	consider := func(status corev1.ContainerStatus) {
+		if status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
+			return
+		}
+		startedAt := status.State.Running.StartedAt.Time
+		if earliest.IsZero() || startedAt.Before(earliest) {
+			earliest = startedAt
+		}
+	}
 	for _, pod := range pods {
 		if pod == nil {
 			continue
 		}
+		restartable := restartableInitContainerNames(pod)
+		for _, status := range pod.Status.InitContainerStatuses {
+			if restartable[status.Name] {
+				consider(status)
+			}
+		}
 		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
-				continue
-			}
-			startedAt := status.State.Running.StartedAt.Time
-			if earliest.IsZero() || startedAt.Before(earliest) {
-				earliest = startedAt
-			}
+			consider(status)
 		}
 	}
 	if earliest.IsZero() || earliest.Before(floor) {
@@ -415,11 +487,8 @@ func findStaleSecretEnvChecks(cache *ResourceCache, pods []*corev1.Pod, events [
 		if pod == nil {
 			continue
 		}
-		statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
-		for _, status := range pod.Status.ContainerStatuses {
-			statuses[status.Name] = status
-		}
-		for _, container := range pod.Spec.Containers {
+		statuses := staleSecretEnvContainerStatuses(pod)
+		for _, container := range staleSecretEnvContainers(pod) {
 			status, ok := statuses[container.Name]
 			if !ok || status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
 				continue
@@ -483,11 +552,8 @@ func findStaleSecretEnvChecksWithManagedFields(cache *ResourceCache, pods []*cor
 		if pod == nil {
 			continue
 		}
-		statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
-		for _, status := range pod.Status.ContainerStatuses {
-			statuses[status.Name] = status
-		}
-		for _, container := range pod.Spec.Containers {
+		statuses := staleSecretEnvContainerStatuses(pod)
+		for _, container := range staleSecretEnvContainers(pod) {
 			status, ok := statuses[container.Name]
 			if !ok || status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
 				continue
@@ -722,8 +788,17 @@ func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) [
 	}
 	// Only a Running-but-not-Ready container can be holding a stale value: a
 	// Waiting or crashlooping container re-reads Secret-backed env on its next
-	// (re)start, so it is deliberately outside this gate.
+	// (re)start, so it is deliberately outside this gate. Restartable init
+	// containers (native sidecars) run for the pod's lifetime and their
+	// readiness feeds the Pod Ready condition, so a not-Ready one bites exactly
+	// like a regular container; pure init containers are already excluded.
 	bitingContainers := make(map[string]bool)
+	restartable := restartableInitContainerNames(pod)
+	for _, status := range pod.Status.InitContainerStatuses {
+		if restartable[status.Name] && status.State.Running != nil && !status.Ready {
+			bitingContainers[status.Name] = true
+		}
+	}
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.State.Running != nil && !status.Ready {
 			bitingContainers[status.Name] = true

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -615,16 +615,12 @@ func secretDataManagerWriteTime(cache *ResourceCache, namespace, name string) (t
 	if cache == nil || cache.secretWriteTimes == nil || cache.Secrets() == nil {
 		return time.Time{}, false
 	}
-	value, ok := cache.secretWriteTimes.Load(secretWriteKey(namespace, name))
-	if !ok {
-		return time.Time{}, false
-	}
-	write, ok := value.(secretDataManagerWrite)
+	write, ok := cache.secretWriteTimes.load(namespace, name)
 	if !ok || write.at.IsZero() {
 		return time.Time{}, false
 	}
 	secret, err := cache.Secrets().Secrets(namespace).Get(name)
-	if err != nil || secret == nil || string(secret.UID) != write.uid {
+	if err != nil || secret == nil || secret.Type == corev1.SecretType("helm.sh/release.v1") || string(secret.UID) != write.uid {
 		return time.Time{}, false
 	}
 	return write.at, true
@@ -637,9 +633,7 @@ func secretsWithObservedDataWrites(events []timeline.TimelineEvent) map[string]b
 			continue
 		}
 		for _, field := range event.Diff.Fields {
-			switch field.Path {
-			case "data (added keys)", "data (removed keys)", "data (modified keys)",
-				"stringData (added keys)", "stringData (removed keys)", "stringData (modified keys)":
+			if isSecretDataWritePath(field.Path) {
 				out[event.Namespace+"\x00"+event.Name] = true
 			}
 		}

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -18,9 +18,12 @@ const (
 	envHistoryLookback                  = time.Hour
 	maxStaleSecretEnvChecksPerContainer = 5
 	// A mass Secret rotation coinciding with a rollout can leave many pods
-	// simultaneously not-Ready with in-window key changes; the sweep must not
-	// turn that into an unbounded warning burst.
-	maxStaleSecretEnvDetectionsPerSweep = 20
+	// simultaneously not-Ready with in-window key changes; a sweep must not
+	// turn that into an unbounded warning burst. The bound is per detector
+	// invocation, which is per namespace: the cluster-wide sweep (namespace
+	// "") is a single invocation and thus globally bounded, while an
+	// N-namespace query is bounded at N times this cap.
+	maxStaleSecretEnvDetectionsPerNamespace = 20
 )
 
 type RemovedServiceEnvCheck struct {
@@ -244,8 +247,8 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 		}
 		return out[i].Name < out[j].Name
 	})
-	if len(out) > maxStaleSecretEnvDetectionsPerSweep {
-		out = out[:maxStaleSecretEnvDetectionsPerSweep]
+	if len(out) > maxStaleSecretEnvDetectionsPerNamespace {
+		out = out[:maxStaleSecretEnvDetectionsPerNamespace]
 	}
 	return out
 }

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -17,6 +17,10 @@ import (
 const (
 	envHistoryLookback                  = time.Hour
 	maxStaleSecretEnvChecksPerContainer = 5
+	// A mass Secret rotation coinciding with a rollout can leave many pods
+	// simultaneously not-Ready with in-window key changes; the sweep must not
+	// turn that into an unbounded warning burst.
+	maxStaleSecretEnvDetectionsPerSweep = 20
 )
 
 type RemovedServiceEnvCheck struct {
@@ -240,6 +244,9 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 		}
 		return out[i].Name < out[j].Name
 	})
+	if len(out) > maxStaleSecretEnvDetectionsPerSweep {
+		out = out[:maxStaleSecretEnvDetectionsPerSweep]
+	}
 	return out
 }
 
@@ -515,6 +522,9 @@ func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) [
 	if !readyKnown || ready {
 		return nil
 	}
+	// Only a Running-but-not-Ready container can be holding a stale value: a
+	// Waiting or crashlooping container re-reads Secret-backed env on its next
+	// (re)start, so it is deliberately outside this gate.
 	bitingContainers := make(map[string]bool)
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.State.Running != nil && !status.Ready {

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -120,7 +120,7 @@ func findRemovedServiceEnvChecks(cache *ResourceCache, wl envServiceWorkload, ui
 				continue
 			}
 			seenPaths[change.Path] = true
-			if change.NewValue != nil {
+			if change.NewValue != nil || workloadSpecHasEnv(wl.spec, container, envName) {
 				continue
 			}
 			oldValue, ok := change.OldValue.(string)
@@ -158,6 +158,22 @@ func findRemovedServiceEnvChecks(cache *ResourceCache, wl envServiceWorkload, ui
 		return out[i].EnvName < out[j].EnvName
 	})
 	return out
+}
+
+func workloadSpecHasEnv(spec corev1.PodSpec, containerName, envName string) bool {
+	for _, containers := range [][]corev1.Container{spec.InitContainers, spec.Containers} {
+		for _, container := range containers {
+			if container.Name != containerName {
+				continue
+			}
+			for _, env := range container.Env {
+				if env.Name == envName {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func parseWorkloadEnvPath(path string) (container, envName string, ok bool) {
@@ -736,9 +752,10 @@ func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]
 }
 
 func isSecretDataModificationPath(path string) bool {
-	// Added keys were absent from existing envFrom environments, so they cannot make an injected value stale.
+	// Added keys were absent from existing environments, so they cannot make an injected value stale.
 	switch path {
-	case "data (modified keys)", "stringData (modified keys)":
+	case "data (modified keys)", "data (removed keys)",
+		"stringData (modified keys)", "stringData (removed keys)":
 		return true
 	default:
 		return false

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -443,7 +443,7 @@ func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]
 			continue
 		}
 		for _, field := range event.Diff.Fields {
-			if !isSecretDataChangePath(field.Path) {
+			if !isSecretDataModificationPath(field.Path) {
 				continue
 			}
 			keys := stringValues(field.NewValue)
@@ -464,9 +464,9 @@ func latestSecretDataChanges(events []timeline.TimelineEvent) map[secretDataKey]
 	return out
 }
 
-func isSecretDataChangePath(path string) bool {
+func isSecretDataModificationPath(path string) bool {
 	switch path {
-	case "data (modified keys)", "data (added keys)", "stringData (modified keys)", "stringData (added keys)":
+	case "data (modified keys)", "stringData (modified keys)":
 		return true
 	default:
 		return false

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -201,6 +202,49 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		}
 		if !podHasSecretEnvReference(pod) {
 			t.Fatal("envFrom Secret must pass the timeline-query precheck")
+		}
+	})
+
+	t.Run("newly added secretKeyRef key is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("key-ref-added", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		added := secretHistoryEvent(changedAt, "shop", "db-conn", "data (added keys)", []string{"password"})
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{added}); len(checks) != 0 {
+			t.Fatalf("added-key event must not mark a secretKeyRef env stale: %+v", checks)
+		}
+	})
+
+	// Known accepted limitation: the promotion gate corroborates on the same
+	// container being Running-and-not-Ready, but cannot distinguish "not Ready
+	// because of the stale value" from "not Ready for an unrelated reason while
+	// a consumed key happened to change in-window." The hedged message wording
+	// ("may be running a stale env value") is the mitigation.
+	t.Run("unrelated not-Ready with coincidental change still promotes (documented limitation)", func(t *testing.T) {
+		pod := staleSecretEnvPod("coincidental", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || !strings.Contains(detections[0].Message, "may be running a stale env value") {
+			t.Fatalf("expected one hedged warning for the coincidental case: %+v", detections)
+		}
+	})
+
+	t.Run("promotion sweep is capped", func(t *testing.T) {
+		objects := []runtime.Object{secret}
+		var pods []*corev1.Pod
+		for i := 0; i < maxStaleSecretEnvDetectionsPerSweep+5; i++ {
+			pod := staleSecretEnvPod(fmt.Sprintf("burst-%02d", i), startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+			pods = append(pods, pod)
+			objects = append(objects, pod)
+		}
+		cache := envHistoryTestCache(t, objects...)
+		setEnvHistoryEvents(t, change)
+		if checks := findStaleSecretEnvChecks(cache, pods, []timeline.TimelineEvent{change}); len(checks) != maxStaleSecretEnvDetectionsPerSweep+5 {
+			t.Fatalf("precondition: every burst pod should produce a fact, got %d", len(checks))
+		}
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != maxStaleSecretEnvDetectionsPerSweep {
+			t.Fatalf("mass rotation + rollout must not burst past the sweep cap: got %d, want %d", len(detections), maxStaleSecretEnvDetectionsPerSweep)
 		}
 	})
 }

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -232,19 +232,19 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 	t.Run("promotion sweep is capped", func(t *testing.T) {
 		objects := []runtime.Object{secret}
 		var pods []*corev1.Pod
-		for i := 0; i < maxStaleSecretEnvDetectionsPerSweep+5; i++ {
+		for i := 0; i < maxStaleSecretEnvDetectionsPerNamespace+5; i++ {
 			pod := staleSecretEnvPod(fmt.Sprintf("burst-%02d", i), startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
 			pods = append(pods, pod)
 			objects = append(objects, pod)
 		}
 		cache := envHistoryTestCache(t, objects...)
 		setEnvHistoryEvents(t, change)
-		if checks := findStaleSecretEnvChecks(cache, pods, []timeline.TimelineEvent{change}); len(checks) != maxStaleSecretEnvDetectionsPerSweep+5 {
+		if checks := findStaleSecretEnvChecks(cache, pods, []timeline.TimelineEvent{change}); len(checks) != maxStaleSecretEnvDetectionsPerNamespace+5 {
 			t.Fatalf("precondition: every burst pod should produce a fact, got %d", len(checks))
 		}
 		detections := detectStaleSecretEnv(cache, "shop", now)
-		if len(detections) != maxStaleSecretEnvDetectionsPerSweep {
-			t.Fatalf("mass rotation + rollout must not burst past the sweep cap: got %d, want %d", len(detections), maxStaleSecretEnvDetectionsPerSweep)
+		if len(detections) != maxStaleSecretEnvDetectionsPerNamespace {
+			t.Fatalf("mass rotation + rollout must not burst past the sweep cap: got %d, want %d", len(detections), maxStaleSecretEnvDetectionsPerNamespace)
 		}
 	})
 }

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -197,7 +198,7 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{Prefix: "DB_", SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "db-conn"}}}}
 		cache := envHistoryTestCache(t, pod, secret)
 		checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change})
-		if len(checks) != 1 || checks[0].Source != "envFrom" || checks[0].EnvName != "DB_password" || checks[0].Key != "password" {
+		if len(checks) != 1 || checks[0].ReferenceKind != "envFrom" || checks[0].EvidenceSource != staleSecretEvidenceObservedChange || checks[0].EnvName != "DB_password" || checks[0].Key != "password" {
 			t.Fatalf("unexpected envFrom fact: %+v", checks)
 		}
 		if !podHasSecretEnvReference(pod) {
@@ -249,6 +250,262 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 	})
 }
 
+func TestStaleSecretEnvManagedFieldsFallback(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	startedAt := now.Add(-2 * time.Minute)
+	changedAt := now.Add(-time.Minute)
+	newSecret := func() *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "db-conn",
+				Namespace: "shop",
+				ManagedFields: []metav1.ManagedFieldsEntry{{
+					Manager:    "secret-controller",
+					Operation:  metav1.ManagedFieldsOperationUpdate,
+					Time:       &metav1.Time{Time: changedAt},
+					FieldsType: "FieldsV1",
+					FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}},"f:metadata":{"f:annotations":{"f:sync":{}}}}`)},
+				}},
+			},
+			Data: map[string][]byte{"password": []byte("sentinel-secret-value")},
+		}
+	}
+
+	t.Run("empty timeline emits hedged FYI without a key", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, newSecret())
+		if checks := FindStaleSecretEnvChecksForObject(context.Background(), cache, pod); len(checks) != 0 {
+			t.Fatalf("basic object context must not emit coarse managedFields evidence: %+v", checks)
+		}
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, nil)
+		if len(checks) != 1 {
+			t.Fatalf("got %d managedFields checks, want 1: %+v", len(checks), checks)
+		}
+		check := checks[0]
+		if check.EvidenceSource != staleSecretEvidenceManagedFields || check.ReferenceKind != "secretKeyRef" || check.Key != "" || check.EnvName != "" || !check.SecretChangedAt.Equal(changedAt) {
+			t.Fatalf("unexpected managedFields check: %+v", check)
+		}
+		if !strings.Contains(check.Message, "managedFields cannot identify which field changed") || !strings.Contains(check.Message, "if the write touched a consumed key") || strings.Contains(check.Message, "password") {
+			t.Fatalf("fallback wording is not properly hedged: %q", check.Message)
+		}
+		encoded, err := json.Marshal(checks)
+		if err != nil {
+			t.Fatalf("marshal checks: %v", err)
+		}
+		if strings.Contains(string(encoded), "sentinel-secret-value") {
+			t.Fatalf("Secret value leaked into fallback output: %s", encoded)
+		}
+	})
+
+	t.Run("precise timeline evidence wins for the whole Secret", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, newSecret())
+		precise := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"password"})
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{precise})
+		if len(checks) != 1 || checks[0].EvidenceSource != staleSecretEvidenceObservedChange || checks[0].Key != "password" {
+			t.Fatalf("precise evidence must replace the fallback: %+v", checks)
+		}
+
+		otherKey := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"host"})
+		if checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{otherKey}); len(checks) != 0 {
+			t.Fatalf("any precise in-window evidence for the Secret must suppress coarse fallback: %+v", checks)
+		}
+
+		addedKey := secretHistoryEvent(changedAt, "shop", "db-conn", "data (added keys)", []string{"new-flag"})
+		if checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{addedKey}); len(checks) != 0 {
+			t.Fatalf("an observed added-key-only write must suppress the coarse fallback without claiming staleness: %+v", checks)
+		}
+	})
+
+	t.Run("diagnostic history reaches back to the running container start", func(t *testing.T) {
+		oldStart := now.Add(-2 * time.Hour)
+		oldChange := now.Add(-90 * time.Minute)
+		pod := staleSecretEnvPod("long-running", oldStart, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		secret := newSecret()
+		secret.ManagedFields[0].Time = &metav1.Time{Time: oldChange}
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, secretHistoryEvent(oldChange, "shop", "db-conn", "data (modified keys)", []string{"password"}))
+		checks := FindStaleSecretEnvChecksForPods(context.Background(), cache, []*corev1.Pod{pod})
+		if len(checks) != 1 || checks[0].EvidenceSource != staleSecretEvidenceObservedChange || checks[0].Key != "password" {
+			t.Fatalf("older precise evidence should win over managedFields fallback: %+v", checks)
+		}
+	})
+
+	t.Run("pre-start write and restart suppress", func(t *testing.T) {
+		secret := newSecret()
+		secret.ManagedFields[0].Time = &metav1.Time{Time: startedAt.Add(-time.Second)}
+		pod := staleSecretEnvPod("pre-start", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		if checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, nil); len(checks) != 0 {
+			t.Fatalf("pre-start Secret write must not produce a check: %+v", checks)
+		}
+
+		restarted := staleSecretEnvPod("restarted", changedAt.Add(time.Second), true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		restartedCache := envHistoryTestCache(t, restarted, newSecret())
+		if checks := findStaleSecretEnvChecksWithManagedFields(restartedCache, []*corev1.Pod{restarted}, nil); len(checks) != 0 {
+			t.Fatalf("container restart after the Secret write must suppress: %+v", checks)
+		}
+	})
+
+	t.Run("waiting container and volume-only use are ignored", func(t *testing.T) {
+		waiting := staleSecretEnvPod("waiting", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		waiting.Status.ContainerStatuses[0].State = corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}
+		waitingCache := envHistoryTestCache(t, waiting, newSecret())
+		if checks := findStaleSecretEnvChecksWithManagedFields(waitingCache, []*corev1.Pod{waiting}, nil); len(checks) != 0 {
+			t.Fatalf("waiting container must not produce a managedFields fallback: %+v", checks)
+		}
+		precise := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"password"})
+		if checks := findStaleSecretEnvChecks(waitingCache, []*corev1.Pod{waiting}, []timeline.TimelineEvent{precise}); len(checks) != 0 {
+			t.Fatalf("waiting container must not produce a precise stale-env FYI: %+v", checks)
+		}
+
+		volume := staleSecretEnvPod("volume", startedAt, true)
+		volume.Spec.Volumes = []corev1.Volume{{Name: "creds", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "db-conn"}}}}
+		volumeCache := envHistoryTestCache(t, volume, newSecret())
+		if checks := findStaleSecretEnvChecksWithManagedFields(volumeCache, []*corev1.Pod{volume}, nil); len(checks) != 0 {
+			t.Fatalf("Secret volume must not produce a managedFields fallback: %+v", checks)
+		}
+	})
+
+	t.Run("metadata-only caveat remains FYI-only", func(t *testing.T) {
+		pod := staleSecretEnvPod("not-ready", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, newSecret())
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, nil)
+		if len(checks) != 1 {
+			t.Fatalf("data-owning manager write should produce one hedged FYI: %+v", checks)
+		}
+		if biting := staleSecretEnvBitingChecks(pod, checks); len(biting) != 0 {
+			t.Fatalf("managedFields fallback must never enter issue promotion: %+v", biting)
+		}
+	})
+
+	t.Run("envFrom is eligible but unavailable metadata fails closed", func(t *testing.T) {
+		pod := staleSecretEnvPod("env-from", startedAt, true)
+		pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+			Prefix:    "DB_",
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "db-conn"}},
+		}}
+		cache := envHistoryTestCache(t, pod, newSecret())
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, nil)
+		if len(checks) != 1 || checks[0].ReferenceKind != "envFrom" || checks[0].Prefix != "DB_" || checks[0].Key != "" {
+			t.Fatalf("unexpected envFrom managedFields check: %+v", checks)
+		}
+
+		withoutManagedFields := newSecret()
+		withoutManagedFields.ManagedFields = nil
+		noSignalCache := envHistoryTestCache(t, pod, withoutManagedFields)
+		if checks := findStaleSecretEnvChecksWithManagedFields(noSignalCache, []*corev1.Pod{pod}, nil); len(checks) != 0 {
+			t.Fatalf("missing managedFields must fail closed: %+v", checks)
+		}
+	})
+
+	t.Run("precise evidence wins the per-container cap", func(t *testing.T) {
+		pod := staleSecretEnvPod("many-secrets", startedAt, true, secretKeyEnv("PRECISE", "precise", "password"))
+		objects := []runtime.Object{pod}
+		preciseSecret := newSecret()
+		preciseSecret.Name = "precise"
+		objects = append(objects, preciseSecret)
+		for i := 0; i < maxStaleSecretEnvChecksPerContainer; i++ {
+			name := fmt.Sprintf("coarse-%d", i)
+			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, secretKeyEnv(fmt.Sprintf("COARSE_%d", i), name, "password"))
+			secret := newSecret()
+			secret.Name = name
+			objects = append(objects, secret)
+		}
+		cache := envHistoryTestCache(t, objects...)
+		precise := secretHistoryEvent(changedAt, "shop", "precise", "data (modified keys)", []string{"password"})
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{precise})
+		if len(checks) != maxStaleSecretEnvChecksPerContainer {
+			t.Fatalf("checks = %d, want per-container cap %d: %+v", len(checks), maxStaleSecretEnvChecksPerContainer, checks)
+		}
+		if checks[0].EvidenceSource != staleSecretEvidenceObservedChange || checks[0].SecretName != "precise" {
+			t.Fatalf("precise evidence was displaced by coarse fallback: %+v", checks)
+		}
+	})
+
+	t.Run("workload replicas are grouped before the cap", func(t *testing.T) {
+		objects := []runtime.Object{newSecret()}
+		var pods []*corev1.Pod
+		for i := 0; i < maxStaleSecretEnvDetectionsPerNamespace+5; i++ {
+			pod := staleSecretEnvPod(fmt.Sprintf("catalog-%02d", i), startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+			pods = append(pods, pod)
+			objects = append(objects, pod)
+		}
+		cache := envHistoryTestCache(t, objects...)
+		setEnvHistoryEvents(t)
+		checks := FindStaleSecretEnvChecksForPods(context.Background(), cache, pods)
+		if len(checks) != 1 || checks[0].AffectedPods != maxStaleSecretEnvDetectionsPerNamespace+5 {
+			t.Fatalf("replica checks were not grouped before bounding: %+v", checks)
+		}
+	})
+
+	t.Run("workload-sized distinct fallback is capped", func(t *testing.T) {
+		var objects []runtime.Object
+		var pods []*corev1.Pod
+		for i := 0; i < maxStaleSecretEnvDetectionsPerNamespace+5; i++ {
+			name := fmt.Sprintf("db-conn-%02d", i)
+			pod := staleSecretEnvPod(fmt.Sprintf("catalog-%02d", i), startedAt, true, secretKeyEnv("DB_PASSWORD", name, "password"))
+			secret := newSecret()
+			secret.Name = name
+			pods = append(pods, pod)
+			objects = append(objects, pod, secret)
+		}
+		cache := envHistoryTestCache(t, objects...)
+		setEnvHistoryEvents(t)
+		checks := FindStaleSecretEnvChecksForPods(context.Background(), cache, pods)
+		if len(checks) != maxStaleSecretEnvDetectionsPerNamespace {
+			t.Fatalf("managedFields workload checks = %d, want cap %d", len(checks), maxStaleSecretEnvDetectionsPerNamespace)
+		}
+	})
+}
+
+func TestSecretDataManagerWriteIndex(t *testing.T) {
+	dataWrite := time.Date(2026, time.July, 23, 8, 0, 0, 0, time.UTC)
+	metadataWrite := dataWrite.Add(time.Hour)
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "credentials", Namespace: "shop", UID: types.UID("old"),
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{
+				Manager: "secret-controller", Operation: metav1.ManagedFieldsOperationUpdate,
+				Time: &metav1.Time{Time: dataWrite}, FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
+			},
+			{
+				Manager: "metadata-controller", Operation: metav1.ManagedFieldsOperationUpdate,
+				Time: &metav1.Time{Time: metadataWrite}, FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:annotations":{"f:data":{}}}}`)},
+			},
+		},
+	}}
+	index := &sync.Map{}
+	captureSecretDataManagerWriteTime(index, secret)
+	value, ok := index.Load(secretWriteKey("shop", "credentials"))
+	write, typed := value.(secretDataManagerWrite)
+	if !ok || !typed || write.uid != "old" || !write.at.Equal(dataWrite) {
+		t.Fatalf("index captured (%+v, %v), want old UID at %v", value, ok, dataWrite)
+	}
+
+	recreated := secret.DeepCopy()
+	recreated.UID = types.UID("new")
+	recreated.ManagedFields[0].Time = &metav1.Time{Time: dataWrite.Add(2 * time.Hour)}
+	captureSecretDataManagerWriteTime(index, recreated)
+	deleteSecretDataManagerWriteTime(index, k8score.ResourceChange{
+		Kind: "Secret", Namespace: "shop", Name: "credentials", UID: "old", Operation: k8score.OpDelete,
+	})
+	value, ok = index.Load(secretWriteKey("shop", "credentials"))
+	write, typed = value.(secretDataManagerWrite)
+	if !ok || !typed || write.uid != "new" {
+		t.Fatalf("old delete removed the recreated Secret's timestamp: %+v", value)
+	}
+
+	helmRelease := recreated.DeepCopy()
+	helmRelease.Type = corev1.SecretType("helm.sh/release.v1")
+	captureSecretDataManagerWriteTime(index, helmRelease)
+	if _, ok := index.Load(secretWriteKey("shop", "credentials")); ok {
+		t.Fatal("Helm release payload Secret should not occupy the diagnostic timestamp index")
+	}
+}
+
 func TestStaleSecretEnvDetectionResolvesWorkloadOwner(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	controller := true
@@ -270,6 +527,7 @@ func TestStaleSecretEnvDetectionResolvesWorkloadOwner(t *testing.T) {
 
 func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache {
 	t.Helper()
+	secretWriteTimes := &sync.Map{}
 	core, err := k8score.NewResourceCache(k8score.CacheConfig{
 		Client: fake.NewClientset(objects...),
 		ResourceTypes: map[string]bool{
@@ -277,12 +535,15 @@ func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache
 			k8score.Deployments: true, k8score.ReplicaSets: true,
 		},
 		DeferredTypes: map[string]bool{},
+		OnTransform: func(obj any) {
+			captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewResourceCache: %v", err)
 	}
 	t.Cleanup(core.Stop)
-	return &ResourceCache{ResourceCache: core, secretsEnabled: true}
+	return &ResourceCache{ResourceCache: core, secretsEnabled: true, secretWriteTimes: secretWriteTimes}
 }
 
 func setEnvHistoryEvents(t *testing.T, events ...timeline.TimelineEvent) {

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -74,6 +74,15 @@ func TestRemovedServiceEnvExposureAndPrecision(t *testing.T) {
 		}
 	})
 
+	t.Run("current env suppresses removal hidden by container re-add", func(t *testing.T) {
+		restoredDeployment := deployment.DeepCopy()
+		restoredDeployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "CART_ADDR", Value: "cart:8080"}}
+		restoredCache := envHistoryTestCache(t, restoredDeployment, service)
+		if checks := findRemovedServiceEnvChecks(restoredCache, envServiceWorkloadForDeployment(restoredDeployment), "", []timeline.TimelineEvent{removal}); len(checks) != 0 {
+			t.Fatalf("current env should suppress historical removal hidden by container-level diffs: %+v", checks)
+		}
+	})
+
 	t.Run("init container Service env removal is recorded", func(t *testing.T) {
 		initDeployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "frontend", Namespace: "shop"},
@@ -199,6 +208,50 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		added := secretHistoryEvent(changedAt, "shop", "db-conn", "data (added keys)", []string{"password"})
 		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{added}); len(checks) != 0 {
 			t.Fatalf("key added after container start is absent, not a stale env value: %+v", checks)
+		}
+	})
+
+	t.Run("removed consumed keys are stale evidence", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			path          string
+			pod           *corev1.Pod
+			referenceKind string
+			envName       string
+		}{
+			{
+				name:          "secretKeyRef data",
+				path:          "data (removed keys)",
+				pod:           staleSecretEnvPod("key-ref-removed", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password")),
+				referenceKind: "secretKeyRef",
+				envName:       "DB_PASSWORD",
+			},
+			{
+				name: "envFrom stringData",
+				path: "stringData (removed keys)",
+				pod: func() *corev1.Pod {
+					pod := staleSecretEnvPod("env-from-removed", startedAt, false)
+					pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+						Prefix:    "DB_",
+						SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "db-conn"}},
+					}}
+					return pod
+				}(),
+				referenceKind: "envFrom",
+				envName:       "DB_password",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				secretAfterRemoval := secret.DeepCopy()
+				delete(secretAfterRemoval.Data, "password")
+				cache := envHistoryTestCache(t, tt.pod, secretAfterRemoval)
+				removed := envHistoryEvent(changedAt, "Secret", "shop", "db-conn", tt.path, []string{"password"}, nil)
+				checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{tt.pod}, []timeline.TimelineEvent{removed})
+				if len(checks) != 1 || checks[0].ReferenceKind != tt.referenceKind || checks[0].EnvName != tt.envName || checks[0].Key != "password" {
+					t.Fatalf("removed consumed key was not reported as stale evidence: %+v", checks)
+				}
+			})
 		}
 	})
 

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -73,6 +73,22 @@ func TestRemovedServiceEnvExposureAndPrecision(t *testing.T) {
 			t.Fatalf("restored env should suppress older removal: %+v", checks)
 		}
 	})
+
+	t.Run("init container Service env removal is recorded", func(t *testing.T) {
+		initDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "frontend", Namespace: "shop"},
+			Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Name: "wait-for-cart"}},
+				Containers:     []corev1.Container{{Name: "frontend"}},
+			}}},
+		}
+		initCache := envHistoryTestCache(t, initDeployment, service)
+		initRemoval := envHistoryEvent(now.Add(-time.Minute), "Deployment", "shop", "frontend", "spec.template.spec.initContainers[wait-for-cart].env[CART_ADDR]", "cart:8080", nil)
+		checks := findRemovedServiceEnvChecks(initCache, envServiceWorkloadForDeployment(initDeployment), "", []timeline.TimelineEvent{initRemoval})
+		if len(checks) != 1 || checks[0].Container != "wait-for-cart" || checks[0].EnvName != "CART_ADDR" || checks[0].ServiceName != "cart" {
+			t.Fatalf("init container Service env removal was not recorded: %+v", checks)
+		}
+	})
 }
 
 func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
@@ -228,6 +244,73 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		detections := detectStaleSecretEnv(cache, "shop", now)
 		if len(detections) != 1 || !strings.Contains(detections[0].Message, "may be running a stale env value") {
 			t.Fatalf("expected one hedged warning for the coincidental case: %+v", detections)
+		}
+	})
+
+	t.Run("issue sweep reaches past the one-hour window to container start", func(t *testing.T) {
+		oldStart := now.Add(-3 * time.Hour)
+		oldChange := now.Add(-2 * time.Hour)
+		pod := staleSecretEnvPod("long-running-broken", oldStart, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, secretHistoryEvent(oldChange, "shop", "db-conn", "data (modified keys)", []string{"password"}))
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" {
+			t.Fatalf("a 2h-old key change on a container started 3h ago must still promote to an issue: %+v", detections)
+		}
+	})
+
+	t.Run("restartable init sidecar promotes", func(t *testing.T) {
+		pod := staleSecretEnvPod("sidecar-broken", startedAt, false)
+		pod.Spec.Containers = []corev1.Container{{Name: "app"}}
+		pod.Spec.InitContainers = []corev1.Container{{
+			Name:          "vault-agent",
+			RestartPolicy: alwaysRestartPolicy(),
+			Env:           []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")},
+		}}
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: "app", Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		}}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+			Name: "vault-agent", Ready: false,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		}}
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		if !podHasSecretEnvReference(pod) {
+			t.Fatal("restartable init sidecar Secret env must pass the timeline-query precheck")
+		}
+		checks := FindStaleSecretEnvChecksForObject(context.Background(), cache, pod)
+		if len(checks) != 1 || checks[0].Container != "vault-agent" {
+			t.Fatalf("restartable init sidecar lost its stale env fact: %+v", checks)
+		}
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" || !strings.Contains(detections[0].Message, "Container vault-agent") {
+			t.Fatalf("not-Ready restartable init sidecar must promote: %+v", detections)
+		}
+	})
+
+	t.Run("regular init container is not detected", func(t *testing.T) {
+		pod := staleSecretEnvPod("init-only", startedAt, false)
+		pod.Spec.Containers = []corev1.Container{{Name: "app"}}
+		pod.Spec.InitContainers = []corev1.Container{{
+			Name: "migrate", // no RestartPolicy => runs once, re-reads env on next pod start
+			Env:  []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")},
+		}}
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: "app", Ready: false,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		}}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+			Name: "migrate", Ready: false,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		}}
+		cache := envHistoryTestCache(t, pod, secret)
+		if podHasSecretEnvReference(pod) {
+			t.Fatal("a regular init container's Secret env must not trigger the timeline-query precheck")
+		}
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
+			t.Fatalf("a regular init container must be excluded from the stale-env walk: %+v", checks)
 		}
 	})
 
@@ -868,6 +951,11 @@ func secretHistoryEvent(timestamp time.Time, namespace, name, path string, value
 		EventType: timeline.EventTypeUpdate,
 		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: path, NewValue: value}}},
 	}
+}
+
+func alwaysRestartPolicy() *corev1.ContainerRestartPolicy {
+	policy := corev1.ContainerRestartPolicyAlways
+	return &policy
 }
 
 func secretKeyEnv(envName, secretName, key string) corev1.EnvVar {

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -173,6 +173,16 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		}
 	})
 
+	t.Run("newly added envFrom key is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("env-from-added", startedAt, false)
+		pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "db-conn"}}}}
+		cache := envHistoryTestCache(t, pod, secret)
+		added := secretHistoryEvent(changedAt, "shop", "db-conn", "data (added keys)", []string{"password"})
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{added}); len(checks) != 0 {
+			t.Fatalf("key added after container start is absent, not a stale env value: %+v", checks)
+		}
+	})
+
 	t.Run("different key is ignored", func(t *testing.T) {
 		pod := staleSecretEnvPod("other-key", startedAt, false, secretKeyEnv("DB_HOST", "db-conn", "host"))
 		cache := envHistoryTestCache(t, pod, secret)

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,7 +15,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestRemovedServiceEnvExposureAndPrecision(t *testing.T) {
@@ -297,6 +298,30 @@ func TestStaleSecretEnvManagedFieldsFallback(t *testing.T) {
 		}
 	})
 
+	t.Run("metadata write preserves the prior data timestamp in diagnosis", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		secret := newSecret()
+		secret.UID = types.UID("secret-uid")
+		secret.ResourceVersion = "1"
+		cache := envHistoryTestCache(t, pod, secret)
+
+		metadataOnly := secret.DeepCopy()
+		metadataOnly.ResourceVersion = "2"
+		metadataOnly.Annotations = map[string]string{"rotation": "checked"}
+		metadataOnly.ManagedFields[0].Time = &metav1.Time{Time: now}
+		cache.secretWriteTimes.capture(metadataOnly)
+		cache.secretWriteTimes.reconcile(k8score.ResourceChange{
+			Kind: "Secret", Namespace: "shop", Name: "db-conn", UID: "secret-uid",
+			Operation: k8score.OpUpdate,
+			Diff:      &k8score.DiffInfo{Fields: []k8score.FieldChange{{Path: "metadata.annotations"}}},
+		}, metadataOnly)
+
+		checks := findStaleSecretEnvChecksWithManagedFields(cache, []*corev1.Pod{pod}, nil)
+		if len(checks) != 1 || !checks[0].SecretChangedAt.Equal(changedAt) {
+			t.Fatalf("metadata-only write replaced the real data timestamp in diagnosis: %+v", checks)
+		}
+	})
+
 	t.Run("precise timeline evidence wins for the whole Secret", func(t *testing.T) {
 		pod := staleSecretEnvPod("catalog", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
 		cache := envHistoryTestCache(t, pod, newSecret())
@@ -462,47 +487,311 @@ func TestStaleSecretEnvManagedFieldsFallback(t *testing.T) {
 func TestSecretDataManagerWriteIndex(t *testing.T) {
 	dataWrite := time.Date(2026, time.July, 23, 8, 0, 0, 0, time.UTC)
 	metadataWrite := dataWrite.Add(time.Hour)
-	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Name: "credentials", Namespace: "shop", UID: types.UID("old"),
-		ManagedFields: []metav1.ManagedFieldsEntry{
-			{
-				Manager: "secret-controller", Operation: metav1.ManagedFieldsOperationUpdate,
-				Time: &metav1.Time{Time: dataWrite}, FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
-			},
-			{
-				Manager: "metadata-controller", Operation: metav1.ManagedFieldsOperationUpdate,
-				Time: &metav1.Time{Time: metadataWrite}, FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:annotations":{"f:data":{}}}}`)},
-			},
-		},
-	}}
-	index := &sync.Map{}
-	captureSecretDataManagerWriteTime(index, secret)
-	value, ok := index.Load(secretWriteKey("shop", "credentials"))
-	write, typed := value.(secretDataManagerWrite)
-	if !ok || !typed || write.uid != "old" || !write.at.Equal(dataWrite) {
-		t.Fatalf("index captured (%+v, %v), want old UID at %v", value, ok, dataWrite)
+	dataField := func(manager string, at time.Time) metav1.ManagedFieldsEntry {
+		return metav1.ManagedFieldsEntry{
+			Manager: manager, Operation: metav1.ManagedFieldsOperationUpdate,
+			Time: &metav1.Time{Time: at}, FieldsType: "FieldsV1",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
+		}
+	}
+	metadataField := func(manager string, at time.Time) metav1.ManagedFieldsEntry {
+		return metav1.ManagedFieldsEntry{
+			Manager: manager, Operation: metav1.ManagedFieldsOperationUpdate,
+			Time: &metav1.Time{Time: at}, FieldsType: "FieldsV1",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:annotations":{"f:data":{}}}}`)},
+		}
+	}
+	secret := func(uid, resourceVersion string, fields ...metav1.ManagedFieldsEntry) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "credentials", Namespace: "shop", UID: types.UID(uid),
+			ResourceVersion: resourceVersion, ManagedFields: fields,
+		}}
+	}
+	change := func(uid, operation string, diff *k8score.DiffInfo) k8score.ResourceChange {
+		return k8score.ResourceChange{
+			Kind: "Secret", Namespace: "shop", Name: "credentials",
+			UID: uid, Operation: operation, Diff: diff,
+		}
+	}
+	dataDiff := &k8score.DiffInfo{Fields: []k8score.FieldChange{{Path: "data (modified keys)"}}}
+	metadataDiff := &k8score.DiffInfo{Fields: []k8score.FieldChange{{Path: "metadata.annotations"}}}
+	assertWrite := func(t *testing.T, index *secretDataManagerWriteIndex, uid string, at time.Time) {
+		t.Helper()
+		write, ok := index.load("shop", "credentials")
+		if !ok || write.uid != uid || !write.at.Equal(at) {
+			t.Fatalf("indexed write = (%+v, %v), want UID %s at %v", write, ok, uid, at)
+		}
 	}
 
-	recreated := secret.DeepCopy()
-	recreated.UID = types.UID("new")
-	recreated.ManagedFields[0].Time = &metav1.Time{Time: dataWrite.Add(2 * time.Hour)}
-	captureSecretDataManagerWriteTime(index, recreated)
-	deleteSecretDataManagerWriteTime(index, k8score.ResourceChange{
-		Kind: "Secret", Namespace: "shop", Name: "credentials", UID: "old", Operation: k8score.OpDelete,
+	t.Run("metadata-only update with no prior state stays suppressed", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		metadataOnly := secret("old", "2", dataField("secret-controller", metadataWrite))
+		index.capture(metadataOnly)
+		index.reconcile(change("old", k8score.OpUpdate, metadataDiff), metadataOnly)
+		if write, ok := index.load("shop", "credentials"); ok {
+			t.Fatalf("metadata-only update created a write timestamp without prior state: %+v", write)
+		}
 	})
-	value, ok = index.Load(secretWriteKey("shop", "credentials"))
-	write, typed = value.(secretDataManagerWrite)
-	if !ok || !typed || write.uid != "new" {
-		t.Fatalf("old delete removed the recreated Secret's timestamp: %+v", value)
+
+	t.Run("same data-owning manager metadata write preserves real data timestamp", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		initial := secret("old", "1", dataField("secret-controller", dataWrite))
+		index.capture(initial)
+		index.reconcile(change("old", k8score.OpAdd, nil), initial)
+
+		metadataOnly := secret("old", "2", dataField("secret-controller", metadataWrite))
+		index.capture(metadataOnly)
+		index.reconcile(change("old", k8score.OpUpdate, metadataDiff), metadataOnly)
+		assertWrite(t, index, "old", dataWrite)
+	})
+
+	t.Run("different manager metadata update preserves prior timestamp", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		initial := secret("old", "1", dataField("secret-controller", dataWrite))
+		index.capture(initial)
+		index.reconcile(change("old", k8score.OpAdd, nil), initial)
+
+		metadataOnly := secret("old", "2",
+			dataField("secret-controller", dataWrite),
+			metadataField("metadata-controller", metadataWrite),
+		)
+		index.capture(metadataOnly)
+		index.reconcile(change("old", k8score.OpUpdate, metadataDiff), metadataOnly)
+		assertWrite(t, index, "old", dataWrite)
+	})
+
+	t.Run("later data write publishes only on exact object version", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		actualWrite := secret("old", "3", dataField("secret-controller", metadataWrite))
+		index.capture(actualWrite)
+
+		wrongVersion := actualWrite.DeepCopy()
+		wrongVersion.ResourceVersion = "4"
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), wrongVersion)
+		if write, ok := index.load("shop", "credentials"); ok {
+			t.Fatalf("mismatched resourceVersion published staged timestamp: %+v", write)
+		}
+
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), actualWrite)
+		assertWrite(t, index, "old", metadataWrite)
+	})
+
+	t.Run("queued data then metadata callbacks preserve the real write", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		dataUpdate := secret("old", "2", dataField("secret-controller", dataWrite))
+		metadataUpdate := secret("old", "3", dataField("secret-controller", metadataWrite))
+		index.capture(dataUpdate)
+		index.capture(metadataUpdate)
+
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), dataUpdate)
+		index.reconcile(change("old", k8score.OpUpdate, metadataDiff), metadataUpdate)
+		assertWrite(t, index, "old", dataWrite)
+	})
+
+	t.Run("unmatched callbacks remain globally bounded", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		index.pendingLimit = 2
+		for _, resourceVersion := range []string{"1", "2", "3"} {
+			index.capture(secret("old", resourceVersion, dataField("secret-controller", dataWrite)))
+		}
+		index.mu.Lock()
+		pending := len(index.pending)
+		index.mu.Unlock()
+		if pending != 1 {
+			t.Fatalf("pending candidates = %d after bounded reset, want 1", pending)
+		}
+
+		stale := secret("old", "2", dataField("secret-controller", dataWrite))
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), stale)
+		if write, ok := index.load("shop", "credentials"); ok {
+			t.Fatalf("evicted stale callback published a timestamp: %+v", write)
+		}
+		latest := secret("old", "3", dataField("secret-controller", metadataWrite))
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), latest)
+		assertWrite(t, index, "old", dataWrite)
+		index.mu.Lock()
+		pending = len(index.pending)
+		index.mu.Unlock()
+		if pending != 0 {
+			t.Fatalf("pending candidates = %d after exact callback, want 0", pending)
+		}
+	})
+
+	t.Run("recreate and late old callbacks are UID safe", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		oldSecret := secret("old", "1", dataField("secret-controller", dataWrite))
+		index.capture(oldSecret)
+		index.reconcile(change("old", k8score.OpAdd, nil), oldSecret)
+
+		recreatedAt := dataWrite.Add(2 * time.Hour)
+		recreated := secret("new", "1", dataField("secret-controller", recreatedAt))
+		index.capture(recreated)
+		index.reconcile(change("new", k8score.OpAdd, nil), recreated)
+		index.reconcile(change("old", k8score.OpDelete, nil), oldSecret)
+		assertWrite(t, index, "new", recreatedAt)
+
+		lateOld := secret("old", "2", dataField("secret-controller", recreatedAt.Add(time.Hour)))
+		index.capture(lateOld)
+		index.reconcile(change("old", k8score.OpUpdate, dataDiff), lateOld)
+		assertWrite(t, index, "new", recreatedAt)
+	})
+
+	t.Run("Helm release payload clears only its matching UID", func(t *testing.T) {
+		index := newSecretDataManagerWriteIndex()
+		recreated := secret("new", "1", dataField("secret-controller", dataWrite))
+		index.capture(recreated)
+		index.reconcile(change("new", k8score.OpAdd, nil), recreated)
+
+		helmRelease := recreated.DeepCopy()
+		helmRelease.ResourceVersion = "2"
+		helmRelease.Type = corev1.SecretType("helm.sh/release.v1")
+		index.capture(helmRelease)
+		index.reconcile(change("new", k8score.OpUpdate, metadataDiff), helmRelease)
+		if write, ok := index.load("shop", "credentials"); ok {
+			t.Fatalf("Helm release payload Secret occupied the diagnostic timestamp index: %+v", write)
+		}
+	})
+}
+
+func TestSecretDataManagerWriteIndexInformerLifecycle(t *testing.T) {
+	dataWrite := time.Date(2026, time.July, 23, 8, 0, 0, 0, time.UTC)
+	metadataWrite := dataWrite.Add(time.Hour)
+	actualWrite := metadataWrite.Add(time.Hour)
+	managedData := func(at time.Time) []metav1.ManagedFieldsEntry {
+		return []metav1.ManagedFieldsEntry{{
+			Manager: "secret-controller", Operation: metav1.ManagedFieldsOperationUpdate,
+			Time: &metav1.Time{Time: at}, FieldsType: "FieldsV1",
+			FieldsV1: &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
+		}}
+	}
+	newCache := func(t *testing.T, secret *corev1.Secret) (*k8score.ResourceCache, *secretDataManagerWriteIndex, *watch.RaceFreeFakeWatcher) {
+		t.Helper()
+		index := newSecretDataManagerWriteIndex()
+		client := fake.NewClientset(secret)
+		watcher := watch.NewRaceFreeFake()
+		client.PrependWatchReactor("secrets", func(k8stesting.Action) (bool, watch.Interface, error) {
+			return true, watcher, nil
+		})
+		core, err := k8score.NewResourceCache(k8score.CacheConfig{
+			Client:        client,
+			ResourceTypes: map[string]bool{k8score.Secrets: true},
+			DeferredTypes: map[string]bool{},
+			OnTransform: func(obj any) {
+				index.capture(obj)
+			},
+			OnChange: func(change k8score.ResourceChange, obj, _ any) {
+				index.reconcile(change, obj)
+			},
+			ComputeDiff: func(kind string, oldObj, newObj any) *k8score.DiffInfo {
+				return ComputeDiff(kind, oldObj, newObj)
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewResourceCache: %v", err)
+		}
+		t.Cleanup(core.Stop)
+		return core, index, watcher
+	}
+	waitReconciled := func(t *testing.T, core *k8score.ResourceCache, index *secretDataManagerWriteIndex, secret *corev1.Secret) {
+		t.Helper()
+		version := secretDataManagerWriteVersion{
+			namespace:       secret.Namespace,
+			name:            secret.Name,
+			uid:             string(secret.UID),
+			resourceVersion: secret.ResourceVersion,
+		}
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			cached, err := core.Secrets().Secrets(secret.Namespace).Get(secret.Name)
+			index.mu.Lock()
+			_, pending := index.pending[version]
+			index.mu.Unlock()
+			if err == nil && cached.ResourceVersion == secret.ResourceVersion && !pending {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("Secret %s/%s rv=%s was not reconciled", secret.Namespace, secret.Name, secret.ResourceVersion)
 	}
 
-	helmRelease := recreated.DeepCopy()
-	helmRelease.Type = corev1.SecretType("helm.sh/release.v1")
-	captureSecretDataManagerWriteTime(index, helmRelease)
-	if _, ok := index.Load(secretWriteKey("shop", "credentials")); ok {
-		t.Fatal("Helm release payload Secret should not occupy the diagnostic timestamp index")
+	t.Run("metadata-only update rolls back advanced owner time", func(t *testing.T) {
+		initial := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "credentials", Namespace: "shop", UID: types.UID("secret-uid"),
+				ResourceVersion: "1", ManagedFields: managedData(dataWrite),
+			},
+			Data: map[string][]byte{"password": []byte("old")},
+		}
+		core, index, watcher := newCache(t, initial)
+		waitReconciled(t, core, index, initial)
+
+		metadataOnly := initial.DeepCopy()
+		metadataOnly.ResourceVersion = "2"
+		metadataOnly.ManagedFields = managedData(metadataWrite)
+		metadataOnly.Annotations = map[string]string{"rotation": "checked"}
+		watcher.Modify(metadataOnly.DeepCopy())
+		waitReconciled(t, core, index, metadataOnly)
+		write, ok := index.load("shop", "credentials")
+		if !ok || !write.at.Equal(dataWrite) {
+			t.Fatalf("metadata-only informer update indexed %+v, want prior data timestamp %v", write, dataWrite)
+		}
+	})
+
+	t.Run("no prior stays suppressed until later data write", func(t *testing.T) {
+		initial := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "credentials", Namespace: "shop", UID: types.UID("secret-uid"),
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{"password": []byte("old")},
+		}
+		core, index, watcher := newCache(t, initial)
+		waitReconciled(t, core, index, initial)
+
+		metadataOnly := initial.DeepCopy()
+		metadataOnly.ResourceVersion = "2"
+		metadataOnly.ManagedFields = managedData(metadataWrite)
+		metadataOnly.Annotations = map[string]string{"rotation": "checked"}
+		watcher.Modify(metadataOnly.DeepCopy())
+		waitReconciled(t, core, index, metadataOnly)
+		if write, ok := index.load("shop", "credentials"); ok {
+			t.Fatalf("metadata-only informer update created timestamp without prior state: %+v", write)
+		}
+
+		dataUpdate := metadataOnly.DeepCopy()
+		dataUpdate.ResourceVersion = "3"
+		dataUpdate.ManagedFields = managedData(actualWrite)
+		dataUpdate.Data = map[string][]byte{"password": []byte("new")}
+		watcher.Modify(dataUpdate.DeepCopy())
+		waitReconciled(t, core, index, dataUpdate)
+		write, ok := index.load("shop", "credentials")
+		if !ok || !write.at.Equal(actualWrite) {
+			t.Fatalf("later data write indexed %+v, want %v", write, actualWrite)
+		}
+	})
+}
+
+func TestSecretChangeWritesData(t *testing.T) {
+	for _, path := range []string{
+		"data (added keys)", "data (removed keys)", "data (modified keys)",
+		"stringData (added keys)", "stringData (removed keys)", "stringData (modified keys)",
+	} {
+		t.Run(path, func(t *testing.T) {
+			change := k8score.ResourceChange{Diff: &k8score.DiffInfo{
+				Fields: []k8score.FieldChange{{Path: path}},
+			}}
+			if !secretChangeWritesData(change) {
+				t.Fatalf("%q was not recognized as a Secret payload write", path)
+			}
+		})
+	}
+	for _, change := range []k8score.ResourceChange{
+		{},
+		{Diff: &k8score.DiffInfo{Fields: []k8score.FieldChange{{Path: "metadata.annotations"}}}},
+	} {
+		if secretChangeWritesData(change) {
+			t.Fatalf("non-data change was recognized as a Secret payload write: %+v", change)
+		}
 	}
 }
 
@@ -527,7 +816,7 @@ func TestStaleSecretEnvDetectionResolvesWorkloadOwner(t *testing.T) {
 
 func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache {
 	t.Helper()
-	secretWriteTimes := &sync.Map{}
+	secretWriteTimes := newSecretDataManagerWriteIndex()
 	core, err := k8score.NewResourceCache(k8score.CacheConfig{
 		Client: fake.NewClientset(objects...),
 		ResourceTypes: map[string]bool{
@@ -536,7 +825,10 @@ func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache
 		},
 		DeferredTypes: map[string]bool{},
 		OnTransform: func(obj any) {
-			captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+			secretWriteTimes.capture(obj)
+		},
+		OnChange: func(change k8score.ResourceChange, obj, _ any) {
+			secretWriteTimes.reconcile(change, obj)
 		},
 	})
 	if err != nil {

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -1,0 +1,289 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+	"github.com/skyhook-io/radar/pkg/k8score"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRemovedServiceEnvExposureAndPrecision(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "frontend", Namespace: "shop"},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "frontend"}},
+		}}},
+	}
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "cart", Namespace: "shop"}}
+	cache := envHistoryTestCache(t, deployment, service)
+	removal := envHistoryEvent(now.Add(-time.Minute), "Deployment", "shop", "frontend", "spec.template.spec.containers[frontend].env[CART_ADDR]", "cart:8080", nil)
+	setEnvHistoryEvents(t, removal)
+
+	got := FindRemovedServiceEnvChecksForObject(context.Background(), cache, deployment)
+	if len(got) != 1 {
+		t.Fatalf("got %d removed Service env facts, want 1: %+v", len(got), got)
+	}
+	if got[0].Container != "frontend" || got[0].EnvName != "CART_ADDR" || got[0].ServiceName != "cart" || got[0].ReferencedPort != 8080 || !got[0].RemovedAt.Equal(removal.Timestamp) {
+		t.Fatalf("unexpected removed Service env fact: %+v", got[0])
+	}
+	for _, detection := range detectConfigProblems(cache, "shop", now) {
+		if detection.Reason == "RemovedServiceEnv" {
+			t.Fatalf("removed env must remain FYI-only, got issue detection: %+v", detection)
+		}
+	}
+
+	t.Run("missing Service", func(t *testing.T) {
+		missingCache := envHistoryTestCache(t, deployment)
+		if checks := findRemovedServiceEnvChecks(missingCache, envServiceWorkloadForDeployment(deployment), "", []timeline.TimelineEvent{removal}); len(checks) != 0 {
+			t.Fatalf("missing Service should suppress fact: %+v", checks)
+		}
+	})
+
+	t.Run("non-Service value", func(t *testing.T) {
+		event := envHistoryEvent(now, "Deployment", "shop", "frontend", "spec.template.spec.containers[frontend].env[LOG_LEVEL]", "debug", nil)
+		if checks := findRemovedServiceEnvChecks(cache, envServiceWorkloadForDeployment(deployment), "", []timeline.TimelineEvent{event}); len(checks) != 0 {
+			t.Fatalf("ordinary env removal should not produce fact: %+v", checks)
+		}
+	})
+
+	t.Run("no removal", func(t *testing.T) {
+		event := envHistoryEvent(now, "Deployment", "shop", "frontend", "spec.template.spec.containers[frontend].env[CART_ADDR]", "cart:8080", "cart:9090")
+		if checks := findRemovedServiceEnvChecks(cache, envServiceWorkloadForDeployment(deployment), "", []timeline.TimelineEvent{event}); len(checks) != 0 {
+			t.Fatalf("env update should not produce removal fact: %+v", checks)
+		}
+	})
+
+	t.Run("later restore suppresses old removal", func(t *testing.T) {
+		restored := envHistoryEvent(now, "Deployment", "shop", "frontend", "spec.template.spec.containers[frontend].env[CART_ADDR]", nil, "cart:8080")
+		if checks := findRemovedServiceEnvChecks(cache, envServiceWorkloadForDeployment(deployment), "", []timeline.TimelineEvent{removal, restored}); len(checks) != 0 {
+			t.Fatalf("restored env should suppress older removal: %+v", checks)
+		}
+	})
+}
+
+func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	changedAt := now.Add(-time.Minute)
+	startedAt := changedAt.Add(-time.Minute)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-conn", Namespace: "shop"},
+		Data:       map[string][]byte{"password": []byte("sentinel-secret-value"), "host": []byte("db")},
+	}
+	change := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"password"})
+
+	t.Run("healthy is FYI only", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog-healthy", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		checks := FindStaleSecretEnvChecksForObject(context.Background(), cache, pod)
+		if len(checks) != 1 {
+			t.Fatalf("got %d stale Secret env facts, want 1: %+v", len(checks), checks)
+		}
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
+			t.Fatalf("healthy stale pod must remain FYI-only: %+v", detections)
+		}
+	})
+
+	t.Run("running not-Ready promotes", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog-broken", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		checks := FindStaleSecretEnvChecksForObject(context.Background(), cache, pod)
+		if len(checks) != 1 {
+			t.Fatalf("not-Ready pod lost FYI fact: %+v", checks)
+		}
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" || detections[0].Severity != "warning" || detections[0].Kind != "Pod" || detections[0].Name != pod.Name || detections[0].Fingerprint != "stale-secret-env" {
+			t.Fatalf("unexpected promoted detection: %+v", detections)
+		}
+		encoded, err := json.Marshal(struct {
+			Checks     []StaleSecretEnvCheck `json:"checks"`
+			Detections []Detection           `json:"detections"`
+		}{checks, detections})
+		if err != nil {
+			t.Fatalf("marshal result: %v", err)
+		}
+		if strings.Contains(string(encoded), "sentinel-secret-value") {
+			t.Fatalf("Secret value leaked into diagnostic output: %s", encoded)
+		}
+	})
+
+	t.Run("promotion describes only not-Ready containers", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog-mixed", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "sidecar", Env: []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")}})
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+			Name: "sidecar", Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		})
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || !strings.Contains(detections[0].Message, "Container app") || strings.Contains(detections[0].Message, "2 stale") {
+			t.Fatalf("promotion should describe only the biting container checks: %+v", detections)
+		}
+	})
+
+	t.Run("mounted Secret volume is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("volume-only", startedAt, false)
+		pod.Spec.Volumes = []corev1.Volume{{Name: "creds", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "db-conn"}}}}
+		cache := envHistoryTestCache(t, pod, secret)
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
+			t.Fatalf("mounted Secret must not produce env staleness: %+v", checks)
+		}
+		if podHasSecretEnvReference(pod) {
+			t.Fatal("mounted Secret must not trigger the timeline-query precheck")
+		}
+	})
+
+	t.Run("restart after change suppresses", func(t *testing.T) {
+		pod := staleSecretEnvPod("restarted", changedAt.Add(time.Second), false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
+			t.Fatalf("post-change start must suppress stale fact: %+v", checks)
+		}
+	})
+
+	t.Run("backoff latest start after change suppresses", func(t *testing.T) {
+		pod := staleSecretEnvPod("backoff", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		pod.Status.ContainerStatuses[0].State = corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}
+		pod.Status.ContainerStatuses[0].LastTerminationState = corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{StartedAt: metav1.NewTime(changedAt.Add(time.Second))}}
+		cache := envHistoryTestCache(t, pod, secret)
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
+			t.Fatalf("post-change crashloop attempt must suppress stale fact: %+v", checks)
+		}
+	})
+
+	t.Run("metadata-only update is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("metadata", startedAt, false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		metadata := secretHistoryEvent(changedAt, "shop", "db-conn", "immutable", true)
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{metadata}); len(checks) != 0 {
+			t.Fatalf("metadata-only Secret update must not produce fact: %+v", checks)
+		}
+	})
+
+	t.Run("different key is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("other-key", startedAt, false, secretKeyEnv("DB_HOST", "db-conn", "host"))
+		cache := envHistoryTestCache(t, pod, secret)
+		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
+			t.Fatalf("change to unconsumed key must not produce fact: %+v", checks)
+		}
+	})
+
+	t.Run("envFrom imports changed key but not values", func(t *testing.T) {
+		pod := staleSecretEnvPod("env-from", startedAt, true)
+		pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{Prefix: "DB_", SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "db-conn"}}}}
+		cache := envHistoryTestCache(t, pod, secret)
+		checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change})
+		if len(checks) != 1 || checks[0].Source != "envFrom" || checks[0].EnvName != "DB_password" || checks[0].Key != "password" {
+			t.Fatalf("unexpected envFrom fact: %+v", checks)
+		}
+		if !podHasSecretEnvReference(pod) {
+			t.Fatal("envFrom Secret must pass the timeline-query precheck")
+		}
+	})
+}
+
+func TestStaleSecretEnvDetectionResolvesWorkloadOwner(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	controller := true
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: "shop", UID: types.UID("dep")}}
+	replicaSet := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "catalog-abc", Namespace: "shop", UID: types.UID("rs"),
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: deployment.Name, UID: deployment.UID, Controller: &controller}},
+	}}
+	pod := staleSecretEnvPod("catalog-abc-1", now.Add(-2*time.Minute), false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+	pod.OwnerReferences = []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: replicaSet.Name, UID: replicaSet.UID, Controller: &controller}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "db-conn", Namespace: "shop"}}
+	cache := envHistoryTestCache(t, deployment, replicaSet, pod, secret)
+	setEnvHistoryEvents(t, secretHistoryEvent(now.Add(-time.Minute), "shop", "db-conn", "data (modified keys)", []string{"password"}))
+	detections := detectStaleSecretEnv(cache, "shop", now)
+	if len(detections) != 1 || detections[0].OwnerGroup != "apps" || detections[0].OwnerKind != "Deployment" || detections[0].OwnerName != "catalog" {
+		t.Fatalf("stale pod detection did not resolve stable workload owner: %+v", detections)
+	}
+}
+
+func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache {
+	t.Helper()
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client: fake.NewClientset(objects...),
+		ResourceTypes: map[string]bool{
+			k8score.Pods: true, k8score.Secrets: true, k8score.Services: true,
+			k8score.Deployments: true, k8score.ReplicaSets: true,
+		},
+		DeferredTypes: map[string]bool{},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	return &ResourceCache{ResourceCache: core, secretsEnabled: true}
+}
+
+func setEnvHistoryEvents(t *testing.T, events ...timeline.TimelineEvent) {
+	t.Helper()
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(timeline.ResetStore)
+	for _, event := range events {
+		if err := timeline.RecordEvent(context.Background(), event); err != nil {
+			t.Fatalf("RecordEvent: %v", err)
+		}
+	}
+}
+
+func envHistoryEvent(timestamp time.Time, kind, namespace, name, path string, oldValue, newValue any) timeline.TimelineEvent {
+	return timeline.TimelineEvent{
+		ID: "env-" + path, Timestamp: timestamp, Source: timeline.SourceInformer,
+		ClusterContext: ActiveClusterContext(), Kind: kind, Namespace: namespace, Name: name,
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: path, OldValue: oldValue, NewValue: newValue}}},
+	}
+}
+
+func secretHistoryEvent(timestamp time.Time, namespace, name, path string, value any) timeline.TimelineEvent {
+	return timeline.TimelineEvent{
+		ID: "secret-" + path, Timestamp: timestamp, Source: timeline.SourceInformer,
+		ClusterContext: ActiveClusterContext(), Kind: "Secret", Namespace: namespace, Name: name,
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: path, NewValue: value}}},
+	}
+}
+
+func secretKeyEnv(envName, secretName, key string) corev1.EnvVar {
+	return corev1.EnvVar{Name: envName, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: secretName}, Key: key,
+	}}}
+}
+
+func staleSecretEnvPod(name string, startedAt time.Time, ready bool, env ...corev1.EnvVar) *corev1.Pod {
+	condition := corev1.ConditionFalse
+	if ready {
+		condition = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "shop"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Env: env}}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: condition}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app", Ready: ready,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+			}},
+		},
+	}
+}

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -815,8 +815,11 @@ func TestSecretDataManagerWriteIndexInformerLifecycle(t *testing.T) {
 			OnTransform: func(obj any) {
 				index.capture(obj)
 			},
-			OnChange: func(change k8score.ResourceChange, obj, _ any) {
+			OnObservedChange: func(change k8score.ResourceChange, obj, _ any) {
 				index.reconcile(change, obj)
+			},
+			IsNoisyResource: func(kind, _ string, _ string) bool {
+				return kind == "Secret"
 			},
 			ComputeDiff: func(kind string, oldObj, newObj any) *k8score.DiffInfo {
 				return ComputeDiff(kind, oldObj, newObj)
@@ -963,7 +966,7 @@ func envHistoryTestCache(t *testing.T, objects ...runtime.Object) *ResourceCache
 		OnTransform: func(obj any) {
 			secretWriteTimes.capture(obj)
 		},
-		OnChange: func(change k8score.ResourceChange, obj, _ any) {
+		OnObservedChange: func(change k8score.ResourceChange, obj, _ any) {
 			secretWriteTimes.reconcile(change, obj)
 		},
 	})

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -49,14 +49,17 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 		"limitranges":              true,
 	}
 
-	secretWriteTimes := &sync.Map{}
+	secretWriteTimes := newSecretDataManagerWriteIndex()
 	cfg := k8score.CacheConfig{
 		Client:        client,
 		ResourceTypes: enabled,
 		// No deferred types for tests — all sync immediately
 		DeferredTypes: map[string]bool{},
 		OnTransform: func(obj any) {
-			captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+			secretWriteTimes.capture(obj)
+		},
+		OnChange: func(change k8score.ResourceChange, obj, _ any) {
+			secretWriteTimes.reconcile(change, obj)
 		},
 	}
 

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -49,11 +49,15 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 		"limitranges":              true,
 	}
 
+	secretWriteTimes := &sync.Map{}
 	cfg := k8score.CacheConfig{
 		Client:        client,
 		ResourceTypes: enabled,
 		// No deferred types for tests — all sync immediately
 		DeferredTypes: map[string]bool{},
+		OnTransform: func(obj any) {
+			captureSecretDataManagerWriteTime(secretWriteTimes, obj)
+		},
 	}
 
 	core, err := k8score.NewResourceCache(cfg)
@@ -64,8 +68,9 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 	initialSyncComplete = true
 
 	resourceCache = &ResourceCache{
-		ResourceCache:  core,
-		secretsEnabled: true,
+		ResourceCache:    core,
+		secretsEnabled:   true,
+		secretWriteTimes: secretWriteTimes,
 	}
 
 	// Mark cacheOnce as "already executed" so InitResourceCache is a no-op.

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -58,7 +58,7 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 		OnTransform: func(obj any) {
 			secretWriteTimes.capture(obj)
 		},
-		OnChange: func(change k8score.ResourceChange, obj, _ any) {
+		OnObservedChange: func(change k8score.ResourceChange, obj, _ any) {
 			secretWriteTimes.reconcile(change, obj)
 		},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1118,6 +1118,8 @@ func buildMCPResourceContext(ctx context.Context, obj runtime.Object, kind, name
 		AppReferences: resourcecontextrefs.AppReferencesFromEnvChecks(
 			k8s.FindEnvServiceRefChecksForObject(cache, obj),
 			k8s.FindDuplicateEnvVarsForObject(obj),
+			k8s.FindRemovedServiceEnvChecksForObject(ctx, cache, obj),
+			k8s.FindStaleSecretEnvChecksForObject(ctx, cache, obj),
 		),
 		ServiceBackends: mcpServiceBackendLookup{cache: cache},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1095,6 +1095,18 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 // (which applies KindForGVK so cross-group CRDs map to the right
 // topology node).
 func buildMCPResourceContext(ctx context.Context, obj runtime.Object, kind, namespace, name string, tier resourcecontext.ContextTier) *resourcecontext.ResourceContext {
+	return buildMCPResourceContextWithStaleChecks(
+		ctx,
+		obj,
+		kind,
+		namespace,
+		name,
+		tier,
+		k8s.FindStaleSecretEnvChecksForObject(ctx, k8s.GetResourceCache(), obj),
+	)
+}
+
+func buildMCPResourceContextWithStaleChecks(ctx context.Context, obj runtime.Object, kind, namespace, name string, tier resourcecontext.ContextTier, staleChecks []k8s.StaleSecretEnvCheck) *resourcecontext.ResourceContext {
 	if obj == nil {
 		return nil
 	}
@@ -1119,7 +1131,7 @@ func buildMCPResourceContext(ctx context.Context, obj runtime.Object, kind, name
 			k8s.FindEnvServiceRefChecksForObject(cache, obj),
 			k8s.FindDuplicateEnvVarsForObject(obj),
 			k8s.FindRemovedServiceEnvChecksForObject(ctx, cache, obj),
-			k8s.FindStaleSecretEnvChecksForObject(ctx, cache, obj),
+			staleChecks,
 		),
 		ServiceBackends: mcpServiceBackendLookup{cache: cache},
 	}

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -204,12 +204,19 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 		return nil, nil, fmt.Errorf("failed to minify: %w", err)
 	}
 
-	resCtx := buildMCPResourceContext(ctx, obj, kindNorm, input.Namespace, input.Name, resourcecontext.TierDiagnostic)
-
 	pods, err := resolveDiagnosePods(cache, kindNorm, input.Namespace, input.Name, obj)
 	if err != nil {
 		return nil, nil, err
 	}
+	resCtx := buildMCPResourceContextWithStaleChecks(
+		ctx,
+		obj,
+		kindNorm,
+		input.Namespace,
+		input.Name,
+		resourcecontext.TierDiagnostic,
+		k8s.FindStaleSecretEnvChecksForPods(ctx, cache, pods),
+	)
 
 	tailLines := int64(100)
 	if input.TailLines > 0 {

--- a/internal/mcp/tools_diagnose_test.go
+++ b/internal/mcp/tools_diagnose_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"strings"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,8 @@ func setupFakeCacheForDiagnoseTests(t *testing.T) {
 		deployName = "cart"
 	)
 	selector := map[string]string{"app": "cart"}
+	startedAt := time.Now().UTC().Add(-2 * time.Minute)
+	secretChangedAt := startedAt.Add(time.Minute)
 
 	fakeClient := fake.NewClientset(
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
@@ -44,9 +47,41 @@ func setupFakeCacheForDiagnoseTests(t *testing.T) {
 				Labels:    selector,
 			},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: "cart"}},
+				Containers: []corev1.Container{{
+					Name: "cart",
+					Env: []corev1.EnvVar{{
+						Name: "DB_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cart-db"},
+							Key:                  "password",
+						}},
+					}},
+				}},
 			},
-			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "cart",
+					Ready: true,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.NewTime(startedAt),
+					}},
+				}},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cart-db",
+				Namespace: ns,
+				ManagedFields: []metav1.ManagedFieldsEntry{{
+					Manager:    "secret-controller",
+					Operation:  metav1.ManagedFieldsOperationUpdate,
+					Time:       &metav1.Time{Time: secretChangedAt},
+					FieldsType: "FieldsV1",
+					FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
+				}},
+			},
+			Data: map[string][]byte{"password": []byte("diagnose-secret-sentinel")},
 		},
 	)
 
@@ -326,6 +361,12 @@ func TestHandleDiagnose_DeploymentResolvesPods(t *testing.T) {
 	// No kube client on ctx in tests — diagnose surfaces this distinctly.
 	if !strings.Contains(body, "logsError") {
 		t.Errorf("expected logsError when no kube client present: %s", body)
+	}
+	if !strings.Contains(body, `"evidenceSource":"managed_fields_mtime"`) || !strings.Contains(body, `"name":"cart-db"`) {
+		t.Errorf("expected workload diagnosis to aggregate the Pod's stale Secret env FYI: %s", body)
+	}
+	if strings.Contains(body, "diagnose-secret-sentinel") || strings.Contains(body, `"key":"password"`) {
+		t.Errorf("managedFields fallback leaked Secret data or claimed a specific stale key: %s", body)
 	}
 }
 

--- a/internal/resourcecontextrefs/app_references.go
+++ b/internal/resourcecontextrefs/app_references.go
@@ -6,15 +6,19 @@ import (
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 )
 
-const maxDuplicateEnvVarContextOccurrences = 5
+const (
+	maxDuplicateEnvVarContextOccurrences = 5
+	maxStaleSecretEnvContextReferences   = 5
+)
 
-func AppReferencesFromEnvChecks(serviceChecks []k8s.EnvServiceRefCheck, duplicateChecks []k8s.DuplicateEnvVarCheck) *resourcecontext.AppReferences {
-	if len(serviceChecks) == 0 && len(duplicateChecks) == 0 {
+func AppReferencesFromEnvChecks(serviceChecks []k8s.EnvServiceRefCheck, duplicateChecks []k8s.DuplicateEnvVarCheck, removedChecks []k8s.RemovedServiceEnvCheck, staleChecks []k8s.StaleSecretEnvCheck) *resourcecontext.AppReferences {
+	if len(serviceChecks) == 0 && len(duplicateChecks) == 0 && len(removedChecks) == 0 && len(staleChecks) == 0 {
 		return nil
 	}
 	out := &resourcecontext.AppReferences{
-		ServiceEnv:   make([]resourcecontext.ServiceEnvReference, 0, len(serviceChecks)),
-		DuplicateEnv: make([]resourcecontext.DuplicateEnvVarReference, 0, len(duplicateChecks)),
+		ServiceEnv:        make([]resourcecontext.ServiceEnvReference, 0, len(serviceChecks)),
+		DuplicateEnv:      make([]resourcecontext.DuplicateEnvVarReference, 0, len(duplicateChecks)),
+		RemovedServiceEnv: make([]resourcecontext.RemovedServiceEnvReference, 0, len(removedChecks)),
 	}
 	for _, check := range serviceChecks {
 		out.ServiceEnv = append(out.ServiceEnv, resourcecontext.ServiceEnvReference{
@@ -47,6 +51,33 @@ func AppReferencesFromEnvChecks(serviceChecks []k8s.EnvServiceRefCheck, duplicat
 			Occurrences:       occurrences,
 			LastDeclaredValue: aicontext.RedactSecrets(check.LastDeclaredValue),
 			Message:           aicontext.RedactSecrets(check.Message),
+		})
+	}
+	for _, check := range removedChecks {
+		out.RemovedServiceEnv = append(out.RemovedServiceEnv, resourcecontext.RemovedServiceEnvReference{
+			Container:      check.Container,
+			Env:            check.EnvName,
+			OldValue:       aicontext.RedactSecrets(check.OldValue),
+			Service:        resourcecontext.ContextRef{Kind: "Service", Namespace: check.ServiceNamespace, Name: check.ServiceName},
+			ReferencedPort: check.ReferencedPort,
+			RemovedAt:      check.RemovedAt,
+			Message:        aicontext.RedactSecrets(check.Message),
+		})
+	}
+	if len(staleChecks) > maxStaleSecretEnvContextReferences {
+		staleChecks = staleChecks[:maxStaleSecretEnvContextReferences]
+	}
+	for _, check := range staleChecks {
+		out.StaleSecretEnv = append(out.StaleSecretEnv, resourcecontext.StaleSecretEnvReference{
+			Container:           check.Container,
+			Env:                 check.EnvName,
+			Source:              check.Source,
+			Prefix:              check.Prefix,
+			Secret:              resourcecontext.ContextRef{Kind: "Secret", Namespace: check.Namespace, Name: check.SecretName},
+			Key:                 check.Key,
+			ContainerStartedAt:  check.ContainerStartedAt,
+			SecretDataChangedAt: check.SecretDataChangedAt,
+			Message:             aicontext.RedactSecrets(check.Message),
 		})
 	}
 	return out

--- a/internal/resourcecontextrefs/app_references.go
+++ b/internal/resourcecontextrefs/app_references.go
@@ -1,6 +1,8 @@
 package resourcecontextrefs
 
 import (
+	"sort"
+
 	"github.com/skyhook-io/radar/internal/k8s"
 	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
@@ -64,20 +66,77 @@ func AppReferencesFromEnvChecks(serviceChecks []k8s.EnvServiceRefCheck, duplicat
 			Message:        aicontext.RedactSecrets(check.Message),
 		})
 	}
-	if len(staleChecks) > maxStaleSecretEnvContextReferences {
-		staleChecks = staleChecks[:maxStaleSecretEnvContextReferences]
+	type staleGroup struct {
+		check        k8s.StaleSecretEnvCheck
+		pods         map[string]bool
+		affectedPods int
 	}
+	groupsByKey := make(map[string]*staleGroup)
 	for _, check := range staleChecks {
+		key := check.Container + "\x00" + check.EnvName + "\x00" + check.ReferenceKind + "\x00" +
+			check.EvidenceSource + "\x00" + check.Prefix + "\x00" + check.SecretName + "\x00" + check.Key
+		group := groupsByKey[key]
+		if group == nil {
+			group = &staleGroup{check: check, pods: make(map[string]bool)}
+			groupsByKey[key] = group
+		}
+		group.pods[check.PodName] = true
+		if check.AffectedPods > group.affectedPods {
+			group.affectedPods = check.AffectedPods
+		}
+		if check.PodName < group.check.PodName {
+			group.check = check
+		}
+	}
+	groups := make([]*staleGroup, 0, len(groupsByKey))
+	for _, group := range groupsByKey {
+		groups = append(groups, group)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		a, b := groups[i].check, groups[j].check
+		if a.EvidenceSource != b.EvidenceSource {
+			return a.EvidenceSource == "observed_change"
+		}
+		if a.SecretName != b.SecretName {
+			return a.SecretName < b.SecretName
+		}
+		if a.Container != b.Container {
+			return a.Container < b.Container
+		}
+		if a.Key != b.Key {
+			return a.Key < b.Key
+		}
+		if a.ReferenceKind != b.ReferenceKind {
+			return a.ReferenceKind < b.ReferenceKind
+		}
+		if a.Prefix != b.Prefix {
+			return a.Prefix < b.Prefix
+		}
+		return a.EnvName < b.EnvName
+	})
+	if len(groups) > maxStaleSecretEnvContextReferences {
+		out.StaleSecretEnvTruncated = true
+		groups = groups[:maxStaleSecretEnvContextReferences]
+	}
+	for _, group := range groups {
+		check := group.check
+		affectedPods := len(group.pods)
+		if group.affectedPods > affectedPods {
+			affectedPods = group.affectedPods
+		}
 		out.StaleSecretEnv = append(out.StaleSecretEnv, resourcecontext.StaleSecretEnvReference{
-			Container:           check.Container,
-			Env:                 check.EnvName,
-			Source:              check.Source,
-			Prefix:              check.Prefix,
-			Secret:              resourcecontext.ContextRef{Kind: "Secret", Namespace: check.Namespace, Name: check.SecretName},
-			Key:                 check.Key,
-			ContainerStartedAt:  check.ContainerStartedAt,
-			SecretDataChangedAt: check.SecretDataChangedAt,
-			Message:             aicontext.RedactSecrets(check.Message),
+			Pod:                check.PodName,
+			AffectedPods:       affectedPods,
+			Container:          check.Container,
+			Env:                check.EnvName,
+			ReferenceKind:      check.ReferenceKind,
+			EvidenceSource:     check.EvidenceSource,
+			Prefix:             check.Prefix,
+			Secret:             resourcecontext.ContextRef{Kind: "Secret", Namespace: check.Namespace, Name: check.SecretName},
+			Key:                check.Key,
+			ContainerStartedAt: check.ContainerStartedAt,
+			SecretChangedAt:    check.SecretChangedAt,
+			Message:            aicontext.RedactSecrets(check.Message),
 		})
 	}
 	return out

--- a/internal/resourcecontextrefs/app_references_test.go
+++ b/internal/resourcecontextrefs/app_references_test.go
@@ -2,6 +2,7 @@ package resourcecontextrefs
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -52,8 +53,8 @@ func TestAppReferencesFromEnvChecks_HistoryFacts(t *testing.T) {
 		ServiceNamespace: "shop", ServiceName: "cart", ReferencedPort: 8080, RemovedAt: removedAt,
 		Message: "removed cart:8080 with password=sentinel-secret-value",
 	}}, []k8s.StaleSecretEnvCheck{{
-		Namespace: "shop", PodName: "catalog-1", Container: "app", EnvName: "DB_PASSWORD", Source: "secretKeyRef",
-		SecretName: "db-conn", Key: "password", ContainerStartedAt: startedAt, SecretDataChangedAt: changedAt,
+		Namespace: "shop", PodName: "catalog-1", Container: "app", EnvName: "DB_PASSWORD", ReferenceKind: "secretKeyRef", EvidenceSource: "observed_change",
+		SecretName: "db-conn", Key: "password", ContainerStartedAt: startedAt, SecretChangedAt: changedAt,
 		Message: "Secret key changed; password=sentinel-secret-value",
 	}})
 	if got == nil || len(got.RemovedServiceEnv) != 1 || len(got.StaleSecretEnv) != 1 {
@@ -64,7 +65,7 @@ func TestAppReferencesFromEnvChecks_HistoryFacts(t *testing.T) {
 		t.Fatalf("unexpected removed env mapping: %+v", removed)
 	}
 	stale := got.StaleSecretEnv[0]
-	if stale.Secret.Kind != "Secret" || stale.Secret.Name != "db-conn" || stale.Key != "password" || !stale.ContainerStartedAt.Equal(startedAt) || !stale.SecretDataChangedAt.Equal(changedAt) {
+	if stale.Pod != "catalog-1" || stale.AffectedPods != 1 || stale.Secret.Kind != "Secret" || stale.Secret.Name != "db-conn" || stale.Key != "password" || stale.ReferenceKind != "secretKeyRef" || stale.EvidenceSource != "observed_change" || !stale.ContainerStartedAt.Equal(startedAt) || !stale.SecretChangedAt.Equal(changedAt) {
 		t.Fatalf("unexpected stale Secret mapping: %+v", stale)
 	}
 	encoded, err := json.Marshal(got)
@@ -73,6 +74,54 @@ func TestAppReferencesFromEnvChecks_HistoryFacts(t *testing.T) {
 	}
 	if strings.Contains(string(encoded), "sentinel-secret-value") {
 		t.Fatalf("sensitive value leaked through AppReferences: %s", encoded)
+	}
+}
+
+func TestAppReferencesFromEnvChecks_GroupsReplicaFactsAndMarksTruncation(t *testing.T) {
+	startedAt := time.Date(2026, time.July, 22, 6, 47, 0, 0, time.UTC)
+	changedAt := startedAt.Add(time.Minute)
+	var checks []k8s.StaleSecretEnvCheck
+	for i := 0; i < maxStaleSecretEnvContextReferences+1; i++ {
+		checks = append(checks, k8s.StaleSecretEnvCheck{
+			Namespace: "shop", PodName: "catalog-b", Container: "app",
+			ReferenceKind: "secretKeyRef", EvidenceSource: "managed_fields_mtime",
+			SecretName: fmt.Sprintf("secret-%d", i), ContainerStartedAt: startedAt, SecretChangedAt: changedAt,
+		})
+	}
+	checks = append(checks, k8s.StaleSecretEnvCheck{
+		Namespace: "shop", PodName: "catalog-a", Container: "app",
+		ReferenceKind: "secretKeyRef", EvidenceSource: "managed_fields_mtime",
+		SecretName: "secret-0", ContainerStartedAt: startedAt.Add(time.Second), SecretChangedAt: changedAt,
+	})
+	got := AppReferencesFromEnvChecks(nil, nil, nil, checks)
+	if got == nil || len(got.StaleSecretEnv) != maxStaleSecretEnvContextReferences || !got.StaleSecretEnvTruncated {
+		t.Fatalf("unexpected grouped/truncated stale Secret refs: %+v", got)
+	}
+	first := got.StaleSecretEnv[0]
+	if first.Secret.Name != "secret-0" || first.Pod != "catalog-a" || first.AffectedPods != 2 {
+		t.Fatalf("replica facts were not grouped with deterministic sample pod: %+v", first)
+	}
+}
+
+func TestAppReferencesFromEnvChecks_ManagedFieldsFallbackOmitsUnknownKey(t *testing.T) {
+	startedAt := time.Date(2026, time.July, 22, 6, 47, 0, 0, time.UTC)
+	changedAt := startedAt.Add(time.Minute)
+	got := AppReferencesFromEnvChecks(nil, nil, nil, []k8s.StaleSecretEnvCheck{{
+		Namespace: "shop", PodName: "catalog-1", Container: "app",
+		ReferenceKind: "envFrom", EvidenceSource: "managed_fields_mtime", Prefix: "DB_",
+		SecretName: "db-conn", ContainerStartedAt: startedAt, SecretChangedAt: changedAt,
+		Message: "if the write touched a consumed key the env value may be stale",
+	}})
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal AppReferences: %v", err)
+	}
+	text := string(encoded)
+	if !strings.Contains(text, `"referenceKind":"envFrom"`) || !strings.Contains(text, `"evidenceSource":"managed_fields_mtime"`) {
+		t.Fatalf("managedFields provenance missing from AppReferences: %s", text)
+	}
+	if strings.Contains(text, `"key"`) || strings.Contains(text, `"env"`) {
+		t.Fatalf("unknown fallback key/env must be omitted, not serialized empty: %s", text)
 	}
 }
 

--- a/internal/resourcecontextrefs/app_references_test.go
+++ b/internal/resourcecontextrefs/app_references_test.go
@@ -1,13 +1,16 @@
 package resourcecontextrefs
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 )
 
 func TestAppReferencesFromEnvChecks(t *testing.T) {
-	if got := AppReferencesFromEnvChecks(nil, nil); got != nil {
+	if got := AppReferencesFromEnvChecks(nil, nil, nil, nil); got != nil {
 		t.Fatalf("empty checks should return nil, got %+v", got)
 	}
 
@@ -21,7 +24,7 @@ func TestAppReferencesFromEnvChecks(t *testing.T) {
 		ReferencedPort:   8080,
 		ServicePorts:     []string{"80/TCP"},
 		Message:          "env var references Service port 8080 with password=supersecret, but Service exposes 80/TCP",
-	}}, nil)
+	}}, nil, nil, nil)
 	if got == nil || len(got.ServiceEnv) != 1 {
 		t.Fatalf("expected one service env reference, got %+v", got)
 	}
@@ -40,6 +43,39 @@ func TestAppReferencesFromEnvChecks(t *testing.T) {
 	}
 }
 
+func TestAppReferencesFromEnvChecks_HistoryFacts(t *testing.T) {
+	removedAt := time.Date(2026, time.July, 22, 6, 47, 0, 0, time.UTC)
+	startedAt := removedAt.Add(time.Hour)
+	changedAt := startedAt.Add(time.Minute)
+	got := AppReferencesFromEnvChecks(nil, nil, []k8s.RemovedServiceEnvCheck{{
+		Container: "frontend", EnvName: "CART_ADDR", OldValue: "cart:8080?password=sentinel-secret-value",
+		ServiceNamespace: "shop", ServiceName: "cart", ReferencedPort: 8080, RemovedAt: removedAt,
+		Message: "removed cart:8080 with password=sentinel-secret-value",
+	}}, []k8s.StaleSecretEnvCheck{{
+		Namespace: "shop", PodName: "catalog-1", Container: "app", EnvName: "DB_PASSWORD", Source: "secretKeyRef",
+		SecretName: "db-conn", Key: "password", ContainerStartedAt: startedAt, SecretDataChangedAt: changedAt,
+		Message: "Secret key changed; password=sentinel-secret-value",
+	}})
+	if got == nil || len(got.RemovedServiceEnv) != 1 || len(got.StaleSecretEnv) != 1 {
+		t.Fatalf("history facts were not mapped: %+v", got)
+	}
+	removed := got.RemovedServiceEnv[0]
+	if removed.Service.Kind != "Service" || removed.Service.Name != "cart" || !removed.RemovedAt.Equal(removedAt) || removed.ReferencedPort != 8080 {
+		t.Fatalf("unexpected removed env mapping: %+v", removed)
+	}
+	stale := got.StaleSecretEnv[0]
+	if stale.Secret.Kind != "Secret" || stale.Secret.Name != "db-conn" || stale.Key != "password" || !stale.ContainerStartedAt.Equal(startedAt) || !stale.SecretDataChangedAt.Equal(changedAt) {
+		t.Fatalf("unexpected stale Secret mapping: %+v", stale)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal AppReferences: %v", err)
+	}
+	if strings.Contains(string(encoded), "sentinel-secret-value") {
+		t.Fatalf("sensitive value leaked through AppReferences: %s", encoded)
+	}
+}
+
 func TestAppReferencesFromEnvChecks_DuplicateEnv(t *testing.T) {
 	got := AppReferencesFromEnvChecks(nil, []k8s.DuplicateEnvVarCheck{{
 		Container:         "app",
@@ -50,7 +86,7 @@ func TestAppReferencesFromEnvChecks_DuplicateEnv(t *testing.T) {
 			{Position: 3, Value: "password=second-secret"},
 		},
 		Message: "API_TOKEN appears twice: password=first-secret then password=second-secret",
-	}})
+	}}, nil, nil)
 	if got == nil || len(got.DuplicateEnv) != 1 {
 		t.Fatalf("expected one duplicate env reference, got %+v", got)
 	}
@@ -77,7 +113,7 @@ func TestAppReferencesFromEnvChecks_BoundsDuplicateOccurrences(t *testing.T) {
 		checks[0].Occurrences = append(checks[0].Occurrences, k8s.DuplicateEnvVarOccurrence{Position: i + 1, Value: value})
 	}
 
-	got := AppReferencesFromEnvChecks(nil, checks)
+	got := AppReferencesFromEnvChecks(nil, checks, nil, nil)
 	if got == nil || len(got.DuplicateEnv) != 1 {
 		t.Fatalf("expected one duplicate env reference, got %+v", got)
 	}

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -433,6 +433,8 @@ func (s *Server) buildAIResourceContext(r *http.Request, obj runtime.Object, kin
 		AppReferences: resourcecontextrefs.AppReferencesFromEnvChecks(
 			k8s.FindEnvServiceRefChecksForObject(cache, obj),
 			k8s.FindDuplicateEnvVarsForObject(obj),
+			k8s.FindRemovedServiceEnvChecksForObject(r.Context(), cache, obj),
+			k8s.FindStaleSecretEnvChecksForObject(r.Context(), cache, obj),
 		),
 		ServiceBackends: serviceBackendLookup{cache: cache},
 	}

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -129,10 +129,6 @@ func newPagedInformer(
 		WatchFuncWithContext: watchFn,
 	}
 	inf := cache.NewSharedIndexInformer(lw, example, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	// Factory informers get DropManagedFields via WithTransform; these are built
-	// outside the factory, so apply the same transform directly. SetTransform
-	// only errors once started, which hasn't happened yet.
-	_ = inf.SetTransform(DropManagedFields)
 	return inf
 }
 
@@ -385,10 +381,16 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 	// Build one factory per unique scope. The cluster-wide factory is
 	// always created so cluster-scoped kinds (nodes, namespaces, PV…)
 	// have a home; namespace-scoped factories are created on demand.
+	transform := func(obj any) (any, error) {
+		if cfg.OnTransform != nil {
+			cfg.OnTransform(obj)
+		}
+		return DropManagedFields(obj)
+	}
 	clusterFactory := informers.NewSharedInformerFactoryWithOptions(
 		cfg.Client,
 		0, // no resync — updates come via watch
-		informers.WithTransform(DropManagedFields),
+		informers.WithTransform(transform),
 	)
 	nsFactories := make(map[string]informers.SharedInformerFactory)
 	for key, s := range scopes {
@@ -403,7 +405,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			nsFactories[namespace] = informers.NewSharedInformerFactoryWithOptions(
 				cfg.Client,
 				0,
-				informers.WithTransform(DropManagedFields),
+				informers.WithTransform(transform),
 				informers.WithNamespace(namespace),
 			)
 		}
@@ -478,7 +480,11 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 
 	buildInformer := func(s informerSetup, factory informers.SharedInformerFactory, namespace string) cache.SharedIndexInformer {
 		if cfg.ListPageSize > 0 && s.pagedSetup != nil {
-			return s.pagedSetup(cfg.Client, namespace, cfg.ListPageSize)
+			inf := s.pagedSetup(cfg.Client, namespace, cfg.ListPageSize)
+			// Paged informers are built outside the factories, so they need the
+			// same caller hook and managed-fields stripping transform here.
+			_ = inf.SetTransform(transform)
+			return inf
 		}
 		return s.setup(factory)
 	}

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -1268,6 +1268,10 @@ func (rc *ResourceCache) enqueueChange(ch chan<- ResourceChange, kind string, ob
 		Diff:      diff,
 	}
 
+	if rc.config.OnObservedChange != nil {
+		rc.safeCallback("OnObservedChange", func() { rc.config.OnObservedChange(change, obj, oldObj) })
+	}
+
 	// Fire OnChange callback (before channel send, matching existing behavior)
 	if !skipCallback && rc.config.OnChange != nil {
 		rc.safeCallback("OnChange", func() { rc.config.OnChange(change, obj, oldObj) })

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -862,6 +862,52 @@ func TestDropManagedFields(t *testing.T) {
 	}
 }
 
+func TestResourceCacheOnTransformSeesManagedFieldsBeforeStripping(t *testing.T) {
+	dataWrite := time.Date(2026, 7, 23, 8, 0, 0, 0, time.UTC)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "credentials",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:    "secret-controller",
+					Operation:  metav1.ManagedFieldsOperationUpdate,
+					Time:       &metav1.Time{Time: dataWrite},
+					FieldsType: "FieldsV1",
+					FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:data":{"f:password":{}}}`)},
+				},
+			},
+		},
+		Data: map[string][]byte{"password": []byte("must-not-leak")},
+	}
+	client := fake.NewSimpleClientset(secret)
+	var captured time.Time
+	rc, err := NewResourceCache(CacheConfig{
+		Client:        client,
+		ResourceTypes: map[string]bool{Secrets: true},
+		OnTransform: func(obj any) {
+			if transformed, ok := obj.(*corev1.Secret); ok && len(transformed.ManagedFields) == 1 {
+				captured = transformed.ManagedFields[0].Time.Time
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+
+	if !captured.Equal(dataWrite) {
+		t.Fatalf("OnTransform captured %v, want %v", captured, dataWrite)
+	}
+	cached, err := rc.Secrets().Secrets("default").Get("credentials")
+	if err != nil {
+		t.Fatalf("cached Secret lookup failed: %v", err)
+	}
+	if len(cached.ManagedFields) != 0 {
+		t.Fatalf("cached Secret leaked %d managedFields entries", len(cached.ManagedFields))
+	}
+}
+
 func TestDropManagedFields_Event(t *testing.T) {
 	event := &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -700,6 +700,47 @@ func TestNewResourceCache_OnReceived(t *testing.T) {
 	}
 }
 
+func TestNewResourceCache_OnObservedChangeSurvivesFiltering(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pod", Namespace: "default", UID: "test-uid",
+	}}
+	client := fake.NewSimpleClientset(pod)
+
+	var mu sync.Mutex
+	var observed, delivered []ResourceChange
+	rc, err := NewResourceCache(CacheConfig{
+		Client:        client,
+		ResourceTypes: map[string]bool{Pods: true},
+		IsNoisyResource: func(string, string, string) bool {
+			return true
+		},
+		OnObservedChange: func(change ResourceChange, _, _ any) {
+			mu.Lock()
+			observed = append(observed, change)
+			mu.Unlock()
+		},
+		OnChange: func(change ResourceChange, _, _ any) {
+			mu.Lock()
+			delivered = append(delivered, change)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(observed) != 1 || observed[0].Kind != "Pod" || observed[0].Name != "test-pod" {
+		t.Fatalf("observed changes = %+v, want filtered Pod add", observed)
+	}
+	if len(delivered) != 0 {
+		t.Fatalf("OnChange received filtered changes: %+v", delivered)
+	}
+}
+
 func TestNewResourceCache_NamespaceScopedValidation(t *testing.T) {
 	client := fake.NewSimpleClientset()
 

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -136,6 +136,11 @@ type CacheConfig struct {
 	// tracking (e.g., timeline.IncrementReceived). May be nil.
 	OnReceived func(kind string)
 
+	// OnTransform is called immediately before managed fields are stripped
+	// from an informer object. Callers may inspect metadata but must not mutate
+	// the object. May be nil.
+	OnTransform func(obj any)
+
 	// OnChange is called for each non-Event resource change after the
 	// change is sent to the changes channel. It receives the change plus
 	// the raw new and old objects for application-specific processing

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -141,6 +141,12 @@ type CacheConfig struct {
 	// the object. May be nil.
 	OnTransform func(obj any)
 
+	// OnObservedChange is called for every non-Event resource change after diff
+	// computation, including changes excluded by noisy filtering or initial-add
+	// suppression. It is intended for internal state reconciliation that must
+	// follow every transformed informer version. May be nil.
+	OnObservedChange func(change ResourceChange, obj, oldObj any)
+
 	// OnChange is called for each non-Event resource change after the
 	// change is sent to the changes channel. It receives the change plus
 	// the raw new and old objects for application-specific processing

--- a/pkg/resourcecontext/build.go
+++ b/pkg/resourcecontext/build.go
@@ -1422,7 +1422,29 @@ func filterAppReferences(ctx context.Context, refs *AppReferences, ac RefAccessC
 	if deniedAny {
 		omitted.add("appReferences.serviceEnv", OmittedRBACDenied)
 	}
-	if len(out.ServiceEnv) == 0 && len(out.DuplicateEnv) == 0 {
+	deniedAny = false
+	for _, ref := range refs.RemovedServiceEnv {
+		if !checkRef(ctx, ac, &ref.Service) {
+			deniedAny = true
+			continue
+		}
+		out.RemovedServiceEnv = append(out.RemovedServiceEnv, ref)
+	}
+	if deniedAny {
+		omitted.add("appReferences.removedServiceEnv", OmittedRBACDenied)
+	}
+	deniedAny = false
+	for _, ref := range refs.StaleSecretEnv {
+		if !checkRef(ctx, ac, &ref.Secret) {
+			deniedAny = true
+			continue
+		}
+		out.StaleSecretEnv = append(out.StaleSecretEnv, ref)
+	}
+	if deniedAny {
+		omitted.add("appReferences.staleSecretEnv", OmittedRBACDenied)
+	}
+	if len(out.ServiceEnv) == 0 && len(out.DuplicateEnv) == 0 && len(out.RemovedServiceEnv) == 0 && len(out.StaleSecretEnv) == 0 {
 		return nil
 	}
 	return out

--- a/pkg/resourcecontext/build.go
+++ b/pkg/resourcecontext/build.go
@@ -1441,6 +1441,9 @@ func filterAppReferences(ctx context.Context, refs *AppReferences, ac RefAccessC
 		}
 		out.StaleSecretEnv = append(out.StaleSecretEnv, ref)
 	}
+	if len(out.StaleSecretEnv) > 0 {
+		out.StaleSecretEnvTruncated = refs.StaleSecretEnvTruncated
+	}
 	if deniedAny {
 		omitted.add("appReferences.staleSecretEnv", OmittedRBACDenied)
 	}

--- a/pkg/resourcecontext/build_test.go
+++ b/pkg/resourcecontext/build_test.go
@@ -824,6 +824,49 @@ func TestBuild_RBACDenied_ServiceReferencePreservesDuplicateEnv(t *testing.T) {
 	}
 }
 
+func TestBuild_RBACDenied_HistoryAppReferences(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: "prod"}}
+	t.Run("removed Service", func(t *testing.T) {
+		rc := Build(context.Background(), pod, Options{
+			Tier:          TierBasic,
+			AccessChecker: denyChecker{kind: "Service", namespace: "shared"},
+			AppReferences: &AppReferences{RemovedServiceEnv: []RemovedServiceEnvReference{{
+				Service: ContextRef{Kind: "Service", Namespace: "shared", Name: "cart"},
+			}}},
+		})
+		if rc.AppReferences != nil {
+			t.Fatalf("denied removed-Service fact should be omitted: %+v", rc.AppReferences)
+		}
+		if !hasOmitted(rc.Omitted, "appReferences.removedServiceEnv") {
+			t.Fatalf("missing removed-Service omission marker: %+v", rc.Omitted)
+		}
+	})
+	t.Run("stale Secret", func(t *testing.T) {
+		rc := Build(context.Background(), pod, Options{
+			Tier:          TierBasic,
+			AccessChecker: denyChecker{kind: "Secret", namespace: "prod"},
+			AppReferences: &AppReferences{StaleSecretEnv: []StaleSecretEnvReference{{
+				Secret: ContextRef{Kind: "Secret", Namespace: "prod", Name: "db-conn"},
+			}}},
+		})
+		if rc.AppReferences != nil {
+			t.Fatalf("denied stale-Secret fact should be omitted: %+v", rc.AppReferences)
+		}
+		if !hasOmitted(rc.Omitted, "appReferences.staleSecretEnv") {
+			t.Fatalf("missing stale-Secret omission marker: %+v", rc.Omitted)
+		}
+	})
+}
+
+func hasOmitted(items []OmittedField, field string) bool {
+	for _, item := range items {
+		if item.Field == field && item.Reason == OmittedRBACDenied {
+			return true
+		}
+	}
+	return false
+}
+
 func TestBuild_NilObj(t *testing.T) {
 	if rc := Build(context.Background(), nil, Options{}); rc != nil {
 		t.Errorf("Build(nil) = %+v, want nil", rc)

--- a/pkg/resourcecontext/types.go
+++ b/pkg/resourcecontext/types.go
@@ -111,10 +111,11 @@ type UsesBlock struct {
 }
 
 type AppReferences struct {
-	ServiceEnv        []ServiceEnvReference        `json:"serviceEnv,omitempty"`
-	DuplicateEnv      []DuplicateEnvVarReference   `json:"duplicateEnv,omitempty"`
-	RemovedServiceEnv []RemovedServiceEnvReference `json:"removedServiceEnv,omitempty"`
-	StaleSecretEnv    []StaleSecretEnvReference    `json:"staleSecretEnv,omitempty"`
+	ServiceEnv              []ServiceEnvReference        `json:"serviceEnv,omitempty"`
+	DuplicateEnv            []DuplicateEnvVarReference   `json:"duplicateEnv,omitempty"`
+	RemovedServiceEnv       []RemovedServiceEnvReference `json:"removedServiceEnv,omitempty"`
+	StaleSecretEnv          []StaleSecretEnvReference    `json:"staleSecretEnv,omitempty"`
+	StaleSecretEnvTruncated bool                         `json:"staleSecretEnvTruncated,omitempty"`
 }
 
 type ServiceEnvReference struct {
@@ -153,15 +154,18 @@ type RemovedServiceEnvReference struct {
 }
 
 type StaleSecretEnvReference struct {
-	Container           string     `json:"container"`
-	Env                 string     `json:"env"`
-	Source              string     `json:"source"`
-	Prefix              string     `json:"prefix,omitempty"`
-	Secret              ContextRef `json:"secret"`
-	Key                 string     `json:"key"`
-	ContainerStartedAt  time.Time  `json:"containerStartedAt"`
-	SecretDataChangedAt time.Time  `json:"secretDataChangedAt"`
-	Message             string     `json:"message,omitempty"`
+	Pod                string     `json:"pod,omitempty"`
+	AffectedPods       int        `json:"affectedPods,omitempty"`
+	Container          string     `json:"container"`
+	Env                string     `json:"env,omitempty"`
+	ReferenceKind      string     `json:"referenceKind"`
+	EvidenceSource     string     `json:"evidenceSource"`
+	Prefix             string     `json:"prefix,omitempty"`
+	Secret             ContextRef `json:"secret"`
+	Key                string     `json:"key,omitempty"`
+	ContainerStartedAt time.Time  `json:"containerStartedAt"`
+	SecretChangedAt    time.Time  `json:"secretChangedAt"`
+	Message            string     `json:"message,omitempty"`
 }
 
 // ReferencedBy lists workload specs that directly reference the subject

--- a/pkg/resourcecontext/types.go
+++ b/pkg/resourcecontext/types.go
@@ -16,6 +16,8 @@
 // and for stable, machine-friendly JSON output.
 package resourcecontext
 
+import "time"
+
 // ResourceContext is the top-level enrichment block attached to a resource
 // response. Every field is optional; the zero value is a valid (empty)
 // "basic"-tier context.
@@ -109,8 +111,10 @@ type UsesBlock struct {
 }
 
 type AppReferences struct {
-	ServiceEnv   []ServiceEnvReference      `json:"serviceEnv,omitempty"`
-	DuplicateEnv []DuplicateEnvVarReference `json:"duplicateEnv,omitempty"`
+	ServiceEnv        []ServiceEnvReference        `json:"serviceEnv,omitempty"`
+	DuplicateEnv      []DuplicateEnvVarReference   `json:"duplicateEnv,omitempty"`
+	RemovedServiceEnv []RemovedServiceEnvReference `json:"removedServiceEnv,omitempty"`
+	StaleSecretEnv    []StaleSecretEnvReference    `json:"staleSecretEnv,omitempty"`
 }
 
 type ServiceEnvReference struct {
@@ -136,6 +140,28 @@ type DuplicateEnvVarReference struct {
 type DuplicateEnvVarOccurrence struct {
 	Position int    `json:"position"`
 	Value    string `json:"value"`
+}
+
+type RemovedServiceEnvReference struct {
+	Container      string     `json:"container"`
+	Env            string     `json:"env"`
+	OldValue       string     `json:"oldValue"`
+	Service        ContextRef `json:"service"`
+	ReferencedPort int32      `json:"referencedPort,omitempty"`
+	RemovedAt      time.Time  `json:"removedAt"`
+	Message        string     `json:"message,omitempty"`
+}
+
+type StaleSecretEnvReference struct {
+	Container           string     `json:"container"`
+	Env                 string     `json:"env"`
+	Source              string     `json:"source"`
+	Prefix              string     `json:"prefix,omitempty"`
+	Secret              ContextRef `json:"secret"`
+	Key                 string     `json:"key"`
+	ContainerStartedAt  time.Time  `json:"containerStartedAt"`
+	SecretDataChangedAt time.Time  `json:"secretDataChangedAt"`
+	Message             string     `json:"message,omitempty"`
 }
 
 // ReferencedBy lists workload specs that directly reference the subject


### PR DESCRIPTION
## Summary

Radar can now surface two application-configuration clues that Kubernetes health alone cannot explain: recently removed Service-address environment variables and Secret-backed environment values that may be stale in a running process. The signals use graduated exposure so useful diagnostic context is available without turning uncertain configuration history into noisy incidents.

## What changed

### Environment-history diagnostics

- Workloads expose recent removal of environment variables that referenced an existing Service through `resourceContext.appReferences.removedServiceEnv`.
- Pods expose precise stale-Secret facts when Radar observed a consumed Secret key change after the current container instance started.
- Precise stale-Secret evidence can become a warning only when that same container is currently Running but not Ready. Waiting and crashlooping containers are excluded because they re-read environment variables on restart.

### On-demand stale-Secret evidence

Explicit workload `diagnose` calls can also detect possible staleness when Radar did not witness the Secret rotation. Radar records metadata-only timestamps from managed-fields entries belonging to managers that own `data` or `stringData`, before the informer transform removes managed fields from cached objects.

This fallback is intentionally conservative:

- It is available only in explicit diagnostic workload context, not ordinary `get_resource` responses or `issues[]`.
- It is always FYI-only and uses hedged wording because managed fields identify ownership and write time, not the exact field changed in that write.
- Managed-fields timestamps are staged by Secret UID and resourceVersion, then published only when the matching informer diff proves that `data` or `stringData` changed. Metadata-only writes preserve the last verified data timestamp, or remain suppressed when there is no prior verified timestamp.
- It never names a specific stale key, never reads or emits Secret values, and validates the current Secret UID before using indexed metadata.
- Exact observed key-change evidence always takes precedence.

### Output and safety

- Replica-equivalent facts are grouped before caps are applied and report the number of affected pods.
- Responses identify reference kind and evidence provenance and report when stale-Secret references were truncated.
- Referenced Services and Secrets remain subject to request-level RBAC filtering.
- Secret volume mounts are excluded because projected volumes refresh independently; only `secretKeyRef` and `envFrom.secretRef` are eligible.
- Newly added keys, metadata-only observed changes, pre-start writes, post-change restarts, missing managed fields, and ambiguous ownership fail closed.

## Testing

- `make tsc`
- `make test`
- `make build`
- `make backend`
- `go build ./...`
- `cd pkg && go build ./...`
- `go test ./internal/k8s/... ./internal/resourcecontextrefs/... ./internal/mcp/... ./internal/server/...`
- `cd pkg && go test ./resourcecontext/...`
- `go test -race -count=1 ./internal/k8s -run 'TestSecretDataManagerWriteIndex|TestSecretChangeWritesData|TestStaleSecretEnvManagedFieldsFallback'`

The built application was smoke-tested against `radar-test-nonprod`: cache initialization completed, cluster APIs returned valid responses, the frontend loaded without console errors, and MCP `diagnose` completed on a real Secret-consuming Deployment without exposing Secret data. The benchmark-positive journey is covered end-to-end with an informer-backed fixture because that temporary benchmark workload is no longer present on accessible clusters.

The managed-fields rollback follow-up is additionally covered through the real informer lifecycle: metadata-only writes with and without prior state, same- and different-manager metadata updates, a later real payload write, queued object versions, UID-safe recreation, callback starvation bounds, and race detection.

Dedicated visual capture was skipped because this changes structured backend diagnostics rather than rendered UI.

## Tradeoff

A manager that owns Secret data may also perform a metadata-only write. Exact-version reconciliation now prevents a witnessed metadata-only update from advancing the fallback timestamp, but the latest managed-fields timestamp at initial observation can still only say that staleness is possible. Keeping it explicit-diagnose-only, hedged, and FYI-only preserves that uncertainty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the informer pipeline and Secret metadata indexing plus new issue detections, but promotion is gated, managed-fields evidence stays diagnose-only/FYI, and behavior is heavily tested for false positives and data leakage.
> 
> **Overview**
> Adds **graduated diagnostics** for configuration clues Kubernetes health checks miss: removed Service-address env vars and Secret-backed env values that may be stale in running containers.
> 
> **FYI context** (`resourceContext.appReferences`): workloads get `removedServiceEnv` from timeline diffs; Pods/workloads get `staleSecretEnv` when Radar observed a consumed Secret key change after the container started. **Workload `diagnose`** can also attach a **managed-fields fallback** (hedged, no specific key) when rotation was not observed—only on that path, not on ordinary `get_resource` or `issues[]`.
> 
> **Issue promotion** is narrow: `StaleSecretEnv` warnings appear only for **Running, not-Ready** pods with **timeline-observed** key changes (not managed-fields fallback). Classified as `invalid_configuration` and grouped under the workload owner with stable IDs.
> 
> The informer stack gains **`OnTransform` / `OnObservedChange`** so Secret **data-owner write times** can be captured from managed fields before stripping, then reconciled against diffs (UID/resourceVersion safe, Helm release secrets excluded, bounded pending queue).
> 
> Replica facts are grouped and capped; Secret values are never read or emitted; RBAC still filters referenced Services/Secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7a49573d7acb2cacce789b6fc02f50c891665d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->