### PR TITLE
ci(docker-build): build multi-arch (amd64+arm64) images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           target: full
           push: true
           build-args: |


### PR DESCRIPTION
Enables the manual **Docker Build** workflow to produce a multi-arch manifest (`linux/amd64,linux/arm64`) so image tags built this way run on arm64 nodes too — needed for chart deployments that must serve both architectures without cutting a GitHub Release.

The `full` target already cross-compiles per-arch via buildx `TARGETOS`/`TARGETARCH` with `CGO_ENABLED=0`, so no Dockerfile change is required.

Trade-off: ad-hoc builds via this workflow are ~2× slower (arm64 leg). Acceptable for release/customer image builds.

https://claude.ai/code/session_01NvL4QWi6VdR6PKMdC8NBzk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input change with no application or runtime code touched; main effect is longer build time for manual image builds.
> 
> **Overview**
> The manual **Docker Build** workflow now passes `platforms: linux/amd64,linux/arm64` to `docker/build-push-action` instead of **amd64 only**, so dispatched builds publish a multi-arch manifest to GHCR for the same tag.
> 
> No Dockerfile edits in this PR—the `full` target already builds per-arch via buildx `TARGETOS`/`TARGETARCH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329bcf5615852c3b6efba033d8e0fe1e9738fdaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->