### PR TITLE
Publish Radar to the official MCP registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,36 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
 
+  mcp-registry:
+    name: MCP Registry
+    runs-on: ubuntu-latest
+    # Needs the labeled image on GHCR first — the registry validates the
+    # io.modelcontextprotocol.server.name label on the exact tag in server.json.
+    needs: [release, docker]
+    if: needs.release.outputs.is_prerelease != 'true'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Stamp version into server.json
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          jq --arg v "$VERSION" --arg repo "${{ env.DOCKER_REPO }}" \
+            '.version = $v | .packages[0].identifier = $repo + ":" + $v' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
   helm:
     name: Helm Chart
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,18 @@ jobs:
             '.version = $v | .packages[0].identifier = $repo + ":" + $v' \
             server.json > server.json.tmp && mv server.json.tmp server.json
 
+      # Pinned + checksum-verified: this job holds id-token: write, so a
+      # mutable "latest" binary would be an unauditable path to our registry
+      # namespace. Bump the version and hash together (checksums file:
+      # registry_<ver>_checksums.txt on the modelcontextprotocol/registry release).
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: "1.8.0"
+          MCP_PUBLISHER_SHA256: "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ LABEL org.opencontainers.image.title="Radar"
 LABEL org.opencontainers.image.description="Modern Kubernetes visibility — topology, traffic, and Helm management"
 LABEL org.opencontainers.image.source="https://github.com/skyhook-io/radar"
 LABEL org.opencontainers.image.vendor="Skyhook"
+# Ownership proof for the official MCP registry — must match the name in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"
 
 COPY --from=backend-builder /radar /radar
 
@@ -88,6 +90,8 @@ LABEL org.opencontainers.image.title="Radar"
 LABEL org.opencontainers.image.description="Modern Kubernetes visibility — topology, traffic, and Helm management"
 LABEL org.opencontainers.image.source="https://github.com/skyhook-io/radar"
 LABEL org.opencontainers.image.vendor="Skyhook"
+# Ownership proof for the official MCP registry — must match the name in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"
 
 ARG TARGETARCH
 COPY radar-${TARGETARCH} /radar

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -176,6 +176,25 @@ Add to `~/.gemini/settings.json`:
 }
 ```
 
+## MCP Registry / Docker
+
+Radar is listed on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.skyhook-io/radar`, packaged as the `ghcr.io/skyhook-io/radar` Docker image. The registry-suggested invocation is:
+
+```bash
+docker run -p 127.0.0.1:9280:9280 \
+  -v ~/.kube/config:/kubeconfig:ro \
+  -e KUBECONFIG=/kubeconfig \
+  ghcr.io/skyhook-io/radar:latest
+```
+
+**Prefer the native install** (`brew install skyhook-io/tap/radar`, krew, or the install script — see the [README](../README.md)) — it uses your kubeconfig exactly as kubectl does. The Docker path has real limitations because the image is distroless (no shell, no cloud CLIs):
+
+- **Exec-plugin auth does not work.** Kubeconfigs for GKE/EKS/AKS typically call `gke-gcloud-auth-plugin`, `aws eks get-token`, or `kubelogin` — none exist inside the container. Only kubeconfigs with embedded certificates or static tokens work.
+- **Local clusters are unreachable.** kind/minikube/Docker Desktop API servers listen on the host's `127.0.0.1`, which inside the container is the container itself.
+- **File ownership matters.** On Linux hosts a `0600` kubeconfig owned by your user is unreadable by the container's `nonroot` (uid 65532) user.
+
+The Docker image's primary use is [in-cluster deployment](in-cluster.md) with a ServiceAccount, where none of these apply.
+
 ## Available Tools
 
 ### Read Tools

--- a/server.json
+++ b/server.json
@@ -20,7 +20,7 @@
           "name": "-p",
           "value": "127.0.0.1:9280:9280",
           "isRequired": true,
-          "description": "Expose Radar's HTTP server (UI + MCP) on localhost:9280 only"
+          "description": "Expose Radar's HTTP server (UI + MCP) on 127.0.0.1:9280 only"
         },
         {
           "type": "named",
@@ -47,7 +47,7 @@
       ],
       "transport": {
         "type": "streamable-http",
-        "url": "http://localhost:9280/mcp"
+        "url": "http://127.0.0.1:9280/mcp"
       }
     }
   ]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.skyhook-io/radar",
+  "title": "Radar",
+  "description": "Kubernetes visibility for AI agents: query workloads, events, logs, topology, and Helm releases.",
+  "repository": {
+    "url": "https://github.com/skyhook-io/radar",
+    "source": "github"
+  },
+  "websiteUrl": "https://radarhq.io",
+  "version": "1.8.6",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/skyhook-io/radar:1.8.6",
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-p",
+          "value": "9280:9280",
+          "isRequired": true,
+          "description": "Expose Radar's HTTP server (UI + MCP) on localhost:9280"
+        },
+        {
+          "type": "named",
+          "name": "-v",
+          "value": "{kubeconfig_path}:/kubeconfig:ro",
+          "isRequired": true,
+          "description": "Mount your kubeconfig into the container (read-only)",
+          "variables": {
+            "kubeconfig_path": {
+              "description": "Path to your kubeconfig file on the host",
+              "format": "filepath",
+              "default": "~/.kube/config",
+              "isRequired": true
+            }
+          }
+        },
+        {
+          "type": "named",
+          "name": "-e",
+          "value": "KUBECONFIG=/kubeconfig",
+          "isRequired": true,
+          "description": "Point Radar at the mounted kubeconfig"
+        }
+      ],
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:9280/mcp"
+      }
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -18,9 +18,9 @@
         {
           "type": "named",
           "name": "-p",
-          "value": "9280:9280",
+          "value": "127.0.0.1:9280:9280",
           "isRequired": true,
-          "description": "Expose Radar's HTTP server (UI + MCP) on localhost:9280"
+          "description": "Expose Radar's HTTP server (UI + MCP) on localhost:9280 only"
         },
         {
           "type": "named",

--- a/server.json
+++ b/server.json
@@ -30,9 +30,8 @@
           "description": "Mount your kubeconfig into the container (read-only)",
           "variables": {
             "kubeconfig_path": {
-              "description": "Path to your kubeconfig file on the host",
+              "description": "Absolute path to your kubeconfig file on the host, e.g. /home/you/.kube/config (a leading ~ is not expanded when the client execs docker directly)",
               "format": "filepath",
-              "default": "~/.kube/config",
               "isRequired": true
             }
           }


### PR DESCRIPTION
## What

Wires Radar into the [official MCP registry](https://registry.modelcontextprotocol.io) so aggregators (PulseMCP, etc.) pick it up automatically. Three pieces, all required by the registry for OCI-packaged servers:

1. **`Dockerfile`** — `LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"` on both the `full` and `release` stages. This is the registry's ownership proof for the ghcr.io image; the value must match the server name in `server.json`. (Verified the registry validator reads image-config labels, so buildx multi-arch manifest lists validate fine.)
2. **`server.json`** — the registry manifest: OCI package pointing at `ghcr.io/skyhook-io/radar:<version>`, streamable-http transport at `http://localhost:9280/mcp`, and docker runtime args. The port mapping is bound to `127.0.0.1` explicitly — Radar's standalone binary is loopback-only by default, and a bare `-p 9280:9280` would re-expose the unauthenticated UI + MCP on all host interfaces.
3. **`.github/workflows/release.yml`** — new `mcp-registry` job: stamps the release version into `server.json` (version + image tag), then `mcp-publisher login github-oidc && mcp-publisher publish`. OIDC needs no secrets — the registry grants `io.github.skyhook-io/*` publish rights to any workflow running in a skyhook-io repo (verified in the registry's `github_oidc.go`). Skipped for pre-releases; ordered after the `docker` job because the registry validates the label on the exact image tag referenced in `server.json`. `mcp-publisher` is **pinned + SHA-256-verified** (the job holds `id-token: write`, so a mutable `latest` download would be an unauditable path into our registry namespace); bump version and hash together.

Also adds a **docs/mcp.md** section documenting the registry-suggested Docker invocation and its honest limits (distroless image → no exec-plugin auth for GKE/EKS/AKS kubeconfigs, loopback API servers unreachable, kubeconfig file-ownership on Linux), steering users to the native brew/krew install.

## Verified

- `mcp-publisher validate` passes against the live registry for both the committed `server.json` and the CI-stamped variant.
- Pinned publisher tarball downloaded and checksum-verified locally against the upstream release checksums file.
- Workflow YAML parses; jq stamp command tested with a fake version.
- Cross-reviewed (Codex adversarial): pinning finding fixed, Docker-path limitation documented, org-wide OIDC namespace grant accepted as a known trade-off (the DNS-auth alternative requires a long-lived private-key secret and changes the public server name).

## Notes

- Nothing publishes until the next release tag — the committed `server.json` references `1.8.6` as a placeholder, but that image predates the label, so the first *real* registry entry will be the first release cut after this merges.
- Registry requirements sourced from `modelcontextprotocol/registry` docs: package-types (OCI label), github-actions (OIDC publish flow), authentication (namespace rules).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release CI with OIDC publish rights and supply-chain-sensitive publisher install, plus public registry metadata and Docker labels tied to image ownership—not runtime cluster logic.
> 
> **Overview**
> Adds **official MCP registry** publishing so Radar can be discovered as `io.github.skyhook-io/radar` with the `ghcr.io/skyhook-io/radar` OCI package.
> 
> **`server.json`** defines the registry manifest: versioned image tag, streamable-http transport at `http://127.0.0.1:9280/mcp`, and required Docker args (loopback-only port bind, kubeconfig mount, `KUBECONFIG`).
> 
> **`Dockerfile`** adds `io.modelcontextprotocol.server.name` on both `full` and `release` image stages so the registry can verify ownership against that manifest.
> 
> **Release workflow** adds an `mcp-registry` job (stable releases only, after Docker push): stamps version into `server.json`, installs **pinned and SHA-verified** `mcp-publisher`, authenticates via GitHub OIDC, and publishes.
> 
> **`docs/mcp.md`** documents the registry Docker invocation and steers users toward native install when exec-plugin auth, local clusters, or kubeconfig permissions make the container path impractical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820aca51da83d83337824e543b3707f13e3716c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->