### PR TITLE
Fix session-expiry return path doubling the host basename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6394,7 +6394,7 @@
     },
     "web": {
       "name": "@skyhook-io/radar-app",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyhook-io/radar-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Radar's full web UI as a reusable React component. Used by Radar's own binary and by external consumers like Radar Cloud.",
   "repository": {
     "type": "git",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,7 +50,7 @@ import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
 import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
-import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
+import { routePath, apiUrl, getAuthHeaders, getCredentialsMode, stripBasename } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
@@ -343,12 +343,19 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   // Auth check — detect if auth is enabled but user is not authenticated
   const { data: authMe, isPending: authMePending } = useAuthMe()
 
-  // Restore navigation path after session-expiry re-auth redirect
+  // Restore navigation path after session-expiry re-auth redirect.
+  // The stored value is basename-relative, but strip defensively anyway:
+  // sessionStorage outlives app upgrades, so a value written by an older
+  // version may still carry the basename — and navigate() re-applies the
+  // basename, which would double it (/c/abc/c/abc/...). Trade-off: if a host
+  // mounts the app at a basename that exactly equals an internal route (e.g.
+  // /topology), this second strip eats the route and re-auth lands on home —
+  // accepted, since a wrong-but-valid landing beats a doubled URL.
   useEffect(() => {
     const returnPath = sessionStorage.getItem('radar_return_path')
     if (returnPath) {
       sessionStorage.removeItem('radar_return_path')
-      navigate(returnPath, { replace: true })
+      navigate(stripBasename(returnPath), { replace: true })
     }
   }, [navigate])
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -42,7 +42,7 @@ import type {
   ArgoRevisionMetadata,
 } from '../types'
 import type { GitOpsOperationResponse } from '../types/gitops'
-import { getApiBase, getAuthHeaders, getCredentialsMode, getBasename, routePath } from './config'
+import { getApiBase, getAuthHeaders, getCredentialsMode, getBasename, routePath, stripBasename } from './config'
 import { pluralToKind } from '../utils/navigation'
 
 // Auto-refresh cadences (ms) — named constants for each polled hook's
@@ -74,11 +74,13 @@ export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<
     const authPrefix = `${getBasename()}/auth`
     if (response.status === 401 && !window.location.pathname.startsWith(authPrefix)) {
       // Save current location so user returns to where they were after re-auth.
+      // Stored basename-relative: the restore path replays it through React
+      // Router's navigate(), which re-applies the basename itself.
       // Editor draft is auto-saved by EditableYamlView via sessionStorage.
       try {
         sessionStorage.setItem(
           'radar_return_path',
-          window.location.pathname + window.location.search,
+          stripBasename(window.location.pathname) + window.location.search,
         )
       } catch {
         /* best-effort */

--- a/web/src/api/config.test.ts
+++ b/web/src/api/config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, afterEach } from 'vitest'
+
+import { setBasename, stripBasename, routePath } from './config'
+
+// setBasename mutates module state — restore standalone default after each test.
+afterEach(() => {
+  setBasename('')
+})
+
+describe('stripBasename', () => {
+  it('passes paths through unchanged when no basename is configured', () => {
+    expect(stripBasename('/resources/pods')).toBe('/resources/pods')
+    expect(stripBasename('/')).toBe('/')
+  })
+
+  it('strips a configured basename prefix', () => {
+    setBasename('/c/abc')
+    expect(stripBasename('/c/abc/resources/pods')).toBe('/resources/pods')
+    expect(stripBasename('/c/abc/timeline?range=1h')).toBe('/timeline?range=1h')
+  })
+
+  it('maps the bare basename to root', () => {
+    setBasename('/c/abc')
+    expect(stripBasename('/c/abc')).toBe('/')
+  })
+
+  it('strips when the basename is followed directly by a query string', () => {
+    setBasename('/c/abc')
+    expect(stripBasename('/c/abc?tab=events')).toBe('?tab=events')
+  })
+
+  it('leaves basename-relative paths unchanged (idempotent)', () => {
+    setBasename('/c/abc')
+    expect(stripBasename('/resources/pods')).toBe('/resources/pods')
+    expect(stripBasename(stripBasename('/c/abc/resources/pods'))).toBe('/resources/pods')
+  })
+
+  it('does not strip a path that merely shares a string prefix', () => {
+    setBasename('/c/abc')
+    expect(stripBasename('/c/abcdef/resources')).toBe('/c/abcdef/resources')
+  })
+
+  it('inverts routePath', () => {
+    setBasename('/c/abc')
+    expect(stripBasename(routePath('/auth/login'))).toBe('/auth/login')
+  })
+})

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -65,6 +65,21 @@ export function routePath(path: string): string {
 }
 
 /**
+ * Inverse of `routePath`: strips the configured basename from a window-level
+ * path so it can be handed to React Router's navigate(), which re-applies the
+ * basename. Passing an already-prefixed path to navigate() doubles the prefix
+ * (e.g. /c/abc/c/abc/...). Basename-relative paths pass through unchanged.
+ */
+export function stripBasename(path: string): string {
+  const prefix = basename;
+  if (!prefix) return path;
+  if (path === prefix || path.startsWith(prefix + '/') || path.startsWith(prefix + '?')) {
+    return path.slice(prefix.length) || '/';
+  }
+  return path;
+}
+
+/**
  * Builds a WebSocket URL for a given API path.
  *
  * When apiBase is relative, uses window.location.host + apiBase + path.

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
 import { isBadgeWorthy } from '../../utils/auditBadges'
 import type { AuditBadgeMessage } from '@skyhook-io/k8s-ui'
-import { apiUrl, getAuthHeaders, getCredentialsMode, getBasename } from '../../api/config'
+import { apiUrl, getAuthHeaders, getCredentialsMode, stripBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { useConnection } from '../../context/ConnectionContext'
 import { initNavigationMap } from '@skyhook-io/k8s-ui'
@@ -295,13 +295,8 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // any host that mounts RadarApp under a non-empty basename (Radar Cloud).
   // Strip the basename here so react-router can re-apply it cleanly.
   const handleNavigate = useMemo(() => {
-    const base = getBasename()
     return (path: string, options?: { replace?: boolean }) => {
-      let p = path
-      if (base && (p === base || p.startsWith(base + '/') || p.startsWith(base + '?'))) {
-        p = p.slice(base.length) || '/'
-      }
-      navigate(p, { replace: options?.replace })
+      navigate(stripBasename(path), { replace: options?.replace })
     }
   }, [navigate])
 


### PR DESCRIPTION
## What

When RadarApp is embedded with a non-empty basename (Radar Cloud mounts it at `/c/:id`), the session-expiry return-path flow doubled the basename: `apiFetch` stored `window.location.pathname + search` — the full path *including* the basename — into `radar_return_path` on 401, and the App mount effect replayed it via react-router `navigate()`, which prepends the basename again → `/c/:id/c/:id/...` (seen in prod PostHog on app.radarhq.io, 2026-07-15).

## How

- New `stripBasename()` in `web/src/api/config.ts` — the inverse of `routePath()`, generalizing the inline strip pattern `ResourcesView.handleNavigate` already used.
- **Store side** (`client.ts`): the saved return path is now basename-relative.
- **Restore side** (`App.tsx`): strips defensively anyway — sessionStorage outlives app upgrades, so a value written by an older version may still carry the basename.
- `ResourcesView.handleNavigate` refactored onto the shared helper so the three sites can't drift.
- 7 unit tests pin the helper (prefix strip, bare-basename → `/`, query-only tail, no false prefix match, idempotence, `routePath` round-trip).
- `@skyhook-io/radar-app` bumped to **0.3.1** (patch). Publish after merge with tag `radar-app-v0.3.1`.

radar-hub-web PR #222 shipped hub-side mitigations (sanitizer + URL watchdog); this fixes the contract at the source.

## Known trade-off (flagged by cross-review)

The defensive restore-side strip is not idempotent if a host mounts the app at a basename that *exactly equals* an internal route (e.g. basename `/topology`): the second strip eats the route and re-auth lands on home. Impossible for Radar Cloud's `/c/:id` shape (no internal route starts with `/c/`), and a wrong-but-valid landing beats a doubled URL, so it's documented in code rather than solved with storage-format versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing helper and auth return-path handling with unit tests; no changes to auth, API contracts, or data handling beyond URL shape.
> 
> **Overview**
> Fixes **doubled host basenames** (e.g. `/c/:id/c/:id/...`) when RadarApp is embedded under a non-empty basename and the user returns after a 401 re-auth. `apiFetch` used to persist the full `window.location.pathname`; replay through `navigate()` prepends the basename again.
> 
> Adds **`stripBasename()`** in `config.ts` as the inverse of `routePath()`. Return paths are stored basename-relative on 401; **`App.tsx`** still strips on restore for older `sessionStorage` values. **`ResourcesView.handleNavigate`** uses the same helper instead of inline logic. **`@skyhook-io/radar-app`** is bumped to **0.3.1**; seven unit tests cover `stripBasename`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61d13f77e216f98b02154d606c90f0609307805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->