### PR TITLE
fix(sse): gate Secret/RBAC/webhook change frames per user

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4311,7 +4311,44 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 		deny[topology.KindNamespace] = true
 	}
-	s.broadcaster.HandleSSE(w, r, deny)
+	s.broadcaster.HandleSSE(w, r, deny, s.deniedSensitiveChangeKinds(r))
+}
+
+// sensitiveChangeKinds are cached kinds whose change frames can carry
+// privileged metadata: Secret diffs expose data key names, Role/binding
+// diffs expose the authorization graph, webhook diffs expose the admission
+// plane. Static list — these are all typed cache kinds with fixed GVRs.
+var sensitiveChangeKinds = []struct{ kind, group, resource string }{
+	{"Secret", "", "secrets"},
+	{"Role", "rbac.authorization.k8s.io", "roles"},
+	{"RoleBinding", "rbac.authorization.k8s.io", "rolebindings"},
+	{"ClusterRole", "rbac.authorization.k8s.io", "clusterroles"},
+	{"ClusterRoleBinding", "rbac.authorization.k8s.io", "clusterrolebindings"},
+	{"MutatingWebhookConfiguration", "admissionregistration.k8s.io", "mutatingwebhookconfigurations"},
+	{"ValidatingWebhookConfiguration", "admissionregistration.k8s.io", "validatingwebhookconfigurations"},
+}
+
+// deniedSensitiveChangeKinds resolves, per authenticated user, which
+// sensitive kinds must be stripped from their k8s_event stream. Cluster-wide
+// list SAR per kind, memoized on the user's permission cache — a deliberate
+// conservative interim: per-namespace secret grants don't unlock the stream
+// (REST reads honor them; the stream doesn't carry enough GVR context yet —
+// see docs/plans/sse-full-authz.md for the full per-(resource,namespace)
+// design). Fail-closed via canRead. Returns nil when auth is off.
+func (s *Server) deniedSensitiveChangeKinds(r *http.Request) map[string]bool {
+	if auth.UserFromContext(r.Context()) == nil {
+		return nil
+	}
+	var denied map[string]bool
+	for _, k := range sensitiveChangeKinds {
+		if !s.canRead(r, k.group, k.resource, "", "list") {
+			if denied == nil {
+				denied = make(map[string]bool, len(sensitiveChangeKinds))
+			}
+			denied[k.kind] = true
+		}
+	}
+	return denied
 }
 
 // Settings handlers

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -69,14 +69,25 @@ type ClientInfo struct {
 	// Resolved once at subscribe time (the request is available there) so the
 	// broadcast loop never runs a SAR. nil/empty for users with full access.
 	DeniedKinds map[topology.NodeKind]bool
+	// DeniedSensitiveKinds are kinds whose k8s_event change frames can carry
+	// privileged metadata (Secret data key names, RBAC rule contents, webhook
+	// configs) and which this user cannot read cluster-wide. Frames for these
+	// kinds are dropped regardless of namespace — including inside namespaces
+	// the user CAN see, closing the "list-pods-only viewer receives Secret
+	// key-name diffs" gap. Resolved once at subscribe time. Conservative
+	// interim: a user with only per-namespace secrets grants also loses these
+	// frames (REST reads are unaffected); the per-(resource,namespace) stream
+	// authorization that lifts this lives in docs/plans/sse-full-authz.md.
+	DeniedSensitiveKinds map[string]bool
 }
 
 type clientRegistration struct {
-	ch               chan SSEEvent
-	namespaces       []string
-	viewMode         string
-	showPolicyEffect bool
-	deniedKinds      map[topology.NodeKind]bool
+	ch                   chan SSEEvent
+	namespaces           []string
+	viewMode             string
+	showPolicyEffect     bool
+	deniedKinds          map[topology.NodeKind]bool
+	deniedSensitiveKinds map[string]bool
 }
 
 // SSEEvent represents an event to send to clients
@@ -388,7 +399,7 @@ func (b *SSEBroadcaster) run() {
 				close(reg.ch) // Signal rejection by closing the channel
 				continue
 			}
-			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds}
+			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds, DeniedSensitiveKinds: reg.deniedSensitiveKinds}
 			b.mu.Unlock()
 			log.Printf("SSE client connected (namespaces=%v, view=%s), total clients: %d", reg.namespaces, reg.viewMode, len(b.clients))
 
@@ -787,6 +798,12 @@ func (b *SSEBroadcaster) broadcastResourceChange(event SSEEvent, namespace, kind
 
 // clientCanSeeChange reports whether a client's RBAC allows a change frame.
 func clientCanSeeChange(info ClientInfo, namespace, kind string) bool {
+	// Sensitive kinds are gated independently of namespace access: being able
+	// to see a namespace must not imply receiving Secret/RBAC/webhook change
+	// metadata from it.
+	if info.DeniedSensitiveKinds[kind] {
+		return false
+	}
 	if namespace != "" {
 		// Namespaced change: deliver only if the client can see that namespace.
 		// nil Namespaces means all-namespace access (no RBAC restriction).
@@ -801,7 +818,7 @@ func clientCanSeeChange(info ClientInfo, namespace, kind string) bool {
 }
 
 // Subscribe adds a new SSE client. Returns nil if max clients reached.
-func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedKinds map[topology.NodeKind]bool, showPolicyEffect ...bool) chan SSEEvent {
+func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedKinds map[topology.NodeKind]bool, deniedSensitiveKinds map[string]bool, showPolicyEffect ...bool) chan SSEEvent {
 	// Check client count before creating the channel to fail fast
 	b.mu.RLock()
 	clientCount := len(b.clients)
@@ -823,7 +840,7 @@ func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedK
 
 	policyEffect := len(showPolicyEffect) > 0 && showPolicyEffect[0]
 	ch := make(chan SSEEvent, 10)
-	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds}
+	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds, deniedSensitiveKinds: deniedSensitiveKinds}
 	return ch
 }
 
@@ -943,7 +960,7 @@ func buildFullTopology() (*topology.Topology, error) {
 }
 
 // HandleSSE is the HTTP handler for the SSE endpoint
-func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, deniedKinds map[topology.NodeKind]bool) {
+func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, deniedKinds map[topology.NodeKind]bool, deniedSensitiveKinds map[string]bool) {
 	// Set SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -966,7 +983,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 	}
 
 	// Subscribe to events
-	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, policyEffect)
+	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, deniedSensitiveKinds, policyEffect)
 	if eventCh == nil {
 		http.Error(w, "Too many SSE connections", http.StatusServiceUnavailable)
 		return

--- a/internal/server/sse_rbac_test.go
+++ b/internal/server/sse_rbac_test.go
@@ -72,3 +72,43 @@ func TestClientCanSeeChange(t *testing.T) {
 		})
 	}
 }
+
+// The sensitive-kind gate: two users in the SAME namespace with different
+// grants must diverge on Secret/RBAC/webhook change frames. Being allowed a
+// namespace must never imply receiving privileged change metadata from it
+// (Secret key names, Role rules, webhook configs).
+func TestClientCanSeeChangeSensitiveKinds(t *testing.T) {
+	denySensitive := map[string]bool{
+		"Secret": true, "Role": true, "RoleBinding": true,
+		"ClusterRole": true, "ClusterRoleBinding": true,
+		"MutatingWebhookConfiguration": true, "ValidatingWebhookConfiguration": true,
+	}
+	// Both clients can see namespace "a"; only one holds cluster-wide reads.
+	privileged := ClientInfo{Namespaces: []string{"a"}}
+	restricted := ClientInfo{Namespaces: []string{"a"}, DeniedSensitiveKinds: denySensitive}
+
+	cases := []struct {
+		name      string
+		info      ClientInfo
+		namespace string
+		kind      string
+		want      bool
+	}{
+		{"privileged sees Secret change in allowed ns", privileged, "a", "Secret", true},
+		{"restricted does NOT see Secret change in ALLOWED ns", restricted, "a", "Secret", false},
+		{"restricted does NOT see Role change in allowed ns", restricted, "a", "Role", false},
+		{"restricted does NOT see RoleBinding change", restricted, "a", "RoleBinding", false},
+		{"restricted does NOT see ClusterRole change", restricted, "", "ClusterRole", false},
+		{"restricted does NOT see webhook change", restricted, "", "MutatingWebhookConfiguration", false},
+		{"restricted still sees ordinary kinds in allowed ns", restricted, "a", "Deployment", true},
+		{"restricted still sees ConfigMap (not in sensitive set)", restricted, "a", "ConfigMap", true},
+		{"privileged unaffected on cluster-scoped sensitive", privileged, "", "ClusterRole", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientCanSeeChange(tc.info, tc.namespace, tc.kind); got != tc.want {
+				t.Fatalf("clientCanSeeChange(%q, %q) = %v, want %v", tc.namespace, tc.kind, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the documented PARTIAL gap in `broadcastResourceChange` (sse.go) for the kinds where it matters: **Secret, Role, RoleBinding, ClusterRole, ClusterRoleBinding, Mutating/ValidatingWebhookConfiguration**.

Before: the k8s_event stream filtered by namespace + cluster-scoped topology kind only — a viewer with just workload-read in namespace X received Secret change frames from X (exposing data **key names** — never values, `diffSecret` emits keys only) and Role/webhook diffs; cluster-scoped RBAC/webhook kinds weren't in the topology denied-set at all.

After: `handleSSE` resolves a per-user denied set for the seven sensitive kinds (cluster-wide list SAR per kind, memoized on the 2-min permission cache — resolved once at subscribe, zero per-frame authorization cost) and `clientCanSeeChange` drops those frames **regardless of namespace**.

Deliberately conservative interim: users holding only per-namespace secret grants also lose Secret frames (REST reads still honor their grants). The full per-(resource,namespace) stream boundary is designed in `docs/plans/sse-full-authz.md` (#913) and replaces this.

Tests: two-users-same-namespace divergence table (the failure mode this fixes), ordinary kinds unaffected, no-auth mode unchanged (nil set). Full server suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated SSE authorization for security-sensitive kinds (secrets metadata, RBAC, webhooks); logic is conservative and subscribe-time only, but incorrect SAR caching could wrongly hide or leak change frames.
> 
> **Overview**
> **Closes an RBAC gap on SSE `k8s_event` frames** where namespace filtering alone let viewers with workload-only access receive change metadata for Secrets (data **key names** in diffs), Roles/bindings, and admission webhook configs—even inside namespaces they were allowed to see.
> 
> On SSE subscribe, the server now resolves a per-user **denied sensitive kinds** set for seven fixed kinds via cluster-wide `list` SAR (memoized on the existing permission cache, fail-closed through `canRead`). That set is stored on each client and **`clientCanSeeChange` drops matching frames regardless of namespace**, before the usual namespace / cluster-scoped topology deny logic.
> 
> **Interim behavior:** users with only per-namespace secret grants still do not get Secret frames on the stream (REST reads unchanged); full per-(resource, namespace) stream auth is documented separately.
> 
> Tests add the two-users-same-namespace divergence case for sensitive kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05cd281e84e7a9f2f943d31fc949d52f35e222e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->