### PR TITLE
Require explicit authorization for releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,11 @@ Radar is a modern Kubernetes visibility tool — local-first, no account require
 - **Don't reference tickets, PRs, bug numbers, or diff history** in code comments (e.g. "fixes SKY-123", "Bugbot caught this on PR #584", "used to read X, now…"). Those belong in the PR description and rot as the codebase evolves. The WHY of the change should stand on its own.
 - This applies to comments written by any tool (Cursor, Bugbot, Copilot) as well as humans — strip ticket/PR references before merging.
 
+## Release and publishing authorization
+
+- Never create, move, or delete Git tags or GitHub Releases; dispatch release or publish workflows; or publish binaries, container images, npm packages, package-manager artifacts, Helm charts, or other distribution artifacts without explicit user approval naming the exact artifact, version, and action.
+- Approval to implement a change, open or merge a PR, or prepare release changes is not authorization to publish. If release authorization is ambiguous, stop and ask.
+
 ## Reference Docs — MUST READ before making changes
 
 Not everything is in this file. The following files contain critical details that are **not duplicated here**. You MUST read them when working in the relevant area — do not guess or rely on memory.


### PR DESCRIPTION
## Summary

Prevents implementation, pull-request, or merge approval from being treated as permission to publish a release. Externally visible release actions require exact, explicit user authorization.

## What changed

- Documents that Git tags and GitHub Releases must not be created, moved, or deleted without explicit approval.
- Applies the same gate to release/publish workflow dispatches and publication of binaries, container images, npm packages, package-manager artifacts, Helm charts, and other distribution artifacts.
- Requires authorization to name the exact artifact, version, and action; ambiguous release requests stop for confirmation.

## Testing

- `git diff --check`
- visual-test: skipped (documentation-only; no UI delta)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/AI guidance in CLAUDE.md; no runtime, CI, or release workflow behavior is modified.
> 
> **Overview**
> Adds a **Release and publishing authorization** section to `CLAUDE.md` so AI assistants and contributors treat publishing as a separate gate from normal development work.
> 
> The policy forbids creating, moving, or deleting Git tags and GitHub Releases; dispatching release/publish workflows; and publishing binaries, images, npm packages, package-manager artifacts, Helm charts, or other distribution artifacts **without explicit user approval** that names the exact artifact, version, and action. Implementing a change, opening or merging a PR, or preparing release-related code is **not** treated as permission to publish; ambiguous release requests must stop for confirmation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b66e22c16a83f9145329d6490d3f574d0e93aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->