### PR TITLE
Stop resource-metrics Prometheus discovery from binding to caretta-vm

### DIFF
--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -8,8 +8,8 @@
 // starting or stopping one owner's forward never tears down the other's. (A
 // single shared forward previously let them clobber each other whenever they
 // wanted different services.) Owners may still read each other's forward
-// address (GetAddress) to reuse a compatible endpoint, but only ever stop their
-// own.
+// address (GetAddressForService) to reuse a forward that targets the same
+// service, but only ever stop their own.
 package portforward
 
 import (
@@ -282,34 +282,15 @@ func stopForwardLocked(f *metricsForward) {
 	f.cancel = nil
 }
 
-// GetAddress returns the address of an active metrics forward for the given
-// context, preferring the caller's own forward (preferOwner) before falling back
-// to another owner's compatible endpoint (read-only reuse — the caller never
-// takes ownership). Preferring the caller's own forward keeps selection
-// deterministic and avoids probing an incompatible peer (e.g. Hubble's relay)
-// while the caller's own forward is still live. Empty if none.
-func GetAddress(preferOwner Owner, currentContext string) string {
-	reg.mu.RLock()
-	defer reg.mu.RUnlock()
-	if f := reg.forwards[preferOwner]; f != nil && f.active && f.contextName == currentContext {
-		return fmt.Sprintf("http://localhost:%d", f.localPort)
-	}
-	for owner, f := range reg.forwards {
-		if owner != preferOwner && f.active && f.contextName == currentContext {
-			return fmt.Sprintf("http://localhost:%d", f.localPort)
-		}
-	}
-	return ""
-}
-
-// GetAddressForService is a target-aware variant of GetAddress: it returns the
-// address of an active forward for the given context ONLY if that forward points
-// at the requested namespace/service, preferring the caller's own forward before
-// a peer's. Unlike GetAddress, it never surfaces a forward bound to a different
-// backend — so a caller that needs a specific service (e.g. Caretta's
-// caretta-vm) can't adopt an unrelated owner's forward (e.g. the cluster's
-// general Prometheus), which answers the same generic /api/v1/query probe but
-// holds none of the caller's metrics. Empty if no matching forward exists.
+// GetAddressForService returns the address of an active forward for the given
+// context ONLY if that forward points at the requested namespace/service,
+// preferring the caller's own forward (preferOwner) before a peer's (read-only
+// reuse — the caller never takes ownership). Matching on the target service means
+// it never surfaces a forward bound to a different backend, so a caller that needs
+// a specific service (e.g. Caretta's caretta-vm) can't adopt an unrelated owner's
+// forward (e.g. the cluster's general Prometheus), which answers the same generic
+// /api/v1/query probe but holds none of the caller's metrics. Empty if no matching
+// forward exists.
 func GetAddressForService(preferOwner Owner, currentContext, namespace, serviceName string) string {
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()

--- a/internal/portforward/portforward_test.go
+++ b/internal/portforward/portforward_test.go
@@ -31,47 +31,25 @@ func TestOwnerScoping(t *testing.T) {
 		t.Fatal("traffic forward was torn down by prometheus Stop (cross-owner clobber)")
 	}
 
-	// GetAddress peeks across owners (read-only reuse) and is context-scoped.
-	if GetAddress(OwnerTraffic, "ctxA") == "" {
-		t.Fatal("GetAddress should surface traffic's forward for ctxA")
+	// GetAddressForService peeks across owners (read-only reuse) and is
+	// context-scoped, matching on the target service.
+	if GetAddressForService(OwnerPrometheus, "ctxA", "caretta", "caretta-vm") == "" {
+		t.Fatal("GetAddressForService should surface traffic's caretta-vm forward for ctxA")
 	}
-	if GetAddress(OwnerTraffic, "ctxB") != "" {
-		t.Fatal("GetAddress must not match a different context")
+	if GetAddressForService(OwnerPrometheus, "ctxB", "caretta", "caretta-vm") != "" {
+		t.Fatal("GetAddressForService must not match a different context")
 	}
 	if !IsConnectedForContext("ctxA") || IsConnectedForContext("ctxB") {
 		t.Fatal("IsConnectedForContext scoping wrong")
 	}
 }
 
-// TestGetAddressPrefersOwn verifies GetAddress returns the caller's own forward
-// when it has one, rather than an arbitrary peer's — so a caller reuses its own
-// live forward instead of probing an incompatible one.
-func TestGetAddressPrefersOwn(t *testing.T) {
-	saved := reg
-	t.Cleanup(func() { reg = saved })
-	reg = &registry{forwards: map[Owner]*metricsForward{}}
-	reg.forwards[OwnerPrometheus] = &metricsForward{active: true, localPort: 1111, contextName: "ctxA"}
-	reg.forwards[OwnerTraffic] = &metricsForward{active: true, localPort: 2222, contextName: "ctxA"}
-
-	if got := GetAddress(OwnerPrometheus, "ctxA"); got != "http://localhost:1111" {
-		t.Fatalf("prometheus got %q, want its own :1111", got)
-	}
-	if got := GetAddress(OwnerTraffic, "ctxA"); got != "http://localhost:2222" {
-		t.Fatalf("traffic got %q, want its own :2222", got)
-	}
-	// With no own forward, fall back to the peer's.
-	Stop(OwnerPrometheus)
-	if got := GetAddress(OwnerPrometheus, "ctxA"); got != "http://localhost:2222" {
-		t.Fatalf("prometheus fallback got %q, want peer :2222", got)
-	}
-}
-
-// TestGetAddressForServiceIsTargetAware pins that the traffic (Caretta) source
-// must NOT adopt the general Prometheus forward. With only a
-// prometheus-owned forward to monitoring/prometheus-operated live, a Caretta
-// lookup for caretta/caretta-vm must return empty (no cross-adoption), forcing a
-// dedicated forward — whereas the old cross-owner GetAddress would hand back the
-// wrong backend, which answers the generic probe but holds no caretta metrics.
+// TestGetAddressForServiceIsTargetAware pins that a caller must NOT adopt a
+// forward bound to a different backend. With only a prometheus-owned forward to
+// monitoring/prometheus-operated live, a Caretta lookup for caretta/caretta-vm
+// must return empty (no cross-adoption), forcing a dedicated forward — the
+// mismatched backend answers the generic probe but holds no caretta metrics. The
+// symmetric case (resource metrics adopting caretta-vm) is guarded the same way.
 func TestGetAddressForServiceIsTargetAware(t *testing.T) {
 	saved := reg
 	t.Cleanup(func() { reg = saved })
@@ -82,14 +60,15 @@ func TestGetAddressForServiceIsTargetAware(t *testing.T) {
 		active: true, localPort: 15329, namespace: "monitoring", serviceName: "prometheus-operated", contextName: "ctxA",
 	}
 
-	// Old behavior: cross-owner fallback would adopt the wrong backend.
-	if got := GetAddress(OwnerTraffic, "ctxA"); got != "http://localhost:15329" {
-		t.Fatalf("precondition: GetAddress should surface the peer forward, got %q", got)
-	}
-
-	// Fixed behavior: target-aware lookup rejects the mismatched service.
+	// A Caretta lookup for its own backend must reject the mismatched service
+	// rather than adopt the general Prometheus forward that happens to be live.
 	if got := GetAddressForService(OwnerTraffic, "ctxA", "caretta", "caretta-vm"); got != "" {
 		t.Fatalf("target-aware lookup adopted the wrong forward: got %q, want empty", got)
+	}
+	// Conversely, resource metrics may reuse the prometheus-operated forward by
+	// exact match — that is the legitimate cross/own-owner reuse.
+	if got := GetAddressForService(OwnerPrometheus, "ctxA", "monitoring", "prometheus-operated"); got != "http://localhost:15329" {
+		t.Fatalf("matching own forward: got %q, want :15329", got)
 	}
 
 	// Once Caretta's own dedicated forward exists, it is reused by exact match.

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -85,16 +85,14 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 		return "", "", fmt.Errorf("manual Prometheus URL %s not reachable", addr)
 	}
 
-	// Layer 2: Reuse traffic system's existing port-forward if present
-	if pfAddr := portforward.GetAddress(portforward.OwnerPrometheus, contextName); pfAddr != "" {
-		if c.probe(ctx, pfAddr) {
-			log.Printf("[prometheus] connected via traffic port-forward %s (%s)", pfAddr, took(start))
-			if !c.markConnected(pfAddr, "", startGen) {
-				return "", "", errDiscoverySuperseded
-			}
-			return pfAddr, "", nil
-		}
-	}
+	// Reuse of an existing managed port-forward happens later, per candidate, in
+	// the port-forward fallback loop below — not here as a blind cross-owner
+	// shortcut. A generic probe can't tell the traffic source's caretta-vm
+	// (traffic-specific, may lack workload metrics) apart from a general
+	// Prometheus, so adopting whatever forward is up before enumeration would let
+	// resource metrics bind to caretta-vm and silently lose workload data. Reusing
+	// only a forward that targets a discovered candidate ties reuse to the same
+	// candidate ranking the port-forward attempts already follow.
 
 	if k8sClient == nil {
 		return "", "", fmt.Errorf("no Kubernetes client available for discovery")
@@ -174,9 +172,45 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 			logDiscoveryEnded(start, err)
 			return "", "", err
 		}
+		c.setDiscoveryServiceFromCandidate(cand)
+
+		// Reuse an existing managed forward (this owner's own, or a peer's such as
+		// the traffic source) only when it already targets THIS candidate. Matching
+		// on (namespace, service) avoids adopting a forward bound to a different
+		// backend — the reason resource metrics could otherwise land on caretta-vm
+		// via a blind cross-owner shortcut. Reuse follows the same per-candidate
+		// order as the port-forward attempts below.
+		if pfAddr := portforward.GetAddressForService(portforward.OwnerPrometheus, contextName, cand.Namespace, cand.Name); pfAddr != "" {
+			if c.probe(ctx, pfAddr+cand.BasePath) {
+				if !c.markConnected(pfAddr, cand.BasePath, startGen) {
+					// Superseded mid-reuse: drop the stale service metadata we just
+					// published, same as the port-forward path below. The forward
+					// itself is pre-existing (own from a prior run, or a peer's), so
+					// unlike that path we must not Stop it here.
+					c.mu.Lock()
+					c.discoveryService = nil
+					c.mu.Unlock()
+					return "", "", errDiscoverySuperseded
+				}
+				log.Printf("[prometheus] reusing managed port-forward %s for %s/%s (%s)",
+					pfAddr, cand.Namespace, cand.Name, took(start))
+				return pfAddr, cand.BasePath, nil
+			}
+			// The reuse probe failed. If that is because the run was superseded
+			// (ctx cancelled) rather than the reused forward being genuinely
+			// unreachable, bail now instead of falling through to Start: Start
+			// would fast-path this same pre-existing forward and the doomed
+			// re-probe below would then Stop a tunnel we must leave up (a newer
+			// generation may already own it) — the very teardown the reuse
+			// supersession path above deliberately avoids.
+			if err := ctx.Err(); err != nil {
+				logDiscoveryEnded(start, err)
+				return "", "", err
+			}
+		}
+
 		log.Printf("[prometheus] port-forward → %s/%s:%d (source=%s, score=%d)...",
 			cand.Namespace, cand.Name, cand.TargetPort, cand.Source, cand.Score)
-		c.setDiscoveryServiceFromCandidate(cand)
 
 		connInfo, pfErr := portforward.Start(portforward.OwnerPrometheus, ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
 		if pfErr != nil {

--- a/pkg/prom/discovery.go
+++ b/pkg/prom/discovery.go
@@ -55,14 +55,18 @@ type DiscoverOptions struct {
 	Logger func(format string, args ...interface{})
 }
 
-// WellKnownLocations is the ordered list of namespaces + service names where
-// Prometheus-compatible services are commonly installed.
-var WellKnownLocations = []struct {
+// wellKnownLoc is a namespace + service name where a Prometheus-compatible
+// service is commonly installed.
+type wellKnownLoc struct {
 	Namespace string
 	Name      string
 	Port      int    // 0 = use service's first port
 	BasePath  string // sub-path for Prometheus API
-}{
+}
+
+// WellKnownLocations is the ordered list of primary Prometheus-compatible
+// service locations, ranked ahead of dynamically-discovered candidates.
+var WellKnownLocations = []wellKnownLoc{
 	// VictoriaMetrics — monitoring namespace first (workload metrics)
 	{"monitoring", "victoria-metrics-victoria-metrics-single-server", 8428, ""},
 	{"monitoring", "victoria-metrics-single-server", 8428, ""},
@@ -84,7 +88,15 @@ var WellKnownLocations = []struct {
 	{"metrics", "prometheus-server", 0, ""},
 	{"kube-system", "prometheus", 0, ""},
 	{"default", "prometheus", 0, ""},
-	// VictoriaMetrics — caretta namespace (traffic-specific, may lack workload metrics)
+}
+
+// fallbackWellKnownLocations are last-resort well-known metrics services, ranked
+// AFTER dynamically-discovered candidates. caretta-vm serves the traffic source's
+// eBPF link metrics and commonly lacks cluster workload (node/pod) metrics, so it
+// must never outrank a real Prometheus — whether that Prometheus is in the primary
+// well-known list or is only turned up by the dynamic scan. It is still returned
+// as a candidate so a cluster whose only metrics backend is caretta-vm keeps working.
+var fallbackWellKnownLocations = []wellKnownLoc{
 	{"caretta", "caretta-vm", 8428, ""},
 }
 
@@ -204,66 +216,24 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 		logf = func(string, ...interface{}) {}
 	}
 
-	var out []Candidate
-
 	// seen de-duplicates candidates by namespace/name/port/basePath so a
-	// service reachable via both the well-known list and the dynamic scan is
-	// probed and port-forwarded only once. Well-known wins ties because it is
-	// appended first.
+	// service reachable via more than one layer is probed and port-forwarded only
+	// once. Earlier layers win ties because they populate seen first.
 	seen := map[string]bool{}
 
-	// Layer 1: well-known locations. Fetch them concurrently — this is ~20
-	// targeted Gets, which run serially would dominate discovery latency against
-	// a remote API server — then assemble in declared order for deterministic
-	// priority. Targeted Gets (not a cluster-wide List) keep this working for
-	// callers with get-but-not-list on Services.
-	found := make([]*corev1.Service, len(WellKnownLocations))
-	getErrs := make([]error, len(WellKnownLocations))
-	sem := make(chan struct{}, wellKnownConcurrency)
-	var wg sync.WaitGroup
-	for i, loc := range WellKnownLocations {
-		wg.Go(func() {
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			svc, err := k8sClient.CoreV1().Services(loc.Namespace).Get(ctx, loc.Name, metav1.GetOptions{})
-			if err != nil {
-				getErrs[i] = err
-				return
-			}
-			found[i] = svc
-		})
-	}
-	wg.Wait()
+	// Layer 1: primary well-known locations, ranked ahead of everything else.
+	out := collectWellKnownLocations(ctx, k8sClient, WellKnownLocations, seen, logf)
 
-	// Assemble in declared order, logging serially — DiscoverOptions.Logger has
-	// no concurrency contract, so it must not be called from the workers above.
-	for i, loc := range WellKnownLocations {
-		svc := found[i]
-		if svc == nil {
-			if err := getErrs[i]; err != nil && !apierrors.IsNotFound(err) {
-				logf("prom.Discover: error checking %s/%s: %v", loc.Namespace, loc.Name, err)
-			}
-			continue
-		}
-		port := resolvePort(*svc, loc.Port)
-		key := candidateKey(svc.Namespace, svc.Name, port, loc.BasePath)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		out = append(out, Candidate{
-			Namespace:   svc.Namespace,
-			Name:        svc.Name,
-			Port:        port,
-			TargetPort:  resolveTargetPort(*svc, port),
-			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
-			BasePath:    loc.BasePath,
-			Source:      CandidateSourceWellKnown,
-		})
-	}
+	// Fallback locations (caretta-vm) are fetched now — so their keys enter `seen`
+	// and the dynamic scan below can't re-surface them as ordinary scored
+	// candidates — but they are held and appended LAST. caretta-vm serves only the
+	// traffic source's link metrics and commonly lacks cluster workload metrics, so
+	// a real Prometheus (well-known or dynamically discovered) must always outrank
+	// it; it stays a candidate only so a caretta-vm-only cluster keeps working.
+	fallback := collectWellKnownLocations(ctx, k8sClient, fallbackWellKnownLocations, seen, logf)
 
 	if !opts.IncludeDynamic {
-		return out, nil
+		return append(out, fallback...), nil
 	}
 
 	// Layer 2: dynamic cluster-wide scan. The score only *ranks* candidates; it
@@ -274,12 +244,27 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 	// lightly-labeled Prometheus. MaxDynamic still bounds how many are returned.
 	svcs, err := k8sClient.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
+		// The cluster-wide list failed, but the well-known + fallback Gets above
+		// still succeeded — return them (including the caretta-vm fallback) rather
+		// than dropping the fallback tier. This is the get-but-not-list RBAC case.
 		logf("prom.Discover: failed to list services: %v", err)
-		return out, nil // well-known results still useful
+		return append(out, fallback...), nil
+	}
+
+	// Services already claimed by the fallback tier must never resurface among the
+	// dynamic candidates — that would rank caretta-vm by score instead of forcing
+	// it last. Match by namespace/name (not the port-keyed `seen`), so a caretta-vm
+	// Service fronted by a non-8428 service port is still suppressed here.
+	fallbackNames := make(map[string]bool, len(fallback))
+	for _, c := range fallback {
+		fallbackNames[c.Namespace+"/"+c.Name] = true
 	}
 
 	var scored []Candidate
 	for _, svc := range svcs.Items {
+		if fallbackNames[svc.Namespace+"/"+svc.Name] {
+			continue
+		}
 		score, bp, identity := ScoreService(svc)
 		// Admit on a Prometheus-family identity signal, not on score alone: a
 		// namespace-only match (score without identity) would send the operator's
@@ -310,7 +295,66 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 	if len(scored) > opts.MaxDynamic {
 		scored = scored[:opts.MaxDynamic]
 	}
-	return append(out, scored...), nil
+	out = append(out, scored...)
+
+	// Fallback tier last: after both the primary well-known list and the dynamic
+	// scan, so a real Prometheus always wins over caretta-vm when one exists.
+	out = append(out, fallback...)
+	return out, nil
+}
+
+// collectWellKnownLocations fetches the given well-known locations concurrently
+// (targeted Gets, not a cluster-wide List, so it works for callers with
+// get-but-not-list on Services) and returns the ones that exist as candidates in
+// declared order. Locations whose key is already in seen are skipped; newly
+// added keys are recorded so later layers de-duplicate against them.
+func collectWellKnownLocations(ctx context.Context, k8sClient kubernetes.Interface, locs []wellKnownLoc, seen map[string]bool, logf func(string, ...interface{})) []Candidate {
+	found := make([]*corev1.Service, len(locs))
+	getErrs := make([]error, len(locs))
+	sem := make(chan struct{}, wellKnownConcurrency)
+	var wg sync.WaitGroup
+	for i, loc := range locs {
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			svc, err := k8sClient.CoreV1().Services(loc.Namespace).Get(ctx, loc.Name, metav1.GetOptions{})
+			if err != nil {
+				getErrs[i] = err
+				return
+			}
+			found[i] = svc
+		})
+	}
+	wg.Wait()
+
+	// Assemble in declared order, logging serially — DiscoverOptions.Logger has
+	// no concurrency contract, so it must not be called from the workers above.
+	var out []Candidate
+	for i, loc := range locs {
+		svc := found[i]
+		if svc == nil {
+			if err := getErrs[i]; err != nil && !apierrors.IsNotFound(err) {
+				logf("prom.Discover: error checking %s/%s: %v", loc.Namespace, loc.Name, err)
+			}
+			continue
+		}
+		port := resolvePort(*svc, loc.Port)
+		key := candidateKey(svc.Namespace, svc.Name, port, loc.BasePath)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, Candidate{
+			Namespace:   svc.Namespace,
+			Name:        svc.Name,
+			Port:        port,
+			TargetPort:  resolveTargetPort(*svc, port),
+			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+			BasePath:    loc.BasePath,
+			Source:      CandidateSourceWellKnown,
+		})
+	}
+	return out
 }
 
 // promPortScore returns the heuristic weight for a port number matching a

--- a/pkg/prom/discovery_test.go
+++ b/pkg/prom/discovery_test.go
@@ -554,3 +554,149 @@ func TestDiscover_LoggerCalledSerially(t *testing.T) {
 		t.Fatal("expected error logs from failed well-known lookups")
 	}
 }
+
+// TestDiscover_CarettaVMRanksAfterDynamicPrometheus pins that caretta-vm, a
+// last-resort fallback that commonly lacks workload metrics, never outranks a
+// real Prometheus — including one discoverable only via the dynamic scan
+// (non-standard namespace/name). Before the fallback tier existed, caretta-vm
+// (a well-known location) sorted ahead of every dynamic candidate.
+func TestDiscover_CarettaVMRanksAfterDynamicPrometheus(t *testing.T) {
+	carettaVM := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "caretta-vm", Namespace: "caretta"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.9",
+			Ports:     []corev1.ServicePort{{Port: 8428}},
+		},
+	}
+	// A real Prometheus at a non-standard location — found only by the dynamic
+	// scan via its app.kubernetes.io/name identity label.
+	dynamicProm := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prom",
+			Namespace: "myteam",
+			Labels:    map[string]string{"app.kubernetes.io/name": "prometheus"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.10",
+			Ports:     []corev1.ServicePort{{Port: 9090}},
+		},
+	}
+
+	k8s := fake.NewSimpleClientset(carettaVM, dynamicProm)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	idx := func(ns, name string) int {
+		for i, c := range cands {
+			if c.Namespace == ns && c.Name == name {
+				return i
+			}
+		}
+		return -1
+	}
+	dynIdx := idx("myteam", "prom")
+	carettaIdx := idx("caretta", "caretta-vm")
+	if dynIdx < 0 {
+		t.Fatalf("dynamic prometheus not discovered: %+v", cands)
+	}
+	if carettaIdx < 0 {
+		t.Fatalf("caretta-vm fallback not discovered: %+v", cands)
+	}
+	if carettaIdx < dynIdx {
+		t.Fatalf("caretta-vm (idx %d) ranked before dynamic prometheus (idx %d) — fallback must rank last", carettaIdx, dynIdx)
+	}
+	if carettaIdx != len(cands)-1 {
+		t.Fatalf("caretta-vm at idx %d, want last candidate (%d): %+v", carettaIdx, len(cands)-1, cands)
+	}
+}
+
+// TestDiscover_CarettaVMReturnedWhenSoleBackend guards the safety net: when
+// caretta-vm is the only metrics backend, it must still be returned so the
+// cluster keeps working — demoting it to a fallback tier must not drop it.
+func TestDiscover_CarettaVMReturnedWhenSoleBackend(t *testing.T) {
+	carettaVM := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "caretta-vm", Namespace: "caretta"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.9",
+			Ports:     []corev1.ServicePort{{Port: 8428}},
+		},
+	}
+	k8s := fake.NewSimpleClientset(carettaVM)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(cands) != 1 || cands[0].Namespace != "caretta" || cands[0].Name != "caretta-vm" {
+		t.Fatalf("want sole caretta-vm candidate, got %+v", cands)
+	}
+}
+
+// TestDiscover_FallbackSurvivesListFailure guards finding-1: when the cluster
+// list fails (get-but-not-list RBAC) but caretta-vm is fetchable via targeted
+// Get, the fallback tier must still be returned — not silently dropped.
+func TestDiscover_FallbackSurvivesListFailure(t *testing.T) {
+	carettaVM := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "caretta-vm", Namespace: "caretta"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.9",
+			Ports:     []corev1.ServicePort{{Port: 8428}},
+		},
+	}
+	k8s := fake.NewSimpleClientset(carettaVM)
+	k8s.PrependReactor("list", "services", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden: cannot list services at cluster scope")
+	})
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(cands) != 1 || cands[0].Namespace != "caretta" || cands[0].Name != "caretta-vm" {
+		t.Fatalf("fallback dropped on list failure: got %+v", cands)
+	}
+}
+
+// TestDiscover_CarettaVMLastEvenWithNonStandardServicePort guards finding-2: a
+// caretta-vm Service fronted by service port 80 -> container 8428 keys as :80 in
+// the dynamic scan but :8428 in the fallback tier. A port-keyed dedup alone would
+// let it reappear among dynamics and lose the last-place invariant; name-based
+// suppression keeps it single and last.
+func TestDiscover_CarettaVMLastEvenWithNonStandardServicePort(t *testing.T) {
+	carettaVM := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "caretta-vm", Namespace: "caretta"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.9",
+			Ports:     []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8428)}},
+		},
+	}
+	dynamicProm := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prom",
+			Namespace: "myteam",
+			Labels:    map[string]string{"app.kubernetes.io/name": "prometheus"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.10",
+			Ports:     []corev1.ServicePort{{Port: 9090}},
+		},
+	}
+	k8s := fake.NewSimpleClientset(carettaVM, dynamicProm)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	carettaCount, carettaIdx := 0, -1
+	for i, c := range cands {
+		if c.Name == "caretta-vm" {
+			carettaCount++
+			carettaIdx = i
+		}
+	}
+	if carettaCount != 1 {
+		t.Fatalf("caretta-vm appeared %d times, want 1: %+v", carettaCount, cands)
+	}
+	if carettaIdx != len(cands)-1 {
+		t.Fatalf("caretta-vm at idx %d, want last (%d): %+v", carettaIdx, len(cands)-1, cands)
+	}
+}


### PR DESCRIPTION
## Problem

The reverse of #1347. Radar's resource-metrics module (per-pod CPU/memory charts) could bind to the traffic source's `caretta-vm`, which serves only Caretta's eBPF link metrics and commonly lacks cluster workload metrics -> charts go blank.

Two independent paths allowed it:

1. **Blind cross-owner port-forward reuse.** `discover()` reused any owner's managed forward via `GetAddress` **before** enumerating candidates, so it could adopt the traffic source's `caretta-vm` forward. The generic `/api/v1/query?query=up` probe passes against `caretta-vm`, so the wrong backend was accepted silently.
2. **Candidate ranking.** `caretta-vm` sat in the primary well-known list, so it outranked any Prometheus discoverable only via the dynamic cluster scan (non-standard name/namespace).

## Fix

1. **Target-aware reuse.** Reuse now happens **per candidate** via `portforward.GetAddressForService` (added in #1347) inside the priority-ordered port-forward fallback loop, so a forward is adopted only when it targets the candidate being tried. The now-unused `GetAddress` is removed. The reuse path also clears `discoveryService` on a superseded commit, matching the port-forward path.
2. **Fallback tier.** `caretta-vm` moves out of the primary well-known list into `fallbackWellKnownLocations`: fetched early (to seed dedup) but appended **last**, and suppressed by `namespace/name` in the dynamic scan so it can't resurface ranked-by-score. A real Prometheus always wins; `caretta-vm` is kept as a candidate only so a `caretta-vm`-only cluster still works. The fallback tier also survives a Services `list` failure (get-but-not-list RBAC).

## Tests

- Target-aware reuse, both directions (`internal/portforward`).
- `caretta-vm` ranks after a dynamic-only Prometheus; remains the sole candidate when it is the only backend; survives a `list` failure; stays single and last with a non-standard service port (`pkg/prom`).
- All tests pass with `-race` across `internal/portforward`, `internal/prometheus`, `internal/traffic`, and the `pkg/prom` module.

## Validation

Reproduced end-to-end on a kind cluster with **real** kube-prometheus-stack + real eBPF Caretta (149 `caretta_links_observed` series in caretta-vm): the pre-fix binary binds Caretta to the general Prometheus and returns **0 flows**; this fix opens a dedicated `caretta-vm` forward and returns real flows, leaving the resource-metrics Prometheus forward untouched.

## Follow-up to #1347

Builds on the `GetAddressForService` primitive introduced in #1347 (now merged). Rebased onto `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus discovery and shared port-forward selection paths used for resource metrics; wrong backend choice previously caused blank charts rather than crashes, but regressions could still affect metrics availability.
> 
> **Overview**
> Fixes resource-metrics (CPU/memory charts) silently binding to **caretta-vm**, which lacks cluster workload metrics.
> 
> **Port-forward reuse:** Removes blind pre-enumeration reuse via `GetAddress`. Reuse now runs **per candidate** in the port-forward loop using `GetAddressForService`, so only a tunnel to that namespace/service is adopted. Superseded reuse clears `discoveryService` without stopping peer-owned forwards; cancelled context bails before `Start` would tear down a reused tunnel.
> 
> **Candidate ranking:** Moves `caretta/caretta-vm` from the primary well-known list into a **fallback tier** (fetched early for dedup, appended last). Dynamic discovery suppresses fallback services by namespace/name so caretta-vm cannot outrank a dynamically found Prometheus; fallback still returns when list RBAC fails or caretta-vm is the only backend.
> 
> **Tests:** Port-forward target-awareness and caretta-vm ordering edge cases (`internal/portforward`, `pkg/prom`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9e6f7fc69c371a2e09378c2b49b8f656ff8bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->