### PR TITLE
chart(radar): guard HTTPRoute config and align chart conventions

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -97,6 +97,11 @@ Override `httpRoute.apiVersion` when cluster Gateway API support requires a
 different version, for example `gateway.networking.k8s.io/v1beta1`. Custom
 rules can define their own `timeouts` independently.
 
+`httpRoute` and `ingress` are mutually exclusive - enabling both fails the
+render. `httpRoute.enabled` requires at least one `parentRefs` entry (the
+Gateway to attach to), otherwise the render fails rather than emit a route
+bound to no Gateway.
+
 ### Connecting to Radar Cloud
 
 To connect Radar to Radar Cloud (hosted SaaS), follow the install wizard at

--- a/deploy/helm/radar/templates/httproute.yaml
+++ b/deploy/helm/radar/templates/httproute.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.httpRoute.enabled -}}
+{{- if .Values.ingress.enabled -}}
+{{- fail "Enable only ONE of ingress.enabled or httpRoute.enabled, not both." -}}
+{{- end -}}
+{{- if not .Values.httpRoute.parentRefs -}}
+{{- fail "httpRoute.enabled=true requires at least one httpRoute.parentRefs entry (the Gateway to attach to)." -}}
+{{- end -}}
 {{- $fullName := include "radar.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := mergeOverwrite (include "radar.labels" . | fromYaml) .Values.httpRoute.labels -}}
@@ -15,8 +21,10 @@ metadata:
 spec:
   parentRefs:
     {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     {{- if .Values.httpRoute.rules }}
     {{- toYaml .Values.httpRoute.rules | nindent 4 }}

--- a/deploy/helm/radar/templates/ingress.yaml
+++ b/deploy/helm/radar/templates/ingress.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled -}}
+{{- if .Values.httpRoute.enabled -}}
+{{- fail "Enable only ONE of ingress.enabled or httpRoute.enabled, not both." -}}
+{{- end -}}
 {{- $fullName := include "radar.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1

--- a/deploy/helm/radar/tests/httproute_test.yaml
+++ b/deploy/helm/radar/tests/httproute_test.yaml
@@ -7,11 +7,12 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders default route to Radar Service with empty hostnames
+  - it: renders default route to Radar Service and omits empty hostnames
     set:
       httpRoute:
         enabled: true
-        parentRefs: []
+        parentRefs:
+          - name: public-gateway
         hostnames: []
     asserts:
       - isKind:
@@ -22,12 +23,11 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-radar
-      - equal:
+      - notExists:
           path: spec.hostnames
-          value: []
       - equal:
-          path: spec.parentRefs
-          value: []
+          path: spec.parentRefs[0].name
+          value: public-gateway
       - equal:
           path: spec.rules[0].matches[0].path
           value:
@@ -45,6 +45,8 @@ tests:
     set:
       httpRoute:
         enabled: true
+        parentRefs:
+          - name: public-gateway
         defaultTimeout: 30s
     asserts:
       - equal:
@@ -83,6 +85,8 @@ tests:
     set:
       httpRoute:
         enabled: true
+        parentRefs:
+          - name: public-gateway
         hostnames:
           - radar.example.com
         rules:
@@ -127,3 +131,24 @@ tests:
       - equal:
           path: spec.rules[1].backendRefs[0].name
           value: radar-admin
+
+  - it: fails when enabled without parentRefs
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: httpRoute.enabled=true requires at least one httpRoute.parentRefs entry (the Gateway to attach to).
+
+  - it: fails when both ingress and httpRoute are enabled
+    set:
+      ingress:
+        enabled: true
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: public-gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: Enable only ONE of ingress.enabled or httpRoute.enabled, not both.

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -159,7 +159,7 @@
     },
     "httpRoute": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "apiVersion": { "type": "string", "minLength": 1 },
@@ -167,7 +167,12 @@
         "labels": { "type": "object", "additionalProperties": { "type": "string" } },
         "parentRefs": {
           "type": "array",
-          "items": { "type": "object", "additionalProperties": true }
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["name"],
+            "properties": { "name": { "type": "string", "minLength": 1 } }
+          }
         },
         "hostnames": {
           "type": "array",


### PR DESCRIPTION
Follow-up to the HTTPRoute support (#1294), tightening it before release.

## Changes
- **`parentRefs`-required guard** — `httpRoute.enabled=true` with empty `parentRefs` previously rendered an HTTPRoute bound to no Gateway (silently non-functional). Now fails the render with a clear message.
- **Mutual-exclusion guard** — `ingress` and `httpRoute` both target the same Service; enabling both now fails the render (mirrored in `ingress.yaml`).
- **`hostnames` omit-when-empty** — stops emitting an empty `hostnames: []` (semantically identical in Gateway API; matches the standard Helm idiom).
- **Schema tightening** — `httpRoute` wrapper closed to known keys (`additionalProperties: false`, catches typos); `parentRefs` items require `name`.
- **Tests** — the two guards get `failedTemplate` coverage; existing cases updated to supply `parentRefs`.
- README documents the guards.

## Tests
- `helm lint` — clean.
- `helm unittest -f tests/httproute_test.yaml` — 7/7 pass.
- Render matrix: default rule -> `radar` Service:9280, both guards fire, unknown wrapper keys rejected.

Note: `tests/service_test.yaml` fails locally on an unrelated pre-existing snapshot (present on `main` before this change) - untouched here.

https://claude.ai/code/session_01X5TtZSgJEf6GcQqC7vKAbo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only Helm template validation and manifest shape for optional ingress/HTTPRoute; no Radar runtime or cluster RBAC behavior changes. May break GitOps values that previously enabled both ingress and HTTPRoute or HTTPRoute without parentRefs.
> 
> **Overview**
> Tightens **Gateway API HTTPRoute** Helm rendering so invalid exposure configs fail at `helm template` instead of producing a broken route.
> 
> **`ingress` and `httpRoute` are mutually exclusive** — enabling both now fails with a clear error (guards in both `httproute.yaml` and `ingress.yaml`).
> 
> **`httpRoute.enabled` requires `parentRefs`** — empty `parentRefs` no longer renders an HTTPRoute with no Gateway parent.
> 
> **Empty `hostnames` are omitted** from the manifest when unset/empty (no `hostnames: []`).
> 
> **`values.schema.json`** closes the `httpRoute` object to known keys and requires each `parentRefs` item to include a non-empty `name`. README documents the guards; **httproute** unit tests cover the new failures and updated defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5129a296c6b96e56a9abfda9028a89025cf6ffc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->