### PR TITLE
build: add MCP registry ownership label to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ LABEL org.opencontainers.image.title="Radar"
 LABEL org.opencontainers.image.description="Modern Kubernetes visibility — topology, traffic, and Helm management"
 LABEL org.opencontainers.image.source="https://github.com/skyhook-io/radar"
 LABEL org.opencontainers.image.vendor="Skyhook"
+# Ownership verification for the official MCP registry
+# (registry.modelcontextprotocol.io). Must match the `name` field in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"
 
 COPY --from=backend-builder /radar /radar
 
@@ -88,6 +91,9 @@ LABEL org.opencontainers.image.title="Radar"
 LABEL org.opencontainers.image.description="Modern Kubernetes visibility — topology, traffic, and Helm management"
 LABEL org.opencontainers.image.source="https://github.com/skyhook-io/radar"
 LABEL org.opencontainers.image.vendor="Skyhook"
+# Ownership verification for the official MCP registry
+# (registry.modelcontextprotocol.io). Must match the `name` field in server.json.
+LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"
 
 ARG TARGETARCH
 COPY radar-${TARGETARCH} /radar


### PR DESCRIPTION
## Why

Radar is not listed in the [official MCP registry](https://registry.modelcontextprotocol.io), and this label is the only thing blocking it.

The registry verifies ownership of an OCI package by reading `io.modelcontextprotocol.server.name` from the published image's labels and checking it matches the `name` field in `server.json`. Radar's image currently carries only the four `org.opencontainers.image.*` labels, so `mcp-publisher publish` is rejected.

This matters beyond that one listing: **most MCP directories ingest from the official registry rather than accepting direct submissions.** PulseMCP's own submit page for servers has no form at all, it just says they ingest from the official registry daily. So this one label is upstream of a lot of distribution.

Measured context, for whatever it's worth: across 48 sampled LLM answers about Kubernetes tooling, Radar was named zero times on the eight prompts that asked directly about MCP and AI-assistant integration. No competitor won those answers either. Being absent from the registries the models and their sources actually read is a plausible part of that.

## What this changes

Three lines, applied to both the `full` and `release` stages so whichever one publishes to `ghcr.io` carries the label:

```dockerfile
LABEL io.modelcontextprotocol.server.name="io.github.skyhook-io/radar"
```

No behaviour change, no build change, labels only.

## The namespace decision is yours

I used `io.github.skyhook-io/radar`, which authenticates via GitHub and requires **Owner** on the `skyhook-io` org.

The alternative is `io.radarhq/radar`, which is better branding but authenticates via an Ed25519 or ECDSA P-384 TXT record on the **apex** of `radarhq.io`. If you prefer that, it's a one-string change here. The label value and the `name` in `server.json` must match exactly either way.

## What happens after this merges

A release needs to be cut so the label lands on a published image, then `server.json` plus `mcp-publisher publish` completes the listing. Happy to do that part, or hand over the `server.json`.

## Verified before opening this

Tested `ghcr.io/skyhook-io/radar:1.8.6` locally: `--mcp-catalog-stdio` completes `initialize` and returns all 28 tools over stdio without needing a reachable cluster, which is what registries and inspectors use. That path already works; only the ownership label is missing.

Related: [docker/mcp-registry#4583](https://github.com/docker/mcp-registry/pull/4583) adds Radar to Docker Desktop's MCP Toolkit and does not depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01454LTozxWERowEyvLvpgzn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker image metadata only; no application logic, security, or runtime behavior changes.
> 
> **Overview**
> Adds the **`io.modelcontextprotocol.server.name`** OCI label (`io.github.skyhook-io/radar`) to both the **`full`** and **`release`** distroless image stages so published images can pass official MCP registry ownership checks against **`server.json`**.
> 
> Comments note the label must match the registry **`name`** field. No runtime, build, or networking changes—metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c367406f3adbbc06fcd20f72c46b8f6ae2dbdf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->