### PR TITLE
feat(resources): pod-vs-node context line in the CPU/Memory tooltip

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -6090,7 +6090,20 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const { mode, totalUsage, denom, markerPct, unlimitedCount } = podAggregate(list, kind)
       if (totalUsage === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
 
-      const tip = buildContainerResourceTooltip(label, list, kind, format)
+      // Pod-vs-node context: how full the pod's node is (the risk signal) and
+      // how much of it this pod takes. Only when node metrics are loaded.
+      const nodeName = resource.spec?.nodeName as string | undefined
+      const node = nodeName ? metrics.nodes.get(nodeName) : undefined
+      const nodeAlloc = node ? (isCPU ? node.cpuAllocatable : node.memoryAllocatable) : 0
+      const nodeCtx = node && nodeAlloc > 0
+        ? {
+            name: nodeName!,
+            usedPct: ((isCPU ? node.cpu : node.memory) / nodeAlloc) * 100,
+            podSharePct: (totalUsage / nodeAlloc) * 100,
+          }
+        : undefined
+
+      const tip = buildContainerResourceTooltip(label, list, kind, format, nodeCtx)
 
       // Every container is limited → aggregate bar against the summed limit; a
       // real pod-level ceiling, so it may go red.
@@ -6752,11 +6765,29 @@ export function podAggregate(list: ContainerResourceMetrics[], kind: 'cpu' | 'me
 // by pct descending, intermixing limited and request-only. Containers with
 // neither render the words "no limit". Capped at CONTAINER_TOOLTIP_CAP rows,
 // with a final "+N more" line pointing at the pod.
+// NodeContext answers "is this pod at risk from its node?" — how full the node
+// is (the risk signal) and how much of the node this pod takes (attribution).
+interface NodeContext {
+  name: string
+  usedPct: number
+  podSharePct: number
+}
+
+// A node this full puts every pod on it at risk (eviction / OOM / throttling),
+// regardless of the pod's own limit headroom — so the line goes amber here.
+const NODE_PRESSURE_PCT = 85
+
+function formatSharePct(pct: number): string {
+  if (pct > 0 && pct < 1) return '<1%'
+  return `${Math.round(pct)}%`
+}
+
 function buildContainerResourceTooltip(
   label: 'CPU' | 'Memory',
   containers: ContainerResourceMetrics[],
   kind: 'cpu' | 'memory',
   formatFn: (n: number) => string,
+  nodeCtx?: NodeContext,
 ) {
   const rows = [...containers].sort((a, b) => {
     const diff = readContainer(b, kind).pct - readContainer(a, kind).pct
@@ -6791,6 +6822,21 @@ function buildContainerResourceTooltip(
       {remaining > 0 && (
         <div className="text-[11px] text-theme-text-tertiary border-t border-theme-border/50 pt-1">
           +{remaining} more → open pod
+        </div>
+      )}
+      {nodeCtx && (
+        <div className="flex flex-col leading-snug border-t border-theme-border/50 pt-1">
+          <span className="text-[11px] text-theme-text-tertiary truncate">Node {nodeCtx.name}</span>
+          <span
+            className={clsx(
+              'text-[11px]',
+              nodeCtx.usedPct >= NODE_PRESSURE_PCT
+                ? 'text-amber-500 font-medium'
+                : 'text-theme-text-secondary',
+            )}
+          >
+            {formatSharePct(nodeCtx.usedPct)} used · this pod {formatSharePct(nodeCtx.podSharePct)}
+          </span>
         </div>
       )}
     </div>

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -6095,10 +6095,14 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const nodeName = resource.spec?.nodeName as string | undefined
       const node = nodeName ? metrics.nodes.get(nodeName) : undefined
       const nodeAlloc = node ? (isCPU ? node.cpuAllocatable : node.memoryAllocatable) : 0
-      const nodeCtx = node && nodeAlloc > 0
+      const nodeUsage = node ? (isCPU ? node.cpu : node.memory) : 0
+      // Zero usage means metrics-server has no sample for the node (down, or not
+      // yet scraped) — the same "no data" NodeCell renders blank — so skip the
+      // line rather than assert a misleading "0% used" that reads as safe.
+      const nodeCtx = node && nodeAlloc > 0 && nodeUsage > 0
         ? {
             name: nodeName!,
-            usedPct: ((isCPU ? node.cpu : node.memory) / nodeAlloc) * 100,
+            usedPct: (nodeUsage / nodeAlloc) * 100,
             podSharePct: (totalUsage / nodeAlloc) * 100,
           }
         : undefined

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -198,7 +198,13 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const podCountAllowsBulkMetrics = countsData != null && podCountKnown && !podCountUnavailable && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
   const selectedKindName = selectedKind?.name.toLowerCase() ?? ''
   const topPodMetricsEnabled = selectedKindName === 'pods' && podCountAllowsBulkMetrics
-  const topNodeMetricsEnabled = selectedKindName === 'nodes' && namespaces.length === 0 && podCountAllowsBulkMetrics
+  // Node metrics back the Nodes table and, for the Pods table, the pod-vs-node
+  // context line in the CPU/Memory tooltip (a pod can be fine against its own
+  // limit yet at risk from a saturated node). Nodes are cluster-wide, so the
+  // pods case is not gated on the namespace filter.
+  const topNodeMetricsEnabled =
+    ((selectedKindName === 'nodes' && namespaces.length === 0) || selectedKindName === 'pods') &&
+    podCountAllowsBulkMetrics
   const largeListGuard = selectedKind && largeListBlocked
     ? {
         kind: selectedKind.name,


### PR DESCRIPTION
## Motivation

The per-container CPU/Memory work (#1298) answers "how is this pod doing against its own limits." But a pod can be well within its own limits and still be at risk from a **saturated node** — evicted, OOM-killed, or throttled because of its neighbors. That dimension was invisible.

## What this adds

A single **node context line** at the bottom of the CPU and Memory tooltips:

```
Node ip-10-0-1-5
87% used · this pod 12%
```

Two signals, together:
- **"X% used"** — how full the pod's node is → the risk signal. Turns **amber when the node is under pressure** (≥85%).
- **"this pod Y%"** — how much of the node this pod takes → attribution (is this pod the cause, or a victim?).

Reading them together is diagnostic: node 88% / pod 8% → the pod is a victim, look elsewhere; node 88% / pod 79% → this pod is the reason.

Both CPU and memory.

## Implementation

Frontend-only. `TopNodeMetrics` already carries node usage and allocatable, so the tooltip joins by `spec.nodeName`; node metrics are now fetched for the Pods table (previously the Nodes table only). No backend change.

## Notes

- Tooltip-only for now (no at-a-glance row tag).
- The `85%` pressure threshold is a single const.

https://claude.ai/code/session_01XgG563HEjaSEr2B3cdsn7q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip and metrics-fetch gating changes; no auth or data-model changes, with slightly more metrics traffic when browsing pods on large clusters.
> 
> **Overview**
> Pod CPU and Memory tooltips now include a **node context** footer when node metrics are available: node name, cluster-wide **% used** on that node, and **this pod’s share** of node allocatable. Node usage at **≥85%** is highlighted in amber (`NODE_PRESSURE_PCT`).
> 
> The tooltip joins pod rows to `metrics.nodes` via `spec.nodeName` and only shows the footer when allocatable exists and usage is non-zero (avoids a misleading “0% used” when metrics-server has no sample).
> 
> **Metrics loading:** `topNodeMetrics` is enabled for the **Pods** table as well as Nodes (still gated by `podCountAllowsBulkMetrics`; pods path is not tied to namespace filter). Same logic is applied in `packages/k8s-ui` and `web` `ResourcesView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac09e90dd414c808fed5df6f978fa195bc7d756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->