### PR TITLE
The version-skew capacity message breaks before its call to action

### DIFF
--- a/web/src/components/capacity/shared.tsx
+++ b/web/src/components/capacity/shared.tsx
@@ -1341,7 +1341,7 @@ export function EmptyState({
 }: {
   icon: ComponentType<{ className?: string }>;
   title: string;
-  detail: string;
+  detail: ReactNode;
   action?: ReactNode;
 }) {
   return (
@@ -1528,7 +1528,14 @@ export function integrationBlock(
         <EmptyState
           icon={Gauge}
           title="Capacity needs a newer Radar"
-          detail="This cluster's Radar predates the Capacity view (added in Radar v1.9.0). Upgrade the in-cluster Radar to enable it."
+          detail={
+            <>
+              This cluster&rsquo;s Radar predates the Capacity view (added in
+              Radar v1.9.0).
+              <br />
+              Upgrade the in-cluster Radar to enable it.
+            </>
+          }
         />
       );
     return (


### PR DESCRIPTION
The two sentences of the pre-v1.9.0 skew state — the fact and the action — now sit on their own lines instead of wrapping mid-parenthetical. `EmptyState.detail` widens from `string` to `ReactNode` (additive; every existing caller passes a string). Pinned tests unchanged and green; `tsc` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to empty-state copy and a backward-compatible prop type widening; no API or business-logic impact.
> 
> **Overview**
> Fixes awkward wrapping in the **Capacity needs a newer Radar** empty state when the host is ahead of an in-cluster Radar that predates v1.9.0. The explanatory sentence and the upgrade call-to-action are now on separate lines instead of breaking mid-parenthetical.
> 
> `EmptyState.detail` is widened from `string` to `ReactNode` so that state can pass a fragment with a line break; other callers still pass plain strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2441bb138ca8463eb3792b66d25ffffa6e28415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->