### PR TITLE
fix(desktop): drop the Paste accelerator on Windows only

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -22,17 +22,19 @@ func reloadAccelerator(goos string) *keys.Accelerator {
 	return keys.Combo("r", keys.ControlKey, keys.ShiftKey)
 }
 
-// pasteAccelerator binds Cmd+V only on macOS. Paste needs an explicit callback
-// (see the Edit menu below), and off macOS the accelerator does not consume the
-// keypress — winc fires the menu action from WM_KEYDOWN and still lets the
-// event reach the webview, which pastes natively on Ctrl+V. Binding both would
-// insert the clipboard twice. Leaving the accelerator off costs only the
-// menu-item hint; Ctrl+V still pastes through the webview.
+// pasteAccelerator drops Ctrl+V on Windows only. Paste needs an explicit
+// callback (see the Edit menu below), and on Windows the accelerator does not
+// consume the keypress — winc fires the menu action from WM_KEYDOWN and still
+// lets the event reach the webview, which pastes natively, so binding both
+// inserts the clipboard twice. macOS and Linux register accelerators through
+// their own toolkits, which do consume the key, so the accelerator there is the
+// single paste path and must stay. The cost on Windows is only the menu-item
+// hint; Ctrl+V still pastes through the webview.
 func pasteAccelerator(goos string) *keys.Accelerator {
-	if goos == "darwin" {
-		return keys.CmdOrCtrl("v")
+	if goos == "windows" {
+		return nil
 	}
-	return nil
+	return keys.CmdOrCtrl("v")
 }
 
 func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
@@ -58,8 +60,8 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	//
 	// Paste: Must use explicit WindowExecJS because WKWebView's native paste:
 	// doesn't work for complex editors like Monaco. We read from the clipboard
-	// API and dispatch a synthetic ClipboardEvent. The accelerator is macOS-only
-	// — see pasteAccelerator.
+	// API and dispatch a synthetic ClipboardEvent. The accelerator is dropped on
+	// Windows — see pasteAccelerator.
 	//
 	// Undo/Redo/SelectAll: Use WindowExecJS (these work fine via execCommand).
 	editMenu := appMenu.AddSubmenu("Edit")

--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -22,6 +22,19 @@ func reloadAccelerator(goos string) *keys.Accelerator {
 	return keys.Combo("r", keys.ControlKey, keys.ShiftKey)
 }
 
+// pasteAccelerator binds Cmd+V only on macOS. Paste needs an explicit callback
+// (see the Edit menu below), and off macOS the accelerator does not consume the
+// keypress — winc fires the menu action from WM_KEYDOWN and still lets the
+// event reach the webview, which pastes natively on Ctrl+V. Binding both would
+// insert the clipboard twice. Leaving the accelerator off costs only the
+// menu-item hint; Ctrl+V still pastes through the webview.
+func pasteAccelerator(goos string) *keys.Accelerator {
+	if goos == "darwin" {
+		return keys.CmdOrCtrl("v")
+	}
+	return nil
+}
+
 func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	appMenu := menu.NewMenu()
 
@@ -45,7 +58,8 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	//
 	// Paste: Must use explicit WindowExecJS because WKWebView's native paste:
 	// doesn't work for complex editors like Monaco. We read from the clipboard
-	// API and dispatch a synthetic ClipboardEvent.
+	// API and dispatch a synthetic ClipboardEvent. The accelerator is macOS-only
+	// — see pasteAccelerator.
 	//
 	// Undo/Redo/SelectAll: Use WindowExecJS (these work fine via execCommand).
 	editMenu := appMenu.AddSubmenu("Edit")
@@ -58,7 +72,7 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	editMenu.AddSeparator()
 	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
 	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
-	editMenu.AddText("Paste", keys.CmdOrCtrl("v"), func(_ *menu.CallbackData) {
+	editMenu.AddText("Paste", pasteAccelerator(goruntime.GOOS), func(_ *menu.CallbackData) {
 		runtime.WindowExecJS(desktopApp.ctx, `
 			navigator.clipboard.readText().then(function(text) {
 				if (!text) return;

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -87,14 +87,14 @@ func TestCreateMenuReloadIsWiredToPlatformAccelerator(t *testing.T) {
 	}
 }
 
-func TestPasteAcceleratorBindsOnlyOnMac(t *testing.T) {
+func TestPasteAcceleratorDroppedOnlyOnWindows(t *testing.T) {
 	cases := []struct {
 		goos string
 		want *keys.Accelerator
 	}{
-		{"darwin", keys.CmdOrCtrl("v")},
 		{"windows", nil},
-		{"linux", nil},
+		{"darwin", keys.CmdOrCtrl("v")},
+		{"linux", keys.CmdOrCtrl("v")},
 	}
 	for _, tc := range cases {
 		t.Run(tc.goos, func(t *testing.T) {
@@ -108,7 +108,8 @@ func TestPasteAcceleratorBindsOnlyOnMac(t *testing.T) {
 
 // TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding pins both halves of the
 // paste contract: the callback must stay (a nil one leaves the item inert on
-// Windows), and off macOS no accelerator may be bound alongside it.
+// Windows), and on Windows no accelerator may be bound alongside it because
+// winc does not consume the key.
 func TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding(t *testing.T) {
 	appMenu := createMenu(&DesktopApp{}, "test")
 	paste := findMenuItem(t, findSubmenu(t, appMenu, "Edit"), "Paste")
@@ -119,8 +120,8 @@ func TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding(t *testing.T) {
 	if !reflect.DeepEqual(paste.Accelerator, pasteAccelerator(goruntime.GOOS)) {
 		t.Fatalf("Paste accelerator = %+v, want %+v", paste.Accelerator, pasteAccelerator(goruntime.GOOS))
 	}
-	if goruntime.GOOS != "darwin" && paste.Accelerator != nil {
-		t.Fatalf("Paste is bound to %+v on %s — the webview pastes on Ctrl+V too, so the clipboard lands twice", paste.Accelerator, goruntime.GOOS)
+	if goruntime.GOOS == "windows" && paste.Accelerator != nil {
+		t.Fatalf("Paste is bound to %+v on windows — the webview pastes on Ctrl+V too, so the clipboard lands twice", paste.Accelerator)
 	}
 }
 

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -87,6 +87,43 @@ func TestCreateMenuReloadIsWiredToPlatformAccelerator(t *testing.T) {
 	}
 }
 
+func TestPasteAcceleratorBindsOnlyOnMac(t *testing.T) {
+	cases := []struct {
+		goos string
+		want *keys.Accelerator
+	}{
+		{"darwin", keys.CmdOrCtrl("v")},
+		{"windows", nil},
+		{"linux", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			got := pasteAccelerator(tc.goos)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("pasteAccelerator(%q) = %+v, want %+v", tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding pins both halves of the
+// paste contract: the callback must stay (a nil one leaves the item inert on
+// Windows), and off macOS no accelerator may be bound alongside it.
+func TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding(t *testing.T) {
+	appMenu := createMenu(&DesktopApp{}, "test")
+	paste := findMenuItem(t, findSubmenu(t, appMenu, "Edit"), "Paste")
+
+	if paste.Click == nil {
+		t.Fatal("Paste item has no callback")
+	}
+	if !reflect.DeepEqual(paste.Accelerator, pasteAccelerator(goruntime.GOOS)) {
+		t.Fatalf("Paste accelerator = %+v, want %+v", paste.Accelerator, pasteAccelerator(goruntime.GOOS))
+	}
+	if goruntime.GOOS != "darwin" && paste.Accelerator != nil {
+		t.Fatalf("Paste is bound to %+v on %s — the webview pastes on Ctrl+V too, so the clipboard lands twice", paste.Accelerator, goruntime.GOOS)
+	}
+}
+
 func findSubmenu(t *testing.T, root *menu.Menu, label string) *menu.Menu {
 	t.Helper()
 	for _, item := range root.Items {


### PR DESCRIPTION
## Description

On Windows, one `Ctrl+V` inserts the clipboard **twice**. Pasting from **Edit → Paste** with the mouse inserts it once, correctly.

The Edit menu registers `Ctrl+V` as a native accelerator *and* attaches an explicit callback that performs its own paste:

```go
editMenu.AddText("Paste", keys.CmdOrCtrl("v"), func(_ *menu.CallbackData) {
    runtime.WindowExecJS(desktopApp.ctx, `... dispatch a synthetic ClipboardEvent ...`)
})
```

On Windows that means two pastes for one keypress, because the accelerator does not consume the key. Wails handles accelerators itself in `WM_KEYDOWN` and falls through to `DefWindowProc` — `winc/form.go`:

```go
case w32.WM_KEYDOWN:
    // Accelerator support.
    key := Key(wparam)
    if uint32(lparam)>>30 == 0 {
        shortcut := Shortcut{ModifiersDown(), key}
        if action, ok := shortcut2Action[shortcut]; ok {
            if action.Enabled() {
                action.onClick.Fire(NewEvent(fm, nil))   // runs the JS paste
            }
        }
    }
    // no return — WebView2 also receives Ctrl+V and pastes natively
```

So the clipboard lands once from the webview's own paste and once from the menu callback. Clicking the menu item sends no key event to the webview, which is why the mouse path was always correct.

This is the same trap already documented for Reload in this file: *"a native menu accelerator fires regardless of webview focus."* Reload was made platform-aware; Paste was not.

**Fix:** drop the Paste accelerator on **Windows only**. Windows is the only platform where the accelerator fails to consume the key. macOS (AppKit) and Linux (GTK) both consume it, so there the accelerator is the *single* paste path and must stay — dropping it would hand Monaco to native webview behavior that isn't verified on either.

On GTK the accelerator is registered by `gtk_widget_add_accelerator` and consumed regardless of whether a handler is connected: `closure_accel_activate` in `gtkwidget.c` returns `can_activate` (widget sensitivity), never handler presence. And `gtkwindow.c` runs `gtk_window_activate_key` *before* `gtk_window_propagate_key_event`, so the accelerator wins over the focused webview.

`Cut`/`Copy` are unaffected and deliberately left alone here: they pass `nil` callbacks, and `windows/menu.go` only binds a handler when `Click != nil`, so their accelerator fires into an unbound event and is a harmless no-op. Doubling needs a bound callback *and* the fall-through; only Paste had both.

### Trade-off

On Windows the Edit menu no longer displays the `Ctrl+V` hint next to Paste. In winc the hint and the key binding are the same thing (`initMenuItemInfoFromAction` writes the label text and registers `shortcut2Action` together), so keeping the hint means keeping the double paste. `Ctrl+V` still works — the webview handles it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Environment: Windows 11 (26200), Go 1.26.1, Node 24.13.1, Wails v2.12.0.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

- Added `TestPasteAcceleratorDroppedOnlyOnWindows` (per-GOOS table) and `TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding` (wiring). The wiring test fails against the unfixed wiring on Windows — `Paste accelerator = &{Key:v Modifiers:[cmdorctrl]}, want <nil>` — and passes with the fix.
- The wiring test also pins that the callback must stay: a `nil` callback binds no handler on Windows, which would leave Edit → Paste inert.
- `go build ./...` — clean.
- `go test ./cmd/desktop/` — pass.
- `go test ./...` — `internal/server` and `internal/timeline` fail, but they fail identically on unmodified `main` (same 5 + 1 tests), so they are pre-existing and unrelated to this change.
- `cd web && npm run tsc` — pass (no frontend files touched).
- `gofmt` — clean.
- Manual check on a `wails build -platform windows/amd64` binary from this branch: `Ctrl+V` inserts the clipboard once in the resource search box and once in the Monaco YAML editor, and **Edit → Paste** from the menu bar still works.

Not tested on macOS or Linux — I don't have access to either. The change is scoped to `windows`, so macOS and Linux behavior is unchanged by construction.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #1276
