### PR TITLE
Make issue change-feed framing constructive

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -354,7 +354,9 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"not make recent changes irrelevant to other issues or application-layer " +
 			"symptoms. A bad config change can itself cause a failure during creation. " +
 			"The token does not " +
-			"claim the changes are causal. `no_critical_issues` means no critical rows " +
+			"claim the changes are causal. `recent_changes_guidance`, when present, states " +
+			"how to treat the feed for this response — follow it. `no_critical_issues` " +
+			"means no critical rows " +
 			"were returned. `recent_changes_truncated=true` means the feed is incomplete, " +
 			"so absence from it is not evidence that a relevant change did not occur. " +
 			"The feed lists recent spec/config changes that may explain failures " +
@@ -2802,6 +2804,7 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 			}); err == nil && len(changes) > 0 {
 				resp.RecentChanges = changes
 				resp.RecentChangesReason = recentChangesReason
+				resp.RecentChangesGuidance = meaningfulchanges.IssueChangesGuidance(recentChangesReason)
 				resp.RecentChangesTruncated = truncated
 			}
 		}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -346,9 +346,18 @@ func registerTools(server *mcp.Server, includeWrites bool) {
 			"distinct same-confidence roots leave it unset). Use these links to walk from a " +
 			"symptom to its likely " +
 			"root, but confirm a medium link before acting on it. " +
-			"When `recent_changes` is present, consider it if the issue list does not " +
-			"explain the reported symptom; `recent_changes_reason` says why Radar " +
-			"attached it. It lists recent spec/config changes that may explain failures " +
+			"When `recent_changes` is present, inspect it before concluding the current " +
+			"issues explain the reported symptom. `recent_changes_reason` says why Radar " +
+			"attached it. `recent_changes_with_all_critical_issues_at_creation` means " +
+			"Radar's best-effort timing evidence places every returned critical row's " +
+			"failure at resource creation. That timing describes those rows only: it does " +
+			"not make recent changes irrelevant to other issues or application-layer " +
+			"symptoms. A bad config change can itself cause a failure during creation. " +
+			"The token does not " +
+			"claim the changes are causal. `no_critical_issues` means no critical rows " +
+			"were returned. `recent_changes_truncated=true` means the feed is incomplete, " +
+			"so absence from it is not evidence that a relevant change did not occur. " +
+			"The feed lists recent spec/config changes that may explain failures " +
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
 			"Single-namespace responses may add per-issue change evidence to eligible " +
@@ -2785,7 +2794,7 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 	})
 	if len(allowedNamespaces) == 1 && stats.TotalMatched == len(out) && meaningfulchanges.IssueChangesQueryEligible(input.Kind, input.Filter, input.Severity) {
 		if recentChangesReason := meaningfulchanges.IssueChangesReason(out); recentChangesReason != "" {
-			if changes, _, err := meaningfulchanges.Recent(ctx, meaningfulchanges.Query{
+			if changes, truncated, err := meaningfulchanges.Recent(ctx, meaningfulchanges.Query{
 				Namespaces: []string{allowedNamespaces[0]},
 				Since:      meaningfulchanges.DefaultSince,
 				Limit:      meaningfulchanges.IssueChangesLimit,
@@ -2793,6 +2802,7 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 			}); err == nil && len(changes) > 0 {
 				resp.RecentChanges = changes
 				resp.RecentChangesReason = recentChangesReason
+				resp.RecentChangesTruncated = truncated
 			}
 		}
 	}

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -94,6 +94,9 @@ func TestIssuesToolDocumentsRecentChangesReasons(t *testing.T) {
 	if !strings.Contains(description, "recent_changes_truncated") {
 		t.Error("issues tool description does not document recent_changes_truncated")
 	}
+	if !strings.Contains(description, "recent_changes_guidance") {
+		t.Error("issues tool description does not document recent_changes_guidance")
+	}
 }
 
 func TestSearchToolSchemaIncludesNamespace(t *testing.T) {

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/skyhook-io/radar/internal/meaningfulchanges"
 )
 
 // setupDialogCatalogPath is the human-facing tool catalog rendered by the MCP
@@ -67,6 +69,30 @@ func TestSetupDialogCoversAllTools(t *testing.T) {
 	if len(staleInDialog) > 0 {
 		t.Errorf("setup dialog catalog (%s) lists tools that are not registered — remove them: %s",
 			setupDialogCatalogPath, strings.Join(staleInDialog, ", "))
+	}
+}
+
+func TestIssuesToolDocumentsRecentChangesReasons(t *testing.T) {
+	var description string
+	for _, tool := range listRegisteredTools(t) {
+		if tool.Name == "issues" {
+			description = tool.Description
+			break
+		}
+	}
+	if description == "" {
+		t.Fatal("issues tool is not registered or has no description")
+	}
+	for _, reason := range []string{
+		meaningfulchanges.ChangesReasonNoCriticalIssues,
+		meaningfulchanges.ChangesReasonWithAllCreationTimeCriticalIssues,
+	} {
+		if !strings.Contains(description, reason) {
+			t.Errorf("issues tool description does not document recent_changes_reason %q", reason)
+		}
+	}
+	if !strings.Contains(description, "recent_changes_truncated") {
+		t.Error("issues tool description does not document recent_changes_truncated")
 	}
 }
 

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -31,6 +31,21 @@ const (
 	ChangesReasonWithAllCreationTimeCriticalIssues = "recent_changes_with_all_critical_issues_at_creation"
 )
 
+// IssueChangesGuidance returns response-level steering prose for reason tokens
+// whose timing evidence could otherwise read as "the changes are irrelevant."
+// The steer rides the response — not just the tool description — because the
+// response is what the model attends to at decision time; the description may
+// be skimmed once or never loaded. It is advice about how to treat the feed,
+// never a causal claim about any specific change.
+func IssueChangesGuidance(reason string) string {
+	if reason != ChangesReasonWithAllCreationTimeCriticalIssues {
+		return ""
+	}
+	return "These critical issues predate the listed changes, but that does not clear the changes: " +
+		"a recent config change can cause application-layer symptoms that produce no issue row. " +
+		"Review the changes before concluding the listed issues explain the reported problem."
+}
+
 var (
 	configKinds = []string{"ConfigMap"}
 	specKinds   = []string{

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -27,8 +27,8 @@ const (
 )
 
 const (
-	ChangesReasonNoCriticalIssues             = "no_critical_issues"
-	ChangesReasonAllCriticalStartedAtCreation = "all_critical_issues_started_at_resource_creation"
+	ChangesReasonNoCriticalIssues                  = "no_critical_issues"
+	ChangesReasonWithAllCreationTimeCriticalIssues = "recent_changes_with_all_critical_issues_at_creation"
 )
 
 var (
@@ -189,7 +189,7 @@ func IssueChangesReason(issues []issuesapi.Issue) string {
 	if criticalCount == 0 {
 		return ChangesReasonNoCriticalIssues
 	}
-	return ChangesReasonAllCriticalStartedAtCreation
+	return ChangesReasonWithAllCreationTimeCriticalIssues
 }
 
 func ConfigMapKind(kind string) bool {

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -41,8 +41,13 @@ func IssueChangesGuidance(reason string) string {
 	if reason != ChangesReasonWithAllCreationTimeCriticalIssues {
 		return ""
 	}
-	return "These critical issues predate the listed changes, but that does not clear the changes: " +
-		"a recent config change can cause application-layer symptoms that produce no issue row. " +
+	// State only what the timing classification establishes: each critical row
+	// has been failing since its own resource was created. That is NOT an
+	// ordering against the change feed — a resource created after a bad change
+	// fails from creation precisely BECAUSE of that change.
+	return "Every returned critical issue is classified as failing since its resource was created. " +
+		"That does not clear the listed changes: a change can break a resource created after it, " +
+		"and can cause application-layer symptoms that produce no issue row. " +
 		"Review the changes before concluding the listed issues explain the reported problem."
 }
 

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -22,15 +22,15 @@ func TestShouldAttachIssueChanges(t *testing.T) {
 	if !ShouldAttachIssueChanges(nil) {
 		t.Fatalf("zero critical issues should allow the recent-changes attachment")
 	}
-	if got := IssueChangesReason(nil); got != ChangesReasonNoCriticalIssues {
-		t.Fatalf("IssueChangesReason(nil) = %q, want %q", got, ChangesReasonNoCriticalIssues)
+	if got, want := IssueChangesReason(nil), "no_critical_issues"; got != want {
+		t.Fatalf("IssueChangesReason(nil) = %q, want %q", got, want)
 	}
 	baseline := []issuesapi.Issue{{Severity: issuesapi.SeverityCritical, IssueTiming: "started_at_resource_creation"}}
 	if !ShouldAttachIssueChanges(baseline) {
-		t.Fatalf("baseline-dominated critical issues should allow the recent-changes attachment")
+		t.Fatalf("creation-time critical issues should allow the recent-changes attachment")
 	}
-	if got := IssueChangesReason(baseline); got != ChangesReasonAllCriticalStartedAtCreation {
-		t.Fatalf("IssueChangesReason(baseline) = %q, want %q", got, ChangesReasonAllCriticalStartedAtCreation)
+	if got, want := IssueChangesReason(baseline), "recent_changes_with_all_critical_issues_at_creation"; got != want {
+		t.Fatalf("IssueChangesReason(baseline) = %q, want %q", got, want)
 	}
 	runtime := []issuesapi.Issue{{Severity: issuesapi.SeverityCritical, IssueTiming: "started_after_resource_was_healthy"}}
 	if ShouldAttachIssueChanges(runtime) {
@@ -38,6 +38,10 @@ func TestShouldAttachIssueChanges(t *testing.T) {
 	}
 	if got := IssueChangesReason(runtime); got != "" {
 		t.Fatalf("IssueChangesReason(runtime) = %q, want empty", got)
+	}
+	mixed := append(append([]issuesapi.Issue{}, baseline...), runtime...)
+	if got := IssueChangesReason(mixed); got != "" {
+		t.Fatalf("IssueChangesReason(mixed) = %q, want empty", got)
 	}
 	unknown := []issuesapi.Issue{{Severity: issuesapi.SeverityCritical}}
 	if ShouldAttachIssueChanges(unknown) {

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -52,6 +52,25 @@ func TestShouldAttachIssueChanges(t *testing.T) {
 	}
 }
 
+// The creation-timing collision is the exact spot where the old dismissive
+// token steered agents away from the change feed; the guidance must ride that
+// reason and no other, and must steer without claiming causation.
+func TestIssueChangesGuidance(t *testing.T) {
+	guidance := IssueChangesGuidance(ChangesReasonWithAllCreationTimeCriticalIssues)
+	if !strings.Contains(guidance, "does not clear the changes") || !strings.Contains(guidance, "Review the changes") {
+		t.Fatalf("collision-reason guidance must steer toward the feed, got %q", guidance)
+	}
+	if strings.Contains(strings.ToLower(guidance), "caused the") {
+		t.Fatalf("guidance must not claim causation, got %q", guidance)
+	}
+	if got := IssueChangesGuidance(ChangesReasonNoCriticalIssues); got != "" {
+		t.Fatalf("no_critical_issues carries no landmine and needs no guidance, got %q", got)
+	}
+	if got := IssueChangesGuidance(""); got != "" {
+		t.Fatalf("empty reason must yield empty guidance, got %q", got)
+	}
+}
+
 func TestIssueChangesQueryEligible(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -57,11 +57,18 @@ func TestShouldAttachIssueChanges(t *testing.T) {
 // reason and no other, and must steer without claiming causation.
 func TestIssueChangesGuidance(t *testing.T) {
 	guidance := IssueChangesGuidance(ChangesReasonWithAllCreationTimeCriticalIssues)
-	if !strings.Contains(guidance, "does not clear the changes") || !strings.Contains(guidance, "Review the changes") {
+	if !strings.Contains(guidance, "does not clear the listed changes") || !strings.Contains(guidance, "Review the changes") {
 		t.Fatalf("collision-reason guidance must steer toward the feed, got %q", guidance)
 	}
 	if strings.Contains(strings.ToLower(guidance), "caused the") {
 		t.Fatalf("guidance must not claim causation, got %q", guidance)
+	}
+	// The timing classification is per-resource ("failing since creation"); it
+	// establishes no ordering against the change feed, so the prose must never
+	// claim the issues predate the changes — a resource created after a bad
+	// change fails from creation because of that change.
+	if strings.Contains(strings.ToLower(guidance), "predate") {
+		t.Fatalf("guidance must not claim an issue-vs-change ordering, got %q", guidance)
 	}
 	if got := IssueChangesGuidance(ChangesReasonNoCriticalIssues); got != "" {
 		t.Fatalf("no_critical_issues carries no landmine and needs no guidance, got %q", got)

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -117,6 +117,7 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 			}); err == nil && len(changes) > 0 {
 				resp.RecentChanges = changes
 				resp.RecentChangesReason = recentChangesReason
+				resp.RecentChangesGuidance = meaningfulchanges.IssueChangesGuidance(recentChangesReason)
 				resp.RecentChangesTruncated = truncated
 			}
 		}

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -109,7 +109,7 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 	})
 	if len(namespaces) == 1 && stats.TotalMatched == len(out) && meaningfulchanges.IssueChangesQueryEligible(q.Get("kind"), q.Get("filter"), q.Get("severity")) {
 		if recentChangesReason := meaningfulchanges.IssueChangesReason(out); recentChangesReason != "" {
-			if changes, _, err := meaningfulchanges.Recent(r.Context(), meaningfulchanges.Query{
+			if changes, truncated, err := meaningfulchanges.Recent(r.Context(), meaningfulchanges.Query{
 				Namespaces: []string{namespaces[0]},
 				Since:      meaningfulchanges.DefaultSince,
 				Limit:      meaningfulchanges.IssueChangesLimit,
@@ -117,6 +117,7 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 			}); err == nil && len(changes) > 0 {
 				resp.RecentChanges = changes
 				resp.RecentChangesReason = recentChangesReason
+				resp.RecentChangesTruncated = truncated
 			}
 		}
 	}

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -439,7 +439,9 @@ type Response struct {
 	RecentChanges       []RecentChange  `json:"recent_changes,omitempty"`
 	RecentChangesReason string          `json:"recent_changes_reason,omitempty"`
 	// A missing change under truncation is unknown, not evidence that no
-	// relevant change occurred in the lookback window.
+	// relevant change occurred in the lookback window. False only vouches for
+	// the lookback window itself: changes older than the window are out of
+	// scope either way, not implied absent.
 	RecentChangesTruncated bool `json:"recent_changes_truncated,omitempty"`
 	// CorrelationTruncated is set when per-issue change correlation skipped
 	// some critical or warning issues (shared cap reached; criticals are

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -438,6 +438,9 @@ type Response struct {
 	ClusterContext      *ClusterContext `json:"cluster_context,omitempty"`
 	RecentChanges       []RecentChange  `json:"recent_changes,omitempty"`
 	RecentChangesReason string          `json:"recent_changes_reason,omitempty"`
+	// A missing change under truncation is unknown, not evidence that no
+	// relevant change occurred in the lookback window.
+	RecentChangesTruncated bool `json:"recent_changes_truncated,omitempty"`
 	// CorrelationTruncated is set when per-issue change correlation skipped
 	// some critical or warning issues (shared cap reached; criticals are
 	// checked first). Under truncation, an issue without correlation markers

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -438,6 +438,10 @@ type Response struct {
 	ClusterContext      *ClusterContext `json:"cluster_context,omitempty"`
 	RecentChanges       []RecentChange  `json:"recent_changes,omitempty"`
 	RecentChangesReason string          `json:"recent_changes_reason,omitempty"`
+	// Agent-facing steer accompanying reasons whose timing evidence could be
+	// misread as "the changes are irrelevant" — advice on how to treat the
+	// feed, never a causal claim about any specific change.
+	RecentChangesGuidance string `json:"recent_changes_guidance,omitempty"`
 	// A missing change under truncation is unknown, not evidence that no
 	// relevant change occurred in the lookback window. False only vouches for
 	// the lookback window itself: changes older than the window are out of

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -438,6 +438,7 @@ export interface IssuesResponse {
   total_matched?: number
   recent_changes?: IssueRecentChange[]
   recent_changes_reason?: string
+  recent_changes_guidance?: string
   recent_changes_truncated?: boolean
   // Present only when RBAC visibility is incomplete (absent = full access).
   // state 'degraded' means core workload reads are denied, so an empty list may

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -438,6 +438,7 @@ export interface IssuesResponse {
   total_matched?: number
   recent_changes?: IssueRecentChange[]
   recent_changes_reason?: string
+  recent_changes_truncated?: boolean
   // Present only when RBAC visibility is incomplete (absent = full access).
   // state 'degraded' means core workload reads are denied, so an empty list may
   // mean "can't see" rather than "nothing broken" — the UI must say so.


### PR DESCRIPTION
## Summary

- replace the dismissive creation-time change-feed reason with a neutral token that preserves the actual universal timing invariant
- make the MCP `issues` contract explicitly require inspecting recent changes without claiming they are causal or irrelevant
- expose `recent_changes_truncated` through the shared REST/MCP response so capped or saturated feeds cannot be mistaken for complete windows
- pin the public wire tokens and MCP documentation with tests

## Product decisions

- No salience classifier: with the reason token unconditionally neutral, nothing needs to rank changes as relevant/irrelevant; a category-based salience gate (`spec_config` lumps routine rollouts and HPA edits together) would add a judgment surface without a consumer.
- No synthetic issue row: direct consumers that are degraded already produce a health issue with correlated change evidence; healthy consumers should remain advisory.
- No inferred feature-flag attribution: Radar keeps the existing structured ConfigMap consumer edges and does not guess application dependencies from names.
- No separate meta-nudge: the change feed is already embedded in `issues`; the tool contract is the appropriate place to correct interpretation.

## Validation

- `go test ./internal/meaningfulchanges ./internal/mcp ./internal/server`
- `go build ./...`
- `(cd pkg && go build ./...)`
- `go test ./internal/mcp/... ./internal/k8s/... ./internal/issues/...`
- `make backend`
- `make test`
- `make tsc`
- `make build`
- captured benchmark payloads inspected for the missing-env and feature-flag scenarios

Visual and live-cluster testing were skipped because this changes response semantics and tool guidance, not rendering, detector behavior, or cluster interaction. A cluster run cannot validate model interpretation of the response contract.

## Residual limitations

- The response framing cannot force an anchored agent to inspect the feed; it removes the misleading steer and documents the intended use.
- Indirect feature-flag-to-service attribution still requires a structured dependency or telemetry signal.
- `recent_changes_truncated=true` reports incompleteness but does not paginate; consumers should narrow with `get_changes`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Response semantics and agent-facing documentation only; no auth, persistence, or detector logic changes.
> 
> **Overview**
> **Issues responses and MCP guidance** now treat the embedded change feed as something to **inspect before** concluding the listed issues explain a symptom, instead of optional context when issues look insufficient.
> 
> The creation-time **`recent_changes_reason`** token is renamed to **`recent_changes_with_all_critical_issues_at_creation`** (replacing `all_critical_issues_started_at_resource_creation`) so it describes timing evidence only—not that changes are irrelevant. **`IssueChangesGuidance`** adds response-level prose for that reason, steering review of the feed without claiming causation.
> 
> **`recent_changes_truncated`** and **`recent_changes_guidance`** are wired through shared **`issues.ListResponse`**, REST **`/api/issues`**, MCP **`issues`**, and the web **`IssuesResponse`** type. MCP **`issues`** tool description documents the new tokens and truncation semantics.
> 
> Tests pin the public reason strings, guidance behavior, and MCP documentation for **`recent_changes_truncated`** / **`recent_changes_guidance`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac485d58c90fd1f4b49113f97f95391ea57eb2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->