### PR TITLE
Ignore Deployment annotation-only generation bumps

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -456,6 +457,21 @@ func getGeneration(obj any) int64 {
 	return m.GetGeneration()
 }
 
+func generationBumpSignalsSpecChange(kind string, oldObj, newObj any) bool {
+	if kind != "Deployment" {
+		return true
+	}
+	oldDeployment, oldOK := oldObj.(*appsv1.Deployment)
+	newDeployment, newOK := newObj.(*appsv1.Deployment)
+	if !oldOK || !newOK {
+		return true
+	}
+
+	// The Deployment API increments generation for top-level annotation
+	// changes because those annotations are copied to ReplicaSets.
+	return !apiequality.Semantic.DeepEqual(oldDeployment.Spec, newDeployment.Spec)
+}
+
 // recordToTimelineStore records a resource change to the timeline.
 // clusterContext is the wiring-time capture (see InitResourceCache), not the
 // live active context — a late callback must stamp the cluster it came from.
@@ -541,12 +557,9 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 		} else if KindHasDiffer(kind) || isUnstructuredUpdate(oldObj, newObj) {
 			// Diff handling found nothing observable — usually a heartbeat,
 			// managedFields-only update, or reconcile counter.
-			// Before dropping, check metadata.generation: it bumps only on
-			// spec changes (status updates don't touch it), so a generation
-			// flip with a nil diff means our diff function missed a real spec
-			// field. Record those with a fallback summary instead of silently
-			// losing them — diff coverage gaps shouldn't become silent drops.
-			if oldGen, newGen := getGeneration(oldObj), getGeneration(newObj); oldGen != newGen && oldGen > 0 && newGen > 0 {
+			// Before dropping, use metadata.generation to catch spec fields our
+			// audited differ does not yet track.
+			if oldGen, newGen := getGeneration(oldObj), getGeneration(newObj); oldGen != newGen && oldGen > 0 && newGen > 0 && generationBumpSignalsSpecChange(kind, oldObj, newObj) {
 				diff = &timeline.DiffInfo{
 					Fields: []timeline.FieldChange{{
 						Path:     "metadata.generation",

--- a/internal/k8s/dedup_diff_test.go
+++ b/internal/k8s/dedup_diff_test.go
@@ -85,3 +85,54 @@ func TestRecordToTimelineStore_PreservesDNSFieldPath(t *testing.T) {
 		t.Fatalf("timeline diff lost DNS values: %+v", *dnsPolicyChange)
 	}
 }
+
+func TestRecordToTimelineStore_DeploymentGenerationFallbackRequiresSpecChange(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*appsv1.Deployment)
+		wantEvents int
+	}{
+		{
+			name: "top-level annotation only",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Annotations = map[string]string{"example.com/revision": "2"}
+			},
+		},
+		{
+			name: "untracked spec field",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.MinReadySeconds = 5
+			},
+			wantEvents: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			oldDeployment := testDeployment("uid-1", "nginx:1.0", now)
+			oldDeployment.Generation = 1
+			newDeployment := oldDeployment.DeepCopy()
+			newDeployment.Generation = 2
+			tt.mutate(newDeployment)
+
+			timeline.ResetStore()
+			if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+				t.Fatalf("InitStore: %v", err)
+			}
+			t.Cleanup(timeline.ResetStore)
+
+			recordToTimelineStore(ActiveClusterContext(), "Deployment", "shop", "web", "uid-1", "update", oldDeployment, newDeployment, nil, false)
+			events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{Kinds: []string{"Deployment"}})
+			if err != nil {
+				t.Fatalf("Query: %v", err)
+			}
+			if len(events) != tt.wantEvents {
+				t.Fatalf("recorded %d events, want %d: %+v", len(events), tt.wantEvents, events)
+			}
+			if tt.wantEvents == 1 && (events[0].Diff == nil || len(events[0].Diff.Fields) != 1 || events[0].Diff.Fields[0].Path != "metadata.generation") {
+				t.Fatalf("expected generation fallback for untracked spec change, got %+v", events[0].Diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Kubernetes Deployments increment `metadata.generation` for top-level annotation changes because those annotations are propagated to ReplicaSets. Radar treated every generation bump with no audited field diff as an untracked spec change, so an annotation-only update appeared in the change feed as:

> spec changed (fields not specifically tracked)

That is both inaccurate and potentially high-volume on clusters with reconcilers that update Deployment annotations.

## What changed

- Recognize the Deployment API's annotation-specific generation behavior.
- Drop a generation-only fallback when a typed Deployment's `spec` is unchanged.
- Preserve the existing safety net for actual spec changes that the audited differ does not yet cover.
- Add integration-level timeline tests for both paths.

The exception is intentionally Deployment-only. Kubernetes' storage strategies for the other audited workload kinds retain spec-based generation semantics.

## Validation

- `go test ./internal/k8s -count=1`
- `make test`
- `make tsc`
- `make build`
- `git diff --check`

### Live test

Tested against a local kind Kubernetes v1.36 cluster with Radar on port 9363 and SQLite timeline storage:

1. Added a top-level annotation to a Deployment. Kubernetes advanced generation from 1 to 2; Radar logged the update as no-diff and emitted no informer/change-feed row.
2. Changed the untracked `spec.minReadySeconds` field. Kubernetes advanced generation from 2 to 3; Radar retained the fallback event with `metadata.generation: 2 → 3`.
3. Verified the retained event in the SQLite timeline, REST change feed, and MCP `get_changes`, where it remained categorized as `spec_config`.

The disposable namespace was deleted and the test cluster restored to its prior stopped state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Deployment no-diff update handling in timeline dedup; other kinds unchanged and behavior is covered by new tests.
> 
> **Overview**
> **Deployment** updates that only change top-level annotations no longer show up in the change feed as untracked spec changes when `metadata.generation` increases but the audited differ finds no fields.
> 
> Timeline recording still uses the **generation fallback** (`metadata.generation` with a generic “spec changed” summary) when a typed **Deployment**’s `spec` actually changes but isn’t covered by the differ. That check is **Deployment-only** via semantic equality on `Spec`; other kinds keep the previous generation-bump behavior.
> 
> Tests cover annotation-only updates (dropped, zero events) versus an untracked spec field like `minReadySeconds` (fallback event retained).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1424d6df4ea91e771a2d013dab741193d7bb889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->