### PR TITLE
fix(rbac): gate cross-kind evidence in the issues pipeline

### DIFF
--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -147,6 +147,7 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 	// symptoms against parent rollups across member pods — both need the flat
 	// rows, so they run BEFORE grouping and BEFORE the public filters.
 	out = applyClusterScopedAccess(out, f)
+	out = applyCrossKindEvidenceAccess(out, f)
 	out = dedupePodSchedulingOverProblem(out)
 	// Same-resource structural-root → symptom: fold a pod's runtime symptom into
 	// the dangling-ref that caused it, and an autoscaler's condition into its

--- a/internal/issues/crashloop_severity_integration_test.go
+++ b/internal/issues/crashloop_severity_integration_test.go
@@ -120,7 +120,7 @@ func TestCompose_CrashLoopCurrentStateControlsRankingAndGrouping(t *testing.T) {
 		t.Fatalf("catalog group cause = %q, want serving recovery copy", grouped.Cause)
 	}
 
-	related := RelatedIssues(provider, []string{"prod"}, "", "Pod", "prod", "catalog-a")
+	related := RelatedIssues(provider, []string{"prod"}, "", "Pod", "prod", "catalog-a", nil)
 	if len(related) != 1 || related[0].Severity != SeverityWarning {
 		t.Fatalf("related issues for recovered pod = %+v, want its warning crashloop", related)
 	}

--- a/internal/issues/cross_kind_access_test.go
+++ b/internal/issues/cross_kind_access_test.go
@@ -1,0 +1,35 @@
+package issues
+
+import "testing"
+
+// A StaleSecretEnv issue is entirely derived from a referenced Secret's change
+// history, so it must be dropped for callers who can't read Secrets in its
+// namespace — while unrelated issues and callers with access are untouched, and
+// a nil CanRead (auth off) changes nothing.
+func TestApplyCrossKindEvidenceAccess_StaleSecretEnv(t *testing.T) {
+	in := []Issue{
+		{Reason: "StaleSecretEnv", Namespace: "team-a", Kind: "Pod", Name: "web"},
+		{Reason: "CrashLoop", Namespace: "team-a", Kind: "Pod", Name: "api"},
+		{Reason: "StaleSecretEnv", Namespace: "team-b", Kind: "Pod", Name: "job"},
+	}
+
+	// nil CanRead (auth off): passthrough.
+	if got := applyCrossKindEvidenceAccess(in, Filters{}); len(got) != 3 {
+		t.Fatalf("nil CanRead must keep all, got %d", len(got))
+	}
+
+	// Can read secrets only in team-a: the team-b StaleSecretEnv drops, team-a
+	// StaleSecretEnv + the unrelated CrashLoop survive.
+	f := Filters{CanRead: func(group, resource, namespace string) bool {
+		return !(resource == "secrets") || namespace == "team-a"
+	}}
+	got := applyCrossKindEvidenceAccess(append([]Issue(nil), in...), f)
+	if len(got) != 2 {
+		t.Fatalf("want 2 issues (team-b StaleSecretEnv dropped), got %d: %+v", len(got), got)
+	}
+	for _, i := range got {
+		if i.Reason == "StaleSecretEnv" && i.Namespace == "team-b" {
+			t.Fatalf("StaleSecretEnv leaked for a namespace without secret read: %+v", i)
+		}
+	}
+}

--- a/internal/issues/external_merge_test.go
+++ b/internal/issues/external_merge_test.go
@@ -149,7 +149,7 @@ func TestMergeExternalIssuesDuplicateEnvPresentationBoundaries(t *testing.T) {
 	if len(composed) != 1 || composedStats.TotalMatched != 1 || !strings.Contains(composed[0].Message, "APP_MODE (app), APP_MODE (init)") {
 		t.Fatalf("composed aggregate lost env evidence: %+v, TotalMatched=%d", composed, composedStats.TotalMatched)
 	}
-	related := RelatedIssues(p, nil, "apps", "Deployment", "apps", "web")
+	related := RelatedIssues(p, nil, "apps", "Deployment", "apps", "web", nil)
 	if len(related) != 2 {
 		t.Fatalf("RelatedIssues rows=%d, want 2 detailed findings", len(related))
 	}

--- a/internal/issues/filters.go
+++ b/internal/issues/filters.go
@@ -51,6 +51,30 @@ func applyClusterScopedAccess(in []Issue, f Filters) []Issue {
 	return out
 }
 
+// applyCrossKindEvidenceAccess gates issues whose evidence exposes a kind the
+// subject-reader may not be able to read. Issues are otherwise namespace-gated
+// only, so a Pod-reader receives evidence a detector derived (as the cache SA)
+// from a Secret / Node / etc. it references. Runs on flat rows after
+// applyClusterScopedAccess. nil CanRead disables it (auth off / tests).
+//
+// StaleSecretEnv is entirely derived from a referenced Secret's change history
+// (the Secret's existence, its data key names for envFrom consumers, and the
+// rotation timing) — none of which is in the Pod's own readable spec. Drop it
+// for callers who can't read Secrets in the issue's namespace.
+func applyCrossKindEvidenceAccess(in []Issue, f Filters) []Issue {
+	if f.CanRead == nil {
+		return in
+	}
+	out := in[:0]
+	for _, i := range in {
+		if i.Reason == "StaleSecretEnv" && !f.CanRead("", "secrets", i.Namespace) {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
 // SeverityRank orders the normalized issue severity, higher = worse. Shared by
 // the grouping comparators here and by the per-resource summary rollups in the
 // server/MCP layers, so all three rank off one function.

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -13,11 +13,14 @@ import (
 // may pass the K8s Kind or a normalized form); group is exact, including the
 // empty core API group, so core/CRD kind collisions cannot bleed into each
 // other's resourceContext.
-func RelatedIssues(p Provider, namespaces []string, group, kind, namespace, name string) []Issue {
+// canRead gates cross-kind evidence (e.g. StaleSecretEnv, derived from a
+// referenced Secret's history) the same way the /api/issues path does; pass nil
+// when auth is off.
+func RelatedIssues(p Provider, namespaces []string, group, kind, namespace, name string, canRead func(group, resource, namespace string) bool) []Issue {
 	// Compose FLAT (uncapped) then group: matching against the flat evidence —
 	// not the grouped issue's inline Members (capped at maxInlineMembers) — is
 	// what makes member #11..#N in a large fan-out resolve correctly.
-	flat := Compose(p, Filters{Namespaces: namespaces, Limit: NoLimit})
+	flat := Compose(p, Filters{Namespaces: namespaces, Limit: NoLimit, CanRead: canRead})
 	grouped := GroupIssues(flat)
 	// Run the grouped-mode enrichment (mirrors the cluster path) so the grouped
 	// issues get coverage-gated incident_parent pointers — GroupIssues alone only

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -256,14 +256,14 @@ func TestRelatedIssues_SubjectAndMember(t *testing.T) {
 		{Kind: "Pod", Namespace: "prod", Name: "web-abc-1", Reason: "CrashLoopBackOff", Severity: "critical",
 			OwnerGroup: "apps", OwnerKind: "Deployment", OwnerName: "web"},
 	}}
-	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "web"); len(got) != 1 {
-		t.Fatalf("RelatedIssues(owning Deployment) = %d, want 1 (subject match)", len(got))
+	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "web", nil); len(got) != 1 {
+		t.Fatalf("RelatedIssues(owning Deployment, nil) = %d, want 1 (subject match)", len(got))
 	}
-	if got := RelatedIssues(p, nil, "", "pod", "prod", "web-abc-1"); len(got) != 1 {
-		t.Errorf("RelatedIssues(evidence Pod, case-insensitive) = %d, want 1 (member match)", len(got))
+	if got := RelatedIssues(p, nil, "", "pod", "prod", "web-abc-1", nil); len(got) != 1 {
+		t.Errorf("RelatedIssues(evidence Pod, case-insensitive, nil) = %d, want 1 (member match)", len(got))
 	}
-	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "other"); len(got) != 0 {
-		t.Errorf("RelatedIssues(unrelated) = %d, want 0", len(got))
+	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "other", nil); len(got) != 0 {
+		t.Errorf("RelatedIssues(unrelated, nil) = %d, want 0", len(got))
 	}
 }
 
@@ -281,9 +281,9 @@ func TestRelatedIssues_PopulatesIncidentParent(t *testing.T) {
 		},
 		podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}}},
 	}
-	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0")
+	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0", nil)
 	if len(got) != 1 {
-		t.Fatalf("RelatedIssues(db-0) = %d, want 1", len(got))
+		t.Fatalf("RelatedIssues(db-0, nil) = %d, want 1", len(got))
 	}
 	ip := got[0].IncidentParent
 	if ip == nil || ip.Ref.Kind != "PersistentVolumeClaim" || ip.Ref.Name != "data" || ip.Confidence != issuesapi.ConfidenceHigh {
@@ -316,9 +316,9 @@ func TestRelatedIssues_IncidentParentCoverageGate(t *testing.T) {
 			{Kind: "Pod", Namespace: "prod", Name: "db-1"},
 		}},
 	}
-	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0")
+	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0", nil)
 	if len(got) != 1 {
-		t.Fatalf("RelatedIssues(db-0) = %d, want 1", len(got))
+		t.Fatalf("RelatedIssues(db-0, nil) = %d, want 1", len(got))
 	}
 	if got[0].IncidentParent != nil {
 		t.Fatalf("partially-covered row (2 of 3 members mount the PVC) must not carry incident_parent, got %+v", got[0].IncidentParent)
@@ -396,11 +396,11 @@ func TestRelatedIssues_GroupIsExact(t *testing.T) {
 		{Kind: "Service", Group: "serving.knative.dev", Namespace: "prod", Name: "api", Reason: "0/1 selected pods ready", Severity: "critical"},
 	}}
 
-	core := RelatedIssues(p, nil, "", "Service", "prod", "api")
+	core := RelatedIssues(p, nil, "", "Service", "prod", "api", nil)
 	if len(core) != 1 || core[0].Group != "" {
 		t.Fatalf("core Service lookup should match only core-group issue, got %+v", core)
 	}
-	knative := RelatedIssues(p, nil, "serving.knative.dev", "Service", "prod", "api")
+	knative := RelatedIssues(p, nil, "serving.knative.dev", "Service", "prod", "api", nil)
 	if len(knative) != 1 || knative[0].Group != "serving.knative.dev" {
 		t.Fatalf("Knative Service lookup should match only serving.knative.dev issue, got %+v", knative)
 	}
@@ -419,10 +419,10 @@ func TestRelatedIssues_UncappedMembers(t *testing.T) {
 		})
 	}
 	p := &fakeProvider{problems: probs}
-	if got := RelatedIssues(p, nil, "", "Pod", "prod", "web-abc-11"); len(got) != 1 {
+	if got := RelatedIssues(p, nil, "", "Pod", "prod", "web-abc-11", nil); len(got) != 1 {
 		t.Errorf("pod beyond the inline-Members cap = %d related issues, want 1 (uncapped lookup)", len(got))
 	}
-	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "web"); len(got) != 1 {
+	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "web", nil); len(got) != 1 {
 		t.Errorf("owning Deployment = %d related issues, want 1", len(got))
 	}
 }

--- a/internal/issues/options.go
+++ b/internal/issues/options.go
@@ -31,6 +31,12 @@ type Filters struct {
 	// nil preserves auth-mode=none and tests where the provider's own
 	// permissions are the only gate.
 	CanReadClusterScoped func(kind, group string) bool
+	// CanRead authorizes a namespaced per-kind read (group, resource, namespace)
+	// for issue evidence that derives from a DIFFERENT kind than the subject —
+	// e.g. a StaleSecretEnv issue on a Pod is built from a referenced Secret's
+	// change history. Handlers provide a per-user SAR-backed predicate; nil
+	// disables the cross-kind evidence gate (auth-mode=none, tests).
+	CanRead func(group, resource, namespace string) bool
 	// Grouped folds the flat rows into the public grouped model
 	// (GroupIssues) before the cap, so the limit counts issue groups, not
 	// replica fan-out. The public /api/issues + MCP issues set this; flat

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -306,13 +306,19 @@ func resolveUnsatisfiableNodeSelector(p PodPlacement, nodes []NodeFacts) []strin
 	return out
 }
 
+// explainMissingLabel and explainMissingExpr report only the pod's OWN
+// unsatisfiable requirement — never the label values the fleet's nodes carry.
+// Those values are cluster-scoped Node content, and scheduling issues are served
+// to namespaced readers who may lack node RBAC; enumerating what the fleet
+// carries would leak node topology (zones, instance types, tenancy/internal
+// labels). `present` gates only the "no node carries the label at all" wording;
+// its values are never emitted.
 func explainMissingLabel(key, val string, nodes []NodeFacts) string {
 	present := distinctLabelValues(nodes, key)
 	if len(present) == 0 {
 		return fmt.Sprintf("no node carries label %s (pod requires %s=%s)", key, key, val)
 	}
-	return fmt.Sprintf("no node has %s=%s — %d node(s) carry %s: [%s]",
-		key, val, countNodesWithLabelKey(nodes, key), key, strings.Join(present, ", "))
+	return fmt.Sprintf("no node has %s=%s", key, val)
 }
 
 func explainMissingExpr(e MatchExpr, nodes []NodeFacts) string {
@@ -322,7 +328,7 @@ func explainMissingExpr(e MatchExpr, nodes []NodeFacts) string {
 		if len(present) == 0 {
 			return fmt.Sprintf("no node carries label %s (pod requires %s in [%s])", e.Key, e.Key, strings.Join(e.Values, ", "))
 		}
-		return fmt.Sprintf("no node has %s in [%s] — fleet %s: [%s]", e.Key, strings.Join(e.Values, ", "), e.Key, strings.Join(present, ", "))
+		return fmt.Sprintf("no node has %s in [%s]", e.Key, strings.Join(e.Values, ", "))
 	case "Exists":
 		return fmt.Sprintf("no node carries label %s (pod requires it to exist)", e.Key)
 	case "DoesNotExist":

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -48,10 +48,13 @@ func TestDetectSchedulingProblems_BindTime(t *testing.T) {
 	}
 	for _, p := range problems {
 		if p.Name == "web" {
-			for _, want := range []string{"kubernetes.io/arch", "arm64", "amd64"} {
+			for _, want := range []string{"kubernetes.io/arch", "arm64"} {
 				if !strings.Contains(p.Message, want) {
 					t.Errorf("message %q should name the offending label %q", p.Message, want)
 				}
+			}
+			if strings.Contains(p.Message, "amd64") {
+				t.Errorf("message leaks the fleet's node label value: %q", p.Message)
 			}
 		}
 	}

--- a/internal/k8s/detect_scheduling_test.go
+++ b/internal/k8s/detect_scheduling_test.go
@@ -160,11 +160,15 @@ func TestResolveUnsatisfiableNodeSelector_ArchMismatch(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d explanations, want 1: %+v", len(got), got)
 	}
-	// Must name the offending key, the required value, and the fleet's actual value.
-	for _, want := range []string{"kubernetes.io/arch", "arm64", "amd64"} {
+	// Names the offending key + the pod's OWN required value; must NOT enumerate
+	// the fleet's actual node label values (cluster-scoped Node content).
+	for _, want := range []string{"kubernetes.io/arch", "arm64"} {
 		if !strings.Contains(got[0], want) {
 			t.Errorf("explanation %q missing %q", got[0], want)
 		}
+	}
+	if strings.Contains(got[0], "amd64") {
+		t.Errorf("explanation leaks the fleet's node label value: %q", got[0])
 	}
 }
 
@@ -177,8 +181,13 @@ func TestResolveUnsatisfiableNodeSelector_ZoneViaAffinity(t *testing.T) {
 		{Expressions: []MatchExpr{{Key: "topology.kubernetes.io/zone", Operator: "In", Values: []string{"us-east-1b"}}}},
 	}}
 	got := resolveUnsatisfiableNodeSelector(p, nodes)
-	if len(got) != 1 || !strings.Contains(got[0], "topology.kubernetes.io/zone") || !strings.Contains(got[0], "us-east-1a") {
-		t.Fatalf("want zone explanation naming the key + fleet value, got %+v", got)
+	// Names the key + the pod's OWN required value (us-east-1b); must NOT leak the
+	// fleet's actual zone (us-east-1a).
+	if len(got) != 1 || !strings.Contains(got[0], "topology.kubernetes.io/zone") || !strings.Contains(got[0], "us-east-1b") {
+		t.Fatalf("want zone explanation naming the key + pod's required value, got %+v", got)
+	}
+	if strings.Contains(got[0], "us-east-1a") {
+		t.Fatalf("explanation leaks the fleet's node zone value: %+v", got)
 	}
 }
 
@@ -246,10 +255,13 @@ func TestDescribeUnschedulable_ArchMismatchNamesLabel(t *testing.T) {
 		{Name: "n2", Labels: map[string]string{"kubernetes.io/arch": "amd64"}},
 	}
 	msg := describeUnschedulable(pod, "0/2 nodes are available: 2 node(s) didn't match Pod's node affinity/selector.", nodes)
-	for _, want := range []string{"kubernetes.io/arch", "arm64", "amd64", "0/2 nodes available"} {
+	for _, want := range []string{"kubernetes.io/arch", "arm64", "0/2 nodes available"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("message %q missing %q", msg, want)
 		}
+	}
+	if strings.Contains(msg, "amd64") {
+		t.Errorf("message leaks the fleet's node label value: %q", msg)
 	}
 	// The resolved label supersedes the generic clause — don't double-report.
 	if strings.Contains(msg, "node affinity/selector mismatch") {

--- a/internal/mcp/mutation_verification.go
+++ b/internal/mcp/mutation_verification.go
@@ -103,7 +103,7 @@ func buildMutationVerification(ctx context.Context, dynClient dynamic.Interface,
 		out["pods"] = pods
 		cacheSnapshot = true
 	}
-	if related := relatedIssuesForObject(post); len(related) > 0 {
+	if related := relatedIssuesForObject(post, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }); len(related) > 0 {
 		out["currentIssues"] = related
 		cacheSnapshot = true
 	}
@@ -747,7 +747,7 @@ func podContainerStatus(pod *corev1.Pod) (bool, int32, string) {
 	return allReady, restarts, waiting
 }
 
-func relatedIssuesForObject(obj *unstructured.Unstructured) []map[string]any {
+func relatedIssuesForObject(obj *unstructured.Unstructured, canRead func(group, resource, namespace string) bool) []map[string]any {
 	if obj == nil {
 		return nil
 	}
@@ -764,7 +764,7 @@ func relatedIssuesForObject(obj *unstructured.Unstructured) []map[string]any {
 	if obj.GetNamespace() != "" {
 		namespaces = []string{obj.GetNamespace()}
 	}
-	matched := issues.RelatedIssues(provider, namespaces, gvk.Group, kind, obj.GetNamespace(), obj.GetName())
+	matched := issues.RelatedIssues(provider, namespaces, gvk.Group, kind, obj.GetNamespace(), obj.GetName(), canRead)
 	if len(matched) == 0 {
 		return nil
 	}

--- a/internal/mcp/resource_context.go
+++ b/internal/mcp/resource_context.go
@@ -64,7 +64,7 @@ func (l mcpServiceBackendLookup) PodsForServiceSelector(namespace string, select
 // Pascal-singular kind required: the composer's Filters.Kinds matcher
 // case-folds both sides but doesn't plural-to-singular convert. Callers
 // pass canonicalKind from obj's TypeMeta.
-func computeMCPIssueSummary(cache *k8s.ResourceCache, group, kind, namespace, name string) *resourcecontext.IssueSummary {
+func computeMCPIssueSummary(cache *k8s.ResourceCache, group, kind, namespace, name string, canRead func(group, resource, namespace string) bool) *resourcecontext.IssueSummary {
 	if cache == nil {
 		return nil
 	}
@@ -80,7 +80,7 @@ func computeMCPIssueSummary(cache *k8s.ResourceCache, group, kind, namespace, na
 	// surfaces the GROUPED issues its pods are evidence for (was empty — the
 	// old flat-by-exact-resource match looked for Kind=Deployment rows, but the
 	// evidence is Kind=Pod), and on a pod past the inline-Members cap too.
-	matched := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name)
+	matched := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name, canRead)
 	if len(matched) == 0 {
 		return nil
 	}

--- a/internal/mcp/summary_context.go
+++ b/internal/mcp/summary_context.go
@@ -30,12 +30,12 @@ import (
 // per-hit between a namespaced and a cluster-wide index — search
 // returns mixed kinds in one response, so a single index can't get
 // both right.
-func newResourceSummaryContextBuilder(namespaces []string) summarycontext.Builder {
+func newResourceSummaryContextBuilder(namespaces []string, canRead func(group, resource, namespace string) bool) summarycontext.Builder {
 	provider := issues.NewCacheProvider()
 	if provider == nil {
 		return nil
 	}
-	idx := summarycontext.BuildIssueIndex(provider, namespaces)
+	idx := summarycontext.BuildIssueIndex(provider, namespaces, canRead)
 	return summarycontext.BuilderFromIndexes(buildSummaryContextTopology(namespaces), idx, idx)
 }
 
@@ -46,15 +46,15 @@ func newResourceSummaryContextBuilder(namespaces []string) summarycontext.Builde
 // canReadClusterScopedKind) already gates which cluster-scoped kinds
 // are reachable, so composing the cluster-wide index doesn't leak
 // rows the user can't see.
-func newSearchSummaryContextBuilder(scanNamespaces []string) summarycontext.Builder {
+func newSearchSummaryContextBuilder(scanNamespaces []string, canRead func(group, resource, namespace string) bool) summarycontext.Builder {
 	provider := issues.NewCacheProvider()
 	if provider == nil {
 		return nil
 	}
-	namespacedIdx := summarycontext.BuildIssueIndex(provider, scanNamespaces)
+	namespacedIdx := summarycontext.BuildIssueIndex(provider, scanNamespaces, canRead)
 	clusterIdx := namespacedIdx
 	if scanNamespaces != nil {
-		clusterIdx = summarycontext.BuildIssueIndex(provider, nil)
+		clusterIdx = summarycontext.BuildIssueIndex(provider, nil, canRead)
 	}
 	return summarycontext.BuilderFromIndexes(buildSummaryContextTopology(scanNamespaces), namespacedIdx, clusterIdx)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -870,7 +870,7 @@ func handleListResources(ctx context.Context, req *mcp.CallToolRequest, input li
 		if clusterScoped {
 			idxNamespaces = nil
 		}
-		if builder := newResourceSummaryContextBuilder(idxNamespaces); builder != nil {
+		if builder := newResourceSummaryContextBuilder(idxNamespaces, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }); builder != nil {
 			summarycontext.AttachToTypedList(results, objs, builder)
 		}
 	}
@@ -910,7 +910,7 @@ func listDynamicResources(ctx context.Context, cache *k8s.ResourceCache, kind, g
 		if clusterScoped {
 			idxNamespaces = nil
 		}
-		if builder := newResourceSummaryContextBuilder(idxNamespaces); builder != nil {
+		if builder := newResourceSummaryContextBuilder(idxNamespaces, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }); builder != nil {
 			summarycontext.AttachToUnstructuredList(allItems, rawItems, builder)
 		}
 	}
@@ -1107,7 +1107,7 @@ func buildMCPResourceContextWithStaleChecks(ctx context.Context, obj runtime.Obj
 	}
 	canonicalGroup := gvk.Group
 
-	issueSum := computeMCPIssueSummary(cache, canonicalGroup, canonicalKind, namespace, name)
+	issueSum := computeMCPIssueSummary(cache, canonicalGroup, canonicalKind, namespace, name, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") })
 	auditSum := computeMCPAuditSummary(cache, canonicalGroup, canonicalKind, namespace, name)
 
 	opts := resourcecontext.Options{
@@ -2747,6 +2747,9 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		CanReadClusterScoped: func(kind, group string) bool {
 			return canReadClusterScopedKind(ctx, kind, group, "list")
 		},
+		CanRead: func(group, resource, namespace string) bool {
+			return canReadInNamespace(ctx, group, resource, namespace, "list")
+		},
 	}
 	if input.Filter != "" {
 		f, err := filter.CachedIssueFilter(input.Filter)
@@ -3061,7 +3064,7 @@ func handleSearch(ctx context.Context, req *mcp.CallToolRequest, input searchInp
 	// builder routes per-hit by scope; CanReadClusterScoped above
 	// already gates which cluster-scoped kinds are reachable.
 	if input.Context != "none" {
-		if builder := newSearchSummaryContextBuilder(scanNamespaces); builder != nil {
+		if builder := newSearchSummaryContextBuilder(scanNamespaces, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }); builder != nil {
 			opts.SummaryBuilder = search.SummaryBuilderFunc(builder)
 		}
 	}

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -240,7 +240,7 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 		// Surface the issues Radar already classified for this object (subject
 		// or affected member), scoped to its namespace — so the agent sees
 		// "crashloop + missing ConfigMap" up front, not just raw logs.
-		RelatedIssues: issues.RelatedIssues(issues.NewCacheProvider(), []string{input.Namespace}, canonicalGroup, canonicalKind, input.Namespace, input.Name),
+		RelatedIssues: issues.RelatedIssues(issues.NewCacheProvider(), []string{input.Namespace}, canonicalGroup, canonicalKind, input.Namespace, input.Name, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }),
 	}
 
 	// Cap the log fan-out so a DaemonSet with 50 nodes doesn't trigger
@@ -418,7 +418,7 @@ func handleGitOpsDiagnose(ctx context.Context, input diagnoseInput, canonicalKin
 	resp := diagnoseResponse{
 		Resource:        minified,
 		GitOpsDiagnosis: gd,
-		RelatedIssues:   issues.RelatedIssues(issues.NewCacheProvider(), []string{input.Namespace}, group, canonicalKind, input.Namespace, input.Name),
+		RelatedIssues:   issues.RelatedIssues(issues.NewCacheProvider(), []string{input.Namespace}, group, canonicalKind, input.Namespace, input.Name, func(g, res, ns string) bool { return canReadInNamespace(ctx, g, res, ns, "list") }),
 		Warnings:        k8score.EnrichRuntimeObjectWarnings(u),
 	}
 	return toJSONResult(resp)

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -37,7 +37,7 @@ func (s *Server) detectManagedBy(ctx context.Context, kind, namespace, name stri
 	return managedByFromMeta(obj)
 }
 
-func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name string) *ai.ResourceHealthSignal {
+func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name string, canRead func(group, resource, namespace string) bool) *ai.ResourceHealthSignal {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil
@@ -51,7 +51,7 @@ func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name
 	if canonicalKind == "" {
 		canonicalKind = kind
 	}
-	issueSum, issueRows := computeIssueSummaryAndRows(cache, gvk.Group, canonicalKind, namespace, name)
+	issueSum, issueRows := computeIssueSummaryAndRows(cache, gvk.Group, canonicalKind, namespace, name, canRead)
 	auditSum, auditRows := computeAuditSummaryAndRows(cache, gvk.Group, canonicalKind, namespace, name)
 
 	var issueCount int
@@ -312,7 +312,7 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	// the Apply confirmation can warn that a direct change will be reverted — rather
 	// than relying on the agent to self-report it. Best effort: "" (unknown) on miss.
 	managedBy := s.detectManagedBy(r.Context(), kind, namespace, name)
-	health := s.detectDiagnoseHealth(r.Context(), kind, namespace, name)
+	health := s.detectDiagnoseHealth(r.Context(), kind, namespace, name, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") })
 	run, err := s.aiRuns.Start(kind, namespace, name, agent, profile, model, effort, managedBy, health)
 	if err != nil {
 		if errors.Is(err, ai.ErrAtCapacity) {

--- a/internal/server/ai_diagnose_managedby_test.go
+++ b/internal/server/ai_diagnose_managedby_test.go
@@ -19,9 +19,9 @@ func obj(labels, ann map[string]string) *unstructured.Unstructured {
 
 func TestManagedByFromMeta(t *testing.T) {
 	cases := []struct {
-		name   string
-		obj    *unstructured.Unstructured
-		want   string
+		name string
+		obj  *unstructured.Unstructured
+		want string
 	}{
 		{"argo label", obj(map[string]string{"argocd.argoproj.io/instance": "app"}, nil), "Argo CD"},
 		{"argo annotation", obj(nil, map[string]string{"argocd.argoproj.io/tracking-id": "app:apps/Deployment"}), "Argo CD"},

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -190,7 +190,7 @@ func (s *Server) handleAIListResources(w http.ResponseWriter, r *http.Request) {
 	// so we pass nil here to compose cluster-wide.
 	if !skipContext && level == aicontext.LevelSummary {
 		idxNamespaces := issueIndexNamespaces(namespaces, kind, group)
-		if builder := s.newResourceSummaryContextBuilder(idxNamespaces); builder != nil {
+		if builder := s.newResourceSummaryContextBuilder(idxNamespaces, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") }); builder != nil {
 			// Typed list resolves group from each object's TypeMeta —
 			// MinifyList sets it via SetTypeMeta before producing rows,
 			// so we can trust apiVersion on the typed source.
@@ -251,7 +251,7 @@ func (s *Server) aiListDynamic(w http.ResponseWriter, r *http.Request, cache *k8
 
 	if !skipContext && level == aicontext.LevelSummary {
 		idxNamespaces := issueIndexNamespaces(namespaces, kind, group)
-		if builder := s.newResourceSummaryContextBuilder(idxNamespaces); builder != nil {
+		if builder := s.newResourceSummaryContextBuilder(idxNamespaces, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") }); builder != nil {
 			summarycontext.AttachToUnstructuredList(results, allItems, builder)
 		}
 	}
@@ -422,7 +422,7 @@ func (s *Server) buildAIResourceContext(r *http.Request, obj runtime.Object, kin
 	}
 	canonicalGroup := gvk.Group
 
-	issueSum := computeIssueSummaryForResource(cache, canonicalGroup, canonicalKind, namespace, name)
+	issueSum := computeIssueSummaryForResource(cache, canonicalGroup, canonicalKind, namespace, name, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") })
 	auditSum := computeAuditSummaryForResource(cache, canonicalGroup, canonicalKind, namespace, name)
 
 	opts := resourcecontext.Options{
@@ -505,15 +505,15 @@ func (s *Server) topologyForContext(namespace string) (*topology.Topology, topol
 // summary silently collapses to nil.
 //
 // Returns nil when no issues match — Build then omits the IssueSummary field.
-func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, namespace, name string) *resourcecontext.IssueSummary {
-	sum, _ := computeIssueSummaryAndRows(cache, group, kind, namespace, name)
+func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, namespace, name string, canRead func(group, resource, namespace string) bool) *resourcecontext.IssueSummary {
+	sum, _ := computeIssueSummaryAndRows(cache, group, kind, namespace, name, canRead)
 	return sum
 }
 
 // computeIssueSummaryAndRows additionally returns the matched rows sorted by
 // (severity desc, reason asc) — the diagnose health frame shows the actual
 // lines, not just the rollup.
-func computeIssueSummaryAndRows(cache *k8s.ResourceCache, group, kind, namespace, name string) (*resourcecontext.IssueSummary, []issues.Issue) {
+func computeIssueSummaryAndRows(cache *k8s.ResourceCache, group, kind, namespace, name string, canRead func(group, resource, namespace string) bool) (*resourcecontext.IssueSummary, []issues.Issue) {
 	if cache == nil {
 		return nil, nil
 	}
@@ -529,7 +529,7 @@ func computeIssueSummaryAndRows(cache *k8s.ResourceCache, group, kind, namespace
 	// surfaces the grouped issues its pods are evidence for, and on a pod beyond
 	// the inline-Members cap too. The old flat-by-exact-resource match missed
 	// both (a Deployment matched no Kind=Pod evidence rows → empty summary).
-	matched := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name)
+	matched := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name, canRead)
 	if len(matched) == 0 {
 		return nil, nil
 	}

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -178,7 +178,7 @@ func (s *Server) handleGitOpsInsights(w http.ResponseWriter, r *http.Request) {
 	canAccess := func(group, kind, namespace, name string) bool {
 		return s.canAccessGitOpsRef(r, req, group, kind, namespace, name, false)
 	}
-	resolver := newInsightsResolver(r.Context(), req.Cache, req.AllowedNamespaces, canAccess)
+	resolver := newInsightsResolver(r.Context(), req.Cache, req.AllowedNamespaces, canAccess, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") })
 	resolver.prefetchLive(gitopsinsights.ManagedResourceRows(root), gitopsinsights.OperationPhase(root))
 	insight := gitopsinsights.Build(root, tree, resolver)
 	insight.Warnings = appendWarnings(insight.Warnings, tree.Warnings...)
@@ -671,6 +671,10 @@ type insightsResolver struct {
 	cache             *k8s.ResourceCache
 	allowedNamespaces []string
 	canAccess         func(group, kind, namespace, name string) bool
+	// canRead gates cross-kind issue evidence (e.g. StaleSecretEnv, derived from
+	// a referenced Secret's history) when composing ResourceProblems — canAccess
+	// only gates the target resource, not the evidence's source kind.
+	canRead func(group, resource, namespace string) bool
 
 	// The cluster-wide issue set is composed at most once per insights request
 	// (lazily, only if a degraded managed resource asks for it) and reused
@@ -696,8 +700,8 @@ type insightsResolver struct {
 	eventIndex map[string][]*corev1.Event
 }
 
-func newInsightsResolver(ctx context.Context, cache *k8s.ResourceCache, allowed []string, canAccess func(group, kind, namespace, name string) bool) *insightsResolver {
-	return &insightsResolver{ctx: ctx, cache: cache, allowedNamespaces: allowed, canAccess: canAccess}
+func newInsightsResolver(ctx context.Context, cache *k8s.ResourceCache, allowed []string, canAccess func(group, kind, namespace, name string) bool, canRead func(group, resource, namespace string) bool) *insightsResolver {
+	return &insightsResolver{ctx: ctx, cache: cache, allowedNamespaces: allowed, canAccess: canAccess, canRead: canRead}
 }
 
 // gitopsLiveGETConcurrency bounds process-wide concurrency of the drift
@@ -855,7 +859,7 @@ func (r *insightsResolver) ResourceProblems(group, kind, namespace, name string)
 		return nil
 	}
 	r.composeOnce.Do(func() {
-		r.composedFlat = issues.Compose(issues.NewCacheProvider(), issues.Filters{Namespaces: r.allowedNamespaces, Limit: issues.NoLimit})
+		r.composedFlat = issues.Compose(issues.NewCacheProvider(), issues.Filters{Namespaces: r.allowedNamespaces, Limit: issues.NoLimit, CanRead: r.canRead})
 		r.composedGrouped = issues.GroupIssues(r.composedFlat)
 	})
 	related := issues.RelatedIssuesFrom(r.composedFlat, r.composedGrouped, group, kind, namespace, name)

--- a/internal/server/gitops_prefetch_test.go
+++ b/internal/server/gitops_prefetch_test.go
@@ -76,7 +76,7 @@ func outOfSyncRow() gitopsinsights.ManagedResourceRow {
 
 func TestPrefetchLiveFetchesOutOfSyncRow(t *testing.T) {
 	dyn := prefetchTestEnv(t)
-	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil, nil)
 	r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
 
 	if got := countGets(dyn); got != 1 {
@@ -101,7 +101,7 @@ func TestPrefetchLiveFetchesOutOfSyncRow(t *testing.T) {
 func TestPrefetchLiveSkipsAllFetchesWhileOperationRuns(t *testing.T) {
 	dyn := prefetchTestEnv(t)
 	for _, phase := range []string{"Running", "Terminating"} {
-		r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+		r := newInsightsResolver(context.Background(), resolverCache(), nil, nil, nil)
 		r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, phase)
 		if got := countGets(dyn); got != 0 {
 			t.Fatalf("phase %s: prefetch issued %d GETs, want 0", phase, got)
@@ -116,7 +116,7 @@ func TestPrefetchLiveSkipsAllFetchesWhileOperationRuns(t *testing.T) {
 // — Argo's own normalization suppresses what a last-applied diff would show.
 func TestPrefetchLiveSkipsCleanlySyncedRows(t *testing.T) {
 	dyn := prefetchTestEnv(t)
-	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, nil, nil)
 	r.prefetchLive([]gitopsinsights.ManagedResourceRow{{
 		Ref:  gitopsinsights.Ref{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"},
 		Sync: "Synced",
@@ -126,7 +126,7 @@ func TestPrefetchLiveSkipsCleanlySyncedRows(t *testing.T) {
 	}
 
 	// A Synced row that recorded a sync error is still worth the fetch.
-	r2 := newInsightsResolver(context.Background(), resolverCache(), nil, nil)
+	r2 := newInsightsResolver(context.Background(), resolverCache(), nil, nil, nil)
 	r2.prefetchLive([]gitopsinsights.ManagedResourceRow{{
 		Ref:          gitopsinsights.Ref{Group: "apps", Kind: "Deployment", Namespace: "prod", Name: "billing"},
 		Sync:         "Synced",
@@ -143,7 +143,7 @@ func TestPrefetchLiveHonorsRBACGatesBeforeFetching(t *testing.T) {
 	dyn := prefetchTestEnv(t)
 
 	denyAll := func(group, kind, namespace, name string) bool { return false }
-	r := newInsightsResolver(context.Background(), resolverCache(), nil, denyAll)
+	r := newInsightsResolver(context.Background(), resolverCache(), nil, denyAll, nil)
 	r.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
 	if got := countGets(dyn); got != 0 {
 		t.Fatalf("prefetch issued %d GETs for access-denied ref, want 0", got)
@@ -153,7 +153,7 @@ func TestPrefetchLiveHonorsRBACGatesBeforeFetching(t *testing.T) {
 	}
 
 	// Namespace allowlist gate: ref outside the allowed set is not fetched.
-	r2 := newInsightsResolver(context.Background(), resolverCache(), []string{"other"}, nil)
+	r2 := newInsightsResolver(context.Background(), resolverCache(), []string{"other"}, nil, nil)
 	r2.prefetchLive([]gitopsinsights.ManagedResourceRow{outOfSyncRow()}, "")
 	if got := countGets(dyn); got != 0 {
 		t.Fatalf("prefetch issued %d GETs for ref outside namespace allowlist, want 0", got)

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -106,6 +106,9 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 			}
 			return s.canRead(r, gvrGroup, gvrResource, "", "list")
 		},
+		CanRead: func(group, resource, namespace string) bool {
+			return s.canRead(r, group, resource, namespace, "list")
+		},
 	}
 	if expr := q.Get("filter"); expr != "" {
 		f, err := filter.CachedIssueFilter(expr)
@@ -251,7 +254,7 @@ func (s *Server) handleResourceIssues(w http.ResponseWriter, r *http.Request) {
 		namespaces = []string{namespace}
 	}
 
-	related := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name)
+	related := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") })
 	if related == nil {
 		related = []issues.Issue{}
 	}

--- a/internal/server/search_handler.go
+++ b/internal/server/search_handler.go
@@ -127,7 +127,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// (CanReadClusterScoped) already constrains which cluster-scoped
 	// kinds are reachable.
 	if r.URL.Query().Get("context") != "none" {
-		if builder := s.newSearchSummaryContextBuilder(scanNamespaces); builder != nil {
+		if builder := s.newSearchSummaryContextBuilder(scanNamespaces, func(g, res, ns string) bool { return s.canRead(r, g, res, ns, "list") }); builder != nil {
 			opts.SummaryBuilder = search.SummaryBuilderFunc(builder)
 		}
 	}

--- a/internal/server/summary_context.go
+++ b/internal/server/summary_context.go
@@ -27,12 +27,12 @@ import (
 // Use newSearchSummaryContextBuilder for search, which routes per-hit
 // between a namespaced and a cluster-wide index — search returns mixed
 // kinds in one response, so a single index can't get both right.
-func (s *Server) newResourceSummaryContextBuilder(namespaces []string) summarycontext.Builder {
+func (s *Server) newResourceSummaryContextBuilder(namespaces []string, canRead func(group, resource, namespace string) bool) summarycontext.Builder {
 	provider := issues.NewCacheProvider()
 	if provider == nil {
 		return nil
 	}
-	idx := summarycontext.BuildIssueIndex(provider, namespaces)
+	idx := summarycontext.BuildIssueIndex(provider, namespaces, canRead)
 	return summarycontext.BuilderFromIndexes(s.broadcaster.GetCachedTopology(), idx, idx)
 }
 
@@ -56,15 +56,15 @@ func (s *Server) newResourceSummaryContextBuilder(namespaces []string) summaryco
 // The cluster-wide index is skipped when scanNamespaces is already nil
 // (cluster-wide user) — both indexes would be identical, so one pass
 // suffices.
-func (s *Server) newSearchSummaryContextBuilder(scanNamespaces []string) summarycontext.Builder {
+func (s *Server) newSearchSummaryContextBuilder(scanNamespaces []string, canRead func(group, resource, namespace string) bool) summarycontext.Builder {
 	provider := issues.NewCacheProvider()
 	if provider == nil {
 		return nil
 	}
-	namespacedIdx := summarycontext.BuildIssueIndex(provider, scanNamespaces)
+	namespacedIdx := summarycontext.BuildIssueIndex(provider, scanNamespaces, canRead)
 	clusterIdx := namespacedIdx
 	if scanNamespaces != nil {
-		clusterIdx = summarycontext.BuildIssueIndex(provider, nil)
+		clusterIdx = summarycontext.BuildIssueIndex(provider, nil, canRead)
 	}
 	return summarycontext.BuilderFromIndexes(s.broadcaster.GetCachedTopology(), namespacedIdx, clusterIdx)
 }

--- a/internal/summarycontext/attach.go
+++ b/internal/summarycontext/attach.go
@@ -4,8 +4,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 	"github.com/skyhook-io/radar/internal/k8s"
+	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 )
 
 // AttachToTypedList fills in SummaryContext for each *aicontext.ResourceSummary

--- a/internal/summarycontext/summarycontext.go
+++ b/internal/summarycontext/summarycontext.go
@@ -186,10 +186,14 @@ func CanonicalSingular(kind string) string {
 // engine emits "Application", silently zeroing issueCount on every CRD
 // row. Bucketing is O(N) over the at-most-namespace-bounded issue set,
 // which the consumer materialises anyway.
-func BuildIssueIndex(p issues.Provider, namespaces []string) IssueIndex {
+// canRead gates cross-kind evidence (e.g. StaleSecretEnv counts, derived from a
+// referenced Secret's history) so the issue COUNT can't side-channel an issue
+// the caller couldn't read directly; pass nil when auth is off.
+func BuildIssueIndex(p issues.Provider, namespaces []string, canRead func(group, resource, namespace string) bool) IssueIndex {
 	filters := issues.Filters{
 		Namespaces: namespaces,
 		Limit:      issues.NoLimit,
+		CanRead:    canRead,
 	}
 	// Compose FLAT (uncapped): every evidence row carries the grouped issue ID
 	// (enrichIdentity keys it on owner-else-self + category) and its resolved

--- a/internal/summarycontext/summarycontext_test.go
+++ b/internal/summarycontext/summarycontext_test.go
@@ -112,7 +112,7 @@ func TestBuildIssueIndex_GroupAware(t *testing.T) {
 			{Kind: "Service", Group: "serving.knative.dev", Namespace: "prod", Name: "api", Reason: "RouteNotReady", Severity: "warning"},
 		},
 	}
-	idx := BuildIssueIndex(p, nil)
+	idx := BuildIssueIndex(p, nil, nil)
 	// The index counts GROUPED issues (consistent with the issues tool), not flat
 	// rows: the two Knative rows share subject+category and fold into one grouped
 	// issue → count 1. The core Service is a distinct group → its own key (the
@@ -138,7 +138,7 @@ func TestBuildIssueIndex_GroupedSubjectPropagation(t *testing.T) {
 				OwnerGroup: "apps", OwnerKind: "Deployment", OwnerName: "web"},
 		},
 	}
-	idx := BuildIssueIndex(p, nil)
+	idx := BuildIssueIndex(p, nil, nil)
 	if got := idx.Count("apps", "Deployment", "prod", "web"); got != 1 {
 		t.Errorf("owning Deployment count = %d, want 1 (Pod-evidenced issue must surface on the grouped subject)", got)
 	}
@@ -161,7 +161,7 @@ func TestBuildIssueIndex_BeyondMaxLimit(t *testing.T) {
 		})
 	}
 	p := &fakeIssuesProvider{problems: probs}
-	idx := BuildIssueIndex(p, nil)
+	idx := BuildIssueIndex(p, nil, nil)
 	tailName := fmtPodName(issues.MaxLimit + 25)
 	if got := idx.Count("", "Pod", "prod", tailName); got != 1 {
 		t.Fatalf("tail pod %s count = %d, want 1 (silent MaxLimit truncation?)", tailName, got)
@@ -205,7 +205,7 @@ func TestBuildIssueIndex_ClusterScopedIssueSurfacedWhenUnfiltered(t *testing.T) 
 	}
 
 	// Cluster-wide compose (nil namespaces) — issue surfaces.
-	idx := BuildIssueIndex(p, nil)
+	idx := BuildIssueIndex(p, nil, nil)
 	if got := idx.Count("", "Node", "", "worker-1"); got != 1 {
 		t.Errorf("cluster-wide index: Node issueCount = %d, want 1 (cluster-scoped issue should appear)", got)
 	}
@@ -214,7 +214,7 @@ func TestBuildIssueIndex_ClusterScopedIssueSurfacedWhenUnfiltered(t *testing.T) 
 	// ["prod","staging"] drops it because the user-namespaced perm
 	// slice never matches "". This is what the pre-fix handler did for
 	// Node lists.
-	scopedIdx := BuildIssueIndex(p, []string{"prod", "staging"})
+	scopedIdx := BuildIssueIndex(p, []string{"prod", "staging"}, nil)
 	if got := scopedIdx.Count("", "Node", "", "worker-1"); got != 0 {
 		t.Errorf("namespace-scoped index: Node issueCount = %d, want 0 (namespace filter drops cluster-scoped issue)", got)
 	}
@@ -243,7 +243,7 @@ func TestBuildIssueIndex_CRDPlural_NonZeroCount(t *testing.T) {
 	// Pre-fix simulation: the handler would have passed kindFilter="applications"
 	// — the URL plural. We no longer take a kindFilter, but verify that
 	// the index contains the row keyed by the canonical singular form.
-	idx := BuildIssueIndex(p, []string{"argocd"})
+	idx := BuildIssueIndex(p, []string{"argocd"}, nil)
 	if got := idx.Count("argoproj.io", "Application", "argocd", "storefront"); got != 1 {
 		t.Errorf("CRD Application count (singular kind) = %d, want 1", got)
 	}
@@ -276,8 +276,8 @@ func TestNewSearchSummaryContextBuilder_BuildsDualIndex(t *testing.T) {
 	}
 
 	// Build the two indexes the search constructor would build.
-	namespacedIdx := BuildIssueIndex(p, []string{"prod"})
-	clusterIdx := BuildIssueIndex(p, nil)
+	namespacedIdx := BuildIssueIndex(p, []string{"prod"}, nil)
+	clusterIdx := BuildIssueIndex(p, nil, nil)
 
 	// Sanity: pre-fix, the search handler passed namespacedIdx for
 	// both; Node issueCount silently zeroed.


### PR DESCRIPTION
## Problem

Issues are computed by detectors running as the cache **ServiceAccount** (which sees everything) and served filtered by **namespace only** — never by whether the caller can read the specific kind an issue's evidence was *derived from*. Two HIGH cross-kind leaks (from the timeline-RBAC audit):

- **StaleSecretEnv** — entirely derived from a referenced **Secret**'s change history: the Secret's existence, its data **key names** (for `envFrom` consumers — not in the pod spec), and the **rotation timing**. A user who can read a Pod but not Secrets in its namespace still received them.
- **Unschedulable** — embedded cluster-scoped **Node label values**: the scheduling explainer enumerated what the fleet's nodes carry for the offending label (zones, instance types, tenancy/internal labels), leaking node topology to a namespaced pod-reader who can't `list nodes`.

Auth is only active for multi-user deployments; with no user on the request the predicates pass through, so **single-user behavior is unchanged**.

## Fix

**StaleSecretEnv** — a new `Filters.CanRead(group, resource, namespace)` (namespaced per-kind SAR) + `applyCrossKindEvidenceAccess`, which drops StaleSecretEnv rows when the caller can't read Secrets in the issue's namespace. Because issue serving fans out across many compose paths, the predicate is threaded through **every** one so the gate can't be bypassed:
- `/api/issues` (grouped + flat) and MCP `issues`
- `RelatedIssues` — per-resource issue summaries: REST `/api/issues/resource`, AI + MCP `get_resource`/`diagnose`, mutation-verification
- `BuildIssueIndex` — issue *counts* in search / `list_resources` (REST + MCP summary-context)
- GitOps insights `ResourceProblems`

**Unschedulable node labels** — the scheduling explainer (`explainMissingLabel`/`explainMissingExpr`) now reports only the pod's **own** unsatisfiable requirement (`no node has disktype=ssd`) and drops the fleet-value enumeration (`— N node(s) carry disktype: [hdd, nvme]`) for all callers. The node values are low-value diagnostic color and cluster-scoped Node content, so removing them (rather than per-user redaction) is the simplest complete fix.

## Tests
- `internal/issues/cross_kind_access_test.go` — StaleSecretEnv dropped when secrets unreadable in the namespace; unrelated issues + authorized callers + nil predicate untouched.
- `internal/k8s/detect_scheduling*_test.go` — updated to assert the redacted message **and** that the fleet value is now absent (regression pins).
- **e2e** (`kind` + proxy auth): a namespaced viewer with no node RBAC gets their pod's Unschedulable issue as `no node has disktype=ssd` — the fleet value `hdd` is **not** present. Passes.
- `go build`, `go vet`, `go test ./...` green (main + `pkg`).

## Scope
The two **HIGH** findings from the audit. The audit's lower-severity items (namespace-wide quota text for Job/SS/DS, Service port lists, OOM→owning-RS limit, deploymentChangeContext rollout, and trivial count leaks) are tracked as a follow-up.

https://claude.ai/code/session_01XNhMe6Zdqwj5EoBazNDnmW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization and data exposure across the issues pipeline, REST, MCP, and GitOps surfaces—security-sensitive RBAC and information-leak fixes that must stay consistent on every compose path.
> 
> **Overview**
> Closes RBAC gaps where issues were namespace-filtered but still exposed **evidence from kinds the caller cannot read**, and where **Unschedulable** text leaked cluster node label values to namespaced readers.
> 
> **StaleSecretEnv** — Adds `Filters.CanRead` (SAR-backed per-kind read) and `applyCrossKindEvidenceAccess`, which drops `StaleSecretEnv` rows when the user cannot list **secrets** in the issue namespace. The predicate is threaded through compose, `RelatedIssues`, issue indexes (`BuildIssueIndex`), REST `/api/issues`, MCP `issues` / `get_resource` / `diagnose` / list/search summary context, GitOps insights `ResourceProblems`, and mutation verification so the gate cannot be bypassed on a side path. `nil` `CanRead` preserves auth-off and tests.
> 
> **Unschedulable messaging** — `explainMissingLabel` / `explainMissingExpr` now state only the pod’s own unsatisfiable selector/affinity (e.g. `no node has kubernetes.io/arch=arm64`) and **no longer enumerate** what nodes in the fleet actually carry (zones, arch values, etc.).
> 
> Tests cover secret gating and scheduling message redaction; existing call sites pass SAR `canRead` from server/MCP handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7d64219413ed4c709ed332d9c937b43305b0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->