### PR TITLE
fix(auth): seed OIDC signing algorithms in explicit-endpoint mode

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -188,7 +189,12 @@ func resolveOIDCProviderMetadata(ctx context.Context, cfg Config) (*oidcProvider
 			return nil, fmt.Errorf("oidc: issuer URL configured for Radar (%q) did not match the issuer URL returned by provider discovery (%q)", cfg.OIDCIssuer, metadata.IssuerURL)
 		}
 	} else {
+		// Explicit-endpoint mode skips discovery, so the provider advertises no
+		// signing algorithms. go-oidc then narrows the verifier to RS256 only,
+		// which would reject valid ES256/PS256/EdDSA tokens; seed the full
+		// supported set so the JWKS keys alone constrain which algorithms verify.
 		metadata.ProviderConfig.IssuerURL = cfg.OIDCIssuer
+		metadata.ProviderConfig.Algorithms = supportedOIDCSigningAlgorithmList()
 	}
 
 	metadata.ProviderConfig.IssuerURL = cfg.OIDCIssuer
@@ -202,6 +208,15 @@ func resolveOIDCProviderMetadata(ctx context.Context, cfg Config) (*oidcProvider
 
 func hasExplicitRequiredOIDCEndpoints(cfg Config) bool {
 	return cfg.OIDCAuthorizationURL != "" && cfg.OIDCTokenURL != "" && cfg.OIDCJWKSURL != ""
+}
+
+func supportedOIDCSigningAlgorithmList() []string {
+	algs := make([]string, 0, len(supportedOIDCSigningAlgorithms))
+	for alg := range supportedOIDCSigningAlgorithms {
+		algs = append(algs, alg)
+	}
+	sort.Strings(algs)
+	return algs
 }
 
 func filterOIDCSigningAlgorithms(algs []string) []string {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -577,6 +577,31 @@ func TestNewOIDCHandler_ExplicitEndpointsDoNotRequireDiscovery(t *testing.T) {
 	}
 }
 
+func TestResolveOIDCProviderMetadata_ExplicitEndpointsSeedSigningAlgorithms(t *testing.T) {
+	metadata, err := resolveOIDCProviderMetadata(context.Background(), Config{
+		Mode:                 "oidc",
+		OIDCIssuer:           "https://auth.example.com",
+		OIDCAuthorizationURL: "https://auth.example.com/authorize",
+		OIDCTokenURL:         "http://auth.authentik.svc/token",
+		OIDCJWKSURL:          "http://auth.authentik.svc/jwks",
+		OIDCClientID:         "radar",
+	})
+	if err != nil {
+		t.Fatalf("resolveOIDCProviderMetadata: %v", err)
+	}
+	// Without discovery the verifier would default to RS256 only; the resolver
+	// must seed the supported set so non-RS256 IdPs still verify.
+	got := map[string]bool{}
+	for _, alg := range metadata.ProviderConfig.Algorithms {
+		got[alg] = true
+	}
+	for _, want := range []string{oidc.RS256, oidc.ES256, oidc.PS256, oidc.EdDSA} {
+		if !got[want] {
+			t.Errorf("explicit-endpoint algorithms %v missing %q", metadata.ProviderConfig.Algorithms, want)
+		}
+	}
+}
+
 func TestNewOIDCHandler_InvalidCACertPath(t *testing.T) {
 	_, err := NewOIDCHandler(context.Background(), Config{
 		Mode:             "oidc",


### PR DESCRIPTION
## Problem

Explicit-endpoint OIDC mode - authorization/token/JWKS URLs set with no `internalIssuerURL` - skips discovery. The provider is then built with no `id_token_signing_alg_values_supported`, so go-oidc narrows the ID-token verifier to **RS256 only** (`verify.go`: empty `SupportedSigningAlgs` defaults to RS256). An IdP that signs with ES256/PS256/EdDSA has valid tokens rejected, even though the JWKS is correct.

This is inconsistent with the split-issuer feature (#1039), which already declares ES/PS/EdDSA in `supportedOIDCSigningAlgorithms` as intended-supported.

## Fix

Seed the provider's `Algorithms` with the supported set in explicit-endpoint mode. The JWKS keys still constrain which algorithms actually verify - this only stops go-oidc from silently collapsing the allow-list to RS256.

## Test

New unit test `TestResolveOIDCProviderMetadata_ExplicitEndpointsSeedSigningAlgorithms` asserts the resolved algorithms include RS256/ES256/PS256/EdDSA. It fails before this change (algorithms empty) and passes after.

## Context

Follow-up to the split public/internal OIDC issuer feature (#1039). That feature's happy path (internal-issuer discovery, RS256) was validated end-to-end on a kind cluster with an in-cluster Dex reachable only via service DNS; this covers the explicit-endpoint, non-RS256 gap that path did not exercise. Found via cross-model review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ID token verification configuration in auth; scope is narrow (explicit-endpoint OIDC only) and algorithms remain filtered to the existing supported set, but misconfiguration could affect login for non-RS256 IdPs.
> 
> **Overview**
> Fixes **OIDC login failures** when Radar is configured with explicit authorization/token/JWKS URLs and **no discovery** (explicit-endpoint mode). In that path, go-oidc used to see an empty signing-algorithm list and **narrow ID token verification to RS256 only**, so IdPs signing with **ES256, PS256, or EdDSA** could return valid tokens that Radar rejected.
> 
> The resolver now **seeds** provider metadata with Radar’s full supported signing set (then still **filters** through the existing allowlist). **JWKS keys** still bound what actually verifies—this only stops the verifier from silently collapsing to RS256.
> 
> Adds **`supportedOIDCSigningAlgorithmList()`** and a unit test that explicit-endpoint resolution includes RS256/ES256/PS256/EdDSA (regression for the empty-algorithms case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ed6593b06b36a32c1dafae4e69a64e02f786c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->