### PR TITLE
Surface exact workload DNS changes in the change feed

### DIFF
--- a/internal/k8s/dedup_diff_test.go
+++ b/internal/k8s/dedup_diff_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/skyhook-io/radar/internal/timeline"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // The cache layer computes the update diff once and hands it to
@@ -46,5 +48,40 @@ func TestRecordToTimelineStore_PrecomputedDiffMatchesRecompute(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("precomputed-diff timeline output differs from recompute:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestRecordToTimelineStore_PreservesDNSFieldPath(t *testing.T) {
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(timeline.ResetStore)
+
+	oldDep := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst}}}}
+	newDep := oldDep.DeepCopy()
+	newDep.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
+	recordToTimelineStore(ActiveClusterContext(), "Deployment", "shop", "web", "uid-1", "update", oldDep, newDep, nil, false)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{Kinds: []string{"Deployment"}})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 1 || events[0].Diff == nil {
+		t.Fatalf("expected one timeline event with a diff, got %+v", events)
+	}
+	var dnsPolicyChange *timeline.FieldChange
+	for _, change := range events[0].Diff.Fields {
+		if change.Path == "spec.template.spec.dnsPolicy" {
+			changeCopy := change
+			dnsPolicyChange = &changeCopy
+			break
+		}
+	}
+	if dnsPolicyChange == nil {
+		t.Fatalf("timeline diff lost exact DNS field path: %+v", events[0].Diff.Fields)
+	}
+	if dnsPolicyChange.OldValue != "ClusterFirst" || dnsPolicyChange.NewValue != "None" {
+		t.Fatalf("timeline diff lost DNS values: %+v", *dnsPolicyChange)
 	}
 }

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -3033,6 +3033,26 @@ func diffPodTemplateConfig(oldSpec, newSpec corev1.PodSpec) ([]FieldChange, []st
 	// Pod-level fields. Volume diffs carry source references only (never
 	// contents); tolerations are summarized to compact strings; affinity is a
 	// bare "changed" marker — its tree is too large to diff usefully.
+	oldDNSPolicy := normalizedDNSPolicy(oldSpec.DNSPolicy)
+	newDNSPolicy := normalizedDNSPolicy(newSpec.DNSPolicy)
+	if oldDNSPolicy != newDNSPolicy {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.dnsPolicy", OldValue: oldDNSPolicy, NewValue: newDNSPolicy})
+		summary = append(summary, fmt.Sprintf("dnsPolicy: %s→%s", oldDNSPolicy, newDNSPolicy))
+	}
+	oldNameservers, oldSearches, oldDNSOptions := dnsConfigValues(oldSpec.DNSConfig)
+	newNameservers, newSearches, newDNSOptions := dnsConfigValues(newSpec.DNSConfig)
+	if !equalStringSlices(oldNameservers, newNameservers) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.dnsConfig.nameservers", OldValue: oldNameservers, NewValue: newNameservers})
+		summary = append(summary, "dnsConfig.nameservers changed")
+	}
+	if !equalStringSlices(oldSearches, newSearches) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.dnsConfig.searches", OldValue: oldSearches, NewValue: newSearches})
+		summary = append(summary, "dnsConfig.searches changed")
+	}
+	if !equalStringSlices(oldDNSOptions, newDNSOptions) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.dnsConfig.options", OldValue: oldDNSOptions, NewValue: newDNSOptions})
+		summary = append(summary, "dnsConfig.options changed")
+	}
 	if oldVols, newVols := volumeSourceRefs(oldSpec.Volumes), volumeSourceRefs(newSpec.Volumes); !equalStringSlices(oldVols, newVols) {
 		changes = append(changes, FieldChange{Path: "spec.template.spec.volumes", OldValue: oldVols, NewValue: newVols})
 		summary = append(summary, "volumes changed")
@@ -3058,6 +3078,32 @@ func diffPodTemplateConfig(oldSpec, newSpec corev1.PodSpec) ([]FieldChange, []st
 		summary = append(summary, "pod securityContext changed")
 	}
 	return changes, summary
+}
+
+func normalizedDNSPolicy(policy corev1.DNSPolicy) string {
+	if policy == "" {
+		return string(corev1.DNSClusterFirst)
+	}
+	return string(policy)
+}
+
+func dnsConfigValues(config *corev1.PodDNSConfig) (nameservers, searches, options []string) {
+	nameservers = []string{}
+	searches = []string{}
+	options = []string{}
+	if config == nil {
+		return nameservers, searches, options
+	}
+	nameservers = append(nameservers, config.Nameservers...)
+	searches = append(searches, config.Searches...)
+	for _, option := range config.Options {
+		value := option.Name
+		if option.Value != nil {
+			value += "=" + *option.Value
+		}
+		options = append(options, value)
+	}
+	return nameservers, searches, options
 }
 
 // volumeSourceRefs renders volumes as "name:sourceType/sourceName" references

--- a/internal/k8s/history_diff_test.go
+++ b/internal/k8s/history_diff_test.go
@@ -210,6 +210,103 @@ func TestDiffPodTemplateConfig_PortsSAandScheduling(t *testing.T) {
 	}
 }
 
+func TestDiffPodTemplateConfig_DNS(t *testing.T) {
+	oldNDots := "2"
+	newNDots := "5"
+	oldSpec := corev1.PodSpec{
+		DNSPolicy: corev1.DNSClusterFirst,
+		DNSConfig: &corev1.PodDNSConfig{
+			Nameservers: []string{"10.96.0.10"},
+			Searches:    []string{"default.svc.cluster.local"},
+			Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: &oldNDots}, {Name: "single-request-reopen"}},
+		},
+	}
+	newSpec := corev1.PodSpec{
+		DNSPolicy: corev1.DNSNone,
+		DNSConfig: &corev1.PodDNSConfig{
+			Nameservers: []string{"1.1.1.1", "8.8.8.8"},
+			Searches:    []string{"svc.cluster.local", "cluster.local"},
+			Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: &newNDots}, {Name: "rotate"}},
+		},
+	}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	expected := map[string]struct {
+		old any
+		new any
+	}{
+		"spec.template.spec.dnsPolicy":             {old: "ClusterFirst", new: "None"},
+		"spec.template.spec.dnsConfig.nameservers": {old: []string{"10.96.0.10"}, new: []string{"1.1.1.1", "8.8.8.8"}},
+		"spec.template.spec.dnsConfig.searches":    {old: []string{"default.svc.cluster.local"}, new: []string{"svc.cluster.local", "cluster.local"}},
+		"spec.template.spec.dnsConfig.options":     {old: []string{"ndots=2", "single-request-reopen"}, new: []string{"ndots=5", "rotate"}},
+	}
+	if len(changes) != len(expected) {
+		t.Fatalf("changes = %+v, want exactly the four DNS fields", changes)
+	}
+	for path, want := range expected {
+		change, ok := findChangePath(changes, path)
+		if !ok {
+			t.Fatalf("missing %s in %+v", path, changes)
+		}
+		if !reflect.DeepEqual(change.OldValue, want.old) || !reflect.DeepEqual(change.NewValue, want.new) {
+			t.Fatalf("%s = %#v→%#v, want %#v→%#v", path, change.OldValue, change.NewValue, want.old, want.new)
+		}
+	}
+	joined := strings.Join(summary, "; ")
+	for _, fragment := range []string{"dnsPolicy: ClusterFirst→None", "dnsConfig.nameservers changed", "dnsConfig.searches changed", "dnsConfig.options changed"} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("summary %q missing %q", joined, fragment)
+		}
+	}
+}
+
+func TestDiffPodTemplateConfig_DNSOrderRemainsObservable(t *testing.T) {
+	oldSpec := corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{
+		Nameservers: []string{"1.1.1.1", "8.8.8.8"},
+		Searches:    []string{"svc.cluster.local", "cluster.local"},
+		Options:     []corev1.PodDNSConfigOption{{Name: "rotate"}, {Name: "single-request-reopen"}},
+	}}
+	newSpec := corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{
+		Nameservers: []string{"8.8.8.8", "1.1.1.1"},
+		Searches:    []string{"cluster.local", "svc.cluster.local"},
+		Options:     []corev1.PodDNSConfigOption{{Name: "single-request-reopen"}, {Name: "rotate"}},
+	}}
+
+	changes, _ := diffPodTemplateConfig(oldSpec, newSpec)
+	for _, path := range []string{
+		"spec.template.spec.dnsConfig.nameservers",
+		"spec.template.spec.dnsConfig.searches",
+		"spec.template.spec.dnsConfig.options",
+	} {
+		change, ok := findChangePath(changes, path)
+		if !ok {
+			t.Fatalf("order-only change at %s was lost: %+v", path, changes)
+		}
+		oldValues := change.OldValue.([]string)
+		newValues := change.NewValue.([]string)
+		if len(oldValues) != 2 || len(newValues) != 2 || oldValues[0] == newValues[0] {
+			t.Fatalf("order-only change at %s lost ordered values: %#v→%#v", path, oldValues, newValues)
+		}
+	}
+}
+
+func TestDiffPodTemplateConfig_DNSDefaultsAndEmptyCollectionsAreEquivalent(t *testing.T) {
+	oldSpec := corev1.PodSpec{}
+	newSpec := corev1.PodSpec{
+		DNSPolicy: corev1.DNSClusterFirst,
+		DNSConfig: &corev1.PodDNSConfig{
+			Nameservers: []string{},
+			Searches:    []string{},
+			Options:     []corev1.PodDNSConfigOption{},
+		},
+	}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	if len(changes) != 0 || len(summary) != 0 {
+		t.Fatalf("API defaults and empty DNS collections produced noise: changes=%+v summary=%+v", changes, summary)
+	}
+}
+
 func TestDiffApplicationCleansFailedOperationMessage(t *testing.T) {
 	rawMessage := `rpc error: code = Unknown desc = app path does not exist`
 	tests := []struct {

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -373,6 +373,46 @@ func TestComputeDiff_StatefulSetEnvRemoval_Detected(t *testing.T) {
 	}
 }
 
+func TestComputeDiff_WorkloadDNSConfig_Detected(t *testing.T) {
+	oldSpec := corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst}
+	newSpec := corev1.PodSpec{
+		DNSPolicy: corev1.DNSNone,
+		DNSConfig: &corev1.PodDNSConfig{Nameservers: []string{"1.1.1.1"}},
+	}
+	tests := []struct {
+		kind string
+		old  any
+		new  any
+	}{
+		{
+			kind: "Deployment",
+			old:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: oldSpec}}},
+			new:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: newSpec}}},
+		},
+		{
+			kind: "StatefulSet",
+			old:  &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: oldSpec}}},
+			new:  &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: newSpec}}},
+		},
+		{
+			kind: "DaemonSet",
+			old:  &appsv1.DaemonSet{Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: oldSpec}}},
+			new:  &appsv1.DaemonSet{Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: newSpec}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			diff := ComputeDiff(tt.kind, tt.old, tt.new)
+			for _, path := range []string{"spec.template.spec.dnsPolicy", "spec.template.spec.dnsConfig.nameservers"} {
+				if diff == nil || !containsPath(diff, path) {
+					t.Fatalf("expected %s change at %s, got %+v", tt.kind, path, diff)
+				}
+			}
+		})
+	}
+}
+
 func TestComputeDiff_FluxKustomizationStalled_Detected(t *testing.T) {
 	mk := func(stalledStatus string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{Object: map[string]any{


### PR DESCRIPTION
## Summary

- emit exact workload history paths for `dnsPolicy` and `dnsConfig.nameservers/searches/options`
- normalize omitted `dnsPolicy` to Kubernetes' `ClusterFirst` default and nil DNS collections to empty collections
- preserve resolver list order and option values as compact, wire-safe strings
- cover Deployment, StatefulSet, and DaemonSet through their shared pod-template differ

This is a precision improvement, not a new detector or ranking rule. DNS-only edits already produced a generation-based `spec_config` entry; this replaces the generic "fields not specifically tracked" row with the actual before/after DNS fields. Existing spec-configuration ranking remains unchanged.

The pending network-path diagnostics PR is independent: it diagnoses current network reachability and does not own workload history diffing, so this PR does not wait for or stack on it.

## Product and scope decisions

- No semantic verdict such as "this resolver will break cluster DNS": the feed reports the observed edit and leaves diagnosis to the agent.
- No ranking changes: existing `spec_config` ordering already ranks the precise edit above rollout status churn.
- No CronJob support in this PR. Adding CronJob to the audited differ map requires complete user-relevant CronJob diff coverage; a DNS-only CronJob differ would violate that contract.
- Other pod-spec gaps evaluated but deferred include host aliases/networking, hostname/subdomain, service-account token mounting, service-link injection, scheduler/runtime class, image-pull secrets, and topology spread. The break-but-remain-Ready candidates are worth a separate allowlist review rather than enabling a noisy full pod-spec deep diff.

Live validation also exposed a pre-existing boundary: Kubernetes increments Deployment generation for top-level annotation changes, so Radar's generic generation fallback can call an annotation-only update a spec change. Label-only metadata updates remain quiet. That fallback policy is not caused by this diff and should be fixed separately with its own cross-kind contract tests.

## Validation

- `go test ./internal/k8s -count=1`
- `make test`
- `make tsc`
- `make build`
- independent code cross-review: no actionable findings
- visual-test: skipped (no UI delta)

Live smoke test against an isolated local kind cluster, using SQLite timeline storage:

1. Started Radar and created a healthy Deployment.
2. Patched only the pod template from `dnsPolicy: ClusterFirst` to `None` and added `dnsConfig.nameservers: ["1.1.1.1"]`.
3. Confirmed the informer event and SQLite row contained:
   - `spec.template.spec.dnsPolicy: ClusterFirst → None`
   - `spec.template.spec.dnsConfig.nameservers: [] → ["1.1.1.1"]`
4. Confirmed MCP `get_changes` returned that edit first as `change_category: spec_config`, above rollout status entries, with no generic generation fallback for the DNS edit.
5. Confirmed a label-only metadata update added no change-feed row.

The disposable namespace was deleted and the previously stopped demo-cluster container was returned to its stopped state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted diff logic and tests in the k8s history/change-feed path; no auth, security, or ranking behavior changes.
> 
> **Overview**
> Workload history diffs now report **precise pod-template DNS edits** instead of relying on generic generation/spec fallback for those fields.
> 
> `diffPodTemplateConfig` emits field paths for `spec.template.spec.dnsPolicy` and `spec.template.spec.dnsConfig.{nameservers,searches,options}`, with omitted `dnsPolicy` normalized to **ClusterFirst**, nil/empty DNS collections treated as equivalent, ordered list comparison (so reorder-only changes show up), and DNS options as compact strings like `ndots=5`. **Deployment**, **StatefulSet**, and **DaemonSet** all pick this up via the shared pod-template differ.
> 
> Tests cover the differ behavior, end-to-end `ComputeDiff` for the three workload kinds, and timeline recording so DNS paths survive `recordToTimelineStore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c673534d6ac2be03bd5faf1d099a5c75682c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->