### PR TITLE
docs(readme): note HTTPRoute guards in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ API installations. The generated default route has no chart-imposed timeout,
 so the Gateway deployment default applies. Set `httpRoute.defaultTimeout` for
 an explicit timeout; custom rules can define their own `timeouts`.
 
+`ingress` and `httpRoute` are mutually exclusive: enabling both stops the
+install with an error, so enable only one. When `httpRoute` is enabled you must
+set at least one `parentRefs` entry (the Gateway the route attaches to);
+otherwise the install fails instead of creating an HTTPRoute that is attached to
+no Gateway.
+
 ```yaml
 httpRoute:
   enabled: true


### PR DESCRIPTION
Small doc follow-up. The HTTPRoute guards landed in the chart README but the root README's Gateway API section didn't mention them.

Adds one line: `httpRoute` and `ingress` are mutually exclusive, and `parentRefs` is required when enabled (the render fails otherwise) - parity with the chart README.

Docs-only, no chart change.

https://claude.ai/code/session_01X5TtZSgJEf6GcQqC7vKAbo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or chart behavior changes.
> 
> **Overview**
> **Docs-only:** the root **README** Gateway API **HTTPRoute** section now matches the Helm chart README on install-time guards.
> 
> It states that **`ingress`** and **`httpRoute`** cannot both be enabled (Helm fails the install), and that with **`httpRoute.enabled`** you must supply at least one **`parentRefs`** entry so the route attaches to a Gateway—otherwise install fails instead of emitting an unattached HTTPRoute.
> 
> No chart or template changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3983f8186e0fd380e7d7023467c3fdfba5abac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->