### PR TITLE
Fix Caretta Live Traffic adopting the general Prometheus port-forward

### DIFF
--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -302,6 +302,32 @@ func GetAddress(preferOwner Owner, currentContext string) string {
 	return ""
 }
 
+// GetAddressForService is a target-aware variant of GetAddress: it returns the
+// address of an active forward for the given context ONLY if that forward points
+// at the requested namespace/service, preferring the caller's own forward before
+// a peer's. Unlike GetAddress, it never surfaces a forward bound to a different
+// backend — so a caller that needs a specific service (e.g. Caretta's
+// caretta-vm) can't adopt an unrelated owner's forward (e.g. the cluster's
+// general Prometheus), which answers the same generic /api/v1/query probe but
+// holds none of the caller's metrics. Empty if no matching forward exists.
+func GetAddressForService(preferOwner Owner, currentContext, namespace, serviceName string) string {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	matches := func(f *metricsForward) bool {
+		return f != nil && f.active && f.contextName == currentContext &&
+			f.namespace == namespace && f.serviceName == serviceName
+	}
+	if matches(reg.forwards[preferOwner]) {
+		return fmt.Sprintf("http://localhost:%d", reg.forwards[preferOwner].localPort)
+	}
+	for owner, f := range reg.forwards {
+		if owner != preferOwner && matches(f) {
+			return fmt.Sprintf("http://localhost:%d", f.localPort)
+		}
+	}
+	return ""
+}
+
 // GetConnectionInfo returns the given owner's connection info.
 func GetConnectionInfo(owner Owner) *ConnectionInfo {
 	reg.mu.RLock()

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -66,6 +66,53 @@ func TestGetAddressPrefersOwn(t *testing.T) {
 	}
 }
 
+// TestGetAddressForServiceIsTargetAware pins that the traffic (Caretta) source
+// must NOT adopt the general Prometheus forward. With only a
+// prometheus-owned forward to monitoring/prometheus-operated live, a Caretta
+// lookup for caretta/caretta-vm must return empty (no cross-adoption), forcing a
+// dedicated forward — whereas the old cross-owner GetAddress would hand back the
+// wrong backend, which answers the generic probe but holds no caretta metrics.
+func TestGetAddressForServiceIsTargetAware(t *testing.T) {
+	saved := reg
+	t.Cleanup(func() { reg = saved })
+	reg = &registry{forwards: map[Owner]*metricsForward{}}
+
+	// Only the general-metrics forward is up (owner=prometheus → prometheus-operated).
+	reg.forwards[OwnerPrometheus] = &metricsForward{
+		active: true, localPort: 15329, namespace: "monitoring", serviceName: "prometheus-operated", contextName: "ctxA",
+	}
+
+	// Old behavior: cross-owner fallback would adopt the wrong backend.
+	if got := GetAddress(OwnerTraffic, "ctxA"); got != "http://localhost:15329" {
+		t.Fatalf("precondition: GetAddress should surface the peer forward, got %q", got)
+	}
+
+	// Fixed behavior: target-aware lookup rejects the mismatched service.
+	if got := GetAddressForService(OwnerTraffic, "ctxA", "caretta", "caretta-vm"); got != "" {
+		t.Fatalf("target-aware lookup adopted the wrong forward: got %q, want empty", got)
+	}
+
+	// Once Caretta's own dedicated forward exists, it is reused by exact match.
+	reg.forwards[OwnerTraffic] = &metricsForward{
+		active: true, localPort: 22222, namespace: "caretta", serviceName: "caretta-vm", contextName: "ctxA",
+	}
+	if got := GetAddressForService(OwnerTraffic, "ctxA", "caretta", "caretta-vm"); got != "http://localhost:22222" {
+		t.Fatalf("own matching forward: got %q, want :22222", got)
+	}
+	// A peer forward that DOES target the requested service is still reusable.
+	delete(reg.forwards, OwnerTraffic)
+	reg.forwards[OwnerPrometheus] = &metricsForward{
+		active: true, localPort: 33333, namespace: "caretta", serviceName: "caretta-vm", contextName: "ctxA",
+	}
+	if got := GetAddressForService(OwnerTraffic, "ctxA", "caretta", "caretta-vm"); got != "http://localhost:33333" {
+		t.Fatalf("matching peer forward: got %q, want :33333", got)
+	}
+	// Context scoping still holds.
+	if got := GetAddressForService(OwnerTraffic, "ctxB", "caretta", "caretta-vm"); got != "" {
+		t.Fatalf("must not match a different context, got %q", got)
+	}
+}
+
 // TestStopBumpsEpochWhileEstablishing pins the invariant that a Stop lands even
 // while a forward is still coming up (not yet active): stopForwardLocked must
 // bump epoch for an inactive forward too, so the in-flight Start sees the change

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -274,20 +274,26 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 		return ""
 	}
 
-	// Check for active managed port-forward first
-	if pfAddr := portforward.GetAddress(portforward.OwnerTraffic, c.currentContext); pfAddr != "" {
-		if c.tryMetricsEndpointLocked(ctx, pfAddr) {
-			log.Printf("[caretta] Using managed port-forward at %s", pfAddr)
-			c.prometheusAddr = pfAddr
-			return pfAddr
-		}
-	}
-
 	// Layer 2+3: Well-known locations, then dynamic discovery
 	info := c.discoverServiceLocked(ctx)
 	if info == nil {
 		log.Printf("[caretta] No Prometheus/VictoriaMetrics service found via any discovery method")
 		return ""
+	}
+
+	// Reuse an existing managed port-forward only if it targets the SAME service
+	// we just discovered. A generic reachability probe can't tell caretta-vm apart
+	// from the cluster's general Prometheus (both answer /api/v1/query), so match
+	// on (namespace, service) — otherwise we'd adopt the general-metrics forward
+	// and query it for caretta_links_observed, which returns 0 flows silently.
+	if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, info.namespace, info.name); pfAddr != "" {
+		testAddr := pfAddr + info.basePath
+		if c.tryMetricsEndpointLocked(ctx, testAddr) {
+			log.Printf("[caretta] Using managed port-forward at %s for %s/%s", pfAddr, info.namespace, info.name)
+			c.prometheusAddr = pfAddr
+			c.metricsBasePath = info.basePath
+			return pfAddr
+		}
 	}
 
 	// Try cluster address (works when running in-cluster)
@@ -562,8 +568,13 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 		}, nil
 	}
 
-	// Check if there's already a valid managed port-forward for this context
-	if pfAddr := portforward.GetAddress(portforward.OwnerTraffic, contextName); pfAddr != "" {
+	// Check if there's already a valid managed port-forward for this context that
+	// targets the SAME service we discovered. Matching on (namespace, service)
+	// stops the traffic source from adopting the general-metrics forward (owner=
+	// prometheus, e.g. prometheus-operated:9090): it answers the generic probe but
+	// holds no caretta_links_observed, so flows would come back empty. On no match
+	// we fall through and start the dedicated forward to caretta-vm below.
+	if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, contextName, metricsInfo.namespace, metricsInfo.name); pfAddr != "" {
 		pfTestAddr := pfAddr + metricsInfo.basePath
 		if c.tryMetricsEndpointLocked(ctx, pfTestAddr) {
 			log.Printf("[caretta] Using existing port-forward at %s", pfAddr)


### PR DESCRIPTION
## Problem

Fixes #1264. Live Traffic (Caretta) shows *No traffic yet* forever with `[caretta] Retrieved 0 flows from Prometheus` in the logs, even though caretta-vm holds the data.

The Caretta traffic source reuses any live managed port-forward for the current context before starting its own. When the resource-metrics module already has a forward up to the cluster's **general Prometheus** (e.g. `monitoring/prometheus-operated:9090`), Caretta adopts that address. The acceptance check only fires a generic `GET /api/v1/query?query=up`, which any Prometheus passes, so the wrong backend is accepted silently. Traffic queries for `caretta_links_observed` then run against a database that has no Caretta metrics -> a successful-but-empty result, and the dedicated `caretta-vm` forward is never created.

## Fix

Make forward reuse **target-aware**: only adopt an existing forward when it points at the same `(namespace, service)` the source discovered.

- Add `portforward.GetAddressForService(preferOwner, ctx, namespace, service)` - a variant of `GetAddress` that returns a forward only when it matches the requested service (own forward preferred, then a peer's). It never surfaces a forward bound to a different backend.
- Use it in both Caretta reuse sites (`Connect` and `discoverPrometheus`). `discoverPrometheus` is reordered so service discovery runs before the reuse check.

A mismatched forward (the general Prometheus) no longer matches, so Caretta falls through and starts its own dedicated forward to `caretta-vm`. Because reuse is now target-verified, the generic reachability probe stays sufficient.

## Tests

- `TestGetAddressForServiceIsTargetAware` reproduces the adoption: with only the general-Prometheus forward live, the old cross-owner `GetAddress` returns that address, while the target-aware lookup returns empty; also covers own-forward reuse, matching-peer reuse, and context scoping.
- `go test ./internal/portforward/ ./internal/traffic/ ./internal/prometheus/` passes; `gofmt` and `go vet` clean.

## Scope note

A symmetric latent issue exists in the reverse direction - `internal/prometheus/discovery.go` reuses another owner's forward via the generic `GetAddress`, so the resource-metrics module could adopt Caretta's `caretta-vm` (blank resource charts). It is out of scope for #1264 and reachable in a narrower window; it will be addressed in a follow-up PR.