### PR TITLE
Improve structured ConfigMap value diffs

### DIFF
--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -1159,9 +1159,8 @@ func structuredConfigValueDiff(key, oldVal, newVal string) ([]FieldChange, bool)
 		return nil, false
 	}
 	state := structuredDiffState{
-		fieldCap:     configMapStructuredFieldCap,
-		nodeCap:      configMapStructuredNodeCap,
-		redactValues: isDotEnvConfigKey(key),
+		fieldCap: configMapStructuredFieldCap,
+		nodeCap:  configMapStructuredNodeCap,
 	}
 	state.diff(fmt.Sprintf("data.%s", key), oldParsed, newParsed, 0)
 	if state.capped {
@@ -1250,6 +1249,11 @@ func isPropertiesConfigKey(key string) bool {
 
 func isDotEnvConfigKey(key string) bool {
 	lower := strings.ToLower(strings.TrimSpace(key))
+	// A structured extension wins: app.env.yaml / app.env.json are YAML/JSON
+	// overlay files that happen to contain ".env.", not dotenv content.
+	if strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".json") {
+		return false
+	}
 	return lower == ".env" || strings.HasPrefix(lower, ".env.") ||
 		strings.HasSuffix(lower, ".env") || strings.Contains(lower, ".env.")
 }
@@ -1329,13 +1333,12 @@ func normalizeStructuredValue(v any) any {
 }
 
 type structuredDiffState struct {
-	changes      []FieldChange
-	fields       int
-	nodes        int
-	fieldCap     int
-	nodeCap      int
-	redactValues bool
-	capped       bool
+	changes  []FieldChange
+	fields   int
+	nodes    int
+	fieldCap int
+	nodeCap  int
+	capped   bool
 }
 
 func (s *structuredDiffState) diff(path string, oldVal, newVal any, depth int) {
@@ -1393,22 +1396,16 @@ func (s *structuredDiffState) add(path string, oldVal, newVal any) {
 		return
 	}
 	s.fields++
-	var oldValue, newValue any
-	if s.redactValues {
-		oldValue = redactPresentConfigValue(oldVal)
-		newValue = redactPresentConfigValue(newVal)
-	} else {
-		oldValue = sanitizeConfigValue(path, oldVal)
-		newValue = sanitizeConfigValue(path, newVal)
-	}
-	s.changes = append(s.changes, FieldChange{Path: path, OldValue: oldValue, NewValue: newValue})
-}
-
-func redactPresentConfigValue(value any) any {
-	if value == nil {
-		return nil
-	}
-	return "[REDACTED]"
+	// Dotenv keys get no special blanket redaction: like workload env vars,
+	// sensitive names ([REDACTED] via sensitivePath) and secret-shaped values
+	// (RedactSecrets) are masked, while a changed LOG_LEVEL stays readable —
+	// hiding every value would discard the diagnostic delta this diff exists
+	// to surface.
+	s.changes = append(s.changes, FieldChange{
+		Path:     path,
+		OldValue: sanitizeConfigValue(path, oldVal),
+		NewValue: sanitizeConfigValue(path, newVal),
+	})
 }
 
 func sanitizeConfigValue(path string, value any) any {

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"reflect"
 	"sort"
@@ -21,7 +22,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/yaml"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Type aliases — canonical definitions live in pkg/k8score.
@@ -978,7 +979,8 @@ func diffConfigMap(oldObj, newObj any) ([]FieldChange, []string) {
 	var changes []FieldChange
 	var summary []string
 
-	// Check data keys (not values for security)
+	// Parseable structured values are path- and pattern-redacted before
+	// emission; all other values remain key-only.
 	oldKeys := getMapKeys(oldCM.Data)
 	newKeys := getMapKeys(newCM.Data)
 
@@ -1151,12 +1153,16 @@ func structuredConfigValueDiff(key, oldVal, newVal string) ([]FieldChange, bool)
 	if !shouldParseStructuredConfigValue(key, oldVal, newVal) {
 		return nil, false
 	}
-	oldParsed, okOld := parseStructuredConfigValue(oldVal)
-	newParsed, okNew := parseStructuredConfigValue(newVal)
+	oldParsed, okOld := parseStructuredConfigValue(key, oldVal)
+	newParsed, okNew := parseStructuredConfigValue(key, newVal)
 	if !okOld || !okNew {
 		return nil, false
 	}
-	state := structuredDiffState{fieldCap: configMapStructuredFieldCap, nodeCap: configMapStructuredNodeCap}
+	state := structuredDiffState{
+		fieldCap:     configMapStructuredFieldCap,
+		nodeCap:      configMapStructuredNodeCap,
+		redactValues: isDotEnvConfigKey(key),
+	}
 	state.diff(fmt.Sprintf("data.%s", key), oldParsed, newParsed, 0)
 	if state.capped {
 		return nil, false
@@ -1166,7 +1172,7 @@ func structuredConfigValueDiff(key, oldVal, newVal string) ([]FieldChange, bool)
 
 func shouldParseStructuredConfigValue(key, oldVal, newVal string) bool {
 	lowerKey := strings.ToLower(strings.TrimSpace(key))
-	if strings.HasSuffix(lowerKey, ".json") || strings.HasSuffix(lowerKey, ".yaml") || strings.HasSuffix(lowerKey, ".yml") {
+	if strings.HasSuffix(lowerKey, ".json") || strings.HasSuffix(lowerKey, ".yaml") || strings.HasSuffix(lowerKey, ".yml") || isPropertiesConfigKey(lowerKey) {
 		return true
 	}
 	return looksLikeStructuredConfigValue(oldVal) && looksLikeStructuredConfigValue(newVal)
@@ -1174,22 +1180,118 @@ func shouldParseStructuredConfigValue(key, oldVal, newVal string) bool {
 
 func looksLikeStructuredConfigValue(value string) bool {
 	trimmed := strings.TrimSpace(value)
-	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return true
+	}
+
+	// A block threshold avoids common one-line prose; structuredRoot remains
+	// the fail-closed guard after YAML parsing.
+	significantLines := 0
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		significantLines++
+		if significantLines >= 2 {
+			return true
+		}
+	}
+	return false
 }
 
-func parseStructuredConfigValue(value string) (any, bool) {
+func parseStructuredConfigValue(key, value string) (any, bool) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return nil, false
+	}
+	if isPropertiesConfigKey(key) {
+		if parsed, ok := parsePropertiesConfigValue(trimmed); ok {
+			return parsed, true
+		}
 	}
 	var parsed any
 	if json.Unmarshal([]byte(trimmed), &parsed) == nil && structuredRoot(parsed) {
 		return normalizeStructuredValue(parsed), true
 	}
-	if yaml.Unmarshal([]byte(trimmed), &parsed) == nil && structuredRoot(parsed) {
-		return normalizeStructuredValue(parsed), true
+	// YAML parsers may accept a leading flow collection while ignoring trailing
+	// format-specific text, so bracketed values must be valid JSON.
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return nil, false
+	}
+	if parsed, ok := parseSingleStructuredYAML(trimmed); ok {
+		return parsed, true
 	}
 	return nil, false
+}
+
+func parseSingleStructuredYAML(value string) (any, bool) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(value), 4096)
+	var parsed any
+	if err := decoder.Decode(&parsed); err != nil || !structuredRoot(parsed) {
+		return nil, false
+	}
+	for {
+		var extra any
+		err := decoder.Decode(&extra)
+		if err == io.EOF {
+			return normalizeStructuredValue(parsed), true
+		}
+		if err != nil || extra != nil {
+			return nil, false
+		}
+	}
+}
+
+func isPropertiesConfigKey(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	return strings.HasSuffix(lower, ".properties") || isDotEnvConfigKey(lower)
+}
+
+func isDotEnvConfigKey(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	return lower == ".env" || strings.HasPrefix(lower, ".env.") ||
+		strings.HasSuffix(lower, ".env") || strings.Contains(lower, ".env.")
+}
+
+func parsePropertiesConfigValue(value string) (any, bool) {
+	parsed := map[string]any{}
+	for _, rawLine := range strings.Split(value, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#!") || strings.HasSuffix(line, "\\") {
+			return nil, false
+		}
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		if !ok || !validPropertiesKey(key) {
+			return nil, false
+		}
+		if _, duplicate := parsed[key]; duplicate {
+			return nil, false
+		}
+		parsed[key] = strings.TrimSpace(val)
+	}
+	return parsed, len(parsed) > 0
+}
+
+func validPropertiesKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, ch := range key {
+		if ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' ||
+			ch == '_' || ch == '-' || ch == '.' || ch == '/' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func structuredRoot(value any) bool {
@@ -1227,12 +1329,13 @@ func normalizeStructuredValue(v any) any {
 }
 
 type structuredDiffState struct {
-	changes  []FieldChange
-	fields   int
-	nodes    int
-	fieldCap int
-	nodeCap  int
-	capped   bool
+	changes      []FieldChange
+	fields       int
+	nodes        int
+	fieldCap     int
+	nodeCap      int
+	redactValues bool
+	capped       bool
 }
 
 func (s *structuredDiffState) diff(path string, oldVal, newVal any, depth int) {
@@ -1290,11 +1393,22 @@ func (s *structuredDiffState) add(path string, oldVal, newVal any) {
 		return
 	}
 	s.fields++
-	s.changes = append(s.changes, FieldChange{
-		Path:     path,
-		OldValue: sanitizeConfigValue(path, oldVal),
-		NewValue: sanitizeConfigValue(path, newVal),
-	})
+	var oldValue, newValue any
+	if s.redactValues {
+		oldValue = redactPresentConfigValue(oldVal)
+		newValue = redactPresentConfigValue(newVal)
+	} else {
+		oldValue = sanitizeConfigValue(path, oldVal)
+		newValue = sanitizeConfigValue(path, newVal)
+	}
+	s.changes = append(s.changes, FieldChange{Path: path, OldValue: oldValue, NewValue: newValue})
+}
+
+func redactPresentConfigValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return "[REDACTED]"
 }
 
 func sanitizeConfigValue(path string, value any) any {
@@ -1327,12 +1441,40 @@ func sensitivePath(path string) bool {
 	if aicontext.IsSensitiveEnvName(path) {
 		return true
 	}
-	for _, part := range strings.FieldsFunc(path, func(r rune) bool { return r == '.' || r == '[' || r == ']' || r == '/' || r == '-' || r == '_' }) {
-		if aicontext.IsSensitiveEnvName(part) {
+	parts := strings.FieldsFunc(path, func(r rune) bool { return r == '.' || r == '[' || r == ']' || r == '/' || r == '-' || r == '_' })
+	for i, part := range parts {
+		if aicontext.IsSensitiveEnvName(part) || sensitiveConfigPathPart(parts, i) {
 			return true
 		}
 	}
 	return false
+}
+
+func sensitiveConfigPathPart(parts []string, index int) bool {
+	part := strings.ToLower(parts[index])
+	switch part {
+	case "pass", "pw", "pwd", "cred", "creds":
+		return true
+	case "key":
+		if index > 0 && sensitiveConfigKeyQualifier(parts[index-1]) {
+			return true
+		}
+	}
+	for _, suffix := range []string{"pass", "pwd", "pw", "key"} {
+		if qualifier, ok := strings.CutSuffix(part, suffix); ok && qualifier != "" && sensitiveConfigKeyQualifier(qualifier) {
+			return true
+		}
+	}
+	return false
+}
+
+func sensitiveConfigKeyQualifier(part string) bool {
+	switch strings.ToLower(part) {
+	case "access", "admin", "api", "auth", "client", "database", "db", "encryption", "hmac", "license", "master", "mongo", "mongodb", "mysql", "pg", "postgres", "postgresql", "private", "redis", "secret", "signing", "smtp", "ssh", "stripe", "tls", "user":
+		return true
+	default:
+		return false
+	}
 }
 
 func truncateConfigScalar(value string, max int) string {

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -1132,7 +1132,7 @@ func diffConfigMapModifiedKeys(oldData, newData map[string]string, keys []string
 	var fallback []string
 	for _, key := range keys {
 		structured, ok := structuredConfigValueDiff(key, oldData[key], newData[key])
-		if !ok || len(structured) == 0 {
+		if !ok || len(structured) == 0 || len(changes)+len(structured) > configMapStructuredFieldCap {
 			fallback = append(fallback, key)
 			continue
 		}
@@ -1159,8 +1159,9 @@ func structuredConfigValueDiff(key, oldVal, newVal string) ([]FieldChange, bool)
 		return nil, false
 	}
 	state := structuredDiffState{
-		fieldCap: configMapStructuredFieldCap,
-		nodeCap:  configMapStructuredNodeCap,
+		fieldCap:     configMapStructuredFieldCap,
+		nodeCap:      configMapStructuredNodeCap,
+		redactValues: isPropertiesConfigKey(key),
 	}
 	state.diff(fmt.Sprintf("data.%s", key), oldParsed, newParsed, 0)
 	if state.capped {
@@ -1333,12 +1334,13 @@ func normalizeStructuredValue(v any) any {
 }
 
 type structuredDiffState struct {
-	changes  []FieldChange
-	fields   int
-	nodes    int
-	fieldCap int
-	nodeCap  int
-	capped   bool
+	changes      []FieldChange
+	fields       int
+	nodes        int
+	fieldCap     int
+	nodeCap      int
+	redactValues bool
+	capped       bool
 }
 
 func (s *structuredDiffState) diff(path string, oldVal, newVal any, depth int) {
@@ -1376,7 +1378,7 @@ func (s *structuredDiffState) diff(path string, oldVal, newVal any, depth int) {
 	newSlice, newIsSlice := newVal.([]any)
 	if oldIsSlice && newIsSlice {
 		if len(oldSlice) != len(newSlice) {
-			s.add(path, oldVal, newVal)
+			s.add(path, oldVal, newVal, depth)
 			return
 		}
 		for i := range oldSlice {
@@ -1386,29 +1388,48 @@ func (s *structuredDiffState) diff(path string, oldVal, newVal any, depth int) {
 	}
 
 	if !reflect.DeepEqual(oldVal, newVal) {
-		s.add(path, oldVal, newVal)
+		s.add(path, oldVal, newVal, depth)
 	}
 }
 
-func (s *structuredDiffState) add(path string, oldVal, newVal any) {
+func (s *structuredDiffState) add(path string, oldVal, newVal any, depth int) {
 	if s.fields >= s.fieldCap {
 		s.capped = true
 		return
 	}
 	s.fields++
-	// Dotenv keys get no special blanket redaction: like workload env vars,
-	// sensitive names ([REDACTED] via sensitivePath) and secret-shaped values
-	// (RedactSecrets) are masked, while a changed LOG_LEVEL stays readable —
-	// hiding every value would discard the diagnostic delta this diff exists
-	// to surface.
+	if s.redactValues {
+		oldVal = redactPresentConfigValue(oldVal)
+		newVal = redactPresentConfigValue(newVal)
+	}
+	oldSanitized := s.sanitizeConfigValue(path, oldVal, depth)
+	newSanitized := s.sanitizeConfigValue(path, newVal, depth)
+	if s.capped {
+		return
+	}
 	s.changes = append(s.changes, FieldChange{
 		Path:     path,
-		OldValue: sanitizeConfigValue(path, oldVal),
-		NewValue: sanitizeConfigValue(path, newVal),
+		OldValue: oldSanitized,
+		NewValue: newSanitized,
 	})
 }
 
-func sanitizeConfigValue(path string, value any) any {
+func redactPresentConfigValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return "[REDACTED]"
+}
+
+func (s *structuredDiffState) sanitizeConfigValue(path string, value any, depth int) any {
+	if s.capped {
+		return nil
+	}
+	s.nodes++
+	if s.nodes > s.nodeCap || depth > configMapStructuredDepthCap {
+		s.capped = true
+		return nil
+	}
 	if sensitivePath(path) {
 		return "[REDACTED]"
 	}
@@ -1418,13 +1439,18 @@ func sanitizeConfigValue(path string, value any) any {
 	case map[string]any:
 		out := make(map[string]any, len(typed))
 		for k, child := range typed {
-			out[k] = sanitizeConfigValue(path+"."+k, child)
+			if s.fields >= s.fieldCap {
+				s.capped = true
+				return nil
+			}
+			s.fields++
+			out[k] = s.sanitizeConfigValue(path+"."+k, child, depth+1)
 		}
 		return out
 	case []any:
 		out := make([]any, len(typed))
 		for i, child := range typed {
-			out[i] = sanitizeConfigValue(fmt.Sprintf("%s[%d]", path, i), child)
+			out[i] = s.sanitizeConfigValue(fmt.Sprintf("%s[%d]", path, i), child, depth+1)
 		}
 		return out
 	case nil:
@@ -1450,8 +1476,10 @@ func sensitivePath(path string) bool {
 func sensitiveConfigPathPart(parts []string, index int) bool {
 	part := strings.ToLower(parts[index])
 	switch part {
-	case "pass", "pw", "pwd", "cred", "creds":
+	case "pass", "pw", "pwd", "passphrase", "cred", "creds":
 		return true
+	case "auth", "dsn", "webhook":
+		return terminalConfigPathPart(parts, index)
 	case "key":
 		if index > 0 && sensitiveConfigKeyQualifier(parts[index-1]) {
 			return true
@@ -1465,9 +1493,23 @@ func sensitiveConfigPathPart(parts []string, index int) bool {
 	return false
 }
 
+func terminalConfigPathPart(parts []string, index int) bool {
+	for _, part := range parts[index+1:] {
+		if part == "" {
+			return false
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func sensitiveConfigKeyQualifier(part string) bool {
 	switch strings.ToLower(part) {
-	case "access", "admin", "api", "auth", "client", "database", "db", "encryption", "hmac", "license", "master", "mongo", "mongodb", "mysql", "pg", "postgres", "postgresql", "private", "redis", "secret", "signing", "smtp", "ssh", "stripe", "tls", "user":
+	case "access", "admin", "api", "app", "auth", "client", "database", "db", "encryption", "hmac", "jwt", "license", "master", "mongo", "mongodb", "mysql", "pg", "postgres", "postgresql", "private", "redis", "secret", "signing", "smtp", "ssh", "stripe", "tls", "user":
 		return true
 	default:
 		return false
@@ -3354,6 +3396,7 @@ func getModifiedKeys(old, new map[string]string) []string {
 			modified = append(modified, k)
 		}
 	}
+	sort.Strings(modified)
 	return modified
 }
 

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -793,7 +793,10 @@ func TestComputeDiff_ConfigMapPropertiesFormats(t *testing.T) {
 	}
 }
 
-func TestComputeDiff_ConfigMapDotEnvRedactsAllValues(t *testing.T) {
+// Dotenv values follow the same discipline as workload env vars: sensitive
+// names redact, everything else stays readable — a changed MODE is exactly the
+// delta this diff exists to surface.
+func TestComputeDiff_ConfigMapDotEnvRedactsSensitiveNamesOnly(t *testing.T) {
 	old := &corev1.ConfigMap{Data: map[string]string{
 		".env": "MODE=old\nDB_PASS=hunter2hunter2",
 	}}
@@ -804,14 +807,36 @@ func TestComputeDiff_ConfigMapDotEnvRedactsAllValues(t *testing.T) {
 	if diff == nil {
 		t.Fatal("ComputeDiff returned nil")
 	}
-	for _, path := range []string{"data..env.MODE", "data..env.DB_PASS"} {
-		change, ok := findChangePath(diff.Fields, path)
-		if !ok {
-			t.Fatalf("expected dotenv change at %q, got %+v", path, diff.Fields)
-		}
-		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
-			t.Fatalf("dotenv value at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
-		}
+	mode, ok := findChangePath(diff.Fields, "data..env.MODE")
+	if !ok || mode.OldValue != "old" || mode.NewValue != "new" {
+		t.Fatalf("non-sensitive dotenv value must stay readable: %+v", diff.Fields)
+	}
+	pass, ok := findChangePath(diff.Fields, "data..env.DB_PASS")
+	if !ok {
+		t.Fatalf("expected dotenv change at data..env.DB_PASS, got %+v", diff.Fields)
+	}
+	if pass.OldValue != "[REDACTED]" || pass.NewValue != "[REDACTED]" {
+		t.Fatalf("sensitive dotenv name was not redacted: %#v -> %#v", pass.OldValue, pass.NewValue)
+	}
+}
+
+// A structured extension beats the dotenv name fragment: app.env.yaml is a
+// YAML overlay whose values must stay visible under normal path/pattern
+// redaction, not be blanket-blanked as dotenv.
+func TestComputeDiff_ConfigMapEnvNamedYAMLKeepsValues(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app.env.yaml": "log:\n  level: info\nnet:\n  port: 8080",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app.env.yaml": "log:\n  level: debug\nnet:\n  port: 8080",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	change, ok := findChangePath(diff.Fields, "data.app.env.yaml.log.level")
+	if !ok || change.OldValue != "info" || change.NewValue != "debug" {
+		t.Fatalf("env-named YAML overlay lost its readable field delta: %+v", diff.Fields)
 	}
 }
 

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -10,6 +10,9 @@ package k8s
 //      the regression.
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -638,24 +641,363 @@ func TestComputeDiff_ConfigMapStructuredJSONByContent(t *testing.T) {
 	}
 }
 
-func TestComputeDiff_ConfigMapYAMLRequiresStructuredKey(t *testing.T) {
+func TestComputeDiff_ConfigMapStructuredYAMLByContent(t *testing.T) {
 	old := &corev1.ConfigMap{Data: map[string]string{
-		"plain": "enabled: false\n",
+		"mongod.conf": "net:\n  tls:\n    mode: disabled\n",
 	}}
 	updated := &corev1.ConfigMap{Data: map[string]string{
-		"plain": "enabled: true\n",
+		"mongod.conf": "net:\n  tls:\n    mode: requireTLS\n    certificateKeyFile: /certs/server.pem\n",
 	}}
 
 	diff := ComputeDiff("ConfigMap", old, updated)
 	if diff == nil {
-		t.Fatalf("ComputeDiff returned nil")
+		t.Fatal("ComputeDiff returned nil")
 	}
-	if diffHasPath(diff, "data.plain.enabled") {
-		t.Fatalf("unexpected structured YAML diff for untyped key, got %+v", diff.Fields)
+	for _, path := range []string{
+		"data.mongod.conf.net.tls.mode",
+		"data.mongod.conf.net.tls.certificateKeyFile",
+	} {
+		if !diffHasPath(diff, path) {
+			t.Errorf("expected structured YAML path %q, got %+v", path, diff.Fields)
+		}
 	}
-	if !diffHasPath(diff, "data (modified keys)") {
-		t.Fatalf("expected key-level fallback diff, got %+v", diff.Fields)
+	if diffHasPath(diff, "data (modified keys)") {
+		t.Fatalf("unexpected key-only fallback for structured YAML: %+v", diff.Fields)
 	}
+}
+
+func TestComputeDiff_ConfigMapMultiDocumentYAMLFallsBack(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "a: 1\n---\nb: 2\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "a: 9\n---\nb: 8\n",
+	}}
+	assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "app-config")
+}
+
+func TestComputeDiff_ConfigMapBracketedPlainConfigFallsBack(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"fluent-bit.conf": "[INPUT]\n  Name tail\n  Path /a.log\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"fluent-bit.conf": "[FILTER]\n  Name grep\n  Regex log err\n",
+	}}
+	assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "fluent-bit.conf")
+}
+
+func TestComputeDiff_ConfigMapOneLineTextFallsBack(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		oldVal string
+		newVal string
+	}{
+		{name: "plain text", oldVal: "hello world", newVal: "goodbye world"},
+		{name: "colon prose", oldVal: "Note: old", newVal: "Note: new"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := &corev1.ConfigMap{Data: map[string]string{"plain": tc.oldVal}}
+			updated := &corev1.ConfigMap{Data: map[string]string{"plain": tc.newVal}}
+			assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "plain")
+		})
+	}
+}
+
+func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    string
+		oldVal string
+		newVal string
+		path   string
+	}{
+		{
+			name:   "yaml",
+			key:    "database.conf",
+			oldVal: "database:\n  connection: postgres://user:oldpass@db.example/app\n",
+			newVal: "database:\n  connection: postgres://user:newpass@db.example/app\n",
+			path:   "data.database.conf.database.connection",
+		},
+		{
+			name:   "json",
+			key:    "database.json",
+			oldVal: `{"database":{"connection":"postgres://user:oldpass@db.example/app"}}`,
+			newVal: `{"database":{"connection":"postgres://user:newpass@db.example/app"}}`,
+			path:   "data.database.json.database.connection",
+		},
+		{
+			name:   "properties",
+			key:    "application.properties",
+			oldVal: "database.url=postgres://user:oldpass@db.example/app",
+			newVal: "database.url=postgres://user:newpass@db.example/app",
+			path:   "data.application.properties.database.url",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.oldVal}}
+			updated := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.newVal}}
+			diff := ComputeDiff("ConfigMap", old, updated)
+			if diff == nil {
+				t.Fatal("ComputeDiff returned nil")
+			}
+			change, ok := findChangePath(diff.Fields, tc.path)
+			if !ok {
+				t.Fatalf("expected credential URL change at %q, got %+v", tc.path, diff.Fields)
+			}
+			want := "postgres://user:[REDACTED]@db.example/app"
+			if change.OldValue != want || change.NewValue != want {
+				t.Fatalf("credential URL redaction = %#v -> %#v, want %q", change.OldValue, change.NewValue, want)
+			}
+		})
+	}
+}
+
+func TestComputeDiff_ConfigMapPropertiesFormats(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    string
+		oldVal string
+		newVal string
+		path   string
+	}{
+		{
+			name:   "single property",
+			key:    "application.properties",
+			oldVal: "mode=old",
+			newVal: "mode=new",
+			path:   "data.application.properties.mode",
+		},
+		{
+			name:   "dotenv",
+			key:    ".env.production",
+			oldVal: "MODE=old\nREGION=us-east-1",
+			newVal: "MODE=new\nREGION=us-east-1",
+			path:   "data..env.production.MODE",
+		},
+		{
+			name:   "colon in property value",
+			key:    "application.properties",
+			oldVal: "DESCRIPTION=Service: legacy\nOWNER=team: payments",
+			newVal: "DESCRIPTION=Service: billing\nOWNER=team: payments",
+			path:   "data.application.properties.DESCRIPTION",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.oldVal}}
+			updated := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.newVal}}
+			diff := ComputeDiff("ConfigMap", old, updated)
+			if diff == nil || !diffHasPath(diff, tc.path) {
+				t.Fatalf("expected properties diff at %q, got %+v", tc.path, diff)
+			}
+		})
+	}
+}
+
+func TestComputeDiff_ConfigMapDotEnvRedactsAllValues(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		".env": "MODE=old\nDB_PASS=hunter2hunter2",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		".env": "MODE=new\nDB_PASS=s3cr3ts3cr3t",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for _, path := range []string{"data..env.MODE", "data..env.DB_PASS"} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected dotenv change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("dotenv value at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapPropertiesRedactsSensitiveAliases(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"application.properties": "db.pass=old-password\nencryption.key=old-key",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"application.properties": "db.pass=new-password\nencryption.key=new-key",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for _, path := range []string{
+		"data.application.properties.db.pass",
+		"data.application.properties.encryption.key",
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected properties change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("sensitive property at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapPropertiesKeepsNonSecretKeys(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"application.properties": "cache_key=old-cache\nauth_mode=optional",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"application.properties": "cache_key=new-cache\nauth_mode=required",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for path, want := range map[string][2]string{
+		"data.application.properties.cache_key": {"old-cache", "new-cache"},
+		"data.application.properties.auth_mode": {"optional", "required"},
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected properties change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != want[0] || change.NewValue != want[1] {
+			t.Fatalf("properties value at %q = %#v -> %#v, want %q -> %q", path, change.OldValue, change.NewValue, want[0], want[1])
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapYAMLRedactsCompactSecretNames(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "dbpass: old-db\nadminpwd: old-admin\nlicensekey: old-license\nsmtppw: old-smtp\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "dbpass: new-db\nadminpwd: new-admin\nlicensekey: new-license\nsmtppw: new-smtp\n",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for _, field := range []string{"dbpass", "adminpwd", "licensekey", "smtppw"} {
+		path := "data.app-config." + field
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected YAML change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("compact secret at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapYAMLKeepsNonSecretSuffixes(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "compass: north\nbypass: disabled\nturkey: wild\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app-config": "compass: south\nbypass: enabled\nturkey: domestic\n",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for path, want := range map[string][2]string{
+		"data.app-config.compass": {"north", "south"},
+		"data.app-config.bypass":  {"disabled", "enabled"},
+		"data.app-config.turkey":  {"wild", "domestic"},
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected YAML change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != want[0] || change.NewValue != want[1] {
+			t.Fatalf("YAML value at %q = %#v -> %#v, want %q -> %q", path, change.OldValue, change.NewValue, want[0], want[1])
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapPropertiesFalsePositivesFallBack(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    string
+		oldVal string
+		newVal string
+	}{
+		{name: "shell script", key: ".env", oldVal: "#!/bin/sh\nFOO=old", newVal: "#!/bin/sh\nFOO=new"},
+		{name: "export syntax", key: ".env", oldVal: "export FOO=old", newVal: "export FOO=new"},
+		{name: "sql", key: "query.properties", oldVal: "select * from users = old", newVal: "select * from users = new"},
+		{name: "prose", key: "notes.properties", oldVal: "this is prose = old", newVal: "this is prose = new"},
+		{name: "ini deferred", key: "server.ini", oldVal: "[server]\nport=80", newVal: "[server]\nport=81"},
+		{name: "toml deferred", key: "server.toml", oldVal: "title = old\n[server]", newVal: "title = new\n[server]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.oldVal}}
+			updated := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.newVal}}
+			assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", tc.key)
+		})
+	}
+}
+
+func TestComputeDiff_ConfigMapStructuredCapsFallBack(t *testing.T) {
+	t.Run("value bytes", func(t *testing.T) {
+		oldVal := `{"payload":"` + strings.Repeat("a", configMapStructuredValueBytes) + `"}`
+		newVal := `{"payload":"` + strings.Repeat("b", configMapStructuredValueBytes) + `"}`
+		old := &corev1.ConfigMap{Data: map[string]string{"large.json": oldVal}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"large.json": newVal}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "large.json")
+	})
+
+	t.Run("field count", func(t *testing.T) {
+		oldFields := make(map[string]string, configMapStructuredFieldCap+1)
+		newFields := make(map[string]string, configMapStructuredFieldCap+1)
+		for i := 0; i <= configMapStructuredFieldCap; i++ {
+			key := fmt.Sprintf("field-%02d", i)
+			oldFields[key] = "old"
+			newFields[key] = "new"
+		}
+		oldVal, err := json.Marshal(oldFields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newVal, err := json.Marshal(newFields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"wide.json": string(oldVal)}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"wide.json": string(newVal)}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "wide.json")
+	})
+
+	t.Run("node count", func(t *testing.T) {
+		oldItems := make([]string, configMapStructuredNodeCap+1)
+		newItems := make([]string, configMapStructuredNodeCap+1)
+		for i := range oldItems {
+			oldItems[i] = "same"
+			newItems[i] = "same"
+		}
+		newItems[len(newItems)-1] = "changed"
+		oldVal, err := json.Marshal(map[string]any{"items": oldItems})
+		if err != nil {
+			t.Fatal(err)
+		}
+		newVal, err := json.Marshal(map[string]any{"items": newItems})
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"large-tree.json": string(oldVal)}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"large-tree.json": string(newVal)}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "large-tree.json")
+	})
+
+	t.Run("depth", func(t *testing.T) {
+		oldVal := `"old"`
+		newVal := `"new"`
+		for range configMapStructuredDepthCap + 1 {
+			oldVal = `{"nested":` + oldVal + `}`
+			newVal = `{"nested":` + newVal + `}`
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"deep.json": oldVal}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"deep.json": newVal}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "deep.json")
+	})
 }
 
 func TestComputeDiff_ConfigMapBinaryData_ReportsModifiedKeyOnly(t *testing.T) {

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -12,6 +12,7 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -710,6 +711,7 @@ func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T)
 		oldVal string
 		newVal string
 		path   string
+		want   string
 	}{
 		{
 			name:   "yaml",
@@ -717,6 +719,7 @@ func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T)
 			oldVal: "database:\n  connection: postgres://user:oldpass@db.example/app\n",
 			newVal: "database:\n  connection: postgres://user:newpass@db.example/app\n",
 			path:   "data.database.conf.database.connection",
+			want:   "postgres://user:[REDACTED]@db.example/app",
 		},
 		{
 			name:   "json",
@@ -724,6 +727,7 @@ func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T)
 			oldVal: `{"database":{"connection":"postgres://user:oldpass@db.example/app"}}`,
 			newVal: `{"database":{"connection":"postgres://user:newpass@db.example/app"}}`,
 			path:   "data.database.json.database.connection",
+			want:   "postgres://user:[REDACTED]@db.example/app",
 		},
 		{
 			name:   "properties",
@@ -731,6 +735,7 @@ func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T)
 			oldVal: "database.url=postgres://user:oldpass@db.example/app",
 			newVal: "database.url=postgres://user:newpass@db.example/app",
 			path:   "data.application.properties.database.url",
+			want:   "[REDACTED]",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -744,9 +749,8 @@ func TestComputeDiff_ConfigMapStructuredValuesRedactCredentialURLs(t *testing.T)
 			if !ok {
 				t.Fatalf("expected credential URL change at %q, got %+v", tc.path, diff.Fields)
 			}
-			want := "postgres://user:[REDACTED]@db.example/app"
-			if change.OldValue != want || change.NewValue != want {
-				t.Fatalf("credential URL redaction = %#v -> %#v, want %q", change.OldValue, change.NewValue, want)
+			if change.OldValue != tc.want || change.NewValue != tc.want {
+				t.Fatalf("credential URL redaction = %#v -> %#v, want %q", change.OldValue, change.NewValue, tc.want)
 			}
 		})
 	}
@@ -793,50 +797,63 @@ func TestComputeDiff_ConfigMapPropertiesFormats(t *testing.T) {
 	}
 }
 
-// Dotenv values follow the same discipline as workload env vars: sensitive
-// names redact, everything else stays readable — a changed MODE is exactly the
-// delta this diff exists to surface.
-func TestComputeDiff_ConfigMapDotEnvRedactsSensitiveNamesOnly(t *testing.T) {
+func TestComputeDiff_ConfigMapDotEnvRedactsAllValues(t *testing.T) {
 	old := &corev1.ConfigMap{Data: map[string]string{
-		".env": "MODE=old\nDB_PASS=hunter2hunter2",
+		".env": "MODE=old\nDB_PASS=hunter2hunter2\nSENDGRID_KEY=old-vendor-secret\nREMOVED=old-value",
 	}}
 	updated := &corev1.ConfigMap{Data: map[string]string{
-		".env": "MODE=new\nDB_PASS=s3cr3ts3cr3t",
+		".env": "MODE=new\nDB_PASS=s3cr3ts3cr3t\nSENDGRID_KEY=new-vendor-secret\nADDED=new-value",
 	}}
 	diff := ComputeDiff("ConfigMap", old, updated)
 	if diff == nil {
 		t.Fatal("ComputeDiff returned nil")
 	}
 	mode, ok := findChangePath(diff.Fields, "data..env.MODE")
-	if !ok || mode.OldValue != "old" || mode.NewValue != "new" {
-		t.Fatalf("non-sensitive dotenv value must stay readable: %+v", diff.Fields)
+	if !ok || mode.OldValue != "[REDACTED]" || mode.NewValue != "[REDACTED]" {
+		t.Fatalf("dotenv value was not redacted: %+v", diff.Fields)
 	}
-	pass, ok := findChangePath(diff.Fields, "data..env.DB_PASS")
-	if !ok {
-		t.Fatalf("expected dotenv change at data..env.DB_PASS, got %+v", diff.Fields)
+	for _, path := range []string{"data..env.DB_PASS", "data..env.SENDGRID_KEY"} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected dotenv change at %s, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("dotenv value at %s was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
 	}
-	if pass.OldValue != "[REDACTED]" || pass.NewValue != "[REDACTED]" {
-		t.Fatalf("sensitive dotenv name was not redacted: %#v -> %#v", pass.OldValue, pass.NewValue)
+	removed, ok := findChangePath(diff.Fields, "data..env.REMOVED")
+	if !ok || removed.OldValue != "[REDACTED]" || removed.NewValue != nil {
+		t.Fatalf("removed dotenv value was not safely represented: %+v", diff.Fields)
+	}
+	added, ok := findChangePath(diff.Fields, "data..env.ADDED")
+	if !ok || added.OldValue != nil || added.NewValue != "[REDACTED]" {
+		t.Fatalf("added dotenv value was not safely represented: %+v", diff.Fields)
 	}
 }
 
-// A structured extension beats the dotenv name fragment: app.env.yaml is a
-// YAML overlay whose values must stay visible under normal path/pattern
-// redaction, not be blanket-blanked as dotenv.
-func TestComputeDiff_ConfigMapEnvNamedYAMLKeepsValues(t *testing.T) {
-	old := &corev1.ConfigMap{Data: map[string]string{
-		"app.env.yaml": "log:\n  level: info\nnet:\n  port: 8080",
-	}}
-	updated := &corev1.ConfigMap{Data: map[string]string{
-		"app.env.yaml": "log:\n  level: debug\nnet:\n  port: 8080",
-	}}
-	diff := ComputeDiff("ConfigMap", old, updated)
-	if diff == nil {
-		t.Fatal("ComputeDiff returned nil")
-	}
-	change, ok := findChangePath(diff.Fields, "data.app.env.yaml.log.level")
-	if !ok || change.OldValue != "info" || change.NewValue != "debug" {
-		t.Fatalf("env-named YAML overlay lost its readable field delta: %+v", diff.Fields)
+func TestComputeDiff_ConfigMapEnvNamedStructuredFilesKeepValues(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    string
+		oldVal string
+		newVal string
+		path   string
+	}{
+		{name: "yaml", key: "app.env.yaml", oldVal: "log:\n  level: info\nnet:\n  port: 8080", newVal: "log:\n  level: debug\nnet:\n  port: 8080", path: "data.app.env.yaml.log.level"},
+		{name: "json", key: "app.env.json", oldVal: `{"log":{"level":"info"}}`, newVal: `{"log":{"level":"debug"}}`, path: "data.app.env.json.log.level"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.oldVal}}
+			updated := &corev1.ConfigMap{Data: map[string]string{tc.key: tc.newVal}}
+			diff := ComputeDiff("ConfigMap", old, updated)
+			if diff == nil {
+				t.Fatal("ComputeDiff returned nil")
+			}
+			change, ok := findChangePath(diff.Fields, tc.path)
+			if !ok || change.OldValue != "info" || change.NewValue != "debug" {
+				t.Fatalf("env-named structured file lost its readable field delta: %+v", diff.Fields)
+			}
+		})
 	}
 }
 
@@ -865,7 +882,7 @@ func TestComputeDiff_ConfigMapPropertiesRedactsSensitiveAliases(t *testing.T) {
 	}
 }
 
-func TestComputeDiff_ConfigMapPropertiesKeepsNonSecretKeys(t *testing.T) {
+func TestComputeDiff_ConfigMapPropertiesRedactsAllValues(t *testing.T) {
 	old := &corev1.ConfigMap{Data: map[string]string{
 		"application.properties": "cache_key=old-cache\nauth_mode=optional",
 	}}
@@ -876,16 +893,16 @@ func TestComputeDiff_ConfigMapPropertiesKeepsNonSecretKeys(t *testing.T) {
 	if diff == nil {
 		t.Fatal("ComputeDiff returned nil")
 	}
-	for path, want := range map[string][2]string{
-		"data.application.properties.cache_key": {"old-cache", "new-cache"},
-		"data.application.properties.auth_mode": {"optional", "required"},
+	for _, path := range []string{
+		"data.application.properties.cache_key",
+		"data.application.properties.auth_mode",
 	} {
 		change, ok := findChangePath(diff.Fields, path)
 		if !ok {
 			t.Fatalf("expected properties change at %q, got %+v", path, diff.Fields)
 		}
-		if change.OldValue != want[0] || change.NewValue != want[1] {
-			t.Fatalf("properties value at %q = %#v -> %#v, want %q -> %q", path, change.OldValue, change.NewValue, want[0], want[1])
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("properties value at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
 		}
 	}
 }
@@ -909,6 +926,67 @@ func TestComputeDiff_ConfigMapYAMLRedactsCompactSecretNames(t *testing.T) {
 		}
 		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
 			t.Fatalf("compact secret at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapYAMLRedactsStructuredSecretAliases(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app.yaml": "keystore:\n  passphrase: old-passphrase\njwt:\n  key: old-jwt\nsentry_dsn: old-dsn\nslack_webhook: old-hook\ndatadog:\n  app_key: old-app-key\ntwilio_auth: old-auth\nauth_mode: optional\ncache_key: old-cache\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app.yaml": "keystore:\n  passphrase: new-passphrase\njwt:\n  key: new-jwt\nsentry_dsn: new-dsn\nslack_webhook: new-hook\ndatadog:\n  app_key: new-app-key\ntwilio_auth: new-auth\nauth_mode: required\ncache_key: new-cache\n",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for _, path := range []string{
+		"data.app.yaml.keystore.passphrase",
+		"data.app.yaml.jwt.key",
+		"data.app.yaml.sentry_dsn",
+		"data.app.yaml.slack_webhook",
+		"data.app.yaml.datadog.app_key",
+		"data.app.yaml.twilio_auth",
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok {
+			t.Fatalf("expected YAML change at %q, got %+v", path, diff.Fields)
+		}
+		if change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("structured secret at %q was not redacted: %#v -> %#v", path, change.OldValue, change.NewValue)
+		}
+	}
+	for path, want := range map[string][2]string{
+		"data.app.yaml.auth_mode": {"optional", "required"},
+		"data.app.yaml.cache_key": {"old-cache", "new-cache"},
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok || change.OldValue != want[0] || change.NewValue != want[1] {
+			t.Fatalf("non-secret YAML value at %q was over-redacted: %+v", path, diff.Fields)
+		}
+	}
+}
+
+func TestComputeDiff_ConfigMapYAMLRedactsSecretArrays(t *testing.T) {
+	old := &corev1.ConfigMap{Data: map[string]string{
+		"app.yaml": "receivers:\n  webhook:\n    - old-hook\n  dsn:\n    - old-dsn\n  auth:\n    - old-auth\n",
+	}}
+	updated := &corev1.ConfigMap{Data: map[string]string{
+		"app.yaml": "receivers:\n  webhook:\n    - new-hook\n  dsn:\n    - new-dsn\n  auth:\n    - new-auth\n",
+	}}
+	diff := ComputeDiff("ConfigMap", old, updated)
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	for _, path := range []string{
+		"data.app.yaml.receivers.webhook[0]",
+		"data.app.yaml.receivers.dsn[0]",
+		"data.app.yaml.receivers.auth[0]",
+	} {
+		change, ok := findChangePath(diff.Fields, path)
+		if !ok || change.OldValue != "[REDACTED]" || change.NewValue != "[REDACTED]" {
+			t.Fatalf("secret array value at %q was not redacted: %+v", path, diff.Fields)
 		}
 	}
 }
@@ -1023,6 +1101,88 @@ func TestComputeDiff_ConfigMapStructuredCapsFallBack(t *testing.T) {
 		updated := &corev1.ConfigMap{Data: map[string]string{"deep.json": newVal}}
 		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "deep.json")
 	})
+
+	t.Run("added subtree field count", func(t *testing.T) {
+		added := make(map[string]any, configMapStructuredFieldCap+1)
+		for i := 0; i <= configMapStructuredFieldCap; i++ {
+			added[fmt.Sprintf("field-%02d", i)] = "value"
+		}
+		oldVal := `{"stable":true}`
+		newVal, err := json.Marshal(map[string]any{"stable": true, "added": added})
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"added-wide.json": oldVal}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"added-wide.json": string(newVal)}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "added-wide.json")
+	})
+
+	t.Run("added subtree node count", func(t *testing.T) {
+		oldVal := `{"stable":true}`
+		newVal, err := json.Marshal(map[string]any{"stable": true, "added": make([]string, configMapStructuredNodeCap+1)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"added-large-tree.json": oldVal}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"added-large-tree.json": string(newVal)}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "added-large-tree.json")
+	})
+
+	t.Run("added subtree depth", func(t *testing.T) {
+		added := any("value")
+		for range configMapStructuredDepthCap + 1 {
+			added = map[string]any{"nested": added}
+		}
+		oldVal := `{"stable":true}`
+		newVal, err := json.Marshal(map[string]any{"stable": true, "added": added})
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := &corev1.ConfigMap{Data: map[string]string{"added-deep.json": oldVal}}
+		updated := &corev1.ConfigMap{Data: map[string]string{"added-deep.json": string(newVal)}}
+		assertKeyOnlyDiff(t, ComputeDiff("ConfigMap", old, updated), "data (modified keys)", "added-deep.json")
+	})
+}
+
+func TestComputeDiff_ConfigMapStructuredFieldCapSpansModifiedKeys(t *testing.T) {
+	oldData := map[string]string{}
+	newData := map[string]string{}
+	for _, configKey := range []string{"a.json", "b.json"} {
+		oldFields := make(map[string]string, 30)
+		newFields := make(map[string]string, 30)
+		for i := range 30 {
+			field := fmt.Sprintf("field-%02d", i)
+			oldFields[field] = "old"
+			newFields[field] = "new"
+		}
+		oldVal, err := json.Marshal(oldFields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newVal, err := json.Marshal(newFields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldData[configKey] = string(oldVal)
+		newData[configKey] = string(newVal)
+	}
+
+	diff := ComputeDiff("ConfigMap", &corev1.ConfigMap{Data: oldData}, &corev1.ConfigMap{Data: newData})
+	if diff == nil {
+		t.Fatal("ComputeDiff returned nil")
+	}
+	if len(diff.Fields) > configMapStructuredFieldCap+1 {
+		t.Fatalf("aggregate structured field cap exceeded: %d fields", len(diff.Fields))
+	}
+	fallback, ok := findChangePath(diff.Fields, "data (modified keys)")
+	if !ok || !reflect.DeepEqual(fallback.OldValue, []string{"b.json"}) || !reflect.DeepEqual(fallback.NewValue, []string{"b.json"}) {
+		t.Fatalf("expected the over-budget key to fall back, got %+v", diff.Fields)
+	}
+	for _, field := range diff.Fields {
+		if strings.HasPrefix(field.Path, "data.b.json.") {
+			t.Fatalf("over-budget key also emitted a structured field: %+v", field)
+		}
+	}
 }
 
 func TestComputeDiff_ConfigMapBinaryData_ReportsModifiedKeyOnly(t *testing.T) {
@@ -1071,6 +1231,9 @@ func assertKeyOnlyDiff(t *testing.T, diff *DiffInfo, path, key string) {
 	t.Helper()
 	if diff == nil {
 		t.Fatal("ComputeDiff returned nil")
+	}
+	if len(diff.Fields) != 1 {
+		t.Fatalf("expected exactly one key-only field for %q, got %+v", key, diff.Fields)
 	}
 	for _, field := range diff.Fields {
 		if field.Path != path {

--- a/pkg/ai/context/redact.go
+++ b/pkg/ai/context/redact.go
@@ -20,6 +20,8 @@ var highConfidenceSecretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\$(?:apr1|2[aby]|5|6)\$[./A-Za-z0-9$]{8,}`), // htpasswd/crypt hashes (basicAuth users)
 }
 
+var credentialURLPattern = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://[^:/@\s]*:)[^/\s?#]+@`)
+
 // base64SecretPattern is a broad catch-all for base64 blobs. It earns its keep
 // in free-text (logs, env values) but over-redacts when applied to arbitrary
 // CRD fields (it eats SHA-like IDs, config hashes, generated names), so the
@@ -67,7 +69,21 @@ func IsSensitiveEnvName(name string) bool {
 }
 
 func applyPatterns(text string, patterns []*regexp.Regexp) string {
-	result := text
+	result := credentialURLPattern.ReplaceAllStringFunc(text, func(match string) string {
+		schemeEnd := strings.Index(match, "://")
+		if schemeEnd < 0 {
+			return match
+		}
+		scheme := strings.ToLower(match[:schemeEnd])
+		if scheme == "docker" || scheme == "docker-pullable" || scheme == "oci" {
+			return match
+		}
+		parts := credentialURLPattern.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		return parts[1] + "[REDACTED]@"
+	})
 	for _, pattern := range patterns {
 		result = pattern.ReplaceAllStringFunc(result, func(match string) string {
 			// For Bearer tokens, preserve the "Bearer " prefix

--- a/pkg/ai/context/redact.go
+++ b/pkg/ai/context/redact.go
@@ -20,16 +20,16 @@ var highConfidenceSecretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\$(?:apr1|2[aby]|5|6)\$[./A-Za-z0-9$]{8,}`), // htpasswd/crypt hashes (basicAuth users)
 }
 
-var credentialURLPattern = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://[^:/@\s]*:)[^/\s?#]+@`)
+var credentialURLPattern = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*)://([^:/@\s]*:)[^/\s?#]+@([A-Za-z0-9._~:%\[\]-]*)`)
+var sha256DigestPattern = regexp.MustCompile(`(?i)^sha256:[a-f0-9]{64}$`)
+var sha256DigestPrefixPattern = regexp.MustCompile(`(?i)(?:^|[^a-z0-9])sha256:$`)
+var containerIDSchemePrefixPattern = regexp.MustCompile(`(?i)\b(?:docker|containerd|cri-o):$`)
 
 // base64SecretPattern is a broad catch-all for base64 blobs. It earns its keep
 // in free-text (logs, env values) but over-redacts when applied to arbitrary
 // CRD fields (it eats SHA-like IDs, config hashes, generated names), so the
 // spec walker deliberately does NOT use it — see RedactInlineSecrets.
 var base64SecretPattern = regexp.MustCompile(`[A-Za-z0-9+/=]{50,}`)
-
-// secretPatterns is the full set used for free-text redaction (logs, env values).
-var secretPatterns = append(append([]*regexp.Regexp{}, highConfidenceSecretPatterns...), base64SecretPattern)
 
 // sensitiveValueKeys are exact key names (normalized: lowercased, '-'/'_'
 // stripped) whose string value is inline secret MATERIAL. Deliberately matched
@@ -59,6 +59,7 @@ func IsSensitiveEnvName(name string) bool {
 	lower := strings.ToLower(name)
 	compact := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(lower)
 	return strings.Contains(lower, "password") || strings.Contains(lower, "passwd") ||
+		strings.Contains(lower, "passphrase") ||
 		strings.Contains(lower, "token") || strings.Contains(lower, "secret") ||
 		strings.Contains(lower, "credential") ||
 		strings.Contains(lower, "api_key") || strings.Contains(lower, "apikey") ||
@@ -70,19 +71,15 @@ func IsSensitiveEnvName(name string) bool {
 
 func applyPatterns(text string, patterns []*regexp.Regexp) string {
 	result := credentialURLPattern.ReplaceAllStringFunc(text, func(match string) string {
-		schemeEnd := strings.Index(match, "://")
-		if schemeEnd < 0 {
-			return match
-		}
-		scheme := strings.ToLower(match[:schemeEnd])
-		if scheme == "docker" || scheme == "docker-pullable" || scheme == "oci" {
-			return match
-		}
 		parts := credentialURLPattern.FindStringSubmatch(match)
-		if len(parts) != 2 {
+		if len(parts) != 4 {
 			return match
 		}
-		return parts[1] + "[REDACTED]@"
+		scheme := strings.ToLower(parts[1])
+		if (scheme == "docker" || scheme == "docker-pullable" || scheme == "oci") && sha256DigestPattern.MatchString(parts[3]) {
+			return match
+		}
+		return parts[1] + "://" + parts[2] + "[REDACTED]@" + parts[3]
 	})
 	for _, pattern := range patterns {
 		result = pattern.ReplaceAllStringFunc(result, func(match string) string {
@@ -110,7 +107,37 @@ func RedactSecrets(text string) string {
 	if text == "" {
 		return text
 	}
-	return applyPatterns(text, secretPatterns)
+	return redactBase64Secrets(applyPatterns(text, highConfidenceSecretPatterns))
+}
+
+func redactBase64Secrets(text string) string {
+	matches := base64SecretPattern.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+
+	var result strings.Builder
+	last := 0
+	for _, match := range matches {
+		result.WriteString(text[last:match[0]])
+		value := text[match[0]:match[1]]
+		prefixStart := max(0, match[0]-12)
+		prefix := text[prefixStart:match[0]]
+		preserve := sha256DigestPattern.MatchString("sha256:"+value) &&
+			sha256DigestPrefixPattern.MatchString(prefix)
+		if strings.HasPrefix(value, "//") && sha256DigestPattern.MatchString("sha256:"+value[2:]) &&
+			containerIDSchemePrefixPattern.MatchString(prefix) {
+			preserve = true
+		}
+		if preserve {
+			result.WriteString(value)
+		} else {
+			result.WriteString("[REDACTED]")
+		}
+		last = match[1]
+	}
+	result.WriteString(text[last:])
+	return result.String()
 }
 
 // RedactInlineSecrets walks an unstructured subtree (a CRD's spec/status) in

--- a/pkg/ai/context/redact_test.go
+++ b/pkg/ai/context/redact_test.go
@@ -71,6 +71,43 @@ func TestRedactSecrets_SafeContent(t *testing.T) {
 	}
 }
 
+func TestRedactSecrets_CredentialURLs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "postgres", in: "postgres://user:pass@db.example/app?ssl=require", want: "postgres://user:[REDACTED]@db.example/app?ssl=require"},
+		{name: "empty username", in: "redis://:p@host", want: "redis://:[REDACTED]@host"},
+		{name: "compound scheme", in: "mongodb+srv://u:p@host", want: "mongodb+srv://u:[REDACTED]@host"},
+		{name: "percent encoded", in: "amqp://user:p%40ss@host", want: "amqp://user:[REDACTED]@host"},
+		{name: "colon in password", in: "mysql://user:p:a:ss@host/db", want: "mysql://user:[REDACTED]@host/db"},
+		{name: "unencoded at in password", in: "mongodb://user:p@ss@host/db", want: "mongodb://user:[REDACTED]@host/db"},
+		{name: "at in query", in: "postgres://user:pass@host?email=a@b", want: "postgres://user:[REDACTED]@host?email=a@b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RedactSecrets(tc.in); got != tc.want {
+				t.Fatalf("RedactSecrets(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactSecrets_PreservesURLsWithoutCredentials(t *testing.T) {
+	for _, input := range []string{
+		"https://api.example.com/v1",
+		"ssh://user@host/repo",
+		"git@github.com:org/repo",
+		"docker://nginx:1.21@sha256:0123456789abcdef",
+		"docker-pullable://nginx:1.21@sha256:0123456789abcdef",
+		"oci://registry.example/app:1.2@sha256:0123456789abcdef",
+	} {
+		if got := RedactSecrets(input); got != input {
+			t.Errorf("RedactSecrets(%q) = %q", input, got)
+		}
+	}
+}
+
 func TestRedactSecrets_EmptyString(t *testing.T) {
 	result := RedactSecrets("")
 	if result != "" {
@@ -153,6 +190,16 @@ func TestRedactInlineSecrets_HighConfidenceValueAnywhere(t *testing.T) {
 	RedactInlineSecrets(spec)
 	if strings.Contains(spec["address"].(string), "ghp_0123456789") {
 		t.Errorf("GitHub PAT in a non-sensitive field not redacted: %v", spec["address"])
+	}
+}
+
+func TestRedactInlineSecrets_CredentialURL(t *testing.T) {
+	spec := map[string]any{
+		"connection": "postgres://user:pass@db.example/app",
+	}
+	RedactInlineSecrets(spec)
+	if got := spec["connection"]; got != "postgres://user:[REDACTED]@db.example/app" {
+		t.Errorf("credential URL redaction = %q", got)
 	}
 }
 

--- a/pkg/ai/context/redact_test.go
+++ b/pkg/ai/context/redact_test.go
@@ -84,6 +84,14 @@ func TestRedactSecrets_CredentialURLs(t *testing.T) {
 		{name: "colon in password", in: "mysql://user:p:a:ss@host/db", want: "mysql://user:[REDACTED]@host/db"},
 		{name: "unencoded at in password", in: "mongodb://user:p@ss@host/db", want: "mongodb://user:[REDACTED]@host/db"},
 		{name: "at in query", in: "postgres://user:pass@host?email=a@b", want: "postgres://user:[REDACTED]@host?email=a@b"},
+		{name: "empty host path", in: "amqp://guest:secret@/vhost", want: "amqp://guest:[REDACTED]@/vhost"},
+		{name: "empty host query", in: "amqp://user:pass@?heartbeat=30", want: "amqp://user:[REDACTED]@?heartbeat=30"},
+		{name: "trailing at", in: "mysql://user:pass@", want: "mysql://user:[REDACTED]@"},
+		{name: "multiple JSON fields", in: `{"primary":"postgres://svc:p1@db1","replica":"postgres://svc:p2@db2"}`, want: `{"primary":"postgres://svc:[REDACTED]@db1","replica":"postgres://svc:[REDACTED]@db2"}`},
+		{name: "multiple comma separated", in: "https://u:p1@e1,https://u:p2@e2", want: "https://u:[REDACTED]@e1,https://u:[REDACTED]@e2"},
+		{name: "docker", in: "docker://user:pass@registry.example/repo", want: "docker://user:[REDACTED]@registry.example/repo"},
+		{name: "docker pullable", in: "docker-pullable://user:pass@registry.example/repo", want: "docker-pullable://user:[REDACTED]@registry.example/repo"},
+		{name: "oci", in: "oci://user:pass@registry.example/repo", want: "oci://user:[REDACTED]@registry.example/repo"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := RedactSecrets(tc.in); got != tc.want {
@@ -98,12 +106,29 @@ func TestRedactSecrets_PreservesURLsWithoutCredentials(t *testing.T) {
 		"https://api.example.com/v1",
 		"ssh://user@host/repo",
 		"git@github.com:org/repo",
-		"docker://nginx:1.21@sha256:0123456789abcdef",
-		"docker-pullable://nginx:1.21@sha256:0123456789abcdef",
-		"oci://registry.example/app:1.2@sha256:0123456789abcdef",
+		"docker://nginx:1.21@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"docker-pullable://nginx:1.21@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"oci://registry.example/app:1.2@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"docker.io/library/nginx@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"docker://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"containerd://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"cri-o://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	} {
 		if got := RedactSecrets(input); got != input {
 			t.Errorf("RedactSecrets(%q) = %q", input, got)
+		}
+	}
+}
+
+func TestRedactSecrets_DoesNotTreatUnanchoredHexAsDigest(t *testing.T) {
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	for input, want := range map[string]string{
+		hash:                "[REDACTED]",
+		"notsha256:" + hash: "notsha256:[REDACTED]",
+	} {
+		if got := RedactSecrets(input); got != want {
+			t.Errorf("RedactSecrets(%q) = %q, want %q", input, got, want)
 		}
 	}
 }
@@ -117,7 +142,7 @@ func TestRedactSecrets_EmptyString(t *testing.T) {
 
 func TestIsSensitiveEnvName(t *testing.T) {
 	for _, name := range []string{
-		"API_PASSWORD", "database-passwd", "AUTH_TOKEN", "client.secret",
+		"API_PASSWORD", "database-passwd", "KEY_PASSPHRASE", "AUTH_TOKEN", "client.secret",
 		"cloud_credential", "API_KEY", "AccessKey", "PRIVATE_KEY",
 	} {
 		if !IsSensitiveEnvName(name) {


### PR DESCRIPTION
## Summary

Make ConfigMap change-feed entries more diagnostic without turning configuration values into a secret-exposure path.

- Show field-level changes for JSON, YAML, extensionless multi-line structured YAML, `.properties`, and dotenv-style entries.
- Parse conservatively: require structured map/list roots, strict single-document YAML, all-lines-valid flat files, and deterministic size/depth/node/field budgets. Ambiguous or oversized content falls back to the existing key-only diff.
- Redact sensitive JSON/YAML paths and secret-shaped scalar values, including credential-bearing URLs and common nested/array aliases.
- For actual dotenv and `.properties` files, expose changed names but redact every present value. Files such as `app.env.yaml` and `app.env.json` are treated as structured YAML/JSON instead.
- Preserve explicit SHA-256 image digests and standard container IDs while masking passwords in Docker/OCI and ordinary credential URLs, including multiple URLs on one line.
- Keep Secrets value-free and leave INI, TOML, and other format-specific plain text on key-only fallback.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `make test`
- `(cd pkg && go test ./...)`
- `go test ./internal/k8s -run TestComputeDiff_ConfigMapStructuredFieldCapSpansModifiedKeys -count=50`
- `make build` (frontend typecheck/build/embed and backend build)

Visual testing was skipped because there is no UI change. Live-cluster testing was skipped because this is deterministic backend parsing, diffing, and redaction logic with no cluster-dependent behavior.