### PR TITLE
feat(helm): add configurable HTTPRoute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ helm install radar skyhook/radar -n radar --create-namespace
 
 See the [In-Cluster Deployment Guide](docs/in-cluster.md) for ingress, authentication, and RBAC configuration.
 
+### Gateway API HTTPRoute
+
+Chart supports optional Gateway API `HTTPRoute` generation. Enable
+`httpRoute.enabled`, set `parentRefs`, and use `httpRoute.rules` for multiple
+path prefixes, per-route timeouts, filters, or custom backends. `hostnames`
+defaults to an empty list, and `apiVersion` can be overridden for older Gateway
+API installations. The generated default route has no chart-imposed timeout,
+so the Gateway deployment default applies. Set `httpRoute.defaultTimeout` for
+an explicit timeout; custom rules can define their own `timeouts`.
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+  hostnames: []
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: radar
+          port: 9280
+```
+
+See the [Helm Chart README](deploy/helm/radar/README.md#with-gateway-api-httproute)
+for full configuration details and timeout examples.
+
 </details>
 
 ---

--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: "1.7.6"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -53,6 +53,50 @@ helm upgrade --install radar skyhook/radar \
   --set ingress.tls[0].hosts[0]=radar.example.com
 ```
 
+### With Gateway API HTTPRoute
+
+HTTPRoute is disabled by default. Empty `httpRoute.rules` creates a `/`
+`PathPrefix` route to Radar's Service. The generated rule has no timeout by
+default, so the Gateway deployment's default timeout applies. Set
+`httpRoute.defaultTimeout` to add an explicit request timeout, or set it to
+`0s` to explicitly disable timeout. Set `rules` for multiple prefixes,
+timeouts, filters, or custom backends; supplied rules replace that default and
+pass through unchanged.
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+  hostnames: []
+  # Optional timeout for chart-generated default rule.
+  # defaultTimeout: 30s
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      timeouts:
+        request: 30s
+        backendRequest: 20s
+      backendRefs:
+        - name: radar
+          port: 9280
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /admin
+      timeouts:
+        request: 2m
+      backendRefs:
+        - name: radar
+          port: 9280
+```
+
+Override `httpRoute.apiVersion` when cluster Gateway API support requires a
+different version, for example `gateway.networking.k8s.io/v1beta1`. Custom
+rules can define their own `timeouts` independently.
+
 ### Connecting to Radar Cloud
 
 To connect Radar to Radar Cloud (hosted SaaS), follow the install wizard at
@@ -113,6 +157,11 @@ lands in the Helm release state. Rotation requires a pod restart. See
 | `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
+| `httpRoute.enabled` | Enable Gateway API HTTPRoute | `false` |
+| `httpRoute.apiVersion` | HTTPRoute API version override | `gateway.networking.k8s.io/v1` |
+| `httpRoute.hostnames` | HTTPRoute hostnames | `[]` |
+| `httpRoute.defaultTimeout` | Optional request timeout for generated default rule; empty uses Gateway deployment default | `""` |
+| `httpRoute.rules` | HTTPRoute rules, passed through unchanged | `[]` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |
 | `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
 | `timeline.maxSize` | SQLite max DB + WAL size before oldest events are pruned (`0` disables) | `800Mi` |

--- a/deploy/helm/radar/templates/httproute.yaml
+++ b/deploy/helm/radar/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "radar.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := mergeOverwrite (include "radar.labels" . | fromYaml) .Values.httpRoute.labels -}}
+apiVersion: {{ .Values.httpRoute.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- toYaml $labels | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      {{- with .Values.httpRoute.defaultTimeout }}
+      timeouts:
+        request: {{ . | quote }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/radar/tests/httproute_test.yaml
+++ b/deploy/helm/radar/tests/httproute_test.yaml
@@ -1,0 +1,129 @@
+suite: HTTPRoute
+templates:
+  - httproute.yaml
+tests:
+  - it: is disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders default route to Radar Service with empty hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs: []
+        hostnames: []
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-radar
+      - equal:
+          path: spec.hostnames
+          value: []
+      - equal:
+          path: spec.parentRefs
+          value: []
+      - equal:
+          path: spec.rules[0].matches[0].path
+          value:
+            type: PathPrefix
+            value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0]
+          value:
+            name: RELEASE-NAME-radar
+            port: 9280
+      - notExists:
+          path: spec.rules[0].timeouts
+
+  - it: adds optional default timeout only when configured
+    set:
+      httpRoute:
+        enabled: true
+        defaultTimeout: 30s
+    asserts:
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 30s
+
+  - it: supports API version override and metadata
+    set:
+      httpRoute:
+        enabled: true
+        apiVersion: gateway.networking.k8s.io/v1beta1
+        annotations:
+          example.com/owner: platform
+        labels:
+          example.com/tier: edge
+        parentRefs:
+          - name: public-gateway
+            sectionName: https
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1beta1
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+      - equal:
+          path: metadata.labels["example.com/tier"]
+          value: edge
+      - equal:
+          path: spec.parentRefs[0]
+          value:
+            name: public-gateway
+            sectionName: https
+
+  - it: passes multiple custom rules through and replaces default
+    set:
+      httpRoute:
+        enabled: true
+        hostnames:
+          - radar.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /api
+            timeouts:
+              request: 30s
+              backendRequest: 20s
+            backendRefs:
+              - name: radar-api
+                port: 9000
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /admin
+            timeouts:
+              request: 2m
+            backendRefs:
+              - name: radar-admin
+                port: 9001
+    asserts:
+      - equal:
+          path: spec.hostnames
+          value:
+            - radar.example.com
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+      - notEqual:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 30s
+            backendRequest: 20s
+      - equal:
+          path: spec.rules[1].timeouts.request
+          value: 2m
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: radar-admin

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -157,6 +157,29 @@
         }
       }
     },
+    "httpRoute": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string", "minLength": 1 },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "parentRefs": {
+          "type": "array",
+          "items": { "type": "object", "additionalProperties": true }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "defaultTimeout": { "type": "string" },
+        "rules": {
+          "type": "array",
+          "items": { "type": "object", "additionalProperties": true }
+        }
+      }
+    },
     "resources": { "type": "object" },
     "timeline": {
       "type": "object",

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -214,6 +214,20 @@ ingress:
   #    hosts:
   #      - radar.example.com
 
+httpRoute:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  annotations: {}
+  labels: {}
+  parentRefs: []
+  hostnames: []
+  # Optional request timeout for chart-generated default rule. Empty means
+  # Gateway deployment default applies. Set 0s to explicitly disable timeout.
+  defaultTimeout: ""
+  # When empty, chart emits a default / Prefix rule to Radar Service.
+  # Non-empty rules replace default and pass through unchanged.
+  rules: []
+
 resources:
   limits:
     cpu: 500m


### PR DESCRIPTION
## Summary

- Add opt-in Gateway API HTTPRoute support with configurable API version, parentRefs, hostnames, labels, annotations, and freeform rules.
- Support multiple path prefixes and per-rule timeouts.
- Avoid imposing a timeout on the generated catch-all route; optional `httpRoute.defaultTimeout` adds one when explicitly configured.
- Bump chart version to 1.7.1 and document configuration.

## Tests

- `helm lint deploy/helm/radar`
- `helm unittest -f tests/httproute_test.yaml deploy/helm/radar`
- `./scripts/test-chart.sh`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional Helm templates, values schema, docs, and tests; HTTPRoute stays disabled by default and does not alter Radar runtime behavior unless operators enable it.
> 
> **Overview**
> Adds **opt-in Gateway API `HTTPRoute`** support to the Radar Helm chart (`httpRoute.enabled`, default `false`), alongside existing Ingress.
> 
> When enabled with empty `httpRoute.rules`, the chart emits a default **`/` PathPrefix** rule to the Radar Service and port; **no `timeouts` block** unless `httpRoute.defaultTimeout` is set (Gateway defaults apply). Custom `rules` replace that default and are passed through unchanged for multi-path routes, per-rule timeouts, filters, or alternate backends. **`parentRefs`**, **`hostnames`**, labels/annotations, and **`apiVersion`** (e.g. `v1beta1`) are configurable.
> 
> Chart version bumps to **1.7.1**; `values.yaml`, `values.schema.json`, root **README**, and chart **README** document the new block. **Helm unittest** coverage validates default rendering, optional default timeout, metadata/API version, and custom rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5a98d3124dd0a774739d9e7f16dc10f6aa0153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->