### PR TITLE
fix(ai): fall back to --force when cursor-agent lacks --trust

### DIFF
--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -37,7 +37,7 @@ type cursorAgent struct {
 
 	trustMu    sync.Mutex
 	trustKnown bool
-	trust      bool
+	trustArg   string // resolved workspace-trust flag: "--trust" | "--force" | ""
 }
 
 func (a *cursorAgent) Name() string { return "cursor-agent" }
@@ -79,14 +79,20 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 		"--sandbox", "enabled", // sandbox Cursor's own shell/file tools; MCP calls run server-side in radar
 		"--approve-mcps", // auto-approve the radar server for this headless run
 	}
-	trust, err := a.supportsTrust()
+	// Headless (-p) runs get no TTY, so Cursor can't prompt the workspace-trust
+	// gate — without a trust flag it aborts with "Workspace Trust Required", and
+	// the per-run throwaway workdir means a one-time manual trust never carries
+	// over. Which flag grants trust varies across Cursor releases (--trust was
+	// removed, then re-added), so probe --help and pass what's supported,
+	// preferring the narrowest. --force/--yolo also auto-approve command runs, but
+	// --sandbox enabled already contains Cursor's own shell/file tools and cluster
+	// writes stay gated by the read-only MCP mount, so the extra grant is bounded.
+	trustArg, err := a.resolveTrustFlag()
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	if trust {
-		args = append(args, "--trust")
-	}
+	args = append(args, trustArg)
 	if s.model != "" {
 		args = append(args, "--model", s.model) // free-form Cursor model slug; "" = the user's default
 	}
@@ -103,31 +109,54 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	return cmd, cleanup, nil
 }
 
-func (a *cursorAgent) supportsTrust() (bool, error) {
+// resolveTrustFlag returns the workspace-trust flag to pass this cursor-agent,
+// probing --help once and caching. Prefers --trust (workspace trust only); falls
+// back to --force (also skips command approvals, bounded by --sandbox). Errors if
+// the probe is inconclusive or no known trust flag is supported.
+func (a *cursorAgent) resolveTrustFlag() (string, error) {
 	a.trustMu.Lock()
 	defer a.trustMu.Unlock()
 	if a.trustKnown {
-		return a.trust, nil
+		if a.trustArg == "" {
+			return "", errNoCursorTrustFlag
+		}
+		return a.trustArg, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, _ := exec.CommandContext(ctx, a.bin, "--help").CombinedOutput()
 	if ctx.Err() != nil {
-		return false, fmt.Errorf("ai: Cursor Agent capability probe timed out")
+		return "", fmt.Errorf("ai: Cursor Agent capability probe timed out")
 	}
 	if len(bytes.TrimSpace(out)) == 0 {
-		return false, fmt.Errorf("ai: Cursor Agent capability probe returned no help output")
+		return "", fmt.Errorf("ai: Cursor Agent capability probe returned no help output")
 	}
-	a.trust = cursorHelpSupportsTrust(string(out))
+	a.trustArg = cursorHelpTrustFlag(string(out))
 	a.trustKnown = true
-	log.Printf("[ai] cursor-agent --trust supported=%v", a.trust)
-	return a.trust, nil
+	log.Printf("[ai] cursor-agent trust flag=%q", a.trustArg)
+	if a.trustArg == "" {
+		return "", errNoCursorTrustFlag
+	}
+	return a.trustArg, nil
 }
 
-var cursorTrustFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--trust([[:space:],=]|$)`)
+var errNoCursorTrustFlag = fmt.Errorf("ai: installed cursor-agent supports no known workspace-trust flag (--trust/--force/--yolo); upgrade cursor-agent")
 
-func cursorHelpSupportsTrust(help string) bool {
-	return cursorTrustFlag.MatchString(help)
+var (
+	cursorTrustFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--trust([[:space:],=]|$)`)
+	cursorForceFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?(--force|--yolo)([[:space:],=]|$)`)
+)
+
+// cursorHelpTrustFlag returns the narrowest supported trust flag, or "" if none.
+func cursorHelpTrustFlag(help string) string {
+	switch {
+	case cursorTrustFlag.MatchString(help):
+		return "--trust"
+	case cursorForceFlag.MatchString(help):
+		return "--force"
+	default:
+		return ""
+	}
 }
 
 // writeCursorMCPConfig points Cursor at radar's MCP via the workspace-local config

--- a/internal/ai/agent_cursor_test.go
+++ b/internal/ai/agent_cursor_test.go
@@ -5,9 +5,75 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// writeCursorShim writes a fake cursor-agent that mimics a Cursor release where
+// --trust was removed: --help lists only -f/--force/--yolo, passing --trust aborts
+// with "unknown option '--trust'", a headless run with no trust flag aborts at the
+// workspace-trust gate, and --force/-f/--yolo let the run emit stream-json.
+func writeCursorShim(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell shim not portable to windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor-agent")
+	const script = `#!/bin/sh
+if [ "$1" = "--help" ]; then
+  printf '%s\n' 'Options:' '  -f, --force  Force allow commands unless explicitly denied' '  --yolo  Alias for --force' '  --sandbox <mode>  sandbox' '  --approve-mcps  approve mcps'
+  exit 0
+fi
+trusted=""
+for a in "$@"; do
+  case "$a" in
+    --trust) echo "error: unknown option '--trust'" >&2; exit 1 ;;
+    --force|-f|--yolo) trusted=1 ;;
+  esac
+done
+if [ -z "$trusted" ]; then
+  echo "cursor-agent stopped unexpectedly: Workspace Trust Required" >&2
+  exit 1
+fi
+echo '{"type":"system","subtype":"init","session_id":"sess-shim"}'
+echo '{"type":"result","subtype":"success","is_error":false,"result":"ok"}'
+exit 0
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestCursorTrustFallbackEndToEnd is the regression guard for issue #1272: against
+// a cursor-agent without --trust, dropping the flag entirely leaves the headless
+// run stuck at the workspace-trust gate. command() must probe --help, fall back to
+// --force, and the spawned run must clear the gate and produce stream-json.
+func TestCursorTrustFallbackEndToEnd(t *testing.T) {
+	a := &cursorAgent{bin: writeCursorShim(t)}
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:9/mcp-readonly", prompt: "investigate",
+		workdir: t.TempDir(), profile: ExecutionProfileFullLocal,
+	})
+	if err != nil {
+		t.Fatalf("command(): %v", err)
+	}
+	defer cleanup()
+
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "--trust") || !strings.Contains(args, "--force") {
+		t.Fatalf("expected --force fallback (no --trust); got %q", args)
+	}
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("run must succeed via --force; got %v\n%s", runErr, out)
+	}
+	if strings.Contains(string(out), "Workspace Trust Required") {
+		t.Fatalf("run still hit the trust gate:\n%s", out)
+	}
+}
 
 // TestCursorParseStream_FormatPin locks the Cursor `-p --output-format stream-json`
 // JSONL schema we depend on, captured from a live MCP tool call: system/init carries
@@ -93,7 +159,7 @@ func TestCursorParseStream_ErrorResultNotVerdict(t *testing.T) {
 // stream-json output, sandboxed shell, MCP auto-approval, a workspace-local
 // mcp.json pointed at radar, and --resume only on a continued session.
 func TestCursorCommandFlags(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trust: true}
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: "--trust"}
 	dir := t.TempDir()
 	const url = "http://localhost:9/mcp-readonly"
 
@@ -156,8 +222,10 @@ func TestCursorCommandFlags(t *testing.T) {
 	}
 }
 
-func TestCursorCommandOmitsTrustWhenUnsupported(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true}
+// A Cursor without --trust must fall back to --force so the headless run can
+// clear the workspace-trust gate — omitting a trust flag entirely aborts the run.
+func TestCursorCommandFallsBackToForceWhenTrustUnsupported(t *testing.T) {
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: "--force"}
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
 		profile: ExecutionProfileFullLocal,
@@ -166,8 +234,24 @@ func TestCursorCommandOmitsTrustWhenUnsupported(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	if strings.Contains(strings.Join(cmd.Args, " "), "--trust") {
-		t.Errorf("unsupported Cursor must not receive --trust: %q", cmd.Args)
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "--trust") {
+		t.Errorf("Cursor without --trust must not receive --trust: %q", args)
+	}
+	if !strings.Contains(args, "--force") {
+		t.Errorf("Cursor without --trust must fall back to --force: %q", args)
+	}
+}
+
+// When no known trust flag is supported, command() must error rather than spawn a
+// run that will abort at the trust gate.
+func TestCursorCommandErrorsWhenNoTrustFlag(t *testing.T) {
+	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: ""}
+	if _, _, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
+		profile: ExecutionProfileFullLocal,
+	}); err == nil || !strings.Contains(err.Error(), "trust flag") {
+		t.Fatalf("no supported trust flag = %v, want trust-flag error", err)
 	}
 }
 
@@ -191,18 +275,29 @@ func TestCursorCommandRejectsInconclusiveTrustProbe(t *testing.T) {
 	}
 }
 
-func TestCursorHelpSupportsTrust(t *testing.T) {
-	if !cursorHelpSupportsTrust("  --trust  Trust the current workspace without prompting") {
-		t.Fatal("expected --trust to be detected from Cursor help")
+func TestCursorHelpTrustFlag(t *testing.T) {
+	// --trust present => prefer it (narrowest grant).
+	if got := cursorHelpTrustFlag("  --trust  Trust the current workspace without prompting"); got != "--trust" {
+		t.Fatalf("expected --trust detected, got %q", got)
 	}
+	// --trust gone, --force/-f present => fall back to --force.
 	for _, help := range []string{
-		"  --force  Run everything",
+		"  -f, --force  Force allow commands unless explicitly denied",
+		"  --yolo  Alias for --force (Run Everything)",
+	} {
+		if got := cursorHelpTrustFlag(help); got != "--force" {
+			t.Fatalf("expected --force fallback from %q, got %q", help, got)
+		}
+	}
+	// Neither a real trust nor a force flag => empty (caller errors).
+	for _, help := range []string{
 		"  --trusted-domains  Trust listed domains",
 		"  --no-trust  Disable workspace trust",
 		"Removed: --trust is no longer supported",
+		"  --enforce  something unrelated",
 	} {
-		if cursorHelpSupportsTrust(help) {
-			t.Fatalf("must not infer --trust from %q", help)
+		if got := cursorHelpTrustFlag(help); got != "" {
+			t.Fatalf("must not infer a trust flag from %q, got %q", help, got)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Radar's **diagnose** feature spawns `cursor-agent` headless (`-p`, no TTY) in a fresh throwaway workspace. Cursor gates on **workspace trust**, so Radar must grant it non-interactively. It did this with `--trust`, but a recent Cursor update removed that flag.

The prior fix (#1272 first pass) probes `--help` and only passes `--trust` when it's still listed. But when `--trust` is absent it passes **no** trust flag at all — so the run now aborts one step later at the trust gate:

```
cursor-agent stopped unexpectedly: ⚠ Workspace Trust Required
```

There's no user-side workaround: the workspace is a new throwaway dir every run, so trusting a path once never carries over. Fixes #1272.

## Fix

Resolve the trust flag from `--help` and pass the **narrowest supported** one:

1. `--trust` (workspace trust only) — preferred.
2. `--force` (the alternative Cursor's own gate message advertises: *"Pass --trust, --yolo, or -f"*) — fallback.
3. Neither → error with an actionable message ("upgrade cursor-agent") instead of spawning a run doomed to hang at the gate.

This also survives future Cursor CLI churn (the flag was removed, then re-added across releases) without needing a Radar release each time.

### On the extra grant

`--force`/`--yolo` also auto-approve command runs — broader than `--trust`. That's bounded here: `--sandbox enabled` already contains Cursor's own shell/file tools, and cluster writes stay gated by the read-only MCP mount. Documented inline.

## Verification

Reproduced the failure and verified the fix by driving the real `command()` path against a stub `cursor-agent` that mimics the affected Cursor version (no `--trust` in `--help`; `--trust` → "unknown option"; headless run with no trust flag → "Workspace Trust Required"; `--force` → succeeds):

- **Before:** probe finds no `--trust`, no trust flag passed, run exits 1 at the trust gate.
- **After:** probe resolves `--force`, run clears the gate and emits valid stream-json.

No regression on a Cursor that still has `--trust` (it still passes `--trust`). Full `internal/ai` package tests + `go vet` pass. Added `TestCursorTrustFallbackEndToEnd` as the regression guard.