### PR TITLE
cloud: add --cloud-insecure-skip-verify for self-signed hub trials

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -130,6 +130,7 @@ func main() {
 	cloudURL := flag.String("cloud-url", os.Getenv("RADAR_CLOUD_URL"), "Radar Hub WebSocket URL (e.g. wss://api.radarhq.io/agent) — empty = local-only. Env: RADAR_CLOUD_URL")
 	cloudToken := flag.String("cloud-token", os.Getenv("RADAR_CLOUD_TOKEN"), "Connection token from the Radar install flow (rhc_<random>). Env: RADAR_CLOUD_TOKEN")
 	cloudClusterName := flag.String("cluster-name", os.Getenv("RADAR_CLOUD_CLUSTER_NAME"), "Human-readable cluster name shown in Radar (required with --cloud-url). Env: RADAR_CLOUD_CLUSTER_NAME")
+	cloudInsecureSkipVerify := flag.Bool("cloud-insecure-skip-verify", os.Getenv("RADAR_CLOUD_INSECURE_SKIP_VERIFY") == "true", "Skip TLS verification on the Radar Hub tunnel — for trials against a self-hosted hub with a self-signed cert (insecure: encrypted but not authenticated). Env: RADAR_CLOUD_INSECURE_SKIP_VERIFY")
 	// Tunable deadlines for slow / high-latency / SSH-tunneled clusters.
 	// Defaults preserve the original behavior. Each flag falls back to an
 	// environment variable so Kubernetes deployments can source values from
@@ -409,8 +410,9 @@ func main() {
 				Token:        *cloudToken,
 				ClusterID:    *cloudClusterName,
 				ClusterName:  *cloudClusterName,
-				Namespace:    namespace,
-				APIServerURL: apiServerURL,
+				Namespace:          namespace,
+				APIServerURL:       apiServerURL,
+				InsecureSkipVerify: *cloudInsecureSkipVerify,
 				// The chart sets both env vars only when rbac.selfUpgrade is
 				// enabled. Match handleSelfUpgrade's configuration gate exactly.
 				SelfUpgradeAvailable: namespace != "" && deploymentName != "",

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
             {{- end }}
             - --cloud-url={{ required "cloud.url is required when cloud.enabled=true" .Values.cloud.url }}
             - --cluster-name={{ required "cloud.clusterName is required when cloud.enabled=true" .Values.cloud.clusterName }}
+            {{- if .Values.cloud.insecureSkipVerify }}
+            - --cloud-insecure-skip-verify
+            {{- end }}
             {{- /* cloud.token is injected via RADAR_CLOUD_TOKEN env var below, not the command line */}}
             {{- end }}
           ports:

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -240,7 +240,8 @@
             "memberClusterRole": { "type": "string" },
             "viewerClusterRole": { "type": "string" }
           }
-        }
+        },
+        "insecureSkipVerify": { "type": "boolean" }
       }
     },
     "mcp": {

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -327,6 +327,11 @@ cloud:
   # The Secret must contain a key matching existingSecretKey.
   existingSecret: ""
   existingSecretKey: "token"
+  # Skip TLS verification on the tunnel to the hub — for trials against a
+  # self-hosted hub that serves a self-signed certificate. The tunnel stays
+  # encrypted but is NOT authenticated (a network attacker could impersonate
+  # the hub), so leave false for any hub with a publicly trusted certificate.
+  insecureSkipVerify: false
   # Default ClusterRoleBindings for Radar Cloud identity groups.
   #
   # How it works: Cloud injects X-Forwarded-Groups: cloud:<role>,

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -26,6 +26,13 @@ type Config struct {
 	// e.g. wss://api.radarhq.io/agent
 	URL string
 
+	// InsecureSkipVerify disables TLS certificate verification on the wss
+	// tunnel. Intended only for trials against a self-hosted hub that serves a
+	// self-signed certificate: the connection stays encrypted but is not
+	// authenticated, so a network attacker could impersonate the hub. Leave
+	// false for any hub with a publicly trusted certificate.
+	InsecureSkipVerify bool
+
 	// Token is the cluster bearer token issued by the Cloud install wizard.
 	// Format: rhc_<random>.
 	Token string

--- a/internal/cloud/dialer.go
+++ b/internal/cloud/dialer.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,6 +32,9 @@ func dial(ctx context.Context, cfg Config) (*yamux.Session, error) {
 
 	dialer := *websocket.DefaultDialer
 	dialer.HandshakeTimeout = 10 * time.Second
+	if cfg.InsecureSkipVerify {
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-requested via --cloud-insecure-skip-verify for a self-signed hub
+	}
 	ws, resp, err := dialer.DialContext(ctx, u.String(), headers)
 	if err != nil {
 		if resp != nil {


### PR DESCRIPTION
## What

Adds an opt-in `--cloud-insecure-skip-verify` (env `RADAR_CLOUD_INSECURE_SKIP_VERIFY`, Helm `cloud.insecureSkipVerify`) that disables TLS verification on the connector's `wss` tunnel to Radar Hub.

## Why

The connector dials the hub over `wss://` and verifies the server certificate against the **system trust store with no override** (`internal/cloud/dialer.go` used `websocket.DefaultDialer` with no `TLSClientConfig`). So a **self-hosted hub serving a self-signed certificate can never be connected** — the handshake fails and there's no flag to allow it.

This blocks the self-serve self-hosting trial: on a cloud cluster (LoadBalancer, no cert-manager/DNS), the hub can only present a self-signed cert, and the connector rejects it.

## Change

- `cloud.Config` gains `InsecureSkipVerify bool`; when set, the dialer uses `&tls.Config{InsecureSkipVerify: true}`.
- Plumbed via `--cloud-insecure-skip-verify` flag / `RADAR_CLOUD_INSECURE_SKIP_VERIFY` env (`cmd/explorer/main.go`).
- Helm: `cloud.insecureSkipVerify` value (+ schema entry, since the `cloud` object is `additionalProperties: false`) → renders the flag on the deployment when true.

## Security

The tunnel stays **encrypted but is no longer authenticated** — a network attacker could impersonate the hub. This is strictly for **self-hosted trials** against a self-signed hub; any hub with a publicly trusted cert leaves it `false` (the default). The flag help text says so.

## Tests
`go build ./...`, `go test ./internal/cloud/...` pass; `helm template` renders `--cloud-insecure-skip-verify` only when `cloud.insecureSkipVerify=true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling TLS verification on the cloud tunnel is a deliberate MITM exposure when enabled, but it is opt-in with clear warnings and mirrors existing auth-OIDC insecure-skip patterns; default behavior is unchanged.
> 
> **Overview**
> Adds an **opt-in** way to connect the Radar connector to a self-hosted Radar Hub over `wss` when the hub only presents a **self-signed certificate** (previously the WebSocket dial always verified the server cert and could not connect).
> 
> `cloud.Config` gains `InsecureSkipVerify`; the dialer sets `tls.Config{InsecureSkipVerify: true}` on the gorilla WebSocket client when enabled. Wired through **`--cloud-insecure-skip-verify`**, env **`RADAR_CLOUD_INSECURE_SKIP_VERIFY=true`**, and Helm **`cloud.insecureSkipVerify`** (schema + deployment args). Default remains verification on.
> 
> **Security:** traffic stays encrypted but the hub identity is not authenticated—documented as trial-only; production hubs with public CA certs should leave this false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e7c5383ddc0fb1994af3a3e82e880968cd23d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->