### PR TITLE
fix(auth): single-flight the OIDC login redirect (stops the #1100 login loop)

### DIFF
--- a/web/src/api/client.authRedirect.test.ts
+++ b/web/src/api/client.authRedirect.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Deterministic config so the 401 handler's basename/routePath math is fixed and
+// independent of window/env. client.ts only consumes these six exports.
+vi.mock('./config', () => ({
+  getApiBase: () => '/api',
+  getAuthHeaders: () => ({}),
+  getCredentialsMode: () => 'include' as RequestCredentials,
+  getBasename: () => '',
+  routePath: (p: string) => p,
+  stripBasename: (p: string) => p,
+}))
+
+interface NavRecorder {
+  count: number
+  urls: string[]
+}
+
+// Stub window.location (counting href assignments + reloads) and sessionStorage.
+// Runs in vitest's node environment — there is no real DOM.
+function installDom(pathname = '/traffic'): NavRecorder {
+  const rec: NavRecorder = { count: 0, urls: [] }
+  const location: Record<string, unknown> = {
+    pathname,
+    search: '',
+    _href: `http://radar.local${pathname}`,
+    reload: () => {
+      rec.count++
+      rec.urls.push('[reload]')
+    },
+  }
+  Object.defineProperty(location, 'href', {
+    get() {
+      return location._href as string
+    },
+    set(v: string) {
+      rec.count++
+      rec.urls.push(v)
+      location._href = v
+    },
+  })
+  vi.stubGlobal('window', { location })
+
+  const store = new Map<string, string>()
+  vi.stubGlobal('sessionStorage', {
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+  })
+  return rec
+}
+
+// A 401 whose body advertises the auth mode, matching what the backend returns
+// on a protected /api/* call with no session.
+function make401(authMode: string): Response {
+  const body = JSON.stringify({ authMode })
+  return {
+    status: 401,
+    ok: false,
+    clone() {
+      return make401(authMode)
+    },
+    async json() {
+      return JSON.parse(body)
+    },
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  // Reset module state so the redirect gate starts fresh.
+  vi.resetModules()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('apiFetch OIDC 401 -> login redirect (single-flight)', () => {
+  it('navigates to /auth/login exactly once for a burst of concurrent 401s', async () => {
+    const rec = installDom('/traffic')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('oidc')),
+    )
+    const { apiFetch } = await import('./client')
+
+    // Mirror first paint / mid-session expiry: many protected calls 401 together.
+    const paths = [
+      '/connection',
+      '/capabilities',
+      '/namespaces',
+      '/portforwards',
+      '/dashboard',
+      '/issues',
+      '/auth/me',
+      '/topology',
+    ]
+    await Promise.all(paths.map((p) => apiFetch(`/api${p}`)))
+
+    expect(rec.count).toBe(1)
+    expect(rec.urls).toEqual(['/auth/login'])
+  })
+
+  it('still redirects on the first 401 (guard does not suppress the initial navigation)', async () => {
+    const rec = installDom('/traffic')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('oidc')),
+    )
+    const { apiFetch } = await import('./client')
+
+    await apiFetch('/api/connection')
+
+    expect(rec.count).toBe(1)
+    expect(rec.urls).toEqual(['/auth/login'])
+  })
+
+  it('re-redirects after the throttle window (self-heals canceled nav / bfcache Back)', async () => {
+    const rec = installDom('/traffic')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('oidc')),
+    )
+    const nowSpy = vi.spyOn(Date, 'now')
+    const { apiFetch } = await import('./client')
+
+    nowSpy.mockReturnValue(1_000_000)
+    await apiFetch('/api/connection')
+    expect(rec.count).toBe(1)
+
+    // Within the window a repeat 401 is suppressed (no state rotation).
+    nowSpy.mockReturnValue(1_000_000 + 2_000)
+    await apiFetch('/api/connection')
+    expect(rec.count).toBe(1)
+
+    // Past the window it redirects again instead of stalling until a hard reload.
+    nowSpy.mockReturnValue(1_000_000 + 6_000)
+    await apiFetch('/api/connection')
+    expect(rec.count).toBe(2)
+  })
+
+  it('still redirects (once) when sessionStorage is blocked', async () => {
+    // Simulate private-mode / sandboxed storage where every access throws.
+    const rec = installDom('/traffic')
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+      setItem: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('oidc')),
+    )
+    const { apiFetch } = await import('./client')
+
+    // Fail-open: the throwing read must not abort the redirect...
+    await Promise.all(
+      ['/connection', '/capabilities', '/namespaces'].map((p) => apiFetch(`/api${p}`)),
+    )
+    // ...and the in-memory fallback still collapses the burst to one navigation.
+    expect(rec.count).toBe(1)
+    expect(rec.urls).toEqual(['/auth/login'])
+  })
+
+  it('does not navigate to /auth/login when already on an /auth path', async () => {
+    const rec = installDom('/auth/login')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('oidc')),
+    )
+    const { apiFetch } = await import('./client')
+
+    await apiFetch('/api/connection')
+
+    expect(rec.count).toBe(0)
+    expect(rec.urls).toEqual([])
+  })
+
+  it('proxy/unknown mode reloads (once) instead of hitting /auth/login', async () => {
+    const rec = installDom('/traffic')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => make401('proxy')),
+    )
+    const { apiFetch } = await import('./client')
+
+    await apiFetch('/api/connection')
+
+    expect(rec.urls).toEqual(['[reload]'])
+    expect(rec.urls).not.toContain('/auth/login')
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -68,6 +68,49 @@ const COST_TREND_REFRESH_INTERVAL_MS = 120_000;
 const CHANGES_REFRESH_INTERVAL_MS = 60_000;
 const APPLICATIONS_REFRESH_INTERVAL_MS = 60_000;
 
+// Throttle window for the OIDC login redirect. On first paint (and again on
+// mid-session session expiry) many protected /api/* requests can 401 in the same
+// tick; without a guard each 401 independently navigates to /auth/login, and each
+// /auth/login regenerates the single radar_oidc_state cookie — so callbacks from
+// earlier redirects fail state validation (or get their token exchange canceled)
+// and the login loops until one happens to win. A short time gate collapses the
+// burst to one navigation while still self-recovering if that navigation is
+// canceled or the page is restored from bfcache (module/JS-realm state survives
+// bfcache, so a plain latch would stick). Mirrors the proxy branch's reload
+// throttle below.
+const OIDC_LOGIN_REDIRECT_THROTTLE_MS = 5000;
+const OIDC_LOGIN_REDIRECT_KEY = "radar_oidc_login_redirect";
+
+// In-memory fallback for when sessionStorage is unavailable (private mode,
+// sandboxed/blocked storage). A timestamp, not a boolean latch, so it still
+// self-heals within the throttle window instead of sticking.
+let lastOidcLoginRedirectAt = 0;
+
+// Fail open: if reading storage throws, fall back to the in-memory timestamp so
+// the redirect still fires. Otherwise the 401 handler would reject before
+// redirecting and strand the user on a "not signed in" screen.
+function lastOidcLoginRedirect(): number {
+  try {
+    const stored = sessionStorage.getItem(OIDC_LOGIN_REDIRECT_KEY);
+    if (stored) {
+      const parsed = parseInt(stored);
+      if (!Number.isNaN(parsed)) return parsed;
+    }
+  } catch {
+    /* storage blocked — use the in-memory fallback */
+  }
+  return lastOidcLoginRedirectAt;
+}
+
+function markOidcLoginRedirect(now: number): void {
+  lastOidcLoginRedirectAt = now;
+  try {
+    sessionStorage.setItem(OIDC_LOGIN_REDIRECT_KEY, String(now));
+  } catch {
+    /* best-effort — the in-memory fallback still throttles this realm */
+  }
+}
+
 // Wrapper around fetch that always includes credentials (for session cookies)
 // and handles 401 responses globally. Merges caller-provided headers with
 // auth headers from the config module so library consumers (Radar Hub) can
@@ -112,7 +155,15 @@ export function apiFetch(
       }
 
       if (authMode === "oidc") {
-        window.location.href = routePath("/auth/login");
+        // Only the first 401 in a burst navigates; concurrent 401s within the
+        // window are suppressed so they don't rotate radar_oidc_state. The gate
+        // is time-based, so a canceled navigation or bfcache Back re-auths on the
+        // next 401 instead of stalling until a hard reload.
+        const now = Date.now();
+        if (now - lastOidcLoginRedirect() > OIDC_LOGIN_REDIRECT_THROTTLE_MS) {
+          markOidcLoginRedirect(now);
+          window.location.href = routePath("/auth/login");
+        }
       } else {
         // Proxy mode or unknown — reload is safe for both (proxy re-injects headers,
         // unknown avoids redirecting to /auth/login which doesn't exist in proxy mode).


### PR DESCRIPTION
## Problem

OIDC login loop (#1100). On a fresh, unauthenticated load the SPA fires many protected `/api/*` requests concurrently. In OIDC mode each `401` independently ran `window.location.href = /auth/login`, and every `/auth/login` regenerates the single `radar_oidc_state` cookie. Callbacks from earlier redirects then fail state validation (`400`) or have their in-flight token exchange canceled (`500`), so login loops until one callback happens to win. The same storm recurs on mid-session session expiry, when already-mounted polling queries all `401` together.

The proxy-mode branch of the same handler already throttles this; the OIDC branch didn't.

## Fix

Single-flight the OIDC redirect: only the first `401` in a burst navigates to `/auth/login`. The resulting full-page load tears down the module, so the guard resets naturally on the next load. ~15 lines in `web/src/api/client.ts`.

Fixes #1100


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global 401 handling on every authenticated API call; mis-throttling could delay re-login after session loss, though the time-based gate and existing `/auth` pathname guard limit that exposure.
> 
> **Overview**
> Fixes the OIDC login loop when many protected `/api/*` calls return **401** at once (initial load or session expiry): each redirect was regenerating `radar_oidc_state` and breaking callbacks.
> 
> **`apiFetch` OIDC branch** now **single-flights** navigation to `/auth/login` with a **5s time gate** (same idea as the existing proxy reload throttle). Only the first 401 in a burst sets `window.location.href`; others within the window are ignored. Timestamps live in **`sessionStorage`** (`radar_oidc_login_redirect`) with an **in-memory fallback** if storage throws, so redirects still run and bursts still collapse to one nav.
> 
> After the throttle window, a later 401 can redirect again (covers canceled navigation or **bfcache** restore where module state would stick with a boolean latch). Behavior on `/auth/*` paths and **proxy/unknown** `authMode` (reload, not login) is unchanged.
> 
> Adds **`client.authRedirect.test.ts`** covering concurrent 401s, first-401 redirect, throttle expiry re-redirect, blocked `sessionStorage`, skip redirect on `/auth/login`, and proxy reload path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff7a4e0971a3a4d421026a09442b9b4e7efee75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->