### PR TITLE
Fix diagnose copy claiming "runs locally" for hosted agents

### DIFF
--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -10,6 +10,7 @@ export interface AgentInfo {
   version: string;
   present: boolean;
   supported: boolean;
+  hosted?: boolean;
 }
 
 export interface AgentsResponse {

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -18,7 +18,15 @@ export interface AIDraft {
 // ClearHistoryRow is an immediate action (not part of the staged draft): a
 // two-step confirm button that wipes finished investigations from the local
 // history DB. Live investigations survive.
-function ClearHistoryRow({ onCleared }: { onCleared: () => void }) {
+function ClearHistoryRow({
+  hosted,
+  agentLabel,
+  onCleared,
+}: {
+  hosted: boolean;
+  agentLabel: string;
+  onCleared: () => void;
+}) {
   const [confirming, setConfirming] = useState(false);
   const [state, setState] = useState<"idle" | "busy" | "done" | "error">(
     "idle",
@@ -36,9 +44,15 @@ function ClearHistoryRow({ onCleared }: { onCleared: () => void }) {
   return (
     <div className="mt-3 flex items-center justify-between gap-2 border-t border-theme-border/60 pt-3">
       <p className="text-[11px] leading-snug text-theme-text-tertiary">
-        Investigation transcripts are kept on this machine (
-        <code className="font-mono">~/.radar</code>) so history survives
-        restarts.
+        {hosted ? (
+          `Investigation transcripts are stored by ${agentLabel} so history survives restarts.`
+        ) : (
+          <>
+            Investigation transcripts are kept on this machine (
+            <code className="font-mono">~/.radar</code>) so history survives
+            restarts.
+          </>
+        )}
         {state === "done" && (
           <span className="ml-1 font-medium text-theme-text-secondary">
             History cleared.
@@ -85,12 +99,16 @@ function ClearHistoryRow({ onCleared }: { onCleared: () => void }) {
 export function AISettingsSection({
   available,
   agents,
+  hosted,
+  agentLabel,
   draft,
   onChange,
   onHistoryCleared,
 }: {
   available: boolean;
   agents: AgentInfo[];
+  hosted: boolean;
+  agentLabel: string;
   draft: AIDraft;
   onChange: (patch: Partial<AIDraft>) => void;
   onHistoryCleared: () => void;
@@ -98,19 +116,32 @@ export function AISettingsSection({
   if (!available || agents.length === 0) return null;
   return (
     <>
-      <AgentControls
-        agents={agents}
-        selectedAgent={draft.agent}
-        // Model + effort are agent-specific; reset them when the agent changes.
-        onSelectAgent={(a) => onChange({ agent: a, model: "", effort: "" })}
-        isolated={draft.isolated}
-        onSetIsolated={(v) => onChange({ isolated: v })}
-        model={draft.model}
-        onSetModel={(v) => onChange({ model: v })}
-        effort={draft.effort}
-        onSetEffort={(v) => onChange({ effort: v })}
+      {hosted ? (
+        // The agent, its model, and how it runs are all fixed by the host — none
+        // of the local BYO-agent knobs apply, so there's nothing to configure.
+        <p className="text-xs leading-snug text-theme-text-tertiary">
+          {agentLabel} manages the model and how it runs — there&apos;s nothing to
+          configure here.
+        </p>
+      ) : (
+        <AgentControls
+          agents={agents}
+          selectedAgent={draft.agent}
+          // Model + effort are agent-specific; reset them when the agent changes.
+          onSelectAgent={(a) => onChange({ agent: a, model: "", effort: "" })}
+          isolated={draft.isolated}
+          onSetIsolated={(v) => onChange({ isolated: v })}
+          model={draft.model}
+          onSetModel={(v) => onChange({ model: v })}
+          effort={draft.effort}
+          onSetEffort={(v) => onChange({ effort: v })}
+        />
+      )}
+      <ClearHistoryRow
+        hosted={hosted}
+        agentLabel={agentLabel}
+        onCleared={onHistoryCleared}
       />
-      <ClearHistoryRow onCleared={onHistoryCleared} />
     </>
   );
 }

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -34,6 +34,7 @@ export type DiagnoseView = "home" | "investigation";
 interface DiagnoseCtx {
   available: boolean; // an agent CLI is present (button/entry gate)
   agentLabel: string; // label of the selected agent, e.g. "Claude Code"
+  hosted: boolean; // selected agent runs on the host's backend, not this machine
   agents: AgentInfo[]; // supported agents detected on PATH (for the picker)
   selectedAgent: string; // name of the chosen backend ("claude"/"codex")
   setSelectedAgent: (name: string) => void;
@@ -262,6 +263,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     selectedAgent,
     agents.find((a) => a.name === selectedAgent)?.label,
   );
+  const hosted = !!agents.find((a) => a.name === selectedAgent)?.hosted;
 
   useEffect(() => {
     const onResize = () => setViewportW(window.innerWidth);
@@ -434,6 +436,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const value: DiagnoseCtx = {
     available,
     agentLabel,
+    hosted,
     agents,
     selectedAgent,
     setSelectedAgent,

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -542,7 +542,9 @@ export function InvestigationView({
           <ResultCard
             diagnosis={turns[pinnedIdx].diagnosis!}
             onApply={
-              pinnedIdx === lastRemediationIdx && !stale ? requestApply : undefined
+              pinnedIdx === lastRemediationIdx && !stale && !hosted
+                ? requestApply
+                : undefined
             }
             onAsk={!busy && !stale ? askFollowup : undefined}
             reveal="full"

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -44,7 +44,19 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
-  const { refreshRuns, openInvestigation, startError, hosted } = useDiagnose();
+  const {
+    refreshRuns,
+    openInvestigation,
+    startError,
+    agents,
+    hosted: selectedHosted,
+  } = useDiagnose();
+  // Apply turns execute with the run's stored agent, not the picker's current
+  // selection — gate on the former (fall back to the selection for older runs
+  // that didn't record their agent).
+  const hosted = run.agent
+    ? !!agents.find((a) => a.name === run.agent)?.hosted
+    : selectedHosted;
   const retryDiagnosis = useCallback(
     () => openInvestigation({ kind, namespace, name }),
     [openInvestigation, kind, namespace, name],

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -44,19 +44,9 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
-  const {
-    refreshRuns,
-    openInvestigation,
-    startError,
-    agents,
-    hosted: selectedHosted,
-  } = useDiagnose();
-  // Apply turns execute with the run's stored agent, not the picker's current
-  // selection — gate on the former (fall back to the selection for older runs
-  // that didn't record their agent).
-  const hosted = run.agent
-    ? !!agents.find((a) => a.name === run.agent)?.hosted
-    : selectedHosted;
+  // Apply is off for hosted agents (read-only server-side). Keyed on the selected
+  // agent, which matches run.agent unless a deployment mixes hosted + local agents.
+  const { refreshRuns, openInvestigation, startError, hosted } = useDiagnose();
   const retryDiagnosis = useCallback(
     () => openInvestigation({ kind, namespace, name }),
     [openInvestigation, kind, namespace, name],

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -44,7 +44,7 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
-  const { refreshRuns, openInvestigation, startError } = useDiagnose();
+  const { refreshRuns, openInvestigation, startError, hosted } = useDiagnose();
   const retryDiagnosis = useCallback(
     () => openInvestigation({ kind, namespace, name }),
     [openInvestigation, kind, namespace, name],
@@ -498,7 +498,8 @@ export function InvestigationView({
             <RunContextCard run={run} />
             {turns.map((t, i) => {
               const isLast = i === turns.length - 1;
-              const canApply = i === lastRemediationIdx && !stale;
+              // Hosted runners are read-only — the server refuses apply turns.
+              const canApply = i === lastRemediationIdx && !stale && !hosted;
               const canCheck = isLast && t.status === "done" && !!t.apply;
               return (
                 <TurnView

--- a/web/src/components/diagnose/LocalDiagnoseAction.tsx
+++ b/web/src/components/diagnose/LocalDiagnoseAction.tsx
@@ -5,14 +5,15 @@ import type { RenderDiagnoseAction } from "../../context/DiagnoseCustomization";
 
 // The per-resource AI entry point. It no longer owns a panel — it just dispatches
 // to the single app-level AI surface (DiagnoseContext), opening a new investigation
-// for this resource. Self-hides when no agent CLI is present. A host like Radar Hub
-// overrides this slot with its own action.
+// for this resource. Self-hides when no agent CLI is present. Hosts can override
+// this slot with their own action.
 //
 // Adaptive by health: on a resource with a live problem it reads as a prominent
 // "Diagnose" (find the root cause); when the resource is fine or health is unknown
 // it shrinks to a quiet colored-icon affordance ("ask my agent about this") — so it
 // never implies "something is wrong here" on a healthy resource. The tooltip leads
-// with the BYO framing: this runs the user's OWN agent, locally.
+// with the BYO framing (the user's OWN agent, locally) — unless the agent is
+// hosted, where those claims would be false.
 function DiagnoseResourceButton({
   kind,
   namespace,
@@ -31,9 +32,13 @@ function DiagnoseResourceButton({
   const running = runningKeys.has(runTargetKey(kind, namespace, name));
   const tooltip = running
     ? `${d.agentLabel} is investigating this resource — click to watch it live.`
-    : problem
-      ? `Diagnose with your own ${d.agentLabel} — runs locally, reads this resource's spec, events & logs to find the root cause.`
-      : `Ask your own ${d.agentLabel} about this resource — runs locally, reads its spec, events & logs.`;
+    : d.hosted
+      ? problem
+        ? `Diagnose with ${d.agentLabel} — reads this resource's spec, events & logs to find the root cause.`
+        : `Ask ${d.agentLabel} about this resource — reads its spec, events & logs.`
+      : problem
+        ? `Diagnose with your own ${d.agentLabel} — runs locally, reads this resource's spec, events & logs to find the root cause.`
+        : `Ask your own ${d.agentLabel} about this resource — runs locally, reads its spec, events & logs.`;
   // While an investigation is live, the button advertises it (and clicking focuses
   // the existing run rather than starting a new one — openInvestigation dedups).
   const showLabel = problem || running;
@@ -95,7 +100,11 @@ export function IssueDiagnoseButton({
   if (!d.available) return null;
   return (
     <Tooltip
-      content={`Runs ${d.agentLabel} on your machine and sends it this resource's context to find the root cause`}
+      content={
+        d.hosted
+          ? `Sends this resource's context to ${d.agentLabel} to find the root cause`
+          : `Runs ${d.agentLabel} on your machine and sends it this resource's context to find the root cause`
+      }
       position="left"
     >
       <button
@@ -119,12 +128,15 @@ export function GlobalDiagnoseButton() {
   const { runningKeys } = useDiagnoseLayout();
   if (!d.available) return null;
   const runningCount = runningKeys.size;
+  const agentSuffix = d.hosted
+    ? `powered by ${d.agentLabel}`
+    : `runs your own ${d.agentLabel} locally`;
   return (
     <Tooltip
       content={
         runningCount > 0
-          ? `${runningCount} investigation${runningCount > 1 ? "s" : ""} running — runs your own ${d.agentLabel} locally`
-          : `AI investigations — runs your own ${d.agentLabel} locally`
+          ? `${runningCount} investigation${runningCount > 1 ? "s" : ""} running — ${agentSuffix}`
+          : `AI investigations — ${agentSuffix}`
       }
       position="bottom"
     >

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -517,8 +517,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
               <div className="mb-4">
                 <h3 className="text-base font-semibold text-theme-text-primary">AI diagnose</h3>
                 <p className="mt-0.5 text-xs text-theme-text-tertiary">
-                  Investigate incidents with an AI agent that runs on your own machine — reading
-                  logs, events, and topology to explain what's wrong. No Radar cloud, no API key.
+                  {diag.hosted
+                    ? `Investigate incidents with ${diag.agentLabel} — reading logs, events, and topology to explain what's wrong.`
+                    : "Investigate incidents with an AI agent that runs on your own machine — reading logs, events, and topology to explain what's wrong. No Radar cloud, no API key."}
                 </p>
               </div>
               {aiAvailable ? (
@@ -526,6 +527,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   <AISettingsSection
                     available={diag.available}
                     agents={diag.agents}
+                    hosted={diag.hosted}
+                    agentLabel={diag.agentLabel}
                     draft={aiDraft}
                     onChange={(patch) => {
                       setAiDraft((d) => ({ ...d, ...patch }))
@@ -533,21 +536,23 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                     }}
                     onHistoryCleared={diag.refreshRuns}
                   />
-                  <div className="flex items-center justify-end gap-3">
-                    {aiSaved && !aiDirty && (
-                      <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400/80">
-                        <Check className="w-3 h-3" />
-                        Saved
-                      </span>
-                    )}
-                    <button
-                      onClick={saveAi}
-                      disabled={!aiDirty}
-                      className="px-4 py-1.5 text-sm font-medium btn-brand rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      Save
-                    </button>
-                  </div>
+                  {!diag.hosted && (
+                    <div className="flex items-center justify-end gap-3">
+                      {aiSaved && !aiDirty && (
+                        <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400/80">
+                          <Check className="w-3 h-3" />
+                          Saved
+                        </span>
+                      )}
+                      <button
+                        onClick={saveAi}
+                        disabled={!aiDirty}
+                        className="px-4 py-1.5 text-sm font-medium btn-brand rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                      >
+                        Save
+                      </button>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <AIUnavailableNotice />


### PR DESCRIPTION
## Description

### Problem

  When a host advertises a hosted agent (Radar Hub returns `{name: "hub", label: "Radar Hub (cloud)"}` from `/diagnose/agents`), the diagnose entry points render nonsense claims:
  - Resource button: "Diagnose with **your own** Radar Hub (cloud) — **runs locally**, reads this resource's spec…"
  - Issues pane: "Runs Radar Hub (cloud) **on your machine** and sends it…"
  - Global button: "AI investigations — runs **your own** Radar Hub (cloud) **locally**"

  The copy is hardcoded to the OSS BYO-local-CLI framing regardless of what agent the backend advertises.
  
  ### Fix
  
  - `AgentInfo` gains optional `hosted: boolean` — the host's backend declares that the agent runs server-side, not on the user's machine.
  - `DiagnoseContext` exposes `hosted` for the selected agent.
  - All three tooltips branch on it (hosted → "Diagnose with X — reads this resource's spec…", no locality/ownership claims).
  - `InvestigationView` stops offering **Apply** when hosted — hosted diagnose is read-only server-side (apply turns 403), so the CTA could only error.

  ### Compatibility
  
  Flag absent/false → byte-identical behavior for standalone OSS.
  Radar Hub side: skyhook-dev/radar-hub adds `"hosted": true` to its agents payload (separate PR).



## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only branching on an optional API flag; OSS paths stay unchanged when `hosted` is not set.
> 
> **Overview**
> Adds optional **`hosted`** on **`AgentInfo`** (from `/agents`) and threads **`hosted`** through **`DiagnoseContext`** for the selected agent so the UI can tell server-side runners apart from local BYO CLIs.
> 
> **Copy** on resource, Issues, and global diagnose entry points no longer claims “your own,” “runs locally,” or “on your machine” when **`hosted`** is true; Settings and AI settings use hosted-appropriate descriptions (e.g. transcripts stored by the agent vs `~/.radar`).
> 
> **Hosted mode** hides local-only controls: **`AgentControls`** and the Settings **Save** row for AI prefs, and **Apply** in **`InvestigationView`** (hosted diagnose is read-only server-side).
> 
> When **`hosted`** is absent or false, behavior matches standalone OSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2c9b89766a64ea7ee6f847d2e33c2650142b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->