### PR TITLE
The no-agent-CLI copy names Cursor too

### DIFF
--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -218,7 +218,7 @@ func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 // writes the error) when unavailable.
 func (s *Server) aiReady(w http.ResponseWriter) bool {
 	if s.aiRuns == nil {
-		s.writeError(w, http.StatusNotImplemented, "no agent CLI available — install Claude Code or Codex to enable AI diagnosis")
+		s.writeError(w, http.StatusNotImplemented, "no agent CLI available — install Claude Code, Codex, or Cursor (cursor-agent) to enable AI diagnosis")
 		return false
 	}
 	return s.requireConnected(w)

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -964,8 +964,10 @@ function AIUnavailableNotice() {
     <div className="rounded-md border border-theme-border bg-theme-elevated/50 p-3">
       <p className="text-sm font-medium text-theme-text-primary">No supported agent CLI found</p>
       <p className="mt-1 text-xs text-theme-text-tertiary">
-        Install <span className="text-theme-text-secondary">Claude Code</span> or{' '}
-        <span className="text-theme-text-secondary">Codex</span>, then restart Radar — this tab
+        Install <span className="text-theme-text-secondary">Claude Code</span>,{' '}
+        <span className="text-theme-text-secondary">Codex</span>, or{' '}
+        <span className="text-theme-text-secondary">Cursor</span> (
+        <span className="font-mono">cursor-agent</span>), then restart Radar — this tab
         will show the agent, model, and effort controls.
       </p>
     </div>


### PR DESCRIPTION
The Settings → AI diagnose empty state and the 501 error both said "install Claude Code or Codex" — omitting Cursor (`cursor-agent`), which is a fully supported agent. Both sites now name all three, matching the CLI's own help text and the docs. Found while writing the Diagnose docs page; copy-only, no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes to error and settings UI strings; no logic, auth, or data paths touched.
> 
> **Overview**
> When AI diagnosis is unavailable because no agent CLI is detected, user-facing copy now lists **Cursor** (`cursor-agent`) alongside Claude Code and Codex.
> 
> The **501** response from `aiReady` and the Settings → **AI diagnose** empty state (`AIUnavailableNotice`) were updated in parallel so install guidance matches supported agents elsewhere in the product. **No detection or runtime behavior changes**—text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6340046bc58a9019de39cba914377fc9542d2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->