### PR TITLE
fix(search): keep list search inputs responsive on large clusters

### DIFF
--- a/packages/k8s-ui/src/components/logs/useLogSearch.ts
+++ b/packages/k8s-ui/src/components/logs/useLogSearch.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { useState, useMemo, useCallback, useDeferredValue, useEffect, useRef } from 'react'
 import type { VirtuosoHandle } from 'react-virtuoso'
 import type { LogEntry } from './useLogBuffer'
 import { stripAnsi, escapeRegExp } from '../../utils/log-format'
@@ -40,17 +40,22 @@ export function useLogSearch(
   const [currentMatch, setCurrentMatch] = useState(0)
   const [isOpen, setIsOpen] = useState(false)
 
+  // The scan strips ANSI and regex-tests every buffered line — on a multi-MB
+  // buffer that's too slow to run synchronously per keystroke. Deferring lets
+  // the input echo immediately while the match set catches up.
+  const deferredQuery = useDeferredValue(query)
+
   const { matchIndices, regexError } = useMemo(() => {
-    if (!query) {
+    if (!deferredQuery) {
       return { matchIndices: [] as number[], regexError: null }
     }
 
     try {
       let pattern: RegExp
       if (isRegex) {
-        pattern = new RegExp(query, isCaseSensitive ? 'g' : 'gi')
+        pattern = new RegExp(deferredQuery, isCaseSensitive ? 'g' : 'gi')
       } else {
-        pattern = new RegExp(escapeRegExp(query), isCaseSensitive ? 'g' : 'gi')
+        pattern = new RegExp(escapeRegExp(deferredQuery), isCaseSensitive ? 'g' : 'gi')
       }
 
       const indices: number[] = []
@@ -65,14 +70,14 @@ export function useLogSearch(
     } catch (e) {
       return { matchIndices: [] as number[], regexError: e instanceof Error ? e.message : 'Invalid regex' }
     }
-  }, [entries, query, isRegex, isCaseSensitive])
+  }, [entries, deferredQuery, isRegex, isCaseSensitive])
 
   // Filtered entries for filter mode
   const filteredEntries = useMemo(() => {
-    if (!isFilterMode || !query) return entries
+    if (!isFilterMode || !deferredQuery) return entries
     const matchSet = new Set(matchIndices)
     return entries.filter((_, i) => matchSet.has(i))
-  }, [entries, isFilterMode, query, matchIndices])
+  }, [entries, isFilterMode, deferredQuery, matchIndices])
 
   // Reset current match when search criteria change (but not when new entries arrive during streaming)
   const prevCriteria = useRef({ query, isRegex, isCaseSensitive })

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useEffect, useCallback, useRef, useContext, useId } from 'react'
+import React, { useState, useMemo, useEffect, useCallback, useDeferredValue, useRef, useContext, useId } from 'react'
 import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso'
+import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { PaneLoader } from '../ui/PaneLoader'
 import { RestrictedState } from '../ui/RestrictedState'
 import { Input } from '../ui/Input'
@@ -2185,6 +2186,15 @@ export function ResourcesView({
     setBulkForceDelete(false)
   }, [selectedKind.name, selectedKind.group]) // eslint-disable-line react-hooks/exhaustive-deps
   const [searchTerm, setSearchTerm] = useState(initialFilters.search)
+  // Typing must never wait on the list or the router. The input renders raw
+  // searchTerm; filtering consumes the deferred copy (React yields to keep
+  // keystrokes responsive on large lists); the URL write consumes the
+  // debounced copy (one history entry per pause, not one per keystroke —
+  // per-keystroke navigations re-render the whole route tree and, when
+  // renders lag, the URL→state sync effect could revert in-flight input).
+  // Clearing skips the debounce so the × cleans the URL immediately.
+  const deferredSearchTerm = useDeferredValue(searchTerm)
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 300, (v) => v === '')
   const [regexMode, setRegexMode] = useState(initialFilters.regex)
   const [sortColumn, setSortColumn] = useState<string | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>(null)
@@ -2963,8 +2973,17 @@ export function ResourcesView({
       setOwnerName(newFilters.ownerName)
     }
 
-    // Update search if it changed
-    if (newFilters.search !== searchTerm) {
+    // Update search if it changed — unless this navigation is the echo of our
+    // own debounced URL write (its search equals the value we just wrote), or
+    // the user is mid-typing in the box. During typing the URL intentionally
+    // lags the input, so an un-guarded sync here would revert in-flight
+    // keystrokes whenever a write echo lands mid-burst. Genuinely external
+    // navigations (deep links, back/forward) carry a different search value
+    // and still sync.
+    const isOwnWriteEcho =
+      newFilters.search === debouncedSearchTerm ||
+      (typeof document !== 'undefined' && document.activeElement === searchInputRef.current)
+    if (!isOwnWriteEcho && newFilters.search !== searchTerm) {
       setSearchTerm(newFilters.search)
     }
 
@@ -3173,8 +3192,8 @@ export function ResourcesView({
     shouldPushHistory.current = false
     prevSelectedResourceRef.current = current
 
-    updateURL(selectedKind, searchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
-  }, [selectedKind, searchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
+    updateURL(selectedKind, debouncedSearchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
+  }, [selectedKind, debouncedSearchTerm, regexMode, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
 
   // Handle resource click from URL on mount
   useEffect(() => {
@@ -3605,13 +3624,13 @@ export function ResourcesView({
   // rows shown) rather than zero results, so the table doesn't flash empty
   // while the user is mid-typing a pattern.
   const searchRegex = useMemo<{ re: RegExp | null; error: string | null }>(() => {
-    if (!regexMode || !searchTerm) return { re: null, error: null }
+    if (!regexMode || !deferredSearchTerm) return { re: null, error: null }
     try {
-      return { re: new RegExp(searchTerm, 'i'), error: null }
+      return { re: new RegExp(deferredSearchTerm, 'i'), error: null }
     } catch (e) {
       return { re: null, error: e instanceof Error ? e.message : 'Invalid regex' }
     }
-  }, [regexMode, searchTerm])
+  }, [regexMode, deferredSearchTerm])
 
   // Filter resources by search term, status, problems, and sort
   const filteredResources = useMemo(() => {
@@ -3620,7 +3639,7 @@ export function ResourcesView({
     let result = resources
 
     // Apply search filter
-    if (searchTerm) {
+    if (deferredSearchTerm) {
       if (regexMode) {
         const re = searchRegex.re
         if (re) {
@@ -3630,7 +3649,7 @@ export function ResourcesView({
           )
         }
       } else {
-        const term = searchTerm.toLowerCase()
+        const term = deferredSearchTerm.toLowerCase()
         result = result.filter((r: any) =>
           r.metadata?.name?.toLowerCase().includes(term) ||
           r.metadata?.namespace?.toLowerCase().includes(term)
@@ -3792,7 +3811,7 @@ export function ResourcesView({
     }
 
     return result
-  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
+  }, [resources, deferredSearchTerm, regexMode, searchRegex, columnFilters, columnFilterExcludes, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
 
   // For nodes table: compute the majority minor version so outliers can be highlighted
   const majorityNodeMinorVersion = useMemo(() => {
@@ -3918,6 +3937,16 @@ export function ResourcesView({
   }, [allVisibleChecked, filteredResources, getResourceKey])
 
   const isCheckboxMode = canBulkSelect && bulkMode
+
+  // Stable row handlers so the memoized ResourceRowCells skips re-rendering
+  // rows whose data didn't change on a refetch (React Query's structural
+  // sharing keeps unchanged resources referentially identical).
+  const handleRowClick = useCallback((resource: any, isSelected: boolean) => {
+    if (compareMode) toggleComparePick(resource)
+    else if (isCheckboxMode) toggleChecked(resource)
+    else selectResource(resource, isSelected)
+  }, [compareMode, isCheckboxMode, toggleComparePick, toggleChecked, selectResource])
+  const handleRowMouseEnter = useCallback(() => setHighlightedIndex(-1), [])
 
   // Filter columns by visibility
   const columns = useMemo(() => {
@@ -5045,12 +5074,12 @@ export function ResourcesView({
                     isChecked={checkedResources.has(resourceKey)}
                     showCheckbox={isCheckboxMode}
                     majorityNodeMinorVersion={majorityNodeMinorVersion}
-                    onClick={() => compareMode ? toggleComparePick(resource) : isCheckboxMode ? toggleChecked(resource) : selectResource(resource, isSelected)}
-                    onMouseEnter={() => setHighlightedIndex(-1)}
+                    onRowClick={handleRowClick}
+                    onRowMouseEnter={handleRowMouseEnter}
                     compareMode={compareMode}
                     comparePickIndex={pickIdx}
                     rowHref={rowHrefFor?.(resource)}
-                    onCheckToggle={() => toggleChecked(resource)}
+                    onRowCheckToggle={toggleChecked}
                   />
                 )
               }}
@@ -5200,8 +5229,11 @@ interface ResourceRowCellsProps {
   isChecked?: boolean
   showCheckbox?: boolean
   majorityNodeMinorVersion?: string
-  onClick?: () => void
-  onMouseEnter?: () => void
+  // Row callbacks receive the resource so the parent can pass referentially
+  // stable handlers — per-row closures would defeat React.memo and re-render
+  // every visible row on each SSE-driven refetch.
+  onRowClick?: (resource: any, isSelected: boolean) => void
+  onRowMouseEnter?: () => void
   compareMode?: boolean
   /** -1 when not picked; 0 = pick A; 1 = pick B. */
   comparePickIndex?: number
@@ -5209,7 +5241,7 @@ interface ResourceRowCellsProps {
    *  data cells drop their click handlers. The compare-mode chip column
    *  is unaffected (still toggles picks). */
   rowHref?: string
-  onCheckToggle?: () => void
+  onRowCheckToggle?: (resource: any) => void
 }
 
 function rowHighlightClass(
@@ -5231,9 +5263,11 @@ function rowHighlightClass(
   return 'group-hover/row:bg-theme-surface/50'
 }
 
-function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, hasSpacerColumn, isSelected, isHighlighted, isChecked, showCheckbox, majorityNodeMinorVersion, onClick, onMouseEnter, compareMode, comparePickIndex = -1, rowHref, onCheckToggle }: ResourceRowCellsProps) {
+const ResourceRowCells = React.memo(function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, hasSpacerColumn, isSelected, isHighlighted, isChecked, showCheckbox, majorityNodeMinorVersion, onRowClick, onRowMouseEnter, compareMode, comparePickIndex = -1, rowHref, onRowCheckToggle }: ResourceRowCellsProps) {
   const rowHighlight = rowHighlightClass(compareMode, comparePickIndex, isSelected, isHighlighted, isChecked)
   const pickedSide = comparePickIndex === 0 ? 'a' : comparePickIndex === 1 ? 'b' : null
+  const onClick = onRowClick ? () => onRowClick(resource, !!isSelected) : undefined
+  const onMouseEnter = onRowMouseEnter
   // When the host supplies an anchor, drop per-cell onClick for the data
   // columns: the anchor is the only navigation surface. The compare-mode
   // chip column keeps its onClick so pick toggling still works.
@@ -5268,7 +5302,7 @@ function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, h
       {showCheckbox && (
         <td
           className={clsx('border-b-subtle text-center px-0 py-3 w-10 cursor-pointer transition-colors', rowHighlight)}
-          onClick={(e) => { e.stopPropagation(); onCheckToggle?.() }}
+          onClick={(e) => { e.stopPropagation(); onRowCheckToggle?.(resource) }}
         >
           <input
             type="checkbox"
@@ -5304,7 +5338,7 @@ function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, h
       {hasSpacerColumn && <td className="border-b-subtle p-0" />}
     </>
   )
-}
+})
 
 const VirtuosoTableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
   function VirtuosoTableRow(props, ref) {

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react'
+import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { PaneLoader } from '../ui/PaneLoader'
 import { Tooltip } from '../ui/Tooltip'
 import {
@@ -117,6 +118,10 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
   const [searchInternal, setSearchInternal] = useState('')
   const searchTerm = searchProp ?? searchInternal
   const setSearchTerm = onSearchChange ?? setSearchInternal
+  // Coalesce typing bursts: re-filtering the aggregated list per keystroke is
+  // what makes the search box feel dead on large timelines. Clearing flushes
+  // immediately.
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 300, (v) => v === '')
   const [activityFilterInternal, setActivityFilterInternal] = useState<ActivityFilterKey[]>(
     initialFilter && initialFilter !== 'all' ? [initialFilter] : [],
   )
@@ -174,10 +179,10 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
       if (!matchesActivityFilter(item, activityTypeFilter)) return false
       if (kindFilter.length > 0 && !kindFilter.includes(item.kind)) return false
       if (!showDeleted && item.eventType === 'delete') return false
-      if (!matchesTimelineSearch(item, searchTerm)) return false
+      if (!matchesTimelineSearch(item, debouncedSearchTerm)) return false
       return true
     })
-  }, [events, activityTypeFilter, kindFilter, searchTerm, showDeleted])
+  }, [events, activityTypeFilter, kindFilter, debouncedSearchTerm, showDeleted])
 
   // Aggregated event group type
   type AggregatedItem = {

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useMemo, useRef, useCallback, useEffect } from 'react'
 import { clsx } from 'clsx'
+import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import {
   AlertCircle,
   AlertTriangle,
@@ -795,6 +796,10 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   const [searchInternal, setSearchInternal] = useState('')
   const searchTerm = searchProp ?? searchInternal
   const setSearchTerm = onSearchChange ?? setSearchInternal
+  // Filtering and re-ranking rebuild the whole lane board (tens of thousands
+  // of DOM mutations on a large timeline) — coalesce a typing burst into one
+  // rebuild instead of one per keystroke. Clearing flushes immediately.
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 300, (v) => v === '')
   const [activityFilterInternal, setActivityFilterInternal] = useState<ActivityFilterKey[]>([])
   const activityFilter = activityFilterProp ?? activityFilterInternal
   const setActivityFilter = onActivityFilterChange ?? setActivityFilterInternal
@@ -939,10 +944,10 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
       if (!showDeleted && e.eventType === 'delete') return false
       if (!matchesActivityFilter(e, activityFilter)) return false
       if (kindFilter.length > 0 && !kindFilter.includes(e.kind)) return false
-      if (!matchesTimelineSearch(e, searchTerm)) return false
+      if (!matchesTimelineSearch(e, debouncedSearchTerm)) return false
       return true
     })
-  }, [events, searchTerm, showDeleted, activityFilter, kindFilter])
+  }, [events, debouncedSearchTerm, showDeleted, activityFilter, kindFilter])
 
   // Kind dropdown options: seed set + every kind present in the (unfiltered)
   // events. The swimlane fetches all kinds, so deriving from events is stable.
@@ -1111,8 +1116,8 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   // calm across it is the whole point. Inert when !isLive (local / WorkloadView).
   const laneOrderRef = useRef<string[] | null>(null)
   const rankResetKey = useMemo(
-    () => JSON.stringify([sort, grouping, searchTerm, showDeleted, activityFilter, kindFilter]),
-    [sort, grouping, searchTerm, showDeleted, activityFilter, kindFilter],
+    () => JSON.stringify([sort, grouping, debouncedSearchTerm, showDeleted, activityFilter, kindFilter]),
+    [sort, grouping, debouncedSearchTerm, showDeleted, activityFilter, kindFilter],
   )
   const rankResetKeyRef = useRef(rankResetKey)
   const wasLiveRef = useRef(false)

--- a/packages/k8s-ui/src/hooks/index.ts
+++ b/packages/k8s-ui/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAnimatedUnmount } from './useAnimatedUnmount'
+export { useDebouncedValue } from './useDebouncedValue'
 export { useRefreshAnimation } from './useRefreshAnimation'
 export {
   KeyboardShortcutProvider,

--- a/packages/k8s-ui/src/hooks/useDebouncedValue.ts
+++ b/packages/k8s-ui/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+/** Trailing-edge debounce of a value. Unlike useDeferredValue (which yields to
+ *  React's scheduler but still emits once per input change), this coalesces a
+ *  burst of changes into one emission after `delayMs` of quiet — the right tool
+ *  when each downstream emission has a fixed cost regardless of render pressure
+ *  (router URL writes, live-order re-ranks).
+ *
+ *  `flushWhen` values bypass the delay (e.g. an emptied search box: a delayed
+ *  clear makes the × button feel broken). The flush must reset the pending
+ *  timer state INSIDE the hook — masking it at the call site
+ *  (`v === '' ? '' : debounced`) leaves the stale value armed, and it
+ *  resurfaces if the user types again before the timer fires. */
+export function useDebouncedValue<T>(value: T, delayMs: number, flushWhen?: (value: T) => boolean): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    if (Object.is(debounced, value)) return
+    if (flushWhen?.(value)) {
+      setDebounced(value)
+      return
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-arm only when the input changes; `debounced` catching up (or an inline `flushWhen` identity) must not restart the timer
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
-    "@skyhook-io/k8s-ui": ">=1.8.15",
+    "@skyhook-io/k8s-ui": ">=1.10.0",
     "@tanstack/react-query": ">=5",
     "@xyflow/react": ">=12.0.0",
     "clsx": ">=2",

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -17,6 +17,7 @@ import {
   type TimelineGrouping,
   type TimelineSort,
   type PinnedLaneRef,
+  useDebouncedValue,
 } from '@skyhook-io/k8s-ui'
 import { TimelineList } from './TimelineList'
 import type { ActivityFilterKey } from './TimelineList'
@@ -308,6 +309,17 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
   // Search / activity-type / kind lifted here too, so they survive the view
   // switch and drive both views through one source of truth.
   const [search, setSearch] = useState(() => searchParams.get('q') ?? '')
+  // The `q` URL write is debounced so typing doesn't navigate per keystroke
+  // (clearing applies immediately — a delayed clear makes the × feel broken).
+  // The URL therefore lags the input while typing, so the URL→state read below
+  // must not sync a `q` that is merely the echo of our own write — it would
+  // revert in-flight keystrokes. Echoes are recognized by value: they carry
+  // exactly the debounced search we wrote. Ref instead of a dep: the read
+  // effect keys on searchParams alone (see its comment) and only needs the
+  // written value at fire time.
+  const debouncedSearch = useDebouncedValue(search, 300, (v) => v === '')
+  const writtenSearchRef = useRef(debouncedSearch)
+  writtenSearchRef.current = debouncedSearch
   // Seed the multi-select from the URL `activity` csv, else the home-page
   // deep-link preset: 'all'/undefined means no chips selected (everything).
   const [activityFilter, setActivityFilter] = useState<ActivityFilterKey[]>(
@@ -621,7 +633,9 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     const nextPinnedOnly = sp.get('pinnedOnly') === '1' && pinnedLanes.length > 0
     setPinnedOnly((prev) => (prev === nextPinnedOnly ? prev : nextPinnedOnly))
     const nextSearch = sp.get('q') ?? ''
-    setSearch((prev) => (prev === nextSearch ? prev : nextSearch))
+    if (nextSearch !== writtenSearchRef.current) {
+      setSearch((prev) => (prev === nextSearch ? prev : nextSearch))
+    }
     const nextActivity = parseActivity(sp) ?? []
     setActivityFilter((prev) => (arraysEqual(prev, nextActivity) ? prev : nextActivity))
     const nextKinds = parseKinds(sp)
@@ -638,7 +652,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     const current = searchParamsRef.current
     const target = writeTimelineParams(
       current,
-      { viewMode, mode, showDeleted, pinnedOnly, search, activityFilter, kindFilter, grouping, sort, selectedEventId },
+      { viewMode, mode, showDeleted, pinnedOnly, search: debouncedSearch, activityFilter, kindFilter, grouping, sort, selectedEventId },
       { isRetained: isRetained || isLocal, requiresNamespaceFilter: scopeRequiresNamespaceFilter },
     )
     const targetStr = target.toString()
@@ -652,7 +666,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     const replace = !didMountUrlSyncRef.current || onlyHighFreqDiffer(currentStr, targetStr)
     didMountUrlSyncRef.current = true
     setSearchParamsRef.current(target, { replace })
-  }, [viewMode, mode, showDeleted, pinnedOnly, search, activityFilter, kindFilter, grouping, sort, selectedEventId, isRetained, isLocal, scopeRequiresNamespaceFilter])
+  }, [viewMode, mode, showDeleted, pinnedOnly, debouncedSearch, activityFilter, kindFilter, grouping, sort, selectedEventId, isRetained, isLocal, scopeRequiresNamespaceFilter])
 
   // Fetch all activity - zoom controls what's visible in the UI. This ring feeds
   // the swimlanes and the local strip's histogram, so it also runs in list mode


### PR DESCRIPTION
## Problem

PostHog rageclick telemetry (55 rageclicks / 22 days from a paying customer on a ~1,200-pod cluster) pointed at the shared list search inputs. Replay review + rrweb analysis showed the inputs weren't missing affordances — they were **freezing and eating keystrokes**:

- Every keystroke in the resources search triggered a **router navigation** (full route-tree re-render), and a race in the URL→state sync effect could **revert in-flight keystrokes** when a write echo landed mid-burst (650–950 DOM mutations per keypress).
- SSE-driven refetches re-rendered **every visible table row** every ~3s during incident churn.
- The **first keystroke in Timeline search** rebuilt the entire lane board (~77k DOM mutations): `rankResetKey` includes the search term, dropping the live-order hysteresis per keystroke.

## Fix

- **ResourcesView**: input renders raw state; filtering consumes a `useDeferredValue` copy; the URL write is debounced (300ms, **instant on clear**); the sync effect ignores echoes of our own writes (recognized by value — genuinely external navigations still sync) and never reverts a focused input.
- **Row memoization**: `ResourceRowCells` is `React.memo`'d with stable handlers — rows with unchanged resource identity (React Query structural sharing) skip re-rendering on refetch.
- **Timeline** (swimlanes + list + `q` URL param): debounced search with the same echo guard; one board rebuild per typing pause.
- **Log viewer**: full-buffer scan runs on a deferred query.
- New shared hook **`useDebouncedValue`** (trailing-edge; `flushWhen` predicate so clear bypasses the delay without leaving a stale timer armed).

## Review

Self-review + Cursor (gpt-5.6-sol-high) cross-review; Cursor caught two real issues, both fixed: a clear-then-retype race (flush now lives inside the hook) and the k8s-ui peer range admitting versions without the new export (raised to `>=1.10.0`).

## Verification

- `make tsc` ✓ · k8s-ui vitest 1306 ✓ · web vitest 203 ✓ · Go tests ✓
- Manual QA on a local cluster with Slow-4G/CPU throttling: no vanished characters, URL updates once per pause, × clears instantly, Timeline first keystroke no longer freezes.

## Release note (maintainers)

Publish order matters: tag **`k8s-ui-v1.10.0` first**, then **`radar-app-v1.9.1`** — radar-app now imports the new k8s-ui export and its peer range requires ≥1.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL sync and search timing across core list/timeline views; risk is mainly UX regressions (stale filters, back/forward) rather than security or data handling.
> 
> **Overview**
> Fixes **search inputs freezing and eating keystrokes** on large clusters by separating what the user types from expensive downstream work.
> 
> **ResourcesView** keeps the input on raw `searchTerm` while **filtering** uses `useDeferredValue` and **URL updates** use a new **`useDebouncedValue`** hook (300ms, instant when cleared). The URL→state sync ignores echoes of our own debounced writes and avoids reverting text while the search box is focused. **`ResourceRowCells`** is wrapped in **`React.memo`** with stable row callbacks so SSE refetches don’t re-render unchanged rows.
> 
> **Timeline** list and swimlanes debounce search for filtering and lane re-ranking; **`TimelineView`** debounces the `q` URL param with the same echo guard. **Log search** defers the full-buffer scan via **`useDeferredValue`**.
> 
> Adds shared **`useDebouncedValue`** (exported from k8s-ui) and bumps **`web`** peer **`@skyhook-io/k8s-ui`** to **`>=1.10.0`** for the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d98f35d486519722f8998486b86f5ddbfce5f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->