### PR TITLE
Detect finalizer-stuck ConfigMaps and Secrets sooner

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -1466,8 +1466,11 @@ func terminatingProblem(kind, group string, obj metav1.Object, now time.Time) (D
 		return Detection{}, false
 	}
 	finalizers := obj.GetFinalizers()
+	usesShortWarningWindow := group == "" &&
+		(kind == "ConfigMap" || kind == "Secret") &&
+		hasNonGarbageCollectionFinalizer(finalizers)
 	warningAfter := terminatingWarningAfter
-	if group == "" && (kind == "ConfigMap" || kind == "Secret") && hasNonGarbageCollectionFinalizer(finalizers) {
+	if usesShortWarningWindow {
 		warningAfter = configMapSecretTerminatingWarningAfter
 	}
 	duration := now.Sub(obj.GetDeletionTimestamp().Time)
@@ -1475,7 +1478,9 @@ func terminatingProblem(kind, group string, obj metav1.Object, now time.Time) (D
 		return Detection{}, false
 	}
 	severity := "high"
-	if duration >= terminatingCriticalAfter {
+	if usesShortWarningWindow && duration < terminatingWarningAfter {
+		severity = "medium"
+	} else if duration >= terminatingCriticalAfter {
 		severity = "critical"
 	}
 	msg := "Resource is still present after deletion started"

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -23,6 +23,11 @@ const probeFailureWindow = 10 * time.Minute
 
 const livenessProbeFailedReason = "LivenessProbeFailed"
 
+// Core ConfigMaps and Secrets have no kind-specific graceful termination phase.
+// Once deletion starts, a remaining finalizer is the only thing keeping the
+// object present, so delayed cleanup is actionable sooner than workload drain.
+const configMapSecretTerminatingWarningAfter = 2 * time.Minute
+
 const terminatingWarningAfter = 10 * time.Minute
 const terminatingCriticalAfter = 30 * time.Minute
 
@@ -1460,8 +1465,13 @@ func terminatingProblem(kind, group string, obj metav1.Object, now time.Time) (D
 	if obj.GetDeletionTimestamp() == nil {
 		return Detection{}, false
 	}
+	finalizers := obj.GetFinalizers()
+	warningAfter := terminatingWarningAfter
+	if group == "" && (kind == "ConfigMap" || kind == "Secret") && hasNonGarbageCollectionFinalizer(finalizers) {
+		warningAfter = configMapSecretTerminatingWarningAfter
+	}
 	duration := now.Sub(obj.GetDeletionTimestamp().Time)
-	if duration < terminatingWarningAfter {
+	if duration < warningAfter {
 		return Detection{}, false
 	}
 	severity := "high"
@@ -1469,7 +1479,7 @@ func terminatingProblem(kind, group string, obj metav1.Object, now time.Time) (D
 		severity = "critical"
 	}
 	msg := "Resource is still present after deletion started"
-	if finalizers := obj.GetFinalizers(); len(finalizers) > 0 {
+	if len(finalizers) > 0 {
 		msg = "Waiting on finalizers: " + strings.Join(finalizers, ", ")
 	}
 	// The stuck-termination issue began when deletion was requested — run the
@@ -1496,6 +1506,17 @@ func terminatingProblem(kind, group string, obj metav1.Object, now time.Time) (D
 		IssueTiming:      timingR.IssueTiming,
 		IssueTimingBasis: timingR.Basis,
 	}, true
+}
+
+func hasNonGarbageCollectionFinalizer(finalizers []string) bool {
+	for _, finalizer := range finalizers {
+		// Garbage collection may legitimately wait for dependents to finish
+		// terminating, so it keeps the generic grace period.
+		if finalizer != metav1.FinalizerDeleteDependents && finalizer != metav1.FinalizerOrphanDependents {
+			return true
+		}
+	}
+	return false
 }
 
 func namespaceTerminatingProblem(ns *corev1.Namespace, now time.Time) (Detection, bool) {

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -1840,7 +1840,8 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 	now := time.Now()
 	oldCreated := metav1.NewTime(now.Add(-2 * time.Hour))
 	oldDelete := metav1.NewTime(now.Add(-35 * time.Minute))
-	recentDelete := metav1.NewTime(now.Add(-2 * time.Minute))
+	pastShortWindowDelete := metav1.NewTime(now.Add(-3 * time.Minute))
+	recentDelete := metav1.NewTime(now.Add(-1 * time.Minute))
 	const secretValue = "must-not-appear-in-detection"
 
 	client := fake.NewClientset(
@@ -1849,7 +1850,7 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 				Name:              "config-stuck",
 				Namespace:         "prod",
 				CreationTimestamp: oldCreated,
-				DeletionTimestamp: &oldDelete,
+				DeletionTimestamp: &pastShortWindowDelete,
 				Finalizers:        []string{"example.com/config-finalizer"},
 			},
 		},
@@ -1858,7 +1859,7 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 				Name:              "secret-stuck",
 				Namespace:         "prod",
 				CreationTimestamp: oldCreated,
-				DeletionTimestamp: &oldDelete,
+				DeletionTimestamp: &pastShortWindowDelete,
 				Finalizers:        []string{"example.com/secret-finalizer"},
 			},
 			Data: map[string][]byte{"token": []byte(secretValue)},
@@ -1868,7 +1869,16 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 				Name:              "config-recent",
 				Namespace:         "prod",
 				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &pastShortWindowDelete,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "config-finalizer-recent",
+				Namespace:         "prod",
+				CreationTimestamp: oldCreated,
 				DeletionTimestamp: &recentDelete,
+				Finalizers:        []string{"example.com/config-finalizer"},
 			},
 		},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "config-normal", Namespace: "prod", CreationTimestamp: oldCreated}},
@@ -1888,6 +1898,16 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 				Namespace:         "prod",
 				CreationTimestamp: oldCreated,
 				DeletionTimestamp: &oldDelete,
+				Finalizers:        []string{"example.com/finalizer"},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod-recent",
+				Namespace:         "prod",
+				CreationTimestamp: oldCreated,
+				DeletionTimestamp: &pastShortWindowDelete,
 				Finalizers:        []string{"example.com/finalizer"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodRunning},
@@ -1937,20 +1957,25 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 		t.Fatalf("terminating pod problem = %+v, want finalizer context", p)
 	}
 	assertProblem(t, problems, "Deployment", "deploy-stuck", "Terminating stuck", "critical")
-	assertProblem(t, problems, "ConfigMap", "config-stuck", "Terminating stuck", "critical")
-	if p, ok := lookupProblem(problems, "ConfigMap", "config-stuck", "Terminating stuck"); !ok || !strings.Contains(p.Message, "example.com/config-finalizer") {
+	assertProblem(t, problems, "ConfigMap", "config-stuck", "Terminating stuck", "high")
+	if p, ok := lookupProblem(problems, "ConfigMap", "config-stuck", "Terminating stuck"); !ok || !strings.Contains(p.Message, "example.com/config-finalizer") || p.Fingerprint != "lifecycle:terminating" {
 		t.Fatalf("terminating ConfigMap problem = %+v, want finalizer context", p)
 	}
-	assertProblem(t, problems, "Secret", "secret-stuck", "Terminating stuck", "critical")
+	assertProblem(t, problems, "Secret", "secret-stuck", "Terminating stuck", "high")
 	if p, ok := lookupProblem(problems, "Secret", "secret-stuck", "Terminating stuck"); !ok {
 		t.Fatal("terminating Secret problem not found")
 	} else if !strings.Contains(p.Message, "example.com/secret-finalizer") {
 		t.Fatalf("terminating Secret problem = %+v, want finalizer context", p)
+	} else if p.Fingerprint != "lifecycle:terminating" {
+		t.Fatalf("terminating Secret fingerprint = %q, want lifecycle:terminating", p.Fingerprint)
 	} else if strings.Contains(fmt.Sprintf("%+v", p), secretValue) {
 		t.Fatalf("terminating Secret problem leaked secret data: %+v", p)
 	}
 	if hasProblem(problems, "ConfigMap", "config-recent", "Terminating stuck") {
-		t.Fatalf("recently deleting ConfigMap should not be flagged: %+v", problems)
+		t.Fatalf("ConfigMap without finalizers should keep the generic threshold: %+v", problems)
+	}
+	if hasProblem(problems, "ConfigMap", "config-finalizer-recent", "Terminating stuck") {
+		t.Fatalf("ConfigMap below the short finalizer window should not be flagged: %+v", problems)
 	}
 	if hasProblem(problems, "ConfigMap", "config-normal", "Terminating stuck") ||
 		hasProblem(problems, "Secret", "secret-normal", "Terminating stuck") {
@@ -1964,6 +1989,56 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 	}
 	if hasProblem(problems, "Service", "svc-recent", "Terminating stuck") {
 		t.Fatalf("recently deleting Service should not be flagged: %+v", problems)
+	}
+	if hasProblem(problems, "Pod", "pod-recent", "Terminating stuck") {
+		t.Fatalf("recently deleting Pod should keep the generic threshold: %+v", problems)
+	}
+}
+
+func TestTerminatingProblem_ConfigMapSecretFinalizerThreshold(t *testing.T) {
+	now := time.Now()
+	object := func(deletedAgo time.Duration, finalizers ...string) metav1.Object {
+		deleted := metav1.NewTime(now.Add(-deletedAgo))
+		return &metav1.ObjectMeta{
+			Name:              "target",
+			Namespace:         "prod",
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+			DeletionTimestamp: &deleted,
+			Finalizers:        finalizers,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		kind       string
+		group      string
+		deletedAgo time.Duration
+		finalizers []string
+		want       bool
+		wantLevel  string
+	}{
+		{name: "ConfigMap at short threshold", kind: "ConfigMap", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "Secret at short threshold", kind: "Secret", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "ConfigMap below short threshold", kind: "ConfigMap", deletedAgo: 2*time.Minute - time.Nanosecond, finalizers: []string{"example.com/cleanup"}},
+		{name: "ConfigMap without finalizer", kind: "ConfigMap", deletedAgo: 3 * time.Minute},
+		{name: "ConfigMap with foreground garbage collection keeps generic threshold", kind: "ConfigMap", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents}},
+		{name: "Secret with orphan garbage collection keeps generic threshold", kind: "Secret", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerOrphanDependents}},
+		{name: "ConfigMap with controller and garbage collection finalizers uses short threshold", kind: "ConfigMap", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents, "example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "Pod keeps generic threshold", kind: "Pod", deletedAgo: 3 * time.Minute, finalizers: []string{"example.com/cleanup"}},
+		{name: "colliding CRD kind keeps generic threshold", kind: "ConfigMap", group: "example.com", deletedAgo: 3 * time.Minute, finalizers: []string{"example.com/cleanup"}},
+		{name: "ConfigMap keeps critical threshold", kind: "ConfigMap", deletedAgo: 30 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "critical"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detection, got := terminatingProblem(tt.kind, tt.group, object(tt.deletedAgo, tt.finalizers...), now)
+			if got != tt.want {
+				t.Fatalf("terminatingProblem() emitted = %v, want %v; detection=%+v", got, tt.want, detection)
+			}
+			if got && detection.Severity != tt.wantLevel {
+				t.Fatalf("terminatingProblem() severity = %q, want %q", detection.Severity, tt.wantLevel)
+			}
+		})
 	}
 }
 

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -1957,11 +1957,11 @@ func TestDetectProblems_TerminatingResources(t *testing.T) {
 		t.Fatalf("terminating pod problem = %+v, want finalizer context", p)
 	}
 	assertProblem(t, problems, "Deployment", "deploy-stuck", "Terminating stuck", "critical")
-	assertProblem(t, problems, "ConfigMap", "config-stuck", "Terminating stuck", "high")
+	assertProblem(t, problems, "ConfigMap", "config-stuck", "Terminating stuck", "medium")
 	if p, ok := lookupProblem(problems, "ConfigMap", "config-stuck", "Terminating stuck"); !ok || !strings.Contains(p.Message, "example.com/config-finalizer") || p.Fingerprint != "lifecycle:terminating" {
 		t.Fatalf("terminating ConfigMap problem = %+v, want finalizer context", p)
 	}
-	assertProblem(t, problems, "Secret", "secret-stuck", "Terminating stuck", "high")
+	assertProblem(t, problems, "Secret", "secret-stuck", "Terminating stuck", "medium")
 	if p, ok := lookupProblem(problems, "Secret", "secret-stuck", "Terminating stuck"); !ok {
 		t.Fatal("terminating Secret problem not found")
 	} else if !strings.Contains(p.Message, "example.com/secret-finalizer") {
@@ -2017,16 +2017,22 @@ func TestTerminatingProblem_ConfigMapSecretFinalizerThreshold(t *testing.T) {
 		want       bool
 		wantLevel  string
 	}{
-		{name: "ConfigMap at short threshold", kind: "ConfigMap", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
-		{name: "Secret at short threshold", kind: "Secret", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "ConfigMap at short threshold", kind: "ConfigMap", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "medium"},
+		{name: "Secret at short threshold", kind: "Secret", deletedAgo: 2 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "medium"},
 		{name: "ConfigMap below short threshold", kind: "ConfigMap", deletedAgo: 2*time.Minute - time.Nanosecond, finalizers: []string{"example.com/cleanup"}},
+		{name: "ConfigMap below generic threshold", kind: "ConfigMap", deletedAgo: 10*time.Minute - time.Nanosecond, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "medium"},
+		{name: "ConfigMap at generic threshold", kind: "ConfigMap", deletedAgo: 10 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "ConfigMap below critical threshold", kind: "ConfigMap", deletedAgo: 30*time.Minute - time.Nanosecond, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "ConfigMap at critical threshold", kind: "ConfigMap", deletedAgo: 30 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "critical"},
 		{name: "ConfigMap without finalizer", kind: "ConfigMap", deletedAgo: 3 * time.Minute},
 		{name: "ConfigMap with foreground garbage collection keeps generic threshold", kind: "ConfigMap", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents}},
+		{name: "ConfigMap with foreground garbage collection emits at generic threshold", kind: "ConfigMap", deletedAgo: 10 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents}, want: true, wantLevel: "high"},
 		{name: "Secret with orphan garbage collection keeps generic threshold", kind: "Secret", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerOrphanDependents}},
-		{name: "ConfigMap with controller and garbage collection finalizers uses short threshold", kind: "ConfigMap", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents, "example.com/cleanup"}, want: true, wantLevel: "high"},
+		{name: "ConfigMap with controller and garbage collection finalizers uses short threshold", kind: "ConfigMap", deletedAgo: 3 * time.Minute, finalizers: []string{metav1.FinalizerDeleteDependents, "example.com/cleanup"}, want: true, wantLevel: "medium"},
 		{name: "Pod keeps generic threshold", kind: "Pod", deletedAgo: 3 * time.Minute, finalizers: []string{"example.com/cleanup"}},
+		{name: "Pod below generic threshold", kind: "Pod", deletedAgo: 10*time.Minute - time.Nanosecond, finalizers: []string{"example.com/cleanup"}},
+		{name: "Pod at generic threshold", kind: "Pod", deletedAgo: 10 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "high"},
 		{name: "colliding CRD kind keeps generic threshold", kind: "ConfigMap", group: "example.com", deletedAgo: 3 * time.Minute, finalizers: []string{"example.com/cleanup"}},
-		{name: "ConfigMap keeps critical threshold", kind: "ConfigMap", deletedAgo: 30 * time.Minute, finalizers: []string{"example.com/cleanup"}, want: true, wantLevel: "critical"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Radar now reports finalizer-wedged core ConfigMaps and Secrets on a timescale appropriate to configuration objects instead of waiting for the generic pod-oriented ten-minute threshold. The raw detector used by REST and MCP dashboards ramps these objects from `medium` at two minutes, to `high` at ten minutes, to `critical` at thirty minutes.

The normalized issues surface intentionally remains two-tier: both raw `medium` and `high` appear as `warning` in `/api/issues` and MCP `get_issues`, while raw `critical` remains `critical`.

## What changed

- Core `ConfigMap` and `Secret` objects enter the stuck-terminating path after two minutes when deletion has started and at least one non-GC finalizer remains.
- Raw dashboard severity is `medium` from 2–10 minutes, `high` from 10–30 minutes, and `critical` from 30 minutes onward.
- API-managed `foregroundDeletion` and `orphan` finalizers do not trigger the fast path on their own because dependent garbage collection can legitimately take time.
- A mixed GC plus controller finalizer still triggers the fast path.
- No-finalizer objects, Pods, all other kinds, and non-core CRDs that reuse the ConfigMap or Secret kind retain the generic ten-minute threshold and begin at raw `high`.
- The existing reason, fingerprint, remediation, and message shape are preserved; the message names the blocking finalizers.

The separate Cluster Audit policy and the factual deletion timestamp/finalizer fields in AI summaries are unchanged.

## Testing

Latest severity-ramp validation:

- `go test ./internal/k8s/... -run Terminating -count=1`
- `go test ./internal/k8s/... -count=1`
- `go test ./internal/issues/... -count=1`
- `go test ./internal/mcp/... -count=1`
- `go test ./internal/server/... -count=1`
- `go build ./...`

Earlier full branch validation also passed `make tsc`, `make test`, `make build`, `make backend`, the nested `pkg` build, and `pkg/audit` tests.

Coverage pins exact raw-severity boundaries at two minutes, immediately below and at ten minutes, and immediately below and at thirty minutes. It also covers the generic ten-minute boundary, below-threshold controller finalizers, no-finalizer negatives, Pod and CRD-kind-collision regressions, both GC-only finalizers, mixed GC/controller finalizers, Secret non-leak behavior, namespace scoping, finalizer names, and the existing medium/high-to-warning issues normalization contract.

Live and visual testing were skipped because proving the timing path live would require intentionally wedging cluster objects and waiting. The informer-backed detector tests exercise the production path more deterministically, and there is no UI change.

## Tradeoff

Some legitimate custom controller cleanup can exceed two minutes. The raw dashboard starts at `medium`, normalized issues expose that as `warning`, and critical remains gated at thirty minutes. Kubernetes GC-only finalizers are explicitly excluded from the fast path.