### PR TITLE
Surface zero-availability Deployment rollout risk

### DIFF
--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/skyhook-io/radar/pkg/resourceid"
+	"github.com/skyhook-io/radar/pkg/rolloutdiag"
 	"github.com/skyhook-io/radar/pkg/timeutil"
 )
 
@@ -74,6 +75,9 @@ func RunChecks(input *CheckInput) *ScanResults {
 		findings = append(findings, checkSingleReplica(tr, input.Deployments, hpaTargets)...)
 	} else {
 		missingInputs = append(missingInputs, "horizontalpodautoscalers")
+	}
+	if input.Deployments != nil {
+		findings = append(findings, checkRolloutAvailabilityRisk(tr, input.Deployments)...)
 	}
 	// Only check PDB coverage if we can actually list PDBs (nil = RBAC denied, not "none exist")
 	if input.PodDisruptionBudgets != nil {
@@ -724,6 +728,24 @@ func checkSingleReplica(tr *evalTracker, deployments []*appsv1.Deployment, hpaTa
 				Kind: "Deployment", Namespace: d.Namespace, Name: d.Name,
 				CheckID: "singleReplica", Category: CategoryReliability, Severity: SeverityWarning,
 				Message: "Deployment has only 1 replica",
+			})
+		}
+	}
+	return findings
+}
+
+func checkRolloutAvailabilityRisk(tr *evalTracker, deployments []*appsv1.Deployment) []Finding {
+	var findings []Finding
+	for _, deployment := range deployments {
+		if !rolloutdiag.Applicable(deployment) {
+			continue
+		}
+		tr.record("rolloutAvailabilityRisk", deployment.Namespace)
+		if risk := rolloutdiag.Analyze(deployment); risk != nil {
+			findings = append(findings, Finding{
+				Kind: "Deployment", Namespace: deployment.Namespace, Name: deployment.Name,
+				CheckID: "rolloutAvailabilityRisk", Category: CategoryReliability, Severity: SeverityWarning,
+				Message: risk.Message,
 			})
 		}
 	}

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -599,6 +599,56 @@ func TestSingleReplica_SkippedWithHPA(t *testing.T) {
 	}
 }
 
+func TestRolloutAvailabilityRisk(t *testing.T) {
+	input := &CheckInput{Deployments: []*appsv1.Deployment{
+		rolloutAuditDeployment("risky", 3, appsv1.RollingUpdateDeploymentStrategyType, intstr.FromInt32(0), intstr.FromString("100%")),
+		rolloutAuditDeployment("safe-defaults", 3, "", intstr.IntOrString{}, intstr.IntOrString{}),
+		rolloutAuditDeployment("explicit-recreate", 3, appsv1.RecreateDeploymentStrategyType, intstr.FromInt32(0), intstr.FromString("100%")),
+		rolloutAuditDeployment("single-replica", 1, appsv1.RollingUpdateDeploymentStrategyType, intstr.FromInt32(0), intstr.FromString("100%")),
+	}}
+	input.Deployments[1].Spec.Strategy.RollingUpdate = nil
+
+	results := RunChecks(input)
+	var matching []Finding
+	for _, finding := range results.Findings {
+		if finding.CheckID == "rolloutAvailabilityRisk" {
+			matching = append(matching, finding)
+		}
+	}
+	if len(matching) != 1 {
+		t.Fatalf("rolloutAvailabilityRisk findings = %+v, want exactly one", matching)
+	}
+	finding := matching[0]
+	if finding.Name != "risky" || finding.Namespace != "prod" || finding.Group != "apps" || finding.Severity != SeverityWarning {
+		t.Errorf("finding identity = %+v", finding)
+	}
+	if !strings.Contains(finding.Message, "maxUnavailable=100%") || !strings.Contains(finding.Message, "can drop to zero available pods") {
+		t.Errorf("finding message = %q", finding.Message)
+	}
+	if got, want := results.CheckCounts["rolloutAvailabilityRisk"], (CheckCount{Evaluated: 2, Passed: 1}); got != want {
+		t.Errorf("CheckCounts[rolloutAvailabilityRisk] = %+v, want %+v", got, want)
+	}
+	if got := results.EvaluatedByNamespace["rolloutAvailabilityRisk"]["prod"]; got != 2 {
+		t.Errorf("namespace evaluation count = %d, want 2", got)
+	}
+}
+
+func rolloutAuditDeployment(name string, replicas int32, strategyType appsv1.DeploymentStrategyType, maxSurge, maxUnavailable intstr.IntOrString) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "prod"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: strategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+		},
+	}
+}
+
 func TestEfficiencyChecks(t *testing.T) {
 	input := &CheckInput{
 		LimitRanges: []*corev1.LimitRange{},

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -1,6 +1,9 @@
 package audit
 
-import "github.com/skyhook-io/radar/pkg/checks"
+import (
+	"github.com/skyhook-io/radar/pkg/checks"
+	"github.com/skyhook-io/radar/pkg/rolloutdiag"
+)
 
 // CheckMeta is a check's static definition (human-readable context). Aliased
 // from pkg/checks so the k8s-free Checks rollup and the audit engine share one
@@ -214,6 +217,14 @@ var CheckRegistry = map[string]CheckMeta{
 		Description: "A single-replica deployment has no redundancy — any pod disruption (node drain, OOM, crash) causes downtime.",
 		Remediation: "Set replicas: 2 or higher, or configure an HPA for autoscaling.",
 		References:  []Reference{refDeployments, refDisruptions},
+	},
+	"rolloutAvailabilityRisk": {
+		ID:          "rolloutAvailabilityRisk",
+		Title:       "Rolling update permits zero availability",
+		Category:    CategoryReliability,
+		Description: rolloutdiag.Description,
+		Remediation: rolloutdiag.Remediation,
+		References:  []Reference{refDeployments},
 	},
 	"missingPDB": {
 		ID:          "missingPDB",

--- a/pkg/resourcecontext/build.go
+++ b/pkg/resourcecontext/build.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/skyhook-io/radar/pkg/hpadiag"
+	"github.com/skyhook-io/radar/pkg/rolloutdiag"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -887,13 +888,26 @@ func containerStateSummary(st corev1.ContainerStatus) ContainerStateSummary {
 func buildWorkloadSummary(obj runtime.Object) *WorkloadSummary {
 	switch v := obj.(type) {
 	case *appsv1.Deployment:
-		return &WorkloadSummary{Replicas: &ReplicaSummary{
+		summary := &WorkloadSummary{Replicas: &ReplicaSummary{
 			Desired:     replicasOrZero(v.Spec.Replicas),
 			Ready:       v.Status.ReadyReplicas,
 			Available:   v.Status.AvailableReplicas,
 			Updated:     v.Status.UpdatedReplicas,
 			Unavailable: v.Status.UnavailableReplicas,
 		}}
+		if risk := rolloutdiag.Analyze(v); risk != nil {
+			summary.RolloutRisk = &RolloutRiskSummary{
+				Reason:                 risk.Reason,
+				Replicas:               risk.Replicas,
+				MaxSurge:               risk.MaxSurge,
+				MaxUnavailable:         risk.MaxUnavailable,
+				ResolvedMaxSurge:       risk.ResolvedMaxSurge,
+				ResolvedMaxUnavailable: risk.ResolvedMaxUnavailable,
+				Message:                risk.Message,
+				Action:                 risk.Remediation,
+			}
+		}
+		return summary
 	case *appsv1.StatefulSet:
 		return &WorkloadSummary{Replicas: &ReplicaSummary{
 			Desired:   replicasOrZero(v.Spec.Replicas),

--- a/pkg/resourcecontext/build_test.go
+++ b/pkg/resourcecontext/build_test.go
@@ -3,6 +3,7 @@ package resourcecontext
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/skyhook-io/radar/pkg/topology"
 )
@@ -360,6 +362,71 @@ func TestBuild_Deployment_WorkloadSummaryAndTemplateUses(t *testing.T) {
 	}
 	if rc.Uses.ServiceAccount == nil || rc.Uses.ServiceAccount.Name != "api-sa" {
 		t.Errorf("Uses.ServiceAccount: got %+v", rc.Uses.ServiceAccount)
+	}
+}
+
+func TestBuild_Deployment_RolloutRisk(t *testing.T) {
+	replicas := int32(3)
+	maxSurge := intstr.FromInt32(0)
+	maxUnavailable := intstr.FromString("100%")
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "prod"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+		},
+	}
+
+	rc := Build(context.Background(), dep, Options{Tier: TierBasic, AccessChecker: allowAllChecker{}})
+	if rc.WorkloadSummary == nil || rc.WorkloadSummary.RolloutRisk == nil {
+		t.Fatalf("WorkloadSummary.RolloutRisk: got nil; rc=%+v", rc)
+	}
+	risk := rc.WorkloadSummary.RolloutRisk
+	if risk.Reason != "all_replicas_unavailable_without_surge" || risk.Replicas != 3 {
+		t.Errorf("identity facts: got %+v", risk)
+	}
+	if risk.MaxSurge != "0" || risk.MaxUnavailable != "100%" || risk.ResolvedMaxSurge != 0 || risk.ResolvedMaxUnavailable != 3 {
+		t.Errorf("strategy facts: got %+v", risk)
+	}
+	if !strings.Contains(risk.Message, "can drop to zero available pods") || !strings.Contains(risk.Action, "maxSurge") {
+		t.Errorf("guidance: got %+v", risk)
+	}
+}
+
+func TestBuild_Deployment_OmitsSafeRolloutRisk(t *testing.T) {
+	replicas := int32(3)
+	maxSurge := intstr.FromString("25%")
+	maxUnavailable := intstr.FromString("100%")
+	dep := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+		Replicas: &replicas,
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+			},
+		},
+	}}
+
+	rc := Build(context.Background(), dep, Options{Tier: TierBasic})
+	if rc.WorkloadSummary == nil {
+		t.Fatal("WorkloadSummary: got nil")
+	}
+	if rc.WorkloadSummary.RolloutRisk != nil {
+		t.Fatalf("RolloutRisk: got %+v, want nil", rc.WorkloadSummary.RolloutRisk)
+	}
+	wire, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(wire), "rolloutRisk") {
+		t.Fatalf("safe deployment emitted rolloutRisk: %s", wire)
 	}
 }
 

--- a/pkg/resourcecontext/types.go
+++ b/pkg/resourcecontext/types.go
@@ -188,8 +188,9 @@ type ContainerStateSummary struct {
 }
 
 type WorkloadSummary struct {
-	Replicas   *ReplicaSummary    `json:"replicas,omitempty"`
-	Conditions []ConditionSummary `json:"conditions,omitempty"`
+	Replicas    *ReplicaSummary     `json:"replicas,omitempty"`
+	Conditions  []ConditionSummary  `json:"conditions,omitempty"`
+	RolloutRisk *RolloutRiskSummary `json:"rolloutRisk,omitempty"`
 }
 
 type ReplicaSummary struct {
@@ -198,6 +199,17 @@ type ReplicaSummary struct {
 	Available   int32 `json:"available,omitempty"`
 	Updated     int32 `json:"updated,omitempty"`
 	Unavailable int32 `json:"unavailable,omitempty"`
+}
+
+type RolloutRiskSummary struct {
+	Reason                 string `json:"reason"`
+	Replicas               int32  `json:"replicas"`
+	MaxSurge               string `json:"maxSurge"`
+	MaxUnavailable         string `json:"maxUnavailable"`
+	ResolvedMaxSurge       int32  `json:"resolvedMaxSurge"`
+	ResolvedMaxUnavailable int32  `json:"resolvedMaxUnavailable"`
+	Message                string `json:"message"`
+	Action                 string `json:"action"`
 }
 
 // ServiceSummary adds realized backend state for a Service. The raw Service

--- a/pkg/resourcecontext/types_test.go
+++ b/pkg/resourcecontext/types_test.go
@@ -89,6 +89,36 @@ func TestEmptyResourceContextMarshalsStable(t *testing.T) {
 	}
 }
 
+func TestRolloutRiskSummaryRoundTrip(t *testing.T) {
+	orig := WorkloadSummary{RolloutRisk: &RolloutRiskSummary{
+		Reason:                 "all_replicas_unavailable_without_surge",
+		Replicas:               3,
+		MaxSurge:               "0",
+		MaxUnavailable:         "100%",
+		ResolvedMaxSurge:       0,
+		ResolvedMaxUnavailable: 3,
+		Message:                "rollout policy permits a zero-availability gap",
+		Action:                 "increase maxSurge",
+	}}
+
+	wire, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got WorkloadSummary
+	if err := json.Unmarshal(wire, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch:\nwant %#v\ngot  %#v", orig, got)
+	}
+	for _, want := range []string{`"rolloutRisk"`, `"maxSurge":"0"`, `"maxUnavailable":"100%"`, `"resolvedMaxUnavailable":3`} {
+		if !strings.Contains(string(wire), want) {
+			t.Errorf("wire shape missing %s: %s", want, wire)
+		}
+	}
+}
+
 // TestResourceContextFieldOrdering pins the on-the-wire field order by
 // inspecting the marshaled JSON for a fully populated value. Go's
 // encoder emits struct fields in declaration order, so this guards

--- a/pkg/rolloutdiag/diagnosis.go
+++ b/pkg/rolloutdiag/diagnosis.go
@@ -1,0 +1,87 @@
+package rolloutdiag
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	ReasonAllReplicasUnavailableWithoutSurge = "all_replicas_unavailable_without_surge"
+	Description                              = "A RollingUpdate that permits every replica to be unavailable while allowing no surge can remove all old pods before replacements are ready. Workloads that intentionally require no overlap should use Recreate to express full replacement explicitly."
+	Remediation                              = "Set maxSurge to at least 1 (or a positive percentage) and/or lower maxUnavailable below the full replica count; use strategy.type: Recreate only when a full replacement is intentional."
+)
+
+type Risk struct {
+	Reason                 string `json:"reason"`
+	Replicas               int32  `json:"replicas"`
+	MaxSurge               string `json:"maxSurge"`
+	MaxUnavailable         string `json:"maxUnavailable"`
+	ResolvedMaxSurge       int32  `json:"resolvedMaxSurge"`
+	ResolvedMaxUnavailable int32  `json:"resolvedMaxUnavailable"`
+	Message                string `json:"message"`
+	Remediation            string `json:"remediation"`
+}
+
+func Applicable(deployment *appsv1.Deployment) bool {
+	// This signal targets rollout policies that erase existing multi-replica availability.
+	if deployment == nil || desiredReplicas(deployment) < 2 {
+		return false
+	}
+	return deployment.Spec.Strategy.Type == "" || deployment.Spec.Strategy.Type == appsv1.RollingUpdateDeploymentStrategyType
+}
+
+func Analyze(deployment *appsv1.Deployment) *Risk {
+	if !Applicable(deployment) {
+		return nil
+	}
+
+	rollingUpdate := deployment.Spec.Strategy.RollingUpdate
+	if rollingUpdate == nil || rollingUpdate.MaxSurge == nil || rollingUpdate.MaxUnavailable == nil {
+		return nil
+	}
+
+	replicas := desiredReplicas(deployment)
+	maxSurge, maxUnavailable, err := resolveFenceposts(rollingUpdate.MaxSurge, rollingUpdate.MaxUnavailable, replicas)
+	if err != nil || maxSurge != 0 || maxUnavailable < int(replicas) {
+		return nil
+	}
+
+	return &Risk{
+		Reason:                 ReasonAllReplicasUnavailableWithoutSurge,
+		Replicas:               replicas,
+		MaxSurge:               rollingUpdate.MaxSurge.String(),
+		MaxUnavailable:         rollingUpdate.MaxUnavailable.String(),
+		ResolvedMaxSurge:       int32(maxSurge),
+		ResolvedMaxUnavailable: int32(maxUnavailable),
+		Message: fmt.Sprintf(
+			"RollingUpdate maxUnavailable=%s and maxSurge=%s permit the controller to remove all %d old replicas with no surge capacity, so a rollout can drop to zero available pods and leave no old-version fallback if replacements fail readiness.",
+			rollingUpdate.MaxUnavailable.String(), rollingUpdate.MaxSurge.String(), replicas,
+		),
+		Remediation: Remediation,
+	}
+}
+
+func desiredReplicas(deployment *appsv1.Deployment) int32 {
+	if deployment.Spec.Replicas == nil {
+		return 1
+	}
+	return *deployment.Spec.Replicas
+}
+
+func resolveFenceposts(maxSurge, maxUnavailable *intstr.IntOrString, replicas int32) (int, int, error) {
+	resolvedSurge, err := intstr.GetScaledValueFromIntOrPercent(maxSurge, int(replicas), true)
+	if err != nil {
+		return 0, 0, err
+	}
+	resolvedUnavailable, err := intstr.GetScaledValueFromIntOrPercent(maxUnavailable, int(replicas), false)
+	if err != nil {
+		return 0, 0, err
+	}
+	// The Deployment controller forces progress when both rounded values are zero.
+	if resolvedSurge == 0 && resolvedUnavailable == 0 {
+		resolvedUnavailable = 1
+	}
+	return resolvedSurge, resolvedUnavailable, nil
+}

--- a/pkg/rolloutdiag/diagnosis.go
+++ b/pkg/rolloutdiag/diagnosis.go
@@ -8,20 +8,20 @@ import (
 )
 
 const (
-	ReasonAllReplicasUnavailableWithoutSurge = "all_replicas_unavailable_without_surge"
+	reasonAllReplicasUnavailableWithoutSurge = "all_replicas_unavailable_without_surge"
 	Description                              = "A RollingUpdate that permits every replica to be unavailable while allowing no surge can remove all old pods before replacements are ready. Workloads that intentionally require no overlap should use Recreate to express full replacement explicitly."
 	Remediation                              = "Set maxSurge to at least 1 (or a positive percentage) and/or lower maxUnavailable below the full replica count; use strategy.type: Recreate only when a full replacement is intentional."
 )
 
 type Risk struct {
-	Reason                 string `json:"reason"`
-	Replicas               int32  `json:"replicas"`
-	MaxSurge               string `json:"maxSurge"`
-	MaxUnavailable         string `json:"maxUnavailable"`
-	ResolvedMaxSurge       int32  `json:"resolvedMaxSurge"`
-	ResolvedMaxUnavailable int32  `json:"resolvedMaxUnavailable"`
-	Message                string `json:"message"`
-	Remediation            string `json:"remediation"`
+	Reason                 string
+	Replicas               int32
+	MaxSurge               string
+	MaxUnavailable         string
+	ResolvedMaxSurge       int32
+	ResolvedMaxUnavailable int32
+	Message                string
+	Remediation            string
 }
 
 func Applicable(deployment *appsv1.Deployment) bool {
@@ -49,7 +49,7 @@ func Analyze(deployment *appsv1.Deployment) *Risk {
 	}
 
 	return &Risk{
-		Reason:                 ReasonAllReplicasUnavailableWithoutSurge,
+		Reason:                 reasonAllReplicasUnavailableWithoutSurge,
 		Replicas:               replicas,
 		MaxSurge:               rollingUpdate.MaxSurge.String(),
 		MaxUnavailable:         rollingUpdate.MaxUnavailable.String(),

--- a/pkg/rolloutdiag/diagnosis_test.go
+++ b/pkg/rolloutdiag/diagnosis_test.go
@@ -1,7 +1,6 @@
 package rolloutdiag
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -132,7 +131,7 @@ func TestAnalyzeRiskFactsAndCopy(t *testing.T) {
 	if risk == nil {
 		t.Fatal("Analyze() returned nil")
 	}
-	if risk.Reason != ReasonAllReplicasUnavailableWithoutSurge {
+	if risk.Reason != reasonAllReplicasUnavailableWithoutSurge {
 		t.Errorf("Reason = %q", risk.Reason)
 	}
 	if risk.Replicas != 3 || risk.MaxSurge != "0" || risk.MaxUnavailable != "100%" {
@@ -150,13 +149,6 @@ func TestAnalyzeRiskFactsAndCopy(t *testing.T) {
 		if strings.Contains(risk.Message, forbidden) {
 			t.Errorf("Message %q contains %q", risk.Message, forbidden)
 		}
-	}
-	wire, err := json.Marshal(risk)
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
-	if strings.Contains(string(wire), "sensitive-value") {
-		t.Fatalf("risk leaked pod configuration: %s", wire)
 	}
 }
 

--- a/pkg/rolloutdiag/diagnosis_test.go
+++ b/pkg/rolloutdiag/diagnosis_test.go
@@ -1,0 +1,186 @@
+package rolloutdiag
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestAnalyze(t *testing.T) {
+	tests := []struct {
+		name           string
+		deployment     *appsv1.Deployment
+		wantApplicable bool
+		wantRisk       bool
+	}{
+		{
+			name:           "percentage values",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(stringValue("0%"), stringValue("100%"))),
+			wantApplicable: true,
+			wantRisk:       true,
+		},
+		{
+			name:           "integer values equal replicas",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), intValue(3))),
+			wantApplicable: true,
+			wantRisk:       true,
+		},
+		{
+			name:           "max unavailable exceeds replicas",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), intValue(4))),
+			wantApplicable: true,
+			wantRisk:       true,
+		},
+		{
+			name:           "unset strategy type defaults to rolling update",
+			deployment:     testDeployment(replicaPtr(3), "", rollingUpdate(intValue(0), stringValue("100%"))),
+			wantApplicable: true,
+			wantRisk:       true,
+		},
+		{
+			name:           "nil rolling update uses safe defaults",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, nil),
+			wantApplicable: true,
+		},
+		{
+			name:       "recreate is explicit full replacement",
+			deployment: testDeployment(replicaPtr(3), appsv1.RecreateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("100%"))),
+		},
+		{
+			name:       "unknown strategy is not applicable",
+			deployment: testDeployment(replicaPtr(3), appsv1.DeploymentStrategyType("BlueGreen"), rollingUpdate(intValue(0), stringValue("100%"))),
+		},
+		{
+			name:           "nil max surge uses default",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(nil, stringValue("100%"))),
+			wantApplicable: true,
+		},
+		{
+			name:           "nil max unavailable uses default",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), nil)),
+			wantApplicable: true,
+		},
+		{
+			name:           "positive percentage surge rounds up",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(stringValue("1%"), stringValue("100%"))),
+			wantApplicable: true,
+		},
+		{
+			name:           "default-sized surge preserves overlap",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(stringValue("25%"), stringValue("100%"))),
+			wantApplicable: true,
+		},
+		{
+			name:           "partial max unavailable preserves capacity",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("50%"))),
+			wantApplicable: true,
+		},
+		{
+			name:           "both zero follows controller fencepost rule",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), intValue(0))),
+			wantApplicable: true,
+		},
+		{
+			name:       "one replica is handled by redundancy audit",
+			deployment: testDeployment(replicaPtr(1), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("100%"))),
+		},
+		{
+			name:       "zero replicas has no rollout availability",
+			deployment: testDeployment(replicaPtr(0), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("100%"))),
+		},
+		{
+			name:       "nil replicas defaults to one",
+			deployment: testDeployment(nil, appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("100%"))),
+		},
+		{
+			name:           "invalid surge value",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(stringValue("invalid"), stringValue("100%"))),
+			wantApplicable: true,
+		},
+		{
+			name:           "invalid unavailable value",
+			deployment:     testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("invalid"))),
+			wantApplicable: true,
+		},
+		{name: "nil deployment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Applicable(tt.deployment); got != tt.wantApplicable {
+				t.Fatalf("Applicable() = %v, want %v", got, tt.wantApplicable)
+			}
+			if got := Analyze(tt.deployment); (got != nil) != tt.wantRisk {
+				t.Fatalf("Analyze() = %+v, want risk %v", got, tt.wantRisk)
+			}
+		})
+	}
+}
+
+func TestAnalyzeRiskFactsAndCopy(t *testing.T) {
+	deployment := testDeployment(replicaPtr(3), appsv1.RollingUpdateDeploymentStrategyType, rollingUpdate(intValue(0), stringValue("100%")))
+	deployment.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "app",
+		Env:  []corev1.EnvVar{{Name: "PASSWORD", Value: "sensitive-value"}},
+	}}
+
+	risk := Analyze(deployment)
+	if risk == nil {
+		t.Fatal("Analyze() returned nil")
+	}
+	if risk.Reason != ReasonAllReplicasUnavailableWithoutSurge {
+		t.Errorf("Reason = %q", risk.Reason)
+	}
+	if risk.Replicas != 3 || risk.MaxSurge != "0" || risk.MaxUnavailable != "100%" {
+		t.Errorf("source facts = %+v", risk)
+	}
+	if risk.ResolvedMaxSurge != 0 || risk.ResolvedMaxUnavailable != 3 {
+		t.Errorf("resolved facts = %+v", risk)
+	}
+	for _, want := range []string{"maxUnavailable=100%", "maxSurge=0", "permit", "can drop", "no old-version fallback"} {
+		if !strings.Contains(risk.Message, want) {
+			t.Errorf("Message %q missing %q", risk.Message, want)
+		}
+	}
+	for _, forbidden := range []string{"guarantee", "sensitive-value", "PASSWORD"} {
+		if strings.Contains(risk.Message, forbidden) {
+			t.Errorf("Message %q contains %q", risk.Message, forbidden)
+		}
+	}
+	wire, err := json.Marshal(risk)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(wire), "sensitive-value") {
+		t.Fatalf("risk leaked pod configuration: %s", wire)
+	}
+}
+
+func testDeployment(replicas *int32, strategyType appsv1.DeploymentStrategyType, update *appsv1.RollingUpdateDeployment) *appsv1.Deployment {
+	return &appsv1.Deployment{Spec: appsv1.DeploymentSpec{
+		Replicas: replicas,
+		Strategy: appsv1.DeploymentStrategy{Type: strategyType, RollingUpdate: update},
+	}}
+}
+
+func rollingUpdate(maxSurge, maxUnavailable *intstr.IntOrString) *appsv1.RollingUpdateDeployment {
+	return &appsv1.RollingUpdateDeployment{MaxSurge: maxSurge, MaxUnavailable: maxUnavailable}
+}
+
+func replicaPtr(value int32) *int32 {
+	return &value
+}
+
+func intValue(value int) *intstr.IntOrString {
+	result := intstr.FromInt32(int32(value))
+	return &result
+}
+
+func stringValue(value string) *intstr.IntOrString {
+	result := intstr.FromString(value)
+	return &result
+}


### PR DESCRIPTION
## Summary

Warn operators before a Deployment rollout policy can erase the redundancy they configured. Multi-replica RollingUpdate Deployments that explicitly allow every replica to be unavailable while allowing no surge are surfaced as proactive context and a Reliability audit finding, without adding latent configuration to the ranked incident feed.

## What changed

- Added a pure `rolloutdiag` analyzer shared by all exposure surfaces. It follows Deployment-controller percentage rounding and the both-zero fencepost rule, and reports both source and resolved rollout values.
- Added an optional `workloadSummary.rolloutRisk` block to Deployment resource context so agents receive the risk, its concrete rollout facts, and remediation while inspecting that workload.
- Added the `rolloutAvailabilityRisk` Reliability audit check for applicable multi-replica RollingUpdate Deployments. Safe defaults count as evaluated passes; Recreate, single-replica, and scaled-to-zero workloads are outside this check's denominator.
- Kept the signal out of standing problem detections. Existing availability and stalled-rollout detections remain responsible for active incidents, while this change describes a policy that *permits* a future zero-availability gap.

The analyzer only flags an explicit RollingUpdate block with both knobs present, resolved `maxSurge == 0`, and resolved `maxUnavailable >= replicas`. Recreate is treated as explicit full-replacement intent.

## Testing

- `go test ./rolloutdiag ./resourcecontext ./audit`
- `go test -race ./rolloutdiag ./resourcecontext ./audit`
- `go test ./...` (from `pkg/`)
- `go vet ./...` (from `pkg/`)
- `make test`
- `make build`
- Live test skipped: the change is deterministic analysis of typed Deployment objects and does not add a runtime integration or cluster interaction.
- Visual test skipped: there is no UI change.

## Tradeoffs

- This intentionally targets multi-replica Deployments, where the policy removes configured redundancy. Existing single-replica audit coverage handles the one-replica posture.
- DaemonSet rollout analysis is left out because its availability math and operator intent differ enough to warrant a separate design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only analysis of Deployment specs with no runtime or auth changes; false positives are bounded by explicit RollingUpdate knobs and multi-replica eligibility.
> 
> **Overview**
> Adds proactive detection when a multi-replica **RollingUpdate** Deployment is configured so a rollout can remove every old pod with no surge—surfacing policy risk before an incident, not as a standing problem feed item.
> 
> A new shared **`rolloutdiag`** package analyzes `maxSurge` / `maxUnavailable` (including controller percentage rounding and the both-zero fencepost rule) and returns structured risk facts plus operator-facing message and remediation.
> 
> **Audit:** new Reliability check **`rolloutAvailabilityRisk`** runs when Deployments are listed; safe defaults count as evaluated passes; Recreate, single-replica, and out-of-scope strategies are excluded from the denominator.
> 
> **Resource context:** Deployment **`workloadSummary.rolloutRisk`** is populated only when analysis finds risk; safe rollouts omit the field from JSON.
> 
> Check registry metadata reuses **`rolloutdiag`** description/remediation text for the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222aa67fad4fd45e31cbbcaada5b370c1c3f66ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->