### PR TITLE
feat(auth): log accepted forwarded identity in proxy mode

### DIFF
--- a/internal/auth/forwarded_identity.go
+++ b/internal/auth/forwarded_identity.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"hash/fnv"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// forwardedIdentityLogCap bounds the dedup set so a long-running agent with a
+// large customer base doesn't grow this unbounded. Oldest entries are evicted
+// first (FIFO), not true LRU — simplicity over precision for a diagnostic log.
+const forwardedIdentityLogCap = 1024
+
+// forwardedIdentitySeen deduplicates "[auth] accepted forwarded identity" log
+// lines so a steady stream of requests from the same user/group set doesn't
+// spam operator logs. Keyed by a hash of username + sorted groups, so a
+// changed group set (an IdP group added or removed) is treated as new and
+// logs again.
+var forwardedIdentitySeen = &forwardedIdentityLogger{
+	seen: make(map[uint64]struct{}),
+}
+
+type forwardedIdentityLogger struct {
+	mu    sync.Mutex
+	seen  map[uint64]struct{}
+	order []uint64
+}
+
+// shouldLog reports whether key has not been seen before, recording it if so.
+func (l *forwardedIdentityLogger) shouldLog(key uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, ok := l.seen[key]; ok {
+		return false
+	}
+	if len(l.order) >= forwardedIdentityLogCap {
+		oldest := l.order[0]
+		l.order = l.order[1:]
+		delete(l.seen, oldest)
+	}
+	l.seen[key] = struct{}{}
+	l.order = append(l.order, key)
+	return true
+}
+
+// forwardedIdentityKey hashes username + sorted groups into a single bounded key.
+func forwardedIdentityKey(username string, groups []string) uint64 {
+	sorted := append([]string(nil), groups...)
+	sort.Strings(sorted)
+
+	h := fnv.New64a()
+	h.Write([]byte(username))
+	h.Write([]byte{0})
+	h.Write([]byte(strings.Join(sorted, ",")))
+	return h.Sum64()
+}
+
+// logAcceptedForwardedIdentity logs the first sighting of a distinct
+// (username, group-set) forwarded identity so an operator can see what
+// identity/groups actually arrived from the IdP/hub — e.g. to diagnose a
+// missing `radar:idp:<object-id>` group that never reaches k8s RBAC. Repeat
+// requests with the same identity are suppressed; a changed group set logs
+// again. Usernames and group names are non-sensitive identifiers, safe to log.
+func logAcceptedForwardedIdentity(user *User) {
+	if user == nil || user.Username == "" {
+		return
+	}
+	key := forwardedIdentityKey(user.Username, user.Groups)
+	if !forwardedIdentitySeen.shouldLog(key) {
+		return
+	}
+	log.Printf("[auth] accepted forwarded identity user=%q groups=%q", user.Username, user.Groups)
+}

--- a/internal/auth/forwarded_identity_test.go
+++ b/internal/auth/forwarded_identity_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"log"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -105,16 +106,37 @@ func TestLogAcceptedForwardedIdentity_NilOrEmptyUsernameNoOp(t *testing.T) {
 func TestForwardedIdentityLogger_BoundedEviction(t *testing.T) {
 	l := &forwardedIdentityLogger{seen: make(map[uint64]struct{})}
 
-	// Fill well past the cap and confirm the set never grows unbounded.
-	for i := 0; i < forwardedIdentityLogCap+10; i++ {
-		key := forwardedIdentityKey("user", []string{string(rune('a' + i%26))})
-		l.shouldLog(key)
+	// Fill with forwardedIdentityLogCap+10 DISTINCT keys (one per iteration, via a
+	// unique group per i) so the FIFO eviction branch actually runs; a key that
+	// repeats would just hit the "already seen" short-circuit and never touch cap.
+	const overfill = 10
+	keys := make([]uint64, forwardedIdentityLogCap+overfill)
+	for i := range keys {
+		keys[i] = forwardedIdentityKey("user", []string{strconv.Itoa(i)})
+		if !l.shouldLog(keys[i]) {
+			t.Fatalf("key %d: expected first sighting to log", i)
+		}
 	}
 
-	if len(l.seen) > forwardedIdentityLogCap {
-		t.Errorf("dedup set grew to %d entries, want <= %d", len(l.seen), forwardedIdentityLogCap)
+	if len(l.seen) != forwardedIdentityLogCap {
+		t.Errorf("dedup set has %d entries, want exactly %d", len(l.seen), forwardedIdentityLogCap)
 	}
-	if len(l.order) > forwardedIdentityLogCap {
-		t.Errorf("order slice grew to %d entries, want <= %d", len(l.order), forwardedIdentityLogCap)
+	if len(l.order) != forwardedIdentityLogCap {
+		t.Errorf("order slice has %d entries, want exactly %d", len(l.order), forwardedIdentityLogCap)
+	}
+
+	// The oldest keys must have been evicted...
+	for i := 0; i < overfill; i++ {
+		if _, ok := l.seen[keys[i]]; ok {
+			t.Errorf("key %d should have been evicted (oldest), still present", i)
+		}
+		if !l.shouldLog(keys[i]) {
+			t.Errorf("key %d should log again after eviction (treated as new)", i)
+		}
+	}
+	// ...while the most recently inserted key must survive.
+	newest := keys[len(keys)-1]
+	if l.shouldLog(newest) {
+		t.Error("newest key should still be present (not evicted), but was treated as new")
 	}
 }

--- a/internal/auth/forwarded_identity_test.go
+++ b/internal/auth/forwarded_identity_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+// resetForwardedIdentityLog clears the package-level dedup set so tests don't
+// leak state into each other (the set is shared across the whole test binary).
+func resetForwardedIdentityLog() {
+	forwardedIdentitySeen.mu.Lock()
+	defer forwardedIdentitySeen.mu.Unlock()
+	forwardedIdentitySeen.seen = make(map[uint64]struct{})
+	forwardedIdentitySeen.order = nil
+}
+
+func TestLogAcceptedForwardedIdentity_FirstCallLogs(t *testing.T) {
+	resetForwardedIdentityLog()
+
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	logAcceptedForwardedIdentity(&User{Username: "alice", Groups: []string{"radar:idp:abc123"}})
+
+	line := buf.String()
+	if !strings.Contains(line, "[auth] accepted forwarded identity") {
+		t.Fatalf("expected accepted-identity log line, got: %q", line)
+	}
+	if !strings.Contains(line, `user="alice"`) {
+		t.Errorf("log line missing username: %q", line)
+	}
+	if !strings.Contains(line, "radar:idp:abc123") {
+		t.Errorf("log line missing group: %q", line)
+	}
+}
+
+func TestLogAcceptedForwardedIdentity_IdenticalCallSuppressed(t *testing.T) {
+	resetForwardedIdentityLog()
+
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	user := &User{Username: "bob", Groups: []string{"devs", "radar:idp:xyz789"}}
+	logAcceptedForwardedIdentity(user)
+	firstLen := buf.Len()
+	if firstLen == 0 {
+		t.Fatal("expected first call to log")
+	}
+
+	// Identical (username, groups) combo again — should not add another line.
+	logAcceptedForwardedIdentity(user)
+	if buf.Len() != firstLen {
+		t.Errorf("expected repeat call to be suppressed, buffer grew from %d to %d bytes: %q", firstLen, buf.Len(), buf.String())
+	}
+
+	// Same groups, different order — still the same set, should stay suppressed.
+	logAcceptedForwardedIdentity(&User{Username: "bob", Groups: []string{"radar:idp:xyz789", "devs"}})
+	if buf.Len() != firstLen {
+		t.Errorf("expected reordered-groups call to be suppressed, buffer grew from %d to %d bytes: %q", firstLen, buf.Len(), buf.String())
+	}
+}
+
+func TestLogAcceptedForwardedIdentity_ChangedGroupSetLogsAgain(t *testing.T) {
+	resetForwardedIdentityLog()
+
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	logAcceptedForwardedIdentity(&User{Username: "carol", Groups: []string{"radar:idp:old"}})
+	firstLen := buf.Len()
+	if firstLen == 0 {
+		t.Fatal("expected first call to log")
+	}
+
+	// New IdP group added — distinct combo, must log again.
+	logAcceptedForwardedIdentity(&User{Username: "carol", Groups: []string{"radar:idp:old", "radar:idp:new"}})
+	if buf.Len() <= firstLen {
+		t.Errorf("expected changed group-set to produce a new log line, buffer stayed at %d bytes: %q", buf.Len(), buf.String())
+	}
+	if strings.Count(buf.String(), "[auth] accepted forwarded identity") != 2 {
+		t.Errorf("expected exactly 2 log lines, got: %q", buf.String())
+	}
+}
+
+func TestLogAcceptedForwardedIdentity_NilOrEmptyUsernameNoOp(t *testing.T) {
+	resetForwardedIdentityLog()
+
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	logAcceptedForwardedIdentity(nil)
+	logAcceptedForwardedIdentity(&User{Username: "", Groups: []string{"devs"}})
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output for nil/empty-username user, got: %q", buf.String())
+	}
+}
+
+func TestForwardedIdentityLogger_BoundedEviction(t *testing.T) {
+	l := &forwardedIdentityLogger{seen: make(map[uint64]struct{})}
+
+	// Fill well past the cap and confirm the set never grows unbounded.
+	for i := 0; i < forwardedIdentityLogCap+10; i++ {
+		key := forwardedIdentityKey("user", []string{string(rune('a' + i%26))})
+		l.shouldLog(key)
+	}
+
+	if len(l.seen) > forwardedIdentityLogCap {
+		t.Errorf("dedup set grew to %d entries, want <= %d", len(l.seen), forwardedIdentityLogCap)
+	}
+	if len(l.order) > forwardedIdentityLogCap {
+		t.Errorf("order slice grew to %d entries, want <= %d", len(l.order), forwardedIdentityLogCap)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -130,6 +130,7 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 					}
 
 					user := &User{Username: username, Groups: groups}
+					logAcceptedForwardedIdentity(user)
 					if !cloudProxyMode {
 						cookies := CreateSessionCookie(user, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, secure)
 						for _, c := range cookies {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,14 +1,17 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +105,35 @@ func TestMiddleware_ProxyHeaders(t *testing.T) {
 	}
 	if !found {
 		t.Error("proxy auth should set session cookie")
+	}
+}
+
+func TestMiddleware_ProxyHeaders_LogsAcceptedIdentity(t *testing.T) {
+	resetForwardedIdentityLog()
+
+	mw := Authenticate(proxyConfig())
+	handler := mw(http.HandlerFunc(echoUser))
+
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	req := httptest.NewRequest("GET", "/api/resources/pods", nil)
+	req.Header.Set("X-Forwarded-User", "dave")
+	req.Header.Set("X-Forwarded-Groups", "radar:idp:read-only-team")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	line := buf.String()
+	if !strings.Contains(line, "[auth] accepted forwarded identity") {
+		t.Fatalf("expected accepted-identity log line, got: %q", line)
+	}
+	if !strings.Contains(line, "dave") || !strings.Contains(line, "radar:idp:read-only-team") {
+		t.Errorf("log line missing user/group: %q", line)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Radar logged only rejected forwarded identities; accepted identity was logged only on write ops (`AuditLog`), so reads under `--auth-mode=proxy` gave zero signal about what user/groups arrived. When a customer's IdP groups don't reach k8s RBAC, there was nothing to inspect.
- Log the first sighting of each distinct `(username, group-set)` accepted forwarded identity (`X-Forwarded-User` / `X-Forwarded-Groups`) right after the identity is parsed and accepted in the proxy-mode path, so an operator can see e.g. a missing `radar:idp:<object-id>` group.
- Deduped via a bounded (cap 1024, FIFO eviction) in-memory set keyed by a hash of username + sorted groups, so steady traffic from the same identity doesn't spam the log. A changed group set (group added/removed) logs again.
- Usernames/groups are non-sensitive identifiers; nothing new is logged that isn't already logged for write ops via `AuditLog`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/auth ./internal/server`
- [x] New unit tests: first call logs, identical call suppressed, changed group-set logs again, nil/empty-username no-op, bounded eviction
- [x] New middleware-level test asserting the log line fires through the real `Authenticate` handler on an accepted proxy-mode request

https://claude.ai/code/session_018XvBnESTJB4WFN5TWMzb8X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds bounded diagnostic logging on an existing accepted-auth path; no change to authorization decisions or session handling.
> 
> **Overview**
> Adds **diagnostic logging** when proxy-mode auth accepts `X-Forwarded-User` / `X-Forwarded-Groups`, so operators can see which username and groups actually reached Radar (e.g. missing `radar:idp:*` groups) without relying on write-only audit logs.
> 
> After `ForwardedIdentityAllowed` passes, `logAcceptedForwardedIdentity` emits `[auth] accepted forwarded identity` once per distinct `(username, sorted group set)`; repeats are suppressed via a bounded in-memory dedup set (cap 1024, FIFO eviction). Group membership changes log again.
> 
> New unit and middleware tests cover first log, suppression, reordering, group-set changes, nil/empty user, eviction, and the real `Authenticate` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5889ad43e2f27b1902d496e13f7b594cf19342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->