### PR TITLE
CI pins Helm explicitly: lint/template on Helm 4, unittest on Helm 3 until upstream supports it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,11 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          # Pinned to Helm 3: unpinned runners started resolving Helm 4, whose
-          # plugin layout breaks helm-unittest (fork/exec untt: no such file).
-          # Green/red alternated by runner cache. Unpin deliberately, with a
-          # helm-unittest release that supports Helm 4.
-          version: v3.19.0
+          # Explicit pin (never `latest` — runner caches made green/red a
+          # lottery). Helm 4 on purpose: it's what new users install with,
+          # and lint/template/negative-tests are the chart's user-facing
+          # surface. The unittest step below stays on Helm 3.
+          version: v4.2.3
 
       - name: Lint
         run: helm lint deploy/helm/radar
@@ -173,6 +173,9 @@ jobs:
         uses: helmfile/helmfile-action@v2.2.0
         with:
           helmfile-auto-init: 'true'
+          # Helm 3 ONLY here: helm-unittest cannot run under Helm 4's plugin
+          # layout (fork/exec untt: no such file) — upstream tracking issue
+          # helm-unittest/helm-unittest#777. Lift to 4 when that closes.
           helm-version: v3.19.0
           helm-plugins: >
             https://github.com/helm-unittest/helm-unittest@v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v5
+        with:
+          # Pinned to Helm 3: unpinned runners started resolving Helm 4, whose
+          # plugin layout breaks helm-unittest (fork/exec untt: no such file).
+          # Green/red alternated by runner cache. Unpin deliberately, with a
+          # helm-unittest release that supports Helm 4.
+          version: v3.19.0
 
       - name: Lint
         run: helm lint deploy/helm/radar
@@ -167,6 +173,7 @@ jobs:
         uses: helmfile/helmfile-action@v2.2.0
         with:
           helmfile-auto-init: 'true'
+          helm-version: v3.19.0
           helm-plugins: >
             https://github.com/helm-unittest/helm-unittest@v1.1.0
 


### PR DESCRIPTION
The Helm chart job failed intermittently — green/red within the same hour — because both Helm installs were unpinned (`azure/setup-helm@v5` with no version; helmfile-action's default `helm-version: latest`) and runners resolve whatever's cached, increasingly **Helm 4.2.3**, under which helm-unittest cannot run (`fork/exec …/untt: no such file`; upstream support is open at helm-unittest/helm-unittest#777).

Both installs are now pinned explicitly, deliberately differently:

- **lint / template / negative tests → Helm v4.2.3** — the chart's user-facing surface, tested on what new users actually install with (these steps already pass under 4; the red runs proved it incidentally).
- **helmfile unittest → Helm v3.19.0** — the only step that can't run on 4 today. Lift when #777 closes.

Never `latest` again either way: cache-dependent tool versions turned CI into a runner lottery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no runtime or chart behavior impact; reduces flake risk from unpinned tooling.
> 
> **Overview**
> **Stabilizes the Helm chart CI job** by pinning Helm versions instead of relying on runner caches or `latest`, which caused intermittent failures when runners picked Helm 4 while **helm-unittest** still requires Helm 3.
> 
> The **Install Helm** step (`azure/setup-helm`) now sets **`version: v4.2.3`** for `helm lint`, `helm template`, and the negative validation steps—matching what many users install and exercising the chart’s user-facing surface on Helm 4.
> 
> The **helmfile** action step pins **`helm-version: v3.19.0`** only for the unittest plugin run, with comments pointing to helm-unittest#777 until Helm 4 plugin layout is supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34dea6aa214d69fe0cb2065a4182c8fbad2b2350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->