### PR TITLE
fix(desktop): make Edit menu Cut/Copy work off macOS

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -37,6 +37,21 @@ func pasteAccelerator(goos string) *keys.Accelerator {
 	return keys.CmdOrCtrl("v")
 }
 
+// clipboardDelegate returns nil on macOS, where Cut/Copy rely on the native
+// responder chain. Off macOS a nil callback binds no handler at all, so the menu
+// entries do nothing when clicked; routing through execCommand reaches the
+// copy/cut interception in main.tsx, which also covers Monaco's virtual
+// selection. Both handlers re-read the selection, so the keyboard path staying
+// on the webview is harmless.
+func clipboardDelegate(goos string, desktopApp *DesktopApp, command string) func(*menu.CallbackData) {
+	if goos == "darwin" {
+		return nil
+	}
+	return func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('"+command+"')")
+	}
+}
+
 func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	appMenu := menu.NewMenu()
 
@@ -52,11 +67,12 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 
 	// Edit menu — clipboard handling strategy:
 	//
-	// Copy/Cut: Use nil callbacks to delegate to macOS's native responder chain.
+	// Copy/Cut: On macOS a nil callback delegates to the native responder chain.
 	// WKWebView does NOT dispatch DOM copy/cut events from the native selectors.
 	// Instead, the JS keydown handler in main.tsx intercepts Cmd+C/X before macOS
 	// consumes the event, reads the selection (including Monaco virtual selection),
-	// and writes to the clipboard via navigator.clipboard.writeText().
+	// and writes to the clipboard via navigator.clipboard.writeText(). Elsewhere
+	// there is no responder chain to fall back on — see clipboardDelegate.
 	//
 	// Paste: Must use explicit WindowExecJS because WKWebView's native paste:
 	// doesn't work for complex editors like Monaco. We read from the clipboard
@@ -72,8 +88,8 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('redo')")
 	})
 	editMenu.AddSeparator()
-	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
-	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
+	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), clipboardDelegate(goruntime.GOOS, desktopApp, "cut"))
+	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), clipboardDelegate(goruntime.GOOS, desktopApp, "copy"))
 	editMenu.AddText("Paste", pasteAccelerator(goruntime.GOOS), func(_ *menu.CallbackData) {
 		runtime.WindowExecJS(desktopApp.ctx, `
 			navigator.clipboard.readText().then(function(text) {

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -125,6 +125,36 @@ func TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding(t *testing.T) {
 	}
 }
 
+func TestClipboardDelegateSkipsOnlyMac(t *testing.T) {
+	for _, goos := range []string{"windows", "linux"} {
+		t.Run(goos, func(t *testing.T) {
+			if clipboardDelegate(goos, &DesktopApp{}, "copy") == nil {
+				t.Fatalf("clipboardDelegate(%q) = nil, want a callback", goos)
+			}
+		})
+	}
+	if clipboardDelegate("darwin", &DesktopApp{}, "copy") != nil {
+		t.Fatal("clipboardDelegate(\"darwin\") returned a callback, want nil for the responder chain")
+	}
+}
+
+// TestCreateMenuCutCopyAreClickableOffMac guards the inert-menu-item case: off
+// macOS a nil callback binds no handler, so Edit -> Cut/Copy would do nothing.
+func TestCreateMenuCutCopyAreClickableOffMac(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("macOS delegates Cut/Copy to the native responder chain")
+	}
+	editMenu := findSubmenu(t, createMenu(&DesktopApp{}, "test"), "Edit")
+
+	for _, label := range []string{"Cut", "Copy"} {
+		t.Run(label, func(t *testing.T) {
+			if findMenuItem(t, editMenu, label).Click == nil {
+				t.Fatalf("%s has no callback on %s — the menu entry would be inert", label, goruntime.GOOS)
+			}
+		})
+	}
+}
+
 func findSubmenu(t *testing.T, root *menu.Menu, label string) *menu.Menu {
 	t.Helper()
 	for _, item := range root.Items {


### PR DESCRIPTION
## Description

On Windows and Linux, **Edit → Cut** and **Edit → Copy** do nothing when clicked.

Both items are registered with a `nil` callback:

```go
editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
```

That is correct on macOS, where `nil` delegates to the native responder chain. Off macOS there is nothing to delegate to — Wails only binds a handler when `Click != nil` (`windows/menu.go`), and firing an unbound event is a no-op (`winc/eventmanager.go`), so the entries are wired to nothing.

`Ctrl+C` / `Ctrl+X` were never broken: `web/src/main.tsx` has its own `keydown` listener that checks `e.ctrlKey`, so the keyboard path already worked. Only the menu items were dead.

**Fix:** off macOS, give the two items a callback that calls `document.execCommand('cut'|'copy')`. `main.tsx` already monkey-patches `execCommand` and routes those to `handleCopyOrCut`, so Monaco's virtual selection is handled the same way as the existing right-click path. macOS keeps its `nil` delegation untouched.

The `Ctrl+X`/`Ctrl+C` accelerators are kept, so the menu still shows the hints. Adding a callback does mean the accelerator now fires it as well, so the keyboard path reaches `handleCopyOrCut` twice. That is safe: JS is single-threaded, so the two runs are sequential rather than interleaved, and each one re-reads the selection. Copy writes the same text twice. The first Cut collapses the selection, so the second returns at `if (!text) return` before deleting anything — there is no state in which a second delete has something to remove.

This is why the accelerator is kept here but dropped for Paste. Paste doesn't read the document, it inserts the clipboard, so a second run always has something to do and the duplicate is visible.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Environment: Windows 11 (26200), Go 1.26.1, Node 24.13.1, Wails v2.12.0.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

- Added `TestClipboardDelegateSkipsOnlyMac` and `TestCreateMenuCutCopyAreClickableOffMac`. The wiring test fails against the unfixed code with `Cut has no callback on windows — the menu entry would be inert` (and the same for Copy), and passes with the fix. It skips on `darwin`, where `nil` is correct.
- `go build ./...` — clean.
- `go test ./cmd/desktop/` — pass.
- `go test ./...` — `internal/server` and `internal/timeline` fail identically on unmodified `main`, so they are pre-existing and unrelated.
- `cd web && npm run tsc` — pass (no frontend files touched).
- `gofmt` / `go vet ./cmd/desktop/` — clean.
- Manual check on a `wails build -platform windows/amd64` binary from this branch: **Edit → Copy** and **Edit → Cut** now work (they did nothing before), and `Ctrl+C` / `Ctrl+X` still behave correctly.

Not tested on macOS or Linux — I don't have access to either. The change is scoped to non-`darwin`, so macOS behavior is unchanged by construction.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #1334

Stacked on #1335 (the Paste double-insert fix) — both touch the Edit menu clipboard items, so this branch includes that commit. Please merge that one first, or say the word and I'll rebase this onto `main` as a standalone change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop menu-only change scoped to non-darwin; keyboard shortcuts were already handled in the web layer and duplicate execCommand runs are considered safe per the PR.
> 
> **Overview**
> **Edit → Cut** and **Edit → Copy** were inert on Windows and Linux because Wails only wires menu actions when the callback is non-`nil`; macOS’s `nil` responder-chain delegation does not apply there.
> 
> The PR adds **`clipboardDelegate`**, which on non-macOS runs `document.execCommand('cut'|'copy')` via `WindowExecJS`, reusing the existing **`main.tsx`** `execCommand` hook (Monaco virtual selection). macOS still uses `nil` callbacks. Comments in the Edit menu are updated to document the split behavior.
> 
> Unit tests assert **`clipboardDelegate`** returns a handler on Windows/Linux only, and that Cut/Copy menu items have callbacks off macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c457e9471c46345326e62a6139cc94a81a335d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->