### PR TITLE
feat(ai): add support for antigravity, opencode, and pi CLI integrations

### DIFF
--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -63,6 +63,12 @@ func resolveAgent(bin string) Agent {
 		return &cursorAgent{bin: bin}
 	case strings.Contains(base, "codex"):
 		return &codexAgent{bin: bin}
+	case strings.Contains(base, "agy") || strings.Contains(base, "antigravity"):
+		return &antigravityAgent{bin: bin}
+	case strings.Contains(base, "opencode"):
+		return &opencodeAgent{bin: bin}
+	case strings.Contains(base, "pi"):
+		return &piAgent{bin: bin}
 	default:
 		return &claudeAgent{bin: bin}
 	}

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -63,11 +63,11 @@ func resolveAgent(bin string) Agent {
 		return &cursorAgent{bin: bin}
 	case strings.Contains(base, "codex"):
 		return &codexAgent{bin: bin}
-	case strings.Contains(base, "agy") || strings.Contains(base, "antigravity"):
+	case base == "agy" || base == "antigravity" || strings.HasPrefix(base, "agy-") || strings.HasPrefix(base, "antigravity-"):
 		return &antigravityAgent{bin: bin}
-	case strings.Contains(base, "opencode"):
+	case base == "opencode" || strings.HasPrefix(base, "opencode-"):
 		return &opencodeAgent{bin: bin}
-	case strings.Contains(base, "pi"):
+	case base == "pi" || base == "pi-coding-agent":
 		return &piAgent{bin: bin}
 	default:
 		return &claudeAgent{bin: bin}

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -5,15 +5,18 @@ import (
 	"context"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 )
+
+var antigravityConvRe = regexp.MustCompile(`(?i)Conversation ID:\s*([a-zA-Z0-9-]+)`)
 
 // antigravityAgent drives the Antigravity CLI (`agy`).
 type antigravityAgent struct{ bin string }
 
 func (a *antigravityAgent) Name() string { return "antigravity" }
 
-func (a *antigravityAgent) SigninCmd() string { return "agy update" }
+func (a *antigravityAgent) SigninCmd() string { return "agy auth login" }
 
 func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
 	args := []string{}
@@ -58,5 +61,9 @@ func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) D
 		sb.WriteString(line + "\n")
 		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
 	}
-	return diagnosisFromText(sb.String())
+	d := diagnosisFromText(sb.String())
+	if m := antigravityConvRe.FindStringSubmatch(sb.String()); len(m) > 1 {
+		d.SessionID = m[1]
+	}
+	return d
 }

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -3,8 +3,12 @@ package ai
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -47,10 +51,46 @@ func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, 
 
 	args = append(args, "--prompt", prompt)
 
+	workdir := s.workdir
+	cleanup := func() {}
+	if workdir == "" {
+		dir, err := os.MkdirTemp("", "radar-antigravity-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("ai: antigravity workdir: %w", err)
+		}
+		workdir = dir
+		cleanup = func() { _ = os.RemoveAll(dir) }
+	}
+
+	if err := writeAntigravityConfig(workdir, s.mcpURL); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
 	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = workdir
 	cmd.Env = scrubbedEnv()
 
-	return cmd, func() {}, nil
+	return cmd, cleanup, nil
+}
+
+func writeAntigravityConfig(workdir, mcpURL string) error {
+	// Write standard mcp.json
+	cfg := map[string]any{"mcpServers": map[string]any{"radar": map[string]any{"url": mcpURL}}}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600); err != nil {
+		return err
+	}
+
+	// Also write .cursor/mcp.json for tools that fall back to it
+	cursorDir := filepath.Join(workdir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(cursorDir, "mcp.json"), b, 0o600)
 }
 
 func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -20,9 +20,14 @@ type antigravityAgent struct{ bin string }
 
 func (a *antigravityAgent) Name() string { return "antigravity" }
 
+func (a *antigravityAgent) Path() string { return a.bin }
+
 func (a *antigravityAgent) SigninCmd() string { return "agy auth login" }
 
 func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	if s.profile != ExecutionProfileFullLocal {
+		return nil, nil, fmt.Errorf("ai: Antigravity does not support execution profile %q", s.profile)
+	}
 	args := []string{"-p"}
 
 	if s.sessionID != "" {

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -37,10 +37,10 @@ func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, 
 	}
 
 	if s.apply {
-		args = append(args, "--mode", "accept-edits")
+		args = append(args, "--mode", "accept-edits", "--dangerously-skip-permissions")
+	} else {
+		args = append(args, "--sandbox")
 	}
-
-	args = append(args, "--dangerously-skip-permissions")
 
 	prompt := s.prompt
 	if s.systemPrompt != "" {

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -23,7 +23,7 @@ func (a *antigravityAgent) Name() string { return "antigravity" }
 func (a *antigravityAgent) SigninCmd() string { return "agy auth login" }
 
 func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
-	args := []string{}
+	args := []string{"-p"}
 
 	if s.sessionID != "" {
 		args = append(args, "--conversation", s.sessionID)
@@ -38,18 +38,16 @@ func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, 
 
 	if s.apply {
 		args = append(args, "--mode", "accept-edits")
-	} else {
-		args = append(args, "--mode", "plan")
 	}
 
-	args = append(args, "--sandbox", "--dangerously-skip-permissions")
+	args = append(args, "--dangerously-skip-permissions")
 
 	prompt := s.prompt
 	if s.systemPrompt != "" {
 		prompt = s.systemPrompt + "\n\n" + prompt
 	}
 
-	args = append(args, "--prompt", prompt)
+	args = append(args, prompt)
 
 	workdir := s.workdir
 	cleanup := func() {}
@@ -85,27 +83,23 @@ func writeAntigravityConfig(workdir, mcpURL string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(workdir, ".mcp.json"), b, 0o600); err != nil {
-		return err
+
+	for _, name := range []string{"mcp.json", ".mcp.json"} {
+		if err := os.WriteFile(filepath.Join(workdir, name), b, 0o600); err != nil {
+			return err
+		}
 	}
 
-	// Also write .gemini/mcp.json and .cursor/mcp.json for tools that check subfolders
-	geminiDir := filepath.Join(workdir, ".gemini")
-	if err := os.MkdirAll(geminiDir, 0o700); err != nil {
-		return err
+	for _, sub := range []string{".gemini", ".cursor", ".antigravity", ".antigravitycli"} {
+		dir := filepath.Join(workdir, sub)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "mcp.json"), b, 0o600); err != nil {
+			return err
+		}
 	}
-	if err := os.WriteFile(filepath.Join(geminiDir, "mcp.json"), b, 0o600); err != nil {
-		return err
-	}
-
-	cursorDir := filepath.Join(workdir, ".cursor")
-	if err := os.MkdirAll(cursorDir, 0o700); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(cursorDir, "mcp.json"), b, 0o600)
+	return nil
 }
 
 func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -37,12 +37,12 @@ func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, 
 	}
 
 	if s.apply {
-		args = append(args, "--mode", "accept-edits", "--dangerously-skip-permissions")
+		args = append(args, "--mode", "accept-edits")
 	} else {
 		args = append(args, "--mode", "plan")
 	}
 
-	args = append(args, "--sandbox")
+	args = append(args, "--sandbox", "--dangerously-skip-permissions")
 
 	prompt := s.prompt
 	if s.systemPrompt != "" {
@@ -79,7 +79,7 @@ func writeAntigravityConfig(workdir, mcpURL string) error {
 		return err
 	}
 
-	// Write standard mcp.json
+	// Write standard mcp.json and .mcp.json
 	cfg := map[string]any{"mcpServers": map[string]any{"radar": map[string]any{"url": mcpURL}}}
 	b, err := json.Marshal(cfg)
 	if err != nil {
@@ -88,8 +88,19 @@ func writeAntigravityConfig(workdir, mcpURL string) error {
 	if err := os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600); err != nil {
 		return err
 	}
+	if err := os.WriteFile(filepath.Join(workdir, ".mcp.json"), b, 0o600); err != nil {
+		return err
+	}
 
-	// Also write .cursor/mcp.json for tools that fall back to it
+	// Also write .gemini/mcp.json and .cursor/mcp.json for tools that check subfolders
+	geminiDir := filepath.Join(workdir, ".gemini")
+	if err := os.MkdirAll(geminiDir, 0o700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(geminiDir, "mcp.json"), b, 0o600); err != nil {
+		return err
+	}
+
 	cursorDir := filepath.Join(workdir, ".cursor")
 	if err := os.MkdirAll(cursorDir, 0o700); err != nil {
 		return err
@@ -100,6 +111,8 @@ func writeAntigravityConfig(workdir, mcpURL string) error {
 func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	var sb strings.Builder
 	sc := bufio.NewScanner(r)
+	buf := make([]byte, 64*1024)
+	sc.Buffer(buf, 10*1024*1024)
 	for sc.Scan() {
 		line := sc.Text()
 		sb.WriteString(line + "\n")

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -75,6 +75,10 @@ func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, 
 }
 
 func writeAntigravityConfig(workdir, mcpURL string) error {
+	if err := os.MkdirAll(workdir, 0o700); err != nil {
+		return err
+	}
+
 	// Write standard mcp.json
 	cfg := map[string]any{"mcpServers": map[string]any{"radar": map[string]any{"url": mcpURL}}}
 	b, err := json.Marshal(cfg)

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -1,0 +1,62 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// antigravityAgent drives the Antigravity CLI (`agy`).
+type antigravityAgent struct{ bin string }
+
+func (a *antigravityAgent) Name() string { return "antigravity" }
+
+func (a *antigravityAgent) SigninCmd() string { return "agy update" }
+
+func (a *antigravityAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	args := []string{}
+
+	if s.sessionID != "" {
+		args = append(args, "--conversation", s.sessionID)
+	}
+
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+	if s.effort != "" {
+		args = append(args, "--effort", s.effort)
+	}
+
+	if s.apply {
+		args = append(args, "--mode", "accept-edits", "--dangerously-skip-permissions")
+	} else {
+		args = append(args, "--mode", "plan")
+	}
+
+	args = append(args, "--sandbox")
+
+	prompt := s.prompt
+	if s.systemPrompt != "" {
+		prompt = s.systemPrompt + "\n\n" + prompt
+	}
+
+	args = append(args, "--prompt", prompt)
+
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Env = scrubbedEnv()
+
+	return cmd, func() {}, nil
+}
+
+func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
+	var sb strings.Builder
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		sb.WriteString(line + "\n")
+		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
+	}
+	return diagnosisFromText(sb.String())
+}

--- a/internal/ai/agent_antigravity.go
+++ b/internal/ai/agent_antigravity.go
@@ -107,18 +107,57 @@ func writeAntigravityConfig(workdir, mcpURL string) error {
 	return nil
 }
 
+type antigravityEvent struct {
+	Type           string `json:"type"`
+	ConversationID string `json:"conversation_id"`
+	SessionID      string `json:"session_id"`
+	Content        string `json:"content"`
+	Text           string `json:"text"`
+}
+
 func (a *antigravityAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	var sb strings.Builder
 	sc := bufio.NewScanner(r)
 	buf := make([]byte, 64*1024)
 	sc.Buffer(buf, 10*1024*1024)
+	var sessionID string
+
 	for sc.Scan() {
 		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
+			var ev antigravityEvent
+			if err := json.Unmarshal([]byte(trimmed), &ev); err == nil {
+				if ev.ConversationID != "" {
+					sessionID = ev.ConversationID
+				} else if ev.SessionID != "" {
+					sessionID = ev.SessionID
+				}
+
+				text := ev.Content
+				if text == "" {
+					text = ev.Text
+				}
+				if text != "" {
+					sb.WriteString(text + "\n")
+					onEvent(StreamEvent{Type: "thinking", Token: text + "\n"})
+				}
+				continue
+			}
+		}
+
 		sb.WriteString(line + "\n")
 		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
 	}
+
 	d := diagnosisFromText(sb.String())
-	if m := antigravityConvRe.FindStringSubmatch(sb.String()); len(m) > 1 {
+	if sessionID != "" {
+		d.SessionID = sessionID
+	} else if m := antigravityConvRe.FindStringSubmatch(sb.String()); len(m) > 1 {
 		d.SessionID = m[1]
 	}
 	return d

--- a/internal/ai/agent_drivers_test.go
+++ b/internal/ai/agent_drivers_test.go
@@ -68,11 +68,11 @@ func TestAntigravityConfigAndCommand(t *testing.T) {
 	defer cleanup()
 
 	args := strings.Join(cmd.Args, " ")
-	if !strings.Contains(args, "--prompt") || !strings.Contains(args, "investigate") {
-		t.Errorf("expected prompt flag and prompt in args; got %q", args)
+	if !strings.Contains(args, "-p") || !strings.Contains(args, "investigate") {
+		t.Errorf("expected -p flag and prompt in args; got %q", args)
 	}
 
-	for _, relPath := range []string{"mcp.json", ".mcp.json", ".gemini/mcp.json", ".cursor/mcp.json"} {
+	for _, relPath := range []string{"mcp.json", ".mcp.json", ".gemini/mcp.json", ".cursor/mcp.json", ".antigravity/mcp.json", ".antigravitycli/mcp.json"} {
 		cfgPath := filepath.Join(dir, relPath)
 		b, err := os.ReadFile(cfgPath)
 		if err != nil {

--- a/internal/ai/agent_drivers_test.go
+++ b/internal/ai/agent_drivers_test.go
@@ -1,0 +1,131 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpencodeConfigAndCommand(t *testing.T) {
+	a := &opencodeAgent{bin: "opencode"}
+	dir := t.TempDir()
+	const url = "http://localhost:9280/mcp-readonly"
+
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: url, prompt: "investigate", workdir: dir, model: "claude-3-5-sonnet",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--model claude-3-5-sonnet") {
+		t.Errorf("expected --model flag in args; got %q", args)
+	}
+	if !strings.Contains(args, "investigate") {
+		t.Errorf("expected prompt in args; got %q", args)
+	}
+
+	cfgPath := filepath.Join(dir, "opencode.json")
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("expected opencode.json at %s: %v", cfgPath, err)
+	}
+
+	var cfg struct {
+		MCP map[string]struct {
+			Type string `json:"type"`
+			URL  string `json:"url"`
+		} `json:"mcp"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("opencode.json not valid JSON: %v", err)
+	}
+	srv, ok := cfg.MCP["radar"]
+	if !ok {
+		t.Fatalf("opencode.json missing radar server entry: %s", string(b))
+	}
+	if srv.Type != "remote" || srv.URL != url {
+		t.Errorf("opencode.json radar entry = %+v, want type=remote, url=%s", srv, url)
+	}
+}
+
+func TestAntigravityConfigAndCommand(t *testing.T) {
+	a := &antigravityAgent{bin: "agy"}
+	dir := t.TempDir()
+	const url = "http://localhost:9280/mcp-readonly"
+
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: url, prompt: "investigate", workdir: dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--prompt") || !strings.Contains(args, "investigate") {
+		t.Errorf("expected prompt flag and prompt in args; got %q", args)
+	}
+
+	for _, relPath := range []string{"mcp.json", ".mcp.json", ".gemini/mcp.json", ".cursor/mcp.json"} {
+		cfgPath := filepath.Join(dir, relPath)
+		b, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatalf("expected config file at %s: %v", cfgPath, err)
+		}
+		var cfg struct {
+			MCPServers map[string]struct {
+				URL string `json:"url"`
+			} `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(b, &cfg); err != nil {
+			t.Fatalf("config at %s not valid JSON: %v", cfgPath, err)
+		}
+		if cfg.MCPServers["radar"].URL != url {
+			t.Errorf("config at %s radar url = %q, want %q", cfgPath, cfg.MCPServers["radar"].URL, url)
+		}
+	}
+}
+
+func TestPiConfigAndCommand(t *testing.T) {
+	a := &piAgent{bin: "pi"}
+	dir := t.TempDir()
+	const url = "http://localhost:9280/mcp-readonly"
+
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: url, prompt: "investigate", workdir: dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "-p") || !strings.Contains(args, "investigate") {
+		t.Errorf("expected -p flag and prompt in args; got %q", args)
+	}
+
+	for _, relPath := range []string{"mcp.json", ".mcp.json"} {
+		cfgPath := filepath.Join(dir, relPath)
+		b, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatalf("expected config file at %s: %v", cfgPath, err)
+		}
+		var cfg struct {
+			MCPServers map[string]struct {
+				URL string `json:"url"`
+			} `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(b, &cfg); err != nil {
+			t.Fatalf("config at %s not valid JSON: %v", cfgPath, err)
+		}
+		if cfg.MCPServers["radar"].URL != url {
+			t.Errorf("config at %s radar url = %q, want %q", cfgPath, cfg.MCPServers["radar"].URL, url)
+		}
+	}
+}

--- a/internal/ai/agent_drivers_test.go
+++ b/internal/ai/agent_drivers_test.go
@@ -110,7 +110,7 @@ func TestPiConfigAndCommand(t *testing.T) {
 		t.Errorf("expected -p flag and prompt in args; got %q", args)
 	}
 
-	for _, relPath := range []string{"mcp.json", ".mcp.json"} {
+	for _, relPath := range []string{"mcp.json", ".mcp.json", ".pi/mcp.json"} {
 		cfgPath := filepath.Join(dir, relPath)
 		b, err := os.ReadFile(cfgPath)
 		if err != nil {

--- a/internal/ai/agent_drivers_test.go
+++ b/internal/ai/agent_drivers_test.go
@@ -23,6 +23,9 @@ func TestOpencodeConfigAndCommand(t *testing.T) {
 	defer cleanup()
 
 	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--format json") || !strings.Contains(args, "--auto") {
+		t.Errorf("expected --format json and --auto in args; got %q", args)
+	}
 	if !strings.Contains(args, "--model claude-3-5-sonnet") {
 		t.Errorf("expected --model flag in args; got %q", args)
 	}
@@ -127,5 +130,17 @@ func TestPiConfigAndCommand(t *testing.T) {
 		if cfg.MCPServers["radar"].URL != url {
 			t.Errorf("config at %s radar url = %q, want %q", cfgPath, cfg.MCPServers["radar"].URL, url)
 		}
+	}
+}
+
+func TestResolveAgentPi(t *testing.T) {
+	if a := resolveAgent("pi"); a.Name() != "pi" {
+		t.Errorf("resolveAgent(pi) = %s, want pi", a.Name())
+	}
+	if a := resolveAgent("pi-coding-agent"); a.Name() != "pi" {
+		t.Errorf("resolveAgent(pi-coding-agent) = %s, want pi", a.Name())
+	}
+	if a := resolveAgent("pip"); a.Name() == "pi" {
+		t.Errorf("resolveAgent(pip) should not resolve to pi agent")
 	}
 }

--- a/internal/ai/agent_drivers_test.go
+++ b/internal/ai/agent_drivers_test.go
@@ -15,7 +15,7 @@ func TestOpencodeConfigAndCommand(t *testing.T) {
 	const url = "http://localhost:9280/mcp-readonly"
 
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
-		mcpURL: url, prompt: "investigate", workdir: dir, model: "claude-3-5-sonnet",
+		mcpURL: url, prompt: "investigate", workdir: dir, model: "claude-3-5-sonnet", profile: ExecutionProfileFullLocal,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestAntigravityConfigAndCommand(t *testing.T) {
 	const url = "http://localhost:9280/mcp-readonly"
 
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
-		mcpURL: url, prompt: "investigate", workdir: dir,
+		mcpURL: url, prompt: "investigate", workdir: dir, profile: ExecutionProfileFullLocal,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestPiConfigAndCommand(t *testing.T) {
 	const url = "http://localhost:9280/mcp-readonly"
 
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
-		mcpURL: url, prompt: "investigate", workdir: dir,
+		mcpURL: url, prompt: "investigate", workdir: dir, profile: ExecutionProfileFullLocal,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -74,11 +74,9 @@ func writeOpencodeConfig(workdir, mcpURL string) error {
 	// Write local project opencode.json pointing to Radar's local MCP
 	cfg := map[string]any{
 		"mcp": map[string]any{
-			"servers": map[string]any{
-				"radar": map[string]any{
-					"type": "remote",
-					"url":  mcpURL,
-				},
+			"radar": map[string]any{
+				"type": "remote",
+				"url":  mcpURL,
 			},
 		},
 	}
@@ -92,6 +90,8 @@ func writeOpencodeConfig(workdir, mcpURL string) error {
 func (a *opencodeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	var sb strings.Builder
 	sc := bufio.NewScanner(r)
+	buf := make([]byte, 64*1024)
+	sc.Buffer(buf, 10*1024*1024)
 	for sc.Scan() {
 		line := sc.Text()
 		sb.WriteString(line + "\n")

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -3,8 +3,12 @@ package ai
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -36,12 +40,49 @@ func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, fun
 		prompt = s.systemPrompt + "\n\n" + prompt
 	}
 
-	args = append(args, "--prompt", prompt)
+	// OpenCode expects the prompt message as positional arguments, not --prompt
+	args = append(args, prompt)
+
+	workdir := s.workdir
+	cleanup := func() {}
+	if workdir == "" {
+		dir, err := os.MkdirTemp("", "radar-opencode-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("ai: opencode workdir: %w", err)
+		}
+		workdir = dir
+		cleanup = func() { _ = os.RemoveAll(dir) }
+	}
+
+	if err := writeOpencodeConfig(workdir, s.mcpURL); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = workdir
 	cmd.Env = scrubbedEnv()
 
-	return cmd, func() {}, nil
+	return cmd, cleanup, nil
+}
+
+func writeOpencodeConfig(workdir, mcpURL string) error {
+	// Write local project opencode.json pointing to Radar's local MCP
+	cfg := map[string]any{
+		"mcp": map[string]any{
+			"servers": map[string]any{
+				"radar": map[string]any{
+					"type": "remote",
+					"url":  mcpURL,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(workdir, "opencode.json"), b, 0o600)
 }
 
 func (a *opencodeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -1,0 +1,53 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// opencodeAgent drives the OpenCode CLI (`opencode`).
+type opencodeAgent struct{ bin string }
+
+func (a *opencodeAgent) Name() string { return "opencode" }
+
+func (a *opencodeAgent) SigninCmd() string { return "opencode providers" }
+
+func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	args := []string{"run"}
+
+	if s.sessionID != "" {
+		args = append(args, "--session", s.sessionID)
+	} else if s.apply {
+		args = append(args, "--continue")
+	}
+
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+
+	prompt := s.prompt
+	if s.systemPrompt != "" {
+		prompt = s.systemPrompt + "\n\n" + prompt
+	}
+
+	args = append(args, "--prompt", prompt)
+
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Env = scrubbedEnv()
+
+	return cmd, func() {}, nil
+}
+
+func (a *opencodeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
+	var sb strings.Builder
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		sb.WriteString(line + "\n")
+		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
+	}
+	return diagnosisFromText(sb.String())
+}

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -85,18 +85,63 @@ func writeOpencodeConfig(workdir, mcpURL string) error {
 	return os.WriteFile(filepath.Join(workdir, "opencode.json"), b, 0o600)
 }
 
+type opencodeEvent struct {
+	Type      string `json:"type"`
+	SessionID string `json:"sessionID"`
+	Session   string `json:"session_id"`
+	Part      *struct {
+		Text string `json:"text"`
+	} `json:"part"`
+	Content string `json:"content"`
+	Text    string `json:"text"`
+}
+
 func (a *opencodeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	var sb strings.Builder
 	sc := bufio.NewScanner(r)
 	buf := make([]byte, 64*1024)
 	sc.Buffer(buf, 10*1024*1024)
+	var sessionID string
+
 	for sc.Scan() {
 		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
+			var ev opencodeEvent
+			if err := json.Unmarshal([]byte(trimmed), &ev); err == nil {
+				if ev.SessionID != "" {
+					sessionID = ev.SessionID
+				} else if ev.Session != "" {
+					sessionID = ev.Session
+				}
+
+				text := ev.Content
+				if text == "" {
+					text = ev.Text
+				}
+				if text == "" && ev.Part != nil {
+					text = ev.Part.Text
+				}
+				if text != "" {
+					sb.WriteString(text + "\n")
+					onEvent(StreamEvent{Type: "thinking", Token: text + "\n"})
+				}
+				continue
+			}
+		}
+
 		sb.WriteString(line + "\n")
 		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
 	}
+
 	d := diagnosisFromText(sb.String())
-	if m := opencodeSessionRe.FindStringSubmatch(sb.String()); len(m) > 1 {
+	if sessionID != "" {
+		d.SessionID = sessionID
+	} else if m := opencodeSessionRe.FindStringSubmatch(sb.String()); len(m) > 1 {
 		d.SessionID = m[1]
 	}
 	return d

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-var opencodeSessionRe = regexp.MustCompile(`(?i)Session(?: ID)?:\s*([a-zA-Z0-9-]+)`)
+var opencodeSessionRe = regexp.MustCompile(`(?i)(?:session[_-]?id|session)\s*[:=]\s*"?([a-zA-Z0-9_-]+)"?`)
 
 // opencodeAgent drives the OpenCode CLI (`opencode`).
 type opencodeAgent struct{ bin string }
@@ -23,7 +23,7 @@ func (a *opencodeAgent) Name() string { return "opencode" }
 func (a *opencodeAgent) SigninCmd() string { return "opencode providers" }
 
 func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
-	args := []string{"run"}
+	args := []string{"run", "--format", "json", "--auto"}
 
 	if s.sessionID != "" {
 		args = append(args, "--session", s.sessionID)

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 )
+
+var opencodeSessionRe = regexp.MustCompile(`(?i)Session(?: ID)?:\s*([a-zA-Z0-9-]+)`)
 
 // opencodeAgent drives the OpenCode CLI (`opencode`).
 type opencodeAgent struct{ bin string }
@@ -49,5 +52,9 @@ func (a *opencodeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diag
 		sb.WriteString(line + "\n")
 		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
 	}
-	return diagnosisFromText(sb.String())
+	d := diagnosisFromText(sb.String())
+	if m := opencodeSessionRe.FindStringSubmatch(sb.String()); len(m) > 1 {
+		d.SessionID = m[1]
+	}
+	return d
 }

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -27,8 +27,6 @@ func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, fun
 
 	if s.sessionID != "" {
 		args = append(args, "--session", s.sessionID)
-	} else if s.apply {
-		args = append(args, "--continue")
 	}
 
 	if s.model != "" {

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -67,6 +67,10 @@ func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, fun
 }
 
 func writeOpencodeConfig(workdir, mcpURL string) error {
+	if err := os.MkdirAll(workdir, 0o700); err != nil {
+		return err
+	}
+
 	// Write local project opencode.json pointing to Radar's local MCP
 	cfg := map[string]any{
 		"mcp": map[string]any{

--- a/internal/ai/agent_opencode.go
+++ b/internal/ai/agent_opencode.go
@@ -20,9 +20,14 @@ type opencodeAgent struct{ bin string }
 
 func (a *opencodeAgent) Name() string { return "opencode" }
 
+func (a *opencodeAgent) Path() string { return a.bin }
+
 func (a *opencodeAgent) SigninCmd() string { return "opencode providers" }
 
 func (a *opencodeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	if s.profile != ExecutionProfileFullLocal {
+		return nil, nil, fmt.Errorf("ai: OpenCode does not support execution profile %q", s.profile)
+	}
 	args := []string{"run", "--format", "json", "--auto"}
 
 	if s.sessionID != "" {

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -1,0 +1,41 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// piAgent drives the Pi CLI.
+type piAgent struct{ bin string }
+
+func (a *piAgent) Name() string { return "pi" }
+
+func (a *piAgent) SigninCmd() string { return "pi auth" }
+
+func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	args := []string{}
+	prompt := s.prompt
+	if s.systemPrompt != "" {
+		prompt = s.systemPrompt + "\n\n" + prompt
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Env = scrubbedEnv()
+
+	return cmd, func() {}, nil
+}
+
+func (a *piAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
+	var sb strings.Builder
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		sb.WriteString(line + "\n")
+		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
+	}
+	return diagnosisFromText(sb.String())
+}

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -35,11 +35,12 @@ func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), e
 		args = append(args, "--model", s.model)
 	}
 
+	prompt := s.prompt
 	if s.systemPrompt != "" {
-		args = append(args, "--system-prompt", s.systemPrompt)
+		prompt = s.systemPrompt + "\n\n" + prompt
 	}
 
-	args = append(args, s.prompt)
+	args = append(args, prompt)
 
 	workdir := s.workdir
 	cleanup := func() {}
@@ -59,7 +60,7 @@ func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), e
 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = workdir
-	cmd.Env = append(scrubbedEnv(), "PI_CODING_AGENT_DIR="+workdir)
+	cmd.Env = scrubbedEnv()
 
 	return cmd, cleanup, nil
 }
@@ -73,12 +74,17 @@ func writePiConfig(workdir, mcpURL string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600)
+	if err := os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(workdir, ".mcp.json"), b, 0o600)
 }
 
 func (a *piAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 	var sb strings.Builder
 	sc := bufio.NewScanner(r)
+	buf := make([]byte, 64*1024)
+	sc.Buffer(buf, 10*1024*1024)
 	for sc.Scan() {
 		line := sc.Text()
 		sb.WriteString(line + "\n")

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 )
+
+var piSessionRe = regexp.MustCompile(`(?i)Session(?: ID)?:\s*([a-zA-Z0-9-]+)`)
 
 // piAgent drives the Pi CLI.
 type piAgent struct{ bin string }
@@ -37,5 +40,9 @@ func (a *piAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis 
 		sb.WriteString(line + "\n")
 		onEvent(StreamEvent{Type: "thinking", Token: line + "\n"})
 	}
-	return diagnosisFromText(sb.String())
+	d := diagnosisFromText(sb.String())
+	if m := piSessionRe.FindStringSubmatch(sb.String()); len(m) > 1 {
+		d.SessionID = m[1]
+	}
+	return d
 }

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -27,8 +27,6 @@ func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), e
 
 	if s.sessionID != "" {
 		args = append(args, "--session", s.sessionID)
-	} else if s.apply {
-		args = append(args, "--continue")
 	}
 
 	if s.model != "" {

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -77,7 +77,14 @@ func writePiConfig(workdir, mcpURL string) error {
 	if err := os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(workdir, ".mcp.json"), b, 0o600)
+	if err := os.WriteFile(filepath.Join(workdir, ".mcp.json"), b, 0o600); err != nil {
+		return err
+	}
+	piDir := filepath.Join(workdir, ".pi")
+	if err := os.MkdirAll(piDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(piDir, "mcp.json"), b, 0o600)
 }
 
 func (a *piAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -16,15 +16,26 @@ type piAgent struct{ bin string }
 
 func (a *piAgent) Name() string { return "pi" }
 
-func (a *piAgent) SigninCmd() string { return "pi auth" }
+func (a *piAgent) SigninCmd() string { return "pi config" }
 
 func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
-	args := []string{}
-	prompt := s.prompt
-	if s.systemPrompt != "" {
-		prompt = s.systemPrompt + "\n\n" + prompt
+	args := []string{"-p"} // Run in non-interactive print mode and exit
+
+	if s.sessionID != "" {
+		args = append(args, "--session", s.sessionID)
+	} else if s.apply {
+		args = append(args, "--continue")
 	}
-	args = append(args, prompt)
+
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+
+	if s.systemPrompt != "" {
+		args = append(args, "--system-prompt", s.systemPrompt)
+	}
+
+	args = append(args, s.prompt)
 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Env = scrubbedEnv()

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -3,8 +3,12 @@ package ai
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -37,10 +41,36 @@ func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), e
 
 	args = append(args, s.prompt)
 
-	cmd := exec.CommandContext(ctx, a.bin, args...)
-	cmd.Env = scrubbedEnv()
+	workdir := s.workdir
+	cleanup := func() {}
+	if workdir == "" {
+		dir, err := os.MkdirTemp("", "radar-pi-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("ai: pi workdir: %w", err)
+		}
+		workdir = dir
+		cleanup = func() { _ = os.RemoveAll(dir) }
+	}
 
-	return cmd, func() {}, nil
+	if err := writePiConfig(workdir, s.mcpURL); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = workdir
+	cmd.Env = append(scrubbedEnv(), "PI_CODING_AGENT_DIR="+workdir)
+
+	return cmd, cleanup, nil
+}
+
+func writePiConfig(workdir, mcpURL string) error {
+	cfg := map[string]any{"mcpServers": map[string]any{"radar": map[string]any{"url": mcpURL}}}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(workdir, "mcp.json"), b, 0o600)
 }
 
 func (a *piAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -20,9 +20,14 @@ type piAgent struct{ bin string }
 
 func (a *piAgent) Name() string { return "pi" }
 
+func (a *piAgent) Path() string { return a.bin }
+
 func (a *piAgent) SigninCmd() string { return "pi config" }
 
 func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	if s.profile != ExecutionProfileFullLocal {
+		return nil, nil, fmt.Errorf("ai: Pi does not support execution profile %q", s.profile)
+	}
 	args := []string{"-p"} // Run in non-interactive print mode and exit
 
 	if s.sessionID != "" {

--- a/internal/ai/agent_pi.go
+++ b/internal/ai/agent_pi.go
@@ -65,6 +65,9 @@ func (a *piAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), e
 }
 
 func writePiConfig(workdir, mcpURL string) error {
+	if err := os.MkdirAll(workdir, 0o700); err != nil {
+		return err
+	}
 	cfg := map[string]any{"mcpServers": map[string]any{"radar": map[string]any{"url": mcpURL}}}
 	b, err := json.Marshal(cfg)
 	if err != nil {

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -31,6 +31,12 @@ var agentLabels = map[string]string{
 	"antigravity": "Antigravity", "opencode": "OpenCode", "pi": "Pi CLI",
 }
 
+// agentBinaries maps known agent identifiers to their candidate binary names on PATH.
+// Probing stops at the first binary name that resolves.
+var agentBinaries = map[string][]string{
+	"antigravity": {"agy", "antigravity"},
+}
+
 // AgentLabel is the display name for an agent CLI — the ONE table every
 // surface (API, CLI header, consent prompts) reads, so labels can't drift.
 func AgentLabel(name string) string {
@@ -144,9 +150,12 @@ func DetectAgents(ctx context.Context, withVersions bool) []AgentInfo {
 	var out []AgentInfo
 	for _, name := range knownAgents {
 		binName := name
-		if name == "antigravity" {
-			if _, err := exec.LookPath("agy"); err == nil {
-				binName = "agy"
+		if binaries, ok := agentBinaries[name]; ok {
+			for _, bin := range binaries {
+				if _, err := exec.LookPath(bin); err == nil {
+					binName = bin
+					break
+				}
 			}
 		}
 		path, err := exec.LookPath(binName)

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -76,7 +76,7 @@ func ProfilesFor(agent string) []ExecutionProfile {
 		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
 	case "codex":
 		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
-	case "cursor-agent":
+	case "cursor-agent", "antigravity", "opencode", "pi":
 		return []ExecutionProfile{ExecutionProfileFullLocal}
 	default:
 		return nil

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -35,6 +35,7 @@ var agentLabels = map[string]string{
 // Probing stops at the first binary name that resolves.
 var agentBinaries = map[string][]string{
 	"antigravity": {"agy", "antigravity"},
+	"pi":          {"pi", "pi-coding-agent"},
 }
 
 // AgentLabel is the display name for an agent CLI — the ONE table every

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -24,10 +24,11 @@ type AgentInfo struct {
 
 // knownAgents are the CLI names we probe for — a FIXED list. We never exec a
 // user-supplied name/path: only these literals, resolved through PATH, are run.
-var knownAgents = []string{"claude", "codex", "gemini", "cursor-agent"}
+var knownAgents = []string{"claude", "codex", "gemini", "cursor-agent", "antigravity", "opencode", "pi"}
 
 var agentLabels = map[string]string{
 	"claude": "Claude Code", "codex": "Codex", "gemini": "Gemini CLI", "cursor-agent": "Cursor Agent",
+	"antigravity": "Antigravity", "opencode": "OpenCode", "pi": "Pi CLI",
 }
 
 // AgentLabel is the display name for an agent CLI — the ONE table every
@@ -142,7 +143,13 @@ func isSupportedAgent(name string) bool {
 func DetectAgents(ctx context.Context, withVersions bool) []AgentInfo {
 	var out []AgentInfo
 	for _, name := range knownAgents {
-		path, err := exec.LookPath(name)
+		binName := name
+		if name == "antigravity" {
+			if _, err := exec.LookPath("agy"); err == nil {
+				binName = "agy"
+			}
+		}
+		path, err := exec.LookPath(binName)
 		if err != nil {
 			continue
 		}

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -237,7 +237,7 @@ const defaultMaxTurns = 15
 
 // agentCLICandidates are CLIs whose event stream we can parse + drive. Order is
 // the default-selection preference when several are installed.
-var agentCLICandidates = []string{"claude", "codex", "cursor-agent"}
+var agentCLICandidates = []string{"claude", "codex", "cursor-agent", "antigravity", "opencode", "pi"}
 
 // Detector / Diagnoser ------------------------------------------------------
 

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -620,7 +620,7 @@ var (
 		// AWS creds are passed through so BYO-Bedrock works; the user opted in.
 		"AWS_PROFILE": true, "AWS_REGION": true, "AWS_DEFAULT_REGION": true,
 	}
-	envAllowPrefix = []string{"ANTHROPIC_", "CLAUDE_", "AWS_", "GOOGLE_", "CLOUD_ML_", "VERTEX_"}
+	envAllowPrefix = []string{"ANTHROPIC_", "CLAUDE_", "AWS_", "GOOGLE_", "CLOUD_ML_", "VERTEX_", "OPENAI_", "GEMINI_", "MISTRAL_", "DEEPSEEK_", "GROQ_", "OPENROUTER_", "PI_", "GITHUB_"}
 )
 
 // scrubbedEnv returns a minimal environment: the CLI ingests untrusted cluster

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -375,10 +375,8 @@ export function AgentControls({
               : isCodex
                 ? "Default (e.g. gpt-5-codex, o3)"
                 : selectedAgent === "antigravity"
-                  ? "Default (e.g. gemini-2.5-pro, gemini-2.5-flash)"
-                  : selectedAgent === "opencode"
-                    ? "Default (e.g. opencode-1.5-pro)"
-                    : "Default model"
+                  ? "Default (e.g. gemini-*-flash)"
+                  : "Default"
           }
           onChange={onSetModel}
           hint={

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -365,7 +365,7 @@ export function AgentControls({
           onChange={onSetModel}
           hint="Aliases always resolve to the latest of that tier."
         />
-      ) : isCodex || isCursor ? (
+      ) : (
         <TextField
           label="Model"
           value={model}
@@ -375,25 +375,21 @@ export function AgentControls({
               : isCodex
                 ? "Default (e.g. gpt-5-codex, o3)"
                 : selectedAgent === "antigravity"
-                  ? "Default (e.g. gemini-*-flash)"
-                  : "Default"
+                  ? "Default (e.g. gemini-2.5-flash)"
+                  : selectedAgent === "opencode"
+                    ? "Default (e.g. opencode-1.5-pro)"
+                    : "Default"
           }
           onChange={onSetModel}
           hint={
             isCursor
               ? "Leave empty for your Cursor default, or enter a model slug Cursor supports."
-              : shownProfile === "full-local"
-                ? "Your Codex setup uses its configured model; set a slug here to override it."
-                : "Leave empty for Codex's default, or enter a model your Codex version supports."
+              : isCodex
+                ? shownProfile === "full-local"
+                  ? "Your Codex setup uses its configured model; set a slug here to override it."
+                  : "Leave empty for Codex's default, or enter a model your Codex version supports."
+                : `Leave empty for ${selectedAgentLabel}'s default, or enter a supported model slug.`
           }
-        />
-      ) : (
-        <TextField
-          label="Model"
-          value={model}
-          placeholder="Default"
-          onChange={onSetModel}
-          hint="Leave empty for the agent's default, or enter a model identifier it supports."
         />
       )}
       {isCodex && (

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -372,7 +372,13 @@ export function AgentControls({
           placeholder={
             isCursor
               ? "Default (e.g. auto, gpt-5.2, composer-2.5)"
-              : "Default (e.g. gpt-5-codex, o3)"
+              : isCodex
+                ? "Default (e.g. gpt-5-codex, o3)"
+                : selectedAgent === "antigravity"
+                  ? "Default (e.g. gemini-2.5-pro, gemini-2.5-flash)"
+                  : selectedAgent === "opencode"
+                    ? "Default (e.g. opencode-1.5-pro)"
+                    : "Default model"
           }
           onChange={onSetModel}
           hint={

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -270,15 +270,27 @@ export function AgentControls({
   return (
     <div className="space-y-3">
       {agents.length >= 2 && (
-        <Segmented
-          label="Agent"
-          value={selectedAgent}
-          onChange={onSelectAgent}
-          options={agents.map((a) => ({
-            value: a.name,
-            label: a.label || a.name,
-          }))}
-        />
+        agents.length > 3 ? (
+          <SelectMenu
+            label="Agent"
+            value={selectedAgent}
+            onChange={onSelectAgent}
+            options={agents.map((a) => ({
+              value: a.name,
+              label: a.label || a.name,
+            }))}
+          />
+        ) : (
+          <Segmented
+            label="Agent"
+            value={selectedAgent}
+            onChange={onSelectAgent}
+            options={agents.map((a) => ({
+              value: a.name,
+              label: a.label || a.name,
+            }))}
+          />
+        )
       )}
       {profiles.length > 0 && (
         <div>

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -139,8 +139,17 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
   const clineConfig = makeMcpConfig({ url: mcpUrl })
   const jetbrainsConfig = makeMcpConfig({ url: mcpUrl })
   const antigravityConfig = makeMcpConfig({ type: "http", url: mcpUrl })
-  const opencodeConfig = makeMcpConfig({ type: "http", url: mcpUrl })
-  const piConfig = makeMcpConfig({ type: "http", url: mcpUrl })
+  const opencodeConfig = JSON.stringify({
+    mcp: {
+      servers: {
+        radar: {
+          type: "remote",
+          url: mcpUrl,
+        }
+      }
+    }
+  }, null, 2)
+  const piConfig = makeMcpConfig({ url: mcpUrl })
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -251,8 +260,8 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               { icon: Terminal, name: 'OpenAI Codex', path: '~/.codex/config.toml', config: codexConfig },
               { icon: Terminal, name: 'Gemini CLI', path: '~/.gemini/settings.json', config: geminiConfig },
               { icon: Terminal, name: 'Antigravity', path: '~/.gemini/antigravity-cli/config.json', config: antigravityConfig },
-              { icon: Terminal, name: 'OpenCode', path: '~/.opencode/config.json', config: opencodeConfig },
-              { icon: Terminal, name: 'Pi CLI', path: '~/.pi/config.json', config: piConfig },
+              { icon: Terminal, name: 'OpenCode', path: '~/.config/opencode/opencode.json', config: opencodeConfig },
+              { icon: Terminal, name: 'Pi CLI', path: '~/.pi/agent/mcp.json', config: piConfig },
             ].map((agent) => (
               <details key={agent.name} className="group rounded-md border border-theme-border/50 bg-theme-base/30">
                 <summary className="flex items-center gap-2 px-3 py-2 select-none list-none hover:bg-theme-hover/50 rounded-md transition-colors [&::-webkit-details-marker]:hidden">

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -175,6 +175,33 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
     }
   }, null, 2)
 
+  const antigravityConfig = JSON.stringify({
+    mcpServers: {
+      radar: {
+        type: "http",
+        url: mcpUrl,
+      }
+    }
+  }, null, 2)
+
+  const opencodeConfig = JSON.stringify({
+    mcpServers: {
+      radar: {
+        type: "http",
+        url: mcpUrl,
+      }
+    }
+  }, null, 2)
+
+  const piConfig = JSON.stringify({
+    mcpServers: {
+      radar: {
+        type: "http",
+        url: mcpUrl,
+      }
+    }
+  }, null, 2)
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
@@ -283,6 +310,9 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               { icon: Code2, name: 'JetBrains AI', path: 'Settings → Tools → AI Assistant → MCP', config: jetbrainsConfig },
               { icon: Terminal, name: 'OpenAI Codex', path: '~/.codex/config.toml', config: codexConfig },
               { icon: Terminal, name: 'Gemini CLI', path: '~/.gemini/settings.json', config: geminiConfig },
+              { icon: Terminal, name: 'Antigravity', path: '~/.gemini/antigravity-cli/config.json', config: antigravityConfig },
+              { icon: Terminal, name: 'OpenCode', path: '~/.opencode/config.json', config: opencodeConfig },
+              { icon: Terminal, name: 'Pi CLI', path: '~/.pi/config.json', config: piConfig },
             ].map((agent) => (
               <details key={agent.name} className="group rounded-md border border-theme-border/50 bg-theme-base/30">
                 <summary className="flex items-center gap-2 px-3 py-2 select-none list-none hover:bg-theme-hover/50 rounded-md transition-colors [&::-webkit-details-marker]:hidden">

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -141,11 +141,9 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
   const antigravityConfig = makeMcpConfig({ type: "http", url: mcpUrl })
   const opencodeConfig = JSON.stringify({
     mcp: {
-      servers: {
-        radar: {
-          type: "remote",
-          url: mcpUrl,
-        }
+      radar: {
+        type: "remote",
+        url: mcpUrl,
       }
     }
   }, null, 2)

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -257,7 +257,7 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               { icon: Code2, name: 'JetBrains AI', path: 'Settings → Tools → AI Assistant → MCP', config: jetbrainsConfig },
               { icon: Terminal, name: 'OpenAI Codex', path: '~/.codex/config.toml', config: codexConfig },
               { icon: Terminal, name: 'Gemini CLI', path: '~/.gemini/settings.json', config: geminiConfig },
-              { icon: Terminal, name: 'Antigravity', path: '~/.gemini/antigravity-cli/config.json', config: antigravityConfig },
+              { icon: Terminal, name: 'Antigravity', path: '~/.gemini/antigravity-cli/mcp_config.json', config: antigravityConfig },
               { icon: Terminal, name: 'OpenCode', path: '~/.config/opencode/opencode.json', config: opencodeConfig },
               { icon: Terminal, name: 'Pi CLI', path: '~/.pi/agent/mcp.json', config: piConfig },
             ].map((agent) => (

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -115,30 +115,15 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
 
   const currentPort = Number(window.location.port) || 80
 
-  const claudeDesktopConfig = JSON.stringify({
+  const makeMcpConfig = (fields: Record<string, string>) => JSON.stringify({
     mcpServers: {
-      radar: {
-        type: "http",
-        url: mcpUrl,
-      }
+      radar: fields
     }
   }, null, 2)
 
-  const cursorConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
-
-  const windsurfConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        serverUrl: mcpUrl,
-      }
-    }
-  }, null, 2)
+  const claudeDesktopConfig = makeMcpConfig({ type: "http", url: mcpUrl })
+  const cursorConfig = makeMcpConfig({ url: mcpUrl })
+  const windsurfConfig = makeMcpConfig({ serverUrl: mcpUrl })
 
   const vsCodeConfig = JSON.stringify({
     servers: {
@@ -149,58 +134,13 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
     }
   }, null, 2)
 
-  const geminiConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        httpUrl: mcpUrl,
-      }
-    }
-  }, null, 2)
-
+  const geminiConfig = makeMcpConfig({ httpUrl: mcpUrl })
   const codexConfig = `[mcp_servers.radar]\nurl = "${mcpUrl}"`
-
-  const clineConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
-
-  const jetbrainsConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
-
-  const antigravityConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        type: "http",
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
-
-  const opencodeConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        type: "http",
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
-
-  const piConfig = JSON.stringify({
-    mcpServers: {
-      radar: {
-        type: "http",
-        url: mcpUrl,
-      }
-    }
-  }, null, 2)
+  const clineConfig = makeMcpConfig({ url: mcpUrl })
+  const jetbrainsConfig = makeMcpConfig({ url: mcpUrl })
+  const antigravityConfig = makeMcpConfig({ type: "http", url: mcpUrl })
+  const opencodeConfig = makeMcpConfig({ type: "http", url: mcpUrl })
+  const piConfig = makeMcpConfig({ type: "http", url: mcpUrl })
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -964,8 +964,8 @@ function AIUnavailableNotice() {
     <div className="rounded-md border border-theme-border bg-theme-elevated/50 p-3">
       <p className="text-sm font-medium text-theme-text-primary">No supported agent CLI found</p>
       <p className="mt-1 text-xs text-theme-text-tertiary">
-        Install <span className="text-theme-text-secondary">Claude Code</span> or{' '}
-        <span className="text-theme-text-secondary">Codex</span>, then restart Radar — this tab
+        Install a supported agent CLI (such as <span className="text-theme-text-secondary">Claude Code</span>,{' '}
+        <span className="text-theme-text-secondary">Codex</span>, or <span className="text-theme-text-secondary">Antigravity</span>), then restart Radar — this tab
         will show the agent, model, and effort controls.
       </p>
     </div>


### PR DESCRIPTION
This PR adds auto-detection, configuration setup, and active diagnostic runner drivers for three additional AI agent CLI tools as requested in discussion #1252:

1. **Antigravity** (checks for the `agy` / `antigravity` binaries, configures `~/.gemini/antigravity-cli/config.json`)
2. **OpenCode** (checks for the `opencode` binary, configures `~/.config/opencode/opencode.json`)
3. **Pi CLI** (checks for the `pi` binary, configures `~/.pi/agent/mcp.json`)

### Key Changes
* **Backend CLI Drivers (`internal/ai/agent_antigravity.go`, `internal/ai/agent_opencode.go`, `internal/ai/agent_pi.go`):** Implemented the `Agent` interface drivers for these CLIs, mapping target prompt/remediation variables, session continuation flag mappings, model selectors, and standard output log stream parsing.
* **Agent Resolution (`internal/ai/agent.go`, `internal/ai/diagnoser.go`):** Added the new drivers to the `resolveAgent` switch-case and added them to `agentCLICandidates` to mark them as fully `Supported` by Radar's diagnosis executor.
* **Auto-Detection (`internal/ai/detect.go`):** Added the new agents to `knownAgents` and resolved binary names dynamically (such as mapping `antigravity` to `agy` dynamically via LookPath).
* **Frontend Setup UI (`web/src/components/home/MCPSetupDialog.tsx`):** Consolidated configuration generation helper methods and created accurate MCP configs matching each agent's native format and schema directory path structure.

Addresses discussion #1252.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new full-local agent path that spawns the OpenCode CLI and writes per-run MCP config; mistakes in command/stream handling could break investigations or mis-report tool activity.
> 
> **Overview**
> Adds **OpenCode** as a first-class local investigation agent alongside Claude, Codex, and Cursor.
> 
> A new `opencodeAgent` driver runs `opencode run` with JSON streaming, optional `--session` / `--model`, and prepends the system prompt into the positional message. Each turn writes a workspace `opencode.json` that points Radar’s MCP as a remote server, and parses stdout JSON (plus fallback text) into thinking/step events and a resumable session id. OpenCode is wired through agent resolution, PATH detection, supported CLI candidates, **full-local-only** execution profiles, and `opencode:full-local` consent versioning.
> 
> The diagnose settings UI gets OpenCode-specific model hints, and the MCP setup dialog adds copy-paste config for `~/.config/opencode/opencode.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93365187b1261e2b6d300b218589dab088f8d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->