### PR TITLE
Add explicit AI agent execution profiles

### DIFF
--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -25,6 +25,16 @@ type Agent interface {
 	parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis
 }
 
+// ExecutionProfile describes how Radar starts a local agent. It is a product
+// contract, not a claim about a particular CLI flag: safeguarded is available
+// only when Radar can enforce the restrictions for that agent.
+type ExecutionProfile string
+
+const (
+	ExecutionProfileSafeguarded ExecutionProfile = "safeguarded"
+	ExecutionProfileFullLocal   ExecutionProfile = "full-local"
+)
+
 // turnSpec is everything an Agent needs to build one turn, independent of CLI.
 type turnSpec struct {
 	mcpURL       string // radar MCP endpoint (read-only or full) to point the agent at
@@ -32,7 +42,7 @@ type turnSpec struct {
 	systemPrompt string // SRE+security framing; set only on the first turn (empty on resume)
 	sessionID    string // resume target; empty means a fresh session
 	apply        bool   // user-confirmed remediation turn (write tools allowed)
-	isolated     bool   // run without the user's own CLI config (Codex only)
+	profile      ExecutionProfile
 	model        string // optional model override; empty = the CLI's default
 	effort       string // optional reasoning effort (Codex only); empty = default
 	maxTurns     int

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -15,6 +15,8 @@ import (
 type Agent interface {
 	// Name is the stable backend identifier ("claude", "codex").
 	Name() string
+	// Path is the resolved executable this backend actually drives.
+	Path() string
 	// SigninCmd is shown when the CLI reports that it is signed out.
 	SigninCmd() string
 	// command builds the fully-configured *exec.Cmd for one turn (bin, args, env,

--- a/internal/ai/agent_claude.go
+++ b/internal/ai/agent_claude.go
@@ -17,6 +17,8 @@ type claudeAgent struct{ bin string }
 
 func (a *claudeAgent) Name() string { return "claude" }
 
+func (a *claudeAgent) Path() string { return a.bin }
+
 func (a *claudeAgent) SigninCmd() string { return "claude auth login" }
 
 func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {

--- a/internal/ai/agent_claude.go
+++ b/internal/ai/agent_claude.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -19,6 +20,9 @@ func (a *claudeAgent) Name() string { return "claude" }
 func (a *claudeAgent) SigninCmd() string { return "claude auth login" }
 
 func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	if s.profile != ExecutionProfileSafeguarded {
+		return nil, nil, fmt.Errorf("ai: Claude does not support execution profile %q", s.profile)
+	}
 	cfgPath, cleanup, err := writeMCPConfig(s.mcpURL)
 	if err != nil {
 		return nil, nil, err

--- a/internal/ai/agent_claude.go
+++ b/internal/ai/agent_claude.go
@@ -9,10 +9,9 @@ import (
 	"strconv"
 )
 
-// claudeAgent drives Claude Code. Containment is via CLI flags: --tools "" disables
-// ALL built-in tools (no Bash/WebFetch), and --allowedTools restricts MCP usage to
-// radar's read tools (plus write tools on a confirmed apply turn). The read-only
-// MCP mount enforces the same server-side, so the allowlist is defense-in-depth.
+// claudeAgent drives Claude Code. In safeguarded mode, --tools "" disables all
+// built-in tools and --allowedTools restricts MCP usage to Radar. Full-local
+// deliberately omits those constraints and merges Radar into the user's setup.
 type claudeAgent struct{ bin string }
 
 func (a *claudeAgent) Name() string { return "claude" }
@@ -22,7 +21,9 @@ func (a *claudeAgent) Path() string { return a.bin }
 func (a *claudeAgent) SigninCmd() string { return "claude auth login" }
 
 func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
-	if s.profile != ExecutionProfileSafeguarded {
+	switch s.profile {
+	case ExecutionProfileSafeguarded, ExecutionProfileFullLocal:
+	default:
 		return nil, nil, fmt.Errorf("ai: Claude does not support execution profile %q", s.profile)
 	}
 	cfgPath, cleanup, err := writeMCPConfig(s.mcpURL)
@@ -32,20 +33,25 @@ func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 
 	args := []string{
 		"-p", s.prompt,
-		"--mcp-config", cfgPath, "--strict-mcp-config",
-		"--tools", "", // disable all built-in tools — cluster access is MCP-only
-		"--allowedTools",
+		"--mcp-config", cfgPath,
 	}
-	for _, t := range radarReadTools {
-		args = append(args, "mcp__radar__"+t)
-	}
-	if s.apply {
-		for _, t := range radarWriteTools {
+	if s.profile == ExecutionProfileSafeguarded {
+		args = append(args,
+			"--strict-mcp-config",
+			"--tools", "", // disable all built-in tools — cluster access is MCP-only
+			"--allowedTools",
+		)
+		for _, t := range radarReadTools {
 			args = append(args, "mcp__radar__"+t)
 		}
+		if s.apply {
+			for _, t := range radarWriteTools {
+				args = append(args, "mcp__radar__"+t)
+			}
+		}
+		args = append(args, "--permission-mode", "acceptEdits")
 	}
 	args = append(args,
-		"--permission-mode", "acceptEdits",
 		"--max-turns", strconv.Itoa(s.maxTurns),
 		"--output-format", "stream-json", "--verbose",
 	)
@@ -59,11 +65,12 @@ func (a *claudeAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	}
 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
-	cmd.Env = scrubbedEnv()
+	if s.profile == ExecutionProfileSafeguarded {
+		cmd.Env = scrubbedEnv()
+	}
 	// Run from the user's home dir so the session is stored under a stable,
 	// predictable project path: Claude Code's `--resume <id>` is cwd-scoped, and
-	// the "Open in Claude Code" hand-off resumes from a home-dir terminal. Claude's
-	// built-in tools are disabled (--tools ""), so cwd doesn't widen its access.
+	// the "Open in Claude Code" hand-off resumes from a home-dir terminal.
 	if home, err := os.UserHomeDir(); err == nil {
 		cmd.Dir = home
 	}

--- a/internal/ai/agent_claude_test.go
+++ b/internal/ai/agent_claude_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestClaudeExecutionProfile(t *testing.T) {
+func TestClaudeExecutionProfiles(t *testing.T) {
 	a := &claudeAgent{bin: "claude"}
-	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+	safeguarded, cleanup, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go",
 		profile: ExecutionProfileSafeguarded, maxTurns: 1,
 	})
@@ -16,15 +16,38 @@ func TestClaudeExecutionProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	args := strings.Join(cmd.Args, " ")
-	for _, want := range []string{"--strict-mcp-config", "--tools ", "--allowedTools"} {
-		if !strings.Contains(args, want) {
-			t.Errorf("safeguarded Claude command missing %q: %q", want, args)
+	safeguardedArgs := strings.Join(safeguarded.Args, " ")
+	for _, want := range []string{"--strict-mcp-config", "--tools ", "--allowedTools", "--permission-mode acceptEdits"} {
+		if !strings.Contains(safeguardedArgs, want) {
+			t.Errorf("safeguarded Claude command missing %q: %q", want, safeguardedArgs)
 		}
 	}
-	if _, _, err := a.command(context.Background(), turnSpec{
-		profile: ExecutionProfileFullLocal,
-	}); err == nil {
-		t.Fatal("Claude must reject full-local until the driver implements it")
+	if safeguarded.Env == nil {
+		t.Error("safeguarded Claude must use a minimized environment")
+	}
+
+	fullLocal, cleanupFullLocal, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go",
+		profile: ExecutionProfileFullLocal, maxTurns: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupFullLocal()
+	fullLocalArgs := strings.Join(fullLocal.Args, " ")
+	if !strings.Contains(fullLocalArgs, "--mcp-config") {
+		t.Errorf("full-local Claude must still mount Radar MCP: %q", fullLocalArgs)
+	}
+	for _, excluded := range []string{"--strict-mcp-config", "--tools", "--allowedTools", "--permission-mode"} {
+		if strings.Contains(fullLocalArgs, excluded) {
+			t.Errorf("full-local Claude must inherit normal setup, found %q in %q", excluded, fullLocalArgs)
+		}
+	}
+	if fullLocal.Env != nil {
+		t.Error("full-local Claude must inherit the user's environment")
+	}
+
+	if _, _, err := a.command(context.Background(), turnSpec{profile: ""}); err == nil {
+		t.Fatal("Claude must reject an empty profile rather than fail open")
 	}
 }

--- a/internal/ai/agent_claude_test.go
+++ b/internal/ai/agent_claude_test.go
@@ -1,0 +1,30 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestClaudeExecutionProfile(t *testing.T) {
+	a := &claudeAgent{bin: "claude"}
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go",
+		profile: ExecutionProfileSafeguarded, maxTurns: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"--strict-mcp-config", "--tools ", "--allowedTools"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("safeguarded Claude command missing %q: %q", want, args)
+		}
+	}
+	if _, _, err := a.command(context.Background(), turnSpec{
+		profile: ExecutionProfileFullLocal,
+	}); err == nil {
+		t.Fatal("Claude must reject full-local until the driver implements it")
+	}
+}

--- a/internal/ai/agent_codex.go
+++ b/internal/ai/agent_codex.go
@@ -24,6 +24,8 @@ type codexAgent struct{ bin string }
 
 func (a *codexAgent) Name() string { return "codex" }
 
+func (a *codexAgent) Path() string { return a.bin }
+
 func (a *codexAgent) SigninCmd() string { return "codex login" }
 
 func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
@@ -40,7 +42,7 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 	}
 	mcpCfg := fmt.Sprintf("mcp_servers.radar.url=%q", s.mcpURL)
 
-	// Always start from the base flags; isolation adds --ignore-user-config, an
+	// Always start from the base flags; safeguards add --ignore-user-config, an
 	// empty cwd, and a minimal env. Full-local keeps the user's config (their other
 	// MCP servers, guidelines), their full env, and their home cwd. The shell stays
 	// --sandbox read-only in BOTH modes — but the "cluster writes go only through

--- a/internal/ai/agent_codex.go
+++ b/internal/ai/agent_codex.go
@@ -18,7 +18,7 @@ import (
 //   - --sandbox read-only blocks the model's shell from network + filesystem
 //     writes (verified: no loopback, no kubectl), though it can still READ local
 //     files into context — disclosed to the user;
-//   - --ignore-user-config keeps the user's other MCP servers out of an isolated
+//   - --ignore-user-config keeps the user's other MCP servers out of a safeguarded
 //     run; cmd.Dir is an empty temp dir so it doesn't read the launch directory.
 type codexAgent struct{ bin string }
 
@@ -27,6 +27,11 @@ func (a *codexAgent) Name() string { return "codex" }
 func (a *codexAgent) SigninCmd() string { return "codex login" }
 
 func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	switch s.profile {
+	case ExecutionProfileSafeguarded, ExecutionProfileFullLocal:
+	default:
+		return nil, nil, fmt.Errorf("ai: Codex does not support execution profile %q", s.profile)
+	}
 	// Codex has no system-prompt flag; the framing rides on the first turn's
 	// prompt (the resumed session already carries it).
 	prompt := s.prompt
@@ -36,10 +41,10 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 	mcpCfg := fmt.Sprintf("mcp_servers.radar.url=%q", s.mcpURL)
 
 	// Always start from the base flags; isolation adds --ignore-user-config, an
-	// empty cwd, and a minimal env. "My setup" keeps the user's config (their other
+	// empty cwd, and a minimal env. Full-local keeps the user's config (their other
 	// MCP servers, guidelines), their full env, and their home cwd. The shell stays
 	// --sandbox read-only in BOTH modes — but the "cluster writes go only through
-	// Radar's read-only MCP" containment holds ONLY when isolated. In "my setup"
+	// Radar's read-only MCP" containment holds ONLY when safeguarded. In full-local
 	// the agent also gets the user's own MCP servers (possibly write/network/cloud
 	// capable) + local file reads: a deliberate trusted mode, not a contained one.
 	base := []string{"--json", "--skip-git-repo-check", "-c", mcpCfg}
@@ -52,7 +57,7 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 	// only this cluster" guarantee. The diagnosis needs cluster data via MCP, not the
 	// web. (image_gen is also built in but is inert for k8s and can't be disabled.)
 	base = append(base, "-c", `web_search="disabled"`)
-	if s.isolated {
+	if s.profile == ExecutionProfileSafeguarded {
 		base = append(base, "--ignore-user-config")
 	}
 	if s.model != "" {
@@ -85,7 +90,7 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 
 	cleanup := func() {}
-	if s.isolated {
+	if s.profile == ExecutionProfileSafeguarded {
 		// Empty working dir so the model's shell can't read radar's source / cwd.
 		dir, err := os.MkdirTemp("", "radar-codex-")
 		if err != nil {
@@ -95,7 +100,7 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 		cmd.Dir = dir
 		cmd.Env = codexEnv()
 	}
-	// "My setup": inherit radar's cwd + full env so the user's auth/config/MCPs work.
+	// Full-local: inherit radar's cwd + full env so the user's auth/config/MCPs work.
 
 	return cmd, cleanup, nil
 }

--- a/internal/ai/agent_codex_test.go
+++ b/internal/ai/agent_codex_test.go
@@ -66,46 +66,49 @@ func TestCodexParseStream_FormatPin(t *testing.T) {
 	}
 }
 
-// TestCodexIsolationFlags pins the security-relevant difference between isolated
-// and "my setup": isolated drops the user's config + runs in an empty cwd; both
+// TestCodexExecutionProfiles pins the security-relevant difference between safeguarded
+// and full-local: safeguarded drops the user's config + runs in an empty cwd; both
 // modes keep the read-only sandbox.
-func TestCodexIsolationFlags(t *testing.T) {
+func TestCodexExecutionProfiles(t *testing.T) {
 	a := &codexAgent{bin: "codex"}
 	ctx := context.Background()
 
-	iso, cleanup, err := a.command(ctx, turnSpec{mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", isolated: true})
+	iso, cleanup, err := a.command(ctx, turnSpec{mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileSafeguarded})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup()
 	args := strings.Join(iso.Args, " ")
 	if !strings.Contains(args, "--ignore-user-config") {
-		t.Errorf("isolated mode must pass --ignore-user-config; got %q", args)
+		t.Errorf("safeguarded mode must pass --ignore-user-config; got %q", args)
 	}
 	if !strings.Contains(args, "--sandbox read-only") {
-		t.Errorf("isolated mode must keep --sandbox read-only; got %q", args)
+		t.Errorf("safeguarded mode must keep --sandbox read-only; got %q", args)
 	}
 	if iso.Dir == "" {
-		t.Error("isolated mode must run in a dedicated (empty) cwd")
+		t.Error("safeguarded mode must run in a dedicated (empty) cwd")
 	}
 	if iso.Env == nil {
-		t.Error("isolated mode must use a minimized env, not inherit nil")
+		t.Error("safeguarded mode must use a minimized env, not inherit nil")
 	}
 
-	my, cleanup2, err := a.command(ctx, turnSpec{mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", isolated: false})
+	my, cleanup2, err := a.command(ctx, turnSpec{mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileFullLocal})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup2()
 	myArgs := strings.Join(my.Args, " ")
 	if strings.Contains(myArgs, "--ignore-user-config") {
-		t.Errorf("my-setup mode must NOT drop user config; got %q", myArgs)
+		t.Errorf("full-local mode must NOT drop user config; got %q", myArgs)
 	}
 	if !strings.Contains(myArgs, "--sandbox read-only") {
-		t.Errorf("my-setup mode must still keep --sandbox read-only; got %q", myArgs)
+		t.Errorf("full-local mode must still keep --sandbox read-only; got %q", myArgs)
 	}
 	if my.Dir != "" {
-		t.Error("my-setup mode should inherit radar's cwd (no override)")
+		t.Error("full-local mode should inherit radar's cwd (no override)")
+	}
+	if _, _, err := a.command(ctx, turnSpec{profile: ""}); err == nil {
+		t.Fatal("Codex must reject an empty profile rather than fail open")
 	}
 }
 

--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +41,8 @@ type cursorAgent struct {
 }
 
 func (a *cursorAgent) Name() string { return "cursor-agent" }
+
+func (a *cursorAgent) Path() string { return a.bin }
 
 func (a *cursorAgent) SigninCmd() string { return "cursor-agent login" }
 
@@ -116,11 +120,14 @@ func (a *cursorAgent) supportsTrust() (bool, error) {
 	}
 	a.trust = cursorHelpSupportsTrust(string(out))
 	a.trustKnown = true
+	log.Printf("[ai] cursor-agent --trust supported=%v", a.trust)
 	return a.trust, nil
 }
 
+var cursorTrustFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--trust([[:space:],=]|$)`)
+
 func cursorHelpSupportsTrust(help string) bool {
-	return strings.Contains(help, "--trust")
+	return cursorTrustFlag.MatchString(help)
 }
 
 // writeCursorMCPConfig points Cursor at radar's MCP via the workspace-local config

--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
 // cursorAgent drives the Cursor CLI (`cursor-agent -p`). Containment differs from
@@ -28,13 +30,22 @@ import (
 // is disclosed in the consent UI — this is a BYO "your own setup" mode, not a
 // hermetic one. Cursor's --resume is workspace-scoped, so every turn of a run must
 // share one workspace dir (RunManager supplies a stable per-run dir via turnSpec).
-type cursorAgent struct{ bin string }
+type cursorAgent struct {
+	bin string
+
+	trustMu    sync.Mutex
+	trustKnown bool
+	trust      bool
+}
 
 func (a *cursorAgent) Name() string { return "cursor-agent" }
 
 func (a *cursorAgent) SigninCmd() string { return "cursor-agent login" }
 
 func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	if s.profile != ExecutionProfileFullLocal {
+		return nil, nil, fmt.Errorf("ai: Cursor Agent does not support execution profile %q", s.profile)
+	}
 	// Cursor has no system-prompt flag; the framing rides on the first turn's
 	// prompt (the resumed session already carries it).
 	prompt := s.prompt
@@ -63,7 +74,14 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 		"--workspace", workdir,
 		"--sandbox", "enabled", // sandbox Cursor's own shell/file tools; MCP calls run server-side in radar
 		"--approve-mcps", // auto-approve the radar server for this headless run
-		"--trust",        // headless: trust the workspace without an interactive prompt
+	}
+	trust, err := a.supportsTrust()
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	if trust {
+		args = append(args, "--trust")
 	}
 	if s.model != "" {
 		args = append(args, "--model", s.model) // free-form Cursor model slug; "" = the user's default
@@ -76,9 +94,33 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = workdir
 	// Inherit the full environment: Cursor's auth lives under ~/.cursor (and
-	// CURSOR_API_KEY) and it has no isolated mode, so a scrubbed env would break
-	// login. This is the BYO "your own setup" trust posture, like Codex "my setup".
+	// CURSOR_API_KEY) and it has no safeguarded mode, so a scrubbed env would
+	// break login. This is the full-local trust posture.
 	return cmd, cleanup, nil
+}
+
+func (a *cursorAgent) supportsTrust() (bool, error) {
+	a.trustMu.Lock()
+	defer a.trustMu.Unlock()
+	if a.trustKnown {
+		return a.trust, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, _ := exec.CommandContext(ctx, a.bin, "--help").CombinedOutput()
+	if ctx.Err() != nil {
+		return false, fmt.Errorf("ai: Cursor Agent capability probe timed out")
+	}
+	if len(bytes.TrimSpace(out)) == 0 {
+		return false, fmt.Errorf("ai: Cursor Agent capability probe returned no help output")
+	}
+	a.trust = cursorHelpSupportsTrust(string(out))
+	a.trustKnown = true
+	return a.trust, nil
+}
+
+func cursorHelpSupportsTrust(help string) bool {
+	return strings.Contains(help, "--trust")
 }
 
 // writeCursorMCPConfig points Cursor at radar's MCP via the workspace-local config

--- a/internal/ai/agent_cursor_test.go
+++ b/internal/ai/agent_cursor_test.go
@@ -93,12 +93,13 @@ func TestCursorParseStream_ErrorResultNotVerdict(t *testing.T) {
 // stream-json output, sandboxed shell, MCP auto-approval, a workspace-local
 // mcp.json pointed at radar, and --resume only on a continued session.
 func TestCursorCommandFlags(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent"}
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trust: true}
 	dir := t.TempDir()
 	const url = "http://localhost:9/mcp-readonly"
 
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
 		mcpURL: url, prompt: "go", workdir: dir, model: "sonnet-4.5",
+		profile: ExecutionProfileFullLocal,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -144,6 +145,7 @@ func TestCursorCommandFlags(t *testing.T) {
 	// A continued session passes --resume <id>.
 	resumed, cleanup2, err := a.command(context.Background(), turnSpec{
 		mcpURL: url, prompt: "more", workdir: dir, sessionID: "sess-xyz",
+		profile: ExecutionProfileFullLocal,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -151,6 +153,50 @@ func TestCursorCommandFlags(t *testing.T) {
 	defer cleanup2()
 	if !strings.Contains(strings.Join(resumed.Args, " "), "--resume sess-xyz") {
 		t.Errorf("continued session must pass --resume sess-xyz; got %q", resumed.Args)
+	}
+}
+
+func TestCursorCommandOmitsTrustWhenUnsupported(t *testing.T) {
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true}
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
+		profile: ExecutionProfileFullLocal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if strings.Contains(strings.Join(cmd.Args, " "), "--trust") {
+		t.Errorf("unsupported Cursor must not receive --trust: %q", cmd.Args)
+	}
+}
+
+func TestCursorCommandRejectsUnsupportedProfile(t *testing.T) {
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true}
+	if _, _, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go",
+		profile: ExecutionProfileSafeguarded,
+	}); err == nil {
+		t.Fatal("Cursor must reject safeguarded until the driver can enforce it")
+	}
+}
+
+func TestCursorCommandRejectsInconclusiveTrustProbe(t *testing.T) {
+	a := &cursorAgent{bin: filepath.Join(t.TempDir(), "missing-cursor-agent")}
+	if _, _, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go",
+		workdir: t.TempDir(), profile: ExecutionProfileFullLocal,
+	}); err == nil || !strings.Contains(err.Error(), "capability probe") {
+		t.Fatalf("inconclusive probe = %v, want capability-probe error", err)
+	}
+}
+
+func TestCursorHelpSupportsTrust(t *testing.T) {
+	if !cursorHelpSupportsTrust("  --trust  Trust the current workspace without prompting") {
+		t.Fatal("expected --trust to be detected from Cursor help")
+	}
+	if cursorHelpSupportsTrust("  --force  Run everything") {
+		t.Fatal("must not infer --trust when it is absent from Cursor help")
 	}
 }
 

--- a/internal/ai/agent_cursor_test.go
+++ b/internal/ai/agent_cursor_test.go
@@ -195,8 +195,15 @@ func TestCursorHelpSupportsTrust(t *testing.T) {
 	if !cursorHelpSupportsTrust("  --trust  Trust the current workspace without prompting") {
 		t.Fatal("expected --trust to be detected from Cursor help")
 	}
-	if cursorHelpSupportsTrust("  --force  Run everything") {
-		t.Fatal("must not infer --trust when it is absent from Cursor help")
+	for _, help := range []string{
+		"  --force  Run everything",
+		"  --trusted-domains  Trust listed domains",
+		"  --no-trust  Disable workspace trust",
+		"Removed: --trust is no longer supported",
+	} {
+		if cursorHelpSupportsTrust(help) {
+			t.Fatalf("must not infer --trust from %q", help)
+		}
 	}
 }
 

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -65,7 +65,7 @@ func EffectiveAgent(pick string, agents []AgentInfo) string {
 func ProfilesFor(agent string) []ExecutionProfile {
 	switch agent {
 	case "claude":
-		return []ExecutionProfile{ExecutionProfileSafeguarded}
+		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
 	case "codex":
 		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
 	case "cursor-agent":

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -17,8 +17,9 @@ type AgentInfo struct {
 	// Supported is true when Radar can actually DRIVE this CLI (we parse its
 	// stream-json). Detected-but-unsupported CLIs are shown so the user knows
 	// they exist, but can't be selected to run an investigation yet.
-	Supported bool               `json:"supported"`
-	Profiles  []ExecutionProfile `json:"profiles,omitempty"`
+	Supported       bool                        `json:"supported"`
+	Profiles        []ExecutionProfile          `json:"profiles,omitempty"`
+	ConsentSurfaces map[ExecutionProfile]string `json:"consentSurfaces,omitempty"`
 }
 
 // knownAgents are the CLI names we probe for — a FIXED list. We never exec a
@@ -91,10 +92,33 @@ func SupportsProfile(agent string, profile ExecutionProfile) bool {
 	return false
 }
 
-// ConsentSurfaceFor is profile-based: consent must describe the process that
-// will execute, not merely the binary selected in Settings.
-func ConsentSurfaceFor(profile ExecutionProfile) string {
-	return string(profile)
+func ConsentSurfaceFor(agent string, profile ExecutionProfile) string {
+	if !SupportsProfile(agent, profile) {
+		return ""
+	}
+	return agent + ":" + string(profile)
+}
+
+func ConsentSurfacesFor(agent string) map[ExecutionProfile]string {
+	profiles := ProfilesFor(agent)
+	if len(profiles) == 0 {
+		return nil
+	}
+	surfaces := make(map[ExecutionProfile]string, len(profiles))
+	for _, profile := range profiles {
+		surfaces[profile] = ConsentSurfaceFor(agent, profile)
+	}
+	return surfaces
+}
+
+func AllConsentSurfaces() []string {
+	var surfaces []string
+	for _, agent := range agentCLICandidates {
+		for _, profile := range ProfilesFor(agent) {
+			surfaces = append(surfaces, ConsentSurfaceFor(agent, profile))
+		}
+	}
+	return surfaces
 }
 
 // supportedAgents are the CLIs we can drive today (have a stream-json parser).
@@ -123,12 +147,13 @@ func DetectAgents(ctx context.Context, withVersions bool) []AgentInfo {
 			continue
 		}
 		info := AgentInfo{
-			Name:      name,
-			Label:     agentLabels[name],
-			Path:      path,
-			Present:   true,
-			Supported: isSupportedAgent(name),
-			Profiles:  ProfilesFor(name),
+			Name:            name,
+			Label:           agentLabels[name],
+			Path:            path,
+			Present:         true,
+			Supported:       isSupportedAgent(name),
+			Profiles:        ProfilesFor(name),
+			ConsentSurfaces: ConsentSurfacesFor(name),
 		}
 		if withVersions {
 			info.Version = probeVersion(ctx, path)

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -17,7 +17,8 @@ type AgentInfo struct {
 	// Supported is true when Radar can actually DRIVE this CLI (we parse its
 	// stream-json). Detected-but-unsupported CLIs are shown so the user knows
 	// they exist, but can't be selected to run an investigation yet.
-	Supported bool `json:"supported"`
+	Supported bool               `json:"supported"`
+	Profiles  []ExecutionProfile `json:"profiles,omitempty"`
 }
 
 // knownAgents are the CLI names we probe for — a FIXED list. We never exec a
@@ -57,15 +58,43 @@ func EffectiveAgent(pick string, agents []AgentInfo) string {
 	return def
 }
 
-// ConsentSurfaceFor maps an agent to its consent-disclosure surface. Cursor's
-// trust model is materially different (its global MCP servers can't be
-// excluded), so it has its own; drift between enforcement sites would silently
-// mis-gate consent, so both the server and the CLI call this.
-func ConsentSurfaceFor(agent string) string {
-	if agent == "cursor-agent" {
-		return "cursor"
+// ProfilesFor returns the execution profiles Radar can honestly offer for an
+// agent. Keep this policy beside detection so the API, consent gate, and UI all
+// consume the same source of truth.
+func ProfilesFor(agent string) []ExecutionProfile {
+	switch agent {
+	case "claude":
+		return []ExecutionProfile{ExecutionProfileSafeguarded}
+	case "codex":
+		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
+	case "cursor-agent":
+		return []ExecutionProfile{ExecutionProfileFullLocal}
+	default:
+		return nil
 	}
-	return "standard"
+}
+
+func DefaultProfileFor(agent string) ExecutionProfile {
+	profiles := ProfilesFor(agent)
+	if len(profiles) == 0 {
+		return ""
+	}
+	return profiles[0]
+}
+
+func SupportsProfile(agent string, profile ExecutionProfile) bool {
+	for _, candidate := range ProfilesFor(agent) {
+		if candidate == profile {
+			return true
+		}
+	}
+	return false
+}
+
+// ConsentSurfaceFor is profile-based: consent must describe the process that
+// will execute, not merely the binary selected in Settings.
+func ConsentSurfaceFor(profile ExecutionProfile) string {
+	return string(profile)
 }
 
 // supportedAgents are the CLIs we can drive today (have a stream-json parser).
@@ -99,6 +128,7 @@ func DetectAgents(ctx context.Context, withVersions bool) []AgentInfo {
 			Path:      path,
 			Present:   true,
 			Supported: isSupportedAgent(name),
+			Profiles:  ProfilesFor(name),
 		}
 		if withVersions {
 			info.Version = probeVersion(ctx, path)

--- a/internal/ai/detect_test.go
+++ b/internal/ai/detect_test.go
@@ -7,7 +7,7 @@ func TestExecutionProfiles(t *testing.T) {
 		agent string
 		want  []ExecutionProfile
 	}{
-		{"claude", []ExecutionProfile{ExecutionProfileSafeguarded}},
+		{"claude", []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}},
 		{"codex", []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}},
 		{"cursor-agent", []ExecutionProfile{ExecutionProfileFullLocal}},
 		{"gemini", nil},
@@ -24,8 +24,8 @@ func TestExecutionProfiles(t *testing.T) {
 			}
 		}
 	}
-	if SupportsProfile("claude", ExecutionProfileFullLocal) {
-		t.Error("Claude must not advertise full-local until it has an intentional implementation")
+	if !SupportsProfile("claude", ExecutionProfileFullLocal) {
+		t.Error("Claude must advertise its intentional full-local implementation")
 	}
 }
 
@@ -44,10 +44,10 @@ func TestConsentSurfacesMatchTheExactAgentProfile(t *testing.T) {
 		want    string
 	}{
 		{"claude", ExecutionProfileSafeguarded, "claude:safeguarded"},
+		{"claude", ExecutionProfileFullLocal, "claude:full-local"},
 		{"codex", ExecutionProfileSafeguarded, "codex:safeguarded"},
 		{"codex", ExecutionProfileFullLocal, "codex:full-local"},
 		{"cursor-agent", ExecutionProfileFullLocal, "cursor-agent:full-local"},
-		{"claude", ExecutionProfileFullLocal, ""},
 	}
 	for _, c := range cases {
 		if got := ConsentSurfaceFor(c.agent, c.profile); got != c.want {

--- a/internal/ai/detect_test.go
+++ b/internal/ai/detect_test.go
@@ -2,6 +2,33 @@ package ai
 
 import "testing"
 
+func TestExecutionProfiles(t *testing.T) {
+	cases := []struct {
+		agent string
+		want  []ExecutionProfile
+	}{
+		{"claude", []ExecutionProfile{ExecutionProfileSafeguarded}},
+		{"codex", []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}},
+		{"cursor-agent", []ExecutionProfile{ExecutionProfileFullLocal}},
+		{"gemini", nil},
+	}
+	for _, c := range cases {
+		got := ProfilesFor(c.agent)
+		if len(got) != len(c.want) {
+			t.Errorf("ProfilesFor(%q) = %v, want %v", c.agent, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("ProfilesFor(%q) = %v, want %v", c.agent, got, c.want)
+			}
+		}
+	}
+	if SupportsProfile("claude", ExecutionProfileFullLocal) {
+		t.Error("Claude must not advertise full-local until it has an intentional implementation")
+	}
+}
+
 func TestEffectiveAgentMatchesServerResolution(t *testing.T) {
 	agents := []AgentInfo{
 		{Name: "claude", Supported: false},
@@ -22,7 +49,7 @@ func TestEffectiveAgentMatchesServerResolution(t *testing.T) {
 	if got := EffectiveAgent("", nil); got != "" {
 		t.Errorf("no supported agents should resolve to \"\", got %q", got)
 	}
-	if ConsentSurfaceFor(EffectiveAgent("", agents)) != "cursor" {
-		t.Error("empty pick with Cursor as default must gate on the cursor surface")
+	if ConsentSurfaceFor(DefaultProfileFor(EffectiveAgent("", agents))) != "full-local" {
+		t.Error("empty pick with Cursor as default must gate on the full-local surface")
 	}
 }

--- a/internal/ai/detect_test.go
+++ b/internal/ai/detect_test.go
@@ -29,6 +29,33 @@ func TestExecutionProfiles(t *testing.T) {
 	}
 }
 
+func TestEverySupportedAgentDeclaresProfiles(t *testing.T) {
+	for _, agent := range agentCLICandidates {
+		if len(ProfilesFor(agent)) == 0 {
+			t.Errorf("supported agent %q declares no execution profiles", agent)
+		}
+	}
+}
+
+func TestConsentSurfacesMatchTheExactAgentProfile(t *testing.T) {
+	cases := []struct {
+		agent   string
+		profile ExecutionProfile
+		want    string
+	}{
+		{"claude", ExecutionProfileSafeguarded, "claude:safeguarded"},
+		{"codex", ExecutionProfileSafeguarded, "codex:safeguarded"},
+		{"codex", ExecutionProfileFullLocal, "codex:full-local"},
+		{"cursor-agent", ExecutionProfileFullLocal, "cursor-agent:full-local"},
+		{"claude", ExecutionProfileFullLocal, ""},
+	}
+	for _, c := range cases {
+		if got := ConsentSurfaceFor(c.agent, c.profile); got != c.want {
+			t.Errorf("ConsentSurfaceFor(%q, %q) = %q, want %q", c.agent, c.profile, got, c.want)
+		}
+	}
+}
+
 func TestEffectiveAgentMatchesServerResolution(t *testing.T) {
 	agents := []AgentInfo{
 		{Name: "claude", Supported: false},
@@ -49,7 +76,8 @@ func TestEffectiveAgentMatchesServerResolution(t *testing.T) {
 	if got := EffectiveAgent("", nil); got != "" {
 		t.Errorf("no supported agents should resolve to \"\", got %q", got)
 	}
-	if ConsentSurfaceFor(DefaultProfileFor(EffectiveAgent("", agents))) != "full-local" {
-		t.Error("empty pick with Cursor as default must gate on the full-local surface")
+	effective := EffectiveAgent("", agents)
+	if ConsentSurfaceFor(effective, DefaultProfileFor(effective)) != "cursor-agent:full-local" {
+		t.Error("empty pick with Cursor as default must gate on Cursor's full-local surface")
 	}
 }

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -310,6 +310,31 @@ func NewDetected(ctx context.Context) (*Diagnoser, error) {
 // DefaultAgent is the backend chosen when a run doesn't name one.
 func (d *Diagnoser) DefaultAgent() string { return d.defName }
 
+// AgentInfos reports the exact backends this Diagnoser can drive.
+func (d *Diagnoser) AgentInfos(ctx context.Context, withVersions bool) []AgentInfo {
+	var infos []AgentInfo
+	for _, name := range agentCLICandidates {
+		agent, ok := d.agents[name]
+		if !ok {
+			continue
+		}
+		info := AgentInfo{
+			Name:            name,
+			Label:           AgentLabel(name),
+			Path:            agent.Path(),
+			Present:         true,
+			Supported:       true,
+			Profiles:        ProfilesFor(name),
+			ConsentSurfaces: ConsentSurfacesFor(name),
+		}
+		if withVersions {
+			info.Version = probeVersion(ctx, agent.Path())
+		}
+		infos = append(infos, info)
+	}
+	return infos
+}
+
 // AgentName normalizes a client-requested backend name to one that actually
 // exists, falling back to the default — so a run records the agent it really used.
 func (d *Diagnoser) AgentName(name string) string {

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -60,11 +60,8 @@ type Request struct {
 	// Agent selects which backend CLI drives this turn ("claude"/"codex"). Empty
 	// uses the Diagnoser's default. A run picks once at Start and reuses it.
 	Agent string
-	// Isolated runs the agent without the user's own CLI config (other MCP servers,
-	// guidelines, project files) — the default. When false ("my setup"), the agent
-	// runs with the user's full environment. Only the Codex backend distinguishes
-	// the two; Claude is always strict-MCP-config contained.
-	Isolated bool
+	// Profile is selected and validated before the run starts.
+	Profile ExecutionProfile
 	// Model optionally overrides the CLI's default model (e.g. "opus", "sonnet" for
 	// Claude; a model slug for Codex). Empty leaves the agent's own default.
 	Model string
@@ -352,6 +349,13 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 	if agent == nil {
 		return Diagnosis{}, ErrNoCLI
 	}
+	profile := req.Profile
+	if profile == "" {
+		profile = DefaultProfileFor(agent.Name())
+	}
+	if !SupportsProfile(agent.Name(), profile) {
+		return Diagnosis{}, fmt.Errorf("ai: %s does not support execution profile %q", AgentLabel(agent.Name()), profile)
+	}
 
 	// Read-only investigation turns get the read-only MCP mount; an apply turn
 	// (user-confirmed) gets the full mount with write tools.
@@ -382,7 +386,7 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 
 	cmd, cleanup, err := agent.command(ctx, turnSpec{
 		mcpURL: mcpURL, prompt: prompt, systemPrompt: sys,
-		sessionID: sessionID, apply: req.Apply, isolated: req.Isolated,
+		sessionID: sessionID, apply: req.Apply, profile: profile,
 		model: req.Model, effort: req.Effort, maxTurns: maxTurns(),
 		workdir: req.WorkDir,
 	})

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -66,17 +66,17 @@ type RunManager struct {
 // Run is one investigation: identity, status, the agent session to resume, and the
 // canonical append-only event log (every subscriber reconstructs state from it).
 type Run struct {
-	ID        string // immutable
-	Kind      string // immutable
-	Namespace string // immutable
-	Name      string // immutable
-	Context   string // immutable — kube-context the run is about (baseline)
-	Agent     string // immutable — backend CLI driving this run ("claude"/"codex")
-	WorkDir   string // immutable — per-run scratch dir (under RunManager.workRoot); "" if none
-	Isolated  bool   // immutable — isolation mode chosen at Start
-	Model     string // immutable — optional model override ("" = agent default)
-	Effort    string // immutable — optional reasoning effort (Codex; "" = default)
-	ManagedBy string // immutable — GitOps/Helm owner of the target ("" = none), for the Apply warning
+	ID        string           // immutable
+	Kind      string           // immutable
+	Namespace string           // immutable
+	Name      string           // immutable
+	Context   string           // immutable — kube-context the run is about (baseline)
+	Agent     string           // immutable — backend CLI driving this run ("claude"/"codex")
+	WorkDir   string           // immutable — per-run scratch dir (under RunManager.workRoot); "" if none
+	Profile   ExecutionProfile // immutable — execution profile chosen at Start
+	Model     string           // immutable — optional model override ("" = agent default)
+	Effort    string           // immutable — optional reasoning effort (Codex; "" = default)
+	ManagedBy string           // immutable — GitOps/Helm owner of the target ("" = none), for the Apply warning
 	Health    *ResourceHealthSignal
 	CreatedAt time.Time
 	// OwnerPID is the process that owns this run's lifecycle. Persisted so a
@@ -118,7 +118,7 @@ type RunSummary struct {
 	Name      string                `json:"name"`
 	Context   string                `json:"context"`
 	Agent     string                `json:"agent,omitempty"`
-	Isolated  bool                  `json:"isolated"`
+	Profile   ExecutionProfile      `json:"profile"`
 	Model     string                `json:"model,omitempty"`
 	Effort    string                `json:"effort,omitempty"`
 	ManagedBy string                `json:"managedBy,omitempty"`
@@ -252,7 +252,7 @@ func (m *RunManager) loadPersisted() {
 		}
 		r := &Run{
 			ID: s.ID, Kind: s.Kind, Namespace: s.Namespace, Name: s.Name,
-			Context: s.Context, Agent: s.Agent, Isolated: s.Isolated,
+			Context: s.Context, Agent: s.Agent, Profile: s.Profile,
 			Model: s.Model, Effort: s.Effort, ManagedBy: s.ManagedBy,
 			Health: s.Health, CreatedAt: s.CreatedAt, OwnerPID: s.OwnerPID,
 			store:  m.store,
@@ -406,13 +406,13 @@ func (m *RunManager) ctx() string {
 // Start creates and launches an investigation, or focuses an existing live run for
 // the same target+context instead of duplicating it. Returns ErrAtCapacity when
 // the concurrent-running cap is reached.
-func (m *RunManager) Start(kind, namespace, name, agent string, isolated bool, model, effort, managedBy string, health *ResourceHealthSignal) (RunSummary, error) {
+func (m *RunManager) Start(kind, namespace, name, agent string, profile ExecutionProfile, model, effort, managedBy string, health *ResourceHealthSignal) (RunSummary, error) {
 	cur := m.ctx()
 	m.mu.Lock()
 	// Focus an existing live run for this exact target+mode rather than duplicate it.
 	for _, id := range m.order {
 		r := m.runs[id]
-		if r.matchesTarget(kind, namespace, name, cur, agent, isolated, model, effort) &&
+		if r.matchesTarget(kind, namespace, name, cur, agent, profile, model, effort) &&
 			r.snapshotStatus() == "running" {
 			m.mu.Unlock()
 			return r.Summary(), nil
@@ -425,7 +425,7 @@ func (m *RunManager) Start(kind, namespace, name, agent string, isolated bool, m
 	id := newRunID()
 	r := &Run{
 		ID: id, Kind: kind, Namespace: namespace,
-		Name: name, Context: cur, Agent: agent, WorkDir: m.runWorkDir(id), Isolated: isolated,
+		Name: name, Context: cur, Agent: agent, WorkDir: m.runWorkDir(id), Profile: profile,
 		Model: model, Effort: effort, ManagedBy: managedBy, Health: health, CreatedAt: nowUTC(),
 		OwnerPID: os.Getpid(),
 		store:    m.store,
@@ -451,6 +451,9 @@ func (m *RunManager) AddTurn(id, question string, apply bool, fix string) error 
 	r := m.get(id)
 	if r == nil {
 		return ErrRunNotFound
+	}
+	if !SupportsProfile(r.Agent, r.Profile) {
+		return fmt.Errorf("ai: run uses unsupported execution profile %q", r.Profile)
 	}
 	// A follow-up on a run loaded from history must extend the PERSISTED log —
 	// hydrate before beginTurn so the new turn's sequence numbers continue it.
@@ -488,7 +491,7 @@ func (m *RunManager) launchTurn(r *Run, question string, apply bool, fix, sessio
 			Kind: r.Kind, Namespace: r.Namespace, Name: r.Name,
 			MCPPort: m.mcpPort(), SessionID: session,
 			Question: question, Apply: apply, Fix: fix,
-			Agent: r.Agent, Isolated: r.Isolated, Model: r.Model, Effort: r.Effort,
+			Agent: r.Agent, Profile: r.Profile, Model: r.Model, Effort: r.Effort,
 			Health: r.Health, WorkDir: r.WorkDir,
 		}, func(ev StreamEvent) {
 			// The agent can keep streaming briefly after Stop/context-switch
@@ -777,7 +780,7 @@ func (r *Run) Summary() RunSummary {
 func (r *Run) summaryLocked() RunSummary {
 	return RunSummary{
 		ID: r.ID, Kind: r.Kind, Namespace: r.Namespace, Name: r.Name,
-		Context: r.Context, Agent: r.Agent, Isolated: r.Isolated,
+		Context: r.Context, Agent: r.Agent, Profile: r.Profile,
 		Model: r.Model, Effort: r.Effort, ManagedBy: r.ManagedBy,
 		Health: r.Health,
 		Status: r.status, SessionID: r.sessionID, OwnerPID: r.OwnerPID,
@@ -888,12 +891,12 @@ func (r *Run) markStale() {
 }
 
 // matchesTarget reports whether r is the same investigation as a Start request —
-// same resource + cluster AND same agent/isolation mode. The mode is part of the
-// key so starting codex-isolated never silently focuses a live claude or my-setup
+// same resource + cluster AND same agent/execution profile. The profile is part of the
+// key so starting safeguarded Codex never silently focuses a full-local run
 // run for the same resource. Immutable fields, so no lock needed.
-func (r *Run) matchesTarget(kind, namespace, name, ctx, agent string, isolated bool, model, effort string) bool {
+func (r *Run) matchesTarget(kind, namespace, name, ctx, agent string, profile ExecutionProfile, model, effort string) bool {
 	return r.Kind == kind && r.Namespace == namespace && r.Name == name &&
-		r.Context == ctx && r.Agent == agent && r.Isolated == isolated &&
+		r.Context == ctx && r.Agent == agent && r.Profile == profile &&
 		r.Model == model && r.Effort == effort
 }
 

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -147,7 +147,7 @@ func TestEvictKeepsRunning(t *testing.T) {
 }
 
 // TestRunMatchesTarget pins the Start focus-existing key: same resource+cluster
-// focuses only when the agent AND isolation mode also match, so a different mode
+// focuses only when the agent AND execution profile also match, so a different profile
 // starts its own run instead of silently reusing one.
 func TestRunMatchesTarget(t *testing.T) {
 	r := &Run{
@@ -161,7 +161,7 @@ func TestRunMatchesTarget(t *testing.T) {
 		t.Error("different agent must NOT match")
 	}
 	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", ExecutionProfileFullLocal, "o3", "high") {
-		t.Error("different isolation mode must NOT match")
+		t.Error("different execution profile must NOT match")
 	}
 	if r.matchesTarget("Deployment", "ns", "app", "other", "codex", ExecutionProfileSafeguarded, "o3", "high") {
 		t.Error("different cluster context must NOT match")

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -152,24 +152,24 @@ func TestEvictKeepsRunning(t *testing.T) {
 func TestRunMatchesTarget(t *testing.T) {
 	r := &Run{
 		Kind: "Deployment", Namespace: "ns", Name: "app",
-		Context: "ctx", Agent: "codex", Isolated: true, Model: "o3", Effort: "high",
+		Context: "ctx", Agent: "codex", Profile: ExecutionProfileSafeguarded, Model: "o3", Effort: "high",
 	}
-	if !r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", true, "o3", "high") {
+	if !r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", ExecutionProfileSafeguarded, "o3", "high") {
 		t.Error("identical target+mode should match")
 	}
-	if r.matchesTarget("Deployment", "ns", "app", "ctx", "claude", true, "o3", "high") {
+	if r.matchesTarget("Deployment", "ns", "app", "ctx", "claude", ExecutionProfileSafeguarded, "o3", "high") {
 		t.Error("different agent must NOT match")
 	}
-	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", false, "o3", "high") {
+	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", ExecutionProfileFullLocal, "o3", "high") {
 		t.Error("different isolation mode must NOT match")
 	}
-	if r.matchesTarget("Deployment", "ns", "app", "other", "codex", true, "o3", "high") {
+	if r.matchesTarget("Deployment", "ns", "app", "other", "codex", ExecutionProfileSafeguarded, "o3", "high") {
 		t.Error("different cluster context must NOT match")
 	}
-	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", true, "", "high") {
+	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", ExecutionProfileSafeguarded, "", "high") {
 		t.Error("different model must NOT match")
 	}
-	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", true, "o3", "low") {
+	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", ExecutionProfileSafeguarded, "o3", "low") {
 		t.Error("different effort must NOT match")
 	}
 }
@@ -260,7 +260,8 @@ func TestPersistenceInterruptedRun(t *testing.T) {
 func TestPersistenceCursorNotResumable(t *testing.T) {
 	st, _ := testStore(t)
 	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a",
-		Agent: "cursor-agent", Status: "done", SessionID: "cursor-sess",
+		Agent: "cursor-agent", Profile: ExecutionProfileFullLocal,
+		Status: "done", SessionID: "cursor-sess",
 		CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
 	st.(*sqliteRunStore).barrier()
 
@@ -270,12 +271,27 @@ func TestPersistenceCursorNotResumable(t *testing.T) {
 	}
 }
 
+func TestPersistenceProfilelessRunCannotResume(t *testing.T) {
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-legacy", Kind: "Pod", Name: "p", Context: "ctx-a",
+		Agent: "codex", Status: "done", SessionID: "codex-sess",
+		CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.(*sqliteRunStore).barrier()
+
+	m := persistedManager(t, st, "ctx-a")
+	err := m.AddTurn("run-legacy", "and?", false, "")
+	if err == nil || !strings.Contains(err.Error(), "unsupported execution profile") {
+		t.Fatalf("profileless follow-up = %v, want unsupported profile", err)
+	}
+}
+
 // TestPersistenceForeignContextSweep pins that history from another kube-context
 // loads view-only: stale status, closed stream after replay, follow-ups refused.
 func TestPersistenceForeignContextSweep(t *testing.T) {
 	st, _ := testStore(t)
 	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-OLD",
-		Agent: "claude", Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+		Agent: "claude", Profile: ExecutionProfileSafeguarded,
+		Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
 	st.AppendEvent("run-1", RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
 	st.(*sqliteRunStore).barrier()
 
@@ -452,7 +468,8 @@ func TestPersistenceGracefulShutdown(t *testing.T) {
 func TestHydrationFailureRefusesAppends(t *testing.T) {
 	st, _ := testStore(t)
 	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a",
-		Agent: "claude", Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+		Agent: "claude", Profile: ExecutionProfileSafeguarded,
+		Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
 	st.(*sqliteRunStore).barrier()
 	m := persistedManager(t, st, "ctx-a")
 	st.Close() // simulate the DB becoming unreadable before first hydration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ type Config struct {
 	// AIHistoryDBPath overrides the history DB location (default ~/.radar/ai-runs.db).
 	AIHistoryDBPath string `json:"aiHistoryDbPath,omitempty"`
 	// AIConsent records the acknowledged AI-diagnosis disclosure version per
-	// execution profile ("safeguarded", "full-local"). Machine-scoped on purpose: consent gates a
+	// agent execution profile. Machine-scoped on purpose: consent gates a
 	// machine-scoped action (spawn this machine's agent CLI, persist transcripts
 	// to this machine's disk), so one acknowledgment covers the web panel and
 	// the `radar diagnose` CLI alike.
@@ -69,8 +69,10 @@ type Config struct {
 // the consent copy's claims change materially, and prior acknowledgments stop
 // counting everywhere at once.
 var aiConsentVersions = map[string]string{
-	"safeguarded": "v1",
-	"full-local":  "v1",
+	"claude:safeguarded":      "v1",
+	"codex:safeguarded":       "v1",
+	"codex:full-local":        "v1",
+	"cursor-agent:full-local": "v1",
 }
 
 // AIConsentVersion returns the current disclosure version for a surface

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 // counting everywhere at once.
 var aiConsentVersions = map[string]string{
 	"claude:safeguarded":      "v1",
+	"claude:full-local":       "v1",
 	"codex:safeguarded":       "v1",
 	"codex:full-local":        "v1",
 	"cursor-agent:full-local": "v1",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ type Config struct {
 	// AIHistoryDBPath overrides the history DB location (default ~/.radar/ai-runs.db).
 	AIHistoryDBPath string `json:"aiHistoryDbPath,omitempty"`
 	// AIConsent records the acknowledged AI-diagnosis disclosure version per
-	// surface ("standard", "cursor"). Machine-scoped on purpose: consent gates a
+	// execution profile ("safeguarded", "full-local"). Machine-scoped on purpose: consent gates a
 	// machine-scoped action (spawn this machine's agent CLI, persist transcripts
 	// to this machine's disk), so one acknowledgment covers the web panel and
 	// the `radar diagnose` CLI alike.
@@ -67,11 +67,10 @@ type Config struct {
 // AI-diagnosis consent disclosure versions, per surface. THE single source of
 // truth for the server endpoint and the CLI's standalone path alike — bump when
 // the consent copy's claims change materially, and prior acknowledgments stop
-// counting everywhere at once. (standard v3: transcripts persist to local
-// history; cursor v2: same disclosure on Cursor's distinct trust model.)
+// counting everywhere at once.
 var aiConsentVersions = map[string]string{
-	"standard": "v3",
-	"cursor":   "v2",
+	"safeguarded": "v1",
+	"full-local":  "v1",
 }
 
 // AIConsentVersion returns the current disclosure version for a surface

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -358,9 +358,15 @@ history until cleared.
 		notice += fmt.Sprintf(`Your %s setup uses its normal configuration and other configured
 tools and MCP servers. Radar cannot constrain that external tooling; it may
 access local files or the network and may be able to change your cluster.
-Radar still enables the agent CLI's own sandbox, but that sandbox does not
-constrain external MCP servers.
 `, agentLabel)
+		if agent == "claude" {
+			notice += `Claude uses the permissions from your setup; Radar does not override them.
+`
+		} else {
+			notice += `Radar still enables the agent CLI's own sandbox, but that sandbox does not
+constrain external MCP servers.
+`
+		}
 		if agent == "cursor-agent" {
 			notice += `Cursor always loads your global MCP servers; Radar cannot exclude them.
 `

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -77,7 +77,7 @@ func newFlagSet() (*flag.FlagSet, *options) {
 	fs.StringVar(&o.namespace, "n", "", "Namespace of the resource")
 	fs.StringVar(&o.namespace, "namespace", "", "Namespace of the resource")
 	fs.StringVar(&o.agent, "agent", "", "Agent backend to use (claude|codex|cursor-agent; default = server's pick)")
-	fs.StringVar(&o.profile, "profile", "", "Execution profile (safeguarded|full-local; default = agent's safest available profile)")
+	fs.StringVar(&o.profile, "profile", "", "Execution profile (safeguarded = Radar safeguards; full-local = your agent setup; default = safest available)")
 	fs.StringVar(&o.server, "server", "", "Radar server URL (default: discover the running instance via ~/.radar/mcp-port)")
 	fs.BoolVar(&o.jsonOut, "json", false, "Print the final verdict as JSON on stdout (progress goes to stderr)")
 	fs.BoolVar(&o.open, "open", false, "Also open the investigation in the Radar UI")
@@ -353,14 +353,14 @@ func promptConsent(agent string, profile ai.ExecutionProfile, surface string, re
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
 its model provider under your account). Transcripts are kept in your local Radar
 history until cleared.
-`, agentLabel)
+	`, agentLabel)
 	if profile == ai.ExecutionProfileFullLocal {
-		notice += `Full local setup uses your agent's normal configuration and other configured
+		notice += fmt.Sprintf(`Your %s setup uses its normal configuration and other configured
 tools and MCP servers. Radar cannot constrain that external tooling; it may
 access local files or the network and may be able to change your cluster.
 Radar still enables the agent CLI's own sandbox, but that sandbox does not
 constrain external MCP servers.
-`
+`, agentLabel)
 		if agent == "cursor-agent" {
 			notice += `Cursor always loads your global MCP servers; Radar cannot exclude them.
 `

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -61,6 +62,7 @@ func normalizeKind(k string) string {
 type options struct {
 	namespace  string
 	agent      string
+	profile    string
 	server     string
 	kubeconfig string
 	standalone bool
@@ -75,6 +77,7 @@ func newFlagSet() (*flag.FlagSet, *options) {
 	fs.StringVar(&o.namespace, "n", "", "Namespace of the resource")
 	fs.StringVar(&o.namespace, "namespace", "", "Namespace of the resource")
 	fs.StringVar(&o.agent, "agent", "", "Agent backend to use (claude|codex|cursor-agent; default = server's pick)")
+	fs.StringVar(&o.profile, "profile", "", "Execution profile (safeguarded|full-local; default = agent's safest available profile)")
 	fs.StringVar(&o.server, "server", "", "Radar server URL (default: discover the running instance via ~/.radar/mcp-port)")
 	fs.BoolVar(&o.jsonOut, "json", false, "Print the final verdict as JSON on stdout (progress goes to stderr)")
 	fs.BoolVar(&o.open, "open", false, "Also open the investigation in the Radar UI")
@@ -165,14 +168,19 @@ Flags:
 		// read/write the shared machine-scoped store (~/.radar/config.json)
 		// directly — the ephemeral server then sees it as already given.
 		effective := ai.EffectiveAgent(o.agent, ai.DetectAgents(context.Background(), false))
-		surface := ai.ConsentSurfaceFor(effective)
+		profile, err := executionProfile(effective, o.profile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		surface := ai.ConsentSurfaceFor(profile)
 		if !consentGivenLocal(surface) {
 			if o.yes {
 				if err := recordConsentLocal(surface); err != nil {
 					fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
 					return 1
 				}
-			} else if !promptConsent(consentLabel(effective), surface, recordConsentLocal) {
+			} else if !promptConsent(effective, surface, recordConsentLocal) {
 				fmt.Fprintln(os.Stderr, "aborted")
 				return 1
 			}
@@ -204,7 +212,12 @@ Flags:
 	}
 
 	effective := ai.EffectiveAgent(o.agent, agents.Agents)
-	surface := ai.ConsentSurfaceFor(effective)
+	profile, err := executionProfile(effective, o.profile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	surface := ai.ConsentSurfaceFor(profile)
 	if !agents.Consented[surface] {
 		if o.yes {
 			// --yes acknowledges the disclosure; the server enforces consent at
@@ -213,13 +226,13 @@ Flags:
 				fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
 				return 1
 			}
-		} else if !promptConsent(consentLabel(effective), surface, func(sf string) error { return recordConsentHTTP(base, sf) }) {
+		} else if !promptConsent(effective, surface, func(sf string) error { return recordConsentHTTP(base, sf) }) {
 			fmt.Fprintln(os.Stderr, "aborted")
 			return 1
 		}
 	}
 
-	run, err := startRun(base, kind, o.namespace, name, o.agent)
+	run, err := startRun(base, kind, o.namespace, name, o.agent, profile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -315,21 +328,52 @@ func consentLabel(effective string) string {
 	return ai.AgentLabel(effective)
 }
 
+func executionProfile(agent, requested string) (ai.ExecutionProfile, error) {
+	if agent == "" {
+		return "", errors.New("no supported AI agent found")
+	}
+	profile := ai.DefaultProfileFor(agent)
+	if requested != "" {
+		profile = ai.ExecutionProfile(requested)
+	}
+	if !ai.SupportsProfile(agent, profile) {
+		return "", fmt.Errorf("%s does not support the %q execution profile", consentLabel(agent), profile)
+	}
+	return profile, nil
+}
+
 // promptConsent mirrors the UI's one-time consent card. Interactive terminals
 // get a real y/N gate; non-interactive callers (CI) get the disclosure on
 // stderr and proceed — an explicit `radar diagnose` invocation in a script is
 // already an informed act, and a blocking prompt there would just break CI.
 // record persists the acknowledgment to the shared machine-scoped store.
-func promptConsent(agentLabel, surface string, record func(surface string) error) bool {
+func promptConsent(agent, surface string, record func(surface string) error) bool {
+	agentLabel := consentLabel(agent)
 	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
-its model provider under your account). Through Radar the agent can only READ
-your cluster. Transcripts are kept in your local Radar history until cleared.
+its model provider under your account). Transcripts are kept in your local Radar
+history until cleared.
 `, agentLabel)
-	if surface == "cursor" {
-		notice += `Note: Cursor also loads your own global MCP servers (Radar can't exclude
-them) — if any of those can make changes, Cursor could use them.
+	if surface == "full-local" {
+		notice += `Radar's own investigation tools are read-only. Full local setup also uses
+your agent's other configured tools and MCP servers, which Radar does not
+constrain. They may access local files or the network and may be able to change
+your cluster.
 `
+		if agent == "cursor-agent" {
+			notice += `Cursor always loads your global MCP servers; Radar cannot exclude them.
+`
+		}
+	} else {
+		notice += `Through Radar the agent can only READ your cluster. Radar safeguards limit
+the agent to Radar's investigation tools and exclude your other agent
+configuration and MCP servers.
+`
+		if agent == "codex" {
+			notice += `Codex's sandboxed shell can still read files on this machine; it cannot
+write or reach the network.
+`
+		}
 	}
 	fmt.Fprint(os.Stderr, notice)
 	// A real ioctl-backed check — os.ModeCharDevice would misread /dev/null
@@ -381,9 +425,9 @@ type runSummary struct {
 	} `json:"health"`
 }
 
-func startRun(base, kind, namespace, name, agent string) (runSummary, error) {
+func startRun(base, kind, namespace, name, agent string, profile ai.ExecutionProfile) (runSummary, error) {
 	body, _ := json.Marshal(map[string]any{
-		"kind": kind, "namespace": namespace, "name": name, "agent": agent,
+		"kind": kind, "namespace": namespace, "name": name, "agent": agent, "profile": profile,
 	})
 	resp, err := http.Post(base+"/api/diagnose/runs", "application/json", strings.NewReader(string(body)))
 	if err != nil {

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -167,7 +167,7 @@ Flags:
 		// watching a cluster connect for 30 seconds. No server exists yet, so
 		// read/write the shared machine-scoped store (~/.radar/config.json)
 		// directly — the ephemeral server then sees it as already given.
-		effective := ai.EffectiveAgent(o.agent, ai.DetectAgents(context.Background(), false))
+		effective := standaloneEffectiveAgent(context.Background(), o.agent)
 		profile, err := executionProfile(effective, o.profile)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -326,6 +326,14 @@ func consentLabel(effective string) string {
 		return "your agent CLI"
 	}
 	return ai.AgentLabel(effective)
+}
+
+func standaloneEffectiveAgent(ctx context.Context, requested string) string {
+	diagnoser, err := ai.NewDetected(ctx)
+	if err != nil {
+		return ""
+	}
+	return diagnoser.AgentName(requested)
 }
 
 func executionProfile(agent, requested string) (ai.ExecutionProfile, error) {

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -173,14 +173,14 @@ Flags:
 			fmt.Fprintln(os.Stderr, err)
 			return 2
 		}
-		surface := ai.ConsentSurfaceFor(profile)
+		surface := ai.ConsentSurfaceFor(effective, profile)
 		if !consentGivenLocal(surface) {
 			if o.yes {
 				if err := recordConsentLocal(surface); err != nil {
 					fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
 					return 1
 				}
-			} else if !promptConsent(effective, surface, recordConsentLocal) {
+			} else if !promptConsent(effective, profile, surface, recordConsentLocal) {
 				fmt.Fprintln(os.Stderr, "aborted")
 				return 1
 			}
@@ -217,7 +217,7 @@ Flags:
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
-	surface := ai.ConsentSurfaceFor(profile)
+	surface := ai.ConsentSurfaceFor(effective, profile)
 	if !agents.Consented[surface] {
 		if o.yes {
 			// --yes acknowledges the disclosure; the server enforces consent at
@@ -226,7 +226,7 @@ Flags:
 				fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
 				return 1
 			}
-		} else if !promptConsent(effective, surface, func(sf string) error { return recordConsentHTTP(base, sf) }) {
+		} else if !promptConsent(effective, profile, surface, func(sf string) error { return recordConsentHTTP(base, sf) }) {
 			fmt.Fprintln(os.Stderr, "aborted")
 			return 1
 		}
@@ -347,30 +347,35 @@ func executionProfile(agent, requested string) (ai.ExecutionProfile, error) {
 // stderr and proceed — an explicit `radar diagnose` invocation in a script is
 // already an informed act, and a blocking prompt there would just break CI.
 // record persists the acknowledgment to the shared machine-scoped store.
-func promptConsent(agent, surface string, record func(surface string) error) bool {
+func promptConsent(agent string, profile ai.ExecutionProfile, surface string, record func(surface string) error) bool {
 	agentLabel := consentLabel(agent)
 	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
 its model provider under your account). Transcripts are kept in your local Radar
 history until cleared.
 `, agentLabel)
-	if surface == "full-local" {
-		notice += `Radar's own investigation tools are read-only. Full local setup also uses
-your agent's other configured tools and MCP servers, which Radar does not
-constrain. They may access local files or the network and may be able to change
-your cluster.
+	if profile == ai.ExecutionProfileFullLocal {
+		notice += `Full local setup uses your agent's normal configuration and other configured
+tools and MCP servers. Radar cannot constrain that external tooling; it may
+access local files or the network and may be able to change your cluster.
+Radar still enables the agent CLI's own sandbox, but that sandbox does not
+constrain external MCP servers.
 `
 		if agent == "cursor-agent" {
 			notice += `Cursor always loads your global MCP servers; Radar cannot exclude them.
 `
 		}
 	} else {
-		notice += `Through Radar the agent can only READ your cluster. Radar safeguards limit
-the agent to Radar's investigation tools and exclude your other agent
-configuration and MCP servers.
+		notice += `Radar's investigation tools can only READ your cluster.
 `
-		if agent == "codex" {
-			notice += `Codex's sandboxed shell can still read files on this machine; it cannot
+		if agent == "claude" {
+			notice += `Radar safeguards disable Claude's built-in tools and limit MCP access to
+Radar's read-only investigation tools. Your Claude settings, hooks, and
+CLAUDE.md instructions still apply and are outside Radar's control.
+`
+		} else if agent == "codex" {
+			notice += `Radar safeguards exclude your Codex configuration and other MCP servers.
+Codex's sandboxed shell can still read files on this machine; it cannot
 write or reach the network.
 `
 		}

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -361,7 +361,7 @@ func promptConsent(agent string, profile ai.ExecutionProfile, surface string, re
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
 its model provider under your account). Transcripts are kept in your local Radar
 history until cleared.
-	`, agentLabel)
+`, agentLabel)
 	if profile == ai.ExecutionProfileFullLocal {
 		notice += fmt.Sprintf(`Your %s setup uses its normal configuration and other configured
 tools and MCP servers. Radar cannot constrain that external tooling; it may

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -1,7 +1,9 @@
 package diagnosecli
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -138,5 +140,20 @@ func TestExecutionProfile(t *testing.T) {
 		if err != nil || string(got) != tc.want {
 			t.Errorf("executionProfile(%q, %q) = %q, %v; want %q", tc.agent, tc.requested, got, err, tc.want)
 		}
+	}
+}
+
+func TestStandaloneEffectiveAgentHonorsCLIOverride(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "cursor-agent-custom")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RADAR_AI_CLI_BIN", bin)
+
+	if got := standaloneEffectiveAgent(context.Background(), ""); got != "cursor-agent" {
+		t.Fatalf("standaloneEffectiveAgent() = %q, want cursor-agent", got)
+	}
+	if got := standaloneEffectiveAgent(context.Background(), "codex"); got != "cursor-agent" {
+		t.Fatalf("unsupported explicit pick should fall back to the override, got %q", got)
 	}
 }

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -123,7 +123,7 @@ func TestExecutionProfile(t *testing.T) {
 	}{
 		{"codex", "", "safeguarded", false},
 		{"codex", "full-local", "full-local", false},
-		{"claude", "full-local", "", true},
+		{"claude", "full-local", "full-local", false},
 		{"cursor-agent", "", "full-local", false},
 		{"", "", "", true},
 	}

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -114,3 +114,29 @@ func TestInterleavedFlagParsing(t *testing.T) {
 		t.Fatalf("flags not parsed: ns=%q json=%v", o.namespace, o.jsonOut)
 	}
 }
+
+func TestExecutionProfile(t *testing.T) {
+	cases := []struct {
+		agent, requested string
+		want             string
+		wantErr          bool
+	}{
+		{"codex", "", "safeguarded", false},
+		{"codex", "full-local", "full-local", false},
+		{"claude", "full-local", "", true},
+		{"cursor-agent", "", "full-local", false},
+		{"", "", "", true},
+	}
+	for _, tc := range cases {
+		got, err := executionProfile(tc.agent, tc.requested)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("executionProfile(%q, %q) succeeded, want error", tc.agent, tc.requested)
+			}
+			continue
+		}
+		if err != nil || string(got) != tc.want {
+			t.Errorf("executionProfile(%q, %q) = %q, %v; want %q", tc.agent, tc.requested, got, err, tc.want)
+		}
+	}
+}

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -123,23 +123,56 @@ func managedByFromMeta(obj *unstructured.Unstructured) string {
 // truth with the CLI). Machine-scoped (~/.radar/config.json): one
 // acknowledgment covers the web panel and the CLI.
 func currentConsents() map[string]bool {
-	return map[string]bool{
-		"safeguarded": config.AIConsentGiven("safeguarded"),
-		"full-local":  config.AIConsentGiven("full-local"),
+	consents := make(map[string]bool)
+	for _, surface := range ai.AllConsentSurfaces() {
+		consents[surface] = config.AIConsentGiven(surface)
 	}
+	return consents
 }
 
-// handleListAgents reports the local agent CLIs detected on PATH, for the OSS
-// "AI Agent" picker. Safe: only fixed known names are probed (see ai.DetectAgents).
+// handleListAgents reports local agent CLIs for the OSS "AI Agent" picker.
 func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	// Version probing is slow (execs `<cli> --version`); only do it when asked
 	// (e.g. a settings/picker view) so the Diagnose button's check stays instant.
 	withVersions := r.URL.Query().Get("versions") == "1"
+	var agents []ai.AgentInfo
+	if s.aiDiagnoser != nil {
+		// The initialized Diagnoser is authoritative when an explicit CLI override
+		// narrows the backend set or points at a binary outside PATH.
+		agents = ai.DetectAgents(r.Context(), false)
+		agents = mergeDetectedWithDrivable(agents, s.aiDiagnoser.AgentInfos(r.Context(), withVersions))
+	} else {
+		agents = ai.DetectAgents(r.Context(), withVersions)
+	}
 	s.writeJSON(w, map[string]any{
-		"agents":    ai.DetectAgents(r.Context(), withVersions),
+		"agents":    agents,
 		"enabled":   s.aiRuns != nil,
 		"consented": currentConsents(),
 	})
+}
+
+func mergeDetectedWithDrivable(detected, drivable []ai.AgentInfo) []ai.AgentInfo {
+	byName := make(map[string]ai.AgentInfo, len(drivable))
+	for _, info := range drivable {
+		byName[info.Name] = info
+	}
+	seen := make(map[string]bool, len(detected))
+	for i := range detected {
+		seen[detected[i].Name] = true
+		if actual, ok := byName[detected[i].Name]; ok {
+			detected[i] = actual
+		} else {
+			detected[i].Supported = false
+			detected[i].Profiles = nil
+			detected[i].ConsentSurfaces = nil
+		}
+	}
+	for _, actual := range drivable {
+		if !seen[actual.Name] {
+			detected = append(detected, actual)
+		}
+	}
+	return detected
 }
 
 // handleDiagnoseConsent records the user's acknowledgment of the current
@@ -162,7 +195,7 @@ func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if config.AIConsentVersion(body.Surface) == "" {
-		s.writeError(w, http.StatusBadRequest, "surface must be \"safeguarded\" or \"full-local\"")
+		s.writeError(w, http.StatusBadRequest, "unknown AI consent surface")
 		return
 	}
 	if err := config.RecordAIConsent(body.Surface); err != nil {
@@ -258,8 +291,9 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	}
 	// The server owns the consent store, so it enforces it: spawning an agent
 	// and shipping cluster data to a model provider must not depend on client
-	// code remembering to check. Surface derives from the effective profile.
-	if !config.AIConsentGiven(ai.ConsentSurfaceFor(profile)) {
+	// code remembering to check. Surface derives from the effective agent and
+	// profile because their disclosures can differ.
+	if !config.AIConsentGiven(ai.ConsentSurfaceFor(agent, profile)) {
 		s.writeError(w, http.StatusForbidden, "AI disclosure not acknowledged for this execution profile — approve the consent prompt first")
 		return
 	}

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -124,8 +124,8 @@ func managedByFromMeta(obj *unstructured.Unstructured) string {
 // acknowledgment covers the web panel and the CLI.
 func currentConsents() map[string]bool {
 	return map[string]bool{
-		"standard": config.AIConsentGiven("standard"),
-		"cursor":   config.AIConsentGiven("cursor"),
+		"safeguarded": config.AIConsentGiven("safeguarded"),
+		"full-local":  config.AIConsentGiven("full-local"),
 	}
 }
 
@@ -143,8 +143,7 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleDiagnoseConsent records the user's acknowledgment of the current
-// disclosure for a surface ("standard" = Claude/Codex, "cursor" = Cursor's
-// distinct trust model). Doesn't require a connected cluster — consent can be
+// disclosure for an execution profile. Doesn't require a connected cluster — consent can be
 // given while Radar is still connecting.
 func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 	if !localOriginOK(r) {
@@ -163,7 +162,7 @@ func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if config.AIConsentVersion(body.Surface) == "" {
-		s.writeError(w, http.StatusBadRequest, "surface must be \"standard\" or \"cursor\"")
+		s.writeError(w, http.StatusBadRequest, "surface must be \"safeguarded\" or \"full-local\"")
 		return
 	}
 	if err := config.RecordAIConsent(body.Surface); err != nil {
@@ -227,7 +226,7 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Kind, Namespace, Name string
 		Agent                 string `json:"agent"`
-		Isolated              *bool  `json:"isolated"` // pointer: default ISOLATED when omitted
+		Profile               string `json:"profile"`
 		Model                 string `json:"model"`
 		Effort                string `json:"effort"`
 	}
@@ -249,15 +248,21 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	agent := s.aiRuns.AgentName(strings.TrimSpace(body.Agent))
-	// The server owns the consent store, so it enforces it: spawning an agent
-	// and shipping cluster data to a model provider must not depend on client
-	// code remembering to check. Surface derives from the RESOLVED agent (an
-	// unknown name falls back to the default, never across trust surfaces).
-	if !config.AIConsentGiven(ai.ConsentSurfaceFor(agent)) {
-		s.writeError(w, http.StatusForbidden, "AI disclosure not acknowledged for this agent — approve the consent prompt first")
+	profile := ai.ExecutionProfile(strings.TrimSpace(body.Profile))
+	if profile == "" {
+		profile = ai.DefaultProfileFor(agent)
+	}
+	if !ai.SupportsProfile(agent, profile) {
+		s.writeError(w, http.StatusBadRequest, "selected execution profile is not available for this agent")
 		return
 	}
-	isolated := body.Isolated == nil || *body.Isolated
+	// The server owns the consent store, so it enforces it: spawning an agent
+	// and shipping cluster data to a model provider must not depend on client
+	// code remembering to check. Surface derives from the effective profile.
+	if !config.AIConsentGiven(ai.ConsentSurfaceFor(profile)) {
+		s.writeError(w, http.StatusForbidden, "AI disclosure not acknowledged for this execution profile — approve the consent prompt first")
+		return
+	}
 	model := strings.TrimSpace(body.Model)
 	if len(model) > 100 {
 		s.writeError(w, http.StatusBadRequest, "model name too long")
@@ -273,7 +278,7 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	// than relying on the agent to self-report it. Best effort: "" (unknown) on miss.
 	managedBy := s.detectManagedBy(r.Context(), kind, namespace, name)
 	health := s.detectDiagnoseHealth(r.Context(), kind, namespace, name)
-	run, err := s.aiRuns.Start(kind, namespace, name, agent, isolated, model, effort, managedBy, health)
+	run, err := s.aiRuns.Start(kind, namespace, name, agent, profile, model, effort, managedBy, health)
 	if err != nil {
 		if errors.Is(err, ai.ErrAtCapacity) {
 			s.writeError(w, http.StatusConflict, "too many investigations running — stop or finish one first")

--- a/internal/server/ai_diagnose_test.go
+++ b/internal/server/ai_diagnose_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/skyhook-io/radar/internal/ai"
 	"github.com/skyhook-io/radar/internal/config"
 )
 
@@ -41,23 +42,56 @@ func TestLocalOriginOK(t *testing.T) {
 // both surfaces' checks, per disclosure surface.
 func TestConsentMachineScoped(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if c := currentConsents(); c["safeguarded"] || c["full-local"] {
+	if c := currentConsents(); c["codex:safeguarded"] || c["codex:full-local"] {
 		t.Fatalf("fresh HOME must have no consent, got %v", c)
 	}
-	if err := config.RecordAIConsent("safeguarded"); err != nil {
+	if err := config.RecordAIConsent("codex:safeguarded"); err != nil {
 		t.Fatal(err)
 	}
 	c := currentConsents()
-	if !c["safeguarded"] || c["full-local"] {
+	if !c["codex:safeguarded"] || c["codex:full-local"] {
 		t.Fatalf("safeguarded consent must not cover full-local: %v", c)
+	}
+	if c["claude:safeguarded"] {
+		t.Fatalf("Codex consent must not cover Claude's distinct disclosure: %v", c)
 	}
 	// A stale (older-version) acknowledgment must not count.
 	if _, err := config.Update(func(c *config.Config) {
-		c.AIConsent["full-local"] = "v0"
+		c.AIConsent["codex:full-local"] = "v0"
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if currentConsents()["full-local"] {
+	if currentConsents()["codex:full-local"] {
 		t.Fatal("an older disclosure version must not satisfy consent")
+	}
+}
+
+func TestEveryAgentConsentSurfaceHasAVersion(t *testing.T) {
+	for _, surface := range ai.AllConsentSurfaces() {
+		if config.AIConsentVersion(surface) == "" {
+			t.Errorf("consent surface %q has no disclosure version", surface)
+		}
+	}
+}
+
+func TestMergeDetectedWithDrivableUsesTheActualBackendSet(t *testing.T) {
+	detected := []ai.AgentInfo{
+		{Name: "claude", Supported: true, Profiles: ai.ProfilesFor("claude")},
+		{Name: "codex", Supported: true, Profiles: ai.ProfilesFor("codex")},
+	}
+	drivable := []ai.AgentInfo{
+		{Name: "codex", Path: "/override/codex", Present: true, Supported: true, Profiles: ai.ProfilesFor("codex")},
+		{Name: "cursor-agent", Path: "/override/cursor-agent", Present: true, Supported: true, Profiles: ai.ProfilesFor("cursor-agent")},
+	}
+
+	got := mergeDetectedWithDrivable(detected, drivable)
+	if got[0].Name != "claude" || got[0].Supported || len(got[0].Profiles) != 0 {
+		t.Fatalf("PATH-only Claude must not be advertised as drivable: %+v", got[0])
+	}
+	if got[1].Name != "codex" || !got[1].Supported || got[1].Path != "/override/codex" {
+		t.Fatalf("Codex must use the actual backend metadata: %+v", got[1])
+	}
+	if len(got) != 3 || got[2].Name != "cursor-agent" || !got[2].Supported {
+		t.Fatalf("an override-only backend must still be advertised: %+v", got)
 	}
 }

--- a/internal/server/ai_diagnose_test.go
+++ b/internal/server/ai_diagnose_test.go
@@ -41,23 +41,23 @@ func TestLocalOriginOK(t *testing.T) {
 // both surfaces' checks, per disclosure surface.
 func TestConsentMachineScoped(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if c := currentConsents(); c["standard"] || c["cursor"] {
+	if c := currentConsents(); c["safeguarded"] || c["full-local"] {
 		t.Fatalf("fresh HOME must have no consent, got %v", c)
 	}
-	if err := config.RecordAIConsent("standard"); err != nil {
+	if err := config.RecordAIConsent("safeguarded"); err != nil {
 		t.Fatal(err)
 	}
 	c := currentConsents()
-	if !c["standard"] || c["cursor"] {
-		t.Fatalf("standard consent must not cover cursor's surface: %v", c)
+	if !c["safeguarded"] || c["full-local"] {
+		t.Fatalf("safeguarded consent must not cover full-local: %v", c)
 	}
 	// A stale (older-version) acknowledgment must not count.
 	if _, err := config.Update(func(c *config.Config) {
-		c.AIConsent["cursor"] = "v1"
+		c.AIConsent["full-local"] = "v0"
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if currentConsents()["cursor"] {
+	if currentConsents()["full-local"] {
 		t.Fatal("an older disclosure version must not satisfy consent")
 	}
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,7 +60,7 @@ import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search,
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
-import { SettingsDialog } from './components/settings/SettingsDialog'
+import { SettingsDialog, type SettingsSectionId } from './components/settings/SettingsDialog'
 import type { APIResource, TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPlural, pluralToKind, openExternal, apiVersionToGroup, relatedResourcePath, searchHitToSelectedResource } from './utils/navigation'
 import { type OmnibarHandle } from './components/ui/Omnibar'
@@ -507,13 +507,23 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
   // Settings dialog state
   const [showSettings, setShowSettings] = useState(false)
+  const [settingsSection, setSettingsSection] = useState<SettingsSectionId>('overview')
+  const openSettings = useCallback((section: SettingsSectionId = 'overview') => {
+    setSettingsSection(section)
+    setShowSettings(true)
+  }, [])
 
   // Listen for "open-settings" DOM event (used by MCPSetupDialog etc.)
   useEffect(() => {
-    const handler = () => setShowSettings(true)
+    const handler = (event: Event) => {
+      const section =
+        (event as CustomEvent<{ section?: SettingsSectionId }>).detail?.section ??
+        'overview'
+      openSettings(section)
+    }
     window.addEventListener('radar:open-settings', handler)
     return () => window.removeEventListener('radar:open-settings', handler)
-  }, [])
+  }, [openSettings])
 
   // Listen for "open-local-terminal" DOM event — the AI surface is portaled above
   // the DockProvider, so it can't call useOpenLocalTerminal directly; it dispatches
@@ -853,7 +863,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           description: 'Open settings',
           category: 'General' as const,
           scope: 'global' as const,
-          handler: () => setShowSettings(true),
+          handler: () => openSettings(),
         }]
       : []),
   ])
@@ -1596,7 +1606,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           pinned={navRailEffectivePinned}
           onTogglePinned={toggleNavRailPinned}
           showPinToggle={!railForcedSlim}
-          onOpenSettings={() => setShowSettings(true)}
+          onOpenSettings={() => openSettings()}
           accountSlot={<UserMenu variant="rail" pinned={navRailEffectivePinned} />}
         />
       )}
@@ -2183,7 +2193,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
               navigateToResource(resource)
             }}
             onClearNamespaces={clearAllNamespaces}
-            onOpenSettings={() => setShowSettings(true)}
+            onOpenSettings={() => openSettings()}
           />
         )}
 
@@ -2414,6 +2424,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {/* Settings dialog — My permissions is rendered inline in its own section */}
       <SettingsDialog
         open={showSettings}
+        initialSection={settingsSection}
         onClose={() => setShowSettings(false)}
       />
 

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -11,6 +11,7 @@ export interface AgentInfo {
   present: boolean;
   supported: boolean;
   profiles?: ExecutionProfile[];
+  consentSurfaces?: Partial<Record<ExecutionProfile, string>>;
   hosted?: boolean;
 }
 

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -10,6 +10,7 @@ export interface AgentInfo {
   version: string;
   present: boolean;
   supported: boolean;
+  profiles?: ExecutionProfile[];
   hosted?: boolean;
 }
 
@@ -18,8 +19,10 @@ export interface AgentsResponse {
   enabled: boolean;
   // Machine-scoped consent per disclosure surface, recorded server-side
   // (~/.radar) — one acknowledgment covers the web panel and the CLI.
-  consented?: { standard?: boolean; cursor?: boolean };
+  consented?: Record<string, boolean>;
 }
+
+export type ExecutionProfile = "safeguarded" | "full-local";
 
 export interface DiagnoseStep {
   id: string;
@@ -64,14 +67,7 @@ export interface ResourceHealthSignal {
 }
 
 export interface DiagnoseStreamEvent {
-  type:
-    | "turn"
-    | "phase"
-    | "step"
-    | "thinking"
-    | "done"
-    | "error"
-    | "closed";
+  type: "turn" | "phase" | "step" | "thinking" | "done" | "error" | "closed";
   phase?: string;
   step?: DiagnoseStep;
   token?: string;
@@ -91,7 +87,7 @@ export interface RunSummary {
   name: string;
   context: string;
   agent?: string; // backend CLI that drove this run ("claude"/"codex")
-  isolated?: boolean;
+  profile?: ExecutionProfile;
   model?: string;
   effort?: string;
   managedBy?: string; // GitOps/Helm owner of the target ("Argo CD"/"Flux"/"Helm"), for the Apply warning
@@ -145,7 +141,7 @@ export async function createRun(
   },
   opts?: {
     agent?: string;
-    isolated?: boolean;
+    profile?: ExecutionProfile;
     model?: string;
     effort?: string;
   },
@@ -179,10 +175,8 @@ export async function listRuns(signal?: AbortSignal): Promise<RunsResponse> {
   return { runs: d.runs ?? [], historyDegraded: !!d.historyDegraded };
 }
 
-// recordConsent acknowledges the current disclosure for a surface, server-side.
-export async function recordConsent(
-  surface: "standard" | "cursor",
-): Promise<void> {
+// recordConsent acknowledges the current disclosure for an execution profile, server-side.
+export async function recordConsent(surface: string): Promise<void> {
   const res = await fetch(`${getApiBase()}/diagnose/consent`, {
     method: "POST",
     credentials: getCredentialsMode(),

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -132,16 +132,17 @@ export function AISettingsSection({
           agents={agents}
           selectedAgent={draft.agent}
           // Model + effort are agent-specific; reset them when the agent changes.
-          onSelectAgent={(a) =>
+          onSelectAgent={(a) => {
+            const nextProfile = agents.find(
+              (agent) => agent.name === a,
+            )?.profiles?.[0];
             onChange({
               agent: a,
-              profile:
-                agents.find((agent) => agent.name === a)?.profiles?.[0] ??
-                "safeguarded",
+              profile: nextProfile ?? draft.profile,
               model: "",
               effort: "",
-            })
-          }
+            });
+          }}
           profile={draft.profile}
           onSetProfile={(v) => onChange({ profile: v })}
           model={draft.model}

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -5,12 +5,16 @@
 // Settings tabs' layout — this renders only the controls (no card, no heading).
 import { useState } from "react";
 import { Trash2 } from "lucide-react";
-import { clearHistory, type AgentInfo } from "../../api/diagnose";
+import {
+  clearHistory,
+  type AgentInfo,
+  type ExecutionProfile,
+} from "../../api/diagnose";
 import { AgentControls } from "./parts";
 
 export interface AIDraft {
   agent: string;
-  isolated: boolean;
+  profile: ExecutionProfile;
   model: string;
   effort: string;
 }
@@ -120,17 +124,26 @@ export function AISettingsSection({
         // The agent, its model, and how it runs are all fixed by the host — none
         // of the local BYO-agent knobs apply, so there's nothing to configure.
         <p className="text-xs leading-snug text-theme-text-tertiary">
-          {agentLabel} manages the model and how it runs — there&apos;s nothing to
-          configure here.
+          {agentLabel} manages the model and how it runs — there&apos;s nothing
+          to configure here.
         </p>
       ) : (
         <AgentControls
           agents={agents}
           selectedAgent={draft.agent}
           // Model + effort are agent-specific; reset them when the agent changes.
-          onSelectAgent={(a) => onChange({ agent: a, model: "", effort: "" })}
-          isolated={draft.isolated}
-          onSetIsolated={(v) => onChange({ isolated: v })}
+          onSelectAgent={(a) =>
+            onChange({
+              agent: a,
+              profile:
+                agents.find((agent) => agent.name === a)?.profiles?.[0] ??
+                "safeguarded",
+              model: "",
+              effort: "",
+            })
+          }
+          profile={draft.profile}
+          onSetProfile={(v) => onChange({ profile: v })}
           model={draft.model}
           onSetModel={(v) => onChange({ model: v })}
           effort={draft.effort}

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -160,11 +160,7 @@ function writeStored(key: string, value: string) {
 export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
-  const [consented, setConsented] = useState<Record<string, boolean>>({
-    standard: false,
-    safeguarded: false,
-    "full-local": false,
-  });
+  const [consented, setConsented] = useState<Record<string, boolean>>({});
   const [selectedAgent, setSelectedAgentState] = useState<string>(
     () => readStored(AGENT_KEY) || "",
   );
@@ -206,13 +202,15 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     fetchAgents()
       .then((r) => {
         if (!live) return;
-        setAvailable(r.enabled);
-        setConsented({
-          standard: !!r.consented?.standard,
-          safeguarded: !!r.consented?.safeguarded,
-          "full-local": !!r.consented?.["full-local"],
-        });
-        const supported = r.agents.filter((a) => a.supported);
+        setConsented(r.consented ?? {});
+        const supported = r.agents.filter(
+          (a) =>
+            a.supported &&
+            (a.hosted ||
+              (!!a.profiles?.length &&
+                a.profiles.every((p) => !!a.consentSurfaces?.[p]))),
+        );
+        setAvailable(r.enabled && supported.length > 0);
         setAgents(supported);
         // Keep the stored pick only if it's still installed; else default to the
         // first supported agent (matches the server's default selection).
@@ -223,9 +221,9 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
             : (supported[0]?.name ?? "");
         setSelectedAgentState(next);
         const profiles = supported.find((a) => a.name === next)?.profiles ?? [];
-        if (!profiles.includes(profile)) {
-          setProfileState(profiles[0] ?? "safeguarded");
-          writeStored(PROFILE_KEY, profiles[0] ?? "safeguarded");
+        if (!profiles.includes(profile) && profiles[0]) {
+          setProfileState(profiles[0]);
+          writeStored(PROFILE_KEY, profiles[0]);
         }
         // Model/effort are agent-specific; if the stored agent is gone, its values
         // don't apply to the fallback agent (e.g. a Codex slug under Claude) — drop them.
@@ -275,12 +273,14 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const effectiveProfile =
     selectedAgentInfo?.profiles?.includes(profile)
       ? profile
-      : (selectedAgentInfo?.profiles?.[0] ?? "safeguarded");
+      : (selectedAgentInfo?.profiles?.[0] ?? profile);
   const agentLabel = agentLabelFor(selectedAgent, selectedAgentInfo?.label);
   const hosted = !!selectedAgentInfo?.hosted;
   // Hosted Radar uses its existing per-user disclosure surface and supplies its
   // own copy. Local agents use the execution profile as the consent contract.
-  const consentSurface = hosted ? "standard" : effectiveProfile;
+  const consentSurface = hosted
+    ? "standard"
+    : (selectedAgentInfo?.consentSurfaces?.[effectiveProfile] ?? "");
 
   useEffect(() => {
     const onResize = () => setViewportW(window.innerWidth);
@@ -368,6 +368,12 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     (t: Target) => {
       setStartError(null);
       setOpen(true);
+      if (!hosted && !consentSurface) {
+        setPendingTarget(null);
+        setStartError("Radar can’t run this agent with a verified execution profile.");
+        setView("investigation");
+        return;
+      }
       if (!consentedRef.current[consentSurface]) {
         setPendingTarget(t);
         setView("investigation");
@@ -376,7 +382,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
       setView("investigation");
       startRunRef.current(t);
     },
-    [consentSurface],
+    [consentSurface, hosted],
   );
   const openRun = useCallback((id: string) => {
     setStartError(null);
@@ -417,6 +423,10 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const consentBusyRef = useRef(false);
   const approveConsent = useCallback(() => {
     if (consentBusyRef.current) return;
+    if (!consentSurface) {
+      setStartError("Radar can’t record consent for this agent.");
+      return;
+    }
     consentBusyRef.current = true;
     setStartError(null);
     const t = pendingTarget;

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -221,7 +221,9 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
             : (supported[0]?.name ?? "");
         setSelectedAgentState(next);
         const profiles = supported.find((a) => a.name === next)?.profiles ?? [];
-        if (!profiles.includes(profile) && profiles[0]) {
+        const storedProfile =
+          (readStored(PROFILE_KEY) as ExecutionProfile) || "safeguarded";
+        if (!profiles.includes(storedProfile) && profiles[0]) {
           setProfileState(profiles[0]);
           writeStored(PROFILE_KEY, profiles[0]);
         }

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -22,7 +22,11 @@ import {
   recordConsent,
   DiagnoseError,
 } from "../../api/diagnose";
-import { type RunSummary, type AgentInfo } from "../../api/diagnose";
+import {
+  type RunSummary,
+  type AgentInfo,
+  type ExecutionProfile,
+} from "../../api/diagnose";
 
 export interface Target {
   kind: string;
@@ -38,8 +42,8 @@ interface DiagnoseCtx {
   agents: AgentInfo[]; // supported agents detected on PATH (for the picker)
   selectedAgent: string; // name of the chosen backend ("claude"/"codex")
   setSelectedAgent: (name: string) => void;
-  isolated: boolean; // run the agent without the user's own CLI config
-  setIsolated: (v: boolean) => void;
+  profile: ExecutionProfile;
+  setProfile: (v: ExecutionProfile) => void;
   model: string; // optional model override ("" = the agent's own default)
   setModel: (v: string) => void;
   effort: string; // optional Codex reasoning effort ("" = default)
@@ -108,15 +112,10 @@ const WIDTH_KEY = "radar-ai-panel-width";
 // Consent is machine-scoped and lives server-side (~/.radar): it gates a
 // machine-scoped action (spawn this machine's agent CLI, persist transcripts to
 // this machine's disk), so one acknowledgment covers this panel AND the
-// `radar diagnose` CLI. Cursor gets its own surface — its trust model is
-// materially different (the user's global MCP servers can't be excluded), so
-// approving Claude/Codex never bypasses Cursor's distinct disclosure.
-type ConsentSurface = "standard" | "cursor";
-function consentSurfaceFor(agent: string): ConsentSurface {
-  return agent === "cursor-agent" ? "cursor" : "standard";
-}
+// `radar diagnose` CLI. The execution profile selects the disclosure because
+// it determines the actual access available to the agent process.
 const AGENT_KEY = "radar-ai-agent";
-const ISOLATED_KEY = "radar-ai-isolated";
+const PROFILE_KEY = "radar-ai-profile";
 const MODEL_KEY = "radar-ai-model";
 const EFFORT_KEY = "radar-ai-effort";
 // Push (reflow the app left) only while the app keeps at least this much width to
@@ -161,14 +160,16 @@ function writeStored(key: string, value: string) {
 export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
-  const [consented, setConsented] = useState<
-    Record<ConsentSurface, boolean>
-  >({ standard: false, cursor: false });
+  const [consented, setConsented] = useState<Record<string, boolean>>({
+    standard: false,
+    safeguarded: false,
+    "full-local": false,
+  });
   const [selectedAgent, setSelectedAgentState] = useState<string>(
     () => readStored(AGENT_KEY) || "",
   );
-  const [isolated, setIsolatedState] = useState<boolean>(
-    () => readStored(ISOLATED_KEY) !== "0", // default isolated
+  const [profile, setProfileState] = useState<ExecutionProfile>(
+    () => (readStored(PROFILE_KEY) as ExecutionProfile) || "safeguarded",
   );
   const [model, setModelState] = useState<string>(
     () => readStored(MODEL_KEY) || "",
@@ -208,7 +209,8 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
         setAvailable(r.enabled);
         setConsented({
           standard: !!r.consented?.standard,
-          cursor: !!r.consented?.cursor,
+          safeguarded: !!r.consented?.safeguarded,
+          "full-local": !!r.consented?.["full-local"],
         });
         const supported = r.agents.filter((a) => a.supported);
         setAgents(supported);
@@ -220,6 +222,11 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
             ? stored
             : (supported[0]?.name ?? "");
         setSelectedAgentState(next);
+        const profiles = supported.find((a) => a.name === next)?.profiles ?? [];
+        if (!profiles.includes(profile)) {
+          setProfileState(profiles[0] ?? "safeguarded");
+          writeStored(PROFILE_KEY, profiles[0] ?? "safeguarded");
+        }
         // Model/effort are agent-specific; if the stored agent is gone, its values
         // don't apply to the fallback agent (e.g. a Codex slug under Claude) — drop them.
         if (next !== stored) {
@@ -247,23 +254,33 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     (name: string) => {
       setSelectedAgentState(name);
       writeStored(AGENT_KEY, name);
+      const nextProfile = agents.find((agent) => agent.name === name)?.profiles?.[0];
+      if (nextProfile) {
+        setProfileState(nextProfile);
+        writeStored(PROFILE_KEY, nextProfile);
+      }
       // Model + effort are agent-specific (Claude aliases vs Codex slugs); reset
       // to the new agent's default rather than carry an invalid value across.
       setModel("");
       setEffort("");
     },
-    [setModel, setEffort],
+    [agents, setModel, setEffort],
   );
-  const setIsolated = useCallback((v: boolean) => {
-    setIsolatedState(v);
-    writeStored(ISOLATED_KEY, v ? "1" : "0");
+  const setProfile = useCallback((v: ExecutionProfile) => {
+    setProfileState(v);
+    writeStored(PROFILE_KEY, v);
   }, []);
 
-  const agentLabel = agentLabelFor(
-    selectedAgent,
-    agents.find((a) => a.name === selectedAgent)?.label,
-  );
-  const hosted = !!agents.find((a) => a.name === selectedAgent)?.hosted;
+  const selectedAgentInfo = agents.find((a) => a.name === selectedAgent);
+  const effectiveProfile =
+    selectedAgentInfo?.profiles?.includes(profile)
+      ? profile
+      : (selectedAgentInfo?.profiles?.[0] ?? "safeguarded");
+  const agentLabel = agentLabelFor(selectedAgent, selectedAgentInfo?.label);
+  const hosted = !!selectedAgentInfo?.hosted;
+  // Hosted Radar uses its existing per-user disclosure surface and supplies its
+  // own copy. Local agents use the execution profile as the consent contract.
+  const consentSurface = hosted ? "standard" : effectiveProfile;
 
   useEffect(() => {
     const onResize = () => setViewportW(window.innerWidth);
@@ -314,10 +331,6 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     return () => clearInterval(t);
   }, [open, available, hasRunning, refreshRuns]);
 
-  // Keep the live selected agent reachable from the [] -dep callbacks below
-  // (consent is agent-specific, so they must read the CURRENT pick, not a closure).
-  const selectedAgentRef = useRef(selectedAgent);
-  selectedAgentRef.current = selectedAgent;
   const consentedRef = useRef(consented);
   consentedRef.current = consented;
 
@@ -329,7 +342,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     const seq = ++startSeqRef.current;
     createRun(t, {
       agent: selectedAgent || undefined,
-      isolated,
+      profile: hosted ? undefined : effectiveProfile,
       model: model || undefined,
       effort: effort || undefined,
     })
@@ -351,17 +364,20 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
       });
   };
 
-  const openInvestigation = useCallback((t: Target) => {
-    setStartError(null);
-    setOpen(true);
-    if (!consentedRef.current[consentSurfaceFor(selectedAgentRef.current)]) {
-      setPendingTarget(t);
+  const openInvestigation = useCallback(
+    (t: Target) => {
+      setStartError(null);
+      setOpen(true);
+      if (!consentedRef.current[consentSurface]) {
+        setPendingTarget(t);
+        setView("investigation");
+        return;
+      }
       setView("investigation");
-      return;
-    }
-    setView("investigation");
-    startRunRef.current(t);
-  }, []);
+      startRunRef.current(t);
+    },
+    [consentSurface],
+  );
   const openRun = useCallback((id: string) => {
     setStartError(null);
     setActiveRunId(id);
@@ -403,13 +419,12 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     if (consentBusyRef.current) return;
     consentBusyRef.current = true;
     setStartError(null);
-    const surface = consentSurfaceFor(selectedAgentRef.current);
     const t = pendingTarget;
     // The server ENFORCES consent at start, so the acknowledgment must land
     // before the run request — awaiting also makes it durable for the CLI.
-    recordConsent(surface)
+    recordConsent(consentSurface)
       .then(() => {
-        setConsented((prev) => ({ ...prev, [surface]: true }));
+        setConsented((prev) => ({ ...prev, [consentSurface]: true }));
         // Cleared only on success: a failed write keeps the consent card up
         // (needsConsent = !!pendingTarget) so "try again" works in place.
         setPendingTarget(null);
@@ -421,7 +436,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
       .finally(() => {
         consentBusyRef.current = false;
       });
-  }, [pendingTarget]);
+  }, [consentSurface, pendingTarget]);
   const cancelConsent = useCallback(() => {
     setPendingTarget(null);
     setOpen(false);
@@ -440,8 +455,8 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     agents,
     selectedAgent,
     setSelectedAgent,
-    isolated,
-    setIsolated,
+    profile: effectiveProfile,
+    setProfile,
     model,
     setModel,
     effort,

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -139,7 +139,9 @@ export function agentLabelFor(name: string, fallbackLabel?: string): string {
 // openDiagnoseSettings opens the Settings dialog (App.tsx listens for this DOM
 // event) — the canonical home for AI-diagnosis config.
 export function openDiagnoseSettings() {
-  window.dispatchEvent(new CustomEvent("radar:open-settings"));
+  window.dispatchEvent(
+    new CustomEvent("radar:open-settings", { detail: { section: "ai" } }),
+  );
 }
 
 function readStored(key: string): string | null {

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -35,7 +35,7 @@ function capWord(s: string): string {
 }
 
 // buildConfigLine renders the active AI config as the header subtitle. Codex shows
-// its isolation mode + effective reasoning effort (Default → medium); a model
+// its execution profile + effective reasoning effort (Default → medium); a model
 // override is shown for either agent. Reflects a run's recorded settings, or the
 // current defaults on Home.
 function buildConfigLine(cfg: {
@@ -185,7 +185,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
     ? agentLabelFor(activeRun.agent)
     : d.agentLabel;
   // Header subtitle: the config a focused run actually used (it records agent /
-  // isolation / model / effort), or the current defaults on Home. Codex shows mode
+  // profile / model / effort), or the current defaults on Home. Codex shows mode
   // + reasoning effort; model is shown only when overridden. Clicking opens Settings.
   const configLine = buildConfigLine(
     activeRun ?? {

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -47,7 +47,7 @@ function buildConfigLine(cfg: {
   const parts = [agentLabelFor(cfg.agent ?? "")];
   if (cfg.profile) {
     parts.push(
-      cfg.profile === "full-local" ? "Full local setup" : "Radar safeguards",
+      cfg.profile === "full-local" ? "Your agent setup" : "Radar safeguards",
     );
   }
   if (cfg.agent === "codex") {

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -28,7 +28,7 @@ import { InvestigationView } from "./InvestigationView";
 import { RecentList } from "./Home";
 import { ConsentCard } from "./parts";
 import { buildLaunchCommand, launchAgentLabel, openInTerminal } from "./launch";
-import { type RunSummary } from "../../api/diagnose";
+import { type RunSummary, type ExecutionProfile } from "../../api/diagnose";
 
 function capWord(s: string): string {
   return s ? s[0].toUpperCase() + s.slice(1) : s;
@@ -40,13 +40,17 @@ function capWord(s: string): string {
 // current defaults on Home.
 function buildConfigLine(cfg: {
   agent?: string;
-  isolated?: boolean;
+  profile?: ExecutionProfile;
   model?: string;
   effort?: string;
 }): string {
   const parts = [agentLabelFor(cfg.agent ?? "")];
+  if (cfg.profile) {
+    parts.push(
+      cfg.profile === "full-local" ? "Full local setup" : "Radar safeguards",
+    );
+  }
   if (cfg.agent === "codex") {
-    parts.push(cfg.isolated === false ? "My setup" : "Isolated");
     parts.push(`${capWord(cfg.effort || "medium")} effort`);
   }
   if (cfg.model) parts.push(capWord(cfg.model));
@@ -139,7 +143,8 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
   const d = useDiagnose();
   // Injected settings action: undefined = Radar's own Settings dialog;
   // null = hide the gear + links.
-  const { consentCopy, onOpenSettings: hostOpenSettings } = useDiagnoseCustomization();
+  const { consentCopy, onOpenSettings: hostOpenSettings } =
+    useDiagnoseCustomization();
   const openSettings =
     hostOpenSettings === undefined ? openDiagnoseSettings : hostOpenSettings;
   const {
@@ -185,7 +190,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
   const configLine = buildConfigLine(
     activeRun ?? {
       agent: d.selectedAgent,
-      isolated: d.isolated,
+      profile: d.hosted ? undefined : d.profile,
       model: d.model,
       effort: d.effort,
     },
@@ -208,7 +213,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
         <ConsentCard
           agentName={d.agentLabel}
           agent={d.selectedAgent}
-          isolated={d.isolated}
+          profile={d.profile}
           copy={consentCopy}
           onOpenSettings={openSettings ?? undefined}
           onApprove={d.approveConsent}

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -48,10 +48,26 @@ describe("AgentControls execution profile explanation", () => {
   });
 
   it("discloses the Claude configuration that Radar cannot exclude", () => {
-    const html = renderAgent("claude", ["safeguarded"], "safeguarded");
+    const html = renderAgent(
+      "claude",
+      ["safeguarded", "full-local"],
+      "safeguarded",
+    );
     expect(html).toContain("built-in tools are disabled");
     expect(html).toContain("settings, hooks, and CLAUDE.md instructions still apply");
+    expect(html).toContain("Your claude setup");
     expect(html).not.toContain("other agent configuration is excluded");
+  });
+
+  it("explains that Claude full-local inherits the user's permissions", () => {
+    const html = renderAgent(
+      "claude",
+      ["safeguarded", "full-local"],
+      "full-local",
+    );
+    expect(html).toContain("permissions from your setup");
+    expect(html).toContain("Radar does not override them");
+    expect(html).not.toContain("Radar still enables the agent CLI");
   });
 
   it("does not describe an unknown safeguarded agent as Codex", () => {
@@ -90,5 +106,20 @@ describe("ConsentCard execution profile treatment", () => {
     expect(html).toContain("Radar cannot constrain");
     expect(html).toContain("always loads your global MCP servers");
     expect(html).not.toContain("text-accent");
+  });
+
+  it("does not claim Radar enables a sandbox for Claude's normal setup", () => {
+    const html = renderToStaticMarkup(
+      <ConsentCard
+        agentName="Claude Code"
+        agent="claude"
+        profile="full-local"
+        onApprove={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(html).toContain("permissions from your setup");
+    expect(html).toContain("Radar does not override them");
+    expect(html).not.toContain("Radar still enables the agent CLI");
   });
 });

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -39,7 +39,8 @@ function renderAgent(
 describe("AgentControls execution profile explanation", () => {
   it("shows Cursor's fixed full-local warning even when the stored profile is stale", () => {
     const html = renderAgent("cursor-agent", ["full-local"], "safeguarded");
-    expect(html).toContain("only supports Full local setup");
+    expect(html).toContain("must use this agent");
+    expect(html).toContain("normal setup");
     expect(html).toContain("always loads your global MCP servers");
     expect(html).toContain("still enables the agent CLI");
     expect(html).toContain("does not constrain external MCP servers");
@@ -59,10 +60,20 @@ describe("AgentControls execution profile explanation", () => {
     expect(html).not.toContain("Codex");
     expect(html).not.toContain("built-in tools are disabled");
   });
+
+  it("labels the selectable full-local profile as the user's agent setup", () => {
+    const html = renderAgent(
+      "codex",
+      ["safeguarded", "full-local"],
+      "safeguarded",
+    );
+    expect(html).toContain("Your codex setup");
+    expect(html).not.toContain("Full local setup");
+  });
 });
 
 describe("ConsentCard execution profile treatment", () => {
-  it("uses warning chrome and explicit consequences for full local setup", () => {
+  it("uses warning chrome and explicit consequences for the user's agent setup", () => {
     const html = renderToStaticMarkup(
       <ConsentCard
         agentName="Cursor Agent"
@@ -72,7 +83,8 @@ describe("ConsentCard execution profile treatment", () => {
         onCancel={noop}
       />,
     );
-    expect(html).toContain("Run with your agent’s full local setup?");
+    expect(html).toContain("Run using your Cursor Agent setup?");
+    expect(html).toContain("Continue with my agent setup");
     expect(html).toContain("border-amber-500/40");
     expect(html).toContain("text-amber-500");
     expect(html).toContain("Radar cannot constrain");

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -1,0 +1,82 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { AgentControls, ConsentCard } from "./parts";
+import type { AgentInfo, ExecutionProfile } from "../../api/diagnose";
+
+const noop = vi.fn();
+
+function renderAgent(
+  agent: string,
+  profiles: ExecutionProfile[],
+  profile: ExecutionProfile,
+) {
+  const agents: AgentInfo[] = [
+    {
+      name: agent,
+      label: agent,
+      path: agent,
+      version: "",
+      present: true,
+      supported: true,
+      profiles,
+    },
+  ];
+  return renderToStaticMarkup(
+    <AgentControls
+      agents={agents}
+      selectedAgent={agent}
+      onSelectAgent={noop}
+      profile={profile}
+      onSetProfile={noop}
+      model=""
+      onSetModel={noop}
+      effort=""
+      onSetEffort={noop}
+    />,
+  );
+}
+
+describe("AgentControls execution profile explanation", () => {
+  it("shows Cursor's fixed full-local warning even when the stored profile is stale", () => {
+    const html = renderAgent("cursor-agent", ["full-local"], "safeguarded");
+    expect(html).toContain("only supports Full local setup");
+    expect(html).toContain("always loads your global MCP servers");
+    expect(html).toContain("still enables the agent CLI");
+    expect(html).toContain("does not constrain external MCP servers");
+    expect(html).not.toContain("always runs this agent with safeguards");
+  });
+
+  it("discloses the Claude configuration that Radar cannot exclude", () => {
+    const html = renderAgent("claude", ["safeguarded"], "safeguarded");
+    expect(html).toContain("built-in tools are disabled");
+    expect(html).toContain("settings, hooks, and CLAUDE.md instructions still apply");
+    expect(html).not.toContain("other agent configuration is excluded");
+  });
+
+  it("does not describe an unknown safeguarded agent as Codex", () => {
+    const html = renderAgent("future-agent", ["safeguarded"], "safeguarded");
+    expect(html).toContain("documented restrictions");
+    expect(html).not.toContain("Codex");
+    expect(html).not.toContain("built-in tools are disabled");
+  });
+});
+
+describe("ConsentCard execution profile treatment", () => {
+  it("uses warning chrome and explicit consequences for full local setup", () => {
+    const html = renderToStaticMarkup(
+      <ConsentCard
+        agentName="Cursor Agent"
+        agent="cursor-agent"
+        profile="full-local"
+        onApprove={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(html).toContain("Run with your agent’s full local setup?");
+    expect(html).toContain("border-amber-500/40");
+    expect(html).toContain("text-amber-500");
+    expect(html).toContain("Radar cannot constrain");
+    expect(html).toContain("always loads your global MCP servers");
+    expect(html).not.toContain("text-accent");
+  });
+});

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -295,9 +295,11 @@ export function AgentControls({
               />
               {shownProfile === "safeguarded" ? (
                 <p className="mt-1.5 text-[11px] leading-snug text-theme-text-tertiary">
-                  {isCodex
-                    ? "Radar excludes your Codex configuration and other MCP servers. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
-                    : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
+                  {isClaude
+                    ? "Claude’s built-in tools are disabled, and MCP access is limited to Radar’s read-only investigation tools. Your Claude settings, hooks, and CLAUDE.md instructions still apply and are outside Radar’s control."
+                    : isCodex
+                      ? "Radar excludes your Codex configuration and other MCP servers. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
+                      : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
                 </p>
               ) : (
                 <div className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
@@ -306,10 +308,11 @@ export function AgentControls({
                     Uses your agent&apos;s normal configuration and other
                     configured tools and MCP servers. Radar cannot constrain that
                     external tooling; it may access local files or the network
-                    and may be able to change your cluster. Radar still enables
-                    the agent CLI&apos;s own sandbox, but that sandbox does not
-                    constrain external MCP servers. Choose this only when you
-                    need that setup.
+                    and may be able to change your cluster.{" "}
+                    {isClaude
+                      ? "Claude uses the permissions from your setup; Radar does not override them."
+                      : "Radar still enables the agent CLI’s own sandbox, but that sandbox does not constrain external MCP servers."}{" "}
+                    Choose this only when you need that setup.
                   </span>
                 </div>
               )}
@@ -808,17 +811,24 @@ export function ConsentCard({
                 MCP servers. They may access local files or the network and may
                 be able to change your cluster.
               </>,
-              <>
-                Radar still enables the agent CLI&apos;s own sandbox, but that
-                sandbox does not constrain external MCP servers.
-                {agent === "cursor-agent" && (
-                  <>
-                    {" "}
-                    Cursor always loads your global MCP servers; Radar cannot
-                    exclude them.
-                  </>
-                )}
-              </>,
+              agent === "claude" ? (
+                <>
+                  Claude uses the permissions from your setup; Radar does not
+                  override them.
+                </>
+              ) : (
+                <>
+                  Radar still enables the agent CLI&apos;s own sandbox, but that
+                  sandbox does not constrain external MCP servers.
+                  {agent === "cursor-agent" && (
+                    <>
+                      {" "}
+                      Cursor always loads your global MCP servers; Radar cannot
+                      exclude them.
+                    </>
+                  )}
+                </>
+              ),
             ]
       }
     />

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -27,6 +27,7 @@ import {
   type Diagnosis,
   type DiagnoseStep,
   type AgentInfo,
+  type ExecutionProfile,
   type RunSummary,
 } from "../../api/diagnose";
 import { StatusDot } from "@skyhook-io/k8s-ui";
@@ -228,15 +229,15 @@ function SelectMenu({
   );
 }
 
-// AgentControls is the full AI-diagnosis config block (agent, isolation, model,
+// AgentControls is the full AI-diagnosis config block (agent, execution profile, model,
 // effort) — pure + prop-driven. It lives in Settings, not the investigation panel,
 // since these are set-once preferences rather than per-run knobs.
 export function AgentControls({
   agents,
   selectedAgent,
   onSelectAgent,
-  isolated,
-  onSetIsolated,
+  profile,
+  onSetProfile,
   model,
   onSetModel,
   effort,
@@ -245,8 +246,8 @@ export function AgentControls({
   agents: AgentInfo[];
   selectedAgent: string;
   onSelectAgent: (name: string) => void;
-  isolated: boolean;
-  onSetIsolated: (v: boolean) => void;
+  profile: ExecutionProfile;
+  onSetProfile: (v: ExecutionProfile) => void;
   model: string;
   onSetModel: (v: string) => void;
   effort: string;
@@ -255,6 +256,11 @@ export function AgentControls({
   const isCodex = selectedAgent === "codex";
   const isClaude = selectedAgent === "claude";
   const isCursor = selectedAgent === "cursor-agent";
+  const profiles = agents.find((a) => a.name === selectedAgent)?.profiles ?? [];
+  const profileLabels: Record<ExecutionProfile, string> = {
+    safeguarded: "Radar safeguards",
+    "full-local": "Full local setup",
+  };
   return (
     <div className="space-y-3">
       {agents.length >= 2 && (
@@ -268,29 +274,45 @@ export function AgentControls({
           }))}
         />
       )}
-      {isCodex && (
+      {profiles.length > 0 && (
         <div>
-          <Segmented<boolean>
-            label="Environment"
-            value={isolated}
-            onChange={onSetIsolated}
-            options={[
-              { value: true, label: "Isolated (recommended)" },
-              { value: false, label: "My setup" },
-            ]}
-          />
-          {isolated ? (
+          {profiles.length > 1 ? (
+            <Segmented<ExecutionProfile>
+              label="How Radar runs it"
+              value={profile}
+              onChange={onSetProfile}
+              options={profiles.map((value) => ({
+                value,
+                label: profileLabels[value],
+              }))}
+            />
+          ) : (
+            <>
+              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
+                How Radar runs it
+              </div>
+              <div className="rounded-md border border-theme-border bg-theme-base px-2.5 py-1.5 text-xs text-theme-text-primary">
+                {profileLabels[profiles[0]]}
+              </div>
+            </>
+          )}
+          {profile === "safeguarded" ? (
             <p className="mt-1.5 text-[11px] leading-snug text-theme-text-tertiary">
-              Runs Codex on its own — no access to your other MCP servers,
-              guidelines, or project files.
+              Radar limits the agent to its investigation tools and excludes
+              your other agent configuration.
+              {isCodex &&
+                " Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."}
             </p>
           ) : (
             <div className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
               <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
               <span>
-                Runs Codex with your full setup — your own MCP servers (which may
-                be write- or network-capable) and guidelines, and it can read
-                local files. Only choose this if you rely on that config.
+                Uses your agent&apos;s normal configuration and other configured
+                tools and MCP servers. Radar does not constrain those tools;
+                they may access local files or the network and may be able to
+                change your cluster. Choose this only when you need that setup.
+                {isCursor &&
+                  " Cursor always loads your global MCP servers; Radar cannot exclude them."}
               </span>
             </div>
           )}
@@ -317,8 +339,8 @@ export function AgentControls({
           hint={
             isCursor
               ? "Leave empty for your Cursor default, or enter a model slug Cursor supports."
-              : !isolated
-                ? "“My setup” uses your own Codex config's model; set a slug here to override it."
+              : profile === "full-local"
+                ? "Full local setup uses your own Codex config's model; set a slug here to override it."
                 : "Leave empty for Codex's default, or enter a model your Codex version supports."
           }
         />
@@ -660,7 +682,7 @@ function ConsentCardShell({
 export function ConsentCard({
   agentName,
   agent,
-  isolated = true,
+  profile,
   copy,
   onOpenSettings,
   onApprove,
@@ -668,7 +690,7 @@ export function ConsentCard({
 }: {
   agentName: string;
   agent?: string;
-  isolated?: boolean;
+  profile: ExecutionProfile;
   copy?: DiagnoseConsentCopy;
   onOpenSettings?: () => void;
   onApprove: () => void;
@@ -679,15 +701,16 @@ export function ConsentCard({
   // Tier 1: a host (e.g. radar-hub-web) supplied its own copy — use it verbatim.
   if (copy) return <ConsentCardShell {...copy} {...chrome} />;
 
-  // Tier 2: OSS BYO-local default. Cursor can't be isolated (no flag suppresses
-  // its global MCP servers), so it gets its own honest framing rather than the
-  // isolated/my-setup pair.
-  const isCursor = agent === "cursor-agent";
   return (
     <ConsentCardShell
       {...chrome}
+      approveLabel={
+        profile === "full-local"
+          ? "Continue with full local setup"
+          : "Approve & investigate"
+      }
       title={
-        isolated && !isCursor
+        profile === "safeguarded"
           ? "Run a read-only AI investigation?"
           : "Run an AI investigation?"
       }
@@ -698,45 +721,45 @@ export function ConsentCard({
             your own {agentName}
           </span>{" "}
           on your machine — no Radar cloud, no API key, no account. Radar sends
-          this resource&apos;s spec, recent events, and pod logs to it (and on to
-          its model provider under your account, not to Radar). Transcripts are
-          kept in your local Radar history on this machine until cleared.
-          {isolated && !isCursor && (
+          this resource&apos;s spec, recent events, and pod logs to it (and on
+          to its model provider under your account, not to Radar). Transcripts
+          are kept in your local Radar history on this machine until cleared.
+          {profile === "safeguarded" && (
             <>
               {" "}
               Through Radar the agent can only{" "}
-              <span className="font-medium">read</span> — it cannot change your
-              cluster.
+              <span className="font-medium">read</span> your cluster during this
+              investigation.
             </>
           )}
         </>
       }
       bullets={[
-        isCursor ? (
+        profile === "safeguarded" ? (
           <>
-            Through Radar the agent only{" "}
-            <span className="font-medium">reads</span> your cluster. But Cursor
-            also loads your own global MCP servers and Radar can&apos;t exclude
-            them (unlike Claude or Codex), so if any of those can make changes,
-            Cursor could use them.
-          </>
-        ) : isolated ? (
-          <>
-            Isolated: only Radar&apos;s read-only investigation tools — your
-            other CLI config and MCP servers are excluded.
+            Radar safeguards: only Radar&apos;s read-only investigation tools —
+            your other agent configuration and MCP servers are excluded.
             {agent === "codex" && (
               <>
                 {" "}
-                Codex&apos;s sandboxed shell can still <em>read</em> files on
-                your machine (it cannot write or reach the network).
+                Codex&apos;s sandboxed shell can still read files on this
+                machine; it cannot write or reach the network.
               </>
             )}
           </>
         ) : (
           <>
-            &ldquo;My setup&rdquo;: the agent also runs with your own CLI config
-            + MCP servers and can read local files. Only Radar&apos;s own tools
-            are read-only.
+            Full local setup: Radar&apos;s own investigation tools are read-only,
+            but the agent&apos;s other configured tools and MCP servers are not
+            constrained by Radar. They may access local files or the network and
+            may be able to change your cluster.
+            {agent === "cursor-agent" && (
+              <>
+                {" "}
+                Cursor always loads your global MCP servers; Radar cannot exclude
+                them.
+              </>
+            )}
           </>
         ),
       ]}

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -256,13 +256,16 @@ export function AgentControls({
   const isCodex = selectedAgent === "codex";
   const isClaude = selectedAgent === "claude";
   const isCursor = selectedAgent === "cursor-agent";
-  const profiles = agents.find((a) => a.name === selectedAgent)?.profiles ?? [];
+  const selectedAgentInfo = agents.find((a) => a.name === selectedAgent);
+  const selectedAgentLabel =
+    selectedAgentInfo?.label || selectedAgent || "agent";
+  const profiles = selectedAgentInfo?.profiles ?? [];
   const shownProfile = profiles.includes(profile)
     ? profile
     : (profiles[0] ?? profile);
   const profileLabels: Record<ExecutionProfile, string> = {
     safeguarded: "Radar safeguards",
-    "full-local": "Full local setup",
+    "full-local": `Your ${selectedAgentLabel} setup`,
   };
   return (
     <div className="space-y-3">
@@ -327,11 +330,11 @@ export function AgentControls({
             <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
               <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
               <span>
-                This agent only supports Full local setup. Radar cannot constrain
-                its external tools or MCP servers; they may access local files
-                or the network and may be able to change your cluster. Radar
-                still enables the agent CLI&apos;s own sandbox, but that sandbox
-                does not constrain external MCP servers.
+                Radar must use this agent&apos;s normal setup. Radar cannot
+                constrain its external tools or MCP servers; they may access
+                local files or the network and may be able to change your
+                cluster. Radar still enables the agent CLI&apos;s own sandbox,
+                but that sandbox does not constrain external MCP servers.
                 {isCursor &&
                   " Cursor always loads your global MCP servers, so Radar cannot exclude them."}
               </span>
@@ -361,7 +364,7 @@ export function AgentControls({
             isCursor
               ? "Leave empty for your Cursor default, or enter a model slug Cursor supports."
               : shownProfile === "full-local"
-                ? "Full local setup uses your own Codex config's model; set a slug here to override it."
+                ? "Your Codex setup uses its configured model; set a slug here to override it."
                 : "Leave empty for Codex's default, or enter a model your Codex version supports."
           }
         />
@@ -748,13 +751,13 @@ export function ConsentCard({
       warning={profile === "full-local"}
       approveLabel={
         profile === "full-local"
-          ? "Continue with full local setup"
+          ? "Continue with my agent setup"
           : "Approve & investigate"
       }
       title={
         profile === "safeguarded"
           ? "Run an AI investigation with Radar safeguards?"
-          : "Run with your agent’s full local setup?"
+          : `Run using your ${agentName} setup?`
       }
       body={
         <>

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -33,8 +33,8 @@ import {
 import { StatusDot } from "@skyhook-io/k8s-ui";
 import { Markdown } from "../ui/Markdown";
 
-// Segmented two-or-more-way selector — shared shape for the agent picker and the
-// isolation toggle.
+// Segmented two-or-more-way selector — shared shape for the agent and execution
+// profile pickers.
 function Segmented<T extends string | boolean>({
   label,
   options,
@@ -257,6 +257,9 @@ export function AgentControls({
   const isClaude = selectedAgent === "claude";
   const isCursor = selectedAgent === "cursor-agent";
   const profiles = agents.find((a) => a.name === selectedAgent)?.profiles ?? [];
+  const shownProfile = profiles.includes(profile)
+    ? profile
+    : (profiles[0] ?? profile);
   const profileLabels: Record<ExecutionProfile, string> = {
     safeguarded: "Radar safeguards",
     "full-local": "Full local setup",
@@ -277,42 +280,60 @@ export function AgentControls({
       {profiles.length > 0 && (
         <div>
           {profiles.length > 1 ? (
-            <Segmented<ExecutionProfile>
-              label="How Radar runs it"
-              value={profile}
-              onChange={onSetProfile}
-              options={profiles.map((value) => ({
-                value,
-                label: profileLabels[value],
-              }))}
-            />
-          ) : (
             <>
-              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
-                How Radar runs it
-              </div>
-              <div className="rounded-md border border-theme-border bg-theme-base px-2.5 py-1.5 text-xs text-theme-text-primary">
-                {profileLabels[profiles[0]]}
-              </div>
+              <Segmented<ExecutionProfile>
+                label="How Radar runs it"
+                value={shownProfile}
+                onChange={onSetProfile}
+                options={profiles.map((value) => ({
+                  value,
+                  label: profileLabels[value],
+                }))}
+              />
+              {shownProfile === "safeguarded" ? (
+                <p className="mt-1.5 text-[11px] leading-snug text-theme-text-tertiary">
+                  {isCodex
+                    ? "Radar excludes your Codex configuration and other MCP servers. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
+                    : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
+                </p>
+              ) : (
+                <div className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
+                  <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
+                  <span>
+                    Uses your agent&apos;s normal configuration and other
+                    configured tools and MCP servers. Radar cannot constrain that
+                    external tooling; it may access local files or the network
+                    and may be able to change your cluster. Radar still enables
+                    the agent CLI&apos;s own sandbox, but that sandbox does not
+                    constrain external MCP servers. Choose this only when you
+                    need that setup.
+                  </span>
+                </div>
+              )}
             </>
-          )}
-          {profile === "safeguarded" ? (
-            <p className="mt-1.5 text-[11px] leading-snug text-theme-text-tertiary">
-              Radar limits the agent to its investigation tools and excludes
-              your other agent configuration.
-              {isCodex &&
-                " Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."}
-            </p>
+          ) : shownProfile === "safeguarded" ? (
+            <div className="flex items-start gap-1.5 rounded border border-theme-border bg-theme-base p-2 text-[11px] leading-snug text-theme-text-secondary">
+              <ShieldCheck className="mt-0.5 h-3 w-3 shrink-0 text-accent" />
+              <span>
+                Radar always runs this agent with safeguards.
+                {isClaude
+                  ? " Claude’s built-in tools are disabled, and MCP access is limited to Radar’s read-only investigation tools. Your Claude settings, hooks, and CLAUDE.md instructions still apply and are outside Radar’s control."
+                  : isCodex
+                    ? " Your Codex configuration and other MCP servers are excluded. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
+                    : " Review the agent’s documented restrictions before continuing."}
+              </span>
+            </div>
           ) : (
-            <div className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
+            <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
               <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
               <span>
-                Uses your agent&apos;s normal configuration and other configured
-                tools and MCP servers. Radar does not constrain those tools;
-                they may access local files or the network and may be able to
-                change your cluster. Choose this only when you need that setup.
+                This agent only supports Full local setup. Radar cannot constrain
+                its external tools or MCP servers; they may access local files
+                or the network and may be able to change your cluster. Radar
+                still enables the agent CLI&apos;s own sandbox, but that sandbox
+                does not constrain external MCP servers.
                 {isCursor &&
-                  " Cursor always loads your global MCP servers; Radar cannot exclude them."}
+                  " Cursor always loads your global MCP servers, so Radar cannot exclude them."}
               </span>
             </div>
           )}
@@ -326,7 +347,7 @@ export function AgentControls({
           onChange={onSetModel}
           hint="Aliases always resolve to the latest of that tier."
         />
-      ) : (
+      ) : isCodex || isCursor ? (
         <TextField
           label="Model"
           value={model}
@@ -339,10 +360,18 @@ export function AgentControls({
           hint={
             isCursor
               ? "Leave empty for your Cursor default, or enter a model slug Cursor supports."
-              : profile === "full-local"
+              : shownProfile === "full-local"
                 ? "Full local setup uses your own Codex config's model; set a slug here to override it."
                 : "Leave empty for Codex's default, or enter a model your Codex version supports."
           }
+        />
+      ) : (
+        <TextField
+          label="Model"
+          value={model}
+          placeholder="Default"
+          onChange={onSetModel}
+          hint="Leave empty for the agent's default, or enter a model identifier it supports."
         />
       )}
       {isCodex && (
@@ -613,10 +642,12 @@ function ConsentCardShell({
   bullets,
   settingsLabel,
   approveLabel = "Approve & investigate",
+  warning = false,
   onOpenSettings,
   onApprove,
   onCancel,
 }: DiagnoseConsentCopy & {
+  warning?: boolean;
   onOpenSettings?: () => void;
   onApprove: () => void;
   onCancel: () => void;
@@ -628,9 +659,19 @@ function ConsentCardShell({
       ? "Change the agent and how it runs in Settings"
       : settingsLabel;
   return (
-    <div className="rounded-lg border border-theme-border bg-theme-elevated p-4">
+    <div
+      className={
+        warning
+          ? "rounded-lg border border-amber-500/40 bg-amber-500/10 p-4"
+          : "rounded-lg border border-theme-border bg-theme-elevated p-4"
+      }
+    >
       <div className="mb-2 flex items-center gap-2">
-        <ShieldCheck className="h-4 w-4 text-accent" />
+        {warning ? (
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+        ) : (
+          <ShieldCheck className="h-4 w-4 text-accent" />
+        )}
         <div className="text-sm font-medium text-theme-text-primary">
           {title}
         </div>
@@ -704,6 +745,7 @@ export function ConsentCard({
   return (
     <ConsentCardShell
       {...chrome}
+      warning={profile === "full-local"}
       approveLabel={
         profile === "full-local"
           ? "Continue with full local setup"
@@ -711,8 +753,8 @@ export function ConsentCard({
       }
       title={
         profile === "safeguarded"
-          ? "Run a read-only AI investigation?"
-          : "Run an AI investigation?"
+          ? "Run an AI investigation with Radar safeguards?"
+          : "Run with your agent’s full local setup?"
       }
       body={
         <>
@@ -727,42 +769,55 @@ export function ConsentCard({
           {profile === "safeguarded" && (
             <>
               {" "}
-              Through Radar the agent can only{" "}
-              <span className="font-medium">read</span> your cluster during this
-              investigation.
+              Radar&apos;s investigation tools can only{" "}
+              <span className="font-medium">read</span> your cluster.
             </>
           )}
         </>
       }
-      bullets={[
-        profile === "safeguarded" ? (
-          <>
-            Radar safeguards: only Radar&apos;s read-only investigation tools —
-            your other agent configuration and MCP servers are excluded.
-            {agent === "codex" && (
+      bullets={
+        profile === "safeguarded"
+          ? [
+              agent === "claude" ? (
+                <>
+                  Radar safeguards disable Claude&apos;s built-in tools and limit
+                  MCP access to Radar&apos;s read-only investigation tools. Your
+                  Claude settings, hooks, and CLAUDE.md instructions still apply
+                  and are outside Radar&apos;s control.
+                </>
+              ) : agent === "codex" ? (
+                <>
+                  Radar safeguards exclude your Codex configuration and other MCP
+                  servers. Codex&apos;s sandboxed shell can still read files on
+                  this machine; it cannot write or reach the network.
+                </>
+              ) : (
+                <>
+                  Radar uses this agent&apos;s safeguarded execution profile.
+                  Review the agent&apos;s documented restrictions before
+                  continuing.
+                </>
+              ),
+            ]
+          : [
               <>
-                {" "}
-                Codex&apos;s sandboxed shell can still read files on this
-                machine; it cannot write or reach the network.
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            Full local setup: Radar&apos;s own investigation tools are read-only,
-            but the agent&apos;s other configured tools and MCP servers are not
-            constrained by Radar. They may access local files or the network and
-            may be able to change your cluster.
-            {agent === "cursor-agent" && (
+                Radar cannot constrain the agent&apos;s other configured tools or
+                MCP servers. They may access local files or the network and may
+                be able to change your cluster.
+              </>,
               <>
-                {" "}
-                Cursor always loads your global MCP servers; Radar cannot exclude
-                them.
-              </>
-            )}
-          </>
-        ),
-      ]}
+                Radar still enables the agent CLI&apos;s own sandbox, but that
+                sandbox does not constrain external MCP servers.
+                {agent === "cursor-agent" && (
+                  <>
+                    {" "}
+                    Cursor always loads your global MCP servers; Radar cannot
+                    exclude them.
+                  </>
+                )}
+              </>,
+            ]
+      }
     />
   );
 }

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -60,6 +60,7 @@ interface ConfigResponse {
 interface SettingsDialogProps {
   open: boolean
   onClose: () => void
+  initialSection?: SettingsSectionId
 }
 
 // The settings surface splits into three honest apply buckets:
@@ -68,7 +69,7 @@ interface SettingsDialogProps {
 //   • Live integrations (Prometheus, Argo CD) — their own Apply/Connect endpoints
 //     re-point the running server; effect immediately, NOT part of footer dirty.
 //   • AI diagnose — client-side prefs, self-saving, editable by everyone.
-type SectionId =
+export type SettingsSectionId =
   | 'overview' | 'perms' | 'connection' | 'prometheus' | 'argocd' | 'ai' | 'advanced'
 
 // Only STARTUP fields count toward footer dirty. Integration fields (prometheusUrl,
@@ -89,7 +90,11 @@ function normalizeStartup(c: Config) {
   }
 }
 
-export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+export function SettingsDialog({
+  open,
+  onClose,
+  initialSection = 'overview',
+}: SettingsDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const { shouldRender, isOpen } = useAnimatedUnmount(open, 200)
   const { data: versionInfo } = useVersionCheck()
@@ -107,7 +112,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [saving, setSaving] = useState(false)
   const [saveMessage, setSaveMessage] = useState<string | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [section, setSection] = useState<SectionId>('overview')
+  const [section, setSection] = useState<SettingsSectionId>('overview')
   const [confirmingClose, setConfirmingClose] = useState(false)
 
   // AI Diagnosis prefs are client-side (localStorage) and now SELF-SAVING: the
@@ -162,12 +167,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       model: diag.model,
       effort: diag.effort,
     })
-    // Overview is the landing section — a status-at-a-glance of what Radar is
-    // connected to (cluster, integrations, MCP, AI), useful to owners and
-    // viewers alike, rather than dropping owners on a config form or everyone
-    // on a permissions dump.
-    setSection('overview')
-
     fetch(apiUrl('/config'), { credentials: getCredentialsMode(), headers: getAuthHeaders() })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -184,6 +183,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     // Snapshot-on-open only; we don't want late diag updates to wipe staged edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
+
+  useEffect(() => {
+    if (open) setSection(initialSection)
+  }, [open, initialSection])
 
   useEffect(() => {
     if (!open || diag.agents.length === 0) return
@@ -344,7 +347,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           // Fixed height so the dialog doesn't jump when switching tabs — short
           // tabs leave breathing room, tall ones scroll inside the content pane.
           // max-h keeps it on-screen on short viewports.
-          'sm:rounded-xl sm:max-w-4xl sm:mx-4 sm:h-[620px] sm:max-h-[85vh]',
+          'sm:rounded-xl sm:max-w-4xl sm:mx-4 sm:h-[660px] sm:max-h-[85vh]',
           TRANSITION_PANEL,
           isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
         )}
@@ -676,7 +679,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 // -- Sidebar primitives -------------------------------------------------------
 
 interface NavItemDef {
-  id: SectionId
+  id: SettingsSectionId
   label: string
   icon: LucideIcon
   ownerOnly: boolean
@@ -757,8 +760,8 @@ function SectionPane({
   locked,
   children,
 }: {
-  id: SectionId
-  active: SectionId
+  id: SettingsSectionId
+  active: SettingsSectionId
   title: string
   caption?: string
   live?: boolean
@@ -811,7 +814,7 @@ function LockWall() {
 type OverviewTone = 'ok' | 'warn' | 'off' | 'unknown'
 
 interface OverviewRow {
-  id: SectionId
+  id: SettingsSectionId
   icon: LucideIcon
   label: string
   tone: OverviewTone
@@ -826,7 +829,7 @@ interface OverviewRow {
 // probe, so we don't want it firing when Settings opens on another section);
 // cluster and Prometheus status are shared app-wide caches, so they're read
 // unconditionally.
-function OverviewPanel({ active, onNavigate }: { active: boolean; onNavigate: (s: SectionId) => void }) {
+function OverviewPanel({ active, onNavigate }: { active: boolean; onNavigate: (s: SettingsSectionId) => void }) {
   const { data: cluster } = useClusterInfo()
   const { data: prom } = usePrometheusStatus()
   const { data: argo } = useArgoStatus(active)

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -117,14 +117,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const aiAvailable = diag.available && diag.agents.length > 0
   const [aiDraft, setAiDraft] = useState<AIDraft>({
     agent: diag.selectedAgent,
-    isolated: diag.isolated,
+    profile: diag.profile,
     model: diag.model,
     effort: diag.effort,
   })
   const [aiSaved, setAiSaved] = useState(false)
   const aiDirty =
     aiDraft.agent !== diag.selectedAgent ||
-    aiDraft.isolated !== diag.isolated ||
+    aiDraft.profile !== diag.profile ||
     aiDraft.model !== diag.model ||
     aiDraft.effort !== diag.effort
 
@@ -158,7 +158,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     setAiSaved(false)
     setAiDraft({
       agent: diag.selectedAgent,
-      isolated: diag.isolated,
+      profile: diag.profile,
       model: diag.model,
       effort: diag.effort,
     })
@@ -234,7 +234,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   // agent first, then restore the draft's model/effort.
   const saveAi = useCallback(() => {
     diag.setSelectedAgent(aiDraft.agent)
-    diag.setIsolated(aiDraft.isolated)
+    diag.setProfile(aiDraft.profile)
     diag.setModel(aiDraft.model)
     diag.setEffort(aiDraft.effort)
     setAiSaved(true)

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -185,6 +185,15 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
+  useEffect(() => {
+    if (!open || diag.agents.length === 0) return
+    setAiDraft((current) => {
+      const profiles = diag.agents.find((agent) => agent.name === current.agent)?.profiles ?? []
+      if (profiles.length === 0 || profiles.includes(current.profile)) return current
+      return { ...current, profile: profiles[0] }
+    })
+  }, [open, diag.agents])
+
   const updateConfigField = useCallback(<K extends keyof Config>(field: K, value: Config[K]) => {
     setEditedConfig((prev) => ({ ...prev, [field]: value }))
     setSaveMessage(null)

--- a/web/src/context/DiagnoseCustomization.tsx
+++ b/web/src/context/DiagnoseCustomization.tsx
@@ -41,7 +41,7 @@ export type DiagnoseConsentCopy = {
   /** Detail list under the body; each entry is rendered as its own "•" row. */
   bullets?: ReactNode[];
   /** Label for the settings link. `null` hides it — for hosts with one fixed
-   *  agent and no isolation choice, where it would open an empty dialog. */
+   *  agent and no execution-profile choice, where it would open an empty dialog. */
   settingsLabel?: string | null;
   approveLabel?: string;
 };


### PR DESCRIPTION
## Summary

- replace the overloaded local `isolated` switch with explicit `safeguarded` and `full-local` execution profiles
- default Claude CLI and Codex to Radar safeguards while allowing users to opt out into their normal agent setup; Cursor exposes only its full local setup because Radar cannot reliably isolate it
- centralize profile capabilities, defaults, validation, persistence, and agent/profile-scoped consent in `internal/ai`
- apply profile-specific driver behavior: strict Radar-only MCP/tool constraints in safeguarded mode, normal user configuration in full-local mode, and explicit rejection of unsupported combinations
- explain the selected behavior in AI settings and require just-in-time consent in the diagnose drawer for each exact agent/profile surface
- deep-link the diagnose drawer’s settings action to the AI settings section and size the dialog to show the full profile configuration without routine scrolling
- probe the installed Cursor Agent for the anchored `--trust` flag rather than assuming version-specific support
- reconcile agents found on `PATH` with the drivers Radar actually initialized, including `RADAR_AI_CLI_BIN` overrides in both the server API and standalone pre-boot consent
- preserve Radar Hub hosted-agent consent while keeping local execution profiles separate

## Product and security model

`Radar safeguards` is the default wherever the installed agent can enforce Radar’s restrictions. `Your <agent> setup` is an explicit opt-out that uses the agent’s normal configuration, tools, and MCP servers.

The disclosure is agent-specific:

- Claude CLI full-local uses the permissions from the user’s setup; Radar does not override them
- Codex full-local retains the CLI’s own sandbox, but Radar cannot constrain external MCP servers
- Cursor is full-local only and always loads global MCP servers, so Radar cannot exclude them

Consent is versioned per exact agent/profile surface. Supported agents must advertise at least one profile, every advertised surface must have a configured disclosure version, and unsupported combinations are rejected centrally and by each driver.

There is intentionally no compatibility translation for the removed `isolated` field, and profileless persisted local runs are not resumed under an implied security posture.

## Verification

- `make tsc`
- `make test`
- `make build`
- focused AI, diagnose CLI, server, and frontend tests
- `git diff --check`
- manual live UI verification of profile switching, agent-specific warnings, consent, settings deep-linking, and dialog sizing
- live real-cluster diagnosis of the same crash-looping pod with:
  - Claude CLI safeguarded
  - Codex safeguarded
  - Codex full-local
  - Cursor full-local
- every live run completed and called Radar MCP tools; no cluster writes were performed
- driver tests cover both Claude CLI profiles, including the full-local command, environment, and MCP behavior
- standalone regression coverage verifies that pre-boot consent honors a `RADAR_AI_CLI_BIN` override
- installed versions exercised: Claude CLI 2.1.220, Codex 0.145.0, Cursor 2026.07.23-e383d2b

## Release note

This intentionally changes the public diagnose customization context from `isolated` / `setIsolated` to `profile` / `setProfile`. The next `@skyhook-io/radar-app` publication containing this PR must use a major tag (`radar-app-v2.0.0`), rather than changing the source package placeholder version.

## Follow-up

The additional CLIs in #1265 can rebase on this framework and declare their supported profiles, defaults, driver enforcement, and disclosure copy individually.

Fixes #1272
