### PR TITLE
fix(auth): constrain Cloud-forwarded identities before impersonation

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -32,16 +32,17 @@ const ErrCodeCloudRoleInsufficient = pkgauth.ErrCodeCloudRoleInsufficient
 
 // Re-export functions from pkg/auth
 var (
-	UserFromContext         = pkgauth.UserFromContext
-	ContextWithUser         = pkgauth.ContextWithUser
-	NewPermissionCache      = pkgauth.NewPermissionCache
-	DiscoverNamespaces      = pkgauth.DiscoverNamespaces
-	SubjectCanI             = pkgauth.SubjectCanI
-	FilterNamespacesForUser = pkgauth.FilterNamespacesForUser
-	NewSessionID            = pkgauth.NewSessionID
-	CreateSessionCookie     = pkgauth.CreateSessionCookie
-	ParseSessionCookie      = pkgauth.ParseSessionCookie
-	ClearSessionCookie      = pkgauth.ClearSessionCookie
-	CloudRoleFromGroups     = pkgauth.CloudRoleFromGroups
-	CloudRoleFromContext    = pkgauth.CloudRoleFromContext
+	UserFromContext          = pkgauth.UserFromContext
+	ContextWithUser          = pkgauth.ContextWithUser
+	NewPermissionCache       = pkgauth.NewPermissionCache
+	DiscoverNamespaces       = pkgauth.DiscoverNamespaces
+	SubjectCanI              = pkgauth.SubjectCanI
+	FilterNamespacesForUser  = pkgauth.FilterNamespacesForUser
+	NewSessionID             = pkgauth.NewSessionID
+	CreateSessionCookie      = pkgauth.CreateSessionCookie
+	ParseSessionCookie       = pkgauth.ParseSessionCookie
+	ClearSessionCookie       = pkgauth.ClearSessionCookie
+	CloudRoleFromGroups      = pkgauth.CloudRoleFromGroups
+	CloudRoleFromContext     = pkgauth.CloudRoleFromContext
+	ForwardedIdentityAllowed = pkgauth.ForwardedIdentityAllowed
 )

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -112,6 +112,23 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 						}
 					}
 
+					// Under Cloud, constrain what Radar will impersonate: reject
+					// reserved K8s principals (system:masters etc.) and anything
+					// outside the radar:/cloud: group vocabulary. The SA's
+					// impersonate grant is cluster-scoped and can't express this,
+					// so it's enforced here or nowhere. No-op outside Cloud — the
+					// operator owns their proxy/OIDC identity chain. Reject the
+					// whole request; a bad principal from the tunnel is an anomaly.
+					if !ForwardedIdentityAllowed(username, groups, cloudProxyMode) {
+						log.Printf("[auth] rejected forwarded identity with disallowed principal (user=%q, cloud=%v)", username, cloudProxyMode)
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusForbidden)
+						json.NewEncoder(w).Encode(map[string]string{
+							"error": "forwarded identity asserts a disallowed principal",
+						})
+						return
+					}
+
 					user := &User{Username: username, Groups: groups}
 					if !cloudProxyMode {
 						cookies := CreateSessionCookie(user, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, secure)

--- a/pkg/auth/identity_filter.go
+++ b/pkg/auth/identity_filter.go
@@ -1,0 +1,87 @@
+package auth
+
+import "strings"
+
+// Forwarded-identity filtering applies ONLY under Radar Cloud. In OSS proxy /
+// OIDC modes the operator owns the entire identity chain (their proxy or IdP
+// is the configured trust root), so Radar forwards whatever they assert. Under
+// Cloud, the control plane is the asserting party over the tunnel, so Radar
+// constrains what it will impersonate — the SA's `impersonate` grant is
+// cluster-scoped and K8s RBAC can't restrict it to a prefix, making this
+// acceptance point the only place the constraint can live.
+
+// reservedPrincipalPrefixes are Kubernetes-reserved identity namespaces a
+// Cloud-forwarded identity must never assert. Blocking them removes the
+// worst-case escalation ceiling (system:masters, the kubelet/node identity,
+// any ServiceAccount that may hold powers beyond the owner tier). It does NOT
+// contain a control plane that asserts an ordinary radar: tier — that's
+// bounded by the tier's own RBAC — and is deliberately not sold as such.
+var reservedPrincipalPrefixes = []string{
+	"system:", // system:masters, system:authenticated, system:nodes, system:serviceaccounts, …
+}
+
+// IsReservedPrincipal reports whether a username or group falls in a reserved
+// Kubernetes namespace. Matched as an exact leading prefix so Radar's own
+// namespaced synthetic principals (e.g. "cloud:system:alerts:…") are
+// unaffected — only leading "system:" is reserved.
+func IsReservedPrincipal(principal string) bool {
+	for _, p := range reservedPrincipalPrefixes {
+		if strings.HasPrefix(principal, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// radarVocabularyPrefixes are the group namespaces the Radar Cloud control
+// plane legitimately injects. A compromised hub can still assert an ordinary
+// radar: tier, but cannot introduce identities outside the vocabulary the
+// chart binds.
+var radarVocabularyPrefixes = []string{"radar:", "cloud:"}
+
+// IsRadarVocabularyGroup reports whether a group is in the Radar Cloud group
+// vocabulary (radar:* canonical or cloud:* legacy).
+func IsRadarVocabularyGroup(group string) bool {
+	for _, p := range radarVocabularyPrefixes {
+		if strings.HasPrefix(group, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ForwardedIdentityAllowed decides whether a forwarded (username, groups)
+// identity may be impersonated. Outside Cloud it always returns true — the
+// operator owns the identity chain. Under Cloud it enforces both:
+//
+//   - reserved-principal rejection: username and every group must be outside
+//     the reserved K8s namespaces (blocks system:masters etc.);
+//   - vocabulary allowlist: username must be a Cloud identity and every group
+//     must be radar:*/cloud:*.
+//
+// Returns false to reject the whole request (never silently drops values — a
+// reserved or out-of-vocabulary principal from the tunnel is an anomaly).
+func ForwardedIdentityAllowed(username string, groups []string, cloudMode bool) bool {
+	if !cloudMode {
+		return true
+	}
+	if IsReservedPrincipal(username) || !isCloudUsername(username) {
+		return false
+	}
+	for _, g := range groups {
+		if IsReservedPrincipal(g) || !IsRadarVocabularyGroup(g) {
+			return false
+		}
+	}
+	return true
+}
+
+// isCloudUsername reports whether a username is one the Radar Cloud control
+// plane legitimately injects: the opaque per-user id the hub sets as
+// X-Forwarded-User, or an internal synthetic principal namespaced under
+// "cloud:system:". The hub never forwards a K8s-reserved username, so
+// rejecting reserved is the meaningful check; the opaque WorkOS id has no
+// fixed prefix to match beyond "non-empty and not reserved".
+func isCloudUsername(username string) bool {
+	return username != "" && !IsReservedPrincipal(username)
+}

--- a/pkg/auth/identity_filter_test.go
+++ b/pkg/auth/identity_filter_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import "testing"
+
+func TestForwardedIdentityAllowed(t *testing.T) {
+	cases := []struct {
+		name      string
+		username  string
+		groups    []string
+		cloudMode bool
+		want      bool
+	}{
+		// Outside Cloud: operator owns the identity chain — never filtered,
+		// including reserved principals a real admin legitimately carries.
+		{"non-cloud: ordinary identity allowed", "alice@company.com", []string{"sre-team"}, false, true},
+		{"non-cloud: system:masters allowed (operator's cluster)", "admin", []string{"system:masters"}, false, true},
+		{"non-cloud: unprefixed groups allowed", "alice", []string{"platform", "sre"}, false, true},
+
+		// Cloud: reserved-principal rejection.
+		{"cloud: system:masters group rejected", "user_01ABC", []string{"radar:owner", "system:masters"}, true, false},
+		{"cloud: system username rejected", "system:node:x", []string{"radar:owner"}, true, false},
+		{"cloud: serviceaccount group rejected", "user_01ABC", []string{"system:serviceaccounts:kube-system"}, true, false},
+
+		// Cloud: vocabulary allowlist.
+		{"cloud: radar tier allowed", "user_01ABC", []string{"radar:owner", "radar:org:o1", "radar:user:u1"}, true, true},
+		{"cloud: legacy cloud tier allowed", "user_01ABC", []string{"cloud:viewer", "cloud:org:o1"}, true, true},
+		{"cloud: radar:idp group allowed", "user_01ABC", []string{"radar:idp:f81d4fae"}, true, true},
+		{"cloud: radar:email allowed", "user_01ABC", []string{"radar:email:a@b.com"}, true, true},
+		{"cloud: non-vocabulary group rejected", "user_01ABC", []string{"radar:owner", "sre-team"}, true, false},
+		{"cloud: empty username rejected", "", []string{"radar:owner"}, true, false},
+		{"cloud: internal synthetic username allowed", "cloud:system:alerts:o1", []string{"radar:owner"}, true, true},
+		{"cloud: no groups, valid user, allowed", "user_01ABC", nil, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ForwardedIdentityAllowed(tc.username, tc.groups, tc.cloudMode)
+			if got != tc.want {
+				t.Errorf("ForwardedIdentityAllowed(%q, %v, cloud=%v) = %v, want %v",
+					tc.username, tc.groups, tc.cloudMode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsReservedPrincipal(t *testing.T) {
+	reserved := []string{"system:masters", "system:authenticated", "system:node:x", "system:serviceaccount:kube-system:default", "system:serviceaccounts"}
+	for _, p := range reserved {
+		if !IsReservedPrincipal(p) {
+			t.Errorf("IsReservedPrincipal(%q) = false, want true", p)
+		}
+	}
+	// Radar's own namespaced synthetic principals must NOT be treated as reserved.
+	notReserved := []string{"cloud:system:alerts:o1", "cloud:system", "radar:owner", "alice@company.com", "sre-team", ""}
+	for _, p := range notReserved {
+		if IsReservedPrincipal(p) {
+			t.Errorf("IsReservedPrincipal(%q) = true, want false", p)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Under Radar Cloud, the control plane asserts each user's identity over the tunnel and the in-cluster agent impersonates the forwarded `X-Forwarded-User`/`-Groups` against the apiserver. The SA's `impersonate users/groups` grant is **cluster-scoped** — K8s RBAC can't restrict impersonation to a prefix (`resourceNames` is exact-match, no wildcards). So a forwarded identity asserting `system:masters` can only be stopped **at the point Radar accepts it**. Nothing did.

## What

`ForwardedIdentityAllowed(username, groups, cloudMode)` in `pkg/auth`, called in the proxy-mode branch of the auth middleware. **Cloud mode only** — two checks:

- **Reserved-principal rejection**: reject any username/group in a K8s-reserved namespace (`system:*` → masters, nodes, service accounts).
- **Vocabulary allowlist**: username must be a Cloud identity; every group must be `radar:*`/`cloud:*`.

Rejects the whole request (403), never silently drops values.

## Scope: Cloud only, by design

Outside Cloud (OSS proxy / OIDC) this is a **no-op**. There the operator owns the entire identity chain — their proxy or IdP is the configured trust root, and real cluster admins legitimately arrive in `system:masters` (K8s binds `cluster-admin` to that group by default). Filtering there would break legitimate deployments for marginal benefit on a boundary the customer already controls. The constraint belongs where **we** are the asserting party.

## Honest scope of the security value

Removes the **worst-case escalation ceiling** — a compromised or bugged hub can't make Radar impersonate `system:masters` or a privileged ServiceAccount. It does **not** contain a hub that asserts an ordinary `radar:owner` (that's bounded by the tier's own RBAC). Defense-in-depth, labeled as such.

## Safety

Radar's synthetic identities (`cloud:system:alerts:<org>`, `radar:system`) are namespaced under `cloud:`/`radar:`, not `system:`, so they pass — covered by tests. OSS behavior is unchanged (no-op).

## Tests

Cloud/non-cloud × reserved × vocabulary × synthetic-identity table (`pkg/auth`); the standalone proxy-auth tests that forward `system:masters` pass unchanged (non-cloud = no filter); `go vet` + `go build ./...` + chart tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the authentication boundary for Radar Cloud impersonation and blocks certain forwarded principals; incorrect allow/deny logic could break legitimate Cloud users or leave escalation paths open.
> 
> **Overview**
> Adds a **Cloud-only gate** on forwarded `X-Forwarded-User` / group headers before Radar builds the impersonation identity. In proxy mode, if the tunneled request asserts a disallowed principal, the middleware returns **403** instead of accepting the identity.
> 
> **`ForwardedIdentityAllowed`** in `pkg/auth` enforces two checks when `cloudProxyMode` is true: reject any username or group with a leading **`system:`** reserved prefix (e.g. `system:masters`), and require every group to be **`radar:*` or `cloud:*`** with a non-empty, non-reserved username. Synthetic principals like `cloud:system:alerts:…` stay allowed because only leading `system:` counts as reserved.
> 
> **OSS / standalone proxy** paths skip filtering (`cloudMode` false) so operators can forward their own IdP/proxy groups unchanged. The helper is re-exported from `internal/auth` and wired into the existing proxy-header branch of **`Authenticate`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04fe12a2707707871321a6794cf39ebb9985b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->