### PR TITLE
fix(timeline): scope event-pipeline drop metrics to the active cluster

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -211,7 +211,12 @@ func BuildTimelineStoreConfig(cfg AppConfig) timeline.StoreConfig {
 func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 	k8s.RegisterHelmFuncs(helm.ResetClient, helm.ReinitClient)
 
-	k8s.RegisterTimelineFuncs(timeline.ResetStore, func() error {
+	k8s.RegisterTimelineFuncs(func() {
+		// Reset the store AND the per-cluster event-pipeline metrics: RecentDrops
+		// name resources from the previous cluster and must not survive the switch.
+		timeline.ResetStore()
+		timeline.ResetMetricsForContextSwitch()
+	}, func() error {
 		return timeline.ReinitStore(timelineStoreCfg)
 	})
 

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -404,7 +404,7 @@ func InitResourceCache(ctx context.Context) error {
 			},
 
 			OnDrop: func(kind, ns, name, reason, op string) {
-				timeline.RecordDrop(kind, ns, name, reason, op)
+				timeline.RecordDrop(kind, ns, name, reason, op, recordClusterContext)
 				if DebugEvents {
 					log.Printf("[DEBUG] Change dropped: %s/%s/%s reason=%s op=%s", kind, ns, name, reason, op)
 				}
@@ -679,7 +679,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 
 	if op == "add" {
 		if store.IsResourceSeen(clusterContext, kind, namespace, name) {
-			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonAlreadySeen, op)
+			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonAlreadySeen, op, clusterContext)
 			if DebugEvents {
 				log.Printf("[DEBUG] Already seen, skipping: %s/%s/%s", kind, namespace, name)
 			}
@@ -760,7 +760,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 					Summary: fmt.Sprintf("spec changed (gen %d→%d, fields not specifically tracked)", oldGen, newGen),
 				}
 			} else {
-				timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op)
+				timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op, clusterContext)
 				if DebugEvents {
 					log.Printf("[DEBUG] No-diff update, skipping: %s/%s/%s", kind, namespace, name)
 				}
@@ -853,7 +853,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 				ctx := context.Background()
 				if err := timeline.RecordEventsWithBroadcast(ctx, events); err != nil {
 					log.Printf("Warning: failed to record historical events: %v", err)
-					timeline.RecordDrop(kind, namespace, name, timeline.DropReasonStoreFailed, op)
+					timeline.RecordDrop(kind, namespace, name, timeline.DropReasonStoreFailed, op, clusterContext)
 					return
 				}
 			}
@@ -867,7 +867,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	ctx := context.Background()
 	if err := timeline.RecordEventsWithBroadcast(ctx, events); err != nil {
 		log.Printf("Warning: failed to record to timeline store: %v", err)
-		timeline.RecordDrop(kind, namespace, name, timeline.DropReasonStoreFailed, op)
+		timeline.RecordDrop(kind, namespace, name, timeline.DropReasonStoreFailed, op, clusterContext)
 		return
 	}
 

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -107,7 +107,7 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 				)
 			},
 			OnDrop: func(kind, ns, name, reason, op string) {
-				timeline.RecordDrop(kind, ns, name, reason, op)
+				timeline.RecordDrop(kind, ns, name, reason, op, recordClusterContext)
 			},
 			OnRecorded: func(kind string) {
 				timeline.IncrementRecorded(kind)

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -343,8 +343,8 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 			Received: snapshot.Counters.Received,
 			Dropped:  snapshot.Counters.Dropped,
 			Recorded: snapshot.Counters.Recorded,
-			// Drop records name individual resources; gate them like /api/debug/events.
-			RecentDrops: s.filterDropsByRBAC(r, snapshot.RecentDrops),
+			// Compose cluster-scope + per-user RBAC on the drop records (see handleDebugEvents).
+			RecentDrops: s.filterDropsByRBAC(r, timeline.DropsForCluster(snapshot.RecentDrops, k8s.ActiveClusterContext())),
 			Uptime:      snapshot.Uptime,
 		}
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4777,7 +4777,10 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 // RBAC gate.
 func (s *Server) handleDebugEvents(w http.ResponseWriter, r *http.Request) {
 	response := timeline.GetDebugEventsResponse()
-	response.RecentDrops = s.filterDropsByRBAC(r, response.RecentDrops)
+	// Compose both protections: scope to the active cluster (a straggler drop from
+	// a previous cluster, recorded in the async informer-shutdown window, must not
+	// surface here) AND per-user RBAC (drop records name resources).
+	response.RecentDrops = s.filterDropsByRBAC(r, timeline.DropsForCluster(response.RecentDrops, k8s.ActiveClusterContext()))
 	s.writeJSON(w, response)
 }
 
@@ -4816,13 +4819,12 @@ func (s *Server) handleDebugEventsDiagnose(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// RBAC: diagnose returns a specific resource's timeline rows (with diffs),
-	// drop history, and recommendations derived from them. The query matches by
-	// kind string only (not group), so authorize each returned row per-kind using
-	// its own apiVersion — disambiguating a Kind that collides with a builtin (a
-	// namespaced CRD Kind=Node must not ride the caller's `list nodes`). The gate
-	// runs inside GetDiagnosis, BEFORE recommendations, so tips can't describe a
-	// row the caller can't read. Auth off → nil filter → no-op.
+	// RBAC + cluster scoping both run inside GetDiagnosis before recommendations:
+	// ActiveClusterContext scopes the store query and the stamped drop history to
+	// the current cluster, and `allow` authorizes each returned row per-kind using
+	// its own apiVersion (disambiguating a Kind that collides with a builtin — a
+	// namespaced CRD Kind=Node must not ride the caller's `list nodes`). Auth off →
+	// nil filter → no-op.
 	var allow func(kind, apiVersion, namespace string) bool
 	if user := auth.UserFromContext(r.Context()); user != nil && s.permCache != nil {
 		authz := s.changeAuthorizerForCtx(r.Context())

--- a/internal/timeline/diagnosis_rbac_test.go
+++ b/internal/timeline/diagnosis_rbac_test.go
@@ -11,7 +11,7 @@ import (
 func TestGetDiagnosis_RecommendationsRespectRBAC(t *testing.T) {
 	m := GetMetrics()
 	m.Reset()
-	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update")
+	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update", "")
 
 	hasNoisyTip := func(recs []string) bool {
 		for _, r := range recs {

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -389,8 +389,7 @@ func broadcastEvent(event TimelineEvent) {
 		case ch <- event:
 		default:
 			// Channel full, skip (subscriber not keeping up)
-			RecordDrop(event.Kind, event.Namespace, event.Name,
-				DropReasonSubscriberFull, string(event.EventType))
+			RecordDrop(event.Kind, event.Namespace, event.Name, DropReasonSubscriberFull, string(event.EventType), event.ClusterContext)
 		}
 	}
 }

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -231,6 +231,13 @@ func DropsForCluster(drops []DropRecord, clusterContext string) []DropRecord {
 // the same kind on the NEW cluster. Process uptime (startTime) is preserved:
 // it reports how long the event pipeline has been running, not a per-cluster
 // session, so it must survive the switch.
+//
+// Best-effort on the counters: unlike RecentDrops (stamped + filtered on read),
+// the counters have no cluster guard, so a straggler informer draining after the
+// switch (async shutdown, up to ~5s) can re-increment them with a few old-cluster
+// ticks after this reset. Accepted: counters carry only kind names, not resource
+// identity, so the exposure is a type label ("Secret") on a debug surface, never
+// a resource name.
 func ResetMetricsForContextSwitch() {
 	m := GetMetrics()
 	m.mu.Lock()

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -31,12 +31,19 @@ type EventMetrics struct {
 
 // DropRecord records a single dropped event for debugging
 type DropRecord struct {
-	Kind      string    `json:"kind"`
-	Namespace string    `json:"namespace"`
-	Name      string    `json:"name"`
-	Reason    string    `json:"reason"`
-	Operation string    `json:"operation"`
-	Time      time.Time `json:"time"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Reason    string `json:"reason"`
+	Operation string `json:"operation"`
+	// ClusterContext is the kubeconfig context the dropped event belonged to,
+	// captured at informer wiring time (NOT read live at drop time). Informer
+	// shutdown on a context switch is asynchronous, so a straggler callback can
+	// record a drop after the switch — stamping the wiring-time context keeps it
+	// attributed to the cluster it came from, and read paths filter to the active
+	// context so a previous cluster's resource names never surface on the new one.
+	ClusterContext string    `json:"clusterContext,omitempty"`
+	Time           time.Time `json:"time"`
 }
 
 // DropReason constants for categorizing why events are dropped
@@ -128,7 +135,7 @@ func GetTotalDropCount() int64 {
 }
 
 // RecordDrop records a dropped event with details for debugging
-func RecordDrop(kind, namespace, name, reason, operation string) {
+func RecordDrop(kind, namespace, name, reason, operation, clusterContext string) {
 	m := GetMetrics()
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -136,12 +143,13 @@ func RecordDrop(kind, namespace, name, reason, operation string) {
 	m.EventsDropped[reason]++
 
 	record := DropRecord{
-		Kind:      kind,
-		Namespace: namespace,
-		Name:      name,
-		Reason:    reason,
-		Operation: operation,
-		Time:      time.Now(),
+		Kind:           kind,
+		Namespace:      namespace,
+		Name:           name,
+		Reason:         reason,
+		Operation:      operation,
+		ClusterContext: clusterContext,
+		Time:           time.Now(),
 	}
 
 	// Keep only the most recent drops (ring buffer style)
@@ -197,6 +205,42 @@ func (m *EventMetrics) Reset() {
 	m.EventsQueried = 0
 	m.EventsFiltered = 0
 	m.startTime = time.Now()
+}
+
+// DropsForCluster returns only the drop records attributed to clusterContext.
+// Read paths pass the active context so a straggler drop stamped with a
+// previously-connected cluster (recorded in the async informer-shutdown window
+// after a switch) is never shown on the new cluster. Strict equality also covers
+// the in-cluster case (both "" ).
+func DropsForCluster(drops []DropRecord, clusterContext string) []DropRecord {
+	out := make([]DropRecord, 0, len(drops))
+	for _, d := range drops {
+		if d.ClusterContext == clusterContext {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// ResetMetricsForContextSwitch clears per-cluster event-pipeline state when the
+// connected cluster changes. RecentDrops name individual resources (kind /
+// namespace / name), and the counters are per-cluster totals, so both must be
+// dropped on a context switch — otherwise the debug/diagnostics drop surfaces
+// expose a previously-connected cluster's resource names to whoever can read
+// the same kind on the NEW cluster. Process uptime (startTime) is preserved:
+// it reports how long the event pipeline has been running, not a per-cluster
+// session, so it must survive the switch.
+func ResetMetricsForContextSwitch() {
+	m := GetMetrics()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.EventsReceived = make(map[string]int64)
+	m.EventsDropped = make(map[string]int64)
+	m.EventsRecorded = make(map[string]int64)
+	m.RecentDrops = make([]DropRecord, 0, m.maxRecentDrops)
+	m.EventsQueried = 0
+	m.EventsFiltered = 0
 }
 
 // MetricsSnapshot is a JSON-serializable snapshot of metrics
@@ -264,12 +308,12 @@ type ResourceInfo struct {
 	Name      string `json:"name"`
 }
 
-// GetDiagnosis diagnoses why events for a specific resource might be missing
 // GetDiagnosis diagnoses why events for a resource might be missing. `allow`, when
 // non-nil, authorizes each timeline row / drop by (kind, apiVersion, namespace)
 // BEFORE the recommendations are derived from them — so a caller who can't read
 // some of the matched rows gets neither those rows nor tips computed from them.
-// nil `allow` (auth off) returns everything.
+// nil `allow` (auth off) returns everything. Rows are also scoped to the active
+// clusterContext (store query + stamped drop provenance).
 func GetDiagnosis(kind, namespace, name, clusterContext string, allow func(kind, apiVersion, namespace string) bool) DiagnoseResponse {
 	resp := DiagnoseResponse{
 		Resource: ResourceInfo{
@@ -307,11 +351,14 @@ func GetDiagnosis(kind, namespace, name, clusterContext string, allow func(kind,
 		}
 	}
 
-	// Check for drops related to this resource
+	// Check for drops related to this resource. Scope to the active cluster so a
+	// straggler drop from a previously-connected cluster (recorded in the async
+	// informer-shutdown window after a switch) neither appears in DropHistory nor
+	// influences the recommendations derived from it.
 	metrics := GetMetrics()
 	metrics.mu.RLock()
 	for _, drop := range metrics.RecentDrops {
-		if drop.Kind == kind && drop.Namespace == namespace && drop.Name == name {
+		if drop.ClusterContext == clusterContext && drop.Kind == kind && drop.Namespace == namespace && drop.Name == name {
 			resp.DropHistory = append(resp.DropHistory, drop)
 		}
 	}

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -210,8 +210,9 @@ func (m *EventMetrics) Reset() {
 // DropsForCluster returns only the drop records attributed to clusterContext.
 // Read paths pass the active context so a straggler drop stamped with a
 // previously-connected cluster (recorded in the async informer-shutdown window
-// after a switch) is never shown on the new cluster. Strict equality also covers
-// the in-cluster case (both "" ).
+// after a switch) is never shown on the new cluster. Both the stamp and the read
+// filter come from ActiveClusterContext(), so the in-cluster case matches too
+// (both sides use the "in-cluster" sentinel).
 func DropsForCluster(drops []DropRecord, clusterContext string) []DropRecord {
 	out := make([]DropRecord, 0, len(drops))
 	for _, d := range drops {

--- a/internal/timeline/metrics_test.go
+++ b/internal/timeline/metrics_test.go
@@ -1,0 +1,69 @@
+package timeline
+
+import (
+	"testing"
+	"time"
+)
+
+// A context switch must clear the per-cluster drop records + counters (they name
+// resources from the previous cluster) while preserving process uptime.
+func TestResetMetricsForContextSwitch(t *testing.T) {
+	m := GetMetrics()
+	m.Reset() // start from a clean slate for a deterministic test
+	start := m.startTime
+
+	// Simulate activity on "cluster A": a dropped Secret names a resource.
+	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update", "cluster-a")
+	RecordDrop("ConfigMap", "team-a", "app-cfg", DropReasonAlreadySeen, "update", "cluster-a")
+	if snap := m.GetSnapshot(); len(snap.RecentDrops) != 2 {
+		t.Fatalf("precondition: want 2 recent drops, got %d", len(snap.RecentDrops))
+	}
+
+	// Let a measurable amount of process time pass so we can assert uptime survives.
+	time.Sleep(5 * time.Millisecond)
+
+	ResetMetricsForContextSwitch()
+
+	snap := m.GetSnapshot()
+	if len(snap.RecentDrops) != 0 {
+		t.Fatalf("RecentDrops must be cleared on context switch, got %d: %+v", len(snap.RecentDrops), snap.RecentDrops)
+	}
+	if len(snap.Counters.Dropped) != 0 {
+		t.Fatalf("dropped counters must reset on context switch, got %+v", snap.Counters.Dropped)
+	}
+	if m.startTime != start {
+		t.Fatalf("startTime (process uptime) must be preserved across a context switch")
+	}
+	if snap.Uptime == "" {
+		t.Fatalf("uptime must still be reported after a context switch")
+	}
+}
+
+// Drops are stamped with the cluster they came from (captured at wiring time,
+// not read live), and read paths keep only the active cluster's — so a straggler
+// drop recorded after a switch, stamped with the OLD cluster, is filtered out
+// even though ResetMetricsForContextSwitch already ran. This closes the
+// late-callback race that a reset alone leaves open.
+func TestDropsForCluster_FiltersStaleClusterDrops(t *testing.T) {
+	m := GetMetrics()
+	m.Reset()
+
+	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update", "cluster-a")
+	// Simulate a switch to cluster-b, then a STRAGGLER old-informer callback that
+	// fires after the reset — it is stamped with its wiring-time cluster (a).
+	ResetMetricsForContextSwitch()
+	RecordDrop("Secret", "team-a", "db-creds", DropReasonNoisyFilter, "update", "cluster-a")
+	// And a genuine cluster-b drop.
+	RecordDrop("Pod", "team-b", "web", DropReasonAlreadySeen, "update", "cluster-b")
+
+	all := GetMetrics().GetSnapshot().RecentDrops
+	active := DropsForCluster(all, "cluster-b")
+	for _, d := range active {
+		if d.ClusterContext != "cluster-b" {
+			t.Fatalf("active-cluster view must exclude cluster-a straggler, got %+v", d)
+		}
+	}
+	if len(active) != 1 || active[0].Name != "web" {
+		t.Fatalf("want only the cluster-b Pod drop, got %+v", active)
+	}
+}


### PR DESCRIPTION
## Problem

Event-pipeline **drop records** (`RecentDrops`) name individual resources (kind / namespace / name). They were process-global, carried **no cluster provenance**, and were **not reset on a kubeconfig context switch**. After switching clusters, the drop surfaces — `/api/debug/events`, `/api/debug/events/diagnose` (`drop_history` + its recommendations), and `/api/diagnostics` — exposed a **previously-connected cluster's resource names** to whoever can read the same kind on the new cluster.

Found by cross-review of the timeline per-kind RBAC work; this is its dedicated fix.

## Fix

- **Stamp provenance at wiring time.** `DropRecord` gains a `ClusterContext`, captured from the informer's `recordClusterContext` (the same wiring-time capture the timeline events use), passed through all `RecordDrop` call sites. Informer shutdown on a switch is asynchronous (up to ~5s, then abandoned), so a straggler callback can record a drop *after* the switch — stamping the wiring-time context keeps it attributed to the cluster it came from instead of being read live (which would mis-attribute it to the new cluster).
- **Filter on read.** `timeline.DropsForCluster(drops, active)` keeps only the active cluster's drops, applied in `handleDebugEvents` and `/api/diagnostics`. `GetDiagnosis` scopes both its `DropHistory` **and** the recommendations derived from it.
- **Reset the un-stamped counters.** `ResetMetricsForContextSwitch` clears the per-cluster pipeline counters on switch (they carry no resource identity, so they only need a reset, not stamping). **Process uptime is preserved** — it measures the pipeline's lifetime, not a per-cluster session.

Stamp+filter (not reset alone) is what closes the late-callback race — reset-at-switch-time can't stop a straggler from repopulating `RecentDrops` afterward, but a straggler stamped with the old cluster is filtered out on read.

## Tests

- Unit (`internal/timeline/metrics_test.go`): reset clears drops+counters while preserving uptime; a straggler drop stamped with the old cluster is filtered out of the active-cluster view.
- e2e: two `kind` clusters — generate noisy-secret drops on cluster A, `POST /api/contexts/<B>`, assert A's resource names are gone from `RecentDrops` on B. Passes.
- `go build`, `go vet`, `go test ./...` green.

## Scope

Deliberately limited to **drop-metrics** cross-cluster provenance. `GetDiagnosis`'s timeline-**store** query (its `TimelineEvents`) cluster-scoping is a separate change and is not touched here.

https://claude.ai/code/session_01XNhMe6Zdqwj5EoBazNDnmW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches diagnostic/debug surfaces and context-switch lifecycle; mitigates information disclosure rather than changing core auth, with documented best-effort behavior on unstamped counters after async informer drain.
> 
> **Overview**
> **Fixes a cross-cluster leak** where global `RecentDrops` (kind/namespace/name) could show a previous kubeconfig context’s resources on debug/diagnostics APIs after a switch.
> 
> **`DropRecord` is stamped** with `ClusterContext` at informer wiring time (same as timeline events), and **all `RecordDrop` call sites** pass that context so late straggler callbacks stay attributed to the old cluster.
> 
> **On read**, `DropsForCluster` limits drops to `ActiveClusterContext()` in `/api/debug/events` and diagnostics; **`GetDiagnosis`** filters drop history (and thus recommendations) by active cluster. **On switch**, timeline reset now also runs **`ResetMetricsForContextSwitch`** to clear drops and per-cluster counters while keeping process uptime.
> 
> Unit tests cover reset behavior and filtering stale stamped drops after a simulated straggler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670a750c80f6be726c1e813d9733ddaa2d637996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->