### PR TITLE
Surface observed stale Secret env issues for Ready pods

### DIFF
--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -314,6 +314,43 @@ func TestCompose_StaleSecretEnvSurvivesAsStableWorkloadIssue(t *testing.T) {
 	}
 }
 
+func TestCompose_ReadyStaleSecretEnvWorkloadDetectionKeepsAgentGuidance(t *testing.T) {
+	const message = "Deployment/catalog has 2 Ready pods whose running containers loaded 2 Secret-backed environment values before Radar observed the consumed Secret keys change; they may still hold pre-change values."
+	const cause = "Radar observed consumed Secret keys change after these Ready container instances started; Kubernetes does not refresh Secret-backed environment variables in running containers."
+	const action = "Confirm no rollout is already replacing the affected pods, then restart Deployment/catalog so its containers re-read Secret-backed environment variables."
+	p := &fakeProvider{problems: []k8s.Detection{{
+		Group: "apps", Kind: "Deployment", Namespace: "shop", Name: "catalog",
+		Severity: "warning", Reason: "StaleSecretEnv", Message: message,
+		Fingerprint: "stale-secret-env", Cause: cause, Action: action,
+	}}}
+
+	out := Compose(p, Filters{Grouped: true})
+	if len(out) != 1 {
+		t.Fatalf("Ready stale-env workload detection was dropped or duplicated: %+v", out)
+	}
+	issue := out[0]
+	if issue.Group != "apps" || issue.Kind != "Deployment" || issue.Namespace != "shop" || issue.Name != "catalog" ||
+		issue.Category != issuesapi.CategoryInvalidConfiguration || issue.Message != message || issue.Cause != cause || issue.Action != action {
+		t.Fatalf("Ready stale-env issue lost its workload identity or agent guidance: %+v", issue)
+	}
+}
+
+func TestCompose_StaleSecretEnvIdentityStableAcrossReadyTransition(t *testing.T) {
+	ready := Compose(&fakeProvider{problems: []k8s.Detection{{
+		Group: "batch", Kind: "Job", Namespace: "shop", Name: "report",
+		Severity: "warning", Reason: "StaleSecretEnv", Fingerprint: "stale-secret-env",
+	}}}, Filters{Grouped: true})
+	notReady := Compose(&fakeProvider{problems: []k8s.Detection{{
+		Kind: "Pod", Namespace: "shop", Name: "report-abc",
+		OwnerGroup: "batch", OwnerKind: "Job", OwnerName: "report",
+		Severity: "warning", Reason: "StaleSecretEnv", Fingerprint: "stale-secret-env",
+	}}}, Filters{Grouped: true})
+
+	if len(ready) != 1 || len(notReady) != 1 || ready[0].ID == "" || ready[0].ID != notReady[0].ID {
+		t.Fatalf("Ready and not-Ready exposure re-keyed the same Job-owned stale-env condition: ready=%+v notReady=%+v", ready, notReady)
+	}
+}
+
 func TestCompose_GroupedKindFilterMatchesSubject(t *testing.T) {
 	// A crashlooping Deployment is evidenced by Pod rows that fold under the
 	// Deployment subject. On the GROUPED surface, kind=Deployment must return

--- a/internal/k8s/detect_env_history.go
+++ b/internal/k8s/detect_env_history.go
@@ -17,6 +17,8 @@ import (
 const (
 	envHistoryLookback                  = time.Hour
 	envHistoryContextMaxLookback        = 24 * time.Hour
+	staleSecretEnvRolloutEvidenceWindow = 10 * time.Minute
+	maxSecretDataHistoryEvents          = 1000
 	maxStaleSecretEnvChecksPerContainer = 5
 	// A mass Secret rotation coinciding with a rollout can leave many pods
 	// simultaneously not-Ready with in-window key changes; a sweep must not
@@ -209,7 +211,8 @@ func FindStaleSecretEnvChecksForObject(ctx context.Context, cache *ResourceCache
 		return nil
 	}
 	now := time.Now()
-	return findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, querySecretDataHistory(ctx, pod.Namespace, staleSecretEnvHistorySince([]*corev1.Pod{pod}, now)))
+	pods := []*corev1.Pod{pod}
+	return findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(ctx, pod.Namespace, pods, staleSecretEnvHistorySince(pods, now)))
 }
 
 // FindStaleSecretEnvChecksForPods aggregates the Pod-level facts needed by a
@@ -233,8 +236,9 @@ func FindStaleSecretEnvChecksForPods(ctx context.Context, cache *ResourceCache, 
 	var out []StaleSecretEnvCheck
 	for _, namespace := range namespaces {
 		now := time.Now()
-		events := querySecretDataHistory(ctx, namespace, staleSecretEnvHistorySince(podsByNamespace[namespace], now))
-		checks := groupStaleSecretEnvChecks(findStaleSecretEnvChecksWithManagedFields(cache, podsByNamespace[namespace], events))
+		pods := podsByNamespace[namespace]
+		events := querySecretDataHistory(ctx, namespace, pods, staleSecretEnvHistorySince(pods, now))
+		checks := groupStaleSecretEnvChecks(findStaleSecretEnvChecksWithManagedFields(cache, pods, events))
 		if len(checks) > maxStaleSecretEnvDetectionsPerNamespace {
 			checks = checks[:maxStaleSecretEnvDetectionsPerNamespace]
 		}
@@ -287,66 +291,366 @@ func detectStaleSecretEnv(cache *ResourceCache, namespace string, now time.Time)
 		logConfigListError("Pod", namespace, err)
 		return nil
 	}
-	usesSecretEnv := false
+	var secretEnvPods []*corev1.Pod
 	for _, pod := range pods {
 		if podHasSecretEnvReference(pod) {
-			usesSecretEnv = true
-			break
+			secretEnvPods = append(secretEnvPods, pod)
 		}
 	}
-	if !usesSecretEnv {
+	if len(secretEnvPods) == 0 {
 		return nil
 	}
-	checks := findStaleSecretEnvChecks(cache, pods, querySecretDataHistory(context.Background(), namespace, staleSecretEnvHistorySince(pods, now)))
+	events := querySecretDataHistory(context.Background(), namespace, secretEnvPods, staleSecretEnvHistorySince(secretEnvPods, now))
+	checks := findStaleSecretEnvChecks(cache, secretEnvPods, events)
 	checksByPod := make(map[string][]StaleSecretEnvCheck)
 	for _, check := range checks {
 		key := check.Namespace + "\x00" + check.PodName
 		checksByPod[key] = append(checksByPod[key], check)
 	}
-	var out []Detection
+
+	subjectByPod := make(map[string]staleSecretEnvSubject, len(pods))
+	podsBySubject := make(map[string][]*corev1.Pod)
+	for _, pod := range pods {
+		subject := staleSecretEnvSubjectForPod(cache, pod)
+		podKey := pod.Namespace + "\x00" + pod.Name
+		subjectByPod[podKey] = subject
+		podsBySubject[subject.key()] = append(podsBySubject[subject.key()], pod)
+	}
+
+	var notReadyOut []Detection
+	readyGroups := make(map[string]*staleSecretEnvReadyGroup)
+	notReadySubjects := make(map[string]bool)
 	for _, pod := range pods {
 		podChecks := checksByPod[pod.Namespace+"\x00"+pod.Name]
-		bitingChecks := staleSecretEnvBitingChecks(pod, podChecks)
-		if len(bitingChecks) == 0 {
+		issueChecks, podReady := staleSecretEnvIssueChecks(pod, podChecks)
+		if len(issueChecks) == 0 {
 			continue
 		}
-		changedAt := bitingChecks[0].SecretChangedAt
-		for _, check := range bitingChecks[1:] {
-			if check.SecretChangedAt.Before(changedAt) {
-				changedAt = check.SecretChangedAt
+		subject := subjectByPod[pod.Namespace+"\x00"+pod.Name]
+		if podReady {
+			group := readyGroups[subject.key()]
+			if group == nil {
+				group = &staleSecretEnvReadyGroup{subject: subject}
+				readyGroups[subject.key()] = group
+			}
+			group.checks = append(group.checks, issueChecks...)
+			continue
+		}
+
+		notReadySubjects[subject.key()] = true
+		ownerGroup, ownerKind, ownerName := podOwnerKindName(cache, pod)
+		notReadyOut = append(notReadyOut, Detection{
+			Kind:        "Pod",
+			Namespace:   pod.Namespace,
+			Name:        pod.Name,
+			Severity:    "warning",
+			Reason:      "StaleSecretEnv",
+			Message:     staleSecretEnvDetectionMessage(issueChecks),
+			OwnerGroup:  ownerGroup,
+			OwnerKind:   ownerKind,
+			OwnerName:   ownerName,
+			Fingerprint: "stale-secret-env",
+			Cause:       "A running container loaded a Secret-backed environment value before Radar observed that Secret key change.",
+			Action:      "Restart the pod so its containers re-read Secret-backed environment variables.",
+		})
+		setStaleSecretEnvDetectionAge(&notReadyOut[len(notReadyOut)-1], issueChecks, now)
+	}
+
+	readyKeys := make([]string, 0, len(readyGroups))
+	for key := range readyGroups {
+		readyKeys = append(readyKeys, key)
+	}
+	sort.Strings(readyKeys)
+	var readyOut []Detection
+	for _, key := range readyKeys {
+		if notReadySubjects[key] {
+			continue
+		}
+		group := readyGroups[key]
+		rolloutEvidence := newStaleSecretEnvRolloutEvidence(group.subject, podsBySubject[key], now)
+		var currentChecks []StaleSecretEnvCheck
+		for _, check := range group.checks {
+			if !rolloutEvidence.supersedes(check) {
+				currentChecks = append(currentChecks, check)
 			}
 		}
-		age := ageSeconds(now, changedAt)
-		ownerGroup, ownerKind, ownerName := podOwnerKindName(cache, pod)
-		out = append(out, Detection{
-			Kind:            "Pod",
-			Namespace:       pod.Namespace,
-			Name:            pod.Name,
-			Severity:        "warning",
-			Reason:          "StaleSecretEnv",
-			Message:         staleSecretEnvDetectionMessage(bitingChecks),
-			Age:             FormatAge(time.Duration(age) * time.Second),
-			AgeSeconds:      age,
-			Duration:        FormatAge(time.Duration(age) * time.Second),
-			DurationSeconds: age,
-			OwnerGroup:      ownerGroup,
-			OwnerKind:       ownerKind,
-			OwnerName:       ownerName,
-			Fingerprint:     "stale-secret-env",
-			Cause:           "A running container loaded a Secret-backed environment value before Radar observed that Secret key change.",
-			Action:          "Restart the pod so its containers re-read Secret-backed environment variables.",
-		})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Namespace != out[j].Namespace {
-			return out[i].Namespace < out[j].Namespace
+		if len(currentChecks) == 0 {
+			continue
 		}
-		return out[i].Name < out[j].Name
+		affectedPods := make(map[string]bool)
+		for _, check := range currentChecks {
+			affectedPods[check.PodName] = true
+		}
+		detection := Detection{
+			Group:       group.subject.group,
+			Kind:        group.subject.kind,
+			Namespace:   group.subject.namespace,
+			Name:        group.subject.name,
+			Severity:    "warning",
+			Reason:      "StaleSecretEnv",
+			Message:     staleSecretEnvReadyDetectionMessage(group.subject, len(affectedPods), len(currentChecks)),
+			Fingerprint: "stale-secret-env",
+			Cause:       "Radar observed consumed Secret keys change after these Ready container instances started; Kubernetes does not refresh Secret-backed environment variables in running containers.",
+			Action:      staleSecretEnvReadyAction(group.subject),
+		}
+		setStaleSecretEnvDetectionAge(&detection, currentChecks, now)
+		readyOut = append(readyOut, detection)
+	}
+
+	sort.Slice(notReadyOut, func(i, j int) bool {
+		if notReadyOut[i].Namespace != notReadyOut[j].Namespace {
+			return notReadyOut[i].Namespace < notReadyOut[j].Namespace
+		}
+		return notReadyOut[i].Name < notReadyOut[j].Name
 	})
+	sort.Slice(readyOut, func(i, j int) bool {
+		if readyOut[i].Namespace != readyOut[j].Namespace {
+			return readyOut[i].Namespace < readyOut[j].Namespace
+		}
+		if readyOut[i].Kind != readyOut[j].Kind {
+			return readyOut[i].Kind < readyOut[j].Kind
+		}
+		return readyOut[i].Name < readyOut[j].Name
+	})
+	out := append(notReadyOut, readyOut...)
 	if len(out) > maxStaleSecretEnvDetectionsPerNamespace {
 		out = out[:maxStaleSecretEnvDetectionsPerNamespace]
 	}
 	return out
+}
+
+type staleSecretEnvSubject struct {
+	group       string
+	kind        string
+	namespace   string
+	name        string
+	restartable bool
+}
+
+func staleSecretEnvSubjectForPod(cache *ResourceCache, pod *corev1.Pod) staleSecretEnvSubject {
+	group, kind, name := podOwnerKindName(cache, pod)
+	if kind == "" {
+		kind = "Pod"
+		name = pod.Name
+	}
+	return staleSecretEnvSubject{
+		group: group, kind: kind, namespace: pod.Namespace, name: name,
+		restartable: staleSecretEnvRestartableOwner(group, kind),
+	}
+}
+
+func staleSecretEnvRestartableOwner(group, kind string) bool {
+	switch kind {
+	case "Deployment", "StatefulSet", "DaemonSet":
+		return group == "apps"
+	case "Rollout":
+		return group == "argoproj.io"
+	default:
+		return false
+	}
+}
+
+func (s staleSecretEnvSubject) key() string {
+	return s.group + "\x00" + s.kind + "\x00" + s.namespace + "\x00" + s.name
+}
+
+type staleSecretEnvReadyGroup struct {
+	subject staleSecretEnvSubject
+	checks  []StaleSecretEnvCheck
+}
+
+type staleSecretEnvConsumption struct {
+	container string
+	secret    string
+	key       string
+}
+
+type staleSecretEnvReplacement struct {
+	revision  string
+	startedAt time.Time
+}
+
+type staleSecretEnvRolloutEvidence struct {
+	revisionByPod map[string]string
+	replacements  map[staleSecretEnvConsumption][]staleSecretEnvReplacement
+}
+
+func newStaleSecretEnvRolloutEvidence(subject staleSecretEnvSubject, pods []*corev1.Pod, now time.Time) staleSecretEnvRolloutEvidence {
+	evidence := staleSecretEnvRolloutEvidence{}
+	if (subject.group != "apps" || subject.kind != "Deployment") &&
+		(subject.group != "argoproj.io" || subject.kind != "Rollout") {
+		return evidence
+	}
+	evidence.revisionByPod = make(map[string]string, len(pods))
+	evidence.replacements = make(map[staleSecretEnvConsumption][]staleSecretEnvReplacement)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		revisionRef := controllerOwnerRef(pod.OwnerReferences)
+		if revisionRef == nil || revisionRef.Kind != "ReplicaSet" {
+			continue
+		}
+		revision := ownerReferenceIdentity(revisionRef)
+		evidence.revisionByPod[pod.Name] = revision
+		if pod.DeletionTimestamp != nil || !isPodReadyForProblem(pod) {
+			continue
+		}
+		statusByContainer := staleSecretEnvContainerStatuses(pod)
+		for _, container := range staleSecretEnvContainers(pod) {
+			status, ok := statusByContainer[container.Name]
+			if !ok || !status.Ready || status.State.Running == nil || status.State.Running.StartedAt.IsZero() {
+				continue
+			}
+			startedAt := status.State.Running.StartedAt.Time
+			if startedAt.After(now) || now.Sub(startedAt) > staleSecretEnvRolloutEvidenceWindow {
+				continue
+			}
+			replacement := staleSecretEnvReplacement{revision: revision, startedAt: startedAt}
+			for _, env := range container.Env {
+				if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+					continue
+				}
+				ref := env.ValueFrom.SecretKeyRef
+				evidence.add(staleSecretEnvConsumption{container: container.Name, secret: ref.Name, key: ref.Key}, replacement)
+			}
+			for _, envFrom := range container.EnvFrom {
+				if envFrom.SecretRef != nil {
+					evidence.add(staleSecretEnvConsumption{container: container.Name, secret: envFrom.SecretRef.Name}, replacement)
+				}
+			}
+		}
+	}
+	return evidence
+}
+
+func (e *staleSecretEnvRolloutEvidence) add(consumption staleSecretEnvConsumption, replacement staleSecretEnvReplacement) {
+	candidates := e.replacements[consumption]
+	for i := range candidates {
+		if candidates[i].revision == replacement.revision {
+			if replacement.startedAt.After(candidates[i].startedAt) {
+				candidates[i] = replacement
+			}
+			e.replacements[consumption] = candidates
+			return
+		}
+	}
+	candidates = append(candidates, replacement)
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].startedAt.After(candidates[j].startedAt)
+	})
+	if len(candidates) > 2 {
+		candidates = candidates[:2]
+	}
+	e.replacements[consumption] = candidates
+}
+
+func (e staleSecretEnvRolloutEvidence) supersedes(check StaleSecretEnvCheck) bool {
+	staleRevision := e.revisionByPod[check.PodName]
+	if staleRevision == "" {
+		return false
+	}
+	consumptions := [...]staleSecretEnvConsumption{
+		{container: check.Container, secret: check.SecretName, key: check.Key},
+		{container: check.Container, secret: check.SecretName},
+	}
+	for _, consumption := range consumptions {
+		for _, replacement := range e.replacements[consumption] {
+			if replacement.revision != staleRevision && !replacement.startedAt.Before(check.SecretChangedAt) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ownerReferenceIdentity(ref *metav1.OwnerReference) string {
+	if ref.UID != "" {
+		return string(ref.UID)
+	}
+	return ref.APIVersion + "\x00" + ref.Kind + "\x00" + ref.Name
+}
+
+func secretEnvReferenceNames(pods []*corev1.Pod) []string {
+	names := make(map[string]bool)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, container := range staleSecretEnvContainers(pod) {
+			for _, env := range container.Env {
+				if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name != "" {
+					names[env.ValueFrom.SecretKeyRef.Name] = true
+				}
+			}
+			for _, envFrom := range container.EnvFrom {
+				if envFrom.SecretRef != nil && envFrom.SecretRef.Name != "" {
+					names[envFrom.SecretRef.Name] = true
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func secretEnvReferenceNamespaces(pods []*corev1.Pod) []string {
+	namespaces := make(map[string]bool)
+	for _, pod := range pods {
+		if pod != nil && pod.Namespace != "" {
+			namespaces[pod.Namespace] = true
+		}
+	}
+	out := make([]string, 0, len(namespaces))
+	for namespace := range namespaces {
+		out = append(out, namespace)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func setStaleSecretEnvDetectionAge(detection *Detection, checks []StaleSecretEnvCheck, now time.Time) {
+	changedAt := checks[0].SecretChangedAt
+	for _, check := range checks[1:] {
+		if check.SecretChangedAt.Before(changedAt) {
+			changedAt = check.SecretChangedAt
+		}
+	}
+	age := ageSeconds(now, changedAt)
+	detection.Age = FormatAge(time.Duration(age) * time.Second)
+	detection.AgeSeconds = age
+	detection.Duration = FormatAge(time.Duration(age) * time.Second)
+	detection.DurationSeconds = age
+}
+
+func staleSecretEnvReadyDetectionMessage(subject staleSecretEnvSubject, podCount, checkCount int) string {
+	if podCount == 1 {
+		if checkCount == 1 {
+			if subject.kind != "Pod" {
+				return fmt.Sprintf("%s/%s has a Ready pod whose running container loaded a Secret-backed environment value before Radar observed its consumed Secret key change; it may still hold the pre-change value.", subject.kind, subject.name)
+			}
+			return fmt.Sprintf("%s/%s is Ready, but a running container loaded a Secret-backed environment value before Radar observed its consumed Secret key change; it may still hold the pre-change value.", subject.kind, subject.name)
+		}
+		if subject.kind != "Pod" {
+			return fmt.Sprintf("%s/%s has a Ready pod whose running containers loaded %d Secret-backed environment values before Radar observed the consumed Secret keys change; they may still hold pre-change values.", subject.kind, subject.name, checkCount)
+		}
+		return fmt.Sprintf("%s/%s is Ready, but its running containers loaded %d Secret-backed environment values before Radar observed the consumed Secret keys change; they may still hold pre-change values.", subject.kind, subject.name, checkCount)
+	}
+	return fmt.Sprintf("%s/%s has %d Ready pods whose running containers loaded %d Secret-backed environment values before Radar observed the consumed Secret keys change; they may still hold pre-change values.", subject.kind, subject.name, podCount, checkCount)
+}
+
+func staleSecretEnvReadyAction(subject staleSecretEnvSubject) string {
+	if subject.restartable {
+		return fmt.Sprintf("Confirm no rollout is already replacing the affected pods, then restart %s/%s so its containers re-read Secret-backed environment variables.", subject.kind, subject.name)
+	}
+	if subject.kind == "Pod" {
+		return fmt.Sprintf("Confirm no replacement is already in progress, then replace Pod/%s through its owning controller (or recreate it if standalone) so its containers re-read Secret-backed environment variables.", subject.name)
+	}
+	return fmt.Sprintf("Confirm no replacement is already in progress, then use %s/%s's normal controller workflow to replace the affected pods so they re-read Secret-backed environment variables.", subject.kind, subject.name)
 }
 
 func podHasSecretEnvReference(pod *corev1.Pod) bool {
@@ -419,19 +723,31 @@ func isRestartableInitContainer(container corev1.Container) bool {
 	return container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }
 
-func querySecretDataHistory(ctx context.Context, namespace string, since time.Time) []timeline.TimelineEvent {
+func querySecretDataHistory(ctx context.Context, namespace string, pods []*corev1.Pod, since time.Time) []timeline.TimelineEvent {
+	names := secretEnvReferenceNames(pods)
+	if len(names) == 0 {
+		return nil
+	}
 	opts := timeline.QueryOptions{
 		Kinds:          []string{"Secret"},
+		Names:          names,
 		Since:          since,
 		Sources:        []timeline.EventSource{timeline.SourceInformer},
 		EventTypes:     []timeline.EventType{timeline.EventTypeUpdate},
 		ClusterContext: ActiveClusterContext(),
-		Limit:          1000,
+		IncludeManaged: true,
+		Limit:          maxSecretDataHistoryEvents,
 	}
 	if namespace != "" {
 		opts.Namespaces = []string{namespace}
+	} else {
+		opts.Namespaces = secretEnvReferenceNamespaces(pods)
 	}
-	return queryEnvHistory(ctx, opts)
+	events := queryEnvHistory(ctx, opts)
+	if len(events) >= maxSecretDataHistoryEvents {
+		return nil
+	}
+	return events
 }
 
 func staleSecretEnvHistorySince(pods []*corev1.Pod, now time.Time) time.Time {
@@ -788,9 +1104,9 @@ func sortTimelineEventsNewestFirst(events []timeline.TimelineEvent) {
 	})
 }
 
-func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) []StaleSecretEnvCheck {
-	if pod == nil || pod.Status.Phase != corev1.PodRunning {
-		return nil
+func staleSecretEnvIssueChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) ([]StaleSecretEnvCheck, bool) {
+	if pod == nil || pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+		return nil, false
 	}
 	readyKnown, ready := false, false
 	for _, condition := range pod.Status.Conditions {
@@ -800,34 +1116,31 @@ func staleSecretEnvBitingChecks(pod *corev1.Pod, checks []StaleSecretEnvCheck) [
 			break
 		}
 	}
-	if !readyKnown || ready {
-		return nil
+	if !readyKnown {
+		return nil, false
 	}
-	// Only a Running-but-not-Ready container can be holding a stale value: a
-	// Waiting or crashlooping container re-reads Secret-backed env on its next
-	// (re)start, so it is deliberately outside this gate. Restartable init
-	// containers (native sidecars) run for the pod's lifetime and their
-	// readiness feeds the Pod Ready condition, so a not-Ready one bites exactly
-	// like a regular container; pure init containers are already excluded.
-	bitingContainers := make(map[string]bool)
+	// Waiting containers re-read Secret-backed env on their next start. Running
+	// containers can retain it; for a not-Ready pod, only a not-Ready container
+	// is evidence that the stale value is biting.
+	eligibleContainers := make(map[string]bool)
 	restartable := restartableInitContainerNames(pod)
 	for _, status := range pod.Status.InitContainerStatuses {
-		if restartable[status.Name] && status.State.Running != nil && !status.Ready {
-			bitingContainers[status.Name] = true
+		if restartable[status.Name] && status.State.Running != nil && (ready || !status.Ready) {
+			eligibleContainers[status.Name] = true
 		}
 	}
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.State.Running != nil && !status.Ready {
-			bitingContainers[status.Name] = true
+		if status.State.Running != nil && (ready || !status.Ready) {
+			eligibleContainers[status.Name] = true
 		}
 	}
 	var out []StaleSecretEnvCheck
 	for _, check := range checks {
-		if check.EvidenceSource == staleSecretEvidenceObservedChange && bitingContainers[check.Container] {
+		if check.EvidenceSource == staleSecretEvidenceObservedChange && eligibleContainers[check.Container] {
 			out = append(out, check)
 		}
 	}
-	return out
+	return out, ready
 }
 
 func staleSecretEnvDetectionMessage(checks []StaleSecretEnvCheck) string {

--- a/internal/k8s/detect_env_history_test.go
+++ b/internal/k8s/detect_env_history_test.go
@@ -110,7 +110,7 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 	}
 	change := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"password"})
 
-	t.Run("healthy is FYI only", func(t *testing.T) {
+	t.Run("Ready pod with observed key change promotes", func(t *testing.T) {
 		pod := staleSecretEnvPod("catalog-healthy", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
 		cache := envHistoryTestCache(t, pod, secret)
 		setEnvHistoryEvents(t, change)
@@ -118,8 +118,29 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		if len(checks) != 1 {
 			t.Fatalf("got %d stale Secret env facts, want 1: %+v", len(checks), checks)
 		}
-		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
-			t.Fatalf("healthy stale pod must remain FYI-only: %+v", detections)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" || detections[0].Severity != "warning" ||
+			detections[0].Kind != "Pod" || detections[0].Name != pod.Name || detections[0].Fingerprint != "stale-secret-env" {
+			t.Fatalf("unexpected Ready-pod detection: %+v", detections)
+		}
+		detection := detections[0]
+		if !strings.Contains(detection.Message, "is Ready") || !strings.Contains(detection.Message, "may still hold the pre-change value") ||
+			!strings.Contains(detection.Cause, "does not refresh") || !strings.Contains(detection.Action, "Confirm no replacement") {
+			t.Fatalf("Ready-pod detection did not preserve evidence and uncertainty: %+v", detection)
+		}
+	})
+
+	t.Run("Ready pod consumes an operator-owned Secret rotation", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog-external-secret", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		cache := envHistoryTestCache(t, pod, secret)
+		managedChange := change
+		managedChange.ID = "managed-secret-change"
+		managedChange.Owner = &timeline.OwnerInfo{Kind: "ExternalSecret", Name: "db-conn"}
+		setEnvHistoryEvents(t, managedChange)
+
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" || detections[0].Name != pod.Name {
+			t.Fatalf("owner-bearing Secret updates must remain exact observed evidence: %+v", detections)
 		}
 	})
 
@@ -134,6 +155,11 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		detections := detectStaleSecretEnv(cache, "shop", now)
 		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" || detections[0].Severity != "warning" || detections[0].Kind != "Pod" || detections[0].Name != pod.Name || detections[0].Fingerprint != "stale-secret-env" {
 			t.Fatalf("unexpected promoted detection: %+v", detections)
+		}
+		if detections[0].Message != "Container app is not Ready and may be running a stale env value for Secret/db-conn key password; restart the pod to refresh it." ||
+			detections[0].Cause != "A running container loaded a Secret-backed environment value before Radar observed that Secret key change." ||
+			detections[0].Action != "Restart the pod so its containers re-read Secret-backed environment variables." {
+			t.Fatalf("not-Ready detection contract changed: %+v", detections[0])
 		}
 		encoded, err := json.Marshal(struct {
 			Checks     []StaleSecretEnvCheck `json:"checks"`
@@ -175,10 +201,41 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 	})
 
 	t.Run("restart after change suppresses", func(t *testing.T) {
-		pod := staleSecretEnvPod("restarted", changedAt.Add(time.Second), false, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		pod := staleSecretEnvPod("restarted", changedAt.Add(time.Second), true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
 		cache := envHistoryTestCache(t, pod, secret)
 		if checks := findStaleSecretEnvChecks(cache, []*corev1.Pod{pod}, []timeline.TimelineEvent{change}); len(checks) != 0 {
 			t.Fatalf("post-change start must suppress stale fact: %+v", checks)
+		}
+		setEnvHistoryEvents(t, change)
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
+			t.Fatalf("post-change Ready pod must not produce an issue: %+v", detections)
+		}
+	})
+
+	t.Run("terminating Ready pod is ignored", func(t *testing.T) {
+		pod := staleSecretEnvPod("terminating", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		deletedAt := metav1.NewTime(now.Add(-time.Second))
+		pod.DeletionTimestamp = &deletedAt
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
+			t.Fatalf("terminating pod must not produce a stale-env issue: %+v", detections)
+		}
+	})
+
+	t.Run("Ready issue describes only containers started before the change", func(t *testing.T) {
+		pod := staleSecretEnvPod("catalog-mixed-starts", startedAt, true, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "sidecar", Env: []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")}})
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+			Name: "sidecar", Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(changedAt.Add(time.Second))}},
+		})
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || !strings.Contains(detections[0].Message, "a Secret-backed environment value") ||
+			strings.Contains(detections[0].Message, "2 Secret-backed") {
+			t.Fatalf("Ready issue must include only pre-change container instances: %+v", detections)
 		}
 	})
 
@@ -343,6 +400,26 @@ func TestStaleSecretEnvExposureAndFalsePositiveMatrix(t *testing.T) {
 		}
 	})
 
+	t.Run("Ready restartable init sidecar promotes", func(t *testing.T) {
+		pod := staleSecretEnvPod("sidecar-ready", startedAt, true)
+		pod.Spec.InitContainers = []corev1.Container{{
+			Name:          "vault-agent",
+			RestartPolicy: alwaysRestartPolicy(),
+			Env:           []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")},
+		}}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+			Name: "vault-agent", Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)}},
+		}}
+		cache := envHistoryTestCache(t, pod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Reason != "StaleSecretEnv" ||
+			!strings.Contains(detections[0].Message, "is Ready") {
+			t.Fatalf("Ready restartable init sidecar must promote from exact observed evidence: %+v", detections)
+		}
+	})
+
 	t.Run("regular init container is not detected", func(t *testing.T) {
 		pod := staleSecretEnvPod("init-only", startedAt, false)
 		pod.Spec.Containers = []corev1.Container{{Name: "app"}}
@@ -490,6 +567,9 @@ func TestStaleSecretEnvManagedFieldsFallback(t *testing.T) {
 		if len(checks) != 1 || checks[0].EvidenceSource != staleSecretEvidenceObservedChange || checks[0].Key != "password" {
 			t.Fatalf("older precise evidence should win over managedFields fallback: %+v", checks)
 		}
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 1 || detections[0].Name != pod.Name {
+			t.Fatalf("live issue horizon must align with precise diagnostic history: %+v", detections)
+		}
 	})
 
 	t.Run("pre-start write and restart suppress", func(t *testing.T) {
@@ -535,8 +615,8 @@ func TestStaleSecretEnvManagedFieldsFallback(t *testing.T) {
 		if len(checks) != 1 {
 			t.Fatalf("data-owning manager write should produce one hedged FYI: %+v", checks)
 		}
-		if biting := staleSecretEnvBitingChecks(pod, checks); len(biting) != 0 {
-			t.Fatalf("managedFields fallback must never enter issue promotion: %+v", biting)
+		if issueChecks, _ := staleSecretEnvIssueChecks(pod, checks); len(issueChecks) != 0 {
+			t.Fatalf("managedFields fallback must never enter issue promotion: %+v", issueChecks)
 		}
 	})
 
@@ -950,6 +1030,226 @@ func TestStaleSecretEnvDetectionResolvesWorkloadOwner(t *testing.T) {
 	detections := detectStaleSecretEnv(cache, "shop", now)
 	if len(detections) != 1 || detections[0].OwnerGroup != "apps" || detections[0].OwnerKind != "Deployment" || detections[0].OwnerName != "catalog" {
 		t.Fatalf("stale pod detection did not resolve stable workload owner: %+v", detections)
+	}
+}
+
+func TestStaleSecretEnvReadyWorkloadAggregationAndRolloutSuppression(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	changedAt := now.Add(-time.Minute)
+	startedAt := changedAt.Add(-time.Minute)
+	controller := true
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: "shop", UID: types.UID("dep")}}
+	replicaSet := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "catalog-abc", Namespace: "shop", UID: types.UID("rs"),
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: deployment.Name, UID: deployment.UID, Controller: &controller}},
+	}}
+	replacementReplicaSet := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "catalog-def", Namespace: "shop", UID: types.UID("replacement-rs"),
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: deployment.Name, UID: deployment.UID, Controller: &controller}},
+	}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "db-conn", Namespace: "shop"}}
+	change := secretHistoryEvent(changedAt, "shop", "db-conn", "data (modified keys)", []string{"password"})
+	ownedPodForReplicaSet := func(replicaSet *appsv1.ReplicaSet, name string, start time.Time, ready bool) *corev1.Pod {
+		pod := staleSecretEnvPod(name, start, ready, secretKeyEnv("DB_PASSWORD", "db-conn", "password"))
+		pod.OwnerReferences = []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: replicaSet.Name, UID: replicaSet.UID, Controller: &controller}}
+		return pod
+	}
+	ownedPod := func(name string, start time.Time, ready bool) *corev1.Pod {
+		return ownedPodForReplicaSet(replicaSet, name, start, ready)
+	}
+
+	t.Run("Ready replicas aggregate to one workload issue", func(t *testing.T) {
+		first := ownedPod("catalog-abc-1", startedAt, true)
+		second := ownedPod("catalog-abc-2", startedAt, true)
+		cache := envHistoryTestCache(t, deployment, replicaSet, first, second, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Group != "apps" || detections[0].Kind != "Deployment" ||
+			detections[0].Name != "catalog" || detections[0].OwnerKind != "" {
+			t.Fatalf("Ready replicas did not aggregate under the workload: %+v", detections)
+		}
+		if !strings.Contains(detections[0].Message, "2 Ready pods") || !strings.Contains(detections[0].Message, "2 Secret-backed environment values") ||
+			!strings.Contains(detections[0].Action, "Confirm no rollout") {
+			t.Fatalf("aggregated workload issue is not operationally clear: %+v", detections[0])
+		}
+	})
+
+	t.Run("post-change sibling suppresses an in-progress rollout", func(t *testing.T) {
+		oldPod := ownedPod("catalog-abc-old", startedAt, true)
+		newPod := ownedPodForReplicaSet(replacementReplicaSet, "catalog-def-new", changedAt.Add(time.Second), true)
+		cache := envHistoryTestCache(t, deployment, replicaSet, replacementReplicaSet, oldPod, newPod, secret)
+		setEnvHistoryEvents(t, change)
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
+			t.Fatalf("a Ready replacement revision consuming the changed key must suppress rollout noise: %+v", detections)
+		}
+	})
+
+	t.Run("post-change init sidecar sibling suppresses an in-progress rollout", func(t *testing.T) {
+		oldPod := ownedPod("catalog-abc-old", startedAt, true)
+		newPod := ownedPodForReplicaSet(replacementReplicaSet, "catalog-def-new", changedAt.Add(time.Second), true)
+		for _, pod := range []*corev1.Pod{oldPod, newPod} {
+			start := pod.Status.ContainerStatuses[0].State.Running.StartedAt
+			pod.Spec.Containers[0].Env = nil
+			pod.Spec.InitContainers = []corev1.Container{{
+				Name:          "vault-agent",
+				RestartPolicy: alwaysRestartPolicy(),
+				Env:           []corev1.EnvVar{secretKeyEnv("DB_PASSWORD", "db-conn", "password")},
+			}}
+			pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+				Name: "vault-agent", Ready: true,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: start}},
+			}}
+		}
+		cache := envHistoryTestCache(t, deployment, replicaSet, replacementReplicaSet, oldPod, newPod, secret)
+		setEnvHistoryEvents(t, change)
+		if detections := detectStaleSecretEnv(cache, "shop", now); len(detections) != 0 {
+			t.Fatalf("a Ready replacement revision with the same restartable init sidecar must suppress rollout noise: %+v", detections)
+		}
+	})
+
+	t.Run("same-revision replacement does not suppress indefinitely", func(t *testing.T) {
+		oldPod := ownedPod("catalog-abc-old", startedAt, true)
+		manuallyReplacedPod := ownedPod("catalog-abc-new", changedAt.Add(time.Second), true)
+		cache := envHistoryTestCache(t, deployment, replicaSet, oldPod, manuallyReplacedPod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Kind != "Deployment" || detections[0].Name != deployment.Name {
+			t.Fatalf("same-revision sibling must not hide a stale pod indefinitely: %+v", detections)
+		}
+	})
+
+	t.Run("old replacement evidence does not suppress indefinitely", func(t *testing.T) {
+		olderChangeAt := now.Add(-30 * time.Minute)
+		oldPod := ownedPod("catalog-abc-old", olderChangeAt.Add(-time.Minute), true)
+		oldReplacement := ownedPodForReplicaSet(replacementReplicaSet, "catalog-def-old", olderChangeAt.Add(time.Minute), true)
+		cache := envHistoryTestCache(t, deployment, replicaSet, replacementReplicaSet, oldPod, oldReplacement, secret)
+		setEnvHistoryEvents(t, secretHistoryEvent(olderChangeAt, "shop", "db-conn", "data (modified keys)", []string{"password"}))
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Kind != "Deployment" || detections[0].Name != deployment.Name {
+			t.Fatalf("expired rollout evidence must not hide a stale pod indefinitely: %+v", detections)
+		}
+	})
+
+	t.Run("replacement revision must consume the same Secret key", func(t *testing.T) {
+		oldPod := ownedPod("catalog-abc-old", startedAt, true)
+		newPod := ownedPodForReplicaSet(replacementReplicaSet, "catalog-def-new", changedAt.Add(time.Second), true)
+		newPod.Spec.Containers[0].Env = []corev1.EnvVar{secretKeyEnv("OTHER", "other-secret", "token")}
+		cache := envHistoryTestCache(t, deployment, replicaSet, replacementReplicaSet, oldPod, newPod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Kind != "Deployment" || detections[0].Name != deployment.Name {
+			t.Fatalf("an unrelated replacement revision must not suppress the stale key: %+v", detections)
+		}
+	})
+
+	t.Run("not-Ready evidence takes precedence over the Ready summary", func(t *testing.T) {
+		readyPod := ownedPod("catalog-abc-ready", startedAt, true)
+		brokenPod := ownedPod("catalog-abc-broken", startedAt, false)
+		cache := envHistoryTestCache(t, deployment, replicaSet, readyPod, brokenPod, secret)
+		setEnvHistoryEvents(t, change)
+		detections := detectStaleSecretEnv(cache, "shop", now)
+		if len(detections) != 1 || detections[0].Kind != "Pod" || detections[0].Name != brokenPod.Name ||
+			detections[0].OwnerKind != "Deployment" || !strings.Contains(detections[0].Message, "is not Ready") {
+			t.Fatalf("not-Ready pod must retain the established issue contract without a duplicate Ready summary: %+v", detections)
+		}
+	})
+}
+
+func TestStaleSecretEnvReadySubjectKeepsOwnerIdentityAndSafeAction(t *testing.T) {
+	controller := true
+	pod := staleSecretEnvPod("report-abc", time.Now().Add(-time.Minute), true)
+	pod.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "batch/v1", Kind: "Job", Name: "report", Controller: &controller,
+	}}
+
+	subject := staleSecretEnvSubjectForPod(nil, pod)
+	if subject.group != "batch" || subject.kind != "Job" || subject.name != "report" || subject.restartable {
+		t.Fatalf("non-restartable Job owner must retain stable owner identity without restart capability: %+v", subject)
+	}
+	if action := staleSecretEnvReadyAction(subject); !strings.Contains(action, "Job/report's normal controller workflow") ||
+		strings.Contains(action, "restart Job/") {
+		t.Fatalf("non-restartable controller received unsafe workload guidance: %q", action)
+	}
+}
+
+func TestStaleSecretEnvNonRestartableOwnerDoesNotDuplicateReadyAndNotReady(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	changedAt := now.Add(-time.Minute)
+	controller := true
+	ownedPod := func(name string, ready bool) *corev1.Pod {
+		pod := staleSecretEnvPod(name, changedAt.Add(-time.Minute), ready, secretKeyEnv("TOKEN", "job-secret", "token"))
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "batch/v1", Kind: "Job", Name: "report", UID: types.UID("job"), Controller: &controller,
+		}}
+		return pod
+	}
+	readyPod := ownedPod("report-ready", true)
+	notReadyPod := ownedPod("report-not-ready", false)
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "job-secret", Namespace: "shop"}}
+	readyCache := envHistoryTestCache(t, readyPod.DeepCopy(), secret.DeepCopy())
+	setEnvHistoryEvents(t, secretHistoryEvent(changedAt, "shop", "job-secret", "data (modified keys)", []string{"token"}))
+	readyDetections := detectStaleSecretEnv(readyCache, "shop", now)
+	if len(readyDetections) != 1 || readyDetections[0].Group != "batch" || readyDetections[0].Kind != "Job" ||
+		readyDetections[0].Name != "report" || !strings.Contains(readyDetections[0].Message, "has a Ready pod") ||
+		strings.Contains(readyDetections[0].Message, "Job/report is Ready") || strings.Contains(readyDetections[0].Action, "restart Job/") {
+		t.Fatalf("Ready Job-owned pod lost stable identity or received unsafe wording: %+v", readyDetections)
+	}
+
+	cache := envHistoryTestCache(t, readyPod, notReadyPod, secret)
+	setEnvHistoryEvents(t, secretHistoryEvent(changedAt, "shop", "job-secret", "data (modified keys)", []string{"token"}))
+
+	detections := detectStaleSecretEnv(cache, "shop", now)
+	if len(detections) != 1 || detections[0].Kind != "Pod" || detections[0].Name != notReadyPod.Name ||
+		detections[0].OwnerGroup != "batch" || detections[0].OwnerKind != "Job" || detections[0].OwnerName != "report" {
+		t.Fatalf("not-Ready evidence must dominate without a duplicate Ready Job issue: %+v", detections)
+	}
+}
+
+func TestStaleSecretEnvRolloutEvidenceIndexBoundsReplacementCandidates(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	controller := true
+	var pods []*corev1.Pod
+	for i := 0; i < 100; i++ {
+		pod := staleSecretEnvPod(fmt.Sprintf("catalog-%03d", i), now.Add(-time.Minute), true, secretKeyEnv("PASSWORD", "db-conn", "password"))
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "apps/v1", Kind: "ReplicaSet", Name: fmt.Sprintf("catalog-%03d", i),
+			UID: types.UID(fmt.Sprintf("rs-%03d", i)), Controller: &controller,
+		}}
+		pods = append(pods, pod)
+	}
+	subject := staleSecretEnvSubject{group: "apps", kind: "Deployment", namespace: "shop", name: "catalog", restartable: true}
+	evidence := newStaleSecretEnvRolloutEvidence(subject, pods, now)
+	key := staleSecretEnvConsumption{container: "app", secret: "db-conn", key: "password"}
+	if got := len(evidence.replacements[key]); got != 2 {
+		t.Fatalf("replacement candidates = %d, want a lookup bounded to the two newest revisions", got)
+	}
+	check := StaleSecretEnvCheck{
+		PodName: pods[0].Name, Container: "app", SecretName: "db-conn", Key: "password",
+		SecretChangedAt: now.Add(-2 * time.Minute),
+	}
+	if !evidence.supersedes(check) {
+		t.Fatal("bounded replacement index lost valid evidence from another revision")
+	}
+}
+
+func TestQuerySecretDataHistoryFailsClosedWhenReferencedHistorySaturates(t *testing.T) {
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: maxSecretDataHistoryEvents + 1}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(timeline.ResetStore)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	pod := staleSecretEnvPod("catalog", now.Add(-time.Hour), true, secretKeyEnv("PASSWORD", "db-conn", "password"))
+	for i := 0; i < maxSecretDataHistoryEvents; i++ {
+		event := secretHistoryEvent(now.Add(-time.Duration(i)*time.Second), "shop", "db-conn", "data (modified keys)", []string{"password"})
+		event.ID = fmt.Sprintf("secret-saturation-%04d", i)
+		if err := timeline.RecordEvent(context.Background(), event); err != nil {
+			t.Fatalf("RecordEvent %d: %v", i, err)
+		}
+	}
+	if events := querySecretDataHistory(context.Background(), "", []*corev1.Pod{pod}, now.Add(-24*time.Hour)); len(events) != 0 {
+		t.Fatalf("saturated history must fail closed instead of returning a misleading partial set: %d events", len(events))
 	}
 }
 


### PR DESCRIPTION
## Summary

Radar can observe a Secret key rotation while the consuming process remains Ready and continues using the environment value captured at startup. This surfaces that exact, directional evidence in the ranked issue stream so agents and operators see that the running pod may be stale—not that the current Secret is wrong.

This PR is stacked on #1234 and should merge after it (or be retargeted to `main` once #1234 lands).

## What changed

- Promote Ready pods to a `StaleSecretEnv` warning only when Radar observed the consumed Secret key change and the current container instance started strictly before it. Managed-fields-only inference remains diagnosis/FYI evidence.
- Use a 24-hour, container-start-aware exact-history horizon for both diagnosis and issue exposure. Queries are restricted to referenced Secret names and namespaces, include controller-managed Secrets, remain one bounded store scan, and fail closed if the result saturates.
- Aggregate Ready replicas under their stable top-level owner while preserving stable owner-based issue identity across Ready transitions. Existing not-Ready evidence retains its Pod-level message and takes precedence over the hedged Ready summary.
- Keep remediation wording capability-aware: restartable workloads get a confirmation-first rollout action; other controllers retain stable identity with controller-safe replacement guidance.
- Suppress rollout noise only with bounded evidence of a Ready replacement from a different ReplicaSet revision that started after the observed change and consumes the same Secret key. The evidence index is linear in replica count and keeps constant-size lookup candidates.
- Ignore terminating pods and retain the existing detection cap.

## Testing

- `make tsc`
- `make test`
- `make build`
- `go test ./internal/k8s/... ./internal/issues/... -count=1`
- Focused detector and issue-composition tests, including:
  - Ready/not-Ready exposure and stable identity
  - post-change restart, terminating pod, and inferred-evidence guards
  - owner-managed Secret updates
  - exact-history saturation fail-closed behavior
  - workload aggregation and bounded rollout suppression
  - non-restartable controller wording and duplicate prevention
- Live-tested against `radar-test-nonprod` in an isolated disposable namespace:
  - a Ready BusyBox Deployment retained `before-rotation` after its Secret changed
  - `/api/issues` emitted exactly one workload-scoped `StaleSecretEnv` warning with the expected directional cause and action
  - the Issues UI rendered that warning with no browser console errors
  - after a rollout, the replacement loaded `after-rotation` and the issue cleared
  - the Radar process and disposable namespace were removed

Visual screenshot testing was skipped because this is a backend detector change with no UI layout or styling delta; the real UI journey was still exercised with Playwright.

## Notes

This gives an agent the ranked evidence needed to distinguish a current Secret from a process that captured an older value. It improves the benchmark journey materially, but does not by itself guarantee an agent will prioritize the issue over louder application logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live issue detection and aggregation for Secret env staleness; logic is complex but bounded, fail-closed on history saturation, and heavily tested—no direct auth or data exfiltration paths.
> 
> **Overview**
> **Ready pods can now raise ranked `StaleSecretEnv` warnings** when Radar has *observed* the consumed Secret key change and the running container started strictly before that change—instead of treating healthy Ready workloads as FYI-only.
> 
> The detector **splits exposure by readiness**: not-Ready pods keep Pod-level messages and owner refs; Ready replicas **aggregate under the stable workload subject** (e.g. `Deployment/catalog`) with hedged cause/action text. **Not-Ready evidence wins** over a Ready summary for the same owner, and **issue identity stays stable** across Ready ↔ not-Ready transitions (`issues` compose tests).
> 
> **Secret history queries** are tightened to referenced Secret names/namespaces, include controller-managed updates, use a container-start-aware 24h window, and **fail closed** if the timeline query hits the event cap (avoids partial false negatives).
> 
> **Rollout noise suppression** for Deployments/Rollouts: if a newer ReplicaSet revision has Ready pods that started after the change and consume the same Secret key, stale checks on older revision pods are dropped (bounded 10m window, capped replacement index).
> 
> **Remediation wording** is capability-aware (restartable apps vs Job/controller-safe replacement). Terminating pods are ignored; managed-fields-only inference still does not promote to issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93eaabd303961ed4413a8c7eace59131a3ffe6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->