### PR TITLE
Rank crashloops by current serving state

### DIFF
--- a/internal/issues/crashloop_severity_integration_test.go
+++ b/internal/issues/crashloop_severity_integration_test.go
@@ -1,0 +1,127 @@
+package issues
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
+
+func TestCompose_CrashLoopCurrentStateControlsRankingAndGrouping(t *testing.T) {
+	defer k8s.ResetTestState()
+
+	now := time.Now()
+	controller := true
+	crashState := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+		Reason:     "Error",
+		ExitCode:   1,
+		FinishedAt: metav1.NewTime(now.Add(-time.Minute)),
+	}}
+	recovered := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "prod",
+				CreationTimestamp: metav1.NewTime(now.Add(-8 * time.Minute)),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "catalog-rs",
+					Controller: &controller,
+				}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:                 "app",
+					Ready:                true,
+					RestartCount:         2,
+					State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}},
+					LastTerminationState: crashState,
+				}},
+			},
+		}
+	}
+	down := recovered("down-now")
+	down.OwnerReferences = nil
+	down.Status.ContainerStatuses[0].Ready = false
+	down.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+	}
+
+	replicas := int32(2)
+	client := fake.NewClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: "prod"},
+			Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          2,
+				ReadyReplicas:     2,
+				AvailableReplicas: 2,
+				UpdatedReplicas:   2,
+			},
+		},
+		&appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+			Name:      "catalog-rs",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "catalog",
+				Controller: &controller,
+			}},
+		}},
+		recovered("catalog-a"),
+		recovered("catalog-b"),
+		down,
+	)
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	provider := &CacheProvider{cache: k8s.GetResourceCache()}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(provider.DetectProblems([]string{"prod"})) >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	got := Compose(provider, Filters{Namespaces: []string{"prod"}, Grouped: true, Limit: NoLimit})
+	if len(got) < 2 {
+		t.Fatalf("issues = %+v, want critical down row and grouped warning row", got)
+	}
+	if got[0].Name != "down-now" || got[0].Severity != SeverityCritical {
+		t.Fatalf("first issue = %+v, want currently-down crashloop ranked critical first", got[0])
+	}
+
+	var grouped *Issue
+	for i := range got {
+		if got[i].Category == issuesapi.CategoryCrashLoop && got[i].Name == "catalog" {
+			grouped = &got[i]
+			break
+		}
+	}
+	if grouped == nil {
+		t.Fatalf("issues = %+v, want catalog crashloop group", got)
+	}
+	if grouped.Severity != SeverityWarning || grouped.Count != 2 {
+		t.Fatalf("catalog group = %+v, want warning with two affected pods", *grouped)
+	}
+	if !strings.Contains(grouped.Cause, "is serving again") || strings.Contains(grouped.Cause, "is crashlooping") {
+		t.Fatalf("catalog group cause = %q, want serving recovery copy", grouped.Cause)
+	}
+
+	related := RelatedIssues(provider, []string{"prod"}, "", "Pod", "prod", "catalog-a")
+	if len(related) != 1 || related[0].Severity != SeverityWarning {
+		t.Fatalf("related issues for recovered pod = %+v, want its warning crashloop", related)
+	}
+}

--- a/internal/k8s/detect_crashloop_severity_test.go
+++ b/internal/k8s/detect_crashloop_severity_test.go
@@ -1,0 +1,168 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDetectProblems_CrashLoopSeverityTracksCurrentState(t *testing.T) {
+	defer ResetTestState()
+
+	now := time.Now()
+	controller := true
+	crash := func(finished time.Time) corev1.ContainerState {
+		return corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason:     "Error",
+			ExitCode:   1,
+			FinishedAt: metav1.NewTime(finished),
+		}}
+	}
+	runningCrashPod := func(name string, started time.Time, restarts int32) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "prod",
+				CreationTimestamp: metav1.NewTime(now.Add(-8 * time.Minute)),
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:                 "app",
+					Ready:                true,
+					RestartCount:         restarts,
+					State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(started)}},
+					LastTerminationState: crash(started.Add(-time.Second)),
+				}},
+			},
+		}
+	}
+
+	recoveredStartup := runningCrashPod("recovered-startup", now.Add(-time.Minute), 2)
+	recoveredStartup.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "catalog-rs",
+		Controller: &controller,
+	}}
+	highCountServing := runningCrashPod("high-count-serving", now.Add(-time.Minute), 40)
+	stable := runningCrashPod("stable", now.Add(-6*time.Minute), 2)
+	probeReady := runningCrashPod("probe-ready", now.Add(-time.Minute), 2)
+	probeReady.Spec.Containers = []corev1.Container{{Name: "app", ReadinessProbe: &corev1.Probe{}}}
+	imagePullSibling := runningCrashPod("image-pull-sibling", now.Add(-time.Minute), 2)
+	imagePullSibling.Status.ContainerStatuses = append(imagePullSibling.Status.ContainerStatuses, corev1.ContainerStatus{
+		Name:  "image",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+	})
+	oomSibling := runningCrashPod("oom-sibling", now.Add(-time.Minute), 2)
+	oomSibling.Status.ContainerStatuses = append(oomSibling.Status.ContainerStatuses, corev1.ContainerStatus{
+		Name: "memory",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason: "OOMKilled", ExitCode: 137,
+		}},
+	})
+	fatalInit := runningCrashPod("fatal-init", now.Add(-time.Minute), 2)
+	fatalInit.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "setup",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CreateContainerConfigError"}},
+	}}
+	downAtCreation := runningCrashPod("down-at-creation", now.Add(-time.Minute), 2)
+	downAtCreation.Status.ContainerStatuses[0].Ready = false
+	downAtCreation.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+	}
+	runtimeDown := downAtCreation.DeepCopy()
+	runtimeDown.Name = "runtime-down"
+	runtimeDown.CreationTimestamp = metav1.NewTime(now.Add(-2 * time.Hour))
+	stillStarting := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "still-starting",
+			Namespace:         "prod",
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "app",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+			}},
+		},
+	}
+
+	deployCreated := now.Add(-8 * time.Minute)
+	client := fake.NewClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:              "catalog",
+			Namespace:         "prod",
+			CreationTimestamp: metav1.NewTime(deployCreated),
+		}},
+		&appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+			Name:              "catalog-rs",
+			Namespace:         "prod",
+			CreationTimestamp: metav1.NewTime(deployCreated),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "catalog",
+				Controller: &controller,
+			}},
+		}},
+		recoveredStartup,
+		highCountServing,
+		stable,
+		probeReady,
+		imagePullSibling,
+		oomSibling,
+		fatalInit,
+		downAtCreation,
+		runtimeDown,
+		stillStarting,
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	var problems []Detection
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		problems = DetectProblems(GetResourceCache(), "prod")
+		if hasProblem(problems, "Pod", "recovered-startup", "CrashLoopBackOff") &&
+			hasProblem(problems, "Pod", "down-at-creation", "CrashLoopBackOff") &&
+			hasProblem(problems, "Pod", "image-pull-sibling", "ImagePullBackOff") &&
+			hasProblem(problems, "Pod", "oom-sibling", "OOMKilled") &&
+			hasProblem(problems, "Pod", "fatal-init", "CreateContainerConfigError") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	assertProblem(t, problems, "Pod", "recovered-startup", "CrashLoopBackOff", "high")
+	recovered, ok := lookupProblem(problems, "Pod", "recovered-startup", "CrashLoopBackOff")
+	if !ok || recovered.IssueTiming != "started_at_resource_creation" {
+		t.Fatalf("recovered startup issue = %+v, want warning with at-creation timing", recovered)
+	}
+	if !strings.Contains(recovered.Cause, "is serving again") || strings.Contains(recovered.Cause, "is crashlooping") {
+		t.Fatalf("recovered startup cause = %q, want serving recovery copy", recovered.Cause)
+	}
+	if !strings.Contains(recovered.Action, "Watch for another restart") {
+		t.Fatalf("recovered startup action = %q, want repeat-crash guidance", recovered.Action)
+	}
+	assertProblem(t, problems, "Pod", "high-count-serving", "CrashLoopBackOff", "high")
+	assertProblem(t, problems, "Pod", "down-at-creation", "CrashLoopBackOff", "critical")
+	assertProblem(t, problems, "Pod", "runtime-down", "CrashLoopBackOff", "critical")
+	assertProblem(t, problems, "Pod", "image-pull-sibling", "ImagePullBackOff", "critical")
+	assertProblem(t, problems, "Pod", "oom-sibling", "OOMKilled", "critical")
+	assertProblem(t, problems, "Pod", "fatal-init", "CreateContainerConfigError", "critical")
+
+	for _, name := range []string{"stable", "still-starting"} {
+		if _, ok := lookupProblem(problems, "Pod", name, "CrashLoopBackOff"); ok {
+			t.Errorf("%s unexpectedly emitted a crashloop problem: %+v", name, problems)
+		}
+	}
+	assertProblem(t, problems, "Pod", "probe-ready", "CrashLoopBackOff", "high")
+}

--- a/internal/mcp/crashloop_severity_test.go
+++ b/internal/mcp/crashloop_severity_test.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func TestBuildDashboard_CrashLoopCurrentStateControlsHealthBucket(t *testing.T) {
+	defer k8s.ResetTestState()
+
+	now := time.Now()
+	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+		Reason:     "Error",
+		ExitCode:   1,
+		FinishedAt: metav1.NewTime(now.Add(-time.Minute)),
+	}}
+	recovered := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "recovered", Namespace: "prod"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:                 "app",
+				Ready:                true,
+				RestartCount:         2,
+				State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}},
+				LastTerminationState: crash,
+			}},
+		},
+	}
+	down := recovered.DeepCopy()
+	down.Name = "down"
+	down.Status.ContainerStatuses[0].Ready = false
+	down.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+	}
+
+	if err := k8s.InitTestResourceCache(fake.NewClientset(recovered, down)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	var dashboard mcpDashboard
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dashboard = buildDashboard(context.Background(), k8s.GetResourceCache(), "prod", false, false)
+		if dashboard.ResourceCounts["pods"] == 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if dashboard.Health.WarningPods != 1 || dashboard.Health.ErrorPods != 1 {
+		t.Fatalf("health = %+v, want one warning recovered pod and one error down pod", dashboard.Health)
+	}
+	for _, problem := range dashboard.Problems {
+		if problem.Name == "recovered" && problem.Severity == "critical" {
+			t.Fatalf("recovered pod remained a critical MCP problem: %+v", problem)
+		}
+	}
+}

--- a/internal/mcp/tools_diagnose_crash_cause.go
+++ b/internal/mcp/tools_diagnose_crash_cause.go
@@ -41,6 +41,7 @@ const (
 type diagnoseCrashCause struct {
 	Pods      []string `json:"pods"`
 	Container string   `json:"container"`
+	State     string   `json:"state"`
 	Reason    string   `json:"reason,omitempty"`
 	ExitCode  int32    `json:"exitCode"`
 	LogLine   string   `json:"logLine"`
@@ -58,6 +59,7 @@ type diagnoseLogKey struct {
 
 type diagnoseCrashCauseKey struct {
 	container     string
+	state         string
 	reason        string
 	exitCode      int32
 	logLine       string
@@ -88,6 +90,10 @@ func crashCauseForDiagnose(pods []*corev1.Pod, current, previous []podLogEntry, 
 			continue
 		}
 		for _, status := range health.ActiveCrashLoopContainerStatuses(pod, now) {
+			state := "down"
+			if health.IsCrashLoopContainerServing(pod, status) {
+				state = "recovering"
+			}
 			term := status.LastTerminationState.Terminated
 			logs := previousByContainer[diagnoseLogKey{pod: pod.Name, container: status.Name}]
 			logSource := "previous"
@@ -111,6 +117,7 @@ func crashCauseForDiagnose(pods []*corev1.Pod, current, previous []podLogEntry, 
 			line = truncateCrashLogLine(line, maxCrashCauseRunes)
 			key := diagnoseCrashCauseKey{
 				container:     status.Name,
+				state:         state,
 				reason:        term.Reason,
 				exitCode:      term.ExitCode,
 				logLine:       line,
@@ -132,6 +139,7 @@ func crashCauseForDiagnose(pods []*corev1.Pod, current, previous []podLogEntry, 
 			cause := diagnoseCrashCause{
 				Pods:          []string{pod.Name},
 				Container:     status.Name,
+				State:         state,
 				Reason:        term.Reason,
 				ExitCode:      term.ExitCode,
 				LogLine:       line,

--- a/internal/mcp/tools_diagnose_crash_cause_test.go
+++ b/internal/mcp/tools_diagnose_crash_cause_test.go
@@ -38,6 +38,9 @@ func TestCrashCauseForDiagnoseSelectsAndDeduplicatesEvidence(t *testing.T) {
 	if cause.Container != "app" || cause.Reason != "Error" || cause.ExitCode != 1 {
 		t.Fatalf("status attribution = %+v, want app/Error/1", cause)
 	}
+	if cause.State != "down" {
+		t.Fatalf("state = %q, want down", cause.State)
+	}
 	if cause.LogLine != "panic: assignment to entry in nil map" || cause.LogSource != "previous" || cause.LineSelection != crashLineFatalPattern {
 		t.Fatalf("selected evidence = %+v, want matched previous panic", cause)
 	}
@@ -83,25 +86,69 @@ func TestCrashCauseForDiagnoseFallbackAndRedaction(t *testing.T) {
 	}
 }
 
-func TestCrashCauseForDiagnoseFailsClosed(t *testing.T) {
+func TestCrashCauseForDiagnoseIncludesRecentServingWarning(t *testing.T) {
 	now := time.Now()
 	recovered := activeCrashLoopPod("recovered", "app", now)
 	recovered.Spec.Containers[0].ReadinessProbe = &corev1.Probe{}
 	recovered.Status.ContainerStatuses[0].Ready = true
-	recovered.Status.ContainerStatuses[0].State = corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}}
+	recovered.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))},
+	}
+	previous := []podLogEntry{{
+		Pod: "recovered", Container: "app", Logs: aicontext.FilterLogs("FATAL startup dependency unavailable"),
+	}}
+
+	got, truncated := crashCauseForDiagnose([]*corev1.Pod{recovered}, nil, previous, now)
+	if truncated || len(got) != 1 {
+		t.Fatalf("recent serving crash causes=%+v truncated=%v, want one warning-context cause", got, truncated)
+	}
+	if strings.Join(got[0].Pods, ",") != "recovered" || got[0].LogLine != "FATAL startup dependency unavailable" {
+		t.Fatalf("recent serving crash cause = %+v", got[0])
+	}
+	if got[0].State != "recovering" {
+		t.Fatalf("recent serving crash state = %q, want recovering", got[0].State)
+	}
+}
+
+func TestCrashCauseForDiagnoseKeepsRecoveringAndDownEvidenceSeparate(t *testing.T) {
+	now := time.Now()
+	down := activeCrashLoopPod("down", "app", now)
+	recovering := activeCrashLoopPod("recovering", "app", now)
+	recovering.Status.ContainerStatuses[0].Ready = true
+	recovering.Status.ContainerStatuses[0].State = corev1.ContainerState{
+		Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))},
+	}
+	previous := []podLogEntry{
+		{Pod: "down", Container: "app", Logs: aicontext.FilterLogs("FATAL shared startup failure")},
+		{Pod: "recovering", Container: "app", Logs: aicontext.FilterLogs("FATAL shared startup failure")},
+	}
+
+	got, truncated := crashCauseForDiagnose([]*corev1.Pod{recovering, down}, nil, previous, now)
+	if truncated || len(got) != 2 {
+		t.Fatalf("crash causes=%+v truncated=%v, want distinct down and recovering rows", got, truncated)
+	}
+	if got[0].State != "down" || strings.Join(got[0].Pods, ",") != "down" {
+		t.Fatalf("down crash cause = %+v", got[0])
+	}
+	if got[1].State != "recovering" || strings.Join(got[1].Pods, ",") != "recovering" {
+		t.Fatalf("recovering crash cause = %+v", got[1])
+	}
+}
+
+func TestCrashCauseForDiagnoseFailsClosed(t *testing.T) {
+	now := time.Now()
 	failedOnce := activeCrashLoopPod("failed-once", "app", now)
 	failedOnce.Status.ContainerStatuses[0].RestartCount = 0
 	missing := activeCrashLoopPod("missing", "app", now)
 	errored := activeCrashLoopPod("errored", "app", now)
 	empty := activeCrashLoopPod("empty", "app", now)
 	previous := []podLogEntry{
-		{Pod: "recovered", Container: "app", Logs: aicontext.FilterLogs("FATAL stale")},
 		{Pod: "failed-once", Container: "app", Logs: aicontext.FilterLogs("FATAL not a crashloop")},
 		{Pod: "errored", Container: "app", Error: "previous container not found"},
 		{Pod: "empty", Container: "app", Logs: aicontext.FilterLogs("")},
 	}
 
-	got, truncated := crashCauseForDiagnose([]*corev1.Pod{recovered, failedOnce, missing, errored, empty}, nil, previous, now)
+	got, truncated := crashCauseForDiagnose([]*corev1.Pod{failedOnce, missing, errored, empty}, nil, previous, now)
 	if truncated || len(got) != 0 {
 		t.Fatalf("fail-closed cases returned causes=%+v truncated=%v", got, truncated)
 	}

--- a/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
@@ -26,6 +26,210 @@ describe('getPodStatus', () => {
     }
     expect(getPodStatus(crashing).level).toBe('unhealthy')
   })
+
+  it('deranks a serving container with unsettled crash history', () => {
+    const recovered = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: true,
+          restartCount: 2,
+          state: { running: {} },
+          lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+        }],
+      },
+    }
+    expect(getPodStatus(recovered)).toMatchObject({ text: 'Restarted (2)', level: 'degraded' })
+    expect(getPodPhaseDisplay(recovered)).toMatchObject({
+      text: 'Running — Recently restarted (2 restarts)',
+      level: 'degraded',
+    })
+  })
+
+  it('keeps a non-serving container with crash history unhealthy', () => {
+    const down = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: false,
+          restartCount: 2,
+          state: { running: {} },
+          lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+        }],
+      },
+    }
+    expect(getPodStatus(down).level).toBe('unhealthy')
+    expect(getPodPhaseDisplay(down).level).toBe('unhealthy')
+  })
+
+  it('keeps a readiness-probed flapper visible until the settle window', () => {
+    const flapper = {
+      spec: { containers: [{ name: 'app', readinessProbe: { tcpSocket: { port: 8080 } } }] },
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: true,
+          restartCount: 2,
+          state: { running: { startedAt: new Date(Date.now() - 60 * 1000).toISOString() } },
+          lastState: {
+            terminated: {
+              reason: 'Error',
+              exitCode: 1,
+              finishedAt: new Date(Date.now() - 60 * 1000).toISOString(),
+            },
+          },
+        }],
+      },
+    }
+    expect(getPodStatus(flapper).level).toBe('degraded')
+
+    const settled = structuredClone(flapper)
+    settled.status.containerStatuses[0].state.running.startedAt = new Date(Date.now() - 6 * 60 * 1000).toISOString()
+    expect(getPodStatus(settled).level).toBe('healthy')
+  })
+
+  it('lets an active sibling failure outrank recovered crash history', () => {
+    const pod = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          {
+            name: 'app',
+            ready: true,
+            restartCount: 2,
+            state: { running: {} },
+            lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+          },
+          {
+            name: 'image',
+            ready: false,
+            state: { waiting: { reason: 'ImagePullBackOff' } },
+          },
+        ],
+      },
+    }
+    expect(getPodStatus(pod)).toMatchObject({ text: 'ImagePullBackOff', level: 'unhealthy' })
+    expect(getPodPhaseDisplay(pod)).toMatchObject({
+      text: 'Running — ImagePullBackOff',
+      level: 'unhealthy',
+    })
+  })
+
+  it('keeps a not-ready sibling visible ahead of recovered crash history', () => {
+    const pod = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          {
+            name: 'app',
+            ready: true,
+            restartCount: 1,
+            state: { running: {} },
+            lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+          },
+          {
+            name: 'sidecar',
+            ready: false,
+            restartCount: 0,
+            state: { running: {} },
+          },
+        ],
+      },
+    }
+    expect(getPodStatus(pod)).toMatchObject({ text: 'Running (1/2)', level: 'degraded' })
+    expect(getPodPhaseDisplay(pod)).toMatchObject({
+      text: 'Running — Not Ready (1/2)',
+      level: 'degraded',
+    })
+  })
+
+  it('counts only crash history still inside the settle window', () => {
+    const pod = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          {
+            name: 'app',
+            ready: true,
+            restartCount: 1,
+            state: { running: {} },
+            lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+          },
+          {
+            name: 'settled-sidecar',
+            ready: true,
+            restartCount: 40,
+            state: { running: { startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString() } },
+            lastState: {
+              terminated: {
+                reason: 'Error',
+                exitCode: 1,
+                finishedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    }
+    expect(getPodStatus(pod)).toMatchObject({ text: 'Restarted (1)', level: 'degraded' })
+    expect(getPodPhaseDisplay(pod)).toMatchObject({
+      text: 'Running — Recently restarted (1 restart)',
+      level: 'degraded',
+    })
+  })
+
+  it('does not revive old crash history after a long node outage', () => {
+    const pod = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: true,
+          restartCount: 5,
+          state: { running: { startedAt: new Date(Date.now() - 30 * 1000).toISOString() } },
+          lastState: {
+            terminated: {
+              reason: 'Error',
+              exitCode: 1,
+              finishedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+            },
+          },
+        }],
+      },
+    }
+    expect(getPodStatus(pod)).toMatchObject({ text: 'Running', level: 'healthy' })
+
+    const maxBackoffContinuation = structuredClone(pod)
+    maxBackoffContinuation.status.containerStatuses[0].state.running.startedAt =
+      new Date(Date.now() - 60 * 1000).toISOString()
+    maxBackoffContinuation.status.containerStatuses[0].lastState.terminated.finishedAt =
+      new Date(Date.now() - 6 * 60 * 1000).toISOString()
+    expect(getPodStatus(maxBackoffContinuation).level).toBe('degraded')
+  })
+
+  it('shows Terminating instead of a recovered-crash warning during graceful deletion', () => {
+    const terminating = {
+      metadata: { deletionTimestamp: new Date().toISOString() },
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: true,
+          restartCount: 2,
+          state: { running: {} },
+          lastState: { terminated: { reason: 'Error', exitCode: 1 } },
+        }],
+      },
+    }
+    expect(getPodStatus(terminating)).toMatchObject({ text: 'Terminating', level: 'neutral' })
+    expect(getPodPhaseDisplay(terminating)).toMatchObject({
+      text: 'Running — Terminating',
+      level: 'neutral',
+    })
+  })
 })
 
 const podRunningHealthy = {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -171,6 +171,63 @@ function firstFatalContainer(pod: any): { name: string; reason: string } | null 
   return null
 }
 
+const CRASH_SETTLE_MS = 5 * 60 * 1000
+const STALE_CRASH_STATE_GAP_MS = 2 * CRASH_SETTLE_MS
+
+function stableCrashHistory(cs: any): boolean {
+  if (!cs?.restartCount) return false
+
+  const startedAt = cs?.state?.running?.startedAt
+  const finishedAt = cs?.lastState?.terminated?.finishedAt
+  if (startedAt) {
+    const startedAtMs = new Date(startedAt).getTime()
+    if (Number.isFinite(startedAtMs) && Date.now() - startedAtMs >= CRASH_SETTLE_MS) return false
+    if (finishedAt) {
+      const finishedAtMs = new Date(finishedAt).getTime()
+      if (
+        Number.isFinite(startedAtMs)
+        && Number.isFinite(finishedAtMs)
+        && startedAtMs - finishedAtMs > STALE_CRASH_STATE_GAP_MS
+      ) return false
+    }
+  } else if (cs?.state?.running && finishedAt) {
+    const finishedAtMs = new Date(finishedAt).getTime()
+    if (Number.isFinite(finishedAtMs) && Date.now() - finishedAtMs >= CRASH_SETTLE_MS) return false
+  }
+  if (cs?.state?.terminated?.exitCode === 0) return false
+
+  const term = cs?.lastState?.terminated
+  if (!term || term.reason === 'OOMKilled') return false
+  return term.reason === 'CrashLoopBackOff' || term.reason === 'Error' || Number(term.exitCode ?? 0) !== 0
+}
+
+function podCrashHistoryLevel(pod: any): 'degraded' | 'unhealthy' | null {
+  let degraded = false
+  for (const cs of pod?.status?.containerStatuses || []) {
+    if (!stableCrashHistory(cs)) continue
+    if (!(cs?.state?.running && cs?.ready)) return 'unhealthy'
+    degraded = true
+  }
+
+  const initContainers = pod?.spec?.initContainers || []
+  for (const cs of pod?.status?.initContainerStatuses || []) {
+    const spec = initContainers.find((c: any) => c?.name === cs?.name)
+    const restartable = spec?.restartPolicy === 'Always'
+    if (!stableCrashHistory(cs)) continue
+    if (!(restartable && cs?.state?.running && cs?.ready)) return 'unhealthy'
+    degraded = true
+  }
+  return degraded ? 'degraded' : null
+}
+
+function podCrashRestartTotal(pod: any): number {
+  const main = pod?.status?.containerStatuses || []
+  const init = pod?.status?.initContainerStatuses || []
+  return [...main, ...init]
+    .filter(stableCrashHistory)
+    .reduce((sum, cs) => sum + (cs?.restartCount || 0), 0)
+}
+
 export function getPodStatus(pod: any): StatusBadge {
   const phase = pod.status?.phase || 'Unknown'
   const containerStatuses = pod.status?.containerStatuses || []
@@ -194,6 +251,17 @@ export function getPodStatus(pod: any): StatusBadge {
     return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
+  const crashHistoryLevel = phase !== 'Succeeded' && phase !== 'Unknown'
+    ? podCrashHistoryLevel(pod)
+    : null
+  if (crashHistoryLevel === 'unhealthy') {
+    return {
+      text: 'CrashLoopBackOff',
+      color: healthColors.unhealthy,
+      level: 'unhealthy',
+    }
+  }
+
   // Terminating: neutral while gracefully shutting down, degraded once stuck
   // (a wedged finalizer / preStop hook holding the pod open).
   if (pod.metadata?.deletionTimestamp) {
@@ -201,6 +269,16 @@ export function getPodStatus(pod: any): StatusBadge {
       return { text: 'Terminating', color: healthColors.degraded, level: 'degraded' }
     }
     return { text: 'Terminating', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const hasUnsettledMainContainer = containerStatuses.some((c: any) => !containerSettledOk(c))
+  if (crashHistoryLevel === 'degraded' && !hasUnsettledMainContainer) {
+    const restarts = podCrashRestartTotal(pod)
+    return {
+      text: `Restarted (${restarts})`,
+      color: healthColors.degraded,
+      level: 'degraded',
+    }
   }
 
   switch (phase) {
@@ -288,6 +366,18 @@ export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
     return { phase, text: 'Failed', level: 'unhealthy' }
   }
 
+  const crashHistoryLevel = phase !== 'Succeeded' && phase !== 'Unknown'
+    ? podCrashHistoryLevel(pod)
+    : null
+  if (crashHistoryLevel === 'unhealthy') {
+    return {
+      phase,
+      text: `${phase} — CrashLoopBackOff`,
+      level: 'unhealthy',
+      hint: 'At least one container has crash history and is not serving now.',
+    }
+  }
+
   // Terminating: neutral while gracefully shutting down, degraded once stuck.
   if (pod?.metadata?.deletionTimestamp) {
     const stuck = minutesSince(pod.metadata.deletionTimestamp) >= TERMINATING_STUCK_MINUTES
@@ -298,6 +388,17 @@ export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
       hint: stuck
         ? 'Pod has been terminating for a while — a finalizer or preStop hook may be wedged.'
         : 'Pod has a deletionTimestamp set; awaiting graceful termination.',
+    }
+  }
+
+  const hasUnsettledMainContainer = containerStatuses.some((c) => !containerSettledOk(c))
+  if (crashHistoryLevel === 'degraded' && !hasUnsettledMainContainer) {
+    const crashRestarts = podCrashRestartTotal(pod)
+    return {
+      phase,
+      text: `${phase} — Recently restarted (${crashRestarts} restart${crashRestarts === 1 ? '' : 's'})`,
+      level: 'degraded',
+      hint: 'Containers are ready now but remain in the crash settle window.',
     }
   }
 

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -16,7 +16,7 @@ import (
 //
 //	Succeeded            → neutral  (completed; lifecycle, not a problem)
 //	Failed               → unhealthy
-//	stable crashloop     → unhealthy
+//	stable crashloop     → unhealthy when down, degraded when Running+Ready
 //	fatal waiting reason → unhealthy
 //	active OOMKilled     → unhealthy
 //	Pending > 5m         → degraded ; Pending < 5m → healthy (startup grace)
@@ -76,14 +76,12 @@ func classifyPodLevel(pod *corev1.Pod, now time.Time) Level {
 		return LevelUnknown
 	}
 
-	// Stable crashloop: a container that has restarted with a recorded crash
-	// outcome is a failure REGARDLESS of whether the kubelet currently reports it
-	// Waiting (backing off) or Running (just restarted, about to die again).
-	// Keying off the instantaneous phase here is what made severity flap
-	// poll-to-poll; the stable history fields don't oscillate, so neither does
-	// the verdict. Checked before the per-state scan below so a momentary
-	// "Running" can't downgrade it.
-	if podHasStableCrashLoop(pod, now) {
+	// Crash history keeps the problem present across the kubelet's
+	// Waiting→Running oscillation, while current state controls urgency.
+	// Unhealthy may return immediately; degraded must not mask an unrelated
+	// fatal state on another container.
+	crashLoopLevel := podStableCrashLoopLevel(pod, now)
+	if crashLoopLevel == LevelUnhealthy {
 		return LevelUnhealthy
 	}
 
@@ -101,6 +99,9 @@ func classifyPodLevel(pod *corev1.Pod, now time.Time) Level {
 		if cs.State.Waiting != nil && isFatalWaitingReason(cs.State.Waiting.Reason) {
 			return LevelUnhealthy
 		}
+	}
+	if crashLoopLevel == LevelDegraded {
+		return LevelDegraded
 	}
 
 	// Pods pending past the startup grace window.
@@ -266,6 +267,25 @@ func PodCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string
 		ref = fmt.Sprintf("init container %q", candidate.status.Name)
 	}
 	run := shortRunContext(term)
+	if IsCrashLoopContainerServing(pod, candidate.status) {
+		exit := fmt.Sprintf("exit code %d", term.ExitCode)
+		action := "Watch for another restart. If it repeats, inspect previous container logs and verify the pod command, args, config, and dependencies."
+		switch term.ExitCode {
+		case 127:
+			exit = "exit code 127 (command not found)"
+			action = "Watch for another restart. If it repeats, check the image entrypoint and pod command/args; verify the binary exists in the image."
+		case 126:
+			exit = "exit code 126 (command found but not executable)"
+			action = "Watch for another restart. If it repeats, check executable permissions, the shebang/interpreter, and the pod command/args."
+		case 139:
+			exit = "exit code 139 (segmentation fault)"
+			action = "Watch for another restart. If it repeats, inspect previous container logs and recent image/code changes; check native libraries or unsafe code."
+		case 137:
+			exit = "exit code 137 (Kubernetes did not report OOMKilled)"
+			action = "Watch for another restart. If it repeats, check node pressure, process-level SIGKILLs, and memory limits."
+		}
+		return fmt.Sprintf("%s restarted after %s and is serving again within the 5-minute settle window.%s", ref, exit, run), action
+	}
 
 	switch term.ExitCode {
 	case 127:
@@ -289,8 +309,8 @@ func PodCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string
 func activeCrashLoopCandidate(pod *corev1.Pod, now time.Time) (crashLoopCandidate, bool) {
 	var best crashLoopCandidate
 	have := false
-	consider := func(cs corev1.ContainerStatus, init bool, index int, readyTrusted bool) {
-		if !isStableCrashLoop(&cs, now, readyTrusted) {
+	consider := func(cs corev1.ContainerStatus, init bool, index int) {
+		if !isStableCrashLoop(&cs, now) {
 			return
 		}
 		c := crashLoopCandidate{
@@ -307,11 +327,12 @@ func activeCrashLoopCandidate(pod *corev1.Pod, now time.Time) (crashLoopCandidat
 		}
 	}
 	for i := range pod.Status.InitContainerStatuses {
-		consider(pod.Status.InitContainerStatuses[i], true, i, false)
+		cs := pod.Status.InitContainerStatuses[i]
+		consider(cs, true, i)
 	}
 	for i := range pod.Status.ContainerStatuses {
 		cs := pod.Status.ContainerStatuses[i]
-		consider(cs, false, i, containerHasReadinessProbe(pod.Spec.Containers, cs.Name))
+		consider(cs, false, i)
 	}
 	return best, have
 }

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -207,10 +207,8 @@ func TestPodGoldenVectors(t *testing.T) {
 	}
 }
 
-// TestPodStableCrashLoopAcrossPhases pins crashloop monotonicity: a crashlooping
-// container's instantaneous State flaps Waiting → Running → Waiting poll-to-poll,
-// but the Verdict (Level + Reason) must stay fixed because it reads the stable
-// history fields.
+// TestPodStableCrashLoopAcrossPhases pins a non-serving crashloop's continuity
+// while its instantaneous State flaps Waiting → Running → Waiting.
 func TestPodStableCrashLoopAcrossPhases(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	crashHistory := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}}

--- a/pkg/health/reasons.go
+++ b/pkg/health/reasons.go
@@ -19,7 +19,11 @@ const (
 // a still-unhealthy container is treated as actively thrashing.
 const highRestartThreshold = 3
 
-const shortCrashRunWindow = 10 * time.Second
+const (
+	shortCrashRunWindow = 10 * time.Second
+	crashSettleWindow   = 5 * time.Minute
+	staleCrashStateGap  = 2 * crashSettleWindow
+)
 
 // isStableCrashLoop reports whether a container is in an ACTIVE crashloop: it
 // has restarted with a crash-class last termination (CrashLoopBackOff / generic
@@ -30,28 +34,35 @@ const shortCrashRunWindow = 10 * time.Second
 // container that crashed once and is now running healthily: RestartCount and
 // LastTerminationState persist for the life of the container, so without the
 // recovery guard below a pod that restarted once at startup would read as a
-// crashloop forever. Three recovery signals clear it: a container currently
-// Ready when that Ready is probe-gated (readyTrusted) has passed its readiness
-// probe and is serving NOW; a container Running continuously past the kubelet's
-// max CrashLoopBackOff backoff (5m) has outlived the loop; and a container whose
-// CURRENT state is a clean exit (Terminated, exit 0) has succeeded — the common
+// crashloop forever. Two recovery signals clear it: a container Running
+// continuously past the kubelet's max CrashLoopBackOff backoff (5m) has
+// outlived the loop, and a container whose CURRENT state is a clean exit
+// (Terminated, exit 0) has succeeded — the common
 // init-container-retries-then-completes case, whose failed prior attempt lingers
-// in LastTerminationState. OOMKilled is intentionally excluded — it has its own
-// category/severity path upstream.
-//
-// readyTrusted gates the Ready short-circuit because Ready is only a meaningful
-// recovery signal when a readiness probe backs it: without a probe Ready just
-// mirrors Running and flips true during a loop's brief between-crash window, so
-// for probe-less containers the 5m Running guard below stays the discriminator.
-func isStableCrashLoop(cs *corev1.ContainerStatus, now time.Time, readyTrusted bool) bool {
+// in LastTerminationState. A passing readiness probe proves the container is
+// serving now, so it controls severity, but it does not erase a recent restart;
+// that keeps a real flapper visible as warning across its Ready/Waiting cycle.
+// OOMKilled is intentionally excluded — it has its own category/severity path
+// upstream.
+func isStableCrashLoop(cs *corev1.ContainerStatus, now time.Time) bool {
 	if cs.RestartCount == 0 {
 		return false
 	}
-	if readyTrusted && cs.Ready {
-		return false
-	}
-	if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) > 5*time.Minute {
-		return false
+	if r := cs.State.Running; r != nil {
+		if !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) >= crashSettleWindow {
+			return false
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil && !t.FinishedAt.IsZero() {
+			if r.StartedAt.IsZero() && now.Sub(t.FinishedAt.Time) >= crashSettleWindow {
+				return false
+			}
+			// A gap well beyond the kubelet's maximum crash backoff means the
+			// old termination and this new run are not one continuous loop
+			// (for example, a node returning after a long outage).
+			if !r.StartedAt.IsZero() && r.StartedAt.Sub(t.FinishedAt.Time) > staleCrashStateGap {
+				return false
+			}
+		}
 	}
 	if term := cs.State.Terminated; term != nil && term.ExitCode == 0 {
 		return false
@@ -82,16 +93,13 @@ func ActiveCrashLoopContainerStatuses(pod *corev1.Pod, now time.Time) []corev1.C
 	var active []corev1.ContainerStatus
 	for i := range pod.Status.ContainerStatuses {
 		cs := pod.Status.ContainerStatuses[i]
-		if isStableCrashLoop(&cs, now, containerHasReadinessProbe(pod.Spec.Containers, cs.Name)) {
+		if isStableCrashLoop(&cs, now) {
 			active = append(active, cs)
 		}
 	}
-	// Init containers carry no readiness probe and their Ready field is not a
-	// serving signal — never trust Ready as recovery there; the Running-window
-	// and clean-exit guards still apply.
 	for i := range pod.Status.InitContainerStatuses {
 		cs := pod.Status.InitContainerStatuses[i]
-		if isStableCrashLoop(&cs, now, false) {
+		if isStableCrashLoop(&cs, now) {
 			active = append(active, cs)
 		}
 	}
@@ -101,27 +109,64 @@ func ActiveCrashLoopContainerStatuses(pod *corev1.Pod, now time.Time) []corev1.C
 // podHasStableCrashLoop reports whether any main or init container is in a
 // stable crashloop (see isStableCrashLoop).
 func podHasStableCrashLoop(pod *corev1.Pod, now time.Time) bool {
+	return podStableCrashLoopLevel(pod, now) != ""
+}
+
+// IsCrashLoopContainerServing reports whether a crash-history status represents
+// a serving main container or a serving native sidecar.
+func IsCrashLoopContainerServing(pod *corev1.Pod, cs corev1.ContainerStatus) bool {
+	if pod == nil || cs.State.Running == nil || !cs.Ready {
+		return false
+	}
 	for i := range pod.Status.ContainerStatuses {
-		cs := &pod.Status.ContainerStatuses[i]
-		if isStableCrashLoop(cs, now, containerHasReadinessProbe(pod.Spec.Containers, cs.Name)) {
+		if pod.Status.ContainerStatuses[i].Name == cs.Name {
 			return true
 		}
 	}
+	return restartableInitContainer(pod, cs.Name)
+}
+
+func podStableCrashLoopLevel(pod *corev1.Pod, now time.Time) Level {
+	level := Level("")
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if !isStableCrashLoop(cs, now) {
+			continue
+		}
+		if IsCrashLoopContainerServing(pod, *cs) {
+			level = LevelDegraded
+			continue
+		}
+		return LevelUnhealthy
+	}
 	for i := range pod.Status.InitContainerStatuses {
-		if isStableCrashLoop(&pod.Status.InitContainerStatuses[i], now, false) {
-			return true
+		cs := &pod.Status.InitContainerStatuses[i]
+		if !isStableCrashLoop(cs, now) {
+			continue
+		}
+		if IsCrashLoopContainerServing(pod, *cs) {
+			level = LevelDegraded
+			continue
+		}
+		return LevelUnhealthy
+	}
+	return level
+}
+
+func containerHasReadinessProbe(containers []corev1.Container, name string) bool {
+	for i := range containers {
+		if containers[i].Name == name {
+			return containers[i].ReadinessProbe != nil
 		}
 	}
 	return false
 }
 
-// containerHasReadinessProbe reports whether the named container declares a
-// readiness probe — the condition under which its ContainerStatus.Ready is a
-// trustworthy "serving now" signal rather than a mirror of Running.
-func containerHasReadinessProbe(containers []corev1.Container, name string) bool {
-	for i := range containers {
-		if containers[i].Name == name {
-			return containers[i].ReadinessProbe != nil
+func restartableInitContainer(pod *corev1.Pod, name string) bool {
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if c.Name == name {
+			return c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
 		}
 	}
 	return false
@@ -153,7 +198,7 @@ func isActivelyThrashing(cs *corev1.ContainerStatus, now time.Time) bool {
 	if cs.State.Waiting != nil {
 		return true
 	}
-	return restartedRecently(cs, now, 5*time.Minute)
+	return restartedRecently(cs, now, crashSettleWindow)
 }
 
 // podActiveThrashContainer reports whether any main container is actively

--- a/pkg/health/recovery_test.go
+++ b/pkg/health/recovery_test.go
@@ -79,8 +79,11 @@ func TestRecoveredAfterCrashIsHealthy(t *testing.T) {
 
 	looping := recovered.DeepCopy()
 	looping.Status.ContainerStatuses[0].State.Running.StartedAt = metav1.NewTime(now.Add(-30 * time.Second))
-	if got := legacy(looping, now); got != "error" {
-		t.Errorf("just-restarted crashloop (Running 30s) = %q, want error", got)
+	if got := legacy(looping, now); got != "warning" {
+		t.Errorf("just-restarted crashloop (Running+Ready 30s) = %q, want warning", got)
+	}
+	if got := PodProblemReason(looping, now); got != "CrashLoopBackOff" {
+		t.Errorf("just-restarted crashloop reason = %q, want CrashLoopBackOff", got)
 	}
 
 	completedInit := &corev1.Pod{Status: corev1.PodStatus{
@@ -130,12 +133,14 @@ func TestRecoveredAfterOOMIsHealthy(t *testing.T) {
 	}
 }
 
-// TestProbeGatedReadyClearsCrashLoop: Ready clears a crashloop only when a
-// readiness probe backs it.
-func TestProbeGatedReadyClearsCrashLoop(t *testing.T) {
+func TestReadyContainerRemainsWarningUntilSettleWindow(t *testing.T) {
 	now := time.Now()
-	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}}
-	probedRecovered := &corev1.Pod{
+	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+		Reason:     "Error",
+		ExitCode:   1,
+		FinishedAt: metav1.NewTime(now.Add(-90 * time.Second)),
+	}}
+	probedFlapper := &corev1.Pod{
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", ReadinessProbe: &corev1.Probe{}}}},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -146,13 +151,267 @@ func TestProbeGatedReadyClearsCrashLoop(t *testing.T) {
 			}},
 		},
 	}
-	if got := legacy(probedRecovered, now); got != "healthy" {
-		t.Errorf("probed Ready pod recovered 90s = %q, want healthy", got)
+	if got := legacy(probedFlapper, now); got != "warning" {
+		t.Errorf("probed Ready pod restarted 90s ago = %q, want warning", got)
 	}
-	probelessLooping := probedRecovered.DeepCopy()
+	probelessLooping := probedFlapper.DeepCopy()
 	probelessLooping.Spec.Containers[0].ReadinessProbe = nil
-	if got := legacy(probelessLooping, now); got != "error" {
-		t.Errorf("probe-less Ready pod Running 90s = %q, want error (Ready untrusted)", got)
+	if got := legacy(probelessLooping, now); got != "warning" {
+		t.Errorf("probe-less Ready pod Running 90s = %q, want warning during settle window", got)
+	}
+	settled := probedFlapper.DeepCopy()
+	settled.Status.ContainerStatuses[0].State.Running.StartedAt = metav1.NewTime(now.Add(-6 * time.Minute))
+	if got := legacy(settled, now); got != "healthy" {
+		t.Errorf("probed Ready pod Running 6m = %q, want healthy", got)
+	}
+	settledWithoutStartedAt := probedFlapper.DeepCopy()
+	settledWithoutStartedAt.Status.ContainerStatuses[0].State.Running.StartedAt = metav1.Time{}
+	settledWithoutStartedAt.Status.ContainerStatuses[0].LastTerminationState.Terminated.FinishedAt = metav1.NewTime(now.Add(-6 * time.Minute))
+	if got := legacy(settledWithoutStartedAt, now); got != "healthy" {
+		t.Errorf("probed Ready pod with old termination fallback = %q, want healthy", got)
+	}
+}
+
+func TestCrashLoopLevelTracksCurrentState(t *testing.T) {
+	now := time.Now()
+	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+		Reason:     "Error",
+		ExitCode:   1,
+		FinishedAt: metav1.NewTime(now.Add(-30 * time.Second)),
+	}}
+	base := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute))},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:                 "app",
+				Ready:                true,
+				RestartCount:         2,
+				State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-30 * time.Second))}},
+				LastTerminationState: crash,
+			}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		edit func(*corev1.Pod)
+		want string
+	}{
+		{
+			name: "recently up",
+			edit: func(*corev1.Pod) {},
+			want: "warning",
+		},
+		{
+			name: "high cumulative restarts stay warning while up",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].RestartCount = 40
+			},
+			want: "warning",
+		},
+		{
+			name: "waiting now",
+			edit: func(pod *corev1.Pod) {
+				cs := &pod.Status.ContainerStatuses[0]
+				cs.Ready = false
+				cs.State = corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}
+			},
+			want: "error",
+		},
+		{
+			name: "running but not ready",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].Ready = false
+			},
+			want: "error",
+		},
+		{
+			name: "stable beyond settle window",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].State.Running.StartedAt = metav1.NewTime(now.Add(-6 * time.Minute))
+			},
+			want: "healthy",
+		},
+		{
+			name: "old crash history separated by node outage is healthy",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.FinishedAt =
+					metav1.NewTime(now.Add(-3 * time.Hour))
+			},
+			want: "healthy",
+		},
+		{
+			name: "maximum backoff gap keeps a real loop visible",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].State.Running.StartedAt =
+					metav1.NewTime(now.Add(-time.Minute))
+				pod.Status.ContainerStatuses[0].LastTerminationState.Terminated.FinishedAt =
+					metav1.NewTime(now.Add(-6 * time.Minute))
+			},
+			want: "warning",
+		},
+		{
+			name: "missing running timestamp fails closed as warning",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].State.Running.StartedAt = metav1.Time{}
+			},
+			want: "warning",
+		},
+		{
+			name: "readiness gate does not make ready container down",
+			edit: func(pod *corev1.Pod) {
+				pod.Status.Conditions = []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+					Reason: "ReadinessGatesNotReady",
+				}}
+			},
+			want: "warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := base.DeepCopy()
+			tt.edit(pod)
+			if got := legacy(pod, now); got != tt.want {
+				t.Fatalf("health = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrashLoopLevelUsesWorstContainerState(t *testing.T) {
+	now := time.Now()
+	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}}
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name:                 "serving",
+				Ready:                true,
+				RestartCount:         1,
+				State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}},
+				LastTerminationState: crash,
+			},
+			{
+				Name:                 "down",
+				RestartCount:         1,
+				State:                corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+				LastTerminationState: crash,
+			},
+		},
+	}}
+
+	if got := legacy(pod, now); got != "error" {
+		t.Fatalf("one recovered + one down container = %q, want error", got)
+	}
+}
+
+func TestRecoveredCrashHistoryDoesNotMaskOtherFailures(t *testing.T) {
+	now := time.Now()
+	recovered := corev1.ContainerStatus{
+		Name:         "app",
+		Ready:        true,
+		RestartCount: 2,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+			StartedAt: metav1.NewTime(now.Add(-time.Minute)),
+		}},
+		LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason: "Error", ExitCode: 1,
+		}},
+	}
+	tests := []struct {
+		name       string
+		addFailure func(*corev1.Pod)
+		wantReason string
+	}{
+		{
+			name: "sibling image pull",
+			addFailure: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+					Name:  "image",
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+				})
+			},
+			wantReason: "ImagePullBackOff",
+		},
+		{
+			name: "sibling oom",
+			addFailure: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+					Name: "memory",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "OOMKilled", ExitCode: 137,
+					}},
+				})
+			},
+			wantReason: "OOMKilled",
+		},
+		{
+			name: "fatal init",
+			addFailure: func(pod *corev1.Pod) {
+				pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+					Name:  "setup",
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CreateContainerConfigError"}},
+				}}
+			},
+			wantReason: "CreateContainerConfigError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{recovered},
+			}}
+			tt.addFailure(pod)
+			if got := legacy(pod, now); got != "error" {
+				t.Fatalf("health = %q, want error", got)
+			}
+			if got := PodProblemReason(pod, now); got != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestRestartableInitCrashLoopUsesServingState(t *testing.T) {
+	now := time.Now()
+	always := corev1.ContainerRestartPolicyAlways
+	crash := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}}
+	sidecar := &corev1.Pod{
+		Spec: corev1.PodSpec{InitContainers: []corev1.Container{{
+			Name:          "sidecar",
+			RestartPolicy: &always,
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:                 "sidecar",
+				Ready:                true,
+				RestartCount:         1,
+				State:                corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}},
+				LastTerminationState: crash,
+			}},
+		},
+	}
+	if got := legacy(sidecar, now); got != "warning" {
+		t.Errorf("probe-less serving sidecar = %q, want warning", got)
+	}
+
+	probed := sidecar.DeepCopy()
+	probed.Spec.InitContainers[0].ReadinessProbe = &corev1.Probe{}
+	if got := legacy(probed, now); got != "warning" {
+		t.Errorf("probe-gated Ready sidecar = %q, want warning during settle window", got)
+	}
+
+	ordinaryInit := sidecar.DeepCopy()
+	ordinaryInit.Spec.InitContainers[0].RestartPolicy = nil
+	if got := legacy(ordinaryInit, now); got != "error" {
+		t.Errorf("ordinary running init with crash history = %q, want error", got)
 	}
 }
 
@@ -240,8 +499,8 @@ func TestActiveCrashLoopContainerStatuses(t *testing.T) {
 	}
 
 	got := ActiveCrashLoopContainerStatuses(pod, now)
-	if len(got) != 2 || got[0].Name != "active" || got[1].Name != "init-active" {
-		t.Fatalf("active crashloop containers = %+v, want active and init-active", got)
+	if len(got) != 3 || got[0].Name != "active" || got[1].Name != "ready" || got[2].Name != "init-active" {
+		t.Fatalf("active crashloop containers = %+v, want active, ready flapper, and init-active", got)
 	}
 	if got := ActiveCrashLoopContainerStatuses(nil, now); got != nil {
 		t.Fatalf("nil pod returned %+v, want nil", got)
@@ -272,6 +531,32 @@ func TestPodCrashLoopDiagnosisOrdersCandidates(t *testing.T) {
 	cause, _ := PodCrashLoopDiagnosis(pod, now)
 	if !strings.Contains(cause, `container "waiting-older"`) || !strings.Contains(cause, "code 126") {
 		t.Fatalf("cause = %q, want current waiting crashloop to win over newer running tick", cause)
+	}
+}
+
+func TestPodCrashLoopDiagnosisUsesServingCopyDuringSettleWindow(t *testing.T) {
+	now := time.Now()
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name:         "app",
+			Ready:        true,
+			RestartCount: 2,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+				StartedAt: metav1.NewTime(now.Add(-time.Minute)),
+			}},
+			LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Error", ExitCode: 1, FinishedAt: metav1.NewTime(now.Add(-time.Minute)),
+			}},
+		}},
+	}}
+
+	cause, action := PodCrashLoopDiagnosis(pod, now)
+	if !strings.Contains(cause, "is serving again") || strings.Contains(cause, "is crashlooping") {
+		t.Fatalf("cause = %q, want recovered serving language", cause)
+	}
+	if !strings.Contains(action, "Watch for another restart") {
+		t.Fatalf("action = %q, want repeat-crash guidance", action)
 	}
 }
 

--- a/pkg/health/testdata/golden_vectors.json
+++ b/pkg/health/testdata/golden_vectors.json
@@ -26,6 +26,42 @@
       "object": { "status": { "phase": "Running", "containerStatuses": [{ "ready": false, "state": { "waiting": { "reason": "CrashLoopBackOff" } } }] } }
     },
     {
+      "name": "pod serving inside crash settle window is degraded",
+      "kind": "Pod",
+      "level": "degraded",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "name": "app", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }] } }
+    },
+    {
+      "name": "pod recovered crash history does not mask sibling image pull",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "name": "app", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }, { "name": "image", "ready": false, "state": { "waiting": { "reason": "ImagePullBackOff" } } }] } }
+    },
+    {
+      "name": "pod recovered crash history does not mask sibling oom",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "name": "app", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }, { "name": "memory", "ready": false, "state": { "terminated": { "reason": "OOMKilled", "exitCode": 137 } } }] } }
+    },
+    {
+      "name": "pod recovered crash history does not mask fatal init",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "name": "app", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }], "initContainerStatuses": [{ "name": "setup", "ready": false, "state": { "waiting": { "reason": "CreateContainerConfigError" } } }] } }
+    },
+    {
+      "name": "pod serving native sidecar inside crash settle window is degraded",
+      "kind": "Pod",
+      "level": "degraded",
+      "object": { "spec": { "initContainers": [{ "name": "sidecar", "restartPolicy": "Always" }] }, "status": { "phase": "Running", "initContainerStatuses": [{ "name": "sidecar", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }] } }
+    },
+    {
+      "name": "pod ordinary init with crash history is unhealthy",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "spec": { "initContainers": [{ "name": "setup" }] }, "status": { "phase": "Pending", "initContainerStatuses": [{ "name": "setup", "ready": true, "restartCount": 2, "state": { "running": {} }, "lastState": { "terminated": { "reason": "Error", "exitCode": 1 } } }] } }
+    },
+    {
       "name": "pod node-lost (phase Unknown) is unknown",
       "kind": "Pod",
       "level": "unknown",


### PR DESCRIPTION
## Summary

Radar now ranks crashloops by whether the container is serving now, instead of keeping a recovered startup crash at critical severity throughout the retention window. Active outages remain critical immediately, while a container that restarted and is serving again stays visible as a warning during a five-minute settle window and then clears.

## What changed

### Canonical serving-state classification

- A container currently in `CrashLoopBackOff`, or otherwise non-serving because of a crash, remains unhealthy and critical with no delay.
- A Running and Ready container with recent crash history is degraded and warning for the existing five-minute settle window.
- A continuously running container clears after the settle window rather than leaving a hidden informational issue.
- Cumulative restart count does not re-escalate a serving container because a snapshot count cannot establish restart frequency.

The classification lives in the shared health layer so issue ranking, resource context, MCP diagnosis, dashboard buckets, topology, and the TypeScript status mirror agree.

### Precedence and continuity

- Fatal init failures, sibling container image-pull or OOM failures, and other current non-serving states take precedence over recovered history.
- Graceful termination takes precedence over the recovered warning in display state.
- Native restartable init sidecars follow the same serving-state rule; ordinary failed init containers remain unhealthy.
- Crash history survives normal maximum-backoff running ticks, but a terminated-to-running discontinuity longer than ten minutes is treated as stale history after a node outage or similar gap.

### Agent and UI context

- Recovered copy says the container restarted and is serving again instead of claiming that it is currently backing off.
- Pod status displays `Restarted (N)` for the recovered warning.
- MCP crash evidence includes an explicit `recovering` or `down` state and keeps those states distinct during grouping.
- Shared Go and TypeScript golden vectors pin cross-surface parity.

## Testing

- `make test`
- `make tsc`
- `make build`
- Full root and nested `pkg` Go test suites
- k8s-ui: 86 files, 1,284 tests
- Shared Go/TypeScript golden-vector tests
- Focused detector, issues, MCP, health, and frontend status suites

Live validation ran against an isolated `radar-bench` namespace using the built branch:

- A readiness-probed container that intentionally crashed twice and stabilized appeared as warning.
- A persistent `CrashLoopBackOff` appeared as critical.
- Dashboard warning/error buckets and issues/diagnosis API responses matched those states.
- The test server and exact temporary namespace were removed afterward.

Screenshot capture was skipped because this changes status classification and copy rather than layout or interaction; rendered behavior is covered by the TypeScript status tests and shared golden vectors.

## Tradeoff

A currently serving high-count flapper remains warning rather than critical because Radar has only cumulative restart count plus the latest termination snapshot, not a reliable restart rate. Critical remains reserved for evidence that the container is currently non-serving.
