### PR TITLE
Feat(diagnose): export the diagnose surface for standalone embedding

### DIFF
--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -23,7 +23,7 @@ import {
   agentLabelFor,
   openDiagnoseSettings,
 } from "./DiagnoseContext";
-import { useDiagnoseConsentCopy } from "../../context/DiagnoseCustomization";
+import { useDiagnoseCustomization } from "../../context/DiagnoseCustomization";
 import { InvestigationView } from "./InvestigationView";
 import { RecentList } from "./Home";
 import { ConsentCard } from "./parts";
@@ -137,7 +137,11 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
 // Helm drawers, so it no longer floats viewport-fixed or DOM-measures the chrome.
 export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
   const d = useDiagnose();
-  const consentCopy = useDiagnoseConsentCopy();
+  // Injected settings action: undefined = Radar's own Settings dialog;
+  // null = hide the gear + links.
+  const { consentCopy, onOpenSettings: hostOpenSettings } = useDiagnoseCustomization();
+  const openSettings =
+    hostOpenSettings === undefined ? openDiagnoseSettings : hostOpenSettings;
   const {
     maximized,
     setMaximized,
@@ -206,7 +210,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           agent={d.selectedAgent}
           isolated={d.isolated}
           copy={consentCopy}
-          onOpenSettings={openDiagnoseSettings}
+          onOpenSettings={openSettings ?? undefined}
           onApprove={d.approveConsent}
           onCancel={d.cancelConsent}
         />
@@ -306,15 +310,17 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
             </div>
             <div className="flex items-center gap-1 text-xs text-theme-text-tertiary">
               <span className="truncate">{configLine}</span>
-              <Tooltip content="AI settings" position="bottom">
-                <button
-                  onClick={openDiagnoseSettings}
-                  className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
-                  aria-label="AI settings"
-                >
-                  <Settings2 className="h-3 w-3" />
-                </button>
-              </Tooltip>
+              {openSettings && (
+                <Tooltip content="AI settings" position="bottom">
+                  <button
+                    onClick={openSettings}
+                    className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
+                    aria-label="AI settings"
+                  >
+                    <Settings2 className="h-3 w-3" />
+                  </button>
+                </Tooltip>
+              )}
             </div>
           </div>
         </div>

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -288,7 +288,7 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
   const uncordonMutation = useUncordonNode()
   const drainMutation = useDrainNode()
 
-  const renderDiagnose = useDiagnoseCustomization()
+  const { renderAction: renderDiagnose } = useDiagnoseCustomization()
 
   return {
     canExec,

--- a/web/src/context/DiagnoseCustomization.tsx
+++ b/web/src/context/DiagnoseCustomization.tsx
@@ -9,7 +9,7 @@
 //
 // Default (no provider): Radar renders no Diagnose button — OSS stays
 // agent-free.
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 /** Render prop for the resource-level Diagnose action. */
@@ -46,31 +46,48 @@ export type DiagnoseConsentCopy = {
   approveLabel?: string;
 };
 
-const DiagnoseCustomizationContext = createContext<RenderDiagnoseAction | undefined>(undefined);
-const DiagnoseConsentCopyContext = createContext<DiagnoseConsentCopy | undefined>(undefined);
+// One context for the whole customization seam — the values are host config
+// set once at mount, so per-value re-render isolation buys nothing.
+export interface DiagnoseCustomization {
+  renderAction: RenderDiagnoseAction | undefined;
+  consentCopy: DiagnoseConsentCopy | undefined;
+  // undefined = default (CustomEvent → Radar's own Settings dialog);
+  // null = hide the settings affordances.
+  onOpenSettings: (() => void) | null | undefined;
+}
+
+const DEFAULTS: DiagnoseCustomization = {
+  renderAction: undefined,
+  consentCopy: undefined,
+  onOpenSettings: undefined,
+};
+
+const DiagnoseCustomizationContext = createContext<DiagnoseCustomization>(DEFAULTS);
 
 export function DiagnoseCustomizationProvider({
   value,
   consentCopy,
+  onOpenSettings,
   children,
 }: {
   value: RenderDiagnoseAction | undefined;
   consentCopy?: DiagnoseConsentCopy;
+  /** Where "AI settings" affordances lead. Omit for Radar's own Settings
+   *  dialog; pass `null` to hide them. */
+  onOpenSettings?: (() => void) | null;
   children: ReactNode;
 }) {
+  const ctx = useMemo(
+    () => ({ renderAction: value, consentCopy, onOpenSettings }),
+    [value, consentCopy, onOpenSettings],
+  );
   return (
-    <DiagnoseCustomizationContext.Provider value={value}>
-      <DiagnoseConsentCopyContext.Provider value={consentCopy}>
-        {children}
-      </DiagnoseConsentCopyContext.Provider>
+    <DiagnoseCustomizationContext.Provider value={ctx}>
+      {children}
     </DiagnoseCustomizationContext.Provider>
   );
 }
 
-export function useDiagnoseCustomization(): RenderDiagnoseAction | undefined {
+export function useDiagnoseCustomization(): DiagnoseCustomization {
   return useContext(DiagnoseCustomizationContext);
-}
-
-export function useDiagnoseConsentCopy(): DiagnoseConsentCopy | undefined {
-  return useContext(DiagnoseConsentCopyContext);
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -30,6 +30,24 @@ export type {
   RenderDiagnoseAction,
   DiagnoseConsentCopy,
 } from './context/DiagnoseCustomization';
+
+// Standalone AI-diagnose surface — mount the investigation panel outside a
+// full <RadarApp>. No router dependency, no client-side cluster state: the
+// backend set via setApiBase() picks the cluster, so hosts remount
+// <DiagnoseProvider key={cluster}> to switch. Mount order: ThemeProvider >
+// DiagnoseCustomizationProvider > DiagnoseProvider > DiagnoseSurface, under a
+// @tanstack/react-query QueryClientProvider.
+export {
+  DiagnoseProvider,
+  useDiagnose,
+  useDiagnoseLayout,
+} from './components/diagnose/DiagnoseContext';
+export type { Target as DiagnoseTarget } from './components/diagnose/DiagnoseContext';
+export { DiagnoseSurface } from './components/diagnose/DiagnoseSurface';
+export { DiagnoseCustomizationProvider } from './context/DiagnoseCustomization';
+// The panel reads Radar's ThemeContext (throws unprovided). It follows
+// localStorage['radar-theme'], so host and panel flip together.
+export { ThemeProvider } from './context/ThemeContext';
 export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';
 
 // Shared cluster-switcher primitive — re-exported from @skyhook-io/k8s-ui so


### PR DESCRIPTION
## Description

### What

  Makes the AI-diagnose surface embeddable on its own: exports `DiagnoseProvider`, `DiagnoseSurface`, `useDiagnose`, `useDiagnoseLayout`, `DiagnoseCustomizationProvider`, `ThemeProvider`, and `DiagnoseTarget` from the package, so a host can mount the investigation panel outside a full `<RadarApp>` (e.g. on a fleet-wide issues page).

### Why

  The panel is already decoupled — no router dependency, no client-side cluster state (the backend set via `setApiBase()` picks the cluster) — it just wasn't exported. Hosts remount `<DiagnoseProvider key={cluster}>` to switch clusters.

### Changes

  - `index.ts` — new exports (additive, non-breaking)
  - `DiagnoseCustomization` — new `onOpenSettings?: (() => void) | null` prop: `null` hides the settings gear/links (a standalone host has nothing behind them); omitted keeps the current CustomEvent → Settings dialog behavior
  - Consolidated the three customization contexts/hooks into one context + one hook (`useDiagnoseCustomization()` now returns the config object) — internal only, the hooks were never exported

  No behavior change for standalone Radar or existing `<RadarApp>` embedders.
  
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public exports and internal context consolidation; default Radar behavior is preserved when customization props are omitted.
> 
> **Overview**
> **Package exports** add a documented mount path for embedding the AI investigation panel without `<RadarApp>`: `DiagnoseProvider`, `DiagnoseSurface`, layout/diagnose hooks, `DiagnoseCustomizationProvider`, `ThemeProvider`, and `DiagnoseTarget`, plus comments on `QueryClientProvider` / `setApiBase()` / cluster remounting.
> 
> **Diagnose customization** collapses separate render-prop and consent contexts into a single `useDiagnoseCustomization()` object (`renderAction`, `consentCopy`, `onOpenSettings`). `DiagnoseCustomizationProvider` accepts optional `onOpenSettings`: omitted keeps Radar’s CustomEvent → Settings dialog; `null` hides settings UI for fixed-agent hosts.
> 
> **DiagnoseSurface** reads that hook and resolves settings as `undefined → openDiagnoseSettings`, otherwise the host callback; the header gear and consent card only wire settings when the resolved handler is truthy.
> 
> **WorkloadView** destructures `renderAction` from the hook instead of treating the hook return value as the render function directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bbf1252f7be44991afb7571c8693a9793bcc44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->