### PR TITLE
Capacity's version-skew state: a 404 names the required Radar version

### DIFF
--- a/web/src/components/capacity/CapacityView.test.tsx
+++ b/web/src/components/capacity/CapacityView.test.tsx
@@ -24,6 +24,8 @@ import type {
 } from "@skyhook-io/k8s-ui";
 import { CapacityView } from "./CapacityView";
 import { updateDemandSearchParam } from "./CapacityDemand";
+import { integrationBlock } from "./shared";
+import { ApiError } from "../../api/client";
 
 vi.mock("../../context/ConnectionContext", () => ({
   useConnection: () => ({ connection: { state: "connected" } }),
@@ -2283,5 +2285,24 @@ describe("CapacityView activity", () => {
     );
     expect(html).toContain("All · 3");
     expect(html).not.toContain("All · ≥3");
+  });
+});
+
+describe("integrationBlock version skew", () => {
+  it("maps a top-level 404 to the pre-v1.9.0 upgrade message, never 'Unknown error'", () => {
+    const html = renderToString(
+      <>{integrationBlock(undefined, new ApiError("404 page not found", 404), false, "Loading")}</>,
+    );
+    expect(html).toContain("Capacity needs a newer Radar");
+    expect(html).toContain("v1.9.0");
+    expect(html).not.toContain("Capacity unavailable");
+  });
+
+  it("keeps ordinary failures on the generic error state", () => {
+    const html = renderToString(
+      <>{integrationBlock(undefined, new ApiError("boom", 500), false, "Loading")}</>,
+    );
+    expect(html).toContain("Capacity unavailable");
+    expect(html).not.toContain("needs a newer Radar");
   });
 });

--- a/web/src/components/capacity/shared.tsx
+++ b/web/src/components/capacity/shared.tsx
@@ -51,6 +51,7 @@ import {
 import {
   isCapacityCursorInvalidError,
   isForbiddenError,
+  isNotFoundError,
   useCapacityPools,
 } from "../../api/client";
 import type { SelectedResource } from "../../types";
@@ -1517,9 +1518,20 @@ export function integrationBlock(
   if (!response && isLoading)
     return <PaneLoader label={loadingLabel} className="min-h-0 flex-1" />;
   if (!response && error) {
-    return isForbiddenError(error) ? (
-      <DeniedCapacityState detail={errorMessage(error)} />
-    ) : (
+    if (isForbiddenError(error))
+      return <DeniedCapacityState detail={errorMessage(error)} />;
+    // A 404 on the top-level capacity routes means the route doesn't exist on
+    // this Radar — a pre-v1.9.0 binary behind a version-skewed host (Radar
+    // Cloud), not a failure. The embedded OSS binary can never hit this.
+    if (isNotFoundError(error))
+      return (
+        <EmptyState
+          icon={Gauge}
+          title="Capacity needs a newer Radar"
+          detail="This cluster's Radar predates the Capacity view (added in Radar v1.9.0). Upgrade the in-cluster Radar to enable it."
+        />
+      );
+    return (
       <EmptyState
         icon={AlertTriangle}
         title="Capacity unavailable"


### PR DESCRIPTION
On a version-skewed host — Radar Cloud embedding current radar-app against a cluster whose in-cluster Radar predates v1.9.0 — every top-level capacity route 404s (the route doesn't exist on that binary), and the page rendered the generic \"Capacity unavailable — Unknown error\". During the Cloud rollout that is the *first* capacity experience most users will have, and it reads as breakage rather than as a version fact.

## What changed

\`integrationBlock\` — the shared top-level state gate for all four capacity screens — gains a not-found branch between the 403 (denied) and generic-error branches: a 404 renders a quiet Gauge empty-state, \"Capacity needs a newer Radar — this cluster's Radar predates the Capacity view (added in Radar v1.9.0). Upgrade the in-cluster Radar to enable it.\"

Scoping notes:
- The embedded OSS binary can never hit this branch (UI and routes ship together); it exists for library consumers with mixed-version fleets.
- Pool detail's entity-level 404 (\"NodePool no longer exists\") intercepts before this gate and keeps its own hedged copy, so a typo'd pool link on a current Radar cannot render the upgrade message.
- Capacity 404s were already classified non-retryable, so the message appears immediately rather than after a retry cycle.

## Testing

Two pins in \`CapacityView.test.tsx\`: a 404 renders the upgrade message (and never \"Unknown error\"); a 500 keeps the generic error state. Full web suite 376 passed; \`tsc\` clean. (The two \"failed suites\" in a bare \`vitest run\` are the Playwright e2e specs being collected by vitest — pre-existing on main, unrelated.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error routing for Capacity load failures; no auth or API contract changes beyond clearer 404 handling.
> 
> **Overview**
> When **Radar Cloud** (or another host) serves a newer UI against an in-cluster Radar **before v1.9.0**, top-level Capacity API routes return **404**. Those failures previously went through the generic **“Capacity unavailable”** path (often **“Unknown error”**), which reads like a broken feature rather than a version gap.
> 
> **`integrationBlock`** in `shared.tsx` now treats **404** like **403**: after the forbidden branch, **`isNotFoundError`** renders a **Gauge** empty state—**“Capacity needs a newer Radar”** with copy that Capacity was added in **v1.9.0** and the in-cluster Radar must be upgraded. Other errors still use the **AlertTriangle** **“Capacity unavailable”** state.
> 
> **`CapacityView.test.tsx`** adds two SSR pins: 404 shows the upgrade message and not **“Capacity unavailable”**; 500 keeps the generic error and not the upgrade copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b575354a155d1fbeade6b3c34eac171b53c91e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->