### PR TITLE
feat(resources): per-container memory/CPU display in the Pods table

### DIFF
--- a/internal/k8s/metrics_history.go
+++ b/internal/k8s/metrics_history.go
@@ -13,6 +13,7 @@ type ContainerMetricsHistory = k8score.ContainerMetricsHistory
 type PodMetricsHistory = k8score.PodMetricsHistory
 type NodeMetricsHistory = k8score.NodeMetricsHistory
 type TopPodMetrics = k8score.TopPodMetrics
+type ContainerResourceMetrics = k8score.ContainerResourceMetrics
 type TopNodeMetrics = k8score.TopNodeMetrics
 type MetricsCollectionHealth = k8score.MetricsCollectionHealth
 type MetricsSourceHealth = k8score.MetricsSourceHealth

--- a/internal/k8s/per_container_resources_test.go
+++ b/internal/k8s/per_container_resources_test.go
@@ -1,0 +1,185 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// resReq builds a ResourceRequirements from CPU/memory request+limit strings.
+// Empty strings are omitted so callers can model "no request" or "no limit".
+func resReq(cpuReq, cpuLim, memReq, memLim string) corev1.ResourceRequirements {
+	req := corev1.ResourceList{}
+	lim := corev1.ResourceList{}
+	if cpuReq != "" {
+		req[corev1.ResourceCPU] = resource.MustParse(cpuReq)
+	}
+	if memReq != "" {
+		req[corev1.ResourceMemory] = resource.MustParse(memReq)
+	}
+	if cpuLim != "" {
+		lim[corev1.ResourceCPU] = resource.MustParse(cpuLim)
+	}
+	if memLim != "" {
+		lim[corev1.ResourceMemory] = resource.MustParse(memLim)
+	}
+	return corev1.ResourceRequirements{Requests: req, Limits: lim}
+}
+
+func alwaysRestart() *corev1.ContainerRestartPolicy {
+	p := corev1.ContainerRestartPolicyAlways
+	return &p
+}
+
+// mixedPod: one regular container, one native sidecar (initContainer with
+// restartPolicy Always), one regular init container (no restartPolicy).
+func mixedPod() *corev1.Pod {
+	return &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Resources: resReq("50m", "100m", "64Mi", "128Mi")},
+			},
+			InitContainers: []corev1.Container{
+				// native sidecar — counted
+				{Name: "istio-proxy", RestartPolicy: alwaysRestart(), Resources: resReq("100m", "200m", "128Mi", "256Mi")},
+				// regular init container — excluded
+				{Name: "setup", Resources: resReq("500m", "500m", "512Mi", "512Mi")},
+			},
+		},
+	}
+}
+
+func TestSumRunningContainerResources(t *testing.T) {
+	got := SumRunningContainerResources(mixedPod())
+
+	// CPU nanocores = MilliValue * 1_000_000. app 50/100m + sidecar 100/200m.
+	wantCPUReq := int64((50 + 100) * 1_000_000)
+	wantCPULim := int64((100 + 200) * 1_000_000)
+	// Memory bytes. app 64/128Mi + sidecar 128/256Mi.
+	wantMemReq := int64((64 + 128) * 1024 * 1024)
+	wantMemLim := int64((128 + 256) * 1024 * 1024)
+
+	if got.CPURequest != wantCPUReq {
+		t.Errorf("CPURequest = %d, want %d", got.CPURequest, wantCPUReq)
+	}
+	if got.CPULimit != wantCPULim {
+		t.Errorf("CPULimit = %d, want %d", got.CPULimit, wantCPULim)
+	}
+	if got.MemoryRequest != wantMemReq {
+		t.Errorf("MemoryRequest = %d, want %d", got.MemoryRequest, wantMemReq)
+	}
+	if got.MemoryLimit != wantMemLim {
+		t.Errorf("MemoryLimit = %d, want %d", got.MemoryLimit, wantMemLim)
+	}
+
+	// The regular init container "setup" (500m / 512Mi) must be excluded — its
+	// resources would inflate every total if native-sidecar detection leaked.
+	if got.CPULimit >= int64(500*1_000_000) {
+		t.Errorf("regular init container leaked into CPULimit: %d", got.CPULimit)
+	}
+}
+
+func TestIsNativeSidecar(t *testing.T) {
+	native := corev1.Container{Name: "sidecar", RestartPolicy: alwaysRestart()}
+	if !isNativeSidecar(&native) {
+		t.Error("initContainer with restartPolicy Always should be a native sidecar")
+	}
+
+	noPolicy := corev1.Container{Name: "init"}
+	if isNativeSidecar(&noPolicy) {
+		t.Error("initContainer with no restartPolicy should not be a native sidecar")
+	}
+
+	onFailure := corev1.ContainerRestartPolicy("OnFailure")
+	other := corev1.Container{Name: "init2", RestartPolicy: &onFailure}
+	if isNativeSidecar(&other) {
+		t.Error("initContainer with restartPolicy != Always should not be a native sidecar")
+	}
+}
+
+func TestBuildPodContainerMetrics(t *testing.T) {
+	usage := map[string]ContainerResourceMetrics{
+		"app":         {Name: "app", CPU: 40 * 1_000_000, Memory: 60 * 1024 * 1024},
+		"istio-proxy": {Name: "istio-proxy", CPU: 90 * 1_000_000, Memory: 130 * 1024 * 1024},
+		// usage-only container: present in metrics, absent from spec.
+		"extra": {Name: "extra", CPU: 5 * 1_000_000, Memory: 5 * 1024 * 1024},
+	}
+
+	got := BuildPodContainerMetrics(mixedPod(), usage)
+
+	byName := map[string]ContainerResourceMetrics{}
+	for _, c := range got {
+		byName[c.Name] = c
+	}
+
+	// Regular container + native sidecar + usage-only container are present;
+	// the excluded regular init container is not.
+	if _, ok := byName["app"]; !ok {
+		t.Error("regular container app missing from breakdown")
+	}
+	if _, ok := byName["istio-proxy"]; !ok {
+		t.Error("native sidecar istio-proxy missing from breakdown")
+	}
+	if _, ok := byName["extra"]; !ok {
+		t.Error("usage-only container extra missing from breakdown")
+	}
+	if _, ok := byName["setup"]; ok {
+		t.Error("regular init container setup should be excluded from breakdown")
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(breakdown) = %d, want 3", len(got))
+	}
+
+	// app carries both usage (from map) and request/limit (from spec).
+	app := byName["app"]
+	if app.CPU != 40*1_000_000 {
+		t.Errorf("app.CPU = %d, want %d", app.CPU, 40*1_000_000)
+	}
+	if app.CPULimit != 100*1_000_000 {
+		t.Errorf("app.CPULimit = %d, want %d", app.CPULimit, 100*1_000_000)
+	}
+	if app.MemoryRequest != 64*1024*1024 {
+		t.Errorf("app.MemoryRequest = %d, want %d", app.MemoryRequest, 64*1024*1024)
+	}
+
+	// usage-only container has usage but zero request/limit.
+	extra := byName["extra"]
+	if extra.CPU != 5*1_000_000 {
+		t.Errorf("extra.CPU = %d, want %d", extra.CPU, 5*1_000_000)
+	}
+	if extra.CPURequest != 0 || extra.CPULimit != 0 || extra.MemoryRequest != 0 || extra.MemoryLimit != 0 {
+		t.Errorf("usage-only container should have zero request/limit, got %+v", extra)
+	}
+}
+
+func TestBuildPodContainerMetricsOmitsSingleContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "solo", Resources: resReq("50m", "100m", "64Mi", "128Mi")},
+			},
+		},
+	}
+	if got := BuildPodContainerMetrics(pod, nil); got != nil {
+		t.Errorf("single-container pod should return nil breakdown, got %+v", got)
+	}
+}
+
+func TestBuildPodContainerMetricsKeepsAppPlusSidecar(t *testing.T) {
+	// One app + one native sidecar = two running containers → NOT omitted.
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Resources: resReq("50m", "100m", "64Mi", "128Mi")},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "istio-proxy", RestartPolicy: alwaysRestart(), Resources: resReq("100m", "200m", "128Mi", "256Mi")},
+			},
+		},
+	}
+	got := BuildPodContainerMetrics(pod, nil)
+	if len(got) != 2 {
+		t.Fatalf("app+sidecar pod should return 2 entries, got %d (%+v)", len(got), got)
+	}
+}

--- a/internal/k8s/per_container_resources_test.go
+++ b/internal/k8s/per_container_resources_test.go
@@ -113,22 +113,25 @@ func TestBuildPodContainerMetrics(t *testing.T) {
 		byName[c.Name] = c
 	}
 
-	// Regular container + native sidecar + usage-only container are present;
-	// the excluded regular init container is not.
+	// Only the pod's declared long-running containers are reported: the regular
+	// container and the native sidecar. The regular init container is excluded,
+	// and so is the usage-only "extra" — a name present only in the metrics
+	// buffer (a completed init / removed ephemeral container whose buffer was
+	// never pruned) must not surface as a phantom row.
 	if _, ok := byName["app"]; !ok {
 		t.Error("regular container app missing from breakdown")
 	}
 	if _, ok := byName["istio-proxy"]; !ok {
 		t.Error("native sidecar istio-proxy missing from breakdown")
 	}
-	if _, ok := byName["extra"]; !ok {
-		t.Error("usage-only container extra missing from breakdown")
+	if _, ok := byName["extra"]; ok {
+		t.Error("usage-only container extra (not in spec) should be excluded as stale")
 	}
 	if _, ok := byName["setup"]; ok {
 		t.Error("regular init container setup should be excluded from breakdown")
 	}
-	if len(got) != 3 {
-		t.Fatalf("len(breakdown) = %d, want 3", len(got))
+	if len(got) != 2 {
+		t.Fatalf("len(breakdown) = %d, want 2", len(got))
 	}
 
 	// app carries both usage (from map) and request/limit (from spec).
@@ -141,15 +144,6 @@ func TestBuildPodContainerMetrics(t *testing.T) {
 	}
 	if app.MemoryRequest != 64*1024*1024 {
 		t.Errorf("app.MemoryRequest = %d, want %d", app.MemoryRequest, 64*1024*1024)
-	}
-
-	// usage-only container has usage but zero request/limit.
-	extra := byName["extra"]
-	if extra.CPU != 5*1_000_000 {
-		t.Errorf("extra.CPU = %d, want %d", extra.CPU, 5*1_000_000)
-	}
-	if extra.CPURequest != 0 || extra.CPULimit != 0 || extra.MemoryRequest != 0 || extra.MemoryLimit != 0 {
-		t.Errorf("usage-only container should have zero request/limit, got %+v", extra)
 	}
 }
 

--- a/internal/k8s/top_metrics.go
+++ b/internal/k8s/top_metrics.go
@@ -398,25 +398,125 @@ func topPodFromObject(cache *ResourceCache, pod *corev1.Pod) TopMetricsItem {
 		Node:      pod.Spec.NodeName,
 		Owner:     topOwnerForPodResolved(cache, pod),
 	}
-	for _, c := range pod.Spec.Containers {
-		if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
-			item.CPURequest += req.MilliValue() * 1000000
-		}
-		if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
-			item.CPULimit += lim.MilliValue() * 1000000
-		}
-		if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
-			item.MemoryRequest += req.Value()
-		}
-		if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
-			item.MemoryLimit += lim.Value()
-		}
-	}
+	totals := SumRunningContainerResources(pod)
+	item.CPURequest = totals.CPURequest
+	item.CPULimit = totals.CPULimit
+	item.MemoryRequest = totals.MemoryRequest
+	item.MemoryLimit = totals.MemoryLimit
 	item.CPURequestMilli = nanoToMilli(item.CPURequest)
 	item.CPULimitMilli = nanoToMilli(item.CPULimit)
 	item.MemoryRequestMi = bytesToMi(item.MemoryRequest)
 	item.MemoryLimitMi = bytesToMi(item.MemoryLimit)
 	return item
+}
+
+// PodResourceTotals holds request/limit sums over a pod's running containers.
+// CPU values are nanocores, memory values are bytes.
+type PodResourceTotals struct {
+	CPURequest    int64
+	CPULimit      int64
+	MemoryRequest int64
+	MemoryLimit   int64
+}
+
+// isNativeSidecar reports whether an init container is a native sidecar — one
+// whose restartPolicy is Always, so it runs for the pod's whole lifetime and
+// holds its resource reservation the same way a regular container does.
+func isNativeSidecar(c *corev1.Container) bool {
+	return c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+func addContainerResources(t *PodResourceTotals, c *corev1.Container) {
+	if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+		t.CPURequest += req.MilliValue() * 1000000
+	}
+	if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
+		t.CPULimit += lim.MilliValue() * 1000000
+	}
+	if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+		t.MemoryRequest += req.Value()
+	}
+	if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+		t.MemoryLimit += lim.Value()
+	}
+}
+
+// SumRunningContainerResources sums resource requests and limits over the union
+// of a pod's regular containers and native sidecars. Regular init containers
+// are excluded — they don't hold a reservation for the pod's whole lifetime.
+// Usage is reported across the same set, so summing here keeps request/limit
+// percentages honest.
+func SumRunningContainerResources(pod *corev1.Pod) PodResourceTotals {
+	var t PodResourceTotals
+	for i := range pod.Spec.Containers {
+		addContainerResources(&t, &pod.Spec.Containers[i])
+	}
+	for i := range pod.Spec.InitContainers {
+		if isNativeSidecar(&pod.Spec.InitContainers[i]) {
+			addContainerResources(&t, &pod.Spec.InitContainers[i])
+		}
+	}
+	return t
+}
+
+// BuildPodContainerMetrics builds per-container resource metrics for a pod's
+// running containers (regular + native sidecars), merging spec requests/limits
+// with observed usage. usage is keyed by container name. Names present only in
+// usage (e.g. ephemeral debug containers reporting metrics) are appended with
+// zero request/limit. Returns nil when the pod has a single running container —
+// callers fall back to the pod-level sums.
+func BuildPodContainerMetrics(pod *corev1.Pod, usage map[string]ContainerResourceMetrics) []ContainerResourceMetrics {
+	specs := make(map[string]corev1.ResourceRequirements, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	order := make([]string, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	runningCount := 0
+	add := func(name string, res corev1.ResourceRequirements) {
+		if _, seen := specs[name]; !seen {
+			order = append(order, name)
+		}
+		specs[name] = res
+		runningCount++
+	}
+	for i := range pod.Spec.Containers {
+		add(pod.Spec.Containers[i].Name, pod.Spec.Containers[i].Resources)
+	}
+	for i := range pod.Spec.InitContainers {
+		if isNativeSidecar(&pod.Spec.InitContainers[i]) {
+			add(pod.Spec.InitContainers[i].Name, pod.Spec.InitContainers[i].Resources)
+		}
+	}
+	if runningCount <= 1 {
+		return nil
+	}
+	for name := range usage {
+		if _, seen := specs[name]; !seen {
+			order = append(order, name)
+			specs[name] = corev1.ResourceRequirements{}
+		}
+	}
+
+	result := make([]ContainerResourceMetrics, 0, len(order))
+	for _, name := range order {
+		cm := ContainerResourceMetrics{Name: name}
+		if u, ok := usage[name]; ok {
+			cm.CPU = u.CPU
+			cm.Memory = u.Memory
+		}
+		res := specs[name]
+		if req, ok := res.Requests[corev1.ResourceCPU]; ok {
+			cm.CPURequest = req.MilliValue() * 1000000
+		}
+		if lim, ok := res.Limits[corev1.ResourceCPU]; ok {
+			cm.CPULimit = lim.MilliValue() * 1000000
+		}
+		if req, ok := res.Requests[corev1.ResourceMemory]; ok {
+			cm.MemoryRequest = req.Value()
+		}
+		if lim, ok := res.Limits[corev1.ResourceMemory]; ok {
+			cm.MemoryLimit = lim.Value()
+		}
+		result = append(result, cm)
+	}
+	return result
 }
 
 func applyPodUsage(item *TopMetricsItem, m TopPodMetrics) {

--- a/internal/k8s/top_metrics.go
+++ b/internal/k8s/top_metrics.go
@@ -487,12 +487,11 @@ func BuildPodContainerMetrics(pod *corev1.Pod, usage map[string]ContainerResourc
 	if runningCount <= 1 {
 		return nil
 	}
-	for name := range usage {
-		if _, seen := specs[name]; !seen {
-			order = append(order, name)
-			specs[name] = corev1.ResourceRequirements{}
-		}
-	}
+	// Only the pod's declared long-running containers (regular + native
+	// sidecars) are reported. A name that appears in the usage map but not
+	// here is a completed init container or a removed ephemeral container whose
+	// per-container buffer was never pruned — including it would add a phantom
+	// zero-limit row and inflate the unbounded count.
 
 	result := make([]ContainerResourceMetrics, 0, len(order))
 	for _, name := range order {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2692,11 +2692,13 @@ func (s *Server) handleTopPods(w http.ResponseWriter, r *http.Request) {
 
 	// Build metrics lookup (may be empty if metrics-server is unavailable)
 	metricsMap := make(map[string]*k8s.TopPodMetrics)
+	var containerUsage map[string]map[string]k8s.ContainerResourceMetrics
 	if store := k8s.GetMetricsHistory(); store != nil {
 		raw := store.GetAllPodMetricsLatest()
 		for i := range raw {
 			metricsMap[raw[i].Namespace+"/"+raw[i].Name] = &raw[i]
 		}
+		containerUsage = store.GetAllPodContainerMetricsLatest()
 	}
 
 	// Get pod lister from cache to enrich with requests/limits
@@ -2749,21 +2751,20 @@ func (s *Server) handleTopPods(w http.ResponseWriter, r *http.Request) {
 			entry.Memory = m.Memory
 		}
 
-		// Sum requests and limits across all containers
-		for _, c := range pod.Spec.Containers {
-			if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
-				entry.CPURequest += req.MilliValue() * 1000000 // millicores to nanocores
-			}
-			if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
-				entry.CPULimit += lim.MilliValue() * 1000000
-			}
-			if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
-				entry.MemoryRequest += req.Value()
-			}
-			if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
-				entry.MemoryLimit += lim.Value()
-			}
-		}
+		// Sum requests and limits over the pod's running containers (regular
+		// containers plus native sidecars) so they align with how usage is
+		// summed — otherwise a native sidecar's usage inflates the pod's
+		// over-limit percentage.
+		totals := k8s.SumRunningContainerResources(pod)
+		entry.CPURequest = totals.CPURequest
+		entry.CPULimit = totals.CPULimit
+		entry.MemoryRequest = totals.MemoryRequest
+		entry.MemoryLimit = totals.MemoryLimit
+
+		// Per-container breakdown drives the table's per-container display.
+		// Nil for single-running-container pods, where the client falls back
+		// to the pod-level sums above.
+		entry.Containers = k8s.BuildPodContainerMetrics(pod, containerUsage[key])
 
 		result = append(result, entry)
 	}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.per-container.test.ts
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.per-container.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { ContainerResourceMetrics } from '../../types'
+import { pickConstraint, readContainer } from './ResourcesView'
+
+// Build a CPU-only container fixture; memory fields default to 0.
+function cpu(name: string, usage: number, request: number, limit: number): ContainerResourceMetrics {
+  return { name, cpu: usage, cpuRequest: request, cpuLimit: limit, memory: 0, memoryRequest: 0, memoryLimit: 0 }
+}
+
+// Build a memory-only container fixture; cpu fields default to 0.
+function mem(name: string, usage: number, request: number, limit: number): ContainerResourceMetrics {
+  return { name, cpu: 0, cpuRequest: 0, cpuLimit: 0, memory: usage, memoryRequest: request, memoryLimit: limit }
+}
+
+describe('readContainer', () => {
+  it("uses limit as the yardstick when a limit is set", () => {
+    const r = readContainer(cpu('app', 50, 25, 100), 'cpu')
+    expect(r.yardstick).toBe('limit')
+    expect(r.denom).toBe(100)
+    expect(r.pct).toBe(50)
+  })
+
+  it('falls back to request when limit is 0 but request is set', () => {
+    const r = readContainer(cpu('app', 80, 100, 0), 'cpu')
+    expect(r.yardstick).toBe('request')
+    expect(r.denom).toBe(100)
+    expect(r.pct).toBe(80)
+  })
+
+  it('allows request-only pct to exceed 100%', () => {
+    const r = readContainer(cpu('app', 200, 100, 0), 'cpu')
+    expect(r.yardstick).toBe('request')
+    expect(r.pct).toBe(200)
+  })
+
+  it("reports 'none' when neither request nor limit is set", () => {
+    const r = readContainer(cpu('app', 40, 0, 0), 'cpu')
+    expect(r.yardstick).toBe('none')
+    expect(r.pct).toBe(-1)
+  })
+
+  it('reads the memory fields for the memory kind', () => {
+    const r = readContainer(mem('app', 64, 32, 128), 'memory')
+    expect(r.yardstick).toBe('limit')
+    expect(r.denom).toBe(128)
+    expect(r.pct).toBe(50)
+  })
+})
+
+describe('pickConstraint', () => {
+  it('prefers a limited container even when a request-only container has a higher ratio', () => {
+    const containers = [
+      cpu('app', 60, 50, 100),   // limited, 60% of limit
+      cpu('sidecar', 200, 100, 0), // request-only, 200% of request
+    ]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.mode).toBe('limit')
+    expect(result.container?.name).toBe('app')
+    expect(result.pct).toBe(60)
+    expect(result.denom).toBe(100)
+    expect(result.unlimitedCount).toBe(1) // the request-only sidecar
+  })
+
+  it('picks the most-constrained LIMITED container among several', () => {
+    const containers = [
+      cpu('a', 30, 0, 100), // 30%
+      cpu('b', 90, 0, 100), // 90%
+      cpu('c', 50, 0, 100), // 50%
+    ]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.mode).toBe('limit')
+    expect(result.container?.name).toBe('b')
+    expect(result.pct).toBe(90)
+    expect(result.unlimitedCount).toBe(0)
+  })
+
+  it('falls back to the most-constrained REQUEST-ONLY container when nothing is limited', () => {
+    const containers = [
+      cpu('a', 50, 100, 0), // 50% of request
+      cpu('b', 90, 100, 0), // 90% of request
+    ]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.mode).toBe('request')
+    expect(result.container?.name).toBe('b')
+    expect(result.pct).toBe(90)
+    expect(result.denom).toBe(100)
+    expect(result.unlimitedCount).toBe(2)
+  })
+
+  it("returns mode 'none' when no container sets a request or limit", () => {
+    const containers = [cpu('a', 10, 0, 0), cpu('b', 20, 0, 0)]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.mode).toBe('none')
+    expect(result.container).toBeNull()
+    expect(result.unlimitedCount).toBe(2)
+  })
+
+  it('breaks ties deterministically — equal pct picks the lexicographically lower name', () => {
+    const containers = [
+      cpu('zzz', 50, 0, 100), // 50%
+      cpu('aaa', 50, 0, 100), // 50%
+    ]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.container?.name).toBe('aaa')
+  })
+
+  it('counts every limit==0 container in unlimitedCount (request-only and unset)', () => {
+    const containers = [
+      cpu('limited', 50, 0, 100),
+      cpu('reqonly', 50, 100, 0),
+      cpu('unset', 10, 0, 0),
+    ]
+    const result = pickConstraint(containers, 'cpu')
+    expect(result.mode).toBe('limit')
+    expect(result.unlimitedCount).toBe(2)
+  })
+})

--- a/packages/k8s-ui/src/components/resources/ResourcesView.per-container.test.ts
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.per-container.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ContainerResourceMetrics } from '../../types'
-import { pickConstraint, readContainer } from './ResourcesView'
+import { podAggregate, readContainer } from './ResourcesView'
 
 // Build a CPU-only container fixture; memory fields default to 0.
 function cpu(name: string, usage: number, request: number, limit: number): ContainerResourceMetrics {
@@ -47,71 +47,65 @@ describe('readContainer', () => {
   })
 })
 
-describe('pickConstraint', () => {
-  it('prefers a limited container even when a request-only container has a higher ratio', () => {
+describe('podAggregate', () => {
+  it("reports mode 'limit' with the summed limit and request marker when every container is limited", () => {
     const containers = [
-      cpu('app', 60, 50, 100),   // limited, 60% of limit
-      cpu('sidecar', 200, 100, 0), // request-only, 200% of request
+      cpu('app', 30, 50, 100),
+      cpu('sidecar', 40, 50, 200),
     ]
-    const result = pickConstraint(containers, 'cpu')
+    const result = podAggregate(containers, 'cpu')
     expect(result.mode).toBe('limit')
-    expect(result.container?.name).toBe('app')
-    expect(result.pct).toBe(60)
-    expect(result.denom).toBe(100)
-    expect(result.unlimitedCount).toBe(1) // the request-only sidecar
-  })
-
-  it('picks the most-constrained LIMITED container among several', () => {
-    const containers = [
-      cpu('a', 30, 0, 100), // 30%
-      cpu('b', 90, 0, 100), // 90%
-      cpu('c', 50, 0, 100), // 50%
-    ]
-    const result = pickConstraint(containers, 'cpu')
-    expect(result.mode).toBe('limit')
-    expect(result.container?.name).toBe('b')
-    expect(result.pct).toBe(90)
+    expect(result.totalUsage).toBe(70)
+    expect(result.denom).toBe(300) // summed limit
+    expect(result.markerPct).toBeCloseTo((100 / 300) * 100) // summed request / summed limit
     expect(result.unlimitedCount).toBe(0)
   })
 
-  it('falls back to the most-constrained REQUEST-ONLY container when nothing is limited', () => {
-    const containers = [
-      cpu('a', 50, 100, 0), // 50% of request
-      cpu('b', 90, 100, 0), // 90% of request
-    ]
-    const result = pickConstraint(containers, 'cpu')
-    expect(result.mode).toBe('request')
-    expect(result.container?.name).toBe('b')
-    expect(result.pct).toBe(90)
-    expect(result.denom).toBe(100)
-    expect(result.unlimitedCount).toBe(2)
-  })
-
-  it("returns mode 'none' when no container sets a request or limit", () => {
-    const containers = [cpu('a', 10, 0, 0), cpu('b', 20, 0, 0)]
-    const result = pickConstraint(containers, 'cpu')
-    expect(result.mode).toBe('none')
-    expect(result.container).toBeNull()
-    expect(result.unlimitedCount).toBe(2)
-  })
-
-  it('breaks ties deterministically — equal pct picks the lexicographically lower name', () => {
-    const containers = [
-      cpu('zzz', 50, 0, 100), // 50%
-      cpu('aaa', 50, 0, 100), // 50%
-    ]
-    const result = pickConstraint(containers, 'cpu')
-    expect(result.container?.name).toBe('aaa')
-  })
-
-  it('counts every limit==0 container in unlimitedCount (request-only and unset)', () => {
-    const containers = [
-      cpu('limited', 50, 0, 100),
-      cpu('reqonly', 50, 100, 0),
-      cpu('unset', 10, 0, 0),
-    ]
-    const result = pickConstraint(containers, 'cpu')
+  it("omits the marker in 'limit' mode when no container sets a request", () => {
+    const containers = [cpu('a', 30, 0, 100), cpu('b', 40, 0, 200)]
+    const result = podAggregate(containers, 'cpu')
     expect(result.mode).toBe('limit')
+    expect(result.markerPct).toBeUndefined()
+  })
+
+  it("reports mode 'partial' with usage and unbounded count when only some containers are limited", () => {
+    const containers = [
+      cpu('app', 80, 0, 0),   // dominant, unbounded
+      cpu('sidecar', 5, 0, 100), // small, limited
+    ]
+    const result = podAggregate(containers, 'cpu')
+    expect(result.mode).toBe('partial')
+    expect(result.totalUsage).toBe(85)
+    expect(result.denom).toBe(0) // a partial limit sum is not a real ceiling
+    expect(result.unlimitedCount).toBe(1)
+  })
+
+  it("reports mode 'request' with the summed request when there are no limits but some requests", () => {
+    const containers = [
+      cpu('a', 50, 100, 0),
+      cpu('b', 40, 200, 0),
+    ]
+    const result = podAggregate(containers, 'cpu')
+    expect(result.mode).toBe('request')
+    expect(result.totalUsage).toBe(90)
+    expect(result.denom).toBe(300) // summed request
     expect(result.unlimitedCount).toBe(2)
+  })
+
+  it("reports mode 'none' when no container sets a request or limit", () => {
+    const containers = [cpu('a', 10, 0, 0), cpu('b', 20, 0, 0)]
+    const result = podAggregate(containers, 'cpu')
+    expect(result.mode).toBe('none')
+    expect(result.totalUsage).toBe(30)
+    expect(result.denom).toBe(0)
+    expect(result.unlimitedCount).toBe(2)
+  })
+
+  it('aggregates the memory fields for the memory kind', () => {
+    const containers = [mem('a', 64, 32, 128), mem('b', 96, 64, 256)]
+    const result = podAggregate(containers, 'memory')
+    expect(result.mode).toBe('limit')
+    expect(result.totalUsage).toBe(160)
+    expect(result.denom).toBe(384) // summed memory limit
   })
 })

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3578,8 +3578,7 @@ export function ResourcesView({
       case 'cpu': {
         if (kindLower === 'pods') {
           const key = `${meta.namespace}/${meta.name}`
-          const m = metricsLookup.pods.get(key)
-          return m ? podMostConstrainedPct(m, 'cpu') : 0
+          return metricsLookup.pods.get(key)?.cpu ?? 0
         }
         if (kindLower === 'nodes') {
           return metricsLookup.nodes.get(meta.name)?.cpu ?? 0
@@ -3589,8 +3588,7 @@ export function ResourcesView({
       case 'memory': {
         if (kindLower === 'pods') {
           const key = `${meta.namespace}/${meta.name}`
-          const m = metricsLookup.pods.get(key)
-          return m ? podMostConstrainedPct(m, 'memory') : 0
+          return metricsLookup.pods.get(key)?.memory ?? 0
         }
         if (kindLower === 'nodes') {
           return metricsLookup.nodes.get(meta.name)?.memory ?? 0
@@ -6089,32 +6087,34 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
             memory: m.memory, memoryRequest: m.memoryRequest, memoryLimit: m.memoryLimit,
           }]
 
-      const totalUsage = list.reduce((sum, c) => sum + (isCPU ? c.cpu : c.memory), 0)
+      const { mode, totalUsage, denom, markerPct, unlimitedCount } = podAggregate(list, kind)
       if (totalUsage === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
 
-      const { mode, container, denom, request, pct, unlimitedCount } = pickConstraint(list, kind)
       const tip = buildContainerResourceTooltip(label, list, kind, format)
 
-      // Nothing set anywhere → plain usage number with a faint "no limit" tag.
-      if (mode === 'none' || !container) {
+      // Every container is limited → aggregate bar against the summed limit; a
+      // real pod-level ceiling, so it may go red.
+      if (mode === 'limit') {
+        const pct = denom > 0 ? (totalUsage / denom) * 100 : 0
         return (
-          <Tooltip content={tip} delay={200} position="top" wrapperClassName="w-full min-w-0">
-            <span className="inline-flex items-center gap-1.5 min-w-0">
-              <span className="text-sm text-theme-text-secondary font-mono">{format(totalUsage)}</span>
-              <span className="text-[10px] text-theme-text-tertiary shrink-0">no limit</span>
-            </span>
-          </Tooltip>
+          <ResourceBar
+            used={format(totalUsage)}
+            total={format(denom)}
+            percent={pct}
+            colorScheme={getBulletBarScheme(pct, markerPct)}
+            markerPercent={markerPct}
+            tooltip={tip}
+          />
         )
       }
 
-      const usage = isCPU ? container.cpu : container.memory
-
-      // Request-only headline: neutral bar (no ceiling → never red), measured
-      // against the request, no marker and no tag.
+      // No limits but some requests → neutral bar against the summed request
+      // (no ceiling → never red), no marker.
       if (mode === 'request') {
+        const pct = denom > 0 ? (totalUsage / denom) * 100 : 0
         return (
           <ResourceBar
-            used={format(usage)}
+            used={format(totalUsage)}
             total={format(denom)}
             percent={pct}
             colorScheme="quiet"
@@ -6123,29 +6123,17 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
         )
       }
 
-      // Limited headline: utilization bar (red-capable) against the limit, with
-      // the request marker; append the "N unbounded" tag when other containers
-      // have no limit.
-      const marker = denom > 0 && request > 0 ? (request / denom) * 100 : undefined
-      const bar = (
-        <ResourceBar
-          used={format(usage)}
-          total={format(denom)}
-          percent={pct}
-          colorScheme={getBulletBarScheme(pct, marker)}
-          markerPercent={marker}
-          tooltip={tip}
-        />
+      // partial (some limited, some not — the sum is not a real ceiling) or none
+      // (nothing set) → plain usage number plus a faint tag.
+      const tag = mode === 'partial' ? `${unlimitedCount} unbounded` : 'no limit'
+      return (
+        <Tooltip content={tip} delay={200} position="top" wrapperClassName="w-full min-w-0">
+          <span className="inline-flex items-center gap-1.5 min-w-0">
+            <span className="text-sm text-theme-text-secondary font-mono">{format(totalUsage)}</span>
+            <span className="text-[10px] text-theme-text-tertiary shrink-0">{tag}</span>
+          </span>
+        </Tooltip>
       )
-      if (unlimitedCount > 0) {
-        return (
-          <div className="flex items-center gap-1.5 min-w-0">
-            <div className="min-w-0 flex-1">{bar}</div>
-            <span className="text-[10px] text-theme-text-tertiary shrink-0">{unlimitedCount} unbounded</span>
-          </div>
-        )
-      }
-      return bar
     }
     case 'gpu': {
       const count = getPodGpuCount(resource)
@@ -6696,61 +6684,67 @@ export function readContainer(c: ContainerResourceMetrics, kind: 'cpu' | 'memory
   return { usage, limit, request, yardstick, denom, pct }
 }
 
-interface CellConstraint {
-  /** Which container the compact cell headline shows, and against what. */
-  mode: Yardstick
-  container: ContainerResourceMetrics | null
+interface PodAggregate {
+  // limit: every container is limited → a real ceiling exists (bar vs summed
+  // limit). partial: some containers limited, some not → the sum is not a true
+  // ceiling, so plain usage + an "unbounded" tag. request: no limits but some
+  // requests → neutral bar vs summed request. none: nothing set → plain usage.
+  mode: 'limit' | 'partial' | 'request' | 'none'
+  totalUsage: number
+  /** summed limit (limit mode) or summed request (request mode); 0 otherwise. */
   denom: number
-  request: number
-  pct: number
-  /** Containers with no limit set (request-only or nothing). */
+  /** request marker as % of summed limit; limit mode only. */
+  markerPct?: number
+  /** number of containers with no limit set. */
   unlimitedCount: number
 }
 
-// pickConstraint chooses what the compact cell renders: the most-constrained
-// LIMITED container if any container sets a limit, else the most-constrained
-// REQUEST-ONLY container, else nothing. Within a mode the pick maximizes pct;
-// tie-break is deterministic — higher pct, then lexicographic container name.
-export function pickConstraint(containers: ContainerResourceMetrics[], kind: 'cpu' | 'memory'): CellConstraint {
-  let limited: ContainerResourceMetrics | null = null
-  let limitedR = { denom: 0, request: 0, pct: -1 }
-  let reqOnly: ContainerResourceMetrics | null = null
-  let reqOnlyR = { denom: 0, request: 0, pct: -1 }
+// podAggregate reduces a pod's containers to the aggregate the compact cell
+// headline renders — total usage measured against a pod-level yardstick. It
+// keeps the dominant consumer visible instead of demoting it behind a small
+// limited container, and stays honest about partial limits (which don't form a
+// real ceiling).
+export function podAggregate(list: ContainerResourceMetrics[], kind: 'cpu' | 'memory'): PodAggregate {
+  const isCPU = kind === 'cpu'
+  let totalUsage = 0
+  let limitedCount = 0
+  let requestedCount = 0
   let unlimitedCount = 0
-  for (const c of containers) {
-    const r = readContainer(c, kind)
-    if (r.yardstick === 'limit') {
-      if (limited === null || r.pct > limitedR.pct || (r.pct === limitedR.pct && c.name < limited.name)) {
-        limited = c
-        limitedR = { denom: r.denom, request: r.request, pct: r.pct }
-      }
+  let summedLimit = 0
+  let summedRequest = 0
+  for (const c of list) {
+    const usage = isCPU ? c.cpu : c.memory
+    const limit = isCPU ? c.cpuLimit : c.memoryLimit
+    const request = isCPU ? c.cpuRequest : c.memoryRequest
+    totalUsage += usage
+    if (limit > 0) {
+      limitedCount++
+      summedLimit += limit
     } else {
       unlimitedCount++
-      if (r.yardstick === 'request') {
-        if (reqOnly === null || r.pct > reqOnlyR.pct || (r.pct === reqOnlyR.pct && c.name < reqOnly.name)) {
-          reqOnly = c
-          reqOnlyR = { denom: r.denom, request: r.request, pct: r.pct }
-        }
-      }
+    }
+    if (request > 0) {
+      requestedCount++
+      summedRequest += request
     }
   }
-  if (limited) return { mode: 'limit', container: limited, denom: limitedR.denom, request: limitedR.request, pct: limitedR.pct, unlimitedCount }
-  if (reqOnly) return { mode: 'request', container: reqOnly, denom: reqOnlyR.denom, request: reqOnlyR.request, pct: reqOnlyR.pct, unlimitedCount }
-  return { mode: 'none', container: null, denom: 0, request: 0, pct: -1, unlimitedCount }
-}
-
-// podMostConstrainedPct returns the percentage the compact cell renders, used
-// for column sorting: pod pressure = max(usage/limit) over limited containers
-// if any, else max(usage/request) over request-only containers if any, else 0.
-function podMostConstrainedPct(m: TopPodMetrics, kind: 'cpu' | 'memory'): number {
-  const list: ContainerResourceMetrics[] = (m.containers && m.containers.length > 0)
-    ? m.containers
-    : [{
-        name: '', cpu: m.cpu, cpuRequest: m.cpuRequest, cpuLimit: m.cpuLimit,
-        memory: m.memory, memoryRequest: m.memoryRequest, memoryLimit: m.memoryLimit,
-      }]
-  const { mode, pct } = pickConstraint(list, kind)
-  return mode === 'none' ? 0 : pct
+  const allLimited = list.length > 0 && limitedCount === list.length
+  if (allLimited) {
+    return {
+      mode: 'limit',
+      totalUsage,
+      denom: summedLimit,
+      markerPct: summedRequest > 0 ? (summedRequest / summedLimit) * 100 : undefined,
+      unlimitedCount,
+    }
+  }
+  if (limitedCount > 0) {
+    return { mode: 'partial', totalUsage, denom: 0, unlimitedCount }
+  }
+  if (requestedCount > 0) {
+    return { mode: 'request', totalUsage, denom: summedRequest, unlimitedCount }
+  }
+  return { mode: 'none', totalUsage, denom: 0, unlimitedCount }
 }
 
 // buildContainerResourceTooltip renders one row per container — usage against

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -6678,7 +6678,7 @@ const CONTAINER_TOOLTIP_CAP = 3
 // no ceiling, so usage above request is normal and the bar stays neutral.
 type Yardstick = 'limit' | 'request' | 'none'
 
-function readContainer(c: ContainerResourceMetrics, kind: 'cpu' | 'memory') {
+export function readContainer(c: ContainerResourceMetrics, kind: 'cpu' | 'memory') {
   const isCPU = kind === 'cpu'
   const usage = isCPU ? c.cpu : c.memory
   const limit = isCPU ? c.cpuLimit : c.memoryLimit
@@ -6711,7 +6711,7 @@ interface CellConstraint {
 // LIMITED container if any container sets a limit, else the most-constrained
 // REQUEST-ONLY container, else nothing. Within a mode the pick maximizes pct;
 // tie-break is deterministic — higher pct, then lexicographic container name.
-function pickConstraint(containers: ContainerResourceMetrics[], kind: 'cpu' | 'memory'): CellConstraint {
+export function pickConstraint(containers: ContainerResourceMetrics[], kind: 'cpu' | 'memory'): CellConstraint {
   let limited: ContainerResourceMetrics | null = null
   let limitedR = { denom: 0, request: 0, pct: -1 }
   let reqOnly: ContainerResourceMetrics | null = null

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -4,7 +4,7 @@ import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { PaneLoader } from '../ui/PaneLoader'
 import { RestrictedState } from '../ui/RestrictedState'
 import { Input } from '../ui/Input'
-import type { TopPodMetrics, TopNodeMetrics } from '../../types'
+import type { TopPodMetrics, TopNodeMetrics, ContainerResourceMetrics } from '../../types'
 import {
   Search,
   RefreshCw,
@@ -3578,7 +3578,8 @@ export function ResourcesView({
       case 'cpu': {
         if (kindLower === 'pods') {
           const key = `${meta.namespace}/${meta.name}`
-          return metricsLookup.pods.get(key)?.cpu ?? 0
+          const m = metricsLookup.pods.get(key)
+          return m ? podMostConstrainedPct(m, 'cpu') : 0
         }
         if (kindLower === 'nodes') {
           return metricsLookup.nodes.get(meta.name)?.cpu ?? 0
@@ -3588,7 +3589,8 @@ export function ResourcesView({
       case 'memory': {
         if (kindLower === 'pods') {
           const key = `${meta.namespace}/${meta.name}`
-          return metricsLookup.pods.get(key)?.memory ?? 0
+          const m = metricsLookup.pods.get(key)
+          return m ? podMostConstrainedPct(m, 'memory') : 0
         }
         if (kindLower === 'nodes') {
           return metricsLookup.nodes.get(meta.name)?.memory ?? 0
@@ -6066,27 +6068,84 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const ip = resource.status?.podIP || '-'
       return <span className="text-sm text-theme-text-secondary font-mono">{ip}</span>
     }
-    case 'cpu': {
-      const key = `${resource.metadata?.namespace}/${resource.metadata?.name}`
-      const m = metrics.pods.get(key)
-      if (!m || m.cpu === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
-      const denom = m.cpuLimit || m.cpuRequest
-      if (!denom) return <span className="text-sm text-theme-text-secondary font-mono">{formatCPU(m.cpu)}</span>
-      const pct = (m.cpu / denom) * 100
-      const marker = m.cpuLimit > 0 && m.cpuRequest > 0 ? (m.cpuRequest / m.cpuLimit) * 100 : undefined
-      const tip = buildResourceTooltip('CPU', m.cpu, m.cpuRequest, m.cpuLimit, formatCPU)
-      return <ResourceBar used={formatCPU(m.cpu)} total={formatCPU(denom)} percent={pct} colorScheme={getBulletBarScheme(pct, marker)} markerPercent={marker} tooltip={tip} />
-    }
+    case 'cpu':
     case 'memory': {
+      const kind = column as 'cpu' | 'memory'
+      const isCPU = kind === 'cpu'
       const key = `${resource.metadata?.namespace}/${resource.metadata?.name}`
       const m = metrics.pods.get(key)
-      if (!m || m.memory === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
-      const denom = m.memoryLimit || m.memoryRequest
-      if (!denom) return <span className="text-sm text-theme-text-secondary font-mono">{formatMemoryShort(m.memory)}</span>
-      const pct = (m.memory / denom) * 100
-      const marker = m.memoryLimit > 0 && m.memoryRequest > 0 ? (m.memoryRequest / m.memoryLimit) * 100 : undefined
-      const tip = buildResourceTooltip('Memory', m.memory, m.memoryRequest, m.memoryLimit, formatMemoryShort)
-      return <ResourceBar used={formatMemoryShort(m.memory)} total={formatMemoryShort(denom)} percent={pct} colorScheme={getBulletBarScheme(pct, marker)} markerPercent={marker} tooltip={tip} />
+      if (!m) return <span className="text-sm text-theme-text-tertiary">-</span>
+      const label = isCPU ? 'CPU' : 'Memory'
+      const format = isCPU ? formatCPU : formatMemoryShort
+
+      // Multi-container pods carry a per-container breakdown; single-container
+      // pods fall back to the (union-summed) pod-level fields as one synthetic
+      // container so the rest of the logic is uniform.
+      const list: ContainerResourceMetrics[] = (m.containers && m.containers.length > 0)
+        ? m.containers
+        : [{
+            name: resource.spec?.containers?.[0]?.name ?? resource.metadata?.name ?? '',
+            cpu: m.cpu, cpuRequest: m.cpuRequest, cpuLimit: m.cpuLimit,
+            memory: m.memory, memoryRequest: m.memoryRequest, memoryLimit: m.memoryLimit,
+          }]
+
+      const totalUsage = list.reduce((sum, c) => sum + (isCPU ? c.cpu : c.memory), 0)
+      if (totalUsage === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
+
+      const { mode, container, denom, request, pct, unlimitedCount } = pickConstraint(list, kind)
+      const tip = buildContainerResourceTooltip(label, list, kind, format)
+
+      // Nothing set anywhere → plain usage number with a faint "no limit" tag.
+      if (mode === 'none' || !container) {
+        return (
+          <Tooltip content={tip} delay={200} position="top" wrapperClassName="w-full min-w-0">
+            <span className="inline-flex items-center gap-1.5 min-w-0">
+              <span className="text-sm text-theme-text-secondary font-mono">{format(totalUsage)}</span>
+              <span className="text-[10px] text-theme-text-tertiary shrink-0">no limit</span>
+            </span>
+          </Tooltip>
+        )
+      }
+
+      const usage = isCPU ? container.cpu : container.memory
+
+      // Request-only headline: neutral bar (no ceiling → never red), measured
+      // against the request, no marker and no tag.
+      if (mode === 'request') {
+        return (
+          <ResourceBar
+            used={format(usage)}
+            total={format(denom)}
+            percent={pct}
+            colorScheme="quiet"
+            tooltip={tip}
+          />
+        )
+      }
+
+      // Limited headline: utilization bar (red-capable) against the limit, with
+      // the request marker; append the "N unbounded" tag when other containers
+      // have no limit.
+      const marker = denom > 0 && request > 0 ? (request / denom) * 100 : undefined
+      const bar = (
+        <ResourceBar
+          used={format(usage)}
+          total={format(denom)}
+          percent={pct}
+          colorScheme={getBulletBarScheme(pct, marker)}
+          markerPercent={marker}
+          tooltip={tip}
+        />
+      )
+      if (unlimitedCount > 0) {
+        return (
+          <div className="flex items-center gap-1.5 min-w-0">
+            <div className="min-w-0 flex-1">{bar}</div>
+            <span className="text-[10px] text-theme-text-tertiary shrink-0">{unlimitedCount} unbounded</span>
+          </div>
+        )
+      }
+      return bar
     }
     case 'gpu': {
       const count = getPodGpuCount(resource)
@@ -6609,65 +6668,137 @@ function getBulletBarScheme(_usagePct: number, _markerPct: number | undefined): 
   return 'utilization'
 }
 
-function buildResourceTooltip(
-  type: 'CPU' | 'Memory',
-  usage: number,
-  request: number,
-  limit: number,
+// Max per-container rows shown in the compact cell tooltip before collapsing
+// the tail into a "+N more" line.
+const CONTAINER_TOOLTIP_CAP = 3
+
+// Per-container resource reading. The yardstick is the container's own limit
+// when set, otherwise its request. A limit means an enforced ceiling (usage can
+// be throttled / OOM-killed → the bar may go red); a request-only container has
+// no ceiling, so usage above request is normal and the bar stays neutral.
+type Yardstick = 'limit' | 'request' | 'none'
+
+function readContainer(c: ContainerResourceMetrics, kind: 'cpu' | 'memory') {
+  const isCPU = kind === 'cpu'
+  const usage = isCPU ? c.cpu : c.memory
+  const limit = isCPU ? c.cpuLimit : c.memoryLimit
+  const request = isCPU ? c.cpuRequest : c.memoryRequest
+  let yardstick: Yardstick = 'none'
+  let denom = 0
+  if (limit > 0) {
+    yardstick = 'limit'
+    denom = limit
+  } else if (request > 0) {
+    yardstick = 'request'
+    denom = request
+  }
+  const pct = denom > 0 ? (usage / denom) * 100 : -1
+  return { usage, limit, request, yardstick, denom, pct }
+}
+
+interface CellConstraint {
+  /** Which container the compact cell headline shows, and against what. */
+  mode: Yardstick
+  container: ContainerResourceMetrics | null
+  denom: number
+  request: number
+  pct: number
+  /** Containers with no limit set (request-only or nothing). */
+  unlimitedCount: number
+}
+
+// pickConstraint chooses what the compact cell renders: the most-constrained
+// LIMITED container if any container sets a limit, else the most-constrained
+// REQUEST-ONLY container, else nothing. Within a mode the pick maximizes pct;
+// tie-break is deterministic — higher pct, then lexicographic container name.
+function pickConstraint(containers: ContainerResourceMetrics[], kind: 'cpu' | 'memory'): CellConstraint {
+  let limited: ContainerResourceMetrics | null = null
+  let limitedR = { denom: 0, request: 0, pct: -1 }
+  let reqOnly: ContainerResourceMetrics | null = null
+  let reqOnlyR = { denom: 0, request: 0, pct: -1 }
+  let unlimitedCount = 0
+  for (const c of containers) {
+    const r = readContainer(c, kind)
+    if (r.yardstick === 'limit') {
+      if (limited === null || r.pct > limitedR.pct || (r.pct === limitedR.pct && c.name < limited.name)) {
+        limited = c
+        limitedR = { denom: r.denom, request: r.request, pct: r.pct }
+      }
+    } else {
+      unlimitedCount++
+      if (r.yardstick === 'request') {
+        if (reqOnly === null || r.pct > reqOnlyR.pct || (r.pct === reqOnlyR.pct && c.name < reqOnly.name)) {
+          reqOnly = c
+          reqOnlyR = { denom: r.denom, request: r.request, pct: r.pct }
+        }
+      }
+    }
+  }
+  if (limited) return { mode: 'limit', container: limited, denom: limitedR.denom, request: limitedR.request, pct: limitedR.pct, unlimitedCount }
+  if (reqOnly) return { mode: 'request', container: reqOnly, denom: reqOnlyR.denom, request: reqOnlyR.request, pct: reqOnlyR.pct, unlimitedCount }
+  return { mode: 'none', container: null, denom: 0, request: 0, pct: -1, unlimitedCount }
+}
+
+// podMostConstrainedPct returns the percentage the compact cell renders, used
+// for column sorting: pod pressure = max(usage/limit) over limited containers
+// if any, else max(usage/request) over request-only containers if any, else 0.
+function podMostConstrainedPct(m: TopPodMetrics, kind: 'cpu' | 'memory'): number {
+  const list: ContainerResourceMetrics[] = (m.containers && m.containers.length > 0)
+    ? m.containers
+    : [{
+        name: '', cpu: m.cpu, cpuRequest: m.cpuRequest, cpuLimit: m.cpuLimit,
+        memory: m.memory, memoryRequest: m.memoryRequest, memoryLimit: m.memoryLimit,
+      }]
+  const { mode, pct } = pickConstraint(list, kind)
+  return mode === 'none' ? 0 : pct
+}
+
+// buildContainerResourceTooltip renders one row per container — usage against
+// its OWN yardstick (limit if set, otherwise request) and percentage — sorted
+// by pct descending, intermixing limited and request-only. Containers with
+// neither render the words "no limit". Capped at CONTAINER_TOOLTIP_CAP rows,
+// with a final "+N more" line pointing at the pod.
+function buildContainerResourceTooltip(
+  label: 'CPU' | 'Memory',
+  containers: ContainerResourceMetrics[],
+  kind: 'cpu' | 'memory',
   formatFn: (n: number) => string,
 ) {
-  const isCPU = type === 'CPU'
-
-  let guidance: string
-  if (limit > 0 && request > 0) {
-    const pctOfLimit = (usage / limit) * 100
-    if (pctOfLimit > 90) {
-      guidance = isCPU
-        ? 'Near the limit — CPU may be throttled'
-        : 'Near the limit — at risk of OOM kill'
-    } else if (usage > request) {
-      guidance = 'Exceeds request — consider raising it if sustained'
-    } else {
-      guidance = 'Below request — healthy headroom'
-    }
-  } else if (limit > 0) {
-    const pctOfLimit = (usage / limit) * 100
-    if (pctOfLimit > 90) {
-      guidance = isCPU
-        ? 'Near the limit — CPU may be throttled'
-        : 'Near the limit — at risk of OOM kill'
-    } else {
-      guidance = 'No request set — scheduling may be suboptimal'
-    }
-  } else if (request > 0) {
-    guidance = usage > request
-      ? `Exceeds request with no limit — unbounded ${isCPU ? 'CPU' : 'memory'} access`
-      : 'No limit set — pod can burst beyond request'
-  } else {
-    guidance = 'No request or limit configured'
-  }
+  const rows = [...containers].sort((a, b) => {
+    const diff = readContainer(b, kind).pct - readContainer(a, kind).pct
+    return diff !== 0 ? diff : a.name.localeCompare(b.name)
+  })
+  const shown = rows.slice(0, CONTAINER_TOOLTIP_CAP)
+  const remaining = rows.length - shown.length
 
   return (
-    <div className="whitespace-normal w-52 flex flex-col gap-1.5 py-0.5">
-      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs font-mono">
-        <span className="text-theme-text-tertiary">Usage</span>
-        <span className="text-theme-text-primary">{formatFn(usage)}</span>
-        {request > 0 && (
-          <>
-            <span className="text-theme-text-tertiary">Request</span>
-            <span className="text-theme-text-primary">{formatFn(request)}</span>
-          </>
-        )}
-        {limit > 0 && (
-          <>
-            <span className="text-theme-text-tertiary">Limit</span>
-            <span className="text-theme-text-primary">{formatFn(limit)}</span>
-          </>
-        )}
+    <div className="whitespace-normal w-72 flex flex-col gap-2 py-0.5">
+      <div className="text-[11px] text-theme-text-tertiary uppercase tracking-wide">{label} by container</div>
+      <div className="flex flex-col gap-2">
+        {shown.map((c) => {
+          const r = readContainer(c, kind)
+          // Container name on its own line, the numbers below it. Limited
+          // containers also show the request (the tooltip is the detail
+          // surface and shouldn't drop it); request-only/unset show their
+          // single yardstick or "no limit".
+          const detail = r.yardstick === 'limit'
+            ? `${formatFn(r.usage)} · ${Math.round(r.pct)}% · ${formatFn(r.denom)} limit${r.request > 0 ? ` · req ${formatFn(r.request)}` : ''}`
+            : r.yardstick === 'request'
+              ? `${formatFn(r.usage)} · ${Math.round(r.pct)}% · ${formatFn(r.denom)} request`
+              : `${formatFn(r.usage)} · no limit`
+          return (
+            <div key={c.name} className="flex flex-col leading-snug">
+              <span className="text-[11px] text-theme-text-tertiary truncate">{c.name}</span>
+              <span className="text-xs font-mono text-theme-text-primary">{detail}</span>
+            </div>
+          )
+        })}
       </div>
-      <div className="text-[11px] text-theme-text-secondary border-t border-theme-border/50 pt-1">
-        {guidance}
-      </div>
+      {remaining > 0 && (
+        <div className="text-[11px] text-theme-text-tertiary border-t border-theme-border/50 pt-1">
+          +{remaining} more → open pod
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -740,8 +740,11 @@ export function PodRenderer({
               {(metricsHistory?.containers || currentMetrics?.containers || []).map((historyContainer) => {
                 // Find current metrics for this container
                 const currentContainerMetrics = currentMetrics?.containers?.find(c => c.name === historyContainer.name)
-                // Find the container spec to compare against limits
+                // Find the container spec to compare against limits. Native
+                // sidecars live in initContainers (restartPolicy Always), so
+                // fall through to them or their chart shows no limit line.
                 const containerSpec = containers.find((c: any) => c.name === historyContainer.name)
+                  || initContainers.find((c: any) => c.name === historyContainer.name && c.restartPolicy === 'Always')
                 const limits = containerSpec?.resources?.limits
                 const requests = containerSpec?.resources?.requests
 

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -1032,15 +1032,28 @@ export type ChartSource = 'local' | 'artifacthub'
 // ============================================================================
 
 // Top metrics types (bulk, for resource table view)
+export interface ContainerResourceMetrics {
+  name: string
+  cpu: number           // nanocores (usage)
+  cpuRequest: number    // nanocores
+  cpuLimit: number      // nanocores
+  memory: number        // bytes (usage)
+  memoryRequest: number // bytes
+  memoryLimit: number   // bytes
+}
+
 export interface TopPodMetrics {
   namespace: string
   name: string
   cpu: number           // nanocores (usage)
   memory: number        // bytes (usage)
-  cpuRequest: number    // nanocores (sum across containers)
-  cpuLimit: number      // nanocores (sum across containers)
-  memoryRequest: number // bytes (sum across containers)
-  memoryLimit: number   // bytes (sum across containers)
+  cpuRequest: number    // nanocores (sum across running containers)
+  cpuLimit: number      // nanocores (sum across running containers)
+  memoryRequest: number // bytes (sum across running containers)
+  memoryLimit: number   // bytes (sum across running containers)
+  // Per-container breakdown; present only for pods with more than one running
+  // container (regular + native sidecars). Absent for single-container pods.
+  containers?: ContainerResourceMetrics[]
 }
 
 export interface TopNodeMetrics {

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -54,6 +54,18 @@ type NodeMetricsHistory struct {
 	MetricsUnavailable          bool               `json:"metricsUnavailable,omitempty"`
 }
 
+// ContainerResourceMetrics holds latest usage plus request/limit for a single
+// container. Usage comes from the metrics API; request/limit from the pod spec.
+type ContainerResourceMetrics struct {
+	Name          string `json:"name"`
+	CPU           int64  `json:"cpu"`
+	CPURequest    int64  `json:"cpuRequest"`
+	CPULimit      int64  `json:"cpuLimit"`
+	Memory        int64  `json:"memory"`
+	MemoryRequest int64  `json:"memoryRequest"`
+	MemoryLimit   int64  `json:"memoryLimit"`
+}
+
 // TopPodMetrics holds the latest metrics snapshot for a single pod.
 type TopPodMetrics struct {
 	Namespace     string `json:"namespace"`
@@ -64,6 +76,10 @@ type TopPodMetrics struct {
 	CPULimit      int64  `json:"cpuLimit"`
 	MemoryRequest int64  `json:"memoryRequest"`
 	MemoryLimit   int64  `json:"memoryLimit"`
+	// Containers carries per-container usage and request/limit for pods with
+	// more than one running container (regular + native sidecars). Omitted for
+	// single-container pods, where the pod-level fields above already suffice.
+	Containers []ContainerResourceMetrics `json:"containers,omitempty"`
 }
 
 // TopNodeMetrics holds the latest metrics snapshot for a single node.
@@ -507,6 +523,36 @@ func (s *MetricsHistoryStore) GetAllPodMetricsLatest() []TopPodMetrics {
 			CPU:       totalCPU,
 			Memory:    totalMem,
 		})
+	}
+	return result
+}
+
+// GetAllPodContainerMetricsLatest returns the latest per-container usage for all
+// tracked pods, keyed by "namespace/name" then container name. Unlike
+// GetAllPodMetricsLatest it does not sum across containers. Only the usage
+// fields (CPU, Memory) are populated; request/limit are filled from the pod
+// spec by callers.
+func (s *MetricsHistoryStore) GetAllPodContainerMetricsLatest() map[string]map[string]ContainerResourceMetrics {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make(map[string]map[string]ContainerResourceMetrics, len(s.podMetrics))
+	for key, podBuf := range s.podMetrics {
+		containers := make(map[string]ContainerResourceMetrics, len(podBuf.containers))
+		for name, buf := range podBuf.containers {
+			if points := buf.GetAll(); len(points) > 0 {
+				last := points[len(points)-1]
+				containers[name] = ContainerResourceMetrics{
+					Name:   name,
+					CPU:    last.CPU,
+					Memory: last.Memory,
+				}
+			}
+		}
+		result[key] = containers
 	}
 	return result
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2028,15 +2028,28 @@ export function useNodeMetricsHistory(nodeName: string) {
 }
 
 // Top metrics types (bulk, for resource table view)
+export interface ContainerResourceMetrics {
+  name: string
+  cpu: number // nanocores (usage)
+  cpuRequest: number // nanocores
+  cpuLimit: number // nanocores
+  memory: number // bytes (usage)
+  memoryRequest: number // bytes
+  memoryLimit: number // bytes
+}
+
 export interface TopPodMetrics {
   namespace: string
   name: string
   cpu: number // nanocores (usage)
   memory: number // bytes (usage)
-  cpuRequest: number // nanocores (sum across containers)
-  cpuLimit: number // nanocores (sum across containers)
-  memoryRequest: number // bytes (sum across containers)
-  memoryLimit: number // bytes (sum across containers)
+  cpuRequest: number // nanocores (sum across running containers)
+  cpuLimit: number // nanocores (sum across running containers)
+  memoryRequest: number // bytes (sum across running containers)
+  memoryLimit: number // bytes (sum across running containers)
+  // Per-container breakdown; present only for pods with more than one running
+  // container (regular + native sidecars). Absent for single-container pods.
+  containers?: ContainerResourceMetrics[]
 }
 
 export interface TopNodeMetrics {


### PR DESCRIPTION
## Problem

The Pods table computed memory/CPU % from pod-level sums: usage summed across **all** containers (including native sidecars), but request/limit summed over `spec.Containers` **only**. On multi-container pods with heterogeneous or missing limits — a broker with no limit next to a small sidecar, or a native sidecar (initContainer with `restartPolicy: Always`) that sets its own limit — this produced false over-limit percentages and "at risk of OOM kill" warnings on healthy pods.

## What changed

A per-container model instead of pod-level sums.

**Backend**
- A shared union-sum helper sums request/limit over regular containers **plus native sidecars**, applied to both the table (`handleTopPods`) and agent/MCP (`topPodFromObject`) paths — so the pod-level % is honest everywhere, including library consumers that read the pod-level fields.
- The table endpoint additionally returns a per-container metrics array (usage/request/limit per container); omitted when a pod has a single running container.
- Existing pod-level fields are kept (additive, non-breaking).

**Frontend**
- The memory/CPU cell shows the **most-constrained container**: usage vs its own limit (can go red), or vs its request in a neutral color when there is no limit, or plain usage when neither is set. A faint tag marks unbounded containers.
- The hover tooltip breaks every container down against its own request/limit.
- The column sorts by that per-container pressure.
- The pod detail drawer resolves native-sidecar specs so their charts show limit lines.

## Scope / compatibility

- Additive API field; existing pod-level fields retained — no breaking change for `@skyhook-io/radar-app` / `@skyhook-io/k8s-ui` consumers.
- Supersedes #1291 (a bounded patch of the same bug).

## Verification

- `make tsc` and `make build` pass.
- Verified live on a kind cluster with multi-container pods: a native-sidecar pod that previously read a false ~126% now reads its most-constrained container honestly; requests-only pods show utilization vs request in a neutral color; pods with no limits show plain usage.

Follow-up in this PR: unit tests for the union-sum/per-container builder and the frontend constraint picker.

Fixes #1249

https://claude.ai/code/session_01XgG563HEjaSEr2B3cdsn7q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pod resource percentages and top-metrics request/limit totals are computed across API and UI; behavior shifts for sidecar-heavy pods but is covered by new unit tests and is intended to fix incorrect alerts rather than introduce new enforcement paths.
> 
> **Overview**
> Fixes **misaligned pod-level CPU/memory %** when usage included native sidecars but request/limit sums only counted `spec.containers`, which produced false over-limit readings on multi-container pods.
> 
> **Backend:** `SumRunningContainerResources` and `BuildPodContainerMetrics` treat **regular containers plus native sidecars** (`initContainers` with `restartPolicy: Always`) as the running set; one-shot init containers and stale usage-only names are excluded. The top-pods handler and `topPodFromObject` use the union sum for pod-level fields; the bulk endpoint adds optional **`containers`** (usage + request/limit per name) when more than one running container exists. `GetAllPodContainerMetricsLatest` supplies per-container usage from the metrics history store.
> 
> **Frontend:** CPU/memory cells use **`podAggregate` / `readContainer`** so the bar reflects summed limits when every container is limited, neutral bars vs summed requests when there are no limits, or plain usage with tags like **unbounded** / **no limit** when limits are partial or missing. Tooltips list each container against its own yardstick. **PodRenderer** resolves sidecar specs from init containers for chart limit lines.
> 
> Types and API clients gain **`ContainerResourceMetrics`**; existing pod-level fields remain additive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f315d65024cefb7e69a8d22015c7cff7cf3609d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->