### PR TITLE
Detect Kubernetes credential loss and recover automatically

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -70,6 +70,8 @@ type AppConfig struct {
 func SetGlobals(cfg AppConfig) {
 	k8s.DebugEvents = cfg.DebugEvents
 	k8s.TimingLogs = cfg.DevMode
+	// Init-only write, before any goroutine reads it; later reads happen under
+	// clientMu and assume no concurrent mutation.
 	k8s.ForceInCluster = cfg.FakeInCluster
 	k8s.ForceDisableHelmWrite = cfg.DisableHelmWrite
 	k8s.ForceDisableExec = cfg.DisableExec

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -320,7 +320,8 @@ var tombstones = timeline.NewTombstoneCache(15*time.Minute, 4000)
 func InitResourceCache(ctx context.Context) error {
 	var initErr error
 	cacheOnce.Do(func() {
-		if k8sClient == nil {
+		client := GetClient()
+		if client == nil {
 			initErr = fmt.Errorf("cannot create resource cache: k8s client not initialized")
 			return
 		}
@@ -359,7 +360,7 @@ func InitResourceCache(ctx context.Context) error {
 		secretWriteTimes := newSecretDataManagerWriteIndex()
 
 		cfg := k8score.CacheConfig{
-			Client:                  k8sClient,
+			Client:                  client,
 			ResourceScopes:          scopes,
 			ResourceScopeNamespaces: permResult.ScopeNamespaces,
 			DeferredTypes:           deferredResources,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -289,24 +289,18 @@ func doInit(opts InitOptions) error {
 	config.QPS = 50
 	config.Burst = 100
 
+	clients, err := newSharedKubernetesClients(config)
+	if err != nil {
+		return err
+	}
+
+	clientMu.Lock()
 	k8sConfig = config
-
-	k8sClient, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create k8s clientset: %w", err)
-	}
-
-	// Create discovery client for API resource discovery
-	discoveryClient, err = discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create discovery client: %w", err)
-	}
-
-	// Create dynamic client for CRD access
-	dynamicClient, err = dynamic.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create dynamic client: %w", err)
-	}
+	k8sClient = clients.clientset
+	discoveryClient = clients.discovery
+	dynamicClient = clients.dynamic
+	activeClientGeneration = clients.generation
+	clientMu.Unlock()
 
 	return nil
 }
@@ -934,6 +928,12 @@ var ForceInCluster bool
 
 // IsInCluster returns true if running inside a Kubernetes cluster
 func IsInCluster() bool {
+	clientMu.RLock()
+	defer clientMu.RUnlock()
+	return isInClusterLocked()
+}
+
+func isInClusterLocked() bool {
 	return ForceInCluster || (kubeconfigPath == "" && len(kubeconfigPaths) == 0)
 }
 
@@ -1126,20 +1126,9 @@ func SwitchContext(name string) error {
 	config.QPS = 50
 	config.Burst = 100
 
-	// Create new clients
-	newK8sClient, err := kubernetes.NewForConfig(config)
+	clients, err := newSharedKubernetesClients(config)
 	if err != nil {
-		return fmt.Errorf("failed to create k8s client for context %q: %w", name, err)
-	}
-
-	newDiscoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create discovery client for context %q: %w", name, err)
-	}
-
-	newDynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create dynamic client for context %q: %w", name, err)
+		return fmt.Errorf("failed to create clients for context %q: %w", name, err)
 	}
 
 	// Update global variables atomically
@@ -1165,9 +1154,10 @@ func SwitchContext(name string) error {
 
 	clientMu.Lock()
 	k8sConfig = config
-	k8sClient = newK8sClient
-	discoveryClient = newDiscoveryClient
-	dynamicClient = newDynamicClient
+	k8sClient = clients.clientset
+	discoveryClient = clients.discovery
+	dynamicClient = clients.dynamic
+	activeClientGeneration = clients.generation
 	contextName = name
 	clusterName = ctx.Cluster
 	contextNamespace = ctx.Namespace

--- a/internal/k8s/cluster_detection.go
+++ b/internal/k8s/cluster_detection.go
@@ -24,8 +24,8 @@ func getServerVersion() string {
 	serverVersionMu.Lock()
 	defer serverVersionMu.Unlock()
 	serverVersionOnce.Do(func() {
-		if k8sClient != nil {
-			if v, err := k8sClient.Discovery().ServerVersion(); err == nil {
+		if client := GetClient(); client != nil {
+			if v, err := client.Discovery().ServerVersion(); err == nil {
 				cachedServerVersion = v.GitVersion
 			}
 		}
@@ -114,8 +114,8 @@ func GetClusterPlatform(ctx context.Context) (string, error) {
 	}
 
 	// Fallback to direct API if cache unavailable
-	if len(nodes) == 0 && k8sClient != nil {
-		nodeList, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+	if client := GetClient(); len(nodes) == 0 && client != nil {
+		nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 			Limit: 1,
 		})
 		if err != nil {
@@ -179,8 +179,8 @@ func IsGKEAutopilot(ctx context.Context) (bool, error) {
 		}
 	}
 
-	if len(nodes) == 0 && k8sClient != nil {
-		nodeList, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: 1})
+	if client := GetClient(); len(nodes) == 0 && client != nil {
+		nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: 1})
 		if err == nil && len(nodeList.Items) > 0 {
 			nodes = nodeList.Items
 		}
@@ -222,8 +222,8 @@ func checkAutopilotViaAnnotations(ctx context.Context) (bool, bool) {
 		}
 	}
 
-	if len(pods) == 0 && k8sClient != nil {
-		podList, err := k8sClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{Limit: 10})
+	if client := GetClient(); len(pods) == 0 && client != nil {
+		podList, err := client.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{Limit: 10})
 		if err == nil {
 			pods = podList.Items
 		}

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -94,6 +94,19 @@ func notifyConnectionChange(status ConnectionStatus) {
 // MarkDisconnectedIfClusterUnreachable updates the shared connection state when
 // a live Kubernetes request proves that the current cluster endpoint is gone.
 func MarkDisconnectedIfClusterUnreachable(message string) bool {
+	if ClassifyError(errors.New(message)) == "auth" {
+		// Credential loss must go through the demotion pipeline — it confirms
+		// with a fresh probe, gates on endpoint reachability, and quiesces
+		// cluster-backed work. Publishing disconnected directly would skip
+		// the teardown AND disarm the pipeline (candidate intake requires
+		// StateConnected), leaving informers hammering the dead credential
+		// for the whole outage.
+		clientMu.RLock()
+		generation := activeClientGeneration
+		clientMu.RUnlock()
+		reportRuntimeAuthFailure(generation, errors.New(message))
+		return false
+	}
 	if !isClusterUnreachableMessage(message) {
 		return false
 	}

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -60,7 +60,10 @@ func SetConnectionStatus(status ConnectionStatus) {
 	connectionStatus = status
 	connectionStatusMu.Unlock()
 
-	// Notify callbacks
+	notifyConnectionChange(status)
+}
+
+func notifyConnectionChange(status ConnectionStatus) {
 	connectionCallbacksMu.RLock()
 	callbacks := make([]ConnectionChangeCallback, len(connectionCallbacks))
 	copy(callbacks, connectionCallbacks)
@@ -268,15 +271,7 @@ func UpdateConnectionProgress(msg string) {
 	connectionStatus = status
 	connectionStatusMu.Unlock()
 
-	// Notify callbacks
-	connectionCallbacksMu.RLock()
-	callbacks := make([]ConnectionChangeCallback, len(connectionCallbacks))
-	copy(callbacks, connectionCallbacks)
-	connectionCallbacksMu.RUnlock()
-
-	for _, cb := range callbacks {
-		cb(status)
-	}
+	notifyConnectionChange(status)
 }
 
 // OnConnectionChange registers a callback to be called when connection status changes

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -60,6 +60,24 @@ func SetConnectionStatus(status ConnectionStatus) {
 	connectionStatus = status
 	connectionStatusMu.Unlock()
 
+	// Publish-side recovery ownership: every route into an auth-shaped
+	// disconnect (bootstrap with expired credentials, failed retry, failed
+	// context switch) must leave a reconnect loop running — the browser no
+	// longer auto-retries auth failures. Owed survives later non-auth
+	// republications (a hung-plugin retry classifies "timeout") and is only
+	// settled by a successful connect.
+	switch status.State {
+	case StateConnected:
+		runtimeAuthRecoveryOwed.Store(false)
+	case StateDisconnected:
+		if strings.HasPrefix(status.ErrorType, "auth") {
+			runtimeAuthRecoveryOwed.Store(true)
+		}
+		if runtimeAuthRecoveryOwed.Load() {
+			startRuntimeAuthRecovery()
+		}
+	}
+
 	notifyConnectionChange(status)
 }
 

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -68,6 +68,7 @@ func SetConnectionStatus(status ConnectionStatus) {
 	switch status.State {
 	case StateConnected:
 		runtimeAuthRecoveryOwed.Store(false)
+		resetInconclusiveStreak()
 	case StateDisconnected:
 		if strings.HasPrefix(status.ErrorType, "auth") {
 			runtimeAuthRecoveryOwed.Store(true)

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"net"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -233,13 +232,26 @@ func isAuthErrorMessage(lower string) bool {
 		"exec credential",
 		"exec plugin",
 		"gke-gcloud-auth-plugin",
+		// client-go's in-tree oidc auth provider returns refresh failures RAW
+		// from RoundTrip (no "getting credentials:" wrapper) — Keycloak/Dex/
+		// IBM IKS kubeconfigs die here. "invalid_grant" is the RFC 6749 code
+		// every IdP emits for an expired/revoked refresh token.
+		"failed to refresh token",
+		"invalid_grant",
+		"cannot refresh without refresh-token",
+		// The exec plugin's TLS client-certificate path (e.g. tsh) fails
+		// without the "getting credentials:" wrapper; this phrasing is
+		// produced only by client-go's exec plugin runner.
+		"exec: executable ",
+		"failed to read token file",
+		"read empty token from file",
 	}
 	for _, marker := range authMarkers {
 		if strings.Contains(lower, marker) {
 			return true
 		}
 	}
-	return strings.Contains(lower, "unable to connect to the server") && strings.Contains(lower, "oauth2")
+	return false
 }
 
 func isRBACErrorMessage(lower string) bool {
@@ -263,6 +275,7 @@ func isConfigErrorMessage(lower string) bool {
 		"k8s config not initialized",
 		"kubernetes client is not initialized",
 		"kubernetes discovery client is not initialized",
+		"no auth provider found for name",
 	}
 	for _, marker := range configMarkers {
 		if strings.Contains(lower, marker) {
@@ -278,7 +291,17 @@ func isTLSCertificateMessage(lower string) bool {
 		strings.Contains(lower, "certificate is valid for") ||
 		strings.Contains(lower, "cannot validate certificate") ||
 		strings.Contains(lower, "certificate has expired") ||
-		strings.Contains(lower, "certificate is not yet valid")
+		strings.Contains(lower, "certificate is not yet valid") ||
+		// TLS alerts rejecting OUR certificate come from mTLS-terminating
+		// proxies in front of the cluster (Teleport, nginx/HAProxy with
+		// client verification) — kube-apiserver itself never sends these; it
+		// uses RequestClientCert and returns 401 instead. Without these
+		// markers the alerts fall through to "network".
+		strings.Contains(lower, "tls: bad certificate") ||
+		strings.Contains(lower, "tls: certificate required") ||
+		strings.Contains(lower, "tls: expired certificate") ||
+		strings.Contains(lower, "tls: unknown certificate") ||
+		strings.Contains(lower, "tls: revoked certificate")
 }
 
 // UpdateConnectionProgress updates the progress message while connecting
@@ -346,10 +369,12 @@ func ClassifyError(err error) string {
 	if errors.As(err, &opErr) {
 		return "network"
 	}
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return "network"
-	}
+	// Deliberately NO *url.Error → "network" mapping: genuine transport
+	// failures unwrap into the typed branches above, so the only errors a
+	// bare url.Error match would catch are RoundTripper-level failures — and
+	// in a Kubernetes client the RoundTripper chain IS the credential chain.
+	// An unrecognized credential error must classify "unknown", not earn a
+	// confidently wrong "network" verdict.
 
 	// Network errors
 	if isTransportNetworkMessage(errLower) {

--- a/internal/k8s/connection_state_test.go
+++ b/internal/k8s/connection_state_test.go
@@ -271,6 +271,46 @@ func TestClassifyError(t *testing.T) {
 			want: "config",
 		},
 		{
+			name: "mtls proxy rejecting client cert is tls",
+			err:  `failed to connect to cluster: Get "https://10.0.0.1:6443/version": remote error: tls: bad certificate`,
+			want: "tls",
+		},
+		{
+			name: "mtls proxy requiring client cert is tls",
+			err:  `Get "https://10.0.0.1:6443/version": remote error: tls: certificate required`,
+			want: "tls",
+		},
+		{
+			name: "mtls proxy unknown certificate is tls",
+			err:  `Get "https://teleport.example.com/version": remote error: tls: unknown certificate authority`,
+			want: "tls",
+		},
+		{
+			name: "oidc refresh token expired is auth",
+			err:  `Get "https://api.example.com/version": failed to refresh token: oauth2: cannot fetch token: 400 Bad Request Response: {"error":"invalid_grant","error_description":"Token is not active"}`,
+			want: "auth",
+		},
+		{
+			name: "oidc no refresh token is auth",
+			err:  "No valid id-token, and cannot refresh without refresh-token",
+			want: "auth",
+		},
+		{
+			name: "exec plugin cert path without wrapper is auth",
+			err:  `Get "https://teleport.example.com/version": exec: executable tsh failed with exit code 1`,
+			want: "auth",
+		},
+		{
+			name: "unreadable token file is auth",
+			err:  `failed to read token file "/var/run/secrets/kubernetes.io/serviceaccount/token": open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`,
+			want: "auth",
+		},
+		{
+			name: "missing auth provider plugin is config",
+			err:  `no Auth Provider found for name "oidc"`,
+			want: "config",
+		},
+		{
 			name: "unknown",
 			err:  "something novel happened",
 			want: "unknown",
@@ -321,6 +361,14 @@ func TestClassifyErrorTypedErrors(t *testing.T) {
 			name: "dns error is network",
 			err:  &url.Error{Op: "Get", URL: "https://cluster.example", Err: &net.DNSError{Err: "no such host", Name: "cluster.example"}},
 			want: "network",
+		},
+		{
+			name: "url-wrapped unrecognized roundtripper failure stays unknown",
+			// http.Client wraps EVERYTHING a RoundTripper returns in url.Error,
+			// and the RoundTripper chain is the credential chain — an unknown
+			// credential failure must not earn a confident "network" verdict.
+			err:  &url.Error{Op: "Get", URL: "https://cluster.example/version", Err: errors.New("novel credential provider failure")},
+			want: "unknown",
 		},
 		{
 			name: "url-wrapped exec credential failure is auth",

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -487,6 +487,16 @@ func performContextSwitch(newContext string, observedOperationGen uint64, requir
 		callback(newContext)
 	}
 
+	// Publish success while still holding contextOpMu: a caller publishing
+	// after this returns races the next queued operation's teardown, and the
+	// window would advertise Connected over dead caches. HTTP handlers'
+	// duplicate publishes dedupe inside SetConnectionStatus.
+	SetConnectionStatus(ConnectionStatus{
+		State:       StateConnected,
+		Context:     newContext,
+		ClusterName: GetClusterName(),
+	})
+
 	return nil
 }
 

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -355,7 +355,25 @@ func connectionProbeHTTPTimeout(ctx context.Context) time.Duration {
 // connected to the current cluster" and NOT mark the connection disconnected.
 var ErrContextSwitchPreflight = errors.New("context switch preflight rejected")
 
+// ErrReconnectSuperseded is returned by PerformContextSwitchIfOperationCurrent
+// when another operation started after the caller captured its generation.
+var ErrReconnectSuperseded = errors.New("reconnect superseded by a newer operation")
+
 func PerformContextSwitch(newContext string) error {
+	return performContextSwitch(newContext, 0, false)
+}
+
+// PerformContextSwitchIfOperationCurrent is the conditional variant used by
+// automatic recovery: it aborts with ErrReconnectSuperseded — before any
+// teardown — if any other operation (user switch, rescope, retry) started
+// since observedOperationGen was captured. The check runs under contextOpMu,
+// which closes the TOCTOU a check-then-switch caller would have: a user
+// switch that started mid-probe bumps the generation before this can.
+func PerformContextSwitchIfOperationCurrent(newContext string, observedOperationGen uint64) error {
+	return performContextSwitch(newContext, observedOperationGen, true)
+}
+
+func performContextSwitch(newContext string, observedOperationGen uint64, requireOperationCurrent bool) error {
 	switchStart := time.Now()
 	log.Printf("[ops] Context switch START → %q", newContext)
 
@@ -367,6 +385,10 @@ func PerformContextSwitch(newContext string) error {
 		activeContextOperations.Add(-1)
 		contextOpMu.Unlock()
 	}()
+
+	if requireOperationCurrent && currentOperationGen() != observedOperationGen {
+		return ErrReconnectSuperseded
+	}
 
 	// Under --namespace-scope, validate the new context has a usable scope target
 	// BEFORE tearing anything down. Otherwise a switch to a context with no

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -86,7 +87,8 @@ var (
 	// from running ResetAllSubsystems + InitAllSubsystems concurrently on the
 	// shared cache singletons. This mutex does — a second request waits for the
 	// first to finish rather than interleaving teardown/init.
-	contextOpMu sync.Mutex
+	contextOpMu             sync.Mutex
+	activeContextOperations atomic.Int32
 
 	// operationCtx is canceled at the start of every context switch and retry.
 	// API calls that should not survive a context switch (RBAC checks, capability
@@ -133,6 +135,16 @@ func NewOperationContext(timeout time.Duration) (context.Context, context.Cancel
 	parent := operationCtx
 	operationMu.Unlock()
 	return context.WithTimeout(parent, timeout)
+}
+
+func newOperationContextForGeneration(generation uint64, timeout time.Duration) (context.Context, context.CancelFunc, bool) {
+	operationMu.Lock()
+	defer operationMu.Unlock()
+	if operationGen != generation {
+		return nil, nil, false
+	}
+	ctx, cancel := context.WithTimeout(operationCtx, timeout)
+	return ctx, cancel, true
 }
 
 // OperationContext returns the current operation context. Callers that need
@@ -340,8 +352,12 @@ func PerformContextSwitch(newContext string) error {
 
 	// Serialize against any other in-flight switch / rescope so their teardown +
 	// init can't interleave on the shared cache. A queued request waits here.
+	activeContextOperations.Add(1)
 	contextOpMu.Lock()
-	defer contextOpMu.Unlock()
+	defer func() {
+		activeContextOperations.Add(-1)
+		contextOpMu.Unlock()
+	}()
 
 	// Under --namespace-scope, validate the new context has a usable scope target
 	// BEFORE tearing anything down. Otherwise a switch to a context with no
@@ -461,8 +477,12 @@ func PerformNamespaceRescope(namespace string) error {
 	// Serialize against any other in-flight switch / rescope (see contextOpMu).
 	// previousNamespace is read under the lock so two rescopes can't both decide
 	// the namespace changed and run teardown/init concurrently.
+	activeContextOperations.Add(1)
 	contextOpMu.Lock()
-	defer contextOpMu.Unlock()
+	defer func() {
+		activeContextOperations.Add(-1)
+		contextOpMu.Unlock()
+	}()
 	previousNamespace := GetNamespaceScopeTarget()
 	if namespace == previousNamespace {
 		return nil

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -82,12 +82,16 @@ var (
 	sessionStopFunc func()
 
 	// contextOpMu serializes the destructive context-changing operations
-	// (PerformContextSwitch, PerformNamespaceRescope). operationGen only decides
-	// which operation gets to roll back / notify; it does NOT stop two operations
-	// from running ResetAllSubsystems + InitAllSubsystems concurrently on the
-	// shared cache singletons. This mutex does — a second request waits for the
-	// first to finish rather than interleaving teardown/init.
-	contextOpMu             sync.Mutex
+	// (PerformContextSwitch, PerformNamespaceRescope, and runtime auth-loss
+	// demotion). operationGen only decides which operation gets to roll back /
+	// notify; it does NOT stop two operations from running ResetAllSubsystems +
+	// InitAllSubsystems concurrently on the shared cache singletons. This mutex
+	// does — a second request waits for the first to finish rather than
+	// interleaving teardown/init.
+	contextOpMu sync.Mutex
+	// Incremented BEFORE contextOpMu is acquired — that ordering is the
+	// mechanism: it makes a queued-but-blocked operation visible to runtime
+	// auth-loss candidate intake, which a try-lock could never see.
 	activeContextOperations atomic.Int32
 
 	// operationCtx is canceled at the start of every context switch and retry.
@@ -97,10 +101,11 @@ var (
 	operationCancel context.CancelFunc
 	operationMu     sync.Mutex
 	// operationGen bumps on every CancelOngoingOperations (i.e. at the start of
-	// every context switch / rescope). An operation captures the generation it
-	// owns; if a newer operation has since started, the older one must not apply
-	// destructive side effects (e.g. a namespace-rescope rollback against the
-	// context a newer switch already moved to).
+	// every context switch / rescope, and on runtime auth-loss demotion). An
+	// operation captures the generation it owns; if a newer operation has since
+	// started, the older one must not apply destructive side effects (e.g. a
+	// namespace-rescope rollback against the context a newer switch already
+	// moved to).
 	operationGen uint64
 )
 
@@ -110,7 +115,8 @@ func init() {
 
 // CancelOngoingOperations cancels any in-flight API calls from previous
 // operations (capabilities checks, RBAC checks, etc.) and creates a fresh
-// operation context. Called at the start of context switch and retry.
+// operation context. Called at the start of context switch and retry, and by
+// runtime auth-loss demotion.
 func CancelOngoingOperations() {
 	operationMu.Lock()
 	defer operationMu.Unlock()
@@ -177,7 +183,10 @@ func stopActiveSessions() {
 // OnBeforeContextSwitch registers a callback fired at the very start of
 // PerformContextSwitch, BEFORE the client is repointed at the new cluster — for
 // teardown that must happen against the old context (e.g. cancelling in-flight
-// AI investigations so their agent can't touch the new cluster).
+// AI investigations so their agent can't touch the new cluster). Runtime
+// auth-loss demotion also fires it as a quiesce-in-place: no switch follows and
+// the argument is the CURRENT context, so callbacks must not infer "changed"
+// by comparing it against the active context name.
 func OnBeforeContextSwitch(callback ContextSwitchCallback) {
 	contextSwitchMu.Lock()
 	defer contextSwitchMu.Unlock()

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -382,6 +382,13 @@ func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) e
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		// A TLS alert IS a response from the endpoint: an mTLS-terminating
+		// proxy (Teleport, nginx with client verification) rejects this
+		// credential-free probe at the handshake, and treating that as
+		// unreachable would veto every demotion behind such a proxy forever.
+		if strings.Contains(strings.ToLower(err.Error()), "remote error: tls:") {
+			return nil
+		}
 		return err
 	}
 	_ = resp.Body.Close()

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -1,0 +1,297 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type sharedKubernetesClients struct {
+	clientset  *kubernetes.Clientset
+	discovery  *discovery.DiscoveryClient
+	dynamic    dynamic.Interface
+	generation uint64
+}
+
+const (
+	runtimeAuthProbeCooldown             = 30 * time.Second
+	runtimeAuthInconclusiveProbeCooldown = 5 * time.Second
+	runtimeAuthEndpointProbeTimeout      = 2 * time.Second
+)
+
+var (
+	clientGenerationCounter atomic.Uint64
+	activeClientGeneration  uint64
+	discoveryRequestTimeout = 32 * time.Second
+
+	runtimeAuthChecksMu      sync.Mutex
+	runtimeAuthChecks        = make(map[uint64]struct{})
+	runtimeAuthProbeAfter    = make(map[uint64]time.Time)
+	runtimeAuthProbe         = TestClusterConnection
+	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
+)
+
+func newSharedKubernetesClients(config *rest.Config) (*sharedKubernetesClients, error) {
+	clientConfig := rest.CopyConfig(config)
+	if clientConfig.UserAgent == "" {
+		clientConfig.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	httpClient, err := rest.HTTPClientFor(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes HTTP client: %w", err)
+	}
+
+	generation := clientGenerationCounter.Add(1)
+	observedClient := *httpClient
+	transport := httpClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	observedClient.Transport = &runtimeAuthRoundTripper{
+		next:       transport,
+		generation: generation,
+	}
+	observedDiscoveryClient := observedClient
+	if observedDiscoveryClient.Timeout == 0 {
+		observedDiscoveryClient.Timeout = discoveryRequestTimeout
+	}
+
+	clientset, err := kubernetes.NewForConfigAndClient(clientConfig, &observedClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s clientset: %w", err)
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(clientConfig, &observedDiscoveryClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	dynamicClient, err := dynamic.NewForConfigAndClient(clientConfig, &observedClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &sharedKubernetesClients{
+		clientset:  clientset,
+		discovery:  discoveryClient,
+		dynamic:    dynamicClient,
+		generation: generation,
+	}, nil
+}
+
+type runtimeAuthRoundTripper struct {
+	next       http.RoundTripper
+	generation uint64
+}
+
+func (rt *runtimeAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.next.RoundTrip(req)
+	if err != nil && ClassifyError(err) == "auth" {
+		reportRuntimeAuthFailure(rt.generation, err)
+	} else if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		reportRuntimeAuthFailure(rt.generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
+	}
+	return resp, err
+}
+
+func reportRuntimeAuthFailure(generation uint64, candidate error) {
+	if candidate == nil || ClassifyError(candidate) != "auth" || !runtimeAuthCandidateIsCurrent(generation) {
+		return
+	}
+
+	operationGeneration := currentOperationGen()
+	runtimeAuthChecksMu.Lock()
+	if _, exists := runtimeAuthChecks[generation]; exists {
+		runtimeAuthChecksMu.Unlock()
+		return
+	}
+	if nextProbe, exists := runtimeAuthProbeAfter[generation]; exists && time.Now().Before(nextProbe) {
+		runtimeAuthChecksMu.Unlock()
+		return
+	}
+	for staleGeneration := range runtimeAuthProbeAfter {
+		if staleGeneration != generation {
+			delete(runtimeAuthProbeAfter, staleGeneration)
+		}
+	}
+	runtimeAuthChecks[generation] = struct{}{}
+	runtimeAuthChecksMu.Unlock()
+
+	go confirmRuntimeAuthFailure(generation, operationGeneration)
+}
+
+func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
+	defer func() {
+		runtimeAuthChecksMu.Lock()
+		delete(runtimeAuthChecks, generation)
+		runtimeAuthChecksMu.Unlock()
+	}()
+
+	if !runtimeAuthCandidateIsCurrent(generation) || currentOperationGen() != operationGeneration {
+		return
+	}
+
+	ctx, cancel, current := newOperationContextForGeneration(operationGeneration, connectionTestOperationTimeout())
+	if !current {
+		return
+	}
+	defer cancel()
+	probe := getRuntimeAuthProbe()
+	err := probe(ctx)
+	if ClassifyError(err) != "auth" {
+		runtimeAuthChecksMu.Lock()
+		runtimeAuthProbeAfter[generation] = time.Now().Add(runtimeAuthCooldown(err))
+		runtimeAuthChecksMu.Unlock()
+		log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: confirmation classified %q",
+			SanitizeForLog(GetContextName()), ClassifyError(err))
+		return
+	}
+
+	endpointConfig, _ := GetConfigSnapshot()
+	endpointCtx, endpointCancel := context.WithTimeout(ctx, runtimeAuthEndpointProbeTimeout)
+	endpointErr := getRuntimeAuthEndpointProbe()(endpointCtx, endpointConfig)
+	endpointCancel()
+	if endpointErr != nil {
+		runtimeAuthChecksMu.Lock()
+		runtimeAuthProbeAfter[generation] = time.Now().Add(runtimeAuthInconclusiveProbeCooldown)
+		runtimeAuthChecksMu.Unlock()
+		log.Printf("[k8s] Runtime authentication candidate inconclusive for context %q: API endpoint is unreachable: %v",
+			SanitizeForLog(GetContextName()), endpointErr)
+		return
+	}
+
+	contextOpMu.Lock()
+	defer contextOpMu.Unlock()
+
+	if !runtimeAuthCandidateIsCurrent(generation) || currentOperationGen() != operationGeneration {
+		return
+	}
+	if !transitionConnectedToRuntimeAuthFailure(err) {
+		return
+	}
+
+	currentContext := GetContextName()
+	log.Printf("[k8s] Runtime Kubernetes authentication lost for context %q; stopping cluster-backed work", SanitizeForLog(currentContext))
+	notifyBeforeContextSwitch(currentContext)
+	CancelOngoingOperations()
+	stopActiveSessions()
+	ResetAllSubsystems()
+}
+
+func runtimeAuthCooldown(err error) time.Duration {
+	classification := ClassifyError(err)
+	if err == nil || classification == "rbac" {
+		return runtimeAuthProbeCooldown
+	}
+	return runtimeAuthInconclusiveProbeCooldown
+}
+
+func runtimeAuthCandidateIsCurrent(generation uint64) bool {
+	if activeContextOperations.Load() != 0 {
+		return false
+	}
+	clientMu.RLock()
+	isInCluster := isInClusterLocked()
+	isCurrent := !isInCluster && activeClientGeneration == generation
+	clientMu.RUnlock()
+	return isCurrent && GetConnectionStatus().State == StateConnected
+}
+
+func getRuntimeAuthProbe() func(context.Context) error {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	return runtimeAuthProbe
+}
+
+func setRuntimeAuthProbe(probe func(context.Context) error) {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	runtimeAuthProbe = probe
+}
+
+func getRuntimeAuthEndpointProbe() func(context.Context, *rest.Config) error {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	return runtimeAuthEndpointProbe
+}
+
+func setRuntimeAuthEndpointProbe(probe func(context.Context, *rest.Config) error) {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	runtimeAuthEndpointProbe = probe
+}
+
+func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) error {
+	if config == nil {
+		return errors.New("Kubernetes config is not initialized")
+	}
+	rawHost := strings.TrimSpace(config.Host)
+	if rawHost == "" {
+		return errors.New("Kubernetes API host is empty")
+	}
+	if !strings.Contains(rawHost, "://") {
+		rawHost = "https://" + rawHost
+	}
+	endpoint, err := url.Parse(rawHost)
+	if err != nil || endpoint.Hostname() == "" {
+		return fmt.Errorf("invalid Kubernetes API host %q", config.Host)
+	}
+
+	probeConfig := rest.CopyConfig(config)
+	probeConfig.Host = strings.TrimRight(rawHost, "/")
+	probeConfig.Username = ""
+	probeConfig.Password = ""
+	probeConfig.BearerToken = ""
+	probeConfig.BearerTokenFile = ""
+	probeConfig.AuthProvider = nil
+	probeConfig.ExecProvider = nil
+	probeConfig.Impersonate = rest.ImpersonationConfig{}
+	probeConfig.Timeout = runtimeAuthEndpointProbeTimeout
+	httpClient, err := rest.HTTPClientFor(probeConfig)
+	if err != nil {
+		return err
+	}
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeConfig.Host+"/version", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+func transitionConnectedToRuntimeAuthFailure(err error) bool {
+	connectionStatusMu.Lock()
+	if connectionStatus.State != StateConnected {
+		connectionStatusMu.Unlock()
+		return false
+	}
+	status := ConnectionStatus{
+		State:       StateDisconnected,
+		Context:     connectionStatus.Context,
+		ClusterName: connectionStatus.ClusterName,
+		Error:       err.Error(),
+		ErrorType:   "auth",
+	}
+	connectionStatus = status
+	connectionStatusMu.Unlock()
+
+	notifyConnectionChange(status)
+	return true
+}

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -145,9 +145,9 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	if !current {
 		return
 	}
-	defer cancel()
 	probe := getRuntimeAuthProbe()
 	err := probe(ctx)
+	cancel()
 	if ClassifyError(err) != "auth" {
 		runtimeAuthChecksMu.Lock()
 		runtimeAuthProbeAfter[generation] = time.Now().Add(runtimeAuthCooldown(err))
@@ -158,7 +158,10 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	}
 
 	endpointConfig, _ := GetConfigSnapshot()
-	endpointCtx, endpointCancel := context.WithTimeout(ctx, runtimeAuthEndpointProbeTimeout)
+	endpointCtx, endpointCancel, current := newOperationContextForGeneration(operationGeneration, runtimeAuthEndpointProbeTimeout)
+	if !current {
+		return
+	}
 	endpointErr := getRuntimeAuthEndpointProbe()(endpointCtx, endpointConfig)
 	endpointCancel()
 	if endpointErr != nil {

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -232,7 +232,7 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	CancelOngoingOperations()
 	stopActiveSessions()
 	ResetAllSubsystems()
-	startRuntimeAuthRecovery(currentContext)
+	startRuntimeAuthRecovery()
 }
 
 func setRuntimeAuthCooldown(generation uint64, cooldown time.Duration) {

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -176,7 +176,7 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	contextOpMu.Lock()
 	defer contextOpMu.Unlock()
 
-	if !runtimeAuthCandidateIsCurrent(generation) || currentOperationGen() != operationGeneration {
+	if !runtimeAuthStateIsCurrent(generation) || currentOperationGen() != operationGeneration {
 		return
 	}
 	if !transitionConnectedToRuntimeAuthFailure(err) {
@@ -203,6 +203,10 @@ func runtimeAuthCandidateIsCurrent(generation uint64) bool {
 	if activeContextOperations.Load() != 0 {
 		return false
 	}
+	return runtimeAuthStateIsCurrent(generation)
+}
+
+func runtimeAuthStateIsCurrent(generation uint64) bool {
 	clientMu.RLock()
 	isInCluster := isInClusterLocked()
 	isCurrent := !isInCluster && activeClientGeneration == generation

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -28,19 +28,30 @@ type sharedKubernetesClients struct {
 const (
 	runtimeAuthProbeCooldown             = 30 * time.Second
 	runtimeAuthInconclusiveProbeCooldown = 5 * time.Second
-	runtimeAuthEndpointProbeTimeout      = 2 * time.Second
+	// Must fit a full TLS handshake + response on high-RTT links: the
+	// confirmation probe has already proven the failure within its own 5s
+	// budget, and a shorter endpoint budget would let slow-but-healthy
+	// networks veto every demotion as "inconclusive" forever.
+	runtimeAuthEndpointProbeTimeout = 5 * time.Second
 )
 
 var (
 	clientGenerationCounter atomic.Uint64
+	// Guarded by clientMu (written in doInit/SwitchContext, read via
+	// runtimeAuthStateIsCurrent) — not an atomic like its neighbors.
 	activeClientGeneration  uint64
 	discoveryRequestTimeout = 32 * time.Second
 
-	runtimeAuthChecksMu      sync.Mutex
-	runtimeAuthChecks        = make(map[uint64]struct{})
-	runtimeAuthProbeAfter    = make(map[uint64]time.Time)
-	runtimeAuthProbe         = TestClusterConnection
-	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
+	runtimeAuthChecksMu sync.Mutex
+	runtimeAuthChecks   = make(map[uint64]struct{})
+	// Cooldown for the single generation that can currently report (older
+	// generations are rejected by runtimeAuthCandidateIsCurrent, so one
+	// scalar pair suffices where a per-generation map would only accrete
+	// garbage).
+	runtimeAuthCooldownGeneration uint64
+	runtimeAuthProbeNotBefore     time.Time
+	runtimeAuthProbe              = TestClusterConnection
+	runtimeAuthEndpointProbe      = defaultRuntimeAuthEndpointProbe
 )
 
 func newSharedKubernetesClients(config *rest.Config) (*sharedKubernetesClients, error) {
@@ -54,6 +65,9 @@ func newSharedKubernetesClients(config *rest.Config) (*sharedKubernetesClients, 
 	}
 
 	generation := clientGenerationCounter.Add(1)
+	// Struct copy matters: rest.HTTPClientFor returns http.DefaultClient
+	// itself for default transports, and swapping Transport in place would
+	// mutate the process-wide client.
 	observedClient := *httpClient
 	transport := httpClient.Transport
 	if transport == nil {
@@ -63,6 +77,11 @@ func newSharedKubernetesClients(config *rest.Config) (*sharedKubernetesClients, 
 		next:       transport,
 		generation: generation,
 	}
+	// The discovery client needs its own shallow copy: client-go applies its
+	// 32s discovery default only when it builds the http.Client itself, so a
+	// caller-supplied client must replicate it — and the Timeout must NOT land
+	// on the shared observedClient, where it would kill long-lived watch and
+	// exec streams.
 	observedDiscoveryClient := observedClient
 	if observedDiscoveryClient.Timeout == 0 {
 		observedDiscoveryClient.Timeout = discoveryRequestTimeout
@@ -96,9 +115,17 @@ type runtimeAuthRoundTripper struct {
 
 func (rt *runtimeAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.next.RoundTrip(req)
+	// Two distinct shapes of credential loss: transport errors carry exec
+	// plugin failures (client-go surfaces them before any request is sent),
+	// while an expired-but-presentable token comes back as a plain 401
+	// response — at this layer it is not an error. 403 is deliberately not a
+	// candidate: RBAC denial is not credential loss.
 	if err != nil && ClassifyError(err) == "auth" {
 		reportRuntimeAuthFailure(rt.generation, err)
 	} else if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		// This synthetic message must keep classifying as "auth"
+		// (isAuthErrorMessage matches "unauthorized") or the report gate
+		// below drops it silently.
 		reportRuntimeAuthFailure(rt.generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
 	}
 	return resp, err
@@ -115,14 +142,9 @@ func reportRuntimeAuthFailure(generation uint64, candidate error) {
 		runtimeAuthChecksMu.Unlock()
 		return
 	}
-	if nextProbe, exists := runtimeAuthProbeAfter[generation]; exists && time.Now().Before(nextProbe) {
+	if runtimeAuthCooldownGeneration == generation && time.Now().Before(runtimeAuthProbeNotBefore) {
 		runtimeAuthChecksMu.Unlock()
 		return
-	}
-	for staleGeneration := range runtimeAuthProbeAfter {
-		if staleGeneration != generation {
-			delete(runtimeAuthProbeAfter, staleGeneration)
-		}
 	}
 	runtimeAuthChecks[generation] = struct{}{}
 	runtimeAuthChecksMu.Unlock()
@@ -149,15 +171,22 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	err := probe(ctx)
 	cancel()
 	if ClassifyError(err) != "auth" {
-		runtimeAuthChecksMu.Lock()
-		runtimeAuthProbeAfter[generation] = time.Now().Add(runtimeAuthCooldown(err))
-		runtimeAuthChecksMu.Unlock()
-		log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: confirmation classified %q",
-			SanitizeForLog(GetContextName()), ClassifyError(err))
+		setRuntimeAuthCooldown(generation, runtimeAuthCooldown(err))
+		if err == nil {
+			log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: credentials accepted by a fresh probe",
+				SanitizeForLog(GetContextName()))
+		} else {
+			log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: confirmation classified %q",
+				SanitizeForLog(GetContextName()), ClassifyError(err))
+		}
 		return
 	}
 
-	endpointConfig, _ := GetConfigSnapshot()
+	// Second gate: the anonymous endpoint probe separates "credentials died"
+	// from "machine is offline" — an unreachable IdP makes some exec plugin
+	// failures classify as auth, and demoting on those would tear down a
+	// healthy session over a VPN blip.
+	endpointConfig := GetConfig()
 	endpointCtx, endpointCancel, current := newOperationContextForGeneration(operationGeneration, runtimeAuthEndpointProbeTimeout)
 	if !current {
 		return
@@ -165,9 +194,7 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	endpointErr := getRuntimeAuthEndpointProbe()(endpointCtx, endpointConfig)
 	endpointCancel()
 	if endpointErr != nil {
-		runtimeAuthChecksMu.Lock()
-		runtimeAuthProbeAfter[generation] = time.Now().Add(runtimeAuthInconclusiveProbeCooldown)
-		runtimeAuthChecksMu.Unlock()
+		setRuntimeAuthCooldown(generation, runtimeAuthInconclusiveProbeCooldown)
 		log.Printf("[k8s] Runtime authentication candidate inconclusive for context %q: API endpoint is unreachable: %v",
 			SanitizeForLog(GetContextName()), endpointErr)
 		return
@@ -176,19 +203,43 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	contextOpMu.Lock()
 	defer contextOpMu.Unlock()
 
+	// Deliberately the WEAKER state check here (no activeContextOperations
+	// gate, unlike candidate intake): a queued context operation is blocked on
+	// contextOpMu right now and cannot abort a demotion that already holds the
+	// lock — the generation and operation-epoch re-checks are what invalidate
+	// a stale demotion.
 	if !runtimeAuthStateIsCurrent(generation) || currentOperationGen() != operationGeneration {
 		return
 	}
-	if !transitionConnectedToRuntimeAuthFailure(err) {
+	// The probe wraps every failure as "cluster unreachable: %w" — exactly the
+	// wrong headline for a credential failure, so surface the underlying error.
+	demotionErr := err
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		demotionErr = unwrapped
+	}
+	if !transitionConnectedToRuntimeAuthFailure(demotionErr) {
 		return
 	}
 
+	// The whole teardown below runs while holding contextOpMu: connection-change
+	// and before-switch callbacks must never take contextOpMu or trigger a
+	// synchronous context operation, or this deadlocks.
 	currentContext := GetContextName()
 	log.Printf("[k8s] Runtime Kubernetes authentication lost for context %q; stopping cluster-backed work", SanitizeForLog(currentContext))
+	// Quiesce-in-place: fired with the current context so registered
+	// consumers cancel cluster-bound work; no actual switch follows.
 	notifyBeforeContextSwitch(currentContext)
 	CancelOngoingOperations()
 	stopActiveSessions()
 	ResetAllSubsystems()
+	startRuntimeAuthRecovery(currentContext)
+}
+
+func setRuntimeAuthCooldown(generation uint64, cooldown time.Duration) {
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthCooldownGeneration = generation
+	runtimeAuthProbeNotBefore = time.Now().Add(cooldown)
+	runtimeAuthChecksMu.Unlock()
 }
 
 func runtimeAuthCooldown(err error) time.Duration {
@@ -199,6 +250,11 @@ func runtimeAuthCooldown(err error) time.Duration {
 	return runtimeAuthInconclusiveProbeCooldown
 }
 
+// runtimeAuthCandidateIsCurrent gates candidate INTAKE: a queued or in-flight
+// context operation either explains the auth failures or is about to replace
+// the client, so new candidates are refused while one is pending. Demotion
+// commit uses the weaker runtimeAuthStateIsCurrent instead — see
+// confirmRuntimeAuthFailure.
 func runtimeAuthCandidateIsCurrent(generation uint64) bool {
 	if activeContextOperations.Load() != 0 {
 		return false
@@ -209,6 +265,9 @@ func runtimeAuthCandidateIsCurrent(generation uint64) bool {
 func runtimeAuthStateIsCurrent(generation uint64) bool {
 	clientMu.RLock()
 	isInCluster := isInClusterLocked()
+	// In-cluster SA tokens are refreshed from disk by client-go, so
+	// credential loss there is transient by construction — demotion is a
+	// kubeconfig-mode concern only.
 	isCurrent := !isInCluster && activeClientGeneration == generation
 	clientMu.RUnlock()
 	return isCurrent && GetConnectionStatus().State == StateConnected
@@ -254,6 +313,9 @@ func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) e
 		return fmt.Errorf("invalid Kubernetes API host %q", config.Host)
 	}
 
+	// Strip every credential carrier so this is a pure reachability check —
+	// including client certs and transport wrappers, which CopyConfig carries
+	// over. Only the CA trust settings survive.
 	probeConfig := rest.CopyConfig(config)
 	probeConfig.Host = strings.TrimRight(rawHost, "/")
 	probeConfig.Username = ""
@@ -263,11 +325,20 @@ func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) e
 	probeConfig.AuthProvider = nil
 	probeConfig.ExecProvider = nil
 	probeConfig.Impersonate = rest.ImpersonationConfig{}
+	probeConfig.WrapTransport = nil
+	probeConfig.Transport = nil
+	probeConfig.TLSClientConfig.CertData = nil
+	probeConfig.TLSClientConfig.KeyData = nil
+	probeConfig.TLSClientConfig.CertFile = ""
+	probeConfig.TLSClientConfig.KeyFile = ""
 	probeConfig.Timeout = runtimeAuthEndpointProbeTimeout
 	httpClient, err := rest.HTTPClientFor(probeConfig)
 	if err != nil {
 		return err
 	}
+	// Any response — 401, or a 30x from an auth proxy fronting the apiserver —
+	// proves reachability. Following the redirect instead could chase a dead
+	// login portal and misread a reachable endpoint as unreachable.
 	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -26,13 +26,18 @@ type sharedKubernetesClients struct {
 }
 
 const (
-	runtimeAuthProbeCooldown             = 30 * time.Second
-	runtimeAuthInconclusiveProbeCooldown = 5 * time.Second
+	runtimeAuthProbeCooldown                = 30 * time.Second
+	runtimeAuthInconclusiveProbeCooldown    = 5 * time.Second
+	runtimeAuthInconclusiveProbeCooldownMax = 5 * time.Minute
 	// Must fit a full TLS handshake + response on high-RTT links: the
 	// confirmation probe has already proven the failure within its own 5s
 	// budget, and a shorter endpoint budget would let slow-but-healthy
 	// networks veto every demotion as "inconclusive" forever.
 	runtimeAuthEndpointProbeTimeout = 5 * time.Second
+
+	// Published instead of the raw probe error, which broadcasts to every SSE
+	// client and can embed credential material on exec-plugin failure paths.
+	runtimeAuthLostMessage = "Kubernetes credentials for this context are no longer valid; re-authenticate to reconnect"
 )
 
 var (
@@ -50,6 +55,7 @@ var (
 	// garbage).
 	runtimeAuthCooldownGeneration uint64
 	runtimeAuthProbeNotBefore     time.Time
+	runtimeAuthInconclusiveStreak int
 	runtimeAuthProbe              = TestClusterConnection
 	runtimeAuthEndpointProbe      = defaultRuntimeAuthEndpointProbe
 )
@@ -170,14 +176,23 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	probe := getRuntimeAuthProbe()
 	err := probe(ctx)
 	cancel()
-	if ClassifyError(err) != "auth" {
-		setRuntimeAuthCooldown(generation, runtimeAuthCooldown(err))
+	classification := ClassifyError(err)
+	// A hung exec plugin never produces an auth-classified error — the fresh
+	// probe times out inside the plugin instead ("auth plugin timeout", the
+	// exec-specific deadline branch). With the endpoint still reachable that
+	// IS a credential-system failure: without this, a wedged plugin keeps the
+	// UI "connected" while every request hangs behind client-go's shared
+	// plugin mutex.
+	hungPlugin := classification == "timeout" && err != nil && UsesExecAuth() &&
+		strings.Contains(err.Error(), "auth plugin timeout")
+	if classification != "auth" && !hungPlugin {
+		setRuntimeAuthCooldown(generation, runtimeAuthCooldown(err), true)
 		if err == nil {
 			log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: credentials accepted by a fresh probe",
 				SanitizeForLog(GetContextName()))
 		} else {
 			log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: confirmation classified %q",
-				SanitizeForLog(GetContextName()), ClassifyError(err))
+				SanitizeForLog(GetContextName()), classification)
 		}
 		return
 	}
@@ -194,9 +209,13 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	endpointErr := getRuntimeAuthEndpointProbe()(endpointCtx, endpointConfig)
 	endpointCancel()
 	if endpointErr != nil {
-		setRuntimeAuthCooldown(generation, runtimeAuthInconclusiveProbeCooldown)
+		// Escalating cooldown: an offline laptop otherwise re-runs the exec
+		// plugin every ~5s indefinitely, and a MITM that 401s credentialed
+		// requests while dropping the anonymous probe could pin that loop
+		// forever.
+		setRuntimeAuthCooldown(generation, nextInconclusiveCooldown(), false)
 		log.Printf("[k8s] Runtime authentication candidate inconclusive for context %q: API endpoint is unreachable: %v",
-			SanitizeForLog(GetContextName()), endpointErr)
+			SanitizeForLog(GetContextName()), SanitizeForLog(endpointErr.Error()))
 		return
 	}
 
@@ -211,13 +230,7 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	if !runtimeAuthStateIsCurrent(generation) || currentOperationGen() != operationGeneration {
 		return
 	}
-	// The probe wraps every failure as "cluster unreachable: %w" — exactly the
-	// wrong headline for a credential failure, so surface the underlying error.
-	demotionErr := err
-	if unwrapped := errors.Unwrap(err); unwrapped != nil {
-		demotionErr = unwrapped
-	}
-	if !transitionConnectedToRuntimeAuthFailure(demotionErr) {
+	if !transitionConnectedToRuntimeAuthFailure() {
 		return
 	}
 
@@ -225,7 +238,15 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	// and before-switch callbacks must never take contextOpMu or trigger a
 	// synchronous context operation, or this deadlocks.
 	currentContext := GetContextName()
-	log.Printf("[k8s] Runtime Kubernetes authentication lost for context %q; stopping cluster-backed work", SanitizeForLog(currentContext))
+	// The raw error stays in the log only — exec-plugin failures can embed
+	// credential material (a malformed plugin's stdout is quoted verbatim by
+	// client-go), and the published status broadcasts to every SSE client.
+	demotionErr := err
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		demotionErr = unwrapped
+	}
+	log.Printf("[k8s] Runtime Kubernetes authentication lost for context %q (%s); stopping cluster-backed work",
+		SanitizeForLog(currentContext), SanitizeForLog(demotionErr.Error()))
 	// Quiesce-in-place: fired with the current context so registered
 	// consumers cancel cluster-bound work; no actual switch follows.
 	notifyBeforeContextSwitch(currentContext)
@@ -235,11 +256,24 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	startRuntimeAuthRecovery()
 }
 
-func setRuntimeAuthCooldown(generation uint64, cooldown time.Duration) {
+func setRuntimeAuthCooldown(generation uint64, cooldown time.Duration, conclusive bool) {
 	runtimeAuthChecksMu.Lock()
 	runtimeAuthCooldownGeneration = generation
 	runtimeAuthProbeNotBefore = time.Now().Add(cooldown)
+	if conclusive {
+		runtimeAuthInconclusiveStreak = 0
+	}
 	runtimeAuthChecksMu.Unlock()
+}
+
+func nextInconclusiveCooldown() time.Duration {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	cooldown := min(runtimeAuthInconclusiveProbeCooldown<<runtimeAuthInconclusiveStreak, runtimeAuthInconclusiveProbeCooldownMax)
+	if runtimeAuthInconclusiveStreak < 30 {
+		runtimeAuthInconclusiveStreak++
+	}
+	return cooldown
 }
 
 func runtimeAuthCooldown(err error) time.Duration {
@@ -354,7 +388,7 @@ func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) e
 	return nil
 }
 
-func transitionConnectedToRuntimeAuthFailure(err error) bool {
+func transitionConnectedToRuntimeAuthFailure() bool {
 	connectionStatusMu.Lock()
 	if connectionStatus.State != StateConnected {
 		connectionStatusMu.Unlock()
@@ -364,12 +398,13 @@ func transitionConnectedToRuntimeAuthFailure(err error) bool {
 		State:       StateDisconnected,
 		Context:     connectionStatus.Context,
 		ClusterName: connectionStatus.ClusterName,
-		Error:       err.Error(),
+		Error:       runtimeAuthLostMessage,
 		ErrorType:   "auth",
 	}
 	connectionStatus = status
 	connectionStatusMu.Unlock()
 
+	runtimeAuthRecoveryOwed.Store(true)
 	notifyConnectionChange(status)
 	return true
 }

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -233,6 +233,10 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	if !transitionConnectedToRuntimeAuthFailure() {
 		return
 	}
+	// Demotion is a conclusive outcome: the next episode's inconclusive
+	// probes must restart from the short cooldown, not inherit this
+	// episode's escalated one.
+	resetInconclusiveStreak()
 
 	// The whole teardown below runs while holding contextOpMu: connection-change
 	// and before-switch callbacks must never take contextOpMu or trigger a
@@ -274,6 +278,12 @@ func nextInconclusiveCooldown() time.Duration {
 		runtimeAuthInconclusiveStreak++
 	}
 	return cooldown
+}
+
+func resetInconclusiveStreak() {
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthInconclusiveStreak = 0
+	runtimeAuthChecksMu.Unlock()
 }
 
 func runtimeAuthCooldown(err error) time.Duration {

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -91,7 +91,11 @@ func runRuntimeAuthRecovery() {
 		if status.State == StateConnecting || activeContextOperations.Load() != 0 {
 			// A connect attempt owns the moment (user-driven switch or retry);
 			// its failure republishes a disconnected status and the debt
-			// persists, so just check again next tick.
+			// persists, so check again soon. Don't re-sleep the accumulated
+			// backoff (worst case 30min): if the operation's failure publish
+			// is byte-identical to the current status, the dedupe in
+			// SetConnectionStatus means no nudge will arrive.
+			interval = initialInterval
 			continue
 		}
 		contextName := status.Context
@@ -99,7 +103,7 @@ func runRuntimeAuthRecovery() {
 		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
 		err := getRuntimeAuthProbe()(ctx)
 		cancel()
-		if err != nil && runtimeAuthCredentialsAreStatic() {
+		if err != nil && ClassifyError(err) == "auth" && runtimeAuthCredentialsAreStatic() {
 			// Probing the in-memory config can never observe new INLINE
 			// credentials (token:/client-certificate-data: are read once at
 			// connect), but a full reconnect re-reads the kubeconfig from

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -144,6 +145,15 @@ func runtimeAuthRecoveryStillOwed() bool {
 	return runtimeAuthRecoveryOwed.Load() && GetConnectionStatus().State != StateConnected
 }
 
+// RuntimeAuthRecoveryOwed reports whether the server-side reconnect loop owns
+// the current disconnect. The browser reads this to suppress its own auto-retry
+// for the whole episode — the live ErrorType can flip to non-auth values while
+// credentials are dead, and browser retries would re-invoke the exec plugin on
+// a much shorter cadence than the loop's backoff.
+func RuntimeAuthRecoveryOwed() bool {
+	return runtimeAuthRecoveryOwed.Load()
+}
+
 // Static means nothing in-process can mint fresh credentials: no exec plugin
 // to re-run, no auth provider to refresh, no token/cert file client-go
 // re-reads. Only a kubeconfig re-read (a full reconnect) can pick up new ones.
@@ -159,7 +169,13 @@ func runtimeAuthCredentialsAreStatic() bool {
 }
 
 func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterval, hungInterval time.Duration) time.Duration {
-	if ClassifyError(err) == "timeout" && UsesExecAuth() {
+	// The long interval is strictly for a wedged exec plugin (its marker is
+	// the exec-specific deadline branch) — a generic timeout under exec auth,
+	// e.g. a subsystem-init deadline during a reconnect whose credentials
+	// already worked, must keep the normal backoff or a transient stall
+	// costs headless deployments half an hour.
+	if err != nil && UsesExecAuth() && ClassifyError(err) == "timeout" &&
+		strings.Contains(strings.ToLower(err.Error()), "auth plugin timeout") {
 		return hungInterval
 	}
 	return min(current*2, maxInterval)

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log"
-	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -12,8 +11,10 @@ import (
 const (
 	defaultRuntimeAuthRecoveryInitialInterval = 30 * time.Second
 	defaultRuntimeAuthRecoveryMaxInterval     = 5 * time.Minute
-	// A hung exec plugin leaks a blocked goroutine and a child process per
-	// probe, so probing rarely bounds the leak while still self-healing.
+	// A hung exec plugin leaks a blocked goroutine per probe (client-go
+	// serializes plugin invocations process-wide, so at most one child
+	// process accumulates), and probing rarely bounds the leak while still
+	// self-healing.
 	defaultRuntimeAuthRecoveryHungInterval = 30 * time.Minute
 )
 
@@ -23,15 +24,24 @@ var (
 	runtimeAuthRecoveryHungInterval    = defaultRuntimeAuthRecoveryHungInterval
 
 	runtimeAuthRecoveryActive atomic.Bool
-	// Wakes a sleeping worker so a new auth-loss episode (possibly on a
-	// different context) isn't stuck waiting out the previous episode's
-	// backoff — worst case the 30min hung-plugin interval.
+	// Explicit recovery debt. The live ConnectionStatus.ErrorType cannot carry
+	// this: while credentials are dead it legitimately flips to non-auth
+	// values (a hung-plugin retry classifies "timeout", Helm handlers mark the
+	// cluster unreachable), and inferring exit from that string would kill the
+	// only reconnect path headless deployments have. Set on any auth-shaped
+	// disconnect, cleared only by a successful connect.
+	runtimeAuthRecoveryOwed atomic.Bool
+	// Wakes a sleeping worker so a new auth-loss episode isn't stuck waiting
+	// out the previous episode's backoff — worst case the 30min hung-plugin
+	// interval.
 	runtimeAuthRecoveryNudge = make(chan struct{}, 1)
-	runtimeAuthReconnect     = PerformContextSwitchIfOperationCurrent
+	// nil means PerformContextSwitchIfOperationCurrent; a direct initializer
+	// would form an init cycle through SetConnectionStatus's recovery hook.
+	runtimeAuthReconnect func(string, uint64) error
 )
 
 // startRuntimeAuthRecovery keeps a headless deployment (MCP-only, no browser
-// tab) from wedging permanently after an auth demotion: nothing else would
+// tab) from wedging permanently after an auth failure: nothing else would
 // ever retry once the user restores credentials, so the server re-probes on a
 // backoff and reconnects itself. Browser sessions benefit too — the reconnect
 // surfaces through SSE and the status poll. The worker reads its target from
@@ -48,31 +58,41 @@ func startRuntimeAuthRecovery() {
 }
 
 func runRuntimeAuthRecovery() {
-	defer runtimeAuthRecoveryActive.Store(false)
+	defer func() {
+		runtimeAuthRecoveryActive.Store(false)
+		// A demotion racing this exit saw the active flag still true and only
+		// nudged; re-check so its episode isn't stranded without a worker.
+		if runtimeAuthRecoveryStillOwed() {
+			startRuntimeAuthRecovery()
+		}
+	}()
 	initialInterval, maxInterval, hungInterval := runtimeAuthRecoveryIntervals()
 	interval := initialInterval
-	lastContext := ""
 	for {
 		select {
 		case <-time.After(interval):
 		case <-runtimeAuthRecoveryNudge:
+			// A nudge marks a new auth-loss episode; don't make it wait out
+			// the previous episode's backoff.
+			interval = initialInterval
 		}
-		contextName, needed := runtimeAuthRecoveryTarget()
-		if !needed {
+		if !runtimeAuthRecoveryOwed.Load() {
 			return
 		}
-		if contextName != lastContext {
-			// New episode (different context demoted while this worker was
-			// sleeping) — don't make it inherit the old episode's backoff.
-			interval = initialInterval
-			lastContext = contextName
+		status := GetConnectionStatus()
+		if status.State == StateConnected {
+			// The publish-side hook clears the debt on connect; this is a
+			// guard against direct status writes that bypass it.
+			runtimeAuthRecoveryOwed.Store(false)
+			return
 		}
-		if activeContextOperations.Load() != 0 {
-			// A user-driven switch or retry is queued or running; let it win
-			// this tick. If it fails, the demoted state persists and the loop
-			// re-checks next tick.
+		if status.State == StateConnecting || activeContextOperations.Load() != 0 {
+			// A connect attempt owns the moment (user-driven switch or retry);
+			// its failure republishes a disconnected status and the debt
+			// persists, so just check again next tick.
 			continue
 		}
+		contextName := status.Context
 		observedGen := currentOperationGen()
 		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
 		err := getRuntimeAuthProbe()(ctx)
@@ -85,7 +105,7 @@ func runRuntimeAuthRecovery() {
 		switchErr := getRuntimeAuthReconnect()(contextName, observedGen)
 		if errors.Is(switchErr, ErrReconnectSuperseded) {
 			// A user operation won the race; its outcome decides whether the
-			// next tick still sees a demoted state.
+			// debt persists.
 			continue
 		}
 		if switchErr != nil {
@@ -93,25 +113,14 @@ func runRuntimeAuthRecovery() {
 			interval = nextRuntimeAuthRecoveryInterval(interval, switchErr, maxInterval, hungInterval)
 			continue
 		}
-		// PerformContextSwitch rebuilds clients and caches but leaves status
-		// publication to its caller (the HTTP handlers do the same).
-		SetConnectionStatus(ConnectionStatus{
-			State:       StateConnected,
-			Context:     GetContextName(),
-			ClusterName: GetClusterName(),
-		})
+		// performContextSwitch published the connected status (and cleared
+		// the debt) while still holding contextOpMu.
 		return
 	}
 }
 
-// The ErrorType prefix check keeps the loop owning every auth-shaped
-// demotion variant without enumerating them.
-func runtimeAuthRecoveryTarget() (string, bool) {
-	status := GetConnectionStatus()
-	if status.State != StateDisconnected || !strings.HasPrefix(status.ErrorType, "auth") {
-		return "", false
-	}
-	return status.Context, true
+func runtimeAuthRecoveryStillOwed() bool {
+	return runtimeAuthRecoveryOwed.Load() && GetConnectionStatus().State != StateConnected
 }
 
 func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterval, hungInterval time.Duration) time.Duration {
@@ -130,6 +139,9 @@ func runtimeAuthRecoveryIntervals() (initial, maxInterval, hung time.Duration) {
 func getRuntimeAuthReconnect() func(string, uint64) error {
 	runtimeAuthChecksMu.Lock()
 	defer runtimeAuthChecksMu.Unlock()
+	if runtimeAuthReconnect == nil {
+		return PerformContextSwitchIfOperationCurrent
+	}
 	return runtimeAuthReconnect
 }
 

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -66,9 +66,11 @@ func runRuntimeAuthRecovery() {
 			startRuntimeAuthRecovery()
 		}
 	}()
-	initialInterval, maxInterval, hungInterval := runtimeAuthRecoveryIntervals()
-	interval := initialInterval
+	interval, _, _ := runtimeAuthRecoveryIntervals()
 	for {
+		// Re-read each pass: a worker can outlive the episode that started it
+		// and adopt the next one, which must not inherit a stale scale.
+		initialInterval, maxInterval, hungInterval := runtimeAuthRecoveryIntervals()
 		select {
 		case <-time.After(interval):
 		case <-runtimeAuthRecoveryNudge:
@@ -97,6 +99,21 @@ func runRuntimeAuthRecovery() {
 		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
 		err := getRuntimeAuthProbe()(ctx)
 		cancel()
+		if err != nil && runtimeAuthCredentialsAreStatic() {
+			// Probing the in-memory config can never observe new INLINE
+			// credentials (token:/client-certificate-data: are read once at
+			// connect), but a full reconnect re-reads the kubeconfig from
+			// disk. Without this, users whose re-login rewrites the file
+			// (oc login's daily tokens, a fresh k3s.yaml) never self-heal —
+			// the pre-recovery-loop browser retry re-read disk every attempt.
+			switchErr := getRuntimeAuthReconnect()(contextName, observedGen)
+			if switchErr == nil {
+				return
+			}
+			if !errors.Is(switchErr, ErrReconnectSuperseded) {
+				err = switchErr
+			}
+		}
 		if err != nil {
 			interval = nextRuntimeAuthRecoveryInterval(interval, err, maxInterval, hungInterval)
 			continue
@@ -121,6 +138,20 @@ func runRuntimeAuthRecovery() {
 
 func runtimeAuthRecoveryStillOwed() bool {
 	return runtimeAuthRecoveryOwed.Load() && GetConnectionStatus().State != StateConnected
+}
+
+// Static means nothing in-process can mint fresh credentials: no exec plugin
+// to re-run, no auth provider to refresh, no token/cert file client-go
+// re-reads. Only a kubeconfig re-read (a full reconnect) can pick up new ones.
+func runtimeAuthCredentialsAreStatic() bool {
+	config := GetConfig()
+	if config == nil {
+		return false
+	}
+	return config.ExecProvider == nil &&
+		config.AuthProvider == nil &&
+		config.BearerTokenFile == "" &&
+		config.TLSClientConfig.CertFile == ""
 }
 
 func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterval, hungInterval time.Duration) time.Duration {

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -1,0 +1,106 @@
+package k8s
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultRuntimeAuthRecoveryInitialInterval = 30 * time.Second
+	defaultRuntimeAuthRecoveryMaxInterval     = 5 * time.Minute
+	// A hung exec plugin leaks a blocked goroutine and a child process per
+	// probe, so probing rarely bounds the leak while still self-healing.
+	defaultRuntimeAuthRecoveryHungInterval = 30 * time.Minute
+)
+
+var (
+	runtimeAuthRecoveryInitialInterval = defaultRuntimeAuthRecoveryInitialInterval
+	runtimeAuthRecoveryMaxInterval     = defaultRuntimeAuthRecoveryMaxInterval
+	runtimeAuthRecoveryHungInterval    = defaultRuntimeAuthRecoveryHungInterval
+
+	runtimeAuthRecoveryActive atomic.Bool
+	runtimeAuthReconnect      = PerformContextSwitch
+)
+
+// startRuntimeAuthRecovery keeps a headless deployment (MCP-only, no browser
+// tab) from wedging permanently after an auth demotion: nothing else would
+// ever retry once the user restores credentials, so the server re-probes on a
+// backoff and reconnects itself. Browser sessions benefit too — the reconnect
+// surfaces through SSE and the status poll.
+func startRuntimeAuthRecovery(contextName string) {
+	if !runtimeAuthRecoveryActive.CompareAndSwap(false, true) {
+		return
+	}
+	go runRuntimeAuthRecovery(contextName)
+}
+
+func runRuntimeAuthRecovery(contextName string) {
+	defer runtimeAuthRecoveryActive.Store(false)
+	initialInterval, maxInterval, hungInterval := runtimeAuthRecoveryIntervals()
+	interval := initialInterval
+	for {
+		time.Sleep(interval)
+		if !runtimeAuthRecoveryStillNeeded(contextName) {
+			return
+		}
+		if activeContextOperations.Load() != 0 {
+			// A user-driven switch or retry is queued or running; let it win
+			// this tick. If it fails, the demoted state persists and the loop
+			// re-checks next tick.
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
+		err := getRuntimeAuthProbe()(ctx)
+		cancel()
+		if err == nil {
+			if !runtimeAuthRecoveryStillNeeded(contextName) {
+				return
+			}
+			log.Printf("[k8s] Credentials restored for context %q; reconnecting automatically", SanitizeForLog(contextName))
+			if switchErr := getRuntimeAuthReconnect()(contextName); switchErr != nil {
+				log.Printf("[k8s] Automatic reconnect failed for context %q: %v", SanitizeForLog(contextName), switchErr)
+				interval = nextRuntimeAuthRecoveryInterval(interval, switchErr, maxInterval, hungInterval)
+				continue
+			}
+			return
+		}
+		interval = nextRuntimeAuthRecoveryInterval(interval, err, maxInterval, hungInterval)
+	}
+}
+
+func runtimeAuthRecoveryIntervals() (initial, maxInterval, hung time.Duration) {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	return runtimeAuthRecoveryInitialInterval, runtimeAuthRecoveryMaxInterval, runtimeAuthRecoveryHungInterval
+}
+
+// The ErrorType prefix check keeps the loop owning every auth-shaped
+// demotion variant without enumerating them.
+func runtimeAuthRecoveryStillNeeded(contextName string) bool {
+	status := GetConnectionStatus()
+	return status.State == StateDisconnected &&
+		status.Context == contextName &&
+		strings.HasPrefix(status.ErrorType, "auth")
+}
+
+func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterval, hungInterval time.Duration) time.Duration {
+	if ClassifyError(err) == "timeout" && UsesExecAuth() {
+		return hungInterval
+	}
+	return min(current*2, maxInterval)
+}
+
+func getRuntimeAuthReconnect() func(string) error {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	return runtimeAuthReconnect
+}
+
+func setRuntimeAuthReconnect(fn func(string) error) {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	runtimeAuthReconnect = fn
+}

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strings"
 	"sync/atomic"
@@ -22,29 +23,49 @@ var (
 	runtimeAuthRecoveryHungInterval    = defaultRuntimeAuthRecoveryHungInterval
 
 	runtimeAuthRecoveryActive atomic.Bool
-	runtimeAuthReconnect      = PerformContextSwitch
+	// Wakes a sleeping worker so a new auth-loss episode (possibly on a
+	// different context) isn't stuck waiting out the previous episode's
+	// backoff — worst case the 30min hung-plugin interval.
+	runtimeAuthRecoveryNudge = make(chan struct{}, 1)
+	runtimeAuthReconnect     = PerformContextSwitchIfOperationCurrent
 )
 
 // startRuntimeAuthRecovery keeps a headless deployment (MCP-only, no browser
 // tab) from wedging permanently after an auth demotion: nothing else would
 // ever retry once the user restores credentials, so the server re-probes on a
 // backoff and reconnects itself. Browser sessions benefit too — the reconnect
-// surfaces through SSE and the status poll.
-func startRuntimeAuthRecovery(contextName string) {
+// surfaces through SSE and the status poll. The worker reads its target from
+// the live connection status, so one worker serves consecutive episodes.
+func startRuntimeAuthRecovery() {
 	if !runtimeAuthRecoveryActive.CompareAndSwap(false, true) {
+		select {
+		case runtimeAuthRecoveryNudge <- struct{}{}:
+		default:
+		}
 		return
 	}
-	go runRuntimeAuthRecovery(contextName)
+	go runRuntimeAuthRecovery()
 }
 
-func runRuntimeAuthRecovery(contextName string) {
+func runRuntimeAuthRecovery() {
 	defer runtimeAuthRecoveryActive.Store(false)
 	initialInterval, maxInterval, hungInterval := runtimeAuthRecoveryIntervals()
 	interval := initialInterval
+	lastContext := ""
 	for {
-		time.Sleep(interval)
-		if !runtimeAuthRecoveryStillNeeded(contextName) {
+		select {
+		case <-time.After(interval):
+		case <-runtimeAuthRecoveryNudge:
+		}
+		contextName, needed := runtimeAuthRecoveryTarget()
+		if !needed {
 			return
+		}
+		if contextName != lastContext {
+			// New episode (different context demoted while this worker was
+			// sleeping) — don't make it inherit the old episode's backoff.
+			interval = initialInterval
+			lastContext = contextName
 		}
 		if activeContextOperations.Load() != 0 {
 			// A user-driven switch or retry is queued or running; let it win
@@ -52,38 +73,45 @@ func runRuntimeAuthRecovery(contextName string) {
 			// re-checks next tick.
 			continue
 		}
+		observedGen := currentOperationGen()
 		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
 		err := getRuntimeAuthProbe()(ctx)
 		cancel()
-		if err == nil {
-			if !runtimeAuthRecoveryStillNeeded(contextName) {
-				return
-			}
-			log.Printf("[k8s] Credentials restored for context %q; reconnecting automatically", SanitizeForLog(contextName))
-			if switchErr := getRuntimeAuthReconnect()(contextName); switchErr != nil {
-				log.Printf("[k8s] Automatic reconnect failed for context %q: %v", SanitizeForLog(contextName), switchErr)
-				interval = nextRuntimeAuthRecoveryInterval(interval, switchErr, maxInterval, hungInterval)
-				continue
-			}
-			return
+		if err != nil {
+			interval = nextRuntimeAuthRecoveryInterval(interval, err, maxInterval, hungInterval)
+			continue
 		}
-		interval = nextRuntimeAuthRecoveryInterval(interval, err, maxInterval, hungInterval)
+		log.Printf("[k8s] Credentials restored for context %q; reconnecting automatically", SanitizeForLog(contextName))
+		switchErr := getRuntimeAuthReconnect()(contextName, observedGen)
+		if errors.Is(switchErr, ErrReconnectSuperseded) {
+			// A user operation won the race; its outcome decides whether the
+			// next tick still sees a demoted state.
+			continue
+		}
+		if switchErr != nil {
+			log.Printf("[k8s] Automatic reconnect failed for context %q: %v", SanitizeForLog(contextName), switchErr)
+			interval = nextRuntimeAuthRecoveryInterval(interval, switchErr, maxInterval, hungInterval)
+			continue
+		}
+		// PerformContextSwitch rebuilds clients and caches but leaves status
+		// publication to its caller (the HTTP handlers do the same).
+		SetConnectionStatus(ConnectionStatus{
+			State:       StateConnected,
+			Context:     GetContextName(),
+			ClusterName: GetClusterName(),
+		})
+		return
 	}
-}
-
-func runtimeAuthRecoveryIntervals() (initial, maxInterval, hung time.Duration) {
-	runtimeAuthChecksMu.Lock()
-	defer runtimeAuthChecksMu.Unlock()
-	return runtimeAuthRecoveryInitialInterval, runtimeAuthRecoveryMaxInterval, runtimeAuthRecoveryHungInterval
 }
 
 // The ErrorType prefix check keeps the loop owning every auth-shaped
 // demotion variant without enumerating them.
-func runtimeAuthRecoveryStillNeeded(contextName string) bool {
+func runtimeAuthRecoveryTarget() (string, bool) {
 	status := GetConnectionStatus()
-	return status.State == StateDisconnected &&
-		status.Context == contextName &&
-		strings.HasPrefix(status.ErrorType, "auth")
+	if status.State != StateDisconnected || !strings.HasPrefix(status.ErrorType, "auth") {
+		return "", false
+	}
+	return status.Context, true
 }
 
 func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterval, hungInterval time.Duration) time.Duration {
@@ -93,13 +121,19 @@ func nextRuntimeAuthRecoveryInterval(current time.Duration, err error, maxInterv
 	return min(current*2, maxInterval)
 }
 
-func getRuntimeAuthReconnect() func(string) error {
+func runtimeAuthRecoveryIntervals() (initial, maxInterval, hung time.Duration) {
+	runtimeAuthChecksMu.Lock()
+	defer runtimeAuthChecksMu.Unlock()
+	return runtimeAuthRecoveryInitialInterval, runtimeAuthRecoveryMaxInterval, runtimeAuthRecoveryHungInterval
+}
+
+func getRuntimeAuthReconnect() func(string, uint64) error {
 	runtimeAuthChecksMu.Lock()
 	defer runtimeAuthChecksMu.Unlock()
 	return runtimeAuthReconnect
 }
 
-func setRuntimeAuthReconnect(fn func(string) error) {
+func setRuntimeAuthReconnect(fn func(string, uint64) error) {
 	runtimeAuthChecksMu.Lock()
 	defer runtimeAuthChecksMu.Unlock()
 	runtimeAuthReconnect = fn

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -106,6 +106,9 @@ func TestRuntimeAuthRoundTripperReportsUnauthorizedResponse(t *testing.T) {
 	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
 		t.Fatalf("connection status = %+v, want disconnected auth", status)
 	}
+	if !runtimeAuthRecoveryActive.Load() {
+		t.Fatal("demotion did not start the runtime auth recovery loop")
+	}
 }
 
 func TestSharedKubernetesClientsPreserveConfiguredTransport(t *testing.T) {
@@ -370,8 +373,12 @@ func TestRuntimeAuthFailureKeepsStateWhenEndpointIsUnreachable(t *testing.T) {
 		t.Fatalf("session stops = %d, want 0", sessionsStopped.Load())
 	}
 	runtimeAuthChecksMu.Lock()
-	nextProbe := runtimeAuthProbeAfter[generation]
+	cooldownGeneration := runtimeAuthCooldownGeneration
+	nextProbe := runtimeAuthProbeNotBefore
 	runtimeAuthChecksMu.Unlock()
+	if cooldownGeneration != generation {
+		t.Fatalf("cooldown generation = %d, want %d", cooldownGeneration, generation)
+	}
 	if remaining := time.Until(nextProbe); remaining <= 0 || remaining > runtimeAuthInconclusiveProbeCooldown {
 		t.Fatalf("next endpoint probe delay = %v, want within %v", remaining, runtimeAuthInconclusiveProbeCooldown)
 	}
@@ -644,6 +651,141 @@ func TestRuntimeAuthRecoveryRearmsThroughSwitchContext(t *testing.T) {
 	}
 }
 
+func TestRuntimeAuthCooldownExpiryReArmsDetection(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("dial tcp: connection refused")
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	if probes.Load() != 1 {
+		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
+	}
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	if probes.Load() != 1 {
+		t.Fatalf("probes during cooldown = %d, want still 1", probes.Load())
+	}
+
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthProbeNotBefore = time.Now().Add(-time.Second)
+	runtimeAuthChecksMu.Unlock()
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	if probes.Load() != 2 {
+		t.Fatalf("probes after cooldown expiry = %d, want 2", probes.Load())
+	}
+}
+
+func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		if probes.Add(1) < 3 {
+			return errors.New("getting credentials: exec plugin failed")
+		}
+		return nil
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(contextName string) error {
+		if contextName != "recovery-context" {
+			t.Errorf("reconnect context = %q, want %q", contextName, "recovery-context")
+		}
+		reconnects.Add(1)
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	startRuntimeAuthRecovery("recovery-context")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for reconnects.Load() == 0 || runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("recovery did not reconnect: probes=%d reconnects=%d active=%v",
+				probes.Load(), reconnects.Load(), runtimeAuthRecoveryActive.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if probes.Load() < 3 {
+		t.Fatalf("probes = %d, want >= 3 (failed probes back off before success)", probes.Load())
+	}
+	if reconnects.Load() != 1 {
+		t.Fatalf("reconnects = %d, want 1", reconnects.Load())
+	}
+}
+
+func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	setRuntimeAuthProbe(func(context.Context) error {
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(string) error {
+		reconnects.Add(1)
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	startRuntimeAuthRecovery("recovery-context")
+	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "recovery-context"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("recovery loop did not exit after connection recovered elsewhere")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if reconnects.Load() != 0 {
+		t.Fatalf("reconnects = %d, want 0", reconnects.Load())
+	}
+}
+
+func TestNextRuntimeAuthRecoveryInterval(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	maxInterval := defaultRuntimeAuthRecoveryMaxInterval
+	hungInterval := defaultRuntimeAuthRecoveryHungInterval
+	if got := nextRuntimeAuthRecoveryInterval(30*time.Second, errors.New("unauthorized"), maxInterval, hungInterval); got != time.Minute {
+		t.Fatalf("interval after auth failure = %v, want %v", got, time.Minute)
+	}
+	if got := nextRuntimeAuthRecoveryInterval(4*time.Minute, errors.New("unauthorized"), maxInterval, hungInterval); got != maxInterval {
+		t.Fatalf("interval at cap = %v, want %v", got, maxInterval)
+	}
+	withContextExecAuth(t, true)
+	if got := nextRuntimeAuthRecoveryInterval(30*time.Second, errors.New("auth plugin timeout: context deadline exceeded"), maxInterval, hungInterval); got != hungInterval {
+		t.Fatalf("interval after hung plugin = %v, want %v", got, hungInterval)
+	}
+}
+
+func setRuntimeAuthRecoveryIntervalsForTest(initial, maxInterval time.Duration) {
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthRecoveryInitialInterval = initial
+	runtimeAuthRecoveryMaxInterval = maxInterval
+	runtimeAuthChecksMu.Unlock()
+}
+
 func prepareRuntimeAuthTest(t *testing.T) uint64 {
 	t.Helper()
 	ResetTestState()
@@ -652,6 +794,9 @@ func prepareRuntimeAuthTest(t *testing.T) uint64 {
 	generation := clientGenerationCounter.Add(1)
 	clientMu.Lock()
 	previousPath := kubeconfigPath
+	// Without a kubeconfig path the package reads as in-cluster
+	// (isInClusterLocked), where runtimeAuthStateIsCurrent is always false and
+	// every assertion below would pass vacuously.
 	kubeconfigPath = "/tmp/radar-runtime-auth-test"
 	activeClientGeneration = generation
 	clientMu.Unlock()

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -377,6 +377,27 @@ func TestRuntimeAuthFailureKeepsStateWhenEndpointIsUnreachable(t *testing.T) {
 	}
 }
 
+func TestRuntimeAuthEndpointProbeGetsIndependentDeadline(t *testing.T) {
+	prepareRuntimeAuthTest(t)
+	operationGeneration := currentOperationGen()
+
+	confirmationCtx, confirmationCancel, current := newOperationContextForGeneration(operationGeneration, time.Millisecond)
+	if !current {
+		t.Fatal("confirmation context generation was unexpectedly stale")
+	}
+	<-confirmationCtx.Done()
+	confirmationCancel()
+
+	endpointCtx, endpointCancel, current := newOperationContextForGeneration(operationGeneration, time.Second)
+	if !current {
+		t.Fatal("endpoint context generation was unexpectedly stale")
+	}
+	defer endpointCancel()
+	if err := endpointCtx.Err(); err != nil {
+		t.Fatalf("endpoint context inherited the exhausted confirmation deadline: %v", err)
+	}
+}
+
 func TestDefaultRuntimeAuthEndpointProbeSkipsExecAuthentication(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -506,6 +506,53 @@ func TestRuntimeAuthFailureIgnoresActiveContextOperation(t *testing.T) {
 	}
 }
 
+func TestRuntimeAuthFailureWinsAgainstQueuedContextOperation(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	setRuntimeAuthProbe(func(context.Context) error {
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	endpointReached := make(chan struct{})
+	releaseEndpoint := make(chan struct{})
+	setRuntimeAuthEndpointProbe(func(context.Context, *rest.Config) error {
+		close(endpointReached)
+		<-releaseEndpoint
+		return nil
+	})
+	sessionStopped := make(chan struct{}, 1)
+	SetSessionStopper(func() { sessionStopped <- struct{}{} })
+	t.Cleanup(func() { SetSessionStopper(nil) })
+
+	contextOpMu.Lock()
+	mutexLocked := true
+	defer func() {
+		if mutexLocked {
+			contextOpMu.Unlock()
+		}
+	}()
+
+	reportRuntimeAuthFailure(generation, errors.New("getting credentials: exec plugin failed"))
+	select {
+	case <-endpointReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime auth endpoint probe did not start")
+	}
+	activeContextOperations.Add(1)
+	t.Cleanup(func() { activeContextOperations.Add(-1) })
+	close(releaseEndpoint)
+	contextOpMu.Unlock()
+	mutexLocked = false
+
+	select {
+	case <-sessionStopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued context operation prevented runtime auth teardown")
+	}
+	waitForRuntimeAuthCheck(t, generation)
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	}
+}
+
 func TestRuntimeAuthFailureDoesNotTearDownRecoveredClient(t *testing.T) {
 	generation := prepareRuntimeAuthTest(t)
 	probeStarted := make(chan struct{})

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1,0 +1,759 @@
+package k8s
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestRuntimeAuthRoundTripperPreservesResults(t *testing.T) {
+	t.Run("transport error", func(t *testing.T) {
+		wantErr := errors.New("getting credentials: exec: executable plugin failed with exit code 1")
+		rt := &runtimeAuthRoundTripper{
+			next: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return nil, wantErr
+			}),
+			generation: 99,
+		}
+
+		resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster.test/version", nil))
+		if resp != nil || !errors.Is(err, wantErr) {
+			t.Fatalf("RoundTrip() = (%v, %v), want (nil, original error)", resp, err)
+		}
+	})
+
+	t.Run("401 response", func(t *testing.T) {
+		wantResp := &http.Response{StatusCode: http.StatusUnauthorized}
+		rt := &runtimeAuthRoundTripper{
+			next: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return wantResp, nil
+			}),
+			generation: 99,
+		}
+
+		resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster.test/version", nil))
+		if resp != wantResp || err != nil {
+			t.Fatalf("RoundTrip() = (%p, %v), want (%p, nil)", resp, err, wantResp)
+		}
+	})
+}
+
+func TestRuntimeAuthRoundTripperIgnoresForbidden(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("unauthorized")
+	})
+	rt := &runtimeAuthRoundTripper{
+		next: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusForbidden}, nil
+		}),
+		generation: generation,
+	}
+
+	resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster.test/version", nil))
+	if err != nil || resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("RoundTrip() = (%v, %v), want original 403 response", resp, err)
+	}
+	if probes.Load() != 0 {
+		t.Fatalf("confirmation probes = %d, want 0", probes.Load())
+	}
+}
+
+func TestRuntimeAuthRoundTripperReportsUnauthorizedResponse(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("unauthorized")
+	})
+	rt := &runtimeAuthRoundTripper{
+		next: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusUnauthorized}, nil
+		}),
+		generation: generation,
+	}
+
+	resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster.test/version", nil))
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("RoundTrip() = (%v, %v), want original 401 response", resp, err)
+	}
+	waitForRuntimeAuthCheck(t, generation)
+	if probes.Load() != 1 {
+		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
+	}
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	}
+}
+
+func TestSharedKubernetesClientsPreserveConfiguredTransport(t *testing.T) {
+	var wrappedCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"gitVersion":"v1.35.0"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	config := &rest.Config{
+		Host: server.URL,
+		WrapTransport: func(next http.RoundTripper) http.RoundTripper {
+			return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				wrappedCalls.Add(1)
+				return next.RoundTrip(req)
+			})
+		},
+	}
+	clients, err := newSharedKubernetesClients(config)
+	if err != nil {
+		t.Fatalf("newSharedKubernetesClients() error = %v", err)
+	}
+
+	if _, err := clients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err != nil {
+		t.Fatalf("GET /version error = %v", err)
+	}
+	if wrappedCalls.Load() != 1 {
+		t.Fatalf("configured transport calls = %d, want 1", wrappedCalls.Load())
+	}
+}
+
+func TestSharedKubernetesClientsPreserveUserAgent(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{name: "default", want: rest.DefaultKubernetesUserAgent()},
+		{name: "configured", configured: "radar-runtime-auth-test", want: "radar-runtime-auth-test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userAgent := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				userAgent <- r.Header.Get("User-Agent")
+				_, _ = w.Write([]byte(`{"gitVersion":"v1.35.0"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			clients, err := newSharedKubernetesClients(&rest.Config{
+				Host:      server.URL,
+				UserAgent: tt.configured,
+			})
+			if err != nil {
+				t.Fatalf("newSharedKubernetesClients() error = %v", err)
+			}
+			if _, err := clients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err != nil {
+				t.Fatalf("GET /version error = %v", err)
+			}
+			if got := <-userAgent; got != tt.want {
+				t.Fatalf("User-Agent = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSharedKubernetesClientsPreserveDiscoveryTimeout(t *testing.T) {
+	previousTimeout := discoveryRequestTimeout
+	discoveryRequestTimeout = 25 * time.Millisecond
+	t.Cleanup(func() { discoveryRequestTimeout = previousTimeout })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(3 * discoveryRequestTimeout)
+		_, _ = w.Write([]byte(`{"gitVersion":"v1.35.0"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	clients, err := newSharedKubernetesClients(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("newSharedKubernetesClients() error = %v", err)
+	}
+
+	if _, err := clients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err != nil {
+		t.Fatalf("clientset request unexpectedly inherited discovery timeout: %v", err)
+	}
+	if _, err := clients.discovery.RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err == nil {
+		t.Fatal("discovery request did not honor its default timeout")
+	}
+}
+
+func TestSharedKubernetesClientsDoNotMutateDefaultHTTPClient(t *testing.T) {
+	originalTransport := http.DefaultClient.Transport
+	clients, err := newSharedKubernetesClients(&rest.Config{Host: "http://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("newSharedKubernetesClients() error = %v", err)
+	}
+	if clients == nil {
+		t.Fatal("newSharedKubernetesClients() returned nil")
+	}
+	if http.DefaultClient.Transport != originalTransport {
+		t.Fatal("newSharedKubernetesClients() mutated http.DefaultClient.Transport")
+	}
+}
+
+func TestRuntimeAuthFailureRequiresPersistentAuthFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		probeErr error
+	}{
+		{name: "credential refresh succeeds"},
+		{name: "forbidden", probeErr: apierrors.NewForbidden(clientcmdapi.SchemeGroupVersion.WithResource("pods").GroupResource(), "", errors.New("denied"))},
+		{name: "network", probeErr: errors.New("dial tcp: connection refused")},
+		{name: "timeout", probeErr: context.DeadlineExceeded},
+		{name: "tls", probeErr: x509.UnknownAuthorityError{}},
+		{name: "unknown", probeErr: errors.New("temporary server failure")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generation := prepareRuntimeAuthTest(t)
+			probeReturned := make(chan struct{})
+			setRuntimeAuthProbe(func(context.Context) error {
+				defer close(probeReturned)
+				return tt.probeErr
+			})
+
+			reportRuntimeAuthFailure(generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
+			select {
+			case <-probeReturned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("runtime auth confirmation probe did not run")
+			}
+			waitForRuntimeAuthCheck(t, generation)
+
+			if got := GetConnectionStatus().State; got != StateConnected {
+				t.Fatalf("connection state = %q, want %q", got, StateConnected)
+			}
+		})
+	}
+}
+
+func TestRuntimeAuthFailureThrottlesDismissedCandidates(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return nil
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+
+	if probes.Load() != 1 {
+		t.Fatalf("confirmation probes = %d, want 1 during cooldown", probes.Load())
+	}
+}
+
+func TestRuntimeAuthCooldown(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{name: "credential refresh succeeds", want: runtimeAuthProbeCooldown},
+		{
+			name: "credential accepted but forbidden",
+			err:  apierrors.NewForbidden(clientcmdapi.SchemeGroupVersion.WithResource("pods").GroupResource(), "", errors.New("denied")),
+			want: runtimeAuthProbeCooldown,
+		},
+		{name: "network is inconclusive", err: errors.New("dial tcp: connection refused"), want: runtimeAuthInconclusiveProbeCooldown},
+		{name: "timeout is inconclusive", err: context.DeadlineExceeded, want: runtimeAuthInconclusiveProbeCooldown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimeAuthCooldown(tt.err); got != tt.want {
+				t.Fatalf("runtimeAuthCooldown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeAuthFailureDemotesAndQuiescesOnce(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("getting credentials: exec: executable gke-gcloud-auth-plugin failed with exit code 1")
+	})
+
+	var callbacks atomic.Int32
+	OnConnectionChange(func(status ConnectionStatus) {
+		if status.State == StateDisconnected {
+			callbacks.Add(1)
+		}
+	})
+	sessionStopped := make(chan struct{}, 1)
+	SetSessionStopper(func() {
+		select {
+		case sessionStopped <- struct{}{}:
+		default:
+		}
+	})
+	t.Cleanup(func() { SetSessionStopper(nil) })
+
+	var callers sync.WaitGroup
+	for range 20 {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			reportRuntimeAuthFailure(generation, errors.New("getting credentials: exec plugin failed"))
+		}()
+	}
+	callers.Wait()
+
+	select {
+	case <-sessionStopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime auth teardown did not stop sessions")
+	}
+	waitForRuntimeAuthCheck(t, generation)
+
+	status := GetConnectionStatus()
+	if status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	}
+	if callbacks.Load() != 1 {
+		t.Fatalf("disconnected callbacks = %d, want 1", callbacks.Load())
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
+	}
+}
+
+func TestRuntimeAuthFailureKeepsStateWhenEndpointIsUnreachable(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	setRuntimeAuthProbe(func(context.Context) error {
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	var endpointProbes atomic.Int32
+	setRuntimeAuthEndpointProbe(func(context.Context, *rest.Config) error {
+		endpointProbes.Add(1)
+		return errors.New("dial tcp: network is unreachable")
+	})
+	var sessionsStopped atomic.Int32
+	SetSessionStopper(func() { sessionsStopped.Add(1) })
+	t.Cleanup(func() { SetSessionStopper(nil) })
+
+	reportRuntimeAuthFailure(generation, errors.New("getting credentials: exec plugin failed"))
+	waitForRuntimeAuthCheck(t, generation)
+
+	if got := GetConnectionStatus().State; got != StateConnected {
+		t.Fatalf("connection state = %q, want %q", got, StateConnected)
+	}
+	if endpointProbes.Load() != 1 {
+		t.Fatalf("endpoint probes = %d, want 1", endpointProbes.Load())
+	}
+	if sessionsStopped.Load() != 0 {
+		t.Fatalf("session stops = %d, want 0", sessionsStopped.Load())
+	}
+	runtimeAuthChecksMu.Lock()
+	nextProbe := runtimeAuthProbeAfter[generation]
+	runtimeAuthChecksMu.Unlock()
+	if remaining := time.Until(nextProbe); remaining <= 0 || remaining > runtimeAuthInconclusiveProbeCooldown {
+		t.Fatalf("next endpoint probe delay = %v, want within %v", remaining, runtimeAuthInconclusiveProbeCooldown)
+	}
+}
+
+func TestDefaultRuntimeAuthEndpointProbeSkipsExecAuthentication(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	err := defaultRuntimeAuthEndpointProbe(context.Background(), &rest.Config{
+		Host: server.URL,
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command:         "/does/not/exist",
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+		},
+	})
+	if err != nil {
+		t.Fatalf("defaultRuntimeAuthEndpointProbe() error = %v, want reachable endpoint", err)
+	}
+}
+
+func TestRuntimeAuthFailureIgnoresInClusterAndStaleClients(t *testing.T) {
+	t.Run("in cluster", func(t *testing.T) {
+		generation := prepareRuntimeAuthTest(t)
+		clientMu.Lock()
+		ForceInCluster = true
+		clientMu.Unlock()
+		t.Cleanup(func() {
+			clientMu.Lock()
+			ForceInCluster = false
+			clientMu.Unlock()
+		})
+		var probes atomic.Int32
+		setRuntimeAuthProbe(func(context.Context) error {
+			probes.Add(1)
+			return errors.New("unauthorized")
+		})
+
+		reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+
+		if probes.Load() != 0 {
+			t.Fatalf("confirmation probes = %d, want 0", probes.Load())
+		}
+		if got := GetConnectionStatus().State; got != StateConnected {
+			t.Fatalf("connection state = %q, want %q", got, StateConnected)
+		}
+	})
+
+	t.Run("stale generation", func(t *testing.T) {
+		generation := prepareRuntimeAuthTest(t)
+		var probes atomic.Int32
+		setRuntimeAuthProbe(func(context.Context) error {
+			probes.Add(1)
+			return errors.New("unauthorized")
+		})
+
+		reportRuntimeAuthFailure(generation-1, errors.New("unauthorized"))
+
+		if probes.Load() != 0 {
+			t.Fatalf("confirmation probes = %d, want 0", probes.Load())
+		}
+		if got := GetConnectionStatus().State; got != StateConnected {
+			t.Fatalf("connection state = %q, want %q", got, StateConnected)
+		}
+	})
+}
+
+func TestRuntimeAuthFailureIgnoresNonConnectedState(t *testing.T) {
+	for _, state := range []ConnectionState{StateConnecting, StateDisconnected} {
+		t.Run(string(state), func(t *testing.T) {
+			generation := prepareRuntimeAuthTest(t)
+			SetConnectionStatus(ConnectionStatus{State: state, Context: "test-context"})
+			var probes atomic.Int32
+			setRuntimeAuthProbe(func(context.Context) error {
+				probes.Add(1)
+				return errors.New("unauthorized")
+			})
+
+			reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+
+			if probes.Load() != 0 {
+				t.Fatalf("confirmation probes = %d, want 0", probes.Load())
+			}
+			if got := GetConnectionStatus().State; got != state {
+				t.Fatalf("connection state = %q, want %q", got, state)
+			}
+		})
+	}
+}
+
+func TestRuntimeAuthFailureIgnoresActiveContextOperation(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	activeContextOperations.Add(1)
+	t.Cleanup(func() { activeContextOperations.Add(-1) })
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("unauthorized")
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+
+	if probes.Load() != 0 {
+		t.Fatalf("confirmation probes = %d, want 0", probes.Load())
+	}
+	if got := GetConnectionStatus().State; got != StateConnected {
+		t.Fatalf("connection state = %q, want %q", got, StateConnected)
+	}
+}
+
+func TestRuntimeAuthFailureDoesNotTearDownRecoveredClient(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	setRuntimeAuthProbe(func(context.Context) error {
+		close(probeStarted)
+		<-releaseProbe
+		return errors.New("getting credentials: exec plugin failed")
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("getting credentials: exec plugin failed"))
+	select {
+	case <-probeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime auth confirmation probe did not start")
+	}
+
+	contextOpMu.Lock()
+	CancelOngoingOperations()
+	clientMu.Lock()
+	activeClientGeneration = generation + 1
+	clientMu.Unlock()
+	contextOpMu.Unlock()
+	close(releaseProbe)
+	waitForRuntimeAuthCheck(t, generation)
+
+	if got := GetConnectionStatus().State; got != StateConnected {
+		t.Fatalf("connection state = %q, want %q", got, StateConnected)
+	}
+}
+
+func TestRuntimeAuthRecoveryRearmsThroughSwitchContext(t *testing.T) {
+	oldGeneration := prepareRuntimeAuthTest(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"gitVersion":"v1.35.0"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	kubeconfigFile := t.TempDir() + "/config"
+	if err := clientcmd.WriteToFile(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"recovered": {Server: server.URL},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"recovered": {Token: "test-token"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"recovered": {
+				Cluster:  "recovered",
+				AuthInfo: "recovered",
+			},
+		},
+		CurrentContext: "recovered",
+	}, kubeconfigFile); err != nil {
+		t.Fatalf("write recovery kubeconfig error = %v", err)
+	}
+	clientMu.Lock()
+	kubeconfigPath = kubeconfigFile
+	clientMu.Unlock()
+	if err := SwitchContext("recovered"); err != nil {
+		t.Fatalf("SwitchContext() error = %v", err)
+	}
+	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "recovered"})
+
+	clientMu.RLock()
+	recoveredGeneration := activeClientGeneration
+	clientMu.RUnlock()
+	if recoveredGeneration == oldGeneration {
+		t.Fatal("SwitchContext() did not publish a new client generation")
+	}
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("unauthorized")
+	})
+	reportRuntimeAuthFailure(oldGeneration, errors.New("unauthorized"))
+	if probes.Load() != 0 || GetConnectionStatus().State != StateConnected {
+		t.Fatal("stale pre-recovery generation was not ignored")
+	}
+
+	reportRuntimeAuthFailure(recoveredGeneration, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, recoveredGeneration)
+	if probes.Load() != 1 {
+		t.Fatalf("recovered generation probes = %d, want 1", probes.Load())
+	}
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	}
+}
+
+func prepareRuntimeAuthTest(t *testing.T) uint64 {
+	t.Helper()
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	generation := clientGenerationCounter.Add(1)
+	clientMu.Lock()
+	previousPath := kubeconfigPath
+	kubeconfigPath = "/tmp/radar-runtime-auth-test"
+	activeClientGeneration = generation
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		kubeconfigPath = previousPath
+		clientMu.Unlock()
+	})
+	SetConnectionStatus(ConnectionStatus{
+		State:       StateConnected,
+		Context:     "test-context",
+		ClusterName: "test-cluster",
+	})
+	setRuntimeAuthEndpointProbe(func(context.Context, *rest.Config) error { return nil })
+	return generation
+}
+
+func waitForRuntimeAuthCheck(t *testing.T, generation uint64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		runtimeAuthChecksMu.Lock()
+		_, running := runtimeAuthChecks[generation]
+		runtimeAuthChecksMu.Unlock()
+		if !running {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("runtime auth confirmation did not finish")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestRuntimeAuthExecCredentialHelper(t *testing.T) {
+	if os.Getenv("RADAR_RUNTIME_AUTH_HELPER") != "1" {
+		return
+	}
+	state, err := os.ReadFile(os.Getenv("RADAR_RUNTIME_AUTH_STATE"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if string(state) == "fail" {
+		fmt.Fprintln(os.Stderr, "reauthentication required")
+		os.Exit(1)
+	}
+
+	expiration := time.Now().Add(100 * time.Millisecond).UTC().Format(time.RFC3339Nano)
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"apiVersion": "client.authentication.k8s.io/v1",
+		"kind":       "ExecCredential",
+		"status": map[string]string{
+			"expirationTimestamp": expiration,
+			"token":               "runtime-auth-test-token",
+		},
+	})
+	os.Exit(0)
+}
+
+func TestRuntimeAuthExecCredentialExpiry(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	statePath := t.TempDir() + "/state"
+	if err := os.WriteFile(statePath, []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer runtime-auth-test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"gitVersion":"v1.35.0"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	config := &rest.Config{
+		Host: server.URL,
+		ExecProvider: &clientcmdapi.ExecConfig{
+			Command:         os.Args[0],
+			Args:            []string{"-test.run=^TestRuntimeAuthExecCredentialHelper$"},
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+			Env: []clientcmdapi.ExecEnvVar{
+				{Name: "RADAR_RUNTIME_AUTH_HELPER", Value: "1"},
+				{Name: "RADAR_RUNTIME_AUTH_STATE", Value: statePath},
+			},
+		},
+	}
+	clients, err := newSharedKubernetesClients(config)
+	if err != nil {
+		t.Fatalf("newSharedKubernetesClients() error = %v", err)
+	}
+	clientMu.Lock()
+	previousPath := kubeconfigPath
+	kubeconfigPath = statePath
+	k8sConfig = config
+	k8sClient = clients.clientset
+	discoveryClient = clients.discovery
+	dynamicClient = clients.dynamic
+	activeClientGeneration = clients.generation
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		kubeconfigPath = previousPath
+		clientMu.Unlock()
+	})
+	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "exec-test"})
+
+	if _, err := clients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err != nil {
+		t.Fatalf("initial GET /version error = %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(statePath, []byte("fail"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionStopped := make(chan struct{}, 1)
+	SetSessionStopper(func() { sessionStopped <- struct{}{} })
+	t.Cleanup(func() { SetSessionStopper(nil) })
+	_, requestErr := clients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background())
+	if ClassifyError(requestErr) != "auth" {
+		t.Fatalf("expired credential request error = %v, want auth", requestErr)
+	}
+	select {
+	case <-sessionStopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runtime exec credential failure did not quiesce Radar")
+	}
+	waitForRuntimeAuthCheck(t, clients.generation)
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	}
+
+	if err := os.WriteFile(statePath, []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recoveredClients, err := newSharedKubernetesClients(config)
+	if err != nil {
+		t.Fatalf("recreate clients after reauth error = %v", err)
+	}
+	if _, err := recoveredClients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background()); err != nil {
+		t.Fatalf("GET /version after reauth error = %v", err)
+	}
+
+	clientMu.Lock()
+	k8sConfig = config
+	k8sClient = recoveredClients.clientset
+	discoveryClient = recoveredClients.discovery
+	dynamicClient = recoveredClients.dynamic
+	activeClientGeneration = recoveredClients.generation
+	clientMu.Unlock()
+	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "exec-test"})
+
+	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(statePath, []byte("fail"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, requestErr = recoveredClients.clientset.Discovery().RESTClient().Get().AbsPath("/version").DoRaw(context.Background())
+	if ClassifyError(requestErr) != "auth" {
+		t.Fatalf("second expired credential request error = %v, want auth", requestErr)
+	}
+	select {
+	case <-sessionStopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second runtime exec credential failure did not quiesce Radar")
+	}
+	waitForRuntimeAuthCheck(t, recoveredClients.generation)
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("second connection status = %+v, want disconnected auth", status)
+	}
+}

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1186,6 +1186,74 @@ func TestRuntimeAuthRecoveryStaticCredentialsReconnectViaDiskReread(t *testing.T
 	}
 }
 
+func TestMarkDisconnectedAuthShapedMessageRoutesThroughDemotionPipeline(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	probeReturned := make(chan struct{}, 1)
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		select {
+		case probeReturned <- struct{}{}:
+		default:
+		}
+		return errors.New("dial tcp: connection refused")
+	})
+
+	marked := MarkDisconnectedIfClusterUnreachable(
+		`failed to list helm releases: Kubernetes cluster unreachable: Get "https://cluster.test/version": getting credentials: exec: executable aws failed with exit code 255`)
+	if marked {
+		t.Fatal("auth-shaped message must not mark disconnected directly — the pipeline decides")
+	}
+	select {
+	case <-probeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth-shaped message did not reach the demotion pipeline")
+	}
+	waitForRuntimeAuthCheck(t, generation)
+	if got := GetConnectionStatus().State; got != StateConnected {
+		t.Fatalf("state = %q, want %q (pipeline dismissed the candidate; no direct publish)", got, StateConnected)
+	}
+}
+
+func TestRuntimeAuthRecoveryStaticCredentialsSkipDiskRereadWhenOffline(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	clientMu.Lock()
+	k8sConfig = &rest.Config{Host: "https://cluster.test", BearerToken: "expired-inline-token"}
+	clientMu.Unlock()
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("dial tcp: connection refused")
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(string, uint64) error {
+		reconnects.Add(1)
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "openshift-context",
+		ErrorType: "auth",
+	})
+	waitForRecoveryWorker(t)
+
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if probes.Load() == 0 {
+		t.Fatal("recovery never probed")
+	}
+	if reconnects.Load() != 0 {
+		t.Fatalf("reconnects = %d, want 0 (a network failure cannot be fixed by a kubeconfig re-read)", reconnects.Load())
+	}
+}
+
 func TestRuntimeAuthRecoveryExecCredentialsSkipDiskRereadAttempts(t *testing.T) {
 	ResetTestState()
 	t.Cleanup(ResetTestState)

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1145,6 +1145,89 @@ func TestSetConnectionStatusStartsRecoveryForAuthPrefixedTypes(t *testing.T) {
 	waitForRecoveryWorker(t)
 }
 
+func TestRuntimeAuthRecoveryStaticCredentialsReconnectViaDiskReread(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	clientMu.Lock()
+	k8sConfig = &rest.Config{Host: "https://cluster.test", BearerToken: "expired-inline-token"}
+	clientMu.Unlock()
+
+	setRuntimeAuthProbe(func(context.Context) error {
+		return errors.New("Kubernetes API returned HTTP 401 Unauthorized")
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
+		// First attempt: kubeconfig still holds the dead token. Second:
+		// the user re-logged in and the disk re-read picks it up.
+		if reconnects.Add(1) == 1 {
+			return errors.New("cluster connection failed: Unauthorized")
+		}
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "openshift-context",
+		ErrorType: "auth",
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtimeAuthRecoveryActive.Load() || reconnects.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("static-credential recovery did not reconnect: reconnects=%d", reconnects.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if status := GetConnectionStatus(); status.State != StateConnected {
+		t.Fatalf("connection did not settle connected, got %+v", status)
+	}
+}
+
+func TestRuntimeAuthRecoveryExecCredentialsSkipDiskRereadAttempts(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	clientMu.Lock()
+	k8sConfig = &rest.Config{
+		Host:         "https://cluster.test",
+		ExecProvider: &clientcmdapi.ExecConfig{Command: "aws"},
+	}
+	clientMu.Unlock()
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(string, uint64) error {
+		reconnects.Add(1)
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "eks-context",
+		ErrorType: "auth",
+	})
+	waitForRecoveryWorker(t)
+
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if probes.Load() == 0 {
+		t.Fatal("recovery never probed")
+	}
+	if reconnects.Load() != 0 {
+		t.Fatalf("reconnects = %d, want 0 (failed probes with an exec plugin must not trigger disk-reread attempts)", reconnects.Load())
+	}
+}
+
 func TestNextRuntimeAuthRecoveryInterval(t *testing.T) {
 	ResetTestState()
 	t.Cleanup(ResetTestState)

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -992,6 +993,24 @@ func TestRuntimeAuthHungPluginTimeoutWithoutExecAuthStaysConnected(t *testing.T)
 
 	if got := GetConnectionStatus().State; got != StateConnected {
 		t.Fatalf("connection state = %q, want %q (plugin-timeout rule is exec-auth only)", got, StateConnected)
+	}
+}
+
+func TestDefaultRuntimeAuthEndpointProbeTreatsTLSAlertAsReachable(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.TLS = &tls.Config{ClientAuth: tls.RequireAndVerifyClientCert}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	// The credential-free probe fails the mTLS handshake with a TLS alert —
+	// which proves the endpoint is reachable, so the probe must report nil or
+	// every demotion behind an mTLS proxy would be vetoed as inconclusive.
+	err := defaultRuntimeAuthEndpointProbe(context.Background(), &rest.Config{
+		Host:            server.URL,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	})
+	if err != nil {
+		t.Fatalf("probe against mTLS-required endpoint = %v, want nil (TLS alert proves reachability)", err)
 	}
 }
 

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -695,12 +695,11 @@ func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
 		return nil
 	})
 	var reconnects atomic.Int32
-	setRuntimeAuthReconnect(func(contextName string) error {
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
 		if contextName != "recovery-context" {
 			t.Errorf("reconnect context = %q, want %q", contextName, "recovery-context")
 		}
 		reconnects.Add(1)
-		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
 		return nil
 	})
 
@@ -709,7 +708,7 @@ func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
 		Context:   "recovery-context",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery("recovery-context")
+	startRuntimeAuthRecovery()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for reconnects.Load() == 0 || runtimeAuthRecoveryActive.Load() {
@@ -725,6 +724,9 @@ func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
 	if reconnects.Load() != 1 {
 		t.Fatalf("reconnects = %d, want 1", reconnects.Load())
 	}
+	if status := GetConnectionStatus(); status.State != StateConnected {
+		t.Fatalf("recovery did not publish connected status, got %+v", status)
+	}
 }
 
 func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
@@ -736,7 +738,7 @@ func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
 		return errors.New("getting credentials: exec plugin failed")
 	})
 	var reconnects atomic.Int32
-	setRuntimeAuthReconnect(func(string) error {
+	setRuntimeAuthReconnect(func(string, uint64) error {
 		reconnects.Add(1)
 		return nil
 	})
@@ -746,7 +748,7 @@ func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
 		Context:   "recovery-context",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery("recovery-context")
+	startRuntimeAuthRecovery()
 	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "recovery-context"})
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -758,6 +760,109 @@ func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
 	}
 	if reconnects.Load() != 0 {
 		t.Fatalf("reconnects = %d, want 0", reconnects.Load())
+	}
+}
+
+func TestPerformContextSwitchIfOperationCurrentAbortsWhenSuperseded(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	var sessionsStopped atomic.Int32
+	SetSessionStopper(func() { sessionsStopped.Add(1) })
+	t.Cleanup(func() { SetSessionStopper(nil) })
+	var beforeSwitchFired atomic.Int32
+	OnBeforeContextSwitch(func(string) { beforeSwitchFired.Add(1) })
+
+	observedGen := currentOperationGen()
+	CancelOngoingOperations()
+
+	err := PerformContextSwitchIfOperationCurrent("any-context", observedGen)
+	if !errors.Is(err, ErrReconnectSuperseded) {
+		t.Fatalf("error = %v, want ErrReconnectSuperseded", err)
+	}
+	if sessionsStopped.Load() != 0 || beforeSwitchFired.Load() != 0 {
+		t.Fatalf("superseded reconnect ran teardown: sessions=%d beforeSwitch=%d",
+			sessionsStopped.Load(), beforeSwitchFired.Load())
+	}
+}
+
+func TestRuntimeAuthRecoveryContinuesWhenSuperseded(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	setRuntimeAuthProbe(func(context.Context) error { return nil })
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(string, uint64) error {
+		if reconnects.Add(1) == 1 {
+			return ErrReconnectSuperseded
+		}
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	startRuntimeAuthRecovery()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("recovery loop did not finish: reconnects=%d", reconnects.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if reconnects.Load() != 2 {
+		t.Fatalf("reconnects = %d, want 2 (superseded attempt retried next tick)", reconnects.Load())
+	}
+	if status := GetConnectionStatus(); status.State != StateConnected {
+		t.Fatalf("recovery did not publish connected status, got %+v", status)
+	}
+}
+
+func TestRuntimeAuthRecoveryRetargetsNewEpisode(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	var probeOK atomic.Bool
+	setRuntimeAuthProbe(func(context.Context) error {
+		if probeOK.Load() {
+			return nil
+		}
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	var reconnectedContext atomic.Value
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
+		reconnectedContext.Store(contextName)
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "context-a",
+		ErrorType: "auth",
+	})
+	startRuntimeAuthRecovery()
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "context-b",
+		ErrorType: "auth",
+	})
+	probeOK.Store(true)
+	startRuntimeAuthRecovery() // CAS fails; nudges the sleeping worker
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("recovery loop did not finish; reconnected=%v", reconnectedContext.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := reconnectedContext.Load(); got != "context-b" {
+		t.Fatalf("reconnected context = %v, want context-b", got)
 	}
 }
 

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1014,6 +1014,37 @@ func TestDefaultRuntimeAuthEndpointProbeTreatsTLSAlertAsReachable(t *testing.T) 
 	}
 }
 
+func TestInconclusiveStreakResetsOnConclusiveOutcomes(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthInconclusiveStreak = 8
+	runtimeAuthChecksMu.Unlock()
+
+	// A connected publish is conclusive: the next episode's first
+	// inconclusive probe must restart at the short cooldown.
+	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "test-context"})
+	if got := nextInconclusiveCooldown(); got != runtimeAuthInconclusiveProbeCooldown {
+		t.Fatalf("cooldown after connected publish = %v, want %v", got, runtimeAuthInconclusiveProbeCooldown)
+	}
+
+	// So is a committed demotion.
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthInconclusiveStreak = 8
+	runtimeAuthChecksMu.Unlock()
+	setRuntimeAuthProbe(func(context.Context) error {
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	if got := GetConnectionStatus().State; got != StateDisconnected {
+		t.Fatalf("state = %q, want demoted", got)
+	}
+	if got := nextInconclusiveCooldown(); got != runtimeAuthInconclusiveProbeCooldown {
+		t.Fatalf("cooldown after demotion = %v, want %v", got, runtimeAuthInconclusiveProbeCooldown)
+	}
+}
+
 func TestRuntimeAuthCooldownIsScopedToGeneration(t *testing.T) {
 	generation := prepareRuntimeAuthTest(t)
 	var probes atomic.Int32

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1343,6 +1343,9 @@ func TestNextRuntimeAuthRecoveryInterval(t *testing.T) {
 	if got := nextRuntimeAuthRecoveryInterval(30*time.Second, errors.New("auth plugin timeout: context deadline exceeded"), maxInterval, hungInterval); got != hungInterval {
 		t.Fatalf("interval after hung plugin = %v, want %v", got, hungInterval)
 	}
+	if got := nextRuntimeAuthRecoveryInterval(30*time.Second, errors.New("subsystem init failed: context deadline exceeded"), maxInterval, hungInterval); got != time.Minute {
+		t.Fatalf("interval after generic timeout under exec auth = %v, want %v (hung interval is for wedged plugins only)", got, time.Minute)
+	}
 }
 
 func setRuntimeAuthRecoveryIntervalsForTest(initial, maxInterval time.Duration) {

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -103,11 +105,27 @@ func TestRuntimeAuthRoundTripperReportsUnauthorizedResponse(t *testing.T) {
 	if probes.Load() != 1 {
 		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
 	}
-	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+	status := GetConnectionStatus()
+	if status.State != StateDisconnected || status.ErrorType != "auth" {
 		t.Fatalf("connection status = %+v, want disconnected auth", status)
 	}
-	if !runtimeAuthRecoveryActive.Load() {
-		t.Fatal("demotion did not start the runtime auth recovery loop")
+	if status.Error != runtimeAuthLostMessage {
+		t.Fatalf("published error = %q, want the fixed credential-loss message (raw probe errors can embed credential material)", status.Error)
+	}
+	if !runtimeAuthRecoveryOwed.Load() {
+		t.Fatal("demotion did not record the recovery debt")
+	}
+	waitForRecoveryWorker(t)
+}
+
+func waitForRecoveryWorker(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("recovery worker did not start")
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -308,6 +326,12 @@ func TestRuntimeAuthFailureDemotesAndQuiescesOnce(t *testing.T) {
 			callbacks.Add(1)
 		}
 	})
+	var beforeSwitchCalls atomic.Int32
+	var beforeSwitchArg atomic.Value
+	OnBeforeContextSwitch(func(contextName string) {
+		beforeSwitchCalls.Add(1)
+		beforeSwitchArg.Store(contextName)
+	})
 	sessionStopped := make(chan struct{}, 1)
 	SetSessionStopper(func() {
 		select {
@@ -316,6 +340,7 @@ func TestRuntimeAuthFailureDemotesAndQuiescesOnce(t *testing.T) {
 		}
 	})
 	t.Cleanup(func() { SetSessionStopper(nil) })
+	genBefore := currentOperationGen()
 
 	var callers sync.WaitGroup
 	for range 20 {
@@ -343,6 +368,17 @@ func TestRuntimeAuthFailureDemotesAndQuiescesOnce(t *testing.T) {
 	}
 	if probes.Load() != 1 {
 		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
+	}
+	// Quiesce-in-place contract: fired exactly once, with the CURRENT context
+	// (consumers must not infer "changed" by comparing against the active name).
+	if beforeSwitchCalls.Load() != 1 {
+		t.Fatalf("before-switch callbacks = %d, want 1", beforeSwitchCalls.Load())
+	}
+	if got := beforeSwitchArg.Load(); got != GetContextName() {
+		t.Fatalf("before-switch context = %v, want the current context %q", got, GetContextName())
+	}
+	if currentOperationGen() == genBefore {
+		t.Fatal("demotion did not cancel ongoing operations (operation generation unchanged)")
 	}
 }
 
@@ -700,15 +736,19 @@ func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
 			t.Errorf("reconnect context = %q, want %q", contextName, "recovery-context")
 		}
 		reconnects.Add(1)
+		// The real reconnect (performContextSwitch) publishes Connected
+		// while holding contextOpMu; the stub mirrors that contract.
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
 		return nil
 	})
 
+	// The publish-side hook alone must set the debt and start the worker —
+	// this is the startup-expired-credentials path, no demotion involved.
 	SetConnectionStatus(ConnectionStatus{
 		State:     StateDisconnected,
 		Context:   "recovery-context",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for reconnects.Load() == 0 || runtimeAuthRecoveryActive.Load() {
@@ -725,7 +765,10 @@ func TestRuntimeAuthRecoveryReconnectsWhenCredentialsReturn(t *testing.T) {
 		t.Fatalf("reconnects = %d, want 1", reconnects.Load())
 	}
 	if status := GetConnectionStatus(); status.State != StateConnected {
-		t.Fatalf("recovery did not publish connected status, got %+v", status)
+		t.Fatalf("connection did not settle connected, got %+v", status)
+	}
+	if runtimeAuthRecoveryOwed.Load() {
+		t.Fatal("recovery debt not cleared by the connected publish")
 	}
 }
 
@@ -748,7 +791,6 @@ func TestRuntimeAuthRecoveryStopsWhenNoLongerNeeded(t *testing.T) {
 		Context:   "recovery-context",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery()
 	SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: "recovery-context"})
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -792,10 +834,11 @@ func TestRuntimeAuthRecoveryContinuesWhenSuperseded(t *testing.T) {
 
 	setRuntimeAuthProbe(func(context.Context) error { return nil })
 	var reconnects atomic.Int32
-	setRuntimeAuthReconnect(func(string, uint64) error {
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
 		if reconnects.Add(1) == 1 {
 			return ErrReconnectSuperseded
 		}
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
 		return nil
 	})
 
@@ -804,10 +847,9 @@ func TestRuntimeAuthRecoveryContinuesWhenSuperseded(t *testing.T) {
 		Context:   "recovery-context",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery()
 
 	deadline := time.Now().Add(2 * time.Second)
-	for runtimeAuthRecoveryActive.Load() {
+	for runtimeAuthRecoveryActive.Load() || reconnects.Load() < 2 {
 		if time.Now().After(deadline) {
 			t.Fatalf("recovery loop did not finish: reconnects=%d", reconnects.Load())
 		}
@@ -817,7 +859,7 @@ func TestRuntimeAuthRecoveryContinuesWhenSuperseded(t *testing.T) {
 		t.Fatalf("reconnects = %d, want 2 (superseded attempt retried next tick)", reconnects.Load())
 	}
 	if status := GetConnectionStatus(); status.State != StateConnected {
-		t.Fatalf("recovery did not publish connected status, got %+v", status)
+		t.Fatalf("connection did not settle connected, got %+v", status)
 	}
 }
 
@@ -835,7 +877,13 @@ func TestRuntimeAuthRecoveryRetargetsNewEpisode(t *testing.T) {
 	})
 	var reconnectedContext atomic.Value
 	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
+		// Mirror the real precondition: a reconnect aimed at a context the
+		// live status has moved past is superseded, not applied.
+		if GetConnectionStatus().Context != contextName {
+			return ErrReconnectSuperseded
+		}
 		reconnectedContext.Store(contextName)
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
 		return nil
 	})
 
@@ -844,18 +892,18 @@ func TestRuntimeAuthRecoveryRetargetsNewEpisode(t *testing.T) {
 		Context:   "context-a",
 		ErrorType: "auth",
 	})
-	startRuntimeAuthRecovery()
 
+	// New episode on a different context: the publish-side hook nudges the
+	// worker awake so it retargets without waiting out the backoff.
 	SetConnectionStatus(ConnectionStatus{
 		State:     StateDisconnected,
 		Context:   "context-b",
 		ErrorType: "auth",
 	})
 	probeOK.Store(true)
-	startRuntimeAuthRecovery() // CAS fails; nudges the sleeping worker
 
 	deadline := time.Now().Add(2 * time.Second)
-	for runtimeAuthRecoveryActive.Load() {
+	for runtimeAuthRecoveryActive.Load() || reconnectedContext.Load() == nil {
 		if time.Now().After(deadline) {
 			t.Fatalf("recovery loop did not finish; reconnected=%v", reconnectedContext.Load())
 		}
@@ -864,6 +912,218 @@ func TestRuntimeAuthRecoveryRetargetsNewEpisode(t *testing.T) {
 	if got := reconnectedContext.Load(); got != "context-b" {
 		t.Fatalf("reconnected context = %v, want context-b", got)
 	}
+}
+
+func TestRuntimeAuthRecoverySurvivesErrorTypeFlip(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	var probes atomic.Int32
+	var probeOK atomic.Bool
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		if probeOK.Load() {
+			return nil
+		}
+		return errors.New("getting credentials: exec plugin failed")
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
+		reconnects.Add(1)
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	waitForRecoveryWorker(t)
+
+	// A failed user retry with a hung plugin republishes as "timeout", and a
+	// Helm handler marking the cluster unreachable does the same with no user
+	// action at all. Neither settles the recovery debt.
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		Error:     "cluster connection failed: auth plugin timeout: context deadline exceeded",
+		ErrorType: "timeout",
+	})
+	probeOK.Store(true)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for reconnects.Load() == 0 || runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("worker died on errorType flip: probes=%d reconnects=%d", probes.Load(), reconnects.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if status := GetConnectionStatus(); status.State != StateConnected {
+		t.Fatalf("connection did not settle connected, got %+v", status)
+	}
+}
+
+func TestRuntimeAuthHungExecPluginDemotesWhenEndpointReachable(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	withContextExecAuth(t, true)
+	setRuntimeAuthProbe(func(context.Context) error {
+		return fmt.Errorf("auth plugin timeout: %w", context.DeadlineExceeded)
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
+		t.Fatalf("connection status = %+v, want disconnected auth (hung plugin with reachable endpoint)", status)
+	}
+}
+
+func TestRuntimeAuthHungPluginTimeoutWithoutExecAuthStaysConnected(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	withContextExecAuth(t, false)
+	setRuntimeAuthProbe(func(context.Context) error {
+		return fmt.Errorf("auth plugin timeout: %w", context.DeadlineExceeded)
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+
+	if got := GetConnectionStatus().State; got != StateConnected {
+		t.Fatalf("connection state = %q, want %q (plugin-timeout rule is exec-auth only)", got, StateConnected)
+	}
+}
+
+func TestRuntimeAuthCooldownIsScopedToGeneration(t *testing.T) {
+	generation := prepareRuntimeAuthTest(t)
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return errors.New("dial tcp: connection refused")
+	})
+
+	reportRuntimeAuthFailure(generation, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, generation)
+	if probes.Load() != 1 {
+		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
+	}
+
+	// A context switch mints a new client generation; the old generation's
+	// cooldown must not suppress the new one's first candidate.
+	newGeneration := clientGenerationCounter.Add(1)
+	clientMu.Lock()
+	activeClientGeneration = newGeneration
+	clientMu.Unlock()
+
+	reportRuntimeAuthFailure(newGeneration, errors.New("unauthorized"))
+	waitForRuntimeAuthCheck(t, newGeneration)
+	if probes.Load() != 2 {
+		t.Fatalf("probes after generation change = %d, want 2 (old cooldown must not apply)", probes.Load())
+	}
+}
+
+func TestRuntimeAuthObserverCoversAllSharedClients(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		request func(t *testing.T, clients *sharedKubernetesClients)
+	}{
+		{name: "dynamic client", request: func(t *testing.T, clients *sharedKubernetesClients) {
+			gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+			if _, err := clients.dynamic.Resource(gvr).List(context.Background(), metav1.ListOptions{}); err == nil {
+				t.Fatal("expected 401 error from dynamic list")
+			}
+		}},
+		{name: "discovery client", request: func(t *testing.T, clients *sharedKubernetesClients) {
+			if _, err := clients.discovery.ServerVersion(); err == nil {
+				t.Fatal("expected 401 error from discovery")
+			}
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			prepareRuntimeAuthTest(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			t.Cleanup(server.Close)
+
+			var probes atomic.Int32
+			setRuntimeAuthProbe(func(context.Context) error {
+				probes.Add(1)
+				return errors.New("dial tcp: connection refused")
+			})
+
+			clients, err := newSharedKubernetesClients(&rest.Config{Host: server.URL})
+			if err != nil {
+				t.Fatalf("newSharedKubernetesClients() error = %v", err)
+			}
+			clientMu.Lock()
+			activeClientGeneration = clients.generation
+			clientMu.Unlock()
+
+			tt.request(t, clients)
+			waitForRuntimeAuthCheck(t, clients.generation)
+			if probes.Load() != 1 {
+				t.Fatalf("confirmation probes = %d, want 1 (401 through this client must reach the observer)", probes.Load())
+			}
+		})
+	}
+}
+
+func TestRuntimeAuthRecoveryYieldsToActiveContextOperation(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		probes.Add(1)
+		return nil
+	})
+	setRuntimeAuthReconnect(func(contextName string, _ uint64) error {
+		SetConnectionStatus(ConnectionStatus{State: StateConnected, Context: contextName})
+		return nil
+	})
+
+	activeContextOperations.Add(1)
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	waitForRecoveryWorker(t)
+	time.Sleep(30 * time.Millisecond)
+	if probes.Load() != 0 {
+		t.Fatalf("probes while a context operation is active = %d, want 0", probes.Load())
+	}
+
+	activeContextOperations.Add(-1)
+	deadline := time.Now().Add(2 * time.Second)
+	for runtimeAuthRecoveryActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("recovery did not proceed after the operation cleared: probes=%d", probes.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if probes.Load() == 0 {
+		t.Fatal("recovery never probed after the context operation cleared")
+	}
+}
+
+func TestSetConnectionStatusStartsRecoveryForAuthPrefixedTypes(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(time.Hour, time.Hour)
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "some-context",
+		ErrorType: "auth-rejected",
+	})
+	if !runtimeAuthRecoveryOwed.Load() {
+		t.Fatal("auth-prefixed disconnect did not record the recovery debt")
+	}
+	waitForRecoveryWorker(t)
 }
 
 func TestNextRuntimeAuthRecoveryInterval(t *testing.T) {

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"sync"
+	"time"
 
 	"github.com/skyhook-io/radar/pkg/k8score"
 	"k8s.io/client-go/dynamic"
@@ -194,6 +195,22 @@ func ResetTestState() {
 	connectionCallbacksMu.Lock()
 	connectionCallbacks = nil
 	connectionCallbacksMu.Unlock()
+
+	runtimeAuthChecksMu.Lock()
+	runtimeAuthChecks = make(map[uint64]struct{})
+	runtimeAuthProbeAfter = make(map[uint64]time.Time)
+	runtimeAuthProbe = TestClusterConnection
+	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
+	runtimeAuthChecksMu.Unlock()
+	activeContextOperations.Store(0)
+	clientMu.Lock()
+	k8sConfig = nil
+	k8sClient = nil
+	discoveryClient = nil
+	dynamicClient = nil
+	activeClientGeneration = 0
+	kubeconfigMode = ""
+	clientMu.Unlock()
 
 	// Reset capabilities cache
 	capabilitiesMu.Lock()

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -200,17 +200,30 @@ func ResetTestState() {
 	runtimeAuthChecks = make(map[uint64]struct{})
 	runtimeAuthCooldownGeneration = 0
 	runtimeAuthProbeNotBefore = time.Time{}
+	runtimeAuthInconclusiveStreak = 0
 	runtimeAuthProbe = TestClusterConnection
 	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
-	runtimeAuthReconnect = PerformContextSwitchIfOperationCurrent
+	runtimeAuthReconnect = nil
 	runtimeAuthRecoveryInitialInterval = defaultRuntimeAuthRecoveryInitialInterval
 	runtimeAuthRecoveryMaxInterval = defaultRuntimeAuthRecoveryMaxInterval
 	runtimeAuthRecoveryHungInterval = defaultRuntimeAuthRecoveryHungInterval
 	runtimeAuthChecksMu.Unlock()
-	runtimeAuthRecoveryActive.Store(false)
-	select {
-	case <-runtimeAuthRecoveryNudge:
-	default:
+	// Clear the debt and nudge rather than forcing the active flag: a
+	// surviving worker wakes, sees no debt, and exits through its own defer.
+	// Forcing the flag false would let a second worker coexist with it. With
+	// no worker alive, drain instead — a stray token would give the next
+	// test's worker a spurious immediate tick.
+	runtimeAuthRecoveryOwed.Store(false)
+	if runtimeAuthRecoveryActive.Load() {
+		select {
+		case runtimeAuthRecoveryNudge <- struct{}{}:
+		default:
+		}
+	} else {
+		select {
+		case <-runtimeAuthRecoveryNudge:
+		default:
+		}
 	}
 	activeContextOperations.Store(0)
 	clientMu.Lock()

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -198,10 +198,16 @@ func ResetTestState() {
 
 	runtimeAuthChecksMu.Lock()
 	runtimeAuthChecks = make(map[uint64]struct{})
-	runtimeAuthProbeAfter = make(map[uint64]time.Time)
+	runtimeAuthCooldownGeneration = 0
+	runtimeAuthProbeNotBefore = time.Time{}
 	runtimeAuthProbe = TestClusterConnection
 	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
+	runtimeAuthReconnect = PerformContextSwitch
+	runtimeAuthRecoveryInitialInterval = defaultRuntimeAuthRecoveryInitialInterval
+	runtimeAuthRecoveryMaxInterval = defaultRuntimeAuthRecoveryMaxInterval
+	runtimeAuthRecoveryHungInterval = defaultRuntimeAuthRecoveryHungInterval
 	runtimeAuthChecksMu.Unlock()
+	runtimeAuthRecoveryActive.Store(false)
 	activeContextOperations.Store(0)
 	clientMu.Lock()
 	k8sConfig = nil

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -208,6 +208,10 @@ func ResetTestState() {
 	runtimeAuthRecoveryHungInterval = defaultRuntimeAuthRecoveryHungInterval
 	runtimeAuthChecksMu.Unlock()
 	runtimeAuthRecoveryActive.Store(false)
+	select {
+	case <-runtimeAuthRecoveryNudge:
+	default:
+	}
 	activeContextOperations.Store(0)
 	clientMu.Lock()
 	k8sConfig = nil

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -202,7 +202,7 @@ func ResetTestState() {
 	runtimeAuthProbeNotBefore = time.Time{}
 	runtimeAuthProbe = TestClusterConnection
 	runtimeAuthEndpointProbe = defaultRuntimeAuthEndpointProbe
-	runtimeAuthReconnect = PerformContextSwitch
+	runtimeAuthReconnect = PerformContextSwitchIfOperationCurrent
 	runtimeAuthRecoveryInitialInterval = defaultRuntimeAuthRecoveryInitialInterval
 	runtimeAuthRecoveryMaxInterval = defaultRuntimeAuthRecoveryMaxInterval
 	runtimeAuthRecoveryHungInterval = defaultRuntimeAuthRecoveryHungInterval

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -1,0 +1,24 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// errNotConnected explains WHY the cluster is unavailable. MCP callers are
+// usually AI agents: a bare "not connected" reads as a dead end, when a
+// credential-loss demotion actually self-heals once the operator
+// re-authenticates.
+func errNotConnected() error {
+	status := k8s.GetConnectionStatus()
+	if status.State == k8s.StateDisconnected && status.Error != "" {
+		if strings.HasPrefix(status.ErrorType, "auth") {
+			return fmt.Errorf("not connected to cluster: %s. Radar re-checks in the background and usually reconnects on its own once credentials are refreshed (exec-plugin and token-file credentials self-heal; a token replaced inside the kubeconfig file needs POST /api/connection/retry)", status.Error)
+		}
+		return fmt.Errorf("not connected to cluster: %s", status.Error)
+	}
+	return errors.New("not connected to cluster")
+}

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -16,7 +16,7 @@ func errNotConnected() error {
 	status := k8s.GetConnectionStatus()
 	if status.State == k8s.StateDisconnected && status.Error != "" {
 		if strings.HasPrefix(status.ErrorType, "auth") {
-			return fmt.Errorf("not connected to cluster: %s. Radar re-checks in the background and usually reconnects on its own once credentials are refreshed (exec-plugin and token-file credentials self-heal; a token replaced inside the kubeconfig file needs POST /api/connection/retry)", status.Error)
+			return fmt.Errorf("not connected to cluster: %s. Radar re-checks in the background and reconnects automatically once credentials are refreshed; POST /api/connection/retry forces an immediate check", status.Error)
 		}
 		return fmt.Errorf("not connected to cluster: %s", status.Error)
 	}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -77,7 +77,7 @@ func handleResourceHealth(ctx context.Context, req *mcp.ReadResourceRequest) (*m
 	}
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return jsonErrorResource("cluster://health", "not connected to cluster"), nil
+		return jsonErrorResource("cluster://health", errNotConnected().Error()), nil
 	}
 
 	dashboard := buildDashboard(ctx, cache, "", canReadClusterScopedKind(ctx, "nodes", "", "list"), canReadClusterScopedKind(ctx, "namespaces", "", "list"))
@@ -107,7 +107,7 @@ func handleResourceEvents(ctx context.Context, req *mcp.ReadResourceRequest) (*m
 	}
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return jsonErrorResource("cluster://events", "not connected to cluster"), nil
+		return jsonErrorResource("cluster://events", errNotConnected().Error()), nil
 	}
 
 	eventLister := cache.Events()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -626,7 +626,7 @@ type issuesInput struct {
 func handleGetDashboard(ctx context.Context, req *mcp.CallToolRequest, input dashboardInput) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	// Dashboard summary doesn't currently take a multi-namespace input, so we
@@ -746,7 +746,7 @@ type topResourcesResponseMCP struct {
 func handleListResources(ctx context.Context, req *mcp.CallToolRequest, input listResourcesInput) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	kind := strings.ToLower(input.Kind)
@@ -921,7 +921,7 @@ func listDynamicResources(ctx context.Context, cache *k8s.ResourceCache, kind, g
 func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getResourceInput) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	kind := strings.ToLower(input.Kind)
@@ -1622,7 +1622,7 @@ func resolveEventTypeFilter(t string) (string, error) {
 func handleGetEvents(ctx context.Context, req *mcp.CallToolRequest, input eventsInput) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	eventLister := cache.Events()
@@ -1738,7 +1738,7 @@ func handleGetPodLogs(ctx context.Context, req *mcp.CallToolRequest, input podLo
 
 	clientset := k8s.ClientFromContext(ctx)
 	if clientset == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	tailLines := int64(200)
@@ -1938,7 +1938,7 @@ type podLogsResponseMCP struct {
 func handleListNamespaces(ctx context.Context, req *mcp.CallToolRequest, input struct{}) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	lister := cache.Namespaces()
@@ -2715,7 +2715,7 @@ func countResources(cache *k8s.ResourceCache, namespace string, d *mcpDashboard,
 func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesInput) (*mcp.CallToolResult, any, error) {
 	provider := issues.NewCacheProvider()
 	if provider == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 	var allowedNamespaces []string
 	if input.Namespace != "" {
@@ -2986,7 +2986,7 @@ func mcpSearchSecretsRBAC(ctx context.Context, scanNamespaces []string) (decisio
 func handleSearch(ctx context.Context, req *mcp.CallToolRequest, input searchInput) (*mcp.CallToolResult, any, error) {
 	provider := search.NewCacheProvider()
 	if provider == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 	query := input.Query
 	if query == "" {

--- a/internal/mcp/tools_apply.go
+++ b/internal/mcp/tools_apply.go
@@ -55,7 +55,7 @@ func handleApplyResource(ctx context.Context, req *mcp.CallToolRequest, input ap
 
 	dynClient := k8s.DynamicClientFromContext(ctx)
 	if dynClient == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	verify := input.Verify == nil || *input.Verify

--- a/internal/mcp/tools_audit.go
+++ b/internal/mcp/tools_audit.go
@@ -54,7 +54,7 @@ func handleGetAudit(ctx context.Context, req *mcp.CallToolRequest, input auditIn
 
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	var requested []string

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -187,7 +187,7 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	obj, err := k8s.FetchResource(cache, kindNorm, input.Namespace, input.Name)
@@ -388,7 +388,7 @@ func handleGitOpsDiagnose(ctx context.Context, input diagnoseInput, canonicalKin
 	}
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 	u, err := cache.GetDynamicWithGroup(ctx, canonicalKind, input.Namespace, input.Name, group)
 	if err != nil {

--- a/internal/mcp/tools_gitops.go
+++ b/internal/mcp/tools_gitops.go
@@ -37,7 +37,7 @@ type manageGitOpsInput struct {
 func handleManageGitOps(ctx context.Context, req *mcp.CallToolRequest, input manageGitOpsInput) (*mcp.CallToolResult, any, error) {
 	dynClient := k8s.DynamicClientFromContext(ctx)
 	if dynClient == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	tool := strings.ToLower(input.Tool)

--- a/internal/mcp/tools_neighborhood.go
+++ b/internal/mcp/tools_neighborhood.go
@@ -45,7 +45,7 @@ type neighborhoodSubgraphMCP struct {
 func handleGetNeighborhood(ctx context.Context, req *mcp.CallToolRequest, input getNeighborhoodInput) (*mcp.CallToolResult, any, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 	if input.Kind == "" || input.Name == "" {
 		return nil, nil, fmt.Errorf("kind and name are required")

--- a/internal/mcp/tools_patch.go
+++ b/internal/mcp/tools_patch.go
@@ -68,7 +68,7 @@ func handlePatchResource(ctx context.Context, req *mcp.CallToolRequest, input pa
 
 	dynClient := k8s.DynamicClientFromContext(ctx)
 	if dynClient == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	patchType, err := parsePatchType(input.PatchType)

--- a/internal/mcp/tools_rbac.go
+++ b/internal/mcp/tools_rbac.go
@@ -182,7 +182,7 @@ func handleGetSubjectPermissions(ctx context.Context, _ *mcp.CallToolRequest, in
 
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	// Build the index inline. The HTTP handler memoizes a singleton; MCP

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -83,7 +83,7 @@ func handleManageWorkload(ctx context.Context, req *mcp.CallToolRequest, input m
 
 	dynClient := k8s.DynamicClientFromContext(ctx)
 	if dynClient == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	switch strings.ToLower(input.Action) {
@@ -138,7 +138,7 @@ func handleManageWorkload(ctx context.Context, req *mcp.CallToolRequest, input m
 func handleManageCronJob(ctx context.Context, req *mcp.CallToolRequest, input manageCronJobInput) (*mcp.CallToolResult, any, error) {
 	dynClient := k8s.DynamicClientFromContext(ctx)
 	if dynClient == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	switch strings.ToLower(input.Action) {
@@ -188,12 +188,12 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 
 	cache := k8s.GetResourceCache()
 	if cache == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	client := k8s.ClientFromContext(ctx)
 	if client == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	// Get the workload's label selector
@@ -644,7 +644,7 @@ func handleManageNode(ctx context.Context, req *mcp.CallToolRequest, input manag
 
 	client := k8s.ClientFromContext(ctx)
 	if client == nil {
-		return nil, nil, fmt.Errorf("not connected to cluster")
+		return nil, nil, errNotConnected()
 	}
 
 	switch strings.ToLower(input.Action) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -235,6 +235,12 @@ func New(cfg Config) *Server {
 		if s.aiRuns != nil {
 			s.aiRuns.OnContextSwitch()
 		}
+		// Runtime auth-loss demotion fires ONLY this callback (quiesce in
+		// place, no switch follows), and Argo CD's private port-forward lives
+		// outside the session manager — without this it survives the
+		// demotion's teardown indefinitely. Reset is idempotent, so the
+		// second call from OnContextSwitch on a real switch is harmless.
+		argocd.Reset()
 	})
 
 	// Let the destructive cache operations (context switch, namespace rescope)
@@ -3927,12 +3933,9 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 
 	// Per-user state (permCache, namespace picks, capabilities cache) is
 	// cleared by the OnContextSwitch callback registered in New().
-
-	k8s.SetConnectionStatus(k8s.ConnectionStatus{
-		State:       k8s.StateConnected,
-		Context:     k8s.GetContextName(),
-		ClusterName: k8s.GetClusterName(),
-	})
+	// PerformContextSwitch published the connected status while still holding
+	// the context-operation lock; publishing again here would race a queued
+	// operation's teardown.
 
 	// Return the new cluster info
 	info, err := k8s.GetClusterInfo(r.Context())
@@ -3998,13 +4001,9 @@ func (s *Server) handleConnectionRetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set connected state after successful reconnection
-	k8s.SetConnectionStatus(k8s.ConnectionStatus{
-		State:       k8s.StateConnected,
-		Context:     k8s.GetContextName(),
-		ClusterName: k8s.GetClusterName(),
-	})
-
+	// PerformContextSwitch published the connected status under the
+	// context-operation lock; a second publish here would race a queued
+	// operation's teardown.
 	s.writeJSON(w, k8s.GetConnectionStatus())
 }
 
@@ -4154,12 +4153,8 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 	}
 
 	// Per-user state cleared via the OnContextSwitch callback (see New()).
-
-	k8s.SetConnectionStatus(k8s.ConnectionStatus{
-		State:       k8s.StateConnected,
-		Context:     k8s.GetContextName(),
-		ClusterName: k8s.GetClusterName(),
-	})
+	// Connected status was published by PerformContextSwitch under the
+	// context-operation lock.
 
 	// Use %q on user-influenced values (context name derived from an uploaded
 	// kubeconfig YAML, temp path partly includes the system TMPDIR) so a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3949,17 +3949,24 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleConnectionStatus(w http.ResponseWriter, r *http.Request) {
 	status := k8s.GetConnectionStatus()
-	contexts, _ := k8s.GetAvailableContexts() // Always works (reads kubeconfig)
 
-	s.writeJSON(w, map[string]any{
+	response := map[string]any{
 		"state":           status.State,
 		"context":         status.Context,
 		"clusterName":     status.ClusterName,
 		"error":           status.Error,
 		"errorType":       status.ErrorType,
 		"progressMessage": status.ProgressMsg,
-		"contexts":        contexts,
-	})
+	}
+	// Context enumeration re-reads kubeconfig files (under the client write
+	// lock in multi-file mode) — too expensive for the UI's perpetual
+	// fallback poll, which opts out via ?contexts=0.
+	if r.URL.Query().Get("contexts") != "0" {
+		contexts, _ := k8s.GetAvailableContexts() // Always works (reads kubeconfig)
+		response["contexts"] = contexts
+	}
+
+	s.writeJSON(w, response)
 }
 
 func (s *Server) handleConnectionRetry(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3960,6 +3960,9 @@ func (s *Server) handleConnectionStatus(w http.ResponseWriter, r *http.Request) 
 		"error":           status.Error,
 		"errorType":       status.ErrorType,
 		"progressMessage": status.ProgressMsg,
+		// Lets the browser stand down its auto-retry for the whole auth-loss
+		// episode, even when the live errorType flips to non-auth values.
+		"authRecoveryOwed": k8s.RuntimeAuthRecoveryOwed(),
 	}
 	// Context enumeration re-reads kubeconfig files (under the client write
 	// lock in multi-file mode) — too expensive for the UI's perpetual

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -994,6 +994,17 @@ func TestSmokeConnection(t *testing.T) {
 	}
 }
 
+func TestSmokeConnectionStatusOnly(t *testing.T) {
+	// The UI's perpetual fallback poll opts out of context enumeration, which
+	// re-reads kubeconfig files under the client write lock on every hit.
+	var body map[string]any
+	assertOK(t, get(t, "/api/connection?contexts=0"), &body)
+	assertKeys(t, body, "state", "context")
+	if _, present := body["contexts"]; present {
+		t.Error("contexts should be omitted when the poll asks for status only")
+	}
+}
+
 func TestSmokeSessions(t *testing.T) {
 	var body map[string]any
 	assertOK(t, get(t, "/api/sessions"), &body)

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -999,7 +999,7 @@ func TestSmokeConnectionStatusOnly(t *testing.T) {
 	// re-reads kubeconfig files under the client write lock on every hit.
 	var body map[string]any
 	assertOK(t, get(t, "/api/connection?contexts=0"), &body)
-	assertKeys(t, body, "state", "context")
+	assertKeys(t, body, "state", "context", "authRecoveryOwed")
 	if _, present := body["contexts"]; present {
 		t.Error("contexts should be omitted when the poll asks for status only")
 	}

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -157,8 +157,9 @@ const errorHints: Record<string, { title: string; hints: string[] }> = {
   tls: {
     title: 'Certificate Error',
     hints: [
-      'Radar reached the Kubernetes API, but could not verify its TLS certificate',
-      'Check the kubeconfig cluster server hostname and certificate-authority settings',
+      'Radar reached the Kubernetes API, but the TLS handshake failed',
+      'If the error mentions "bad certificate" or "certificate required", the cluster rejected Radar\'s client certificate — it may have expired (kubeadm certs expire after a year). Renew it (e.g. kubeadm certs renew) or re-download the kubeconfig',
+      'Otherwise check the kubeconfig cluster server hostname and certificate-authority settings',
       'If this cluster intentionally uses a private CA, refresh the kubeconfig for this context',
     ],
   },
@@ -382,8 +383,10 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
           {isAuth && (
             <p className="mt-4 text-xs text-theme-text-tertiary">
-              Radar re-checks in the background and reconnects once credentials are refreshed.
-              Use Retry Connection to check immediately.
+              Radar re-checks in the background and usually reconnects on its own once
+              credentials are refreshed. Use Retry Connection to check immediately —
+              always needed if you replaced the token or certificate inside the
+              kubeconfig file itself.
             </p>
           )}
         </div>

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -383,10 +383,8 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
           {isAuth && (
             <p className="mt-4 text-xs text-theme-text-tertiary">
-              Radar re-checks in the background and usually reconnects on its own once
-              credentials are refreshed. Use Retry Connection to check immediately —
-              always needed if you replaced the token or certificate inside the
-              kubeconfig file itself.
+              Radar re-checks in the background and reconnects once credentials are
+              refreshed. Use Retry Connection to check immediately.
             </p>
           )}
         </div>

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -382,7 +382,8 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
           {isAuth && (
             <p className="mt-4 text-xs text-theme-text-tertiary">
-              Radar will keep retrying after credentials are refreshed.
+              Radar re-checks in the background and reconnects once credentials are refreshed.
+              Use Retry Connection to check immediately.
             </p>
           )}
         </div>

--- a/web/src/context/ConnectionContext.test.ts
+++ b/web/src/context/ConnectionContext.test.ts
@@ -3,8 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { shouldApplyPolledConnection, shouldAutoRetryConnection } from './ConnectionContext'
 
 describe('shouldAutoRetryConnection', () => {
-  it('retries runtime authentication loss', () => {
-    expect(shouldAutoRetryConnection('auth')).toBe(true)
+  it('retries transient failures', () => {
+    expect(shouldAutoRetryConnection('network')).toBe(true)
+    expect(shouldAutoRetryConnection('timeout')).toBe(true)
+    expect(shouldAutoRetryConnection(undefined)).toBe(true)
+  })
+
+  it('leaves auth-shaped failures to the server-side recovery loop', () => {
+    expect(shouldAutoRetryConnection('auth')).toBe(false)
+    expect(shouldAutoRetryConnection('auth-rejected')).toBe(false)
   })
 
   it('leaves configuration and RBAC errors for the user to resolve', () => {

--- a/web/src/context/ConnectionContext.test.ts
+++ b/web/src/context/ConnectionContext.test.ts
@@ -15,10 +15,18 @@ describe('shouldAutoRetryConnection', () => {
 
 describe('shouldApplyPolledConnection', () => {
   it('recovers a missed disconnected SSE frame', () => {
-    expect(shouldApplyPolledConnection('connected', 'disconnected')).toBe(true)
+    expect(shouldApplyPolledConnection('connected', 'disconnected', 2, 2)).toBe(true)
   })
 
   it('does not flash a connected UI back to startup progress', () => {
-    expect(shouldApplyPolledConnection('connected', 'connecting')).toBe(false)
+    expect(shouldApplyPolledConnection('connected', 'connecting', 2, 2)).toBe(false)
+  })
+
+  it('does not let a poll started before an SSE update overwrite it', () => {
+    expect(shouldApplyPolledConnection('disconnected', 'connected', 1, 2)).toBe(false)
+  })
+
+  it('allows a fresh fallback poll to observe recovery after an SSE update', () => {
+    expect(shouldApplyPolledConnection('disconnected', 'connected', 2, 2)).toBe(true)
   })
 })

--- a/web/src/context/ConnectionContext.test.ts
+++ b/web/src/context/ConnectionContext.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldApplyPolledConnection, shouldAutoRetryConnection } from './ConnectionContext'
+
+describe('shouldAutoRetryConnection', () => {
+  it('retries runtime authentication loss', () => {
+    expect(shouldAutoRetryConnection('auth')).toBe(true)
+  })
+
+  it('leaves configuration and RBAC errors for the user to resolve', () => {
+    expect(shouldAutoRetryConnection('config')).toBe(false)
+    expect(shouldAutoRetryConnection('rbac')).toBe(false)
+  })
+})
+
+describe('shouldApplyPolledConnection', () => {
+  it('recovers a missed disconnected SSE frame', () => {
+    expect(shouldApplyPolledConnection('connected', 'disconnected')).toBe(true)
+  })
+
+  it('does not flash a connected UI back to startup progress', () => {
+    expect(shouldApplyPolledConnection('connected', 'connecting')).toBe(false)
+  })
+})

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -249,6 +249,11 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     },
     onSettled: () => {
       manualRetryPendingRef.current = false
+      // A poll that resolved mid-retry was deliberately dropped; refetch now
+      // rather than leaving the UI on the retry's outcome until the next
+      // 30s tick (a failed retry against a healthy server would otherwise
+      // park the error screen).
+      queryClient.invalidateQueries({ queryKey: ['connection-status'] })
     },
   })
   useEffect(() => {
@@ -307,6 +312,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
           .finally(() => {
             autoRetryInFlightRef.current = false
             setIsAutoRetrying(false)
+            // Mirror the manual-retry onSettled: re-poll so a status update
+            // dropped by the mid-retry guard isn't stranded until next tick.
+            queryClient.invalidateQueries({ queryKey: ['connection-status'] })
             if (!stopped && !recovered) {
               scheduleRetry()
             }

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -14,7 +14,11 @@ export interface ConnectionState {
   progressMessage?: string
 }
 
-type ConnectionStatusResponse = ConnectionState
+interface ConnectionStatusResponse extends ConnectionState {
+  // Server-side auth recovery owns the episode: suppress browser auto-retry
+  // even when errorType has flipped to a non-auth value.
+  authRecoveryOwed?: boolean
+}
 
 interface PolledConnectionStatus extends ConnectionStatusResponse {
   sseGenerationAtStart: number
@@ -106,6 +110,10 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   const autoRetryInFlightRef = useRef(false)
   const autoRetryDelayRef = useRef(AUTO_RETRY_INITIAL_DELAY_MS)
   const manualRetryPendingRef = useRef(false)
+  // Fed by the status poll only (SSE frames don't carry the field, and must
+  // not clear it): while the server's recovery loop owns the episode, browser
+  // auto-retry stands down even if errorType flips to a non-auth value.
+  const serverOwnsRecoveryRef = useRef(false)
   // Whether the QueryClient already held data when this provider mounted. A host
   // can share one client across cluster-scoped RadarApp mounts (see RadarApp's
   // `queryClient` prop); that client may carry another cluster's data under
@@ -180,6 +188,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   // would never be re-applied — a stuck error screen when SSE is down.
   useEffect(() => {
     if (!data) return
+    if (data.authRecoveryOwed !== undefined) {
+      serverOwnsRecoveryRef.current = data.authRecoveryOwed
+    }
     // A poll resolving mid-retry would flip the UI back to the error screen
     // while the retry is still running; the retry's own result supersedes it.
     if (manualRetryPendingRef.current || autoRetryInFlightRef.current) return
@@ -272,6 +283,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       retryTimeout = window.setTimeout(() => {
         if (stopped) return
         if (manualRetryPendingRef.current || autoRetryInFlightRef.current) {
+          scheduleRetry()
+          return
+        }
+        // Checked at fire time (not arm time): the poll may have learned
+        // mid-wait that the server's recovery loop owns this episode.
+        if (serverOwnsRecoveryRef.current) {
           scheduleRetry()
           return
         }

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -40,9 +40,17 @@ class ConnectionRetryError extends Error {
 const ConnectionContext = createContext<ConnectionContextValue | null>(null)
 const AUTO_RETRY_INITIAL_DELAY_MS = 10000
 const AUTO_RETRY_MAX_DELAY_MS = 60000
+const CONNECTION_STATUS_FALLBACK_POLL_MS = 30000
 
 export function shouldAutoRetryConnection(errorType?: string): boolean {
   return errorType !== 'config' && errorType !== 'rbac'
+}
+
+export function shouldApplyPolledConnection(
+  currentState: ConnectionStateType,
+  polledState: ConnectionStateType,
+): boolean {
+  return currentState !== 'connected' || polledState !== 'connecting'
 }
 
 async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
@@ -76,8 +84,8 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   })
   const [contexts, setContexts] = useState<ContextInfo[]>([])
   const [isAutoRetrying, setIsAutoRetrying] = useState(false)
-  // Track if SSE has started delivering connection_state events
-  // Once SSE is active, it becomes the authoritative source for connection state
+  // Track whether SSE has delivered connection state so retry races prefer its
+  // immediate recovery signal over an older failed request.
   const sseActiveRef = useRef(false)
   // Track whether we've reached 'connected' at least once. Distinguishes the
   // initial connect (bootstrap queries already fetched while 'connecting') from
@@ -100,32 +108,33 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   }
 
   // Fetch initial connection status
-  // Poll while connecting to get progress updates (SSE not established yet)
+  // Poll quickly while connecting and slowly otherwise so a dropped SSE state
+  // frame cannot leave the UI stuck on stale connection state.
   const { data } = useQuery<ConnectionStatusResponse>({
     queryKey: ['connection-status'],
     queryFn: fetchConnectionStatus,
     staleTime: 500, // Allow frequent refetches while connecting
-    refetchInterval: connection.state === 'connecting' ? 500 : false, // Poll every 500ms while connecting
+    refetchInterval: connection.state === 'connecting' ? 500 : CONNECTION_STATUS_FALLBACK_POLL_MS,
     refetchOnWindowFocus: false,
   })
 
   // Update state from query result
-  // Once SSE is active, only update contexts from poll (SSE handles connection state)
   useEffect(() => {
     if (data) {
-      // Always update contexts from poll data
       setContexts(data.contexts || [])
-      // Only update connection state from poll if SSE hasn't taken over
-      if (!sseActiveRef.current) {
-        setConnection({
+      setConnection(current => {
+        if (!shouldApplyPolledConnection(current.state, data.state)) {
+          return current
+        }
+        return {
           state: data.state,
           context: data.context,
           clusterName: data.clusterName,
           error: data.error,
           errorType: data.errorType,
           progressMessage: data.progressMessage,
-        })
-      }
+        }
+      })
     }
   }, [data])
 

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -16,7 +16,8 @@ export interface ConnectionState {
 }
 
 interface ConnectionStatusResponse extends ConnectionState {
-  contexts: ContextInfo[]
+  // Omitted when the poll asks for status only (?contexts=0)
+  contexts?: ContextInfo[]
 }
 
 interface PolledConnectionStatus extends ConnectionStatusResponse {
@@ -47,7 +48,11 @@ const AUTO_RETRY_MAX_DELAY_MS = 60000
 const CONNECTION_STATUS_FALLBACK_POLL_MS = 30000
 
 export function shouldAutoRetryConnection(errorType?: string): boolean {
-  return errorType !== 'config' && errorType !== 'rbac'
+  // Auth-shaped failures are excluded: the server runs its own backoff
+  // reconnect loop for those, and each browser retry would invoke the exec
+  // credential plugin again. Manual "Retry Connection" stays available for
+  // an immediate check.
+  return errorType !== 'config' && errorType !== 'rbac' && !errorType?.startsWith('auth')
 }
 
 export function shouldApplyPolledConnection(
@@ -60,12 +65,12 @@ export function shouldApplyPolledConnection(
     && (currentState !== 'connected' || polledState !== 'connecting')
 }
 
-async function fetchConnectionStatus(sseGenerationAtStart: number): Promise<PolledConnectionStatus> {
+async function fetchConnectionStatus(sseGenerationAtStart: number, includeContexts: boolean): Promise<PolledConnectionStatus> {
   // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
   // no longer auth-exempt, so a session that expires while the connection-
   // error screen is parked open must route through that path rather than
   // surfacing as a misleading "cannot connect to cluster" error.
-  const response = await apiFetch(`${getApiBase()}/connection`)
+  const response = await apiFetch(`${getApiBase()}/connection${includeContexts ? '' : '?contexts=0'}`)
   if (!response.ok) {
     throw new Error('Failed to fetch connection status')
   }
@@ -116,48 +121,88 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     cacheWarmAtMountRef.current = queryClient.getQueryCache().getAll().length > 0
   }
 
-  // Fetch initial connection status
+  // Mirror for the poll-apply effect: it needs the current state to detect a
+  // disconnected→connected transition, which a functional updater can't
+  // surface without side effects inside the updater.
+  const connectionRef = useRef(connection)
+  connectionRef.current = connection
+
+  // Cache refresh shared by every path that lands on 'connected'.
+  const refreshCachesOnConnect = useCallback(() => {
+    const firstConnect = !hasConnectedRef.current
+    hasConnectedRef.current = true
+    // A reconnect after a drop (cache stale across the gap), or a first connect
+    // onto a client that already carried data at mount (shared across clusters),
+    // refreshes the whole cache. A clean first connect only needs to recover the
+    // bootstrap queries that 503'd while the cluster was still 'connecting'
+    // (status === 'error'); the rest already fetched fresh during 'connecting',
+    // so re-fetching the whole cache there would double-load every endpoint.
+    if (!firstConnect || cacheWarmAtMountRef.current) {
+      queryClient.invalidateQueries()
+    } else {
+      queryClient.invalidateQueries({ predicate: (q) => q.state.status === 'error' })
+    }
+  }, [queryClient])
+
   // Poll quickly while connecting and slowly otherwise so a dropped SSE state
-  // frame cannot leave the UI stuck on stale connection state.
-  const { data } = useQuery<PolledConnectionStatus>({
+  // frame cannot leave the UI stuck on stale connection state. The steady-state
+  // fallback poll skips context enumeration — on the server that walks
+  // kubeconfig files under a write lock, too costly for a perpetual 30s tick.
+  const { data, error: pollError } = useQuery<PolledConnectionStatus>({
     queryKey: ['connection-status'],
-    queryFn: () => fetchConnectionStatus(sseGenerationRef.current),
+    queryFn: () => fetchConnectionStatus(sseGenerationRef.current, connectionRef.current.state !== 'connected'),
     staleTime: 500, // Allow frequent refetches while connecting
     refetchInterval: connection.state === 'connecting' ? 500 : CONNECTION_STATUS_FALLBACK_POLL_MS,
     refetchOnWindowFocus: false,
   })
 
+  // The poll is the safety net for dropped SSE frames — if it starts failing
+  // the UI may freeze on stale state, so leave a trace.
+  useEffect(() => {
+    if (pollError) {
+      console.warn('[connection] status poll failed:', pollError)
+    }
+  }, [pollError])
+
   // Update state from query result
   useEffect(() => {
-    if (data) {
-      setContexts(data.contexts || [])
-      setConnection(current => {
-        if (!shouldApplyPolledConnection(
-          current.state,
-          data.state,
-          data.sseGenerationAtStart,
-          sseGenerationRef.current,
-        )) {
-          return current
-        }
-        return {
-          state: data.state,
-          context: data.context,
-          clusterName: data.clusterName,
-          error: data.error,
-          errorType: data.errorType,
-          progressMessage: data.progressMessage,
-        }
-      })
+    if (!data) return
+    if (data.contexts) {
+      setContexts(data.contexts)
     }
-  }, [data])
+    // A poll resolving mid-retry would flip the UI back to the error screen
+    // while the retry is still running; the retry's own result supersedes it.
+    if (manualRetryPendingRef.current || autoRetryInFlightRef.current) return
+    const current = connectionRef.current
+    if (!shouldApplyPolledConnection(
+      current.state,
+      data.state,
+      data.sseGenerationAtStart,
+      sseGenerationRef.current,
+    )) {
+      return
+    }
+    const becameConnected = current.state !== 'connected' && data.state === 'connected'
+    setConnection({
+      state: data.state,
+      context: data.context,
+      clusterName: data.clusterName,
+      error: data.error,
+      errorType: data.errorType,
+      progressMessage: data.progressMessage,
+    })
+    if (becameConnected) {
+      refreshCachesOnConnect()
+    }
+  }, [data, refreshCachesOnConnect])
 
   // Retry mutation
   const retryMutation = useMutation({
     mutationFn: retryConnection,
     onMutate: () => {
       manualRetryPendingRef.current = true
-      // Reset SSE active flag - polling can provide state until SSE reconnects
+      // Until SSE re-delivers state, a failed retry may report its own error
+      // rather than deferring to a stale "connected"
       sseActiveRef.current = false
       // Set connecting state while retrying
       setConnection(prev => ({
@@ -267,7 +312,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
 
   // Handler for SSE connection_state events
   const updateFromSSE = useCallback((status: ConnectionState) => {
-    // Mark SSE as active - it's now the authoritative source for connection state
+    // Feed the retry-race guards: a live SSE stream means retry failures must
+    // not clobber a recovery it already delivered. The generation bump lets
+    // in-flight polls detect they raced this frame.
     sseActiveRef.current = true
     sseGenerationRef.current += 1
     setConnection(prev => {
@@ -275,6 +322,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       // pod restarts and the SSE reconnects while the new pod's K8s cache is still
       // syncing. Hiding the main content here causes a flash — keep the 'connected'
       // state and wait for either 'connected' (sync done) or 'disconnected' (failure).
+      // (shouldApplyPolledConnection encodes the same suppression for the poll path.)
       if (prev.state === 'connected' && status.state === 'connecting') {
         return prev
       }
@@ -282,21 +330,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     })
 
     if (status.state === 'connected') {
-      const firstConnect = !hasConnectedRef.current
-      hasConnectedRef.current = true
-      // A reconnect after a drop (cache stale across the gap), or a first connect
-      // onto a client that already carried data at mount (shared across clusters),
-      // refreshes the whole cache. A clean first connect only needs to recover the
-      // bootstrap queries that 503'd while the cluster was still 'connecting'
-      // (status === 'error'); the rest already fetched fresh during 'connecting',
-      // so re-fetching the whole cache there would double-load every endpoint.
-      if (!firstConnect || cacheWarmAtMountRef.current) {
-        queryClient.invalidateQueries()
-      } else {
-        queryClient.invalidateQueries({ predicate: (q) => q.state.status === 'error' })
-      }
+      refreshCachesOnConnect()
     }
-  }, [queryClient])
+  }, [refreshCachesOnConnect])
 
   const value: ConnectionContextValue = {
     connection,

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -19,6 +19,10 @@ interface ConnectionStatusResponse extends ConnectionState {
   contexts: ContextInfo[]
 }
 
+interface PolledConnectionStatus extends ConnectionStatusResponse {
+  sseGenerationAtStart: number
+}
+
 interface ConnectionContextValue {
   connection: ConnectionState
   contexts: ContextInfo[]
@@ -49,11 +53,14 @@ export function shouldAutoRetryConnection(errorType?: string): boolean {
 export function shouldApplyPolledConnection(
   currentState: ConnectionStateType,
   polledState: ConnectionStateType,
+  pollSSEGeneration: number,
+  currentSSEGeneration: number,
 ): boolean {
-  return currentState !== 'connected' || polledState !== 'connecting'
+  return pollSSEGeneration === currentSSEGeneration
+    && (currentState !== 'connected' || polledState !== 'connecting')
 }
 
-async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
+async function fetchConnectionStatus(sseGenerationAtStart: number): Promise<PolledConnectionStatus> {
   // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
   // no longer auth-exempt, so a session that expires while the connection-
   // error screen is parked open must route through that path rather than
@@ -62,7 +69,8 @@ async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
   if (!response.ok) {
     throw new Error('Failed to fetch connection status')
   }
-  return response.json()
+  const status = await response.json() as ConnectionStatusResponse
+  return { ...status, sseGenerationAtStart }
 }
 
 async function retryConnection(): Promise<ConnectionState> {
@@ -87,6 +95,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   // Track whether SSE has delivered connection state so retry races prefer its
   // immediate recovery signal over an older failed request.
   const sseActiveRef = useRef(false)
+  const sseGenerationRef = useRef(0)
   // Track whether we've reached 'connected' at least once. Distinguishes the
   // initial connect (bootstrap queries already fetched while 'connecting') from
   // a reconnect after a drop (cache may be stale across the gap).
@@ -110,9 +119,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   // Fetch initial connection status
   // Poll quickly while connecting and slowly otherwise so a dropped SSE state
   // frame cannot leave the UI stuck on stale connection state.
-  const { data } = useQuery<ConnectionStatusResponse>({
+  const { data } = useQuery<PolledConnectionStatus>({
     queryKey: ['connection-status'],
-    queryFn: fetchConnectionStatus,
+    queryFn: () => fetchConnectionStatus(sseGenerationRef.current),
     staleTime: 500, // Allow frequent refetches while connecting
     refetchInterval: connection.state === 'connecting' ? 500 : CONNECTION_STATUS_FALLBACK_POLL_MS,
     refetchOnWindowFocus: false,
@@ -123,7 +132,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     if (data) {
       setContexts(data.contexts || [])
       setConnection(current => {
-        if (!shouldApplyPolledConnection(current.state, data.state)) {
+        if (!shouldApplyPolledConnection(
+          current.state,
+          data.state,
+          data.sseGenerationAtStart,
+          sseGenerationRef.current,
+        )) {
           return current
         }
         return {
@@ -255,6 +269,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   const updateFromSSE = useCallback((status: ConnectionState) => {
     // Mark SSE as active - it's now the authoritative source for connection state
     sseActiveRef.current = true
+    sseGenerationRef.current += 1
     setConnection(prev => {
       // Don't transition back to 'connecting' from 'connected'. This happens when the
       // pod restarts and the SSE reconnects while the new pod's K8s cache is still

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { ContextInfo } from '../types'
 import { getApiBase } from '../api/config'
 import { apiFetch } from '../api/client'
 
@@ -15,10 +14,7 @@ export interface ConnectionState {
   progressMessage?: string
 }
 
-interface ConnectionStatusResponse extends ConnectionState {
-  // Omitted when the poll asks for status only (?contexts=0)
-  contexts?: ContextInfo[]
-}
+type ConnectionStatusResponse = ConnectionState
 
 interface PolledConnectionStatus extends ConnectionStatusResponse {
   sseGenerationAtStart: number
@@ -26,7 +22,6 @@ interface PolledConnectionStatus extends ConnectionStatusResponse {
 
 interface ConnectionContextValue {
   connection: ConnectionState
-  contexts: ContextInfo[]
   retry: () => void
   isRetrying: boolean
   updateFromSSE: (status: ConnectionState) => void
@@ -65,12 +60,16 @@ export function shouldApplyPolledConnection(
     && (currentState !== 'connected' || polledState !== 'connecting')
 }
 
-async function fetchConnectionStatus(sseGenerationAtStart: number, includeContexts: boolean): Promise<PolledConnectionStatus> {
+async function fetchConnectionStatus(sseGenerationAtStart: number): Promise<PolledConnectionStatus> {
   // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
   // no longer auth-exempt, so a session that expires while the connection-
   // error screen is parked open must route through that path rather than
   // surfacing as a misleading "cannot connect to cluster" error.
-  const response = await apiFetch(`${getApiBase()}/connection${includeContexts ? '' : '?contexts=0'}`)
+  //
+  // ?contexts=0: context enumeration re-reads kubeconfig files under the
+  // client write lock on the server — too costly for a perpetual poll, and
+  // nothing here consumes the list (ContextSwitcher has its own query).
+  const response = await apiFetch(`${getApiBase()}/connection?contexts=0`)
   if (!response.ok) {
     throw new Error('Failed to fetch connection status')
   }
@@ -95,7 +94,6 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     state: 'connecting',
     context: '',
   })
-  const [contexts, setContexts] = useState<ContextInfo[]>([])
   const [isAutoRetrying, setIsAutoRetrying] = useState(false)
   // Track whether SSE has delivered connection state so retry races prefer its
   // immediate recovery signal over an older failed request.
@@ -123,14 +121,25 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
 
   // Mirror for the poll-apply effect: it needs the current state to detect a
   // disconnected→connected transition, which a functional updater can't
-  // surface without side effects inside the updater.
+  // surface without side effects inside the updater. Deliberately written
+  // during render (not in an effect): when an SSE frame and a poll land in the
+  // same commit, the poll effect must already see the SSE-updated state or it
+  // would double-run the connected cache refresh.
   const connectionRef = useRef(connection)
   connectionRef.current = connection
 
   // Cache refresh shared by every path that lands on 'connected'.
+  const lastCacheRefreshAtRef = useRef(0)
   const refreshCachesOnConnect = useCallback(() => {
     const firstConnect = !hasConnectedRef.current
     hasConnectedRef.current = true
+    // Poll and SSE can both observe the same reconnect within moments of each
+    // other (SSE always writes a connected frame on stream open); refreshing
+    // twice cancels and refires every in-flight bootstrap fetch.
+    if (Date.now() - lastCacheRefreshAtRef.current < 1500) {
+      return
+    }
+    lastCacheRefreshAtRef.current = Date.now()
     // A reconnect after a drop (cache stale across the gap), or a first connect
     // onto a client that already carried data at mount (shared across clusters),
     // refreshes the whole cache. A clean first connect only needs to recover the
@@ -145,15 +154,16 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   }, [queryClient])
 
   // Poll quickly while connecting and slowly otherwise so a dropped SSE state
-  // frame cannot leave the UI stuck on stale connection state. The steady-state
-  // fallback poll skips context enumeration — on the server that walks
-  // kubeconfig files under a write lock, too costly for a perpetual 30s tick.
-  const { data, error: pollError } = useQuery<PolledConnectionStatus>({
+  // frame cannot leave the UI stuck on stale connection state. Runs in hidden
+  // tabs and catches up on focus — a parked tab is exactly where a dropped SSE
+  // frame otherwise strands stale state.
+  const { data, dataUpdatedAt, error: pollError } = useQuery<PolledConnectionStatus>({
     queryKey: ['connection-status'],
-    queryFn: () => fetchConnectionStatus(sseGenerationRef.current, connectionRef.current.state !== 'connected'),
+    queryFn: () => fetchConnectionStatus(sseGenerationRef.current),
     staleTime: 500, // Allow frequent refetches while connecting
     refetchInterval: connection.state === 'connecting' ? 500 : CONNECTION_STATUS_FALLBACK_POLL_MS,
-    refetchOnWindowFocus: false,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
   })
 
   // The poll is the safety net for dropped SSE frames — if it starts failing
@@ -164,12 +174,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     }
   }, [pollError])
 
-  // Update state from query result
+  // Update state from query result. dataUpdatedAt is a deliberate dep:
+  // structural sharing keeps `data`'s identity stable across byte-identical
+  // polls, so without it a result dropped by the retry-in-flight guard below
+  // would never be re-applied — a stuck error screen when SSE is down.
   useEffect(() => {
     if (!data) return
-    if (data.contexts) {
-      setContexts(data.contexts)
-    }
     // A poll resolving mid-retry would flip the UI back to the error screen
     // while the retry is still running; the retry's own result supersedes it.
     if (manualRetryPendingRef.current || autoRetryInFlightRef.current) return
@@ -194,7 +204,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     if (becameConnected) {
       refreshCachesOnConnect()
     }
-  }, [data, refreshCachesOnConnect])
+  }, [data, dataUpdatedAt, refreshCachesOnConnect])
 
   // Retry mutation
   const retryMutation = useMutation({
@@ -214,6 +224,12 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     },
     onSuccess: (result) => {
       setConnection(result)
+      if (result.state === 'connected') {
+        // Keep the first-connect bookkeeping and the double-refresh window
+        // honest — the SSE frame that follows must not re-invalidate.
+        hasConnectedRef.current = true
+        lastCacheRefreshAtRef.current = Date.now()
+      }
       // Clear all query cache to get fresh data from new connection
       queryClient.removeQueries()
       queryClient.invalidateQueries()
@@ -265,6 +281,10 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
             autoRetryDelayRef.current = AUTO_RETRY_INITIAL_DELAY_MS
             sseActiveRef.current = false
             setConnection(result)
+            if (result.state === 'connected') {
+              hasConnectedRef.current = true
+              lastCacheRefreshAtRef.current = Date.now()
+            }
             queryClient.removeQueries()
             queryClient.invalidateQueries()
           })
@@ -336,7 +356,6 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
 
   const value: ConnectionContextValue = {
     connection,
-    contexts,
     retry,
     isRetrying: retryMutation.isPending || isAutoRetrying,
     updateFromSSE,


### PR DESCRIPTION
## Summary

When kubeconfig credentials died mid-session (expired SSO token, rotated static token, revoked cert), Radar stayed marked **connected**: the dashboard served stale caches, informers hammered the dead credential, and the exec plugin was re-invoked endlessly. Recovering required noticing and restarting or manually retrying.

Radar now detects credential loss at runtime, demotes the connection cleanly, tells the user exactly what happened, and **reconnects on its own once credentials are restored** — including headless deployments (MCP-only, `--no-browser`) that previously had no recovery path at all.

## What changed

### Detection

All shared Kubernetes clients (typed, dynamic, discovery) are built on one observed HTTP transport. Auth-shaped transport errors and HTTP 401 responses become demotion candidates; a candidate is only acted on after a **confirmation probe** with freshly minted credentials (so client-go's own refresh-on-401 gets its chance first) and an **anonymous endpoint reachability probe** that separates "credentials died" from "machine is offline" — a VPN blip or sleeping laptop never tears down a session. A TLS alert from an mTLS-terminating proxy counts as reachable, and a hung exec plugin (probe dies on the exec-specific timeout while the endpoint is reachable) demotes rather than leaving the UI frozen on "connected".

Error classification covers the failure shapes of the major platforms: exec plugins (EKS/GKE/AKS/DOKS/OKE/Pinniped and the exec cert path), the in-tree OIDC auth provider's raw refresh failures (Keycloak/Dex/IBM IKS), token-file failures, and client-cert rejection alerts from mTLS proxies. An unrecognized RoundTripper failure classifies `unknown` rather than being mislabeled a network problem. In-cluster mode is exempt by design — projected SA tokens refresh from disk.

### Demotion

Committed exactly once under the context-operation lock: in-flight operations cancelled (including AI investigation runs), sessions stopped, subsystems and the Argo CD tunnel reset. The published error is a fixed message — raw credential-provider errors can embed secret material and the status broadcasts to every SSE client; the raw error goes to the server log only. Auth-shaped failures surfaced through Helm handlers route through this same pipeline rather than flipping the global state directly. Repeat candidates are throttled with per-generation cooldowns, and inconclusive (offline) results back off 5s→5min.

### Recovery

A server-side worker owns reconnection with an explicit debt flag, armed by **any** auth-shaped disconnect — runtime demotion, startup with already-expired credentials, failed retries and context switches — and settled only by a successful connect, so it survives the error type flipping (e.g. a hung-plugin retry classifying as timeout). It re-probes on a 30s→5min backoff (30min when the exec plugin hangs, bounding subprocess leaks), yields to user-driven operations, and re-targets across episodes via a nudge channel. Reconnection goes through a generation-revalidated conditional switch that aborts before any teardown if a user operation intervened, and the connected status is published while still holding the operation lock (HTTP handlers no longer publish success separately, closing a stale-overwrite window). Credentials that only exist inline in the kubeconfig (`oc login` tokens, embedded certs) are recovered by re-reading the file from disk — an in-memory probe can never see those change.

### Frontend + MCP

The connection status poll runs continuously (500ms while connecting, 30s steady-state, hidden tabs included, catch-up on focus) so a dropped SSE frame can't strand stale state; it fetches status-only (`?contexts=0`) since context enumeration re-reads kubeconfig files server-side. Poll results are guarded against racing SSE frames and in-flight retries, and a poll-observed reconnect refreshes the query cache exactly once even when SSE reports the same transition. The browser no longer auto-retries auth failures — the server loop owns that — while manual **Retry Connection** remains for an immediate check, and the auth error screen says exactly that. MCP tools return the connection status and the self-heal expectation instead of a bare "not connected to cluster", so agent callers know waiting (or re-authenticating) resolves it.

## Testing

- `make tsc`, `make test`, full Go suites with `-race` for the concurrency-heavy packages
- Real exec-credential integration test (re-invokes the test binary as the plugin, real transport, real probes): expiry → demote across two client generations
- Live binary E2E against a kind cluster with a disposable exec-credential kubeconfig: connect → credential expiry → demotion (~23s) → clean 503s and MCP errors while demoted → **unattended recovery 45s after credential restore** → caches serving data → second expiry re-arms detection; separately: startup with expired credentials → restore → automatic recovery; manual retry during demotion
- Browser flows and multi-tab behavior verified at the API/frame level; no layout/styling changes beyond error-screen copy

## Notes

- A proxy that 401s every request demotes like credential loss — the connection is equally unusable either way; distinguishing the *guidance* shown (e.g. EKS access-entry vs SSO re-login) lands separately with the server-401 classification split.
- A plugin that hangs without ever yielding a 401 produces no candidate (no request-duration watchdog); the hung-plugin path covers the 401-then-hang variant.
- #1297 tracks extending transport observation to impersonated per-user and Helm clients (detection there currently arrives via shared-informer traffic) and a same-context reconnect that preserves per-user view state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core connection lifecycle, global client wiring, context-switch locking, and teardown ordering; mistakes could cause false disconnects, missed recovery, or races with user-driven switches.
> 
> **Overview**
> Mid-session credential expiry used to leave Radar **connected** with stale caches and endless exec-plugin retries. This PR adds **runtime detection**, a clean **demotion** path, and a **server-owned reconnect loop** so headless and browser sessions recover after re-auth without a restart.
> 
> **Backend:** Shared Kubernetes clients now use one HTTP transport that watches auth-shaped errors and HTTP 401s. Candidates are confirmed with a fresh probe and an anonymous endpoint reachability check (so VPN/offline blips do not tear down a healthy session). On commit, the process quiesces cluster work (sessions, subsystems, Argo CD tunnel) and publishes a fixed credential-loss message instead of raw errors that might leak secrets. Error classification is expanded for OIDC refresh failures, exec-plugin paths, token files, and mTLS proxy TLS alerts. A backoff worker reconnects when credentials return, including kubeconfig **disk re-read** for inline tokens; context switches publish **connected** under the operation lock to avoid racing teardown.
> 
> **API & UI:** Connection status exposes `authRecoveryOwed` and supports lightweight polling (`?contexts=0`). The browser polls continuously as an SSE fallback, suppresses auto-retry for auth failures while the server loop runs, and updates auth error copy. MCP tools surface actionable disconnect reasons instead of a generic “not connected”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2456a8eaf8ff35fa3a1daaa9da353a1f45540e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->