### PR TITLE
Chart RBAC for Capacity: cloud tiers read Karpenter; EKS Auto NodeClasses covered

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -266,7 +266,7 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 | `gcpMonitoring` | `monitoring.googleapis.com` |
 | `grafana` | `monitoring.grafana.com`, `tempo.grafana.com`, `loki.grafana.com`, `grafana.integreatly.org` |
 | `istio` | `networking.istio.io`, `security.istio.io` |
-| `karpenter` | `karpenter.sh`, `karpenter.k8s.aws`, `karpenter.azure.com`, `karpenter.k8s.gcp` |
+| `karpenter` | `karpenter.sh`, `karpenter.k8s.aws`, `karpenter.azure.com`, `karpenter.k8s.gcp`, `eks.amazonaws.com` |
 | `keda` | `keda.sh` |
 | `knative` | `serving.knative.dev`, `eventing.knative.dev`, `sources.knative.dev`, `messaging.knative.dev`, `flows.knative.dev`, `networking.internal.knative.dev` |
 | `kubeshark` | `kubeshark.io` |

--- a/deploy/helm/radar/templates/cloud-rbac-cluster-read.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-cluster-read.yaml
@@ -76,6 +76,21 @@ rules:
   - apiGroups: ["node.k8s.io"]
     resources: ["runtimeclasses"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.crdGroups.karpenter }}
+  # The Capacity view gates per-CALLER: the page on "list nodes" (granted
+  # above), the Karpenter screens on "list nodepools". Without this rule every
+  # Cloud tier lands in the denied-NodePools shape on Karpenter clusters even
+  # though the SA caches everything. Same benign-infra class as the rest of
+  # this role — cluster-scoped provisioning config, no secrets. Group-wide
+  # read (not named kinds) because Karpenter's kind set moves with its
+  # versions (NodeOverlays, provider NodeClass variants) and a named list
+  # would strand new kinds in an unexplainable denied state. Gated on the SA's
+  # own karpenter collection for the same reason metrics is below: caller
+  # read is meaningless for data the SA never caches.
+  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws", "karpenter.azure.com", "karpenter.k8s.gcp", "eks.amazonaws.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
   {{- if .Values.rbac.metrics }}
   # On clusters with a standard metrics-server install this is usually
   # redundant — its aggregated-metrics-reader role carries aggregate-to-view

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -300,7 +300,7 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.rbac.crdGroups.karpenter }}
-  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws", "karpenter.azure.com", "karpenter.k8s.gcp"]
+  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws", "karpenter.azure.com", "karpenter.k8s.gcp", "eks.amazonaws.com"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -146,7 +146,7 @@ rbac:
     gcpMonitoring: true     # monitoring.googleapis.com
     grafana: true           # monitoring.grafana.com, tempo/loki/grafana.integreatly.org
     istio: true             # networking.istio.io, security.istio.io
-    karpenter: true         # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.k8s.gcp
+    karpenter: true         # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.k8s.gcp, eks.amazonaws.com (EKS Auto Mode NodeClasses)
     keda: true              # keda.sh
     knative: true           # serving.knative.dev, eventing.knative.dev, sources/messaging/flows/networking.internal.knative.dev
     kubeshark: true         # kubeshark.io


### PR DESCRIPTION
The Capacity view gates per-CALLER: the page on \`list nodes\`, the Karpenter screens on \`list nodepools\`. The radar ServiceAccount already collects everything (\`rbac.crdGroups.karpenter\` defaults on), but in Cloud mode the caller is the hub user under the \`radar:{viewer,member,owner}\` tier bindings — and the cluster-read add-on granted nodes without Karpenter, so every Cloud tier would land in the denied-NodePools shape on Karpenter clusters. No new flag: every permission Capacity needs already has a home in the existing model.

## What changed (in \`deploy/helm/radar\` — the chart's source of truth; releases sync it wholesale to skyhook-io/helm-charts)

- **\`cloud-rbac-cluster-read.yaml\`**: the tier add-on gains group-wide read on \`karpenter.sh\` + the provider NodeClass groups, gated on \`rbac.crdGroups.karpenter\` (caller read is meaningless for data the SA never caches — same rationale as the existing metrics gate). Group-wide rather than named kinds because Karpenter's kind set moves with its versions, and a named list would strand new kinds in an unexplainable denied state.
- **\`eks.amazonaws.com\` joins the karpenter group list** in both the SA ClusterRole and the new tier rule — EKS Auto Mode's NodeClasses live there; without it, Auto Mode clusters lose NodeClass readiness (the cascade attribution) and the Inspect link.
- README + values comment updated to match.

Landing this here rather than in helm-charts means the grants ship with exactly the release whose binary needs them (v1.9.0), and the release pipeline's \`rm -rf && cp\` sync can't erase them. Supersedes skyhook-io/helm-charts#35, closed for that reason.

## Verification

\`helm lint\` clean. Rendered permutations: default → SA rule carries the widened group list; cloud mode → the \`-cluster-read\` role carries the karpenter rule bound to all three tiers; \`rbac.crdGroups.karpenter=false\` → both rules drop together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only RBAC widening for provisioning config CRDs, gated on an existing flag; no secrets or write verbs.
> 
> **Overview**
> Fixes **Radar Cloud** Capacity/Karpenter UX where hub users under `radar:{viewer,member,owner}` could list nodes but were denied on NodePools because the cluster-read add-on never included Karpenter.
> 
> **`cloud-rbac-cluster-read.yaml`** adds group-wide `get/list/watch` on Karpenter provider groups when `rbac.crdGroups.karpenter` is enabled, matching the SA cache gate used for metrics.
> 
> **`eks.amazonaws.com`** is added alongside the existing Karpenter groups in the SA **ClusterRole**, the new tier rule, **README**, and **values** comments so EKS Auto Mode NodeClasses (and related readiness/Inspect behavior) are covered.
> 
> Setting `rbac.crdGroups.karpenter=false` drops both the SA and tier Karpenter rules together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11e51785b18c3214e015ee66d3c6b9167614959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->