### PR TITLE
fix(rbac): enforce per-kind RBAC on all timeline change/diff/drop surfaces

### DIFF
--- a/internal/k8s/change_rbac.go
+++ b/internal/k8s/change_rbac.go
@@ -1,0 +1,127 @@
+package k8s
+
+import "strings"
+
+// namespacedBuiltinKinds maps the lowercase Kind of the well-known namespaced
+// builtin resources to their canonical (group, resource) for SAR lookups. It is
+// the namespaced counterpart of clusterOnlyKinds: together they let
+// ResolveChangeGVR authorize every builtin kind without a discovery round-trip,
+// which (a) avoids a cold-start window where authenticated users briefly see an
+// empty timeline before discovery warms up, and (b) keeps the per-kind gate
+// unit-testable. CRDs and anything not listed here fall through to discovery.
+var namespacedBuiltinKinds = map[string]ClusterOnlyKindInfo{
+	"pod":                     {"", "pods"},
+	"service":                 {"", "services"},
+	"configmap":               {"", "configmaps"},
+	"secret":                  {"", "secrets"},
+	"event":                   {"", "events"},
+	"serviceaccount":          {"", "serviceaccounts"},
+	"persistentvolumeclaim":   {"", "persistentvolumeclaims"},
+	"limitrange":              {"", "limitranges"},
+	"resourcequota":           {"", "resourcequotas"},
+	"deployment":              {"apps", "deployments"},
+	"daemonset":               {"apps", "daemonsets"},
+	"statefulset":             {"apps", "statefulsets"},
+	"replicaset":              {"apps", "replicasets"},
+	"job":                     {"batch", "jobs"},
+	"cronjob":                 {"batch", "cronjobs"},
+	"ingress":                 {"networking.k8s.io", "ingresses"},
+	"networkpolicy":           {"networking.k8s.io", "networkpolicies"},
+	"endpointslice":           {"discovery.k8s.io", "endpointslices"},
+	"horizontalpodautoscaler": {"autoscaling", "horizontalpodautoscalers"},
+	"poddisruptionbudget":     {"policy", "poddisruptionbudgets"},
+	"role":                    {"rbac.authorization.k8s.io", "roles"},
+	"rolebinding":             {"rbac.authorization.k8s.io", "rolebindings"},
+}
+
+// namespacedBuiltinGVR returns the canonical (group, resource) for a well-known
+// namespaced builtin kind. The bool is false for CRDs / unknown kinds (callers
+// fall through to discovery).
+func namespacedBuiltinGVR(kind string) (group, resource string, ok bool) {
+	info, exists := namespacedBuiltinKinds[strings.ToLower(kind)]
+	if !exists {
+		return "", "", false
+	}
+	return info.Group, info.Resource, true
+}
+
+// This file holds the single, shared per-kind authorization decision for
+// timeline/change/diff/drop data. Every surface that returns such data — REST
+// handlers (internal/server) and MCP tools (internal/mcp) — routes through
+// ChangeReadAllowed so the RBAC rule is defined once and can't drift or be
+// forgotten. Each caller supplies its own authorize callback bound to its auth
+// context (REST: canReadUser; MCP: canReadInNamespace); the resolve + scope +
+// fail-closed logic lives here.
+
+// ResolveChangeGVR resolves the (group, resource-plural, cluster-scoped) for a
+// change/timeline event so per-kind SAR gates can authorize it. `group` is the
+// caller's known group hint — a ResourceChange's group (dynamic cache) or the
+// group parsed from an apiVersion — and disambiguates CRD kind collisions.
+// Returns ok=false when neither the cluster-only catalogue nor discovery can
+// resolve it (callers fail closed).
+//
+// The cluster-scoped case is delegated to ClassifyKindScope, which owns the
+// builtin-catalogue-vs-group-hint collision guard; namespaced kinds are then
+// resolved from discovery. clusterScoped drives the SAR namespace — cluster-
+// scoped kinds must authorize at namespace "" even when the event row carries a
+// namespace (a K8s Event about a Node stores the Event's own namespace, not the
+// cluster-scoped involved object's).
+func ResolveChangeGVR(kind, group string) (gvrGroup, gvrResource string, clusterScoped, ok bool) {
+	if kind == "" {
+		return "", "", false, false
+	}
+	if cs, g, r := ClassifyKindScope(kind, group); cs {
+		return g, r, true, true
+	}
+	// Namespaced builtins resolve from the static catalogue — discovery-free and
+	// collision-guarded (a disagreeing group hint means a CRD collision → fall
+	// through to discovery for the real GVR).
+	if g, r, found := namespacedBuiltinGVR(kind); found && (group == "" || group == g) {
+		return g, r, false, true
+	}
+	disc := GetResourceDiscovery()
+	if disc == nil {
+		return "", "", false, false
+	}
+	if group != "" {
+		// Hint present: resolve within that exact group, or fail closed — a
+		// group-less fallback here would re-admit the builtin-collision leak.
+		if ar, found := disc.GetResourceWithGroup(kind, group); found {
+			return ar.Group, ar.Name, !ar.Namespaced, true
+		}
+		return "", "", false, false
+	}
+	if ar, found := disc.GetResource(kind); found {
+		return ar.Group, ar.Name, !ar.Namespaced, true
+	}
+	return "", "", false, false
+}
+
+// GroupFromAPIVersion extracts the API group from an apiVersion string
+// ("apps/v1" → "apps", "v1" → "", "cluster.x-k8s.io/v1beta1" → "cluster.x-k8s.io").
+func GroupFromAPIVersion(apiVersion string) string {
+	if i := strings.IndexByte(apiVersion, '/'); i >= 0 {
+		return apiVersion[:i]
+	}
+	return ""
+}
+
+// ChangeReadAllowed reports whether a change/diff/drop row for (kind, apiVersion,
+// namespace) may be shown to a caller whose per-kind read authority is `authorize`
+// (returns true iff the caller may "list" that group/resource in that namespace).
+//
+// It is the one place the timeline RBAC rule lives: resolve the GVR (apiVersion
+// disambiguates CRD collisions), authorize cluster-scoped kinds at namespace ""
+// (their row's namespace is not the object's), and fail closed when the kind
+// can't be resolved — during discovery warmup an authenticated caller briefly
+// sees fewer rows rather than unauthorized ones.
+func ChangeReadAllowed(kind, apiVersion, namespace string, authorize func(group, resource, namespace string) bool) bool {
+	group, resource, clusterScoped, ok := ResolveChangeGVR(kind, GroupFromAPIVersion(apiVersion))
+	if !ok {
+		return false
+	}
+	if clusterScoped {
+		namespace = ""
+	}
+	return authorize(group, resource, namespace)
+}

--- a/internal/k8s/change_rbac_test.go
+++ b/internal/k8s/change_rbac_test.go
@@ -1,0 +1,89 @@
+package k8s
+
+import "testing"
+
+func TestGroupFromAPIVersion(t *testing.T) {
+	cases := map[string]string{
+		"v1":                           "",
+		"apps/v1":                      "apps",
+		"cluster.x-k8s.io/v1beta1":     "cluster.x-k8s.io",
+		"rbac.authorization.k8s.io/v1": "rbac.authorization.k8s.io",
+		"":                             "",
+	}
+	for in, want := range cases {
+		if got := GroupFromAPIVersion(in); got != want {
+			t.Errorf("GroupFromAPIVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ResolveChangeGVR resolves cluster-only kinds from the static catalogue with no
+// discovery wired — the path that must work before discovery warms up. Namespaced
+// kinds need discovery (nil here) so they resolve to ok=false, which callers treat
+// as fail-closed under auth. The group hint is authoritative: a hint disagreeing
+// with a builtin's group is a CRD Kind collision and must NOT resolve to the
+// builtin GVR (would authorize the CRD's rows against the builtin the user reads).
+func TestResolveChangeGVR_StaticCatalogue(t *testing.T) {
+	cases := []struct {
+		name             string
+		kind, group      string
+		wantG, wantR     string
+		wantClusterScope bool
+		wantOK           bool
+	}{
+		{"core Node cluster-scoped", "Node", "", "", "nodes", true, true},
+		{"ClusterRole matching group", "ClusterRole", "rbac.authorization.k8s.io", "rbac.authorization.k8s.io", "clusterroles", true, true},
+		{"ClusterRole no hint", "ClusterRole", "", "rbac.authorization.k8s.io", "clusterroles", true, true},
+		{"webhook cfg cluster-scoped", "ValidatingWebhookConfiguration", "", "admissionregistration.k8s.io", "validatingwebhookconfigurations", true, true},
+		{"PersistentVolume cluster-scoped", "PersistentVolume", "", "", "persistentvolumes", true, true},
+		// CRD colliding on Kind with a builtin: hint group disagrees → static
+		// catalogue skipped, no discovery → fail closed (NOT the builtin GVR).
+		{"ClusterRole CRD collision fails closed", "ClusterRole", "example.com", "", "", false, false},
+		// Namespaced builtins resolve from the static catalogue (no discovery).
+		{"Secret namespaced builtin", "Secret", "", "", "secrets", false, true},
+		{"Deployment namespaced builtin", "Deployment", "apps", "apps", "deployments", false, true},
+		{"Deployment collision fails closed", "Deployment", "example.com", "", "", false, false},
+		// Unknown kind, no discovery → unresolved (fail closed downstream).
+		{"unknown kind needs discovery", "WidgetCRD", "", "", "", false, false},
+		{"empty kind", "", "", "", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, r, cs, ok := ResolveChangeGVR(tc.kind, tc.group)
+			if ok != tc.wantOK || g != tc.wantG || r != tc.wantR || cs != tc.wantClusterScope {
+				t.Errorf("ResolveChangeGVR(%q, %q) = (%q, %q, cs=%v, ok=%v), want (%q, %q, cs=%v, ok=%v)",
+					tc.kind, tc.group, g, r, cs, ok, tc.wantG, tc.wantR, tc.wantClusterScope, tc.wantOK)
+			}
+		})
+	}
+}
+
+// ChangeReadAllowed forces namespace "" for cluster-scoped kinds and fails closed
+// on unresolved kinds; the authorize callback receives what the SAR would.
+func TestChangeReadAllowed(t *testing.T) {
+	// Node is cluster-scoped → authorize must be called with namespace "".
+	var gotNs string
+	allow := ChangeReadAllowed("Node", "v1", "default", func(group, resource, namespace string) bool {
+		gotNs = namespace
+		return true
+	})
+	if !allow || gotNs != "" {
+		t.Fatalf("cluster-scoped Node: allow=%v ns=%q, want allow=true ns=\"\"", allow, gotNs)
+	}
+
+	// Namespaced builtin authorizes at the row's namespace.
+	gotNs = "unset"
+	ChangeReadAllowed("Secret", "v1", "team-a", func(_, _, namespace string) bool { gotNs = namespace; return true })
+	if gotNs != "team-a" {
+		t.Fatalf("namespaced Secret: authorize ns=%q, want \"team-a\"", gotNs)
+	}
+
+	// Unresolved kind (unknown CRD, no discovery) → fail closed, authorize never consulted.
+	called := false
+	if ChangeReadAllowed("WidgetCRD", "widgets.example.com/v1", "team-a", func(_, _, _ string) bool { called = true; return true }) {
+		t.Fatal("unresolved kind should fail closed")
+	}
+	if called {
+		t.Fatal("authorize must not be called for an unresolved kind")
+	}
+}

--- a/internal/k8s/kinds.go
+++ b/internal/k8s/kinds.go
@@ -86,7 +86,12 @@ func ClusterOnlyKindGVR(kind string) (group, resource string, ok bool) {
 // Returns (false, "", "") for namespaced kinds, unknown kinds, or when
 // discovery isn't available.
 func ClassifyKindScope(kind, group string) (clusterScoped bool, gvrGroup, gvrResource string) {
-	if g, r, ok := ClusterOnlyKindGVR(kind); ok {
+	// The static builtin catalogue is only authoritative when the caller's group
+	// hint is absent or matches it. A disagreeing hint means a CRD colliding on
+	// Kind with a builtin cluster-scoped kind (e.g. Kind=ClusterRole in group
+	// example.com); trusting the builtin GVR there would authorize the CRD's
+	// reads against the builtin the user can list. Fall through to discovery.
+	if g, r, ok := ClusterOnlyKindGVR(kind); ok && (group == "" || group == g) {
 		return true, g, r
 	}
 	disc := GetResourceDiscovery()

--- a/internal/k8s/kinds_test.go
+++ b/internal/k8s/kinds_test.go
@@ -86,11 +86,20 @@ func TestClassifyKindScope_StaticCatalogue(t *testing.T) {
 		t.Error("pods should not be cluster-scoped")
 	}
 
-	// Group passthrough on static catalogue: an explicit group doesn't
-	// change the answer for a static cluster-scoped kind.
-	clusterScoped, group, resource = ClassifyKindScope("nodes", "ignored.example.com")
-	if !clusterScoped || group != "" || resource != "nodes" {
-		t.Errorf("nodes with group: got (%v, %q, %q); want (true, \"\", \"nodes\")", clusterScoped, group, resource)
+	// A group hint MATCHING the builtin's canonical group still resolves the
+	// builtin (clusterroles live in rbac.authorization.k8s.io).
+	clusterScoped, group, resource = ClassifyKindScope("clusterroles", "rbac.authorization.k8s.io")
+	if !clusterScoped || group != "rbac.authorization.k8s.io" || resource != "clusterroles" {
+		t.Errorf("clusterroles with matching group: got (%v, %q, %q); want (true, \"rbac…\", \"clusterroles\")", clusterScoped, group, resource)
+	}
+
+	// A group hint that DISAGREES with the builtin's canonical group is a CRD
+	// Kind collision (e.g. a CRD Kind=Node in another group), not the builtin —
+	// the static catalogue must NOT win, or the CRD's reads would be authorized
+	// against the builtin the caller can list. With no discovery, fail closed.
+	clusterScoped, _, _ = ClassifyKindScope("nodes", "ignored.example.com")
+	if clusterScoped {
+		t.Error("nodes with a foreign group must not resolve to the builtin (collision guard)")
 	}
 }
 

--- a/internal/mcp/changes_rbac_test.go
+++ b/internal/mcp/changes_rbac_test.go
@@ -7,15 +7,18 @@ import (
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
-// The change feed must not become a side channel around the per-kind
-// cluster-scoped SAR that gates every other read: a cluster-wide user without
-// RBAC for admission webhook configs must not see them via get_changes, while
-// namespaced changes and full-access (no per-user RBAC) are unaffected.
-func TestFilterChangesByClusterScopedRBAC(t *testing.T) {
+// filterRecentChangesRBAC must not become a side channel around per-kind RBAC:
+// a user who can see a namespace but not a specific kind in it must not receive
+// that kind's change rows, and cluster-scoped kinds they can't list must drop —
+// while readable kinds, helm-sourced rows, and the no-per-user-RBAC case pass.
+func TestFilterRecentChangesRBAC(t *testing.T) {
 	changes := []issuesapi.RecentChange{
-		{Kind: "MutatingWebhookConfiguration", Name: "pod-policy"}, // cluster-scoped
-		{Kind: "Deployment", Namespace: "shop", Name: "web"},       // namespaced
+		{Kind: "MutatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1", Name: "pod-policy"}, // cluster-scoped
+		{Kind: "Deployment", APIVersion: "apps/v1", Namespace: "shop", Name: "web"},                               // namespaced, readable
+		{Kind: "Secret", APIVersion: "v1", Namespace: "shop", Name: "db"},                                         // namespaced, NOT readable
+		{Kind: "HelmRelease", Source: helmChangeSource, Namespace: "shop", Name: "app"},                           // synthesized helm → passthrough
 	}
+	clone := func() []issuesapi.RecentChange { return append([]issuesapi.RecentChange(nil), changes...) }
 	has := func(got []issuesapi.RecentChange, kind string) bool {
 		for _, c := range got {
 			if c.Kind == kind {
@@ -26,26 +29,27 @@ func TestFilterChangesByClusterScopedRBAC(t *testing.T) {
 	}
 
 	// No per-user RBAC on context (radar-SA / benchmark): nothing is filtered.
-	if got := filterChangesByClusterScopedRBAC(context.Background(), append([]issuesapi.RecentChange(nil), changes...)); len(got) != 2 {
+	if got := filterRecentChangesRBAC(context.Background(), clone()); len(got) != len(changes) {
 		t.Fatalf("no-user context must keep all changes, got %+v", got)
 	}
 
-	// Cluster-wide user WITHOUT webhook RBAC: the webhook change is dropped (the
-	// seeded SAR cache has no grant → canReadClusterScopedKind fails closed),
-	// the namespaced change is kept (gated by namespace, not this check).
-	denied := withClusterAdmin(t, "no-webhook-rbac")
-	got := filterChangesByClusterScopedRBAC(denied, append([]issuesapi.RecentChange(nil), changes...))
+	// User can list deployments in shop, but NOT secrets there and NOT webhooks
+	// cluster-wide (unseeded → SAR against a nil client → fail closed).
+	ctx := withClusterAdmin(t, "scoped")
+	perms := getPermCache().Get("scoped")
+	perms.SetCanI("list", "apps", "deployments", "shop", true)
+
+	got := filterRecentChangesRBAC(ctx, clone())
 	if has(got, "MutatingWebhookConfiguration") {
-		t.Fatalf("cluster-scoped webhook change leaked to a user without RBAC: %+v", got)
+		t.Fatalf("cluster-scoped webhook leaked to a user without RBAC: %+v", got)
+	}
+	if has(got, "Secret") {
+		t.Fatalf("Gap A: unreadable Secret leaked in an allowed namespace: %+v", got)
 	}
 	if !has(got, "Deployment") {
-		t.Fatalf("namespaced change must survive the cluster-scoped filter: %+v", got)
+		t.Fatalf("readable Deployment must survive the per-kind filter: %+v", got)
 	}
-
-	// Same user, now granted webhook read: the webhook change is returned.
-	granted := withClusterAdmin(t, "has-webhook-rbac")
-	grantClusterRead(t, "has-webhook-rbac", "admissionregistration.k8s.io/mutatingwebhookconfigurations")
-	if got := filterChangesByClusterScopedRBAC(granted, append([]issuesapi.RecentChange(nil), changes...)); !has(got, "MutatingWebhookConfiguration") {
-		t.Fatalf("granted user must see the webhook change, got %+v", got)
+	if !has(got, "HelmRelease") {
+		t.Fatalf("helm-sourced row must pass through (gated upstream): %+v", got)
 	}
 }

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -113,6 +113,10 @@ func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Durat
 		log.Printf("[mcp] issue change correlation failed for %s %s/%s: %v", iss.Kind, iss.Namespace, iss.Name, err)
 		return // marker omitted = unknown, never a false "no changes"
 	}
+	// Per-kind RBAC: a workload subject's correlated changes include its consumed
+	// ConfigMaps, which the caller may not be able to read even when authorized on
+	// the workload. Drop what they can't read before building the marker.
+	changes = filterRecentChangesRBAC(ctx, changes)
 	// The marker's contract is non-status evidence: status churn on a
 	// failing workload is the SYMPTOM, not a change that could explain it
 	// — including it would make every failing issue read as "correlated".

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -12,8 +12,59 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
+
+// mcpChangeAuthorizer returns the per-kind authorizer for the ctx user, for the
+// shared k8s.ChangeReadAllowed gate. canReadInNamespace memoizes on the user's
+// permission cache; nil user (auth off) short-circuits to allow inside it.
+func mcpChangeAuthorizer(ctx context.Context) func(group, resource, namespace string) bool {
+	return func(group, resource, namespace string) bool {
+		return canReadInNamespace(ctx, group, resource, namespace, "list")
+	}
+}
+
+// filterRecentChangesRBAC drops RecentChange rows the ctx user can't read, via
+// the shared per-kind gate (APIVersion disambiguates CRD kind collisions). It is
+// the MCP twin of the server-side filter, applied at every MCP surface that
+// emits change rows (get_changes, dashboard, issues recent_changes, per-issue
+// correlation incl. consumed ConfigMaps, diagnose, get_resource).
+//
+// Helm-package-manager rows are a synthesized kind with no real GVR and their
+// own namespace/helm authorization upstream; pass them through rather than
+// fail-closed on an unresolvable kind (preserves the pre-existing behavior — the
+// prior cluster-scoped-only filter also let them through). Auth off → unchanged.
+func filterRecentChangesRBAC(ctx context.Context, changes []issuesapi.RecentChange) []issuesapi.RecentChange {
+	if pkgauth.UserFromContext(ctx) == nil {
+		return changes
+	}
+	authz := mcpChangeAuthorizer(ctx)
+	out := changes[:0]
+	for _, c := range changes {
+		if c.Source == helmChangeSource || k8s.ChangeReadAllowed(c.Kind, c.APIVersion, c.Namespace, authz) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// filterTimelineEventsRBAC is filterRecentChangesRBAC's twin for raw timeline
+// events (the MCP dashboard queries the store directly). Auth off → unchanged.
+func filterTimelineEventsRBAC(ctx context.Context, events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	if pkgauth.UserFromContext(ctx) == nil {
+		return events
+	}
+	authz := mcpChangeAuthorizer(ctx)
+	out := events[:0]
+	for _, e := range events {
+		if k8s.ChangeReadAllowed(e.Kind, e.APIVersion, e.Namespace, authz) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
 
 // MCP read tools share the cluster-wide resource cache (populated by the pod
 // SA), so per-user namespace filtering must happen at read time. This mirrors

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1041,7 +1041,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		if err != nil {
 			changesErr = err.Error()
 		} else {
-			recentChanges = changes
+			recentChanges = filterRecentChangesRBAC(ctx, changes)
 		}
 	}
 
@@ -1193,7 +1193,7 @@ func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result 
 		_, hasChangesErr := result["recentChangesError"]
 		if !hasChanges && !hasChangesErr {
 			if changes, _, err := meaningfulchanges.RecentForResource(ctx, kind, namespace, name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil {
-				result["recentChanges"] = changes
+				result["recentChanges"] = filterRecentChangesRBAC(ctx, changes)
 			} else {
 				result["recentChangesError"] = err.Error()
 			}
@@ -1271,24 +1271,6 @@ func isPodKind(kind string) bool {
 	return kind == "pod" || kind == "pods"
 }
 
-// filterChangesByClusterScopedRBAC drops change entries for cluster-scoped
-// kinds the user lacks RBAC to read. The change feed namespace-filters but did
-// not honor per-kind cluster-scoped RBAC — fine while every tracked kind was
-// namespaced, but now that cluster-scoped kinds (admission webhook configs) are
-// in the feed it would be a side channel around the SAR that gates every other
-// read. No-op when no per-user RBAC is on context: canReadClusterScopedKind
-// returns true (the radar-SA / benchmark case), and it short-circuits true for
-// namespaced kinds, so only cluster-scoped denials are dropped.
-func filterChangesByClusterScopedRBAC(ctx context.Context, changes []issuesapi.RecentChange) []issuesapi.RecentChange {
-	filtered := changes[:0]
-	for _, c := range changes {
-		if canReadClusterScopedKind(ctx, c.Kind, "", "list") {
-			filtered = append(filtered, c)
-		}
-	}
-	return filtered
-}
-
 func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getChangesInput) (*mcp.CallToolResult, any, error) {
 	since := 1 * time.Hour
 	if input.Since != "" {
@@ -1345,7 +1327,7 @@ func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getCh
 	} else {
 		changes = append(changes, helmChanges...)
 	}
-	changes = filterChangesByClusterScopedRBAC(ctx, changes)
+	changes = filterRecentChangesRBAC(ctx, changes)
 	totalMatched := len(changes)
 	meaningfulchanges.RankAndCap(&changes, limit)
 
@@ -2631,6 +2613,9 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 			log.Printf("[mcp] Failed to query timeline for dashboard changes: %v", err)
 		}
 		if err == nil {
+			// Per-kind RBAC: correlation gates by problem match + namespace, not
+			// by whether the caller can read the changed kind in that namespace.
+			changes = filterTimelineEventsRBAC(ctx, changes)
 			for _, c := range changes {
 				key := fmt.Sprintf("%s/%s/%s", c.Kind, c.Namespace, c.Name)
 				// Also check owner chain (e.g. Pod problem → Deployment change)
@@ -2789,6 +2774,8 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 				Limit:      meaningfulchanges.IssueChangesFetchLimit(recentChangesReason),
 				FieldLimit: meaningfulchanges.DefaultFieldLimit,
 			}); err == nil && len(recentResult.Changes) > 0 {
+				// Per-kind RBAC before ranking, so priority/recap see the visible set.
+				recentResult.Changes = filterRecentChangesRBAC(ctx, recentResult.Changes)
 				changes, guidance, recapped := meaningfulchanges.PrioritizeIssueChanges(
 					recentResult.Changes, out, meaningfulchanges.IssueChangePriorityOptions{
 						Reason:             recentChangesReason,

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -307,7 +307,9 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 		}
 	}
 	if changes, _, err := meaningfulchanges.RecentForWorkloadAndConfigMaps(ctx, obj, kindNorm, input.Namespace, input.Name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil && len(changes) > 0 {
-		resp.RecentChanges = changes
+		// Per-kind RBAC: the result includes consumed ConfigMaps the caller may
+		// not be able to read even when authorized on the workload subject.
+		resp.RecentChanges = filterRecentChangesRBAC(ctx, changes)
 	}
 	resp.DNSContext = dnsContextForDiagnose(ctx, cache, obj, pods, resp.LogsCurrent, resp.LogsPrevious, resp.Events)
 	resp.Warnings = k8score.EnrichRuntimeObjectWarnings(obj)

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -758,6 +758,7 @@ func fromEvent(e timeline.TimelineEvent, fieldLimit int) issuesapi.RecentChange 
 	}
 	change := issuesapi.RecentChange{
 		Kind:           e.Kind,
+		APIVersion:     e.APIVersion,
 		Namespace:      e.Namespace,
 		Name:           e.Name,
 		ChangeType:     string(e.EventType),

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -1161,6 +1161,9 @@ func (s *Server) getDashboardRecentChanges(ctx context.Context, namespaces []str
 	if err != nil || len(events) == 0 {
 		return []DashboardChange{}
 	}
+	// Per-kind RBAC: the store namespace-filters, but a workload change the user
+	// can see the namespace of but not read the kind of would still surface here.
+	events = s.filterTimelineEventsByRBAC(ctx, events)
 
 	result := make([]DashboardChange, 0, len(events))
 	for _, e := range events {

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -115,11 +115,11 @@ type DiagTimeline struct {
 	Degraded       bool   `json:"degraded,omitempty"`
 	DegradedReason string `json:"degradedReason,omitempty"`
 	TotalEvents    int64  `json:"totalEvents"`
-	OldestEvent  string `json:"oldestEvent,omitempty"`
-	NewestEvent  string `json:"newestEvent,omitempty"`
-	StorageBytes int64  `json:"storageBytes,omitempty"`
-	StoreErrors  int64  `json:"storeErrors"`
-	TotalDrops   int64  `json:"totalDrops"`
+	OldestEvent    string `json:"oldestEvent,omitempty"`
+	NewestEvent    string `json:"newestEvent,omitempty"`
+	StorageBytes   int64  `json:"storageBytes,omitempty"`
+	StoreErrors    int64  `json:"storeErrors"`
+	TotalDrops     int64  `json:"totalDrops"`
 
 	// SQLite-only retention/cleanup state.
 	RetentionAge       string `json:"retentionAge,omitempty"`
@@ -340,10 +340,11 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		}
 		snapshot := metrics.GetSnapshot()
 		snap.EventPipeline = &DiagEventPipeline{
-			Received:    snapshot.Counters.Received,
-			Dropped:     snapshot.Counters.Dropped,
-			Recorded:    snapshot.Counters.Recorded,
-			RecentDrops: snapshot.RecentDrops,
+			Received: snapshot.Counters.Received,
+			Dropped:  snapshot.Counters.Dropped,
+			Recorded: snapshot.Counters.Recorded,
+			// Drop records name individual resources; gate them like /api/debug/events.
+			RecentDrops: s.filterDropsByRBAC(r, snapshot.RecentDrops),
 			Uptime:      snapshot.Uptime,
 		}
 	})

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,7 +15,26 @@ import (
 	"github.com/skyhook-io/radar/internal/issues"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/meaningfulchanges"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
+
+// filterRecentChangesByRBAC drops RecentChange rows the ctx user can't read, via
+// the shared per-kind gate (RecentChange.APIVersion disambiguates CRD kind
+// collisions). Auth off → returned unchanged. Used by both the /api/issues
+// recent_changes enrichment and per-issue change correlation.
+func (s *Server) filterRecentChangesByRBAC(ctx context.Context, changes []issuesapi.RecentChange) []issuesapi.RecentChange {
+	if auth.UserFromContext(ctx) == nil {
+		return changes
+	}
+	authz := s.changeAuthorizerForCtx(ctx)
+	out := changes[:0]
+	for _, c := range changes {
+		if k8s.ChangeReadAllowed(c.Kind, c.APIVersion, c.Namespace, authz) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
 
 // handleIssues serves GET /api/issues — "what's broken right now."
 // Composes the curated operational sources (workload/pod problems,
@@ -115,6 +135,10 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 				Limit:      meaningfulchanges.IssueChangesFetchLimit(recentChangesReason),
 				FieldLimit: meaningfulchanges.DefaultFieldLimit,
 			}); err == nil && len(recentResult.Changes) > 0 {
+				// Per-kind RBAC: recent_changes is namespace-filtered but not
+				// per-kind — drop changes for kinds the caller can't read before
+				// ranking, so priority/recap logic operates on the visible set.
+				recentResult.Changes = s.filterRecentChangesByRBAC(r.Context(), recentResult.Changes)
 				changes, guidance, recapped := meaningfulchanges.PrioritizeIssueChanges(
 					recentResult.Changes, out, meaningfulchanges.IssueChangePriorityOptions{
 						Reason:             recentChangesReason,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4815,30 +4815,21 @@ func (s *Server) handleDebugEventsDiagnose(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	response := timeline.GetDiagnosis(kind, namespace, name, k8s.ActiveClusterContext())
-
 	// RBAC: diagnose returns a specific resource's timeline rows (with diffs),
-	// drop history, and existence-revealing recommendations. The query matches by
-	// kind string only (not group), so filter the returned rows per-kind using
-	// EACH row's own apiVersion — that disambiguates a Kind that collides with a
-	// builtin (a namespaced CRD Kind=Node must not ride the caller's `list nodes`).
-	// When the caller can see nothing for this resource, neutralize the
-	// recommendations too so they don't confirm its existence. Auth off → no-op.
+	// drop history, and recommendations derived from them. The query matches by
+	// kind string only (not group), so authorize each returned row per-kind using
+	// its own apiVersion — disambiguating a Kind that collides with a builtin (a
+	// namespaced CRD Kind=Node must not ride the caller's `list nodes`). The gate
+	// runs inside GetDiagnosis, BEFORE recommendations, so tips can't describe a
+	// row the caller can't read. Auth off → nil filter → no-op.
+	var allow func(kind, apiVersion, namespace string) bool
 	if user := auth.UserFromContext(r.Context()); user != nil && s.permCache != nil {
 		authz := s.changeAuthorizerForCtx(r.Context())
-		events := response.TimelineEvents[:0]
-		for _, e := range response.TimelineEvents {
-			if k8s.ChangeReadAllowed(e.Kind, e.APIVersion, e.Namespace, authz) {
-				events = append(events, e)
-			}
-		}
-		response.TimelineEvents = events
-		response.DropHistory = s.filterDropsByRBAC(r, response.DropHistory)
-		if len(response.TimelineEvents) == 0 && len(response.DropHistory) == 0 {
-			response.Recommendations = []string{"No diagnostic data available for this resource."}
+		allow = func(kind, apiVersion, namespace string) bool {
+			return k8s.ChangeReadAllowed(kind, apiVersion, namespace, authz)
 		}
 	}
-
+	response := timeline.GetDiagnosis(kind, namespace, name, k8s.ActiveClusterContext(), allow)
 	s.writeJSON(w, response)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1215,14 +1215,31 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 	if user == nil || s.permCache == nil {
 		return true
 	}
-	perms := s.permCache.Get(user.Username)
-	if perms == nil {
+	if s.permCache.Get(user.Username) == nil {
 		// Trigger namespace discovery so SAR cache has a parent UserPermissions
 		// entry. parseNamespacesForUser is the canonical path that populates
-		// this; if it hasn't run yet, fall through to a fresh SAR every time.
+		// this; if it hasn't run yet, canReadUser falls through to a fresh SAR.
 		_ = s.getUserNamespaces(r, []string{})
-		perms = s.permCache.Get(user.Username)
 	}
+	return s.canReadUser(r.Context(), user, group, resource, namespace, verb)
+}
+
+// canReadUser is the request-free core of canRead: it authorizes a single
+// (verb, group, resource, namespace) tuple for an already-resolved user via
+// SubjectAccessReview, memoizing on the user's UserPermissions.canI cache.
+//
+// Split out so the SSE broadcast loop — a background goroutine with no
+// *http.Request — can authorize per-client change frames with the same gate
+// REST uses. The caller captures the user at subscribe time (where the request
+// is available) and passes a long-lived context for SAR cancellation.
+//
+// Fail-closed: no apiserver / SAR error → deny. Returns true only when auth is
+// disabled (nil user) or the SAR allows it.
+func (s *Server) canReadUser(ctx context.Context, user *auth.User, group, resource, namespace, verb string) bool {
+	if user == nil || s.permCache == nil {
+		return true
+	}
+	perms := s.permCache.Get(user.Username)
 	if perms != nil {
 		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
 			return v
@@ -1232,13 +1249,13 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 	if client == nil {
 		// Fail-closed: no apiserver to ask, refuse rather than quietly
 		// serving from the cache.
-		log.Printf("[auth] canRead: K8s client unavailable, denying %s on %s/%s for %s", k8s.SanitizeForLog(verb), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(user.Username))
+		log.Printf("[auth] canReadUser: K8s client unavailable, denying %s on %s/%s for %s", k8s.SanitizeForLog(verb), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(user.Username))
 		return false
 	}
-	allowed, err := auth.SubjectCanI(r.Context(), client, user.Username, user.Groups, namespace, group, resource, verb)
+	allowed, err := auth.SubjectCanI(ctx, client, user.Username, user.Groups, namespace, group, resource, verb)
 	if err != nil {
 		// Fail-closed on SAR error — apiserver said something we don't trust.
-		log.Printf("[auth] canRead SAR failed for %s on %s/%s in ns=%q: %v", k8s.SanitizeForLog(user.Username), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), err)
+		log.Printf("[auth] canReadUser SAR failed for %s on %s/%s in ns=%q: %v", k8s.SanitizeForLog(user.Username), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), err)
 		return false
 	}
 	if perms != nil {
@@ -3101,7 +3118,7 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 			maxSeq = e.Seq
 		}
 	}
-	events = s.filterChangesByClusterScopedRBAC(r, events)
+	events = s.filterEventsByRBAC(r, events)
 
 	// The store epoch validates delta cursors: seq restarts from 1 when the
 	// store is re-created (process restart, context switch), so a client
@@ -3114,29 +3131,142 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, events)
 }
 
-// filterChangesByClusterScopedRBAC drops timeline events for cluster-scoped
-// kinds the user lacks RBAC to read. Namespace-restricted users never reach
-// cluster-scoped events (namespace IN(...) excludes namespace==""), but a
-// cluster-wide user with no per-kind RBAC for, say, admission webhook configs
-// (now tracked) would otherwise see them here — a side channel around the SAR
-// that gates every other read. canRead memoizes per request, so the per-event
-// check is cheap and only fires for cluster-scoped kinds.
-func (s *Server) filterChangesByClusterScopedRBAC(r *http.Request, events []timeline.TimelineEvent) []timeline.TimelineEvent {
-	filtered := events[:0]
-	for _, e := range events {
-		if clusterScoped, group, resource := k8s.ClassifyKindScope(e.Kind, ""); clusterScoped && !s.canRead(r, group, resource, "", "list") {
-			continue
+// filterEventsByRBAC drops timeline events the calling user lacks RBAC to read,
+// authorizing each event's exact kind via SubjectAccessReview.
+//
+// Namespace membership (parseNamespacesForUser) is the upstream gate, but it is
+// not sufficient on its own: within a namespace the user CAN see, they may lack
+// read on a specific kind (e.g. `list pods` but not `list secrets`) — the event
+// still carries the resource name, labels, owner and a change summary, so a
+// namespace-only gate leaks the existence of resources the user can't read.
+// This closes that gap on both axes:
+//   - namespaced events → require (group, resource) read in that namespace;
+//   - cluster-scoped events (namespace=="") → require the cluster-scoped read.
+//
+// canRead memoizes per request on UserPermissions.canI, so repeated kinds are a
+// map hit. Events whose kind can't be resolved (unknown CRD mid-discovery) fail
+// closed. Auth disabled → canReadUser short-circuits to allow, so this is a
+// no-op for the local single-user case.
+func (s *Server) filterEventsByRBAC(r *http.Request, events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	user := auth.UserFromContext(r.Context())
+	if user == nil || s.permCache == nil {
+		// Auth off → nothing to filter; skip GVR resolution entirely.
+		return events
+	}
+
+	// Resolve each event's GVR once and collect the distinct
+	// (group, resource, namespace) tuples to authorize.
+	type key struct{ group, resource, namespace string }
+	type resolution struct {
+		ok bool
+		k  key
+	}
+	resolved := make([]resolution, len(events))
+	distinct := make(map[key]struct{})
+	for i, e := range events {
+		g, res, clusterScoped, ok := k8s.ResolveChangeGVR(e.Kind, k8s.GroupFromAPIVersion(e.APIVersion))
+		// Cluster-scoped kinds authorize at namespace "": the event row may carry
+		// a namespace (a K8s Event about a Node stores the Event's own namespace),
+		// and a namespaced SAR is strictly broader than the cluster-scoped read.
+		ns := e.Namespace
+		if clusterScoped {
+			ns = ""
 		}
-		filtered = append(filtered, e)
+		resolved[i] = resolution{ok: ok, k: key{g, res, ns}}
+		if ok {
+			distinct[key{g, res, ns}] = struct{}{}
+		}
+	}
+
+	// Prime the parent UserPermissions entry once so the parallel canReadUser
+	// calls below share its SAR memo instead of racing to populate it.
+	if s.permCache.Get(user.Username) == nil {
+		_ = s.getUserNamespaces(r, []string{})
+	}
+
+	// Authorize distinct tuples in bounded parallel — a broad timeline load can
+	// span many (kind, namespace) pairs and a serial SAR loop would stack the
+	// round-trips. Mirrors filterNamespacesByCanRead / capabilities probing.
+	allow := make(map[key]bool, len(distinct))
+	var mu sync.Mutex
+	const maxConcurrent = 16
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	ctx := r.Context()
+	for k := range distinct {
+		wg.Add(1)
+		go func(k key) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			ok := s.canReadUser(ctx, user, k.group, k.resource, k.namespace, "list")
+			mu.Lock()
+			allow[k] = ok
+			mu.Unlock()
+		}(k)
+	}
+	wg.Wait()
+
+	filtered := events[:0]
+	for i, e := range events {
+		// Unresolvable kind → fail closed (drop). Otherwise keep only if the
+		// per-kind SAR for this namespace (or cluster scope) allowed it.
+		if resolved[i].ok && allow[resolved[i].k] {
+			filtered = append(filtered, e)
+		}
 	}
 	return filtered
 }
 
+// changeAuthorizerForCtx returns a per-kind authorizer bound to the ctx user, for
+// the shared k8s.ChangeReadAllowed gate. Callers on a request path have already
+// primed the permission cache via parseNamespacesForUser, so canReadUser hits the
+// memo. Nil user (auth off) is handled by canReadUser (returns true).
+func (s *Server) changeAuthorizerForCtx(ctx context.Context) func(group, resource, namespace string) bool {
+	user := auth.UserFromContext(ctx)
+	return func(group, resource, namespace string) bool {
+		return s.canReadUser(ctx, user, group, resource, namespace, "list")
+	}
+}
+
+// filterTimelineEventsByRBAC drops timeline events the ctx user can't read, via
+// the shared per-kind gate. For the low-volume secondary surfaces (dashboard,
+// diagnose); the high-volume /api/changes path uses filterEventsByRBAC with its
+// dedupe+parallel SAR. Auth off → returned unchanged.
+func (s *Server) filterTimelineEventsByRBAC(ctx context.Context, events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	if auth.UserFromContext(ctx) == nil {
+		return events
+	}
+	authz := s.changeAuthorizerForCtx(ctx)
+	out := events[:0]
+	for _, e := range events {
+		if k8s.ChangeReadAllowed(e.Kind, e.APIVersion, e.Namespace, authz) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // handleChangeChildren returns child resource changes for a given parent workload
 func (s *Server) handleChangeChildren(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
 	ownerKind := chi.URLParam(r, "kind")
 	namespace := chi.URLParam(r, "namespace")
 	ownerName := chi.URLParam(r, "name")
+
+	// Gate on the owner's namespace before touching the store: a user who can't
+	// see this namespace must not read change history for workloads in it. The
+	// per-kind SAR below (filterEventsByRBAC) is the authoritative gate; this is
+	// the cheap RBAC-ceiling pre-check. getUserNamespaces (not
+	// parseNamespacesForUser) so the header's namespace *view* pick can't hide a
+	// namespace the user has real access to.
+	if allowed := s.getUserNamespaces(r, nil); !namespaceInAllowed(allowed, namespace) {
+		s.writeJSON(w, []timeline.TimelineEvent{})
+		return
+	}
+
 	sinceStr := r.URL.Query().Get("since")
 
 	var since time.Time
@@ -3161,7 +3291,20 @@ func (s *Server) handleChangeChildren(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	children = s.filterEventsByRBAC(r, children)
+
 	s.writeJSON(w, children)
+}
+
+// namespaceInAllowed reports whether `namespace` is within an allowed set.
+// nil allowed means cluster-wide access (all namespaces); an empty non-nil
+// slice means no access. Mirrors the nil-vs-empty convention used throughout
+// the per-user namespace filtering.
+func namespaceInAllowed(allowed []string, namespace string) bool {
+	if allowed == nil {
+		return true
+	}
+	return slices.Contains(allowed, namespace)
 }
 
 // handleApplyResource creates or updates a Kubernetes resource from YAML.
@@ -4311,7 +4454,20 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 		deny[topology.KindNamespace] = true
 	}
-	s.broadcaster.HandleSSE(w, r, deny)
+	// Per-kind authorizer for change (k8s_event) frames, bound to this request's
+	// user + context so the broadcast goroutine can SAR-gate diff-bearing frames
+	// without a request. Prime the permission cache once here (the request is
+	// available) so the closure's canReadUser calls hit the memo. When auth is
+	// off, UserFromContext is nil and canReadUser short-circuits to allow.
+	user := auth.UserFromContext(r.Context())
+	if user != nil && s.permCache != nil && s.permCache.Get(user.Username) == nil {
+		_ = s.getUserNamespaces(r, []string{})
+	}
+	ctx := r.Context()
+	authorize := func(group, resource, namespace, verb string) bool {
+		return s.canReadUser(ctx, user, group, resource, namespace, verb)
+	}
+	s.broadcaster.HandleSSE(w, r, deny, authorize)
 }
 
 // Settings handlers
@@ -4613,10 +4769,39 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 
 // Debug handlers for event pipeline diagnostics
 
-// handleDebugEvents returns event pipeline metrics and recent drops
+// handleDebugEvents returns event pipeline metrics and recent drops. The
+// aggregate counters/stats carry no resource identity, but RecentDrops name
+// individual resources (kind/namespace/name) — filter those to what the caller
+// may read so this diagnostic endpoint isn't a side channel around the timeline
+// RBAC gate.
 func (s *Server) handleDebugEvents(w http.ResponseWriter, r *http.Request) {
 	response := timeline.GetDebugEventsResponse()
+	response.RecentDrops = s.filterDropsByRBAC(r, response.RecentDrops)
 	s.writeJSON(w, response)
+}
+
+// filterDropsByRBAC drops records for resources the caller can't read, using the
+// same per-kind SAR as the timeline gate. Auth off → returned unchanged. canRead
+// memoizes, and the drop ring is small, so a serial loop is cheap.
+func (s *Server) filterDropsByRBAC(r *http.Request, drops []timeline.DropRecord) []timeline.DropRecord {
+	if auth.UserFromContext(r.Context()) == nil {
+		return drops
+	}
+	out := drops[:0]
+	for _, d := range drops {
+		group, resource, clusterScoped, ok := k8s.ResolveChangeGVR(d.Kind, "")
+		if !ok {
+			continue // unresolved kind → fail closed
+		}
+		ns := d.Namespace
+		if clusterScoped {
+			ns = ""
+		}
+		if s.canRead(r, group, resource, ns, "list") {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 // handleDebugEventsDiagnose diagnoses why events for a specific resource might be missing
@@ -4630,7 +4815,30 @@ func (s *Server) handleDebugEventsDiagnose(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	response := timeline.GetDiagnosis(kind, namespace, name)
+	response := timeline.GetDiagnosis(kind, namespace, name, k8s.ActiveClusterContext())
+
+	// RBAC: diagnose returns a specific resource's timeline rows (with diffs),
+	// drop history, and existence-revealing recommendations. The query matches by
+	// kind string only (not group), so filter the returned rows per-kind using
+	// EACH row's own apiVersion — that disambiguates a Kind that collides with a
+	// builtin (a namespaced CRD Kind=Node must not ride the caller's `list nodes`).
+	// When the caller can see nothing for this resource, neutralize the
+	// recommendations too so they don't confirm its existence. Auth off → no-op.
+	if user := auth.UserFromContext(r.Context()); user != nil && s.permCache != nil {
+		authz := s.changeAuthorizerForCtx(r.Context())
+		events := response.TimelineEvents[:0]
+		for _, e := range response.TimelineEvents {
+			if k8s.ChangeReadAllowed(e.Kind, e.APIVersion, e.Namespace, authz) {
+				events = append(events, e)
+			}
+		}
+		response.TimelineEvents = events
+		response.DropHistory = s.filterDropsByRBAC(r, response.DropHistory)
+		if len(response.TimelineEvents) == 0 && len(response.DropHistory) == 0 {
+			response.Recommendations = []string{"No diagnostic data available for this resource."}
+		}
+	}
+
 	s.writeJSON(w, response)
 }
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -69,6 +69,14 @@ type ClientInfo struct {
 	// Resolved once at subscribe time (the request is available there) so the
 	// broadcast loop never runs a SAR. nil/empty for users with full access.
 	DeniedKinds map[topology.NodeKind]bool
+	// Authorize authorizes a per-resource change frame for this client's user
+	// via SubjectAccessReview (memoized on the user's permission cache). Bound
+	// at subscribe time to the request's user + a connection-lived context, so
+	// the broadcast goroutine can gate diff-bearing k8s_event frames per kind
+	// without holding a request. nil when no authorizer was wired (defensive /
+	// tests) — clientCanSeeChange then falls back to the namespace + denied-kind
+	// gate. When auth is disabled the closure is still set and returns true.
+	Authorize func(group, resource, namespace, verb string) bool
 }
 
 type clientRegistration struct {
@@ -77,6 +85,7 @@ type clientRegistration struct {
 	viewMode         string
 	showPolicyEffect bool
 	deniedKinds      map[topology.NodeKind]bool
+	authorize        func(group, resource, namespace, verb string) bool
 }
 
 // SSEEvent represents an event to send to clients
@@ -388,7 +397,7 @@ func (b *SSEBroadcaster) run() {
 				close(reg.ch) // Signal rejection by closing the channel
 				continue
 			}
-			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds}
+			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds, Authorize: reg.authorize}
 			b.mu.Unlock()
 			log.Printf("SSE client connected (namespaces=%v, view=%s), total clients: %d", reg.namespaces, reg.viewMode, len(b.clients))
 
@@ -535,10 +544,24 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 						"summary": change.Diff.Summary,
 					}
 				}
+				// Resolve the GVR for per-kind authorization. The dynamic cache
+				// stamps the exact GVR on the change (disambiguates CRD kind
+				// collisions); the typed cache leaves it empty, so resolve from
+				// Kind — unambiguous for the well-known typed kinds.
+				group, resource := change.Group, change.Resource
+				namespace := change.Namespace
+				if resource == "" {
+					if g, r, clusterScoped, ok := k8s.ResolveChangeGVR(change.Kind, change.Group); ok {
+						group, resource = g, r
+						if clusterScoped {
+							namespace = ""
+						}
+					}
+				}
 				b.broadcastResourceChange(SSEEvent{
 					Event: "k8s_event",
 					Data:  eventData,
-				}, change.Namespace, change.Kind)
+				}, namespace, group, resource, change.Kind)
 			}
 
 			// Schedule debounced topology update. Re-evaluate debounce on
@@ -771,37 +794,70 @@ func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
 //     cluster-scoped CRDs) aren't in DeniedKinds, and kind-string matching misses
 //     CRD variants (EC2NodeClass vs synthesized NodeClass).
 //
-// The complete fix carries the exact GVR on ResourceChange and authorizes each
-// client via the cached per-user canRead — tracked separately.
-func (b *SSEBroadcaster) broadcastResourceChange(event SSEEvent, namespace, kind string) {
+// The group/resource come from the change's GVR (dynamic cache) or are resolved
+// from its Kind (typed cache); an empty resource means the kind couldn't be
+// resolved and the frame fails closed for authenticated clients.
+//
+// Clients are snapshotted under the lock, then authorized + sent WITHOUT it: an
+// authorization can miss the per-user memo and do a SAR round-trip, and holding
+// b.mu across that would stall registrations and other broadcasts. safeSend
+// tolerates a channel closed by a concurrent Unsubscribe after the snapshot.
+func (b *SSEBroadcaster) broadcastResourceChange(event SSEEvent, namespace, group, resource, kind string) {
 	event = premarshalEventData(event)
-	b.mu.RLock()
-	defer b.mu.RUnlock()
 
+	type target struct {
+		ch   chan SSEEvent
+		info ClientInfo
+	}
+	b.mu.RLock()
+	targets := make([]target, 0, len(b.clients))
 	for ch, info := range b.clients {
-		if clientCanSeeChange(info, namespace, kind) {
-			safeSend(ch, event)
+		targets = append(targets, target{ch: ch, info: info})
+	}
+	b.mu.RUnlock()
+
+	for _, t := range targets {
+		if clientCanSeeChange(t.info, namespace, group, resource, kind) {
+			safeSend(t.ch, event)
 		}
 	}
 }
 
-// clientCanSeeChange reports whether a client's RBAC allows a change frame.
-func clientCanSeeChange(info ClientInfo, namespace, kind string) bool {
-	if namespace != "" {
-		// Namespaced change: deliver only if the client can see that namespace.
-		// nil Namespaces means all-namespace access (no RBAC restriction).
-		if info.Namespaces == nil {
-			return true
+// clientCanSeeChange reports whether a client's RBAC allows a change frame for
+// the given (namespace, group, resource, kind).
+func clientCanSeeChange(info ClientInfo, namespace, group, resource, kind string) bool {
+	if info.Authorize == nil {
+		// No authorizer wired (tests / defensive): fall back to the namespace +
+		// topology-denied-kind gate.
+		if namespace != "" {
+			return info.Namespaces == nil || slices.Contains(info.Namespaces, namespace)
 		}
-		return slices.Contains(info.Namespaces, namespace)
+		return !info.DeniedKinds[topology.NodeKind(kind)]
 	}
-	// Cluster-scoped change (no namespace): deliver unless the kind is one this
-	// client was denied — the per-kind SAR result resolved at subscribe time.
-	return !info.DeniedKinds[topology.NodeKind(kind)]
+
+	if namespace != "" {
+		// Namespaced change: must see the namespace (nil = all) AND hold read on
+		// this kind within it.
+		if info.Namespaces != nil && !slices.Contains(info.Namespaces, namespace) {
+			return false
+		}
+		if resource == "" {
+			return false // unresolved kind under auth — fail closed
+		}
+		return info.Authorize(group, resource, namespace, "list")
+	}
+
+	// Cluster-scoped change (no namespace): require the cluster-scoped read.
+	if resource == "" {
+		return false
+	}
+	return info.Authorize(group, resource, "", "list")
 }
 
 // Subscribe adds a new SSE client. Returns nil if max clients reached.
-func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedKinds map[topology.NodeKind]bool, showPolicyEffect ...bool) chan SSEEvent {
+// authorize gates per-kind change frames for the client's user (may be nil in
+// tests / when no authorizer is wired).
+func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedKinds map[topology.NodeKind]bool, authorize func(group, resource, namespace, verb string) bool, showPolicyEffect ...bool) chan SSEEvent {
 	// Check client count before creating the channel to fail fast
 	b.mu.RLock()
 	clientCount := len(b.clients)
@@ -823,7 +879,7 @@ func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedK
 
 	policyEffect := len(showPolicyEffect) > 0 && showPolicyEffect[0]
 	ch := make(chan SSEEvent, 10)
-	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds}
+	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds, authorize: authorize}
 	return ch
 }
 
@@ -943,7 +999,7 @@ func buildFullTopology() (*topology.Topology, error) {
 }
 
 // HandleSSE is the HTTP handler for the SSE endpoint
-func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, deniedKinds map[topology.NodeKind]bool) {
+func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, deniedKinds map[topology.NodeKind]bool, authorize func(group, resource, namespace, verb string) bool) {
 	// Set SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -966,7 +1022,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 	}
 
 	// Subscribe to events
-	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, policyEffect)
+	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, authorize, policyEffect)
 	if eventCh == nil {
 		http.Error(w, "Too many SSE connections", http.StatusServiceUnavailable)
 		return

--- a/internal/server/sse_rbac_test.go
+++ b/internal/server/sse_rbac_test.go
@@ -34,9 +34,12 @@ func TestDeniedKindsKey(t *testing.T) {
 	}
 }
 
-// clientCanSeeChange gates k8s_event (diff-bearing) frames per client so a
-// restricted user doesn't receive change content for namespaces or cluster-scoped
-// kinds their RBAC forbids.
+// clientCanSeeChange gates k8s_event (diff-bearing) frames per client. Without
+// an authorizer wired (auth off / tests) it falls back to the namespace +
+// topology-denied-kind gate; with one it authorizes the exact (group, resource)
+// against the client's RBAC — closing the two gaps a namespace-only gate leaves:
+// namespaced kinds unreadable within an allowed namespace, and cluster-scoped
+// kinds outside the topology denied set.
 func TestClientCanSeeChange(t *testing.T) {
 	allAccess := ClientInfo{Namespaces: nil}
 	scopedAB := ClientInfo{Namespaces: []string{"a", "b"}}
@@ -51,23 +54,119 @@ func TestClientCanSeeChange(t *testing.T) {
 		name      string
 		info      ClientInfo
 		namespace string
+		group     string
+		resource  string
 		kind      string
 		want      bool
 	}{
-		{"all-access sees namespaced change", allAccess, "a", "ConfigMap", true},
-		{"scoped sees allowed namespace", scopedAB, "a", "Deployment", true},
-		{"scoped does NOT see other namespace", scopedAB, "c", "Deployment", false},
-		{"no-access sees nothing namespaced", noAccess, "a", "ConfigMap", false},
-		{"cluster-scoped allowed when not denied", scopedAB, "", "Node", true},
-		{"cluster-scoped denied kind blocked", deniedNodes, "", "Node", false},
-		{"cluster-scoped non-denied kind allowed", deniedNodes, "", "StorageClass", true},
-		{"Namespace event blocked when can't list namespaces", deniedNamespaces, "", "Namespace", false},
-		{"Namespace event allowed when can list namespaces", scopedAB, "", "Namespace", true},
+		// --- Fallback path (Authorize == nil): namespace + denied-kind gate ---
+		{"all-access sees namespaced change", allAccess, "a", "", "configmaps", "ConfigMap", true},
+		{"scoped sees allowed namespace", scopedAB, "a", "apps", "deployments", "Deployment", true},
+		{"scoped does NOT see other namespace", scopedAB, "c", "apps", "deployments", "Deployment", false},
+		{"no-access sees nothing namespaced", noAccess, "a", "", "configmaps", "ConfigMap", false},
+		{"cluster-scoped allowed when not denied", scopedAB, "", "", "nodes", "Node", true},
+		{"cluster-scoped denied kind blocked", deniedNodes, "", "", "nodes", "Node", false},
+		{"cluster-scoped non-denied kind allowed", deniedNodes, "", "storage.k8s.io", "storageclasses", "StorageClass", true},
+		{"Namespace event blocked when can't list namespaces", deniedNamespaces, "", "", "namespaces", "Namespace", false},
+		{"Namespace event allowed when can list namespaces", scopedAB, "", "", "namespaces", "Namespace", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := clientCanSeeChange(tc.info, tc.namespace, tc.kind); got != tc.want {
-				t.Fatalf("clientCanSeeChange(%v, %q, %q) = %v, want %v", tc.info, tc.namespace, tc.kind, got, tc.want)
+			if got := clientCanSeeChange(tc.info, tc.namespace, tc.group, tc.resource, tc.kind); got != tc.want {
+				t.Fatalf("clientCanSeeChange(%v, %q, %q, %q, %q) = %v, want %v", tc.info, tc.namespace, tc.group, tc.resource, tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClientCanSeeChange_SensitiveKindsSuperset proves the authorizer path is a
+// functional superset of the interim per-kind SSE gate (the standalone
+// sensitive-kinds fix): the SAME kinds — Secret, Role, RoleBinding, ClusterRole,
+// ClusterRoleBinding, and both admission webhook configs — are dropped for a
+// user who can see the namespace but not read that kind, while ordinary readable
+// kinds pass. Ours is per-(kind,namespace) exact rather than cluster-wide, so it
+// also gates these inside individual namespaces (no over-denial of a user who
+// legitimately holds a per-namespace grant) and covers every other kind too.
+func TestClientCanSeeChange_SensitiveKindsSuperset(t *testing.T) {
+	// Restricted user: sees ns "a" and reads deployments there, but not the
+	// sensitive kinds (namespaced ones denied in "a", cluster-scoped ones at "").
+	denied := map[string]bool{
+		"|secrets|a":                                                    true,
+		"rbac.authorization.k8s.io|roles|a":                             true,
+		"rbac.authorization.k8s.io|rolebindings|a":                      true,
+		"rbac.authorization.k8s.io|clusterroles|":                       true,
+		"rbac.authorization.k8s.io|clusterrolebindings|":                true,
+		"admissionregistration.k8s.io|mutatingwebhookconfigurations|":   true,
+		"admissionregistration.k8s.io|validatingwebhookconfigurations|": true,
+	}
+	authorize := func(group, resource, namespace, verb string) bool {
+		return !denied[group+"|"+resource+"|"+namespace]
+	}
+	info := ClientInfo{Namespaces: []string{"a"}, Authorize: authorize}
+
+	cases := []struct {
+		kind, namespace, group, resource string
+		want                             bool
+	}{
+		{"Secret", "a", "", "secrets", false},
+		{"Role", "a", "rbac.authorization.k8s.io", "roles", false},
+		{"RoleBinding", "a", "rbac.authorization.k8s.io", "rolebindings", false},
+		{"ClusterRole", "", "rbac.authorization.k8s.io", "clusterroles", false},
+		{"ClusterRoleBinding", "", "rbac.authorization.k8s.io", "clusterrolebindings", false},
+		{"MutatingWebhookConfiguration", "", "admissionregistration.k8s.io", "mutatingwebhookconfigurations", false},
+		{"ValidatingWebhookConfiguration", "", "admissionregistration.k8s.io", "validatingwebhookconfigurations", false},
+		{"Deployment", "a", "apps", "deployments", true}, // ordinary readable kind unaffected
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			if got := clientCanSeeChange(info, tc.namespace, tc.group, tc.resource, tc.kind); got != tc.want {
+				t.Fatalf("%s in ns %q: got %v, want %v", tc.kind, tc.namespace, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClientCanSeeChange_Authorizer covers the auth-enabled path: the per-kind
+// SubjectAccessReview closure, not the namespace-only fallback, decides. This is
+// the fix for the two RBAC gaps in the live k8s_event stream.
+func TestClientCanSeeChange_Authorizer(t *testing.T) {
+	// authorize allows only (group,resource,namespace) tuples in `allowed`.
+	allowed := map[string]bool{
+		"|pods|a":       true, // core pods in ns a
+		"|configmaps|a": true,
+		"rbac.authorization.k8s.io|clusterroles|": true, // cluster-scoped clusterroles
+	}
+	authorize := func(group, resource, namespace, verb string) bool {
+		return allowed[group+"|"+resource+"|"+namespace]
+	}
+	// Client can SEE namespaces a and b (namespace gate passes), but per-kind
+	// RBAC is narrower than that within them.
+	info := ClientInfo{Namespaces: []string{"a", "b"}, Authorize: authorize}
+
+	cases := []struct {
+		name            string
+		namespace       string
+		group, resource string
+		kind            string
+		want            bool
+	}{
+		// Gap A: namespace is visible, but the kind is not readable there.
+		{"pods in a allowed", "a", "", "pods", "Pod", true},
+		{"secrets in a denied (list-pods-only viewer)", "a", "", "secrets", "Secret", false},
+		{"configmaps in a allowed", "a", "", "configmaps", "ConfigMap", true},
+		{"pods in b denied (no per-kind grant there)", "b", "", "pods", "Pod", false},
+		{"namespace outside client set denied before SAR", "c", "", "pods", "Pod", false},
+		// Gap B: cluster-scoped kind outside the topology denied set.
+		{"clusterroles allowed by SAR", "", "rbac.authorization.k8s.io", "clusterroles", "ClusterRole", true},
+		{"webhookconfigs denied by SAR", "", "admissionregistration.k8s.io", "validatingwebhookconfigurations", "ValidatingWebhookConfiguration", false},
+		// Unresolved kind (empty resource) fails closed under auth.
+		{"unresolved namespaced kind fails closed", "a", "", "", "MysteryCRD", false},
+		{"unresolved cluster-scoped kind fails closed", "", "", "", "MysteryCRD", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientCanSeeChange(info, tc.namespace, tc.group, tc.resource, tc.kind); got != tc.want {
+				t.Fatalf("clientCanSeeChange(ns=%q, %q/%q) = %v, want %v", tc.namespace, tc.group, tc.resource, got, tc.want)
 			}
 		})
 	}

--- a/internal/server/timeline_events.go
+++ b/internal/server/timeline_events.go
@@ -136,7 +136,7 @@ func (s *Server) serveTimelineEventsDelta(w http.ResponseWriter, r *http.Request
 		}
 	}
 	full := len(events) == timelineEventsPageLimit
-	events = s.filterChangesByClusterScopedRBAC(r, events)
+	events = s.filterEventsByRBAC(r, events)
 
 	writeTimelineStream(w, events, timelineEndRecord{
 		Type:   "end",
@@ -192,7 +192,7 @@ func (s *Server) serveTimelineEventsWindow(w http.ResponseWriter, r *http.Reques
 	// `truncated` banner reports. An exactly-limit-sized range over-reports;
 	// harmless, the same heuristic every consumer of this flag uses.
 	truncated := len(events) == limit
-	events = s.filterChangesByClusterScopedRBAC(r, events)
+	events = s.filterEventsByRBAC(r, events)
 
 	writeTimelineStream(w, events, timelineEndRecord{
 		Type:      "end",

--- a/internal/server/timeline_rbac_test.go
+++ b/internal/server/timeline_rbac_test.go
@@ -1,0 +1,24 @@
+package server
+
+import "testing"
+
+func TestNamespaceInAllowed(t *testing.T) {
+	cases := []struct {
+		name    string
+		allowed []string
+		ns      string
+		want    bool
+	}{
+		{"nil = cluster-wide, all namespaces allowed", nil, "anything", true},
+		{"empty non-nil = no access", []string{}, "a", false},
+		{"member allowed", []string{"a", "b"}, "b", true},
+		{"non-member denied", []string{"a", "b"}, "c", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := namespaceInAllowed(tc.allowed, tc.ns); got != tc.want {
+				t.Fatalf("namespaceInAllowed(%v, %q) = %v, want %v", tc.allowed, tc.ns, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/timeline/diagnosis_rbac_test.go
+++ b/internal/timeline/diagnosis_rbac_test.go
@@ -1,0 +1,40 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// GetDiagnosis must derive its recommendations only from rows the caller may
+// read: when `allow` denies a kind, neither the drop nor any tip computed from
+// it may appear — otherwise the recommendation text leaks a filtered-out row.
+func TestGetDiagnosis_RecommendationsRespectRBAC(t *testing.T) {
+	m := GetMetrics()
+	m.Reset()
+	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update")
+
+	hasNoisyTip := func(recs []string) bool {
+		for _, r := range recs {
+			if strings.Contains(r, "noisy_filter") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// nil allow (auth off): the drop and its tip are present.
+	open := GetDiagnosis("Secret", "team-a", "db-creds", "", nil)
+	if len(open.DropHistory) != 1 || !hasNoisyTip(open.Recommendations) {
+		t.Fatalf("nil allow must surface the drop + its tip, got drops=%d recs=%v", len(open.DropHistory), open.Recommendations)
+	}
+
+	// allow denies Secret: no drop row AND no tip derived from it.
+	denySecret := func(kind, apiVersion, namespace string) bool { return kind != "Secret" }
+	gated := GetDiagnosis("Secret", "team-a", "db-creds", "", denySecret)
+	if len(gated.DropHistory) != 0 {
+		t.Fatalf("denied kind must be filtered from DropHistory, got %+v", gated.DropHistory)
+	}
+	if hasNoisyTip(gated.Recommendations) {
+		t.Fatalf("recommendation leaked a filtered-out drop: %v", gated.Recommendations)
+	}
+}

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -265,7 +265,12 @@ type ResourceInfo struct {
 }
 
 // GetDiagnosis diagnoses why events for a specific resource might be missing
-func GetDiagnosis(kind, namespace, name, clusterContext string) DiagnoseResponse {
+// GetDiagnosis diagnoses why events for a resource might be missing. `allow`, when
+// non-nil, authorizes each timeline row / drop by (kind, apiVersion, namespace)
+// BEFORE the recommendations are derived from them — so a caller who can't read
+// some of the matched rows gets neither those rows nor tips computed from them.
+// nil `allow` (auth off) returns everything.
+func GetDiagnosis(kind, namespace, name, clusterContext string, allow func(kind, apiVersion, namespace string) bool) DiagnoseResponse {
 	resp := DiagnoseResponse{
 		Resource: ResourceInfo{
 			Kind:      kind,
@@ -311,6 +316,28 @@ func GetDiagnosis(kind, namespace, name, clusterContext string) DiagnoseResponse
 		}
 	}
 	metrics.mu.RUnlock()
+
+	// Per-kind RBAC: drop rows the caller can't read BEFORE deriving any
+	// recommendation, so tips can't describe a filtered-out event/drop. Drops
+	// carry no apiVersion, so they resolve group-less (a Kind colliding with a
+	// cluster-scoped builtin is the one documented residue).
+	if allow != nil {
+		events := resp.TimelineEvents[:0]
+		for _, e := range resp.TimelineEvents {
+			if allow(e.Kind, e.APIVersion, e.Namespace) {
+				events = append(events, e)
+			}
+		}
+		resp.TimelineEvents = events
+
+		drops := resp.DropHistory[:0]
+		for _, d := range resp.DropHistory {
+			if allow(d.Kind, "", d.Namespace) {
+				drops = append(drops, d)
+			}
+		}
+		resp.DropHistory = drops
+	}
 
 	// Generate recommendations
 	if len(resp.TimelineEvents) == 0 && len(resp.DropHistory) == 0 {

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -265,7 +265,7 @@ type ResourceInfo struct {
 }
 
 // GetDiagnosis diagnoses why events for a specific resource might be missing
-func GetDiagnosis(kind, namespace, name string) DiagnoseResponse {
+func GetDiagnosis(kind, namespace, name, clusterContext string) DiagnoseResponse {
 	resp := DiagnoseResponse{
 		Resource: ResourceInfo{
 			Kind:      kind,
@@ -281,13 +281,16 @@ func GetDiagnosis(kind, namespace, name string) DiagnoseResponse {
 	resp.StorePresent = store != nil
 
 	if store != nil {
-		// Query for events matching this resource
+		// Query for events matching this resource. Scope to the active cluster
+		// context — the persistent store outlives context switches, so an
+		// unscoped query would return a previously-connected cluster's rows.
 		events, err := store.Query(context.Background(), QueryOptions{
 			Namespaces:       []string{namespace},
 			Kinds:            []string{kind},
 			Limit:            50,
 			IncludeManaged:   true,
 			IncludeK8sEvents: true,
+			ClusterContext:   clusterContext,
 		})
 		if err == nil {
 			// Filter to just this resource

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -679,7 +679,7 @@ func TestGetDiagnosis_WithSQLiteStore(t *testing.T) {
 		t.Fatalf("RecordEvent: %v", err)
 	}
 
-	resp := GetDiagnosis("TimelineWidget", "radar-timeline-test", "noise-check")
+	resp := GetDiagnosis("TimelineWidget", "radar-timeline-test", "noise-check", "")
 	if !resp.StorePresent {
 		t.Fatal("expected diagnostics to see the global store")
 	}

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -679,7 +679,7 @@ func TestGetDiagnosis_WithSQLiteStore(t *testing.T) {
 		t.Fatalf("RecordEvent: %v", err)
 	}
 
-	resp := GetDiagnosis("TimelineWidget", "radar-timeline-test", "noise-check", "")
+	resp := GetDiagnosis("TimelineWidget", "radar-timeline-test", "noise-check", "", nil)
 	if !resp.StorePresent {
 		t.Fatal("expected diagnostics to see the global store")
 	}

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -294,8 +294,14 @@ const (
 )
 
 type RecentChange struct {
-	Source         string         `json:"source,omitempty"`
-	Kind           string         `json:"kind"`
+	Source string `json:"source,omitempty"`
+	Kind   string `json:"kind"`
+	// APIVersion disambiguates CRD kind collisions when authorizing this change
+	// for per-kind RBAC (a CRD Kind that shadows a builtin resolves to the wrong
+	// GVR without it). Populated from the source timeline event's apiVersion;
+	// may be empty for synthesized rows (e.g. Helm), which carry no builtin
+	// cluster-scoped collision.
+	APIVersion     string         `json:"apiVersion,omitempty"`
 	Namespace      string         `json:"namespace,omitempty"`
 	Name           string         `json:"name"`
 	ChangeType     string         `json:"changeType"`

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -682,6 +682,8 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 		UID:       uid,
 		Operation: op,
 		Diff:      diff,
+		Group:     gvr.Group,
+		Resource:  gvr.Resource,
 	}
 
 	// Always fire OnChange (even during sync adds — Radar uses this for timeline)

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -65,6 +65,15 @@ type ResourceChange struct {
 	UID       string
 	Operation string    // "add", "update", "delete"
 	Diff      *DiffInfo // Diff details for updates (optional)
+
+	// Group and Resource carry the GVR coordinates for per-kind RBAC
+	// authorization of change frames. Populated by the dynamic cache (which
+	// knows the exact GVR, disambiguating CRD kind collisions like
+	// EC2NodeClass vs a synthesized NodeClass); left empty by the typed cache,
+	// whose kinds are well-known and unambiguously resolvable from Kind alone.
+	// Resource is the plural REST name (e.g. "secrets", "deployments").
+	Group    string
+	Resource string
 }
 
 // DiffInfo contains the diff details for an update operation.


### PR DESCRIPTION
## Problem

Change / timeline / diff data was filtered by **namespace** and, on some paths, by **cluster-scoped kind** — but never by whether the caller can read the **specific kind within a namespace they can otherwise see**. A user with workload-only access in namespace `X` could receive change events (with field-level diffs — including Secret data **key names**, since `diffSecret` emits keys) for Secrets, Roles, ConfigMaps and other kinds they cannot read.

This was systemic: the same gap existed (unfiltered or namespace-only) across REST, the SSE live stream, MCP tools, and debug endpoints — each re-implemented (or omitted) the filter.

Auth is only active for multi-user deployments. With no user on the request (local kubeconfig), the authorizers pass through, so **single-user / OSS-local behavior is unchanged**.

## Approach

One shared authorization decision — `k8s.ChangeReadAllowed(kind, apiVersion, namespace, authorize)`:
- resolves the change's GVR (apiVersion disambiguates CRD-vs-builtin Kind collisions),
- authorizes **cluster-scoped** kinds at namespace `""` (a K8s Event about a Node stores the Event's own namespace, not the object's),
- **fails closed** on an unresolved kind.

Every surface that emits change/diff/drop data routes through it, each supplying its own authorizer (REST: `canReadUser`; MCP: `canReadInNamespace`). The decision is defined once so it can't drift or be forgotten.

### Surfaces gated
- **REST:** `/api/changes`, `/api/timeline/events` (delta + window), `/api/changes/children`, the SSE `k8s_event` stream, `/api/debug/events` + `/api/debug/events/diagnose`, `/api/issues` `recent_changes`, dashboard recent changes, `/api/diagnostics` drops.
- **MCP:** `get_changes`, dashboard, issues `recent_changes`, per-issue correlation (including a workload's consumed ConfigMaps), diagnose, `get_resource`.

### Supporting changes
- Static **namespaced-builtin GVR catalogue** so builtins resolve without discovery — removes a cold-start window where authenticated users would briefly see fewer rows, and keeps the gate unit-testable.
- `ClassifyKindScope` now honors the group hint against the builtin catalogue, closing a **CRD-vs-builtin Kind-collision** authorization bypass (a CRD `Kind=ClusterRole` in another group was authorized against builtin `clusterroles`). This also hardens the ~20 existing `canReadClusterScopedKind` callers; all pass the correct group.
- `issuesapi.RecentChange` gains `APIVersion` (set from the source timeline event) for the same collision disambiguation.
- `GetDiagnosis` is scoped to the active cluster context — it was the only timeline query missing `ClusterContext`, so it could return a previously-connected cluster's rows from the persistent store.

Helm-package-manager rows (`Source == helm`) retain their existing namespace/helm authorization (unchanged from the prior filter).

## Tests
- `internal/k8s/change_rbac_test.go` — GVR resolution, cluster-scoped namespace forcing, CRD-collision fail-closed, `ChangeReadAllowed`.
- `internal/mcp/changes_rbac_test.go` — per-kind gap + cluster-scoped + Helm passthrough.
- `internal/server/sse_rbac_test.go` — authorizer path, and a superset check proving the SSE gate drops the same sensitive kinds a narrower interim would.
- `internal/k8s/kinds_test.go` — collision-guard behavior.
- `go build`, `go vet`, `go test ./...`, and `-race` on the concurrency-sensitive paths all green (main + `pkg` modules).

## Relationship to #1299
This supersedes the interim SSE sensitive-kinds gate in #1299. It covers the same seven kinds (Secret, Role, RoleBinding, ClusterRole, ClusterRoleBinding, Mutating/ValidatingWebhookConfiguration) — verified by a dedicated test — plus every other kind, with **per-(kind, namespace)** precision instead of a cluster-wide approximation, and across all surfaces (not just SSE). A user holding only a per-namespace grant is no longer over-denied; a user who can't read the kind still gets nothing. #1299 is left open for the author to close.

## Known, deliberately-scoped residues
- **Drop records** (`DropRecord`) carry no apiVersion, so they resolve group-less: a dropped event whose Kind collides with a cluster-scoped builtin the caller *can* read could surface (drop metadata only — kind/namespace/name/reason, no diffs). Threading apiVersion would change the shared `k8score.OnDrop` contract; not worth it for this low-value surface.
- **Cross-cluster drop provenance:** drop metrics are process-global and not reset on context switch, so debug/diagnostics drop surfaces could show a prior cluster's resource names after a switch (for a kind the caller can read now). Pre-existing metrics-lifecycle gap, orthogonal to per-kind RBAC — flagged for a separate change.

https://claude.ai/code/session_01XNhMe6Zdqwj5EoBazNDnmW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication/authorization across many user-facing data paths; incorrect SAR or GVR resolution could hide legitimate data or leak sensitive change metadata (including secret key names in diffs).
> 
> **Overview**
> Closes a **namespace-only** RBAC gap on timeline and change data: callers who can see a namespace but not a specific kind (e.g. pods but not secrets) no longer receive those rows’ diffs, names, or summaries through REST, SSE, MCP, or debug paths.
> 
> **Central gate:** `k8s.ChangeReadAllowed` resolves GVR from kind + `apiVersion`, authorizes cluster-scoped kinds at namespace `""`, and **fails closed** when resolution fails. REST and MCP each wire their own SAR-backed `authorize` callback so the rule stays in one place.
> 
> **Surfaces updated:** `/api/changes`, timeline streams, change children, SSE `k8s_event` frames (per-client authorizer at subscribe), issues `recent_changes`, dashboard changes, MCP `get_changes` / diagnose / `get_resource` / issue correlation, and debug drops/diagnose — replacing the older cluster-scoped-only filters.
> 
> **Supporting fixes:** static namespaced-builtin GVR catalogue (no discovery cold-start), `ClassifyKindScope` group-hint collision guard for CRD vs builtin kinds, `RecentChange.APIVersion` and dynamic-cache `Group`/`Resource` on changes, `canReadUser` for SSE without a request, and `GetDiagnosis` scoped to active cluster context with RBAC before recommendations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb4a13f8abe11fc3aa8afec36f57e4b87db4e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->