### PR TITLE
deps: consolidate vetted dependency updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
 	github.com/godbus/dbus/v5 v5.2.2
-	github.com/google/cel-go v0.29.1
+	github.com/google/cel-go v0.29.2
 	github.com/google/go-containerregistry v0.21.7
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/yamux v0.1.2
 	github.com/klauspost/compress v1.19.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/common v0.69.0
+	github.com/prometheus/common v0.70.0
 	github.com/skyhook-io/radar/pkg v0.0.0
 	github.com/wailsapp/wails/v2 v2.12.0
 	golang.org/x/net v0.57.0
@@ -130,7 +130,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/prometheus/procfs v0.21.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.29.1 h1:8Gx3S5HPop5XPOHtZI8vkaGk+DBW/nn9fkpNPbh5dBk=
-github.com/google/cel-go v0.29.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
+github.com/google/cel-go v0.29.2 h1:ZtDxkeiMmz0mxbKDYiNkE5Lk7V5edMRcaaDf2jX002k=
+github.com/google/cel-go v0.29.2/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
 github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -303,12 +303,12 @@ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.69.0 h1:OA85nJQS/T/MaYh/Q2CcgDKSGWqNIgrBDvDH85CuiNk=
-github.com/prometheus/common v0.69.0/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
+github.com/prometheus/common v0.70.0 h1:bcpru3tWPVnxGnETLgOV5jbp/JRXgYEyv65CuBLAMMI=
+github.com/prometheus/common v0.70.0/go.mod h1:S/SFasQmgGiYH6C81LKCtYa8QACgthGg5zxL2udV7SY=
 github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEoIwkU+A6qos=
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
-github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
-github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/prometheus/procfs v0.21.0 h1:Qh/e6TlBjZf+XLLqNCqFGmCU6Kj/2Bu7kj3oAc0UnXc=
+github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 h1:EaDatTxkdHG+U3Bk4EUr+DZ7fOGwTfezUiUJMaIcaho=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5/go.mod h1:fyalQWdtzDBECAQFBJuQe5bzQ02jGd5Qcbgb97Flm7U=
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb27yVE+gIAfeqp8LUCc=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1550,6 +1550,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -5193,9 +5203,9 @@
       }
     },
     "node_modules/react-virtuoso": {
-      "version": "4.18.10",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.10.tgz",
-      "integrity": "sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==",
+      "version": "4.18.11",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.11.tgz",
+      "integrity": "sha512-Qeeq9vqa5seCxACvzbQTUeq3s2/Bu+VlwOMF0jfy3E/ZKHLiXWwJpXBhv2rckqYkvm1XRVFLCBMCmqCU8JNEJg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
@@ -6183,11 +6193,11 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "html-to-image": "^1.11.0",
-        "react-virtuoso": "^4.18.10",
+        "react-virtuoso": "^4.18.11",
         "shiki": "^4.2.0"
       },
       "devDependencies": {
-        "@types/node": "^26.0.1",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -6216,16 +6226,6 @@
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
         "yaml": ">=2.0.0"
-      }
-    },
-    "packages/k8s-ui/node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~8.3.0"
       }
     },
     "packages/k8s-ui/node_modules/@xterm/addon-fit": {
@@ -6263,7 +6263,7 @@
         "diff": "^9.0.0",
         "monaco-editor": "^0.55.1",
         "react-markdown": "^10.1.0",
-        "react-virtuoso": "^4.18.10",
+        "react-virtuoso": "^4.18.11",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.2.0",
         "yaml": "^2.9.0"
@@ -6275,7 +6275,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.1",
         "@tanstack/react-query": "^5.101.2",
-        "@types/node": "^26.0.1",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -6309,16 +6309,6 @@
         "react-dom": ">=19",
         "react-router-dom": ">=7",
         "tailwind-merge": ">=2"
-      }
-    },
-    "web/node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~8.3.0"
       }
     }
   }

--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "html-to-image": "^1.11.0",
-    "react-virtuoso": "^4.18.10",
+    "react-virtuoso": "^4.18.11",
     "shiki": "^4.2.0"
   },
   "peerDependencies": {
@@ -86,7 +86,7 @@
     "yaml": ">=2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "diff": "^9.0.0",
     "monaco-editor": "^0.55.1",
     "react-markdown": "^10.1.0",
-    "react-virtuoso": "^4.18.10",
+    "react-virtuoso": "^4.18.11",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",
     "yaml": "^2.9.0"
@@ -59,7 +59,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.1",
     "@tanstack/react-query": "^5.101.2",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",


### PR DESCRIPTION
## Summary

Consolidates the low-risk Dependabot updates that had been publicly available for at least 72 hours as of 2026-07-22. This keeps routine type, virtualization, CEL, and Prometheus model updates moving while leaving recent, major, and broad-behavior releases isolated for later review.

## Included updates

- `@types/node` 26.0.1 → 26.1.1 ([#1246](https://github.com/skyhook-io/radar/pull/1246)); published 2026-07-08. Type-only update; the lockfile hoists the two identical workspace copies into one root copy.
- `react-virtuoso` 4.18.10 → 4.18.11 ([#1243](https://github.com/skyhook-io/radar/pull/1243)); published 2026-07-17. Patch release for horizontal LTR/RTL direction changes; Radar's existing vertical list usage is unchanged.
- `github.com/google/cel-go` 0.29.1 → 0.29.2 ([#1242](https://github.com/skyhook-io/radar/pull/1242)); published 2026-07-08. Patch release correcting list runtime-cost calculation.
- `github.com/prometheus/common` 0.69.0 → 0.70.0 ([#1244](https://github.com/skyhook-io/radar/pull/1244)); published 2026-07-10. Small release with QUERY-method support and a TLS version string fix; Radar only imports the stable `model` package. This also updates the expected transitive `prometheus/procfs` dependency from 0.20.1 to 0.21.0.

## Scope boundary

- Held for the 72-hour age gate: `prometheus/client_golang` 1.24.0 ([#1245](https://github.com/skyhook-io/radar/pull/1245)), `klauspost/compress` 1.19.1 ([#1239](https://github.com/skyhook-io/radar/pull/1239)), and Prettier 3.9.6 ([#1240](https://github.com/skyhook-io/radar/pull/1240)).
- Held as nontrivial: TypeScript 7 ([#1248](https://github.com/skyhook-io/radar/pull/1248), major and failing frontend CI), ELK 0.12 ([#1247](https://github.com/skyhook-io/radar/pull/1247), layout-engine behavior), Cilium 1.19.3 → 1.19.6 ([#1241](https://github.com/skyhook-io/radar/pull/1241), broad three-release surface), and `actions/setup-go` 7 ([#1238](https://github.com/skyhook-io/radar/pull/1238), major ESM/runtime migration not exercised across release platforms by PR CI).

## Testing

- `npm ci --ignore-scripts`
- `go mod tidy -diff`
- `go mod verify`
- `make tsc`
- `make test`
- `npm test --workspace @skyhook-io/radar-app` (161 tests)
- `npm test --workspace @skyhook-io/k8s-ui` (1,270 tests)
- `make build`
- Visual test skipped: there is no source or intentional rendered-surface change; the Virtuoso patch targets horizontal direction switching, while Radar uses the affected lists vertically.

The standalone `@skyhook-io/k8s-ui` TypeScript command still reports the existing missing `oldValue` fixture field in `application-history.test.ts`; that command is not part of CI and the file is unchanged from `main`.

`npm audit` reports the existing Monaco/DOMPurify advisories; neither dependency or resolved version changes in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch and dev-type updates with no logic or API surface changes in Radar’s own code.
> 
> **Overview**
> Bumps several **low-risk, patch-level** dependencies across Go and the npm workspaces, with lockfile-only changes beyond version pins.
> 
> **Go:** `github.com/google/cel-go` **0.29.1 → 0.29.2** (CEL list runtime-cost fix; affects compiled filters in `internal/filter`) and `github.com/prometheus/common` **0.69.0 → 0.70.0**, with transitive `prometheus/procfs` **0.20.1 → 0.21.0** (Radar’s Prometheus MCP tooling imports `model` from common).
> 
> **Frontend:** `@types/node` **26.0.1 → 26.1.1** in `packages/k8s-ui` and `web`, with duplicate workspace copies **hoisted** to a single root `node_modules` entry in `package-lock.json`. **`react-virtuoso` 4.18.10 → 4.18.11** in both `@skyhook-io/k8s-ui` and `@skyhook-io/radar-app` (patch focused on horizontal LTR/RTL; existing vertical log/list usage is unchanged).
> 
> No application source changes—only `go.mod`/`go.sum`, `package.json`, and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe12504c8a4ec37fd9f15a13e6ef50a372efb98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->