### PR TITLE
Explain effective memory-limit discrepancies on OOM issues

### DIFF
--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -141,6 +141,76 @@ func TestCompose_PopulatesCategoryAndGroup(t *testing.T) {
 	}
 }
 
+func TestCompose_OOMDiagnosisEnrichmentPreservesIssueShape(t *testing.T) {
+	problems := []k8s.Detection{
+		{
+			Kind: "Pod", Namespace: "ns", Name: "oom", Severity: "critical",
+			Reason: "CrashLoopBackOff", Message: "back-off restarting failed container",
+			OwnerKind: "Deployment", OwnerName: "web", RestartCount: 4,
+			LastTerminatedReason: "OOMKilled",
+		},
+		{
+			Kind: "Pod", Namespace: "ns", Name: "image", Severity: "critical",
+			Reason: "ImagePullBackOff", Message: "back-off pulling image",
+			OwnerKind: "Deployment", OwnerName: "worker",
+		},
+	}
+	baseline := Compose(&fakeProvider{problems: problems}, Filters{Limit: NoLimit})
+
+	enrichedProblems := append([]k8s.Detection(nil), problems...)
+	enrichedProblems[0].Cause = "Container was OOMKilled below its owning ReplicaSet template limit."
+	enrichedProblems[0].Action = "Inspect the Pod and ReplicaSet resource discrepancy."
+	enriched := Compose(&fakeProvider{problems: enrichedProblems}, Filters{Limit: NoLimit})
+
+	if len(baseline) != len(enriched) || len(enriched) != 2 {
+		t.Fatalf("issue counts changed: baseline=%d enriched=%d", len(baseline), len(enriched))
+	}
+	for i := range baseline {
+		before, after := baseline[i], enriched[i]
+		if before.Name != after.Name {
+			t.Fatalf("issue order changed at %d: baseline=%q enriched=%q", i, before.Name, after.Name)
+		}
+		if before.ID != after.ID || before.Category != after.Category || before.CategoryGroup != after.CategoryGroup || before.Count != after.Count {
+			t.Fatalf("issue identity changed for %q: baseline=%+v enriched=%+v", before.Name, before, after)
+		}
+	}
+
+	var oom Issue
+	for i := range enriched {
+		if enriched[i].Name == "oom" {
+			oom = enriched[i]
+			break
+		}
+	}
+	if oom.Category != issuesapi.CategoryOOMKilled || oom.Cause != enrichedProblems[0].Cause || oom.Action != enrichedProblems[0].Action {
+		t.Fatalf("OOM diagnosis did not propagate: %+v", oom)
+	}
+	response := NewListResponse(enriched, ComposeStats{TotalMatched: len(enriched)})
+	if response.Total != len(enriched) || response.TotalMatched != len(enriched) || len(response.Issues) != len(enriched) {
+		t.Fatalf("response counts changed: %+v", response)
+	}
+	if response.Issues[0].Name != enriched[0].Name || response.Issues[1].Name != enriched[1].Name {
+		t.Fatalf("response order changed: %+v", response.Issues)
+	}
+
+	forbiddenProblems := append([]k8s.Detection(nil), enrichedProblems...)
+	forbiddenProblems[0].Message = `pods is forbidden: User "system:serviceaccount:ns:default" cannot list resource "configmaps"`
+	forbidden := Compose(&fakeProvider{problems: forbiddenProblems}, Filters{Limit: NoLimit})
+	for i := range forbidden {
+		if forbidden[i].Name != "oom" {
+			continue
+		}
+		if forbidden[i].Reason != "RBACForbidden" || forbidden[i].Category != issuesapi.CategoryRBACForbidden {
+			t.Fatalf("forbidden message did not take category precedence: %+v", forbidden[i])
+		}
+		if forbidden[i].Cause != "" || forbidden[i].Action != "" {
+			t.Fatalf("promoted RBAC issue retained diagnosis for the superseded OOM reason: %+v", forbidden[i])
+		}
+		return
+	}
+	t.Fatal("composed forbidden OOM issue not found")
+}
+
 func TestCompose_ClassifiesArgoWorkflowForbiddenMessage(t *testing.T) {
 	p := &fakeProvider{
 		problems: []k8s.Detection{{

--- a/internal/issues/normalize.go
+++ b/internal/issues/normalize.go
@@ -49,7 +49,13 @@ func fromProblem(p k8s.Detection, now time.Time, source Source) Issue {
 		since = now.Add(-time.Duration(p.AgeSeconds) * time.Second)
 	}
 	reason := p.Reason
+	cause, action := p.Cause, p.Action
 	if isForbiddenMessage(p.Message) && !isBatchFailureProblem(p.Kind, p.Reason) {
+		if reason != "RBACForbidden" {
+			// Detector diagnoses describe the original reason and would mislead
+			// after the message promotes the issue to an RBAC failure.
+			cause, action = "", ""
+		}
 		reason = "RBACForbidden"
 	}
 	iss := Issue{
@@ -62,8 +68,8 @@ func fromProblem(p k8s.Detection, now time.Time, source Source) Issue {
 		Reason:               reason,
 		Message:              p.Message,
 		RawMessage:           p.RawMessage,
-		Cause:                p.Cause,
-		Action:               p.Action,
+		Cause:                cause,
+		Action:               action,
 		RemediationKind:      p.RemediationKind,
 		RemediationTarget:    p.RemediationTarget,
 		OperationRetryCount:  p.OperationRetryCount,

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -430,11 +430,13 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				message = init.message
 				fingerprint = init.fingerprint
 			}
-			var cause, action string
-			if reason == crashLoopReason {
-				cause, action = health.PodCrashLoopDiagnosis(pod, now)
-			} else if c, a := imagePullDiagnosis(reason, message); c != "" {
-				cause, action = c, a
+			cause, action := oomLimitDiagnosis(cache, pod, reason, lastTermReason, now)
+			if cause == "" {
+				if reason == crashLoopReason {
+					cause, action = health.PodCrashLoopDiagnosis(pod, now)
+				} else {
+					cause, action = imagePullDiagnosis(reason, message)
+				}
 			}
 			// IssueTiming: classify whether this pod has been failing since the Deployment
 			// was first created (started_at_resource_creation) or broke after a period of

--- a/internal/k8s/detect_oom.go
+++ b/internal/k8s/detect_oom.go
@@ -1,0 +1,165 @@
+package k8s
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/skyhook-io/radar/pkg/health"
+)
+
+type oomLimitDiscrepancy struct {
+	containerName string
+	replicaSet    string
+	templateLimit resource.Quantity
+	podSpecLimit  resource.Quantity
+	observedLimit resource.Quantity
+	limitSource   string
+}
+
+func oomLimitDiagnosis(cache *ResourceCache, pod *corev1.Pod, reason, lastTerminatedReason string, now time.Time) (string, string) {
+	if !podReasonClassifiesAsOOM(reason, lastTerminatedReason) {
+		return "", ""
+	}
+
+	discrepancy, ok := activeOOMLimitDiscrepancy(cache, pod, now)
+	if !ok {
+		return "", ""
+	}
+
+	var cause string
+	if discrepancy.limitSource == "status" {
+		cause = fmt.Sprintf(
+			"Container %q was OOMKilled. Its currently reported enacted memory limit is %s, below its owning ReplicaSet %q template limit of %s.",
+			discrepancy.containerName,
+			discrepancy.observedLimit.String(),
+			discrepancy.replicaSet,
+			discrepancy.templateLimit.String(),
+		)
+		if !discrepancy.podSpecLimit.IsZero() {
+			cause += fmt.Sprintf(" The current Pod spec limit is %s.", discrepancy.podSpecLimit.String())
+		} else {
+			cause += " The current Pod spec has no explicit memory limit."
+		}
+	} else {
+		cause = fmt.Sprintf(
+			"Container %q was OOMKilled. Its current admitted Pod spec memory limit is %s, below its owning ReplicaSet %q template limit of %s. Kubernetes does not currently report an enacted runtime limit for this container.",
+			discrepancy.containerName,
+			discrepancy.observedLimit.String(),
+			discrepancy.replicaSet,
+			discrepancy.templateLimit.String(),
+		)
+	}
+
+	action := "Determine why the Pod and ReplicaSet differ: inspect Pod resize status, VPA or admission mutation, and whether the ReplicaSet template changed after Pod creation before changing the workload memory limit."
+	return cause, action
+}
+
+func activeOOMLimitDiscrepancy(cache *ResourceCache, pod *corev1.Pod, now time.Time) (oomLimitDiscrepancy, bool) {
+	statuses := health.ActiveOOMKilledContainers(pod, now)
+	if len(statuses) == 0 || cache == nil {
+		return oomLimitDiscrepancy{}, false
+	}
+
+	owner := controllerOwnerRef(pod.OwnerReferences)
+	if owner == nil || owner.APIVersion != "apps/v1" || owner.Kind != "ReplicaSet" || owner.UID == "" {
+		return oomLimitDiscrepancy{}, false
+	}
+	rsLister := cache.ReplicaSets()
+	if rsLister == nil {
+		return oomLimitDiscrepancy{}, false
+	}
+	rs, err := rsLister.ReplicaSets(pod.Namespace).Get(owner.Name)
+	if err != nil || rs.UID == "" || rs.UID != owner.UID {
+		return oomLimitDiscrepancy{}, false
+	}
+
+	for i := range statuses {
+		status := statuses[i]
+		templateLimit, ok := containerMemoryLimit(rs.Spec.Template.Spec.Containers, status.Name)
+		if !ok {
+			continue
+		}
+		podSpecLimit, _ := containerMemoryLimit(pod.Spec.Containers, status.Name)
+
+		d := oomLimitDiscrepancy{
+			containerName: status.Name,
+			replicaSet:    rs.Name,
+			templateLimit: templateLimit,
+			podSpecLimit:  podSpecLimit,
+		}
+		if status.Resources != nil {
+			enactedLimit, exists := explicitMemoryLimit(status.Resources.Limits)
+			if !exists || enactedLimit.Cmp(templateLimit) >= 0 {
+				continue
+			}
+			d.observedLimit = enactedLimit
+			d.limitSource = "status"
+			return d, true
+		}
+
+		if podHasResizeSignal(pod) || podSpecLimit.IsZero() || podSpecLimit.Cmp(templateLimit) >= 0 {
+			continue
+		}
+		d.observedLimit = podSpecLimit
+		d.limitSource = "spec"
+		return d, true
+	}
+	return oomLimitDiscrepancy{}, false
+}
+
+func containerMemoryLimit(containers []corev1.Container, name string) (resource.Quantity, bool) {
+	for i := range containers {
+		if containers[i].Name == name {
+			return explicitMemoryLimit(containers[i].Resources.Limits)
+		}
+	}
+	return resource.Quantity{}, false
+}
+
+func explicitMemoryLimit(limits corev1.ResourceList) (resource.Quantity, bool) {
+	limit, ok := limits[corev1.ResourceMemory]
+	return limit, ok && limit.Sign() > 0
+}
+
+func podHasResizeSignal(pod *corev1.Pod) bool {
+	if pod.Status.Resize != "" {
+		return true
+	}
+	for i := range pod.Status.Conditions {
+		switch pod.Status.Conditions[i].Type {
+		case corev1.PodResizePending, corev1.PodResizeInProgress:
+			return true
+		}
+	}
+	return false
+}
+
+// This mirrors the Pod reason precedence in internal/issues without importing
+// that higher layer back into the detector package. Probe, image, init, and
+// waiting reasons must not receive an OOM-specific cause even with OOM history.
+// Message-driven reason promotion is normalized by the issues composer, which
+// clears any diagnosis belonging to the superseded detector reason.
+func podReasonClassifiesAsOOM(reason, lastTerminatedReason string) bool {
+	if reason == "OOMKilled" {
+		return true
+	}
+	if lastTerminatedReason != "OOMKilled" {
+		return false
+	}
+	if isImagePullReason(reason) {
+		return false
+	}
+	switch reason {
+	case highRestartReason,
+		livenessProbeFailedReason, livenessProbeInvalidReason,
+		readinessProbeFailedReason, readinessProbeInvalidReason,
+		initContainerStalledReason,
+		"CreateContainerConfigError", "CreateContainerError", "RunContainerError", "Pending", "ContainerCreating":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/k8s/detect_oom_test.go
+++ b/internal/k8s/detect_oom_test.go
@@ -1,0 +1,499 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDetectProblems_OOMLimitDiscrepancy(t *testing.T) {
+	defer ResetTestState()
+	now := time.Now()
+
+	type testCase struct {
+		name          string
+		specLimit     string
+		statusLimit   string
+		templateLimit string
+		wantDetection bool
+		wantCause     bool
+		wantReason    string
+		wantContains  []string
+		mutate        func(*corev1.Pod, *appsv1.ReplicaSet) []runtime.Object
+	}
+
+	cases := []testCase{
+		{
+			name: "benchmark-shape", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"currently reported enacted memory limit is 16Mi", "ReplicaSet \"rs-benchmark-shape\" template limit of 256Mi", "current Pod spec limit is 16Mi"},
+		},
+		{
+			name: "status-equal-template", specLimit: "16Mi", statusLimit: "256Mi", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "status-higher-than-template", specLimit: "16Mi", statusLimit: "512Mi", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "equivalent-quantities", specLimit: "0.25Gi", statusLimit: "0.25Gi", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "status-absent-no-resize", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"current admitted Pod spec memory limit is 16Mi", "does not currently report an enacted runtime limit"},
+		},
+		{
+			name: "status-absent-legacy-resize", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Resize = corev1.PodResizeStatusInProgress
+				return nil
+			},
+		},
+		{
+			name: "status-absent-legacy-resize-deferred", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Resize = corev1.PodResizeStatusDeferred
+				return nil
+			},
+		},
+		{
+			name: "status-absent-legacy-resize-infeasible", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Resize = corev1.PodResizeStatusInfeasible
+				return nil
+			},
+		},
+		{
+			name: "status-absent-resize-condition", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: corev1.PodResizePending, Status: corev1.ConditionFalse})
+				return nil
+			},
+		},
+		{
+			name: "status-absent-resize-in-progress-condition", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: corev1.PodResizeInProgress, Status: corev1.ConditionFalse})
+				return nil
+			},
+		},
+		{
+			name: "first-start-oom", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true, wantReason: "OOMKilled",
+			wantContains: []string{"current admitted Pod spec memory limit is 16Mi", "does not currently report an enacted runtime limit"},
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.ContainerStatuses[0].RestartCount = 0
+				pod.Status.ContainerStatuses[0].State = corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137}}
+				pod.Status.ContainerStatuses[0].LastTerminationState = corev1.ContainerState{}
+				return nil
+			},
+		},
+		{
+			name: "runtime-below-desired-spec", specLimit: "256Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"currently reported enacted memory limit is 16Mi", "current Pod spec limit is 256Mi"},
+		},
+		{
+			name: "runtime-status-authoritative-during-resize", specLimit: "512Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"currently reported enacted memory limit is 16Mi", "current Pod spec limit is 512Mi"},
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: corev1.PodResizeInProgress, Status: corev1.ConditionTrue})
+				return nil
+			},
+		},
+		{
+			name: "status-present-without-limit", specLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{}
+				return nil
+			},
+		},
+		{
+			name: "status-present-with-zero-limit", specLimit: "16Mi", statusLimit: "0", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "template-limit-absent", specLimit: "16Mi", statusLimit: "16Mi",
+			wantDetection: true,
+		},
+		{
+			name: "template-limit-zero", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "0",
+			wantDetection: true,
+		},
+		{
+			name: "pod-limit-and-status-absent", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "pod-limit-zero-and-status-absent", specLimit: "0", templateLimit: "256Mi",
+			wantDetection: true,
+		},
+		{
+			name: "status-present-pod-limit-absent", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"currently reported enacted memory limit is 16Mi", "Pod spec has no explicit memory limit"},
+		},
+		{
+			name: "oom-container-missing-from-template", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(_ *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				rs.Spec.Template.Spec.Containers[0].Name = "renamed"
+				return nil
+			},
+		},
+		{
+			name: "owner-uid-mismatch", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.OwnerReferences[0].UID = types.UID("stale-owner")
+				return nil
+			},
+		},
+		{
+			name: "owner-uid-missing", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.OwnerReferences[0].UID = ""
+				return nil
+			},
+		},
+		{
+			name: "cached-owner-uid-missing", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(_ *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				rs.UID = ""
+				return nil
+			},
+		},
+		{
+			name: "replicaset-not-found", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(_ *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				rs.Name = "different-replicaset"
+				return nil
+			},
+		},
+		{
+			name: "non-controller-owner", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				controller := false
+				pod.OwnerReferences[0].Controller = &controller
+				return nil
+			},
+		},
+		{
+			name: "unsupported-owner", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.OwnerReferences[0].Kind = "StatefulSet"
+				return nil
+			},
+		},
+		{
+			name: "different-container-mismatch", specLimit: "256Mi", statusLimit: "256Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "sidecar", Resources: memoryRequirements("16Mi")})
+				pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{Name: "sidecar", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, Resources: statusResources("16Mi")})
+				rs.Spec.Template.Spec.Containers = append(rs.Spec.Template.Spec.Containers, corev1.Container{Name: "sidecar", Resources: memoryRequirements("256Mi")})
+				return nil
+			},
+		},
+		{
+			name: "second-active-container-mismatch", specLimit: "256Mi", statusLimit: "256Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true,
+			wantContains: []string{"Container \"sidecar\"", "currently reported enacted memory limit is 16Mi"},
+			mutate: func(pod *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "sidecar", Resources: memoryRequirements("16Mi")})
+				pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, activeOOMStatus("sidecar", "16Mi", now.Add(-10*time.Second)))
+				rs.Spec.Template.Spec.Containers = append(rs.Spec.Template.Spec.Containers, corev1.Container{Name: "sidecar", Resources: memoryRequirements("256Mi")})
+				return nil
+			},
+		},
+		{
+			name: "old-rollout-rs-match", specLimit: "256Mi", statusLimit: "256Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(_ *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				controller := true
+				rs.OwnerReferences = []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "current-deployment", UID: types.UID("deployment-current"), Controller: &controller}}
+				one := int32(1)
+				return []runtime.Object{&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "current-deployment", Namespace: rs.Namespace, UID: types.UID("deployment-current")},
+					Spec:       appsv1.DeploymentSpec{Replicas: &one, Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Resources: memoryRequirements("512Mi")}}}}},
+					Status:     appsv1.DeploymentStatus{Replicas: 1, AvailableReplicas: 1, ReadyReplicas: 1},
+				}}
+			},
+		},
+		{
+			name: "init-container-oom", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantReason: "OOMKilled",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.ContainerStatuses[0] = corev1.ContainerStatus{Name: "app", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-10 * time.Minute))}}}
+				pod.Spec.InitContainers = []corev1.Container{{Name: "setup", Resources: memoryRequirements("16Mi")}}
+				pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137}}, Resources: statusResources("16Mi")}}
+				return nil
+			},
+		},
+		{
+			name: "recovered-stale-oom", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.Containers[0].ReadinessProbe = &corev1.Probe{}
+				pod.Status.ContainerStatuses[0].Ready = true
+				pod.Status.ContainerStatuses[0].RestartCount = 1
+				pod.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-30 * time.Minute))}}
+				pod.Status.ContainerStatuses[0].LastTerminationState = corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.NewTime(now.Add(-30 * time.Minute))}}
+				return nil
+			},
+		},
+		{
+			name: "recent-running-oom", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true, wantReason: "OOMKilled",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.ContainerStatuses[0].Ready = true
+				pod.Status.ContainerStatuses[0].RestartCount = 1
+				pod.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-2 * time.Minute))}}
+				pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.FinishedAt = metav1.NewTime(now.Add(-2 * time.Minute))
+				return nil
+			},
+		},
+		{
+			name: "long-running-recovered-oom", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.ContainerStatuses[0].Ready = true
+				pod.Status.ContainerStatuses[0].RestartCount = 1
+				pod.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-30 * time.Minute))}}
+				pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.FinishedAt = metav1.NewTime(now.Add(-30 * time.Minute))
+				return nil
+			},
+		},
+		{
+			name: "benchmark-completed-reason", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true, wantReason: "Completed",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.InitContainers = []corev1.Container{{Name: "setup"}}
+				pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}}}
+				return nil
+			},
+		},
+		{
+			name: "readiness-precedence-collision", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantReason: "ReadinessProbeInvalid",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.Containers[0].ReadinessProbe = &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Port: intstr.FromString("health")}}}
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionFalse})
+				return nil
+			},
+		},
+		{
+			name: "liveness-precedence-collision", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantReason: "LivenessProbeInvalid",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Spec.Containers[0].LivenessProbe = &corev1.Probe{ProbeHandler: corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromString("health")}}}
+				return nil
+			},
+		},
+		{
+			name: "image-precedence-collision", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantReason: "ImagePullBackOff",
+			mutate: func(pod *corev1.Pod, rs *appsv1.ReplicaSet) []runtime.Object {
+				imageSpec := corev1.Container{Name: "pulling", Image: "invalid.example/image"}
+				pod.Spec.Containers = append([]corev1.Container{imageSpec}, pod.Spec.Containers...)
+				pod.Status.ContainerStatuses = append([]corev1.ContainerStatus{{Name: "pulling", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}}}, pod.Status.ContainerStatuses...)
+				rs.Spec.Template.Spec.Containers = append([]corev1.Container{imageSpec}, rs.Spec.Template.Spec.Containers...)
+				return nil
+			},
+		},
+		{
+			name: "init-precedence-collision", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantReason: "InitContainerStalled",
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.Status.Phase = corev1.PodPending
+				pod.Spec.InitContainers = []corev1.Container{{Name: "setup", Image: "setup:latest"}}
+				pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{Name: "setup", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-10 * time.Minute))}}}}
+				return nil
+			},
+		},
+		{
+			name: "standalone-pod", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true,
+			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
+				pod.OwnerReferences = nil
+				return nil
+			},
+		},
+	}
+
+	objects := make([]runtime.Object, 0, len(cases)*2)
+	for _, tc := range cases {
+		pod, rs := oomTestObjects(tc.name, tc.specLimit, tc.statusLimit, tc.templateLimit, now)
+		var extra []runtime.Object
+		if tc.mutate != nil {
+			extra = tc.mutate(pod, rs)
+		}
+		objects = append(objects, pod, rs)
+		objects = append(objects, extra...)
+	}
+
+	if err := InitTestResourceCache(fake.NewClientset(objects...)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+
+	wantRows := 0
+	for _, tc := range cases {
+		if tc.wantDetection {
+			wantRows++
+		}
+	}
+	var detections []Detection
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		detections = DetectProblems(cache, "oom-test")
+		rows := 0
+		for _, detection := range detections {
+			if detection.Kind == "Pod" && strings.HasPrefix(detection.Name, "pod-") {
+				rows++
+			}
+		}
+		if rows >= wantRows {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	byName := make(map[string]Detection)
+	for _, detection := range detections {
+		if detection.Kind == "Pod" {
+			byName[detection.Name] = detection
+		}
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			detection, found := byName["pod-"+tc.name]
+			if found != tc.wantDetection {
+				t.Fatalf("detection found = %v, want %v; detections: %+v", found, tc.wantDetection, detections)
+			}
+			if !found {
+				return
+			}
+			if tc.wantReason != "" && detection.Reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", detection.Reason, tc.wantReason)
+			}
+			if tc.wantCause {
+				if detection.Cause == "" || detection.Action == "" {
+					t.Fatalf("expected cause and action, got %+v", detection)
+				}
+				for _, fragment := range tc.wantContains {
+					if !strings.Contains(detection.Cause, fragment) {
+						t.Errorf("cause %q does not contain %q", detection.Cause, fragment)
+					}
+				}
+				if !strings.Contains(detection.Action, "ReplicaSet template") || !strings.Contains(detection.Action, "changed after Pod creation") || !strings.Contains(detection.Action, "VPA") || !strings.Contains(detection.Action, "admission") {
+					t.Errorf("action does not identify bounded mutation sources: %q", detection.Action)
+				}
+			} else if detection.Cause != "" || detection.Action != "" {
+				t.Fatalf("unexpected OOM discrepancy diagnosis: cause=%q action=%q", detection.Cause, detection.Action)
+			}
+		})
+	}
+}
+
+func TestPodReasonClassifiesAsOOM(t *testing.T) {
+	tests := []struct {
+		name, reason, last string
+		want               bool
+	}{
+		{name: "direct", reason: "OOMKilled", want: true},
+		{name: "crashloop", reason: "CrashLoopBackOff", last: "OOMKilled", want: true},
+		{name: "completed", reason: "Completed", last: "OOMKilled", want: true},
+		{name: "failed", reason: "Failed", last: "OOMKilled", want: true},
+		{name: "image", reason: "ImagePullBackOff", last: "OOMKilled"},
+		{name: "readiness", reason: "ReadinessProbeInvalid", last: "OOMKilled"},
+		{name: "liveness", reason: "LivenessProbeFailed", last: "OOMKilled"},
+		{name: "init", reason: "InitContainerStalled", last: "OOMKilled"},
+		{name: "waiting", reason: "ContainerCreating", last: "OOMKilled"},
+		{name: "high restart", reason: "HighRestartCount", last: "OOMKilled"},
+		{name: "no oom history", reason: "CrashLoopBackOff", last: "Error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := podReasonClassifiesAsOOM(tt.reason, tt.last); got != tt.want {
+				t.Fatalf("podReasonClassifiesAsOOM(%q, %q) = %v, want %v", tt.reason, tt.last, got, tt.want)
+			}
+		})
+	}
+}
+
+func oomTestObjects(name, specLimit, statusLimit, templateLimit string, now time.Time) (*corev1.Pod, *appsv1.ReplicaSet) {
+	controller := true
+	rsName := "rs-" + name
+	rsUID := types.UID("uid-" + name)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-" + name,
+			Namespace:         "oom-test",
+			CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rsName, UID: rsUID, Controller: &controller,
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Resources: memoryRequirements(specLimit)}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{activeOOMStatus("app", statusLimit, now.Add(-20*time.Second))},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: rsName, Namespace: "oom-test", UID: rsUID},
+		Spec:       appsv1.ReplicaSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Resources: memoryRequirements(templateLimit)}}}}},
+		Status:     appsv1.ReplicaSetStatus{Replicas: 1, ReadyReplicas: 1, AvailableReplicas: 1},
+	}
+	return pod, rs
+}
+
+func activeOOMStatus(name, limit string, finishedAt time.Time) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:         name,
+		RestartCount: 3,
+		State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+		LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.NewTime(finishedAt),
+		}},
+		Resources: statusResources(limit),
+	}
+}
+
+func memoryRequirements(limit string) corev1.ResourceRequirements {
+	if limit == "" {
+		return corev1.ResourceRequirements{}
+	}
+	return corev1.ResourceRequirements{Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(limit)}}
+}
+
+func statusResources(limit string) *corev1.ResourceRequirements {
+	if limit == "" {
+		return nil
+	}
+	resources := memoryRequirements(limit)
+	return &resources
+}

--- a/pkg/health/reasons.go
+++ b/pkg/health/reasons.go
@@ -164,14 +164,27 @@ func containerRecentlyRecoveredFromOOM(containers []corev1.Container, cs corev1.
 	return cs.State.Waiting != nil || restartedRecently(&cs, now, 5*time.Minute)
 }
 
-func podHasActiveOOMKilled(pod *corev1.Pod, now time.Time) bool {
-	for _, cs := range pod.Status.ContainerStatuses {
+// ActiveOOMKilledContainers returns the regular containers currently affected
+// by an OOM kill. Init containers are excluded so callers can match the result
+// to a workload template's regular containers without conflating the two lists.
+func ActiveOOMKilledContainers(pod *corev1.Pod, now time.Time) []corev1.ContainerStatus {
+	var active []corev1.ContainerStatus
+	for i := range pod.Status.ContainerStatuses {
+		cs := pod.Status.ContainerStatuses[i]
 		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-			return true
+			active = append(active, cs)
+			continue
 		}
 		if containerRecentlyRecoveredFromOOM(pod.Spec.Containers, cs, now) {
-			return true
+			active = append(active, cs)
 		}
+	}
+	return active
+}
+
+func podHasActiveOOMKilled(pod *corev1.Pod, now time.Time) bool {
+	if len(ActiveOOMKilledContainers(pod, now)) > 0 {
+		return true
 	}
 	for _, cs := range pod.Status.InitContainerStatuses {
 		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {

--- a/pkg/health/recovery_test.go
+++ b/pkg/health/recovery_test.go
@@ -176,6 +176,45 @@ func TestStableCrashLoopPreservesSpecificReasons(t *testing.T) {
 	}
 }
 
+func TestActiveOOMKilledContainers(t *testing.T) {
+	now := time.Now()
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "terminated"},
+			{Name: "recent"},
+			{Name: "recovered", ReadinessProbe: &corev1.Probe{}},
+		}},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "terminated",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+				},
+				{
+					Name:                 "recent",
+					State:                corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+				},
+				{
+					Name:                 "recovered",
+					Ready:                true,
+					State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-30 * time.Minute))}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "init",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+			}},
+		},
+	}
+
+	got := ActiveOOMKilledContainers(pod, now)
+	if len(got) != 2 || got[0].Name != "terminated" || got[1].Name != "recent" {
+		t.Fatalf("active regular OOM containers = %+v, want terminated and recent only", got)
+	}
+}
+
 // TestPodCrashLoopDiagnosisOrdersCandidates: the current waiting crashloop wins
 // over a newer running tick.
 func TestPodCrashLoopDiagnosisOrdersCandidates(t *testing.T) {


### PR DESCRIPTION
## Summary

OOM issues now explain when the affected container is running with a lower memory limit than the template of its immediate owning ReplicaSet. This gives operators a concrete, resource-backed lead without adding another issue or claiming which controller or admission component caused the discrepancy.

## What changed

- Enriches only an already-active OOM issue for the exact affected regular container. Issue identity, severity, ordering, and count stay unchanged.
- Compares the enacted container limit from `status.containerStatuses[].resources` with the immediate controller-owned ReplicaSet template. When Kubernetes does not expose status resources, the admitted Pod spec is used only if there is no resize signal and the evidence remains unambiguous.
- Fails closed for stale OOM history, init-container OOMs, missing or mismatched owner UIDs, absent listers, missing/non-positive limits, container-name mismatches, resize activity, equal or higher enacted limits, and reason-precedence conflicts.
- Describes the observed Pod/ReplicaSet discrepancy and points to legitimate explanations including admission mutation, VPA, in-place resize, and a ReplicaSet template changed after Pod creation. It does not attribute a culprit.
- Exposes active regular-container OOM status through the shared health package while preserving the existing init-container health behavior.
- Clears detector-specific diagnosis text when issue normalization supersedes the detector reason with `RBACForbidden`, so the final explanation cannot contradict the final category.

## Testing

- Focused 28-case OOM evidence and fail-closed matrix, including the benchmark-shaped discrepancy, status-vs-spec precedence, stale history, owner UID checks, resize states, multi-container identity, and competing Pod reasons
- Focused issue-composition tests proving unchanged issue shape and diagnosis removal after RBAC promotion
- Focused shared-health tests for active, recovered, regular, and init-container OOM behavior
- `make test`
- `go test ./...` in the shared `pkg` module
- Repeated and race-checked focused detector tests
- `go vet ./...`
- `make tsc`
- `make build`
- Read-only validation against an accessible GKE cluster confirmed that workloads lacking the strict evidence do not receive speculative enrichment; no cluster resources were mutated
- Visual test skipped: there is no UI or rendered-surface change

## Tradeoffs

The detector deliberately accepts false negatives when runtime identity, ownership, resize state, or OOM recency is ambiguous. The Pod-spec fallback is evidence of the admitted object rather than proof of the runtime cgroup value, so it is used only when Kubernetes omits status resources and no resize signal is present; the resulting copy states that limitation explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod problem diagnosis and issue normalization on a sensitive operational path; behavior is heavily gated and tested but wrong limit comparison could mislead operators.
> 
> **Overview**
> Adds **cause/action text** to existing OOM pod issues when the killed container’s effective memory limit is **lower than the immediate controller-owned ReplicaSet template**, without new issues or changed identity, ordering, or counts.
> 
> Pod detection now runs **`oomLimitDiagnosis` before** crash-loop and image-pull parsers. It only fires for active regular-container OOMs with strict evidence: ReplicaSet owner UID match, positive template limit, enacted limit from **`status.containerStatuses[].resources`** (or admitted **Pod spec** only when there is no resize signal and limits are unambiguous). Competing reasons (probes, image pull, init stall, etc.) skip OOM-specific copy.
> 
> **`pkg/health`** exposes **`ActiveOOMKilledContainers`** for regular containers; init OOM behavior stays on the existing path. **Issue normalization** clears detector **cause/action** when a forbidden message promotes the row to **`RBACForbidden`**, so RBAC issues don’t keep OOM diagnosis.
> 
> Tests cover a large OOM evidence matrix, compose shape/RBAC promotion, and active-OOM container selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c575407bd3a88833e39e0742d857a1ba852cf2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->