### PR TITLE
web: store session-expiry return path basename-relative

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,7 +50,7 @@ import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
 import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
-import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
+import { routePath, apiUrl, basenameRelativePath, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
@@ -343,12 +343,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   // Auth check — detect if auth is enabled but user is not authenticated
   const { data: authMe, isPending: authMePending } = useAuthMe()
 
-  // Restore navigation path after session-expiry re-auth redirect
+  // Restore navigation path after session-expiry re-auth redirect. The stored
+  // value is basename-relative, but sessionStorage survives the reload
+  // boundary — an older bundle may have written the full prefixed pathname —
+  // so normalize before handing it to the basename-aware navigate().
   useEffect(() => {
     const returnPath = sessionStorage.getItem('radar_return_path')
     if (returnPath) {
       sessionStorage.removeItem('radar_return_path')
-      navigate(returnPath, { replace: true })
+      navigate(basenameRelativePath(returnPath), { replace: true })
     }
   }, [navigate])
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -42,7 +42,14 @@ import type {
   ArgoRevisionMetadata,
 } from '../types'
 import type { GitOpsOperationResponse } from '../types/gitops'
-import { getApiBase, getAuthHeaders, getCredentialsMode, getBasename, routePath } from './config'
+import {
+  basenameRelativePath,
+  getApiBase,
+  getAuthHeaders,
+  getCredentialsMode,
+  getBasename,
+  routePath,
+} from './config'
 import { pluralToKind } from '../utils/navigation'
 
 // Auto-refresh cadences (ms) — named constants for each polled hook's
@@ -74,11 +81,13 @@ export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<
     const authPrefix = `${getBasename()}/auth`
     if (response.status === 401 && !window.location.pathname.startsWith(authPrefix)) {
       // Save current location so user returns to where they were after re-auth.
-      // Editor draft is auto-saved by EditableYamlView via sessionStorage.
+      // Stored basename-relative: the restore replays it through the router,
+      // whose navigate() re-prepends the basename. Editor draft is auto-saved
+      // by EditableYamlView via sessionStorage.
       try {
         sessionStorage.setItem(
           'radar_return_path',
-          window.location.pathname + window.location.search,
+          basenameRelativePath(window.location.pathname) + window.location.search,
         )
       } catch {
         /* best-effort */

--- a/web/src/api/config.basenameRelativePath.test.ts
+++ b/web/src/api/config.basenameRelativePath.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { basenameRelativePath, setBasename } from './config'
+
+afterEach(() => setBasename(''))
+
+describe('basenameRelativePath', () => {
+  it('returns the path unchanged when no basename is configured (standalone)', () => {
+    expect(basenameRelativePath('/resources/pods?namespaces=default')).toBe(
+      '/resources/pods?namespaces=default',
+    )
+  })
+
+  it('strips the basename from a prefixed path, preserving the query', () => {
+    setBasename('/c/abc')
+    expect(basenameRelativePath('/c/abc/resources/pods?namespaces=kube-system')).toBe(
+      '/resources/pods?namespaces=kube-system',
+    )
+  })
+
+  it('collapses a doubled prefix', () => {
+    setBasename('/c/abc')
+    expect(basenameRelativePath('/c/abc/c/abc/resources/pods')).toBe('/resources/pods')
+  })
+
+  it('maps the bare basename to the root path', () => {
+    setBasename('/c/abc')
+    expect(basenameRelativePath('/c/abc')).toBe('/')
+    expect(basenameRelativePath('/c/abc?namespaces=default')).toBe('/?namespaces=default')
+  })
+
+  it('does not strip a segment that merely shares the basename as a prefix', () => {
+    setBasename('/c/abc')
+    expect(basenameRelativePath('/c/abcdef/resources/pods')).toBe('/c/abcdef/resources/pods')
+  })
+
+  it('leaves unrelated paths untouched', () => {
+    setBasename('/c/abc')
+    expect(basenameRelativePath('/resources/pods')).toBe('/resources/pods')
+    expect(basenameRelativePath('/auth/login')).toBe('/auth/login')
+  })
+})

--- a/web/src/api/config.ts
+++ b/web/src/api/config.ts
@@ -65,6 +65,23 @@ export function routePath(path: string): string {
 }
 
 /**
+ * Inverse of routePath: strips the configured basename from a path (pathname,
+ * optionally with query). Strips repeatedly — a path read back from storage or
+ * the address bar can carry a doubled prefix — so the result is always safe to
+ * hand to React Router's basename-aware navigate(), which re-prepends the
+ * basename and would corrupt an already-prefixed path into `/c/x/c/x/…`.
+ */
+export function basenameRelativePath(path: string): string {
+  if (!basename) return path;
+  let p = path;
+  while (p === basename || p.startsWith(basename + '/') || p.startsWith(basename + '?')) {
+    p = p.slice(basename.length);
+    if (p === '' || p.startsWith('?')) p = '/' + p;
+  }
+  return p;
+}
+
+/**
  * Builds a WebSocket URL for a given API path.
  *
  * When apiBase is relative, uses window.location.host + apiBase + path.


### PR DESCRIPTION
## Problem

When Radar is embedded under a router basename (e.g. `/c/<cluster-id>` in Radar Hub), the session-expiry return-path flow produces doubled URLs: `/c/<id>/c/<id>/resources/pods`. Observed in production hub analytics (15 pageviews from one user, silently bounced from the pods list to the home view under a corrupt URL). Hub-side mitigation shipped in skyhook-dev/radar-hub-web#222; this is the root-cause fix.

## Root cause

1. On a 401, `apiFetch` stores `radar_return_path = window.location.pathname + search` — the **full** window path, including the basename.
2. After re-auth, the `App.tsx` mount effect replays it via `navigate(returnPath, { replace: true })`. The router is mounted with `basename=/c/<id>`, so react-router prepends the prefix again → `/c/<id>/c/<id>/…`.

## Fix

- New `basenameRelativePath()` in `api/config.ts` — the inverse of `routePath()`. Strips the configured basename (repeatedly, since a path read back from storage or the address bar can already carry a doubled prefix); no-op when `basename` is `''` (standalone Radar unaffected).
- **Store side** (`api/client.ts`): save the return path basename-relative.
- **Restore side** (`App.tsx`): normalize through the same helper before `navigate()` — sessionStorage survives the reload boundary, so the stored value may have been written by an older bundle that captured the full prefix. This makes the fix effective for users transitioning across versions, not just fresh sessions.

## Testing

- 6 unit tests for `basenameRelativePath` (standalone no-op, prefix strip preserving query, doubled-prefix collapse, bare-basename → `/`, shared-prefix non-match, unrelated paths).
- `npm run tsc` clean; full web suite passes (26 files / 209 tests).

Once published, radar-hub-web bumps its pin and deletes its temporary sessionStorage sanitizer (the URL watchdog stays to heal corrupt URLs already in users' browser history).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation/auth return-path handling with unit tests; standalone Radar (empty basename) is a no-op.
> 
> **Overview**
> Fixes **doubled basename URLs** (e.g. `/c/id/c/id/resources/pods`) after session expiry when Radar runs under a router basename (Radar Hub).
> 
> Adds **`basenameRelativePath()`** in `api/config.ts` as the inverse of `routePath()`: it strips the configured basename (repeatedly for already-doubled paths) so values are safe for React Router’s basename-aware `navigate()`.
> 
> On **401**, `apiFetch` now stores `radar_return_path` using the basename-relative pathname plus search. On **restore**, `App.tsx` normalizes the stored value through the same helper before `navigate()` so older sessionStorage entries that still hold the full prefixed path still work after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f738ccf20b5d5fa2641155e1e5f460805d97ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->