### PR TITLE
fix(mcp): don't stamp no_recent_changes when RBAC hid correlated evidence

### DIFF
--- a/internal/mcp/changes_rbac_test.go
+++ b/internal/mcp/changes_rbac_test.go
@@ -53,3 +53,44 @@ func TestFilterRecentChangesRBAC(t *testing.T) {
 		t.Fatalf("helm-sourced row must pass through (gated upstream): %+v", got)
 	}
 }
+
+// When per-kind RBAC hides a relevant correlated change, the correlation must
+// report rbacHidden=true so the marker path treats "empty because hidden" as
+// unknown — an issue whose consumed ConfigMap rotated must never be stamped
+// with an affirmative no_recent_changes claim just because the caller can't
+// read ConfigMaps.
+func TestApplyCorrelationVisibilityFilters_RBACHiddenIsNotNoChanges(t *testing.T) {
+	specConfig := func(kind, apiVersion, ns, name string) issuesapi.RecentChange {
+		return issuesapi.RecentChange{Kind: kind, APIVersion: apiVersion, Namespace: ns, Name: name, ChangeCategory: issuesapi.ChangeCategorySpecConfig}
+	}
+
+	ctx := withClusterAdmin(t, "corr-scoped")
+	getPermCache().Get("corr-scoped").SetCanI("list", "apps", "deployments", "shop", true)
+
+	// The only relevant change is an unreadable ConfigMap → empty AND hidden.
+	visible, hidden := applyCorrelationVisibilityFilters(ctx, []issuesapi.RecentChange{
+		specConfig("ConfigMap", "v1", "shop", "app-cfg"),
+	})
+	if len(visible) != 0 || !hidden {
+		t.Fatalf("unreadable ConfigMap: want (0 visible, hidden=true), got (%d, %v)", len(visible), hidden)
+	}
+
+	// A readable Deployment change survives, and a status-churn row dropped by
+	// the category filter does NOT count as hidden — a genuinely quiet subject
+	// must still earn its no_recent_changes marker.
+	visible, hidden = applyCorrelationVisibilityFilters(ctx, []issuesapi.RecentChange{
+		specConfig("Deployment", "apps/v1", "shop", "web"),
+		{Kind: "Deployment", APIVersion: "apps/v1", Namespace: "shop", Name: "web", ChangeCategory: issuesapi.ChangeCategoryRuntimeStatus},
+	})
+	if len(visible) != 1 || hidden {
+		t.Fatalf("readable Deployment: want (1 visible, hidden=false), got (%d, %v)", len(visible), hidden)
+	}
+
+	// Auth off (no user on ctx): passthrough, never hidden.
+	visible, hidden = applyCorrelationVisibilityFilters(context.Background(), []issuesapi.RecentChange{
+		specConfig("ConfigMap", "v1", "shop", "app-cfg"),
+	})
+	if len(visible) != 1 || hidden {
+		t.Fatalf("auth off: want (1 visible, hidden=false), got (%d, %v)", len(visible), hidden)
+	}
+}

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -113,19 +113,13 @@ func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Durat
 		log.Printf("[mcp] issue change correlation failed for %s %s/%s: %v", iss.Kind, iss.Namespace, iss.Name, err)
 		return // marker omitted = unknown, never a false "no changes"
 	}
-	// Per-kind RBAC: a workload subject's correlated changes include its consumed
-	// ConfigMaps, which the caller may not be able to read even when authorized on
-	// the workload. Drop what they can't read before building the marker.
-	changes = filterRecentChangesRBAC(ctx, changes)
-	// The marker's contract is non-status evidence: status churn on a
-	// failing workload is the SYMPTOM, not a change that could explain it
-	// — including it would make every failing issue read as "correlated".
-	changes = filterSpecConfigChanges(changes)
+	changes, rbacHidden := applyCorrelationVisibilityFilters(ctx, changes)
 	if len(changes) == 0 {
 		// A saturated candidate fetch may have missed older changes in
-		// the window (churn-heavy subjects overflow the newest-N query) —
-		// that's unknown, not "no changes".
-		if saturated {
+		// the window (churn-heavy subjects overflow the newest-N query),
+		// and an RBAC-hidden change exists even though this caller can't
+		// see it — both are unknown, not "no changes".
+		if saturated || rbacHidden {
 			return
 		}
 		iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
@@ -137,6 +131,25 @@ func correlateIssue(ctx context.Context, iss *issuesapi.Issue, window time.Durat
 		changes = changes[:correlationChangeCap]
 	}
 	iss.CorrelatedChanges = changes
+}
+
+// applyCorrelationVisibilityFilters reduces candidate changes to the evidence
+// this caller may see. The marker's contract is non-status evidence: status
+// churn on a failing workload is the SYMPTOM, not a change that could explain
+// it — including it would make every failing issue read as "correlated". The
+// category filter runs first so rbacHidden only reflects rows that would have
+// counted as evidence; per-kind RBAC then drops rows the caller can't read (a
+// workload subject's correlated changes include its consumed ConfigMaps).
+//
+// rbacHidden=true means relevant evidence exists that this caller can't see —
+// the marker path must treat that as unknown, never as an affirmative
+// no_recent_changes claim (the consumer would read "chronic issue, nothing
+// changed" for a workload whose consumed ConfigMap just rotated).
+func applyCorrelationVisibilityFilters(ctx context.Context, changes []issuesapi.RecentChange) (visible []issuesapi.RecentChange, rbacHidden bool) {
+	changes = filterSpecConfigChanges(changes)
+	relevant := len(changes)
+	changes = filterRecentChangesRBAC(ctx, changes)
+	return changes, len(changes) < relevant
 }
 
 func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {


### PR DESCRIPTION
## Problem

Found while auditing the #1300/#1302 RBAC work for drop-vs-degrade behavior. Per-issue change correlation (`internal/mcp/issue_correlation.go`) filters a workload issue's correlated changes by per-kind RBAC — a workload subject's candidates include its consumed ConfigMaps, which the caller may not be able to read (#1300). But when that filter **empties** the list, the code fell through to stamping the issue with an affirmative `no_recent_changes` marker.

The marker's own contract says otherwise — fetch errors and saturated fetches deliberately omit it ("marker omitted = unknown, never a false 'no changes'"). RBAC-hidden is the same epistemic state: evidence exists; this caller can't see it. The failure mode is concrete: a user with workload access but no ConfigMap access gets their crashing Deployment certified "no recent changes in the window — chronic issue" when its consumed ConfigMap rotated two minutes ago, and MCP consumers (including AI diagnosis) explicitly weigh that marker.

## Fix

`applyCorrelationVisibilityFilters` applies the category filter first, then the RBAC filter, and reports whether RBAC removed a **relevant** row. When the visible set is empty, `rbacHidden` joins `saturated` in omitting the marker — unknown, not "no changes". Ordering matters: a status-churn row dropped by the category filter must not suppress the marker for a genuinely quiet subject.

`CorrelatedChanges` behavior is unchanged (still only rows the caller may read); auth-off is unchanged (no user → RBAC filter is a passthrough → `rbacHidden` is always false).

## Tests

- `TestApplyCorrelationVisibilityFilters_RBACHiddenIsNotNoChanges`: unreadable ConfigMap as the only relevant change → empty + hidden (marker suppressed); readable Deployment + status-churn row → visible + not hidden (quiet subjects still earn the marker); auth-off passthrough.
- `go build`, `go vet`, full `go test ./...` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes triage marker semantics for MCP/issue consumers (including diagnosis), but scope is limited to the correlation visibility path and aligns with existing “omit = unknown” behavior for errors and saturation.
> 
> **Overview**
> Fixes a false **no_recent_changes** stamp when per-kind RBAC removes correlated evidence (e.g. a consumed ConfigMap the caller cannot list) but the issue subject is still readable.
> 
> Correlation now runs **`applyCorrelationVisibilityFilters`**, which applies spec/lifecycle filtering first, then RBAC, and sets **`rbacHidden`** when relevant rows were dropped for permissions. If the visible set is empty, **`rbacHidden`** is treated like a saturated fetch: the marker is **omitted** (unknown), not an affirmative “nothing changed.” Status-only churn still does not count as hidden, so genuinely quiet subjects still get the marker.
> 
> Adds **`TestApplyCorrelationVisibilityFilters_RBACHiddenIsNotNoChanges`** for hidden ConfigMap, readable Deployment + status churn, and auth-off passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd705f9e3c48561e0aa6080dafeb1e277b5db0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->