### PR TITLE
test(timeline): shared wire-contract conformance suite + OSS conformance

### DIFF
--- a/internal/server/timeline_contract_test.go
+++ b/internal/server/timeline_contract_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
+	pkgtimeline "github.com/skyhook-io/radar/pkg/timeline"
+	"github.com/skyhook-io/radar/pkg/timelineapi/wiretest"
+)
+
+// TestHandleTimelineEvents_WireContract runs the shared timeline wire
+// conformance suite (exported from the radar OSS pkg module) against OSS's own
+// live handler. The same suite backs radar-hub against its handler, so both
+// servers prove they speak the one contract; each declares its capabilities and
+// the suite gates the deliberate divergences on them. OSS's capabilities:
+// "<epoch>:<seq>" cursors, foreign cursor → 400, no coverage records, a 10k row
+// cap, and a required (non-defaulted) window.
+func TestHandleTimelineEvents_WireContract(t *testing.T) {
+	prev := k8s.GetConnectionStatus()
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{State: k8s.StateConnected})
+	t.Cleanup(func() { k8s.SetConnectionStatus(prev) })
+
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(func() {
+		timeline.ResetStore()
+		if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
+			t.Fatalf("re-init global store: %v", err)
+		}
+	})
+
+	s := &Server{}
+	wiretest.Run(t, wiretest.Config{
+		Handler: http.HandlerFunc(s.handleTimelineEvents),
+		PathFor: func(string) string { return "/api/timeline/events" },
+		Seed: func(t *testing.T, events []pkgtimeline.TimelineEvent) {
+			t.Helper()
+			store := timeline.GetStore()
+			for _, e := range events {
+				e.ClusterContext = k8s.ActiveClusterContext()
+				if err := store.Append(t.Context(), e); err != nil {
+					t.Fatalf("seed append %s: %v", e.ID, err)
+				}
+			}
+		},
+		Query:                url.Values{"namespaces": {"default"}},
+		CursorKind:           wiretest.CursorEpochSeq,
+		EmitsCoverage:        false,
+		MaxRows:              10000,
+		RejectsForeignCursor: true,
+		DefaultsWindow:       false,
+	})
+}

--- a/internal/server/timeline_events.go
+++ b/internal/server/timeline_events.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/timeline"
+	"github.com/skyhook-io/radar/pkg/timelineapi"
 )
 
 // timelineEventsPageLimit caps both response shapes at the store's own page
@@ -18,13 +19,9 @@ const timelineEventsPageLimit = 10000
 
 // timelineEndRecord is the NDJSON terminal record closing an events stream.
 // Its shape is the wire contract the web client's retained source parses —
-// the same record the hub emits.
-type timelineEndRecord struct {
-	Type      string `json:"type"`
-	Cursor    string `json:"cursor,omitempty"`
-	More      bool   `json:"more,omitempty"`
-	Truncated bool   `json:"truncated,omitempty"`
-}
+// the same record the hub emits. It aliases the shared timelineapi.EndRecord
+// so this production output and the exported wire type cannot drift.
+type timelineEndRecord = timelineapi.EndRecord
 
 // handleTimelineEvents serves GET /api/timeline/events — the shared timeline
 // wire contract (the same one the hub serves): NDJSON event lines closed by a

--- a/pkg/timelineapi/records.go
+++ b/pkg/timelineapi/records.go
@@ -1,0 +1,116 @@
+// Package timelineapi holds the timeline events wire contract shared by every
+// server that speaks it: radar OSS and radar-hub. The HTTP body is NDJSON —
+// one JSON object per line — where each line is either an event row or one of
+// a small set of control records distinguished by a "type" discriminator. The
+// exported record types below pin that on-the-wire shape so both servers, and
+// the conformance suite in the wiretest subpackage, decode it the same way.
+//
+// The package is deliberately dependency-light (standard library only): it is
+// the lowest common denominator both implementations import, and it must not
+// drag k8s.io or other heavy transitive dependencies into consumers that only
+// need to read the framing.
+package timelineapi
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Control-record discriminator values carried in the "type" field. An NDJSON
+// line with none of these types (event rows carry no "type" field) is a row.
+const (
+	RecordTypeEnd      = "end"
+	RecordTypeCoverage = "coverage"
+	RecordTypeError    = "error"
+)
+
+// EndRecord is the terminal record that closes a successful stream. Its shape
+// is the contract the web client's retained source parses; radar OSS emits it
+// verbatim from internal/server (timelineEndRecord) and radar-hub emits the
+// same shape. Cursor is opaque to clients — feed it back as the delta
+// position; More signals another delta page waits; Truncated signals a window
+// load hit its row cap and the oldest part of the range was cut.
+type EndRecord struct {
+	Type      string `json:"type"`
+	Cursor    string `json:"cursor,omitempty"`
+	More      bool   `json:"more,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// CoverageRecord reports a sub-range of the requested window the server could
+// not answer for (a retention gap: events aged out, or a period predating the
+// current observation). radar OSS never emits it; radar-hub does. Times are
+// event-time epoch milliseconds.
+type CoverageRecord struct {
+	Type             string `json:"type"`
+	EventTimeStartMs int64  `json:"eventTimeStartMs,omitempty"`
+	EventTimeEndMs   int64  `json:"eventTimeEndMs,omitempty"`
+	Reason           string `json:"reason,omitempty"`
+}
+
+// ErrorRecord is an in-stream failure record: a server that has already
+// written rows (and committed 200 + headers) reports a mid-stream failure as a
+// terminal line rather than a broken connection. radar OSS surfaces failures
+// as real HTTP error statuses before the first byte and never emits this;
+// radar-hub emits it.
+type ErrorRecord struct {
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+}
+
+// DecodeStream reads an NDJSON timeline body and routes each line by its "type"
+// discriminator: end → terminal, error → errorRec, coverage → coverage, and
+// everything else (event rows carry no "type") → rows as raw JSON for the
+// caller to unmarshal into its own row type. A successful stream carries
+// exactly one terminal (end or error); rows and coverage may repeat. Blank
+// lines are skipped. Returns an error only on malformed JSON or a read
+// failure — an absent terminal is a caller-level assertion, not a decode
+// error, so partial/cut streams remain inspectable.
+func DecodeStream(r io.Reader) (rows []json.RawMessage, terminal *EndRecord, errorRec *ErrorRecord, coverage []CoverageRecord, err error) {
+	sc := bufio.NewScanner(r)
+	// Rows can be large (an event with a diff); lift the line ceiling well above
+	// bufio's default 64 KiB.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var probe struct {
+			Type string `json:"type"`
+		}
+		if err = json.Unmarshal(line, &probe); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("timelineapi: malformed NDJSON line %q: %w", line, err)
+		}
+		switch probe.Type {
+		case RecordTypeEnd:
+			var end EndRecord
+			if err = json.Unmarshal(line, &end); err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("timelineapi: malformed end record %q: %w", line, err)
+			}
+			terminal = &end
+		case RecordTypeError:
+			var er ErrorRecord
+			if err = json.Unmarshal(line, &er); err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("timelineapi: malformed error record %q: %w", line, err)
+			}
+			errorRec = &er
+		case RecordTypeCoverage:
+			var cov CoverageRecord
+			if err = json.Unmarshal(line, &cov); err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("timelineapi: malformed coverage record %q: %w", line, err)
+			}
+			coverage = append(coverage, cov)
+		default:
+			// Copy: the scanner reuses its buffer on the next Scan.
+			rows = append(rows, append(json.RawMessage(nil), line...))
+		}
+	}
+	if err = sc.Err(); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("timelineapi: reading NDJSON stream: %w", err)
+	}
+	return rows, terminal, errorRec, coverage, nil
+}

--- a/pkg/timelineapi/records_test.go
+++ b/pkg/timelineapi/records_test.go
@@ -1,0 +1,80 @@
+package timelineapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDecodeStreamRoutesByType(t *testing.T) {
+	body := strings.Join([]string{
+		`{"id":"ev-1","kind":"Deployment","namespace":"default","name":"web"}`,
+		``, // blank line tolerated
+		`{"type":"coverage","eventTimeStartMs":100,"eventTimeEndMs":200,"reason":"retention"}`,
+		`{"id":"ev-2","kind":"Pod","namespace":"default","name":"web-abc"}`,
+		`{"type":"end","cursor":"42:7","truncated":true}`,
+	}, "\n")
+
+	rows, end, errRec, coverage, err := DecodeStream(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	if errRec != nil {
+		t.Fatalf("unexpected error record: %+v", errRec)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	var e struct {
+		ID   string `json:"id"`
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(rows[0], &e); err != nil || e.ID != "ev-1" || e.Kind != "Deployment" {
+		t.Fatalf("row 0 = %s (%v), want ev-1/Deployment", rows[0], err)
+	}
+	if len(coverage) != 1 || coverage[0].EventTimeStartMs != 100 || coverage[0].EventTimeEndMs != 200 || coverage[0].Reason != "retention" {
+		t.Fatalf("coverage = %+v, want one retention gap 100..200", coverage)
+	}
+	if end == nil || end.Cursor != "42:7" || !end.Truncated || end.More {
+		t.Fatalf("terminal = %+v, want cursor 42:7 truncated", end)
+	}
+}
+
+func TestDecodeStreamInStreamError(t *testing.T) {
+	body := strings.Join([]string{
+		`{"id":"ev-1","kind":"Pod","namespace":"default","name":"p"}`,
+		`{"type":"error","message":"store unavailable"}`,
+	}, "\n")
+
+	rows, end, errRec, _, err := DecodeStream(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if end != nil {
+		t.Fatalf("expected no end record, got %+v", end)
+	}
+	if errRec == nil || errRec.Message != "store unavailable" {
+		t.Fatalf("error record = %+v, want store unavailable", errRec)
+	}
+}
+
+func TestDecodeStreamMalformed(t *testing.T) {
+	if _, _, _, _, err := DecodeStream(strings.NewReader("{not json}")); err == nil {
+		t.Fatalf("expected error on malformed NDJSON line")
+	}
+}
+
+// The exported EndRecord must marshal to exactly the on-the-wire terminal
+// shape (type/cursor, omitempty flags) the web client parses.
+func TestEndRecordJSONShape(t *testing.T) {
+	got, err := json.Marshal(EndRecord{Type: RecordTypeEnd, Cursor: "9:3"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `{"type":"end","cursor":"9:3"}`; string(got) != want {
+		t.Fatalf("EndRecord JSON = %s, want %s", got, want)
+	}
+}

--- a/pkg/timelineapi/wiretest/conformance.go
+++ b/pkg/timelineapi/wiretest/conformance.go
@@ -1,0 +1,364 @@
+// Package wiretest exports the timeline events WIRE conformance suite: the
+// HTTP-level invariants every server speaking the timeline contract must hold,
+// driven as real requests through the server's own http.Handler. It mirrors
+// the storetest idiom (pkg/timeline/storetest) — the properties live once,
+// here, and each server (radar OSS from internal/server, radar-hub from its
+// own handler) supplies its live handler plus a seed hook and runs the same
+// suite.
+//
+// The two servers diverge deliberately (OSS cursor is "<epoch>:<seq>" and
+// rejects a foreign cursor with 400; hub cursor is a single nanosecond
+// frontier and replays a stale one; hub emits coverage/error records and caps
+// at a higher row count; hub defaults an absent window while OSS requires it).
+// Every such divergence is a DECLARED capability on Config, never a hard-coded
+// expectation — the suite asserts the shared invariants unconditionally and
+// gates the divergent cases on the capability flags.
+package wiretest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	timeline "github.com/skyhook-io/radar/pkg/timeline"
+	"github.com/skyhook-io/radar/pkg/timelineapi"
+)
+
+// CursorKind declares how a server mints its opaque delta cursor. The suite
+// treats the cursor as opaque for round-tripping, but uses this to assert the
+// cursor's structural shape and to synthesize a guaranteed-foreign cursor.
+type CursorKind int
+
+const (
+	// CursorEpochSeq is radar OSS's "<epoch>:<seq>" cursor — an observation
+	// epoch and a monotonic arrival counter.
+	CursorEpochSeq CursorKind = iota
+	// CursorNanoFrontier is radar-hub's single nanosecond event-time frontier.
+	CursorNanoFrontier
+)
+
+// ModeEvents is the timeline events endpoint mode passed to Config.PathFor.
+const ModeEvents = "events"
+
+// Config wires one server's live handler into the suite and declares its
+// capabilities. The shared invariants hold regardless; the capability flags
+// gate the deliberately-divergent cases.
+type Config struct {
+	// Handler is the server's live http.Handler for the timeline endpoint.
+	Handler http.Handler
+	// PathFor returns the request path for a mode (currently only ModeEvents).
+	// OSS returns "/api/timeline/events"; hub returns "/c/{id}/api/timeline/events".
+	PathFor func(mode string) string
+	// Seed loads fixture events into the server's live store. It is called more
+	// than once; each call adds to what is already stored. The server-specific
+	// stamping (cluster context, etc.) belongs here, keeping the suite k8s-free.
+	Seed func(t *testing.T, events []timeline.TimelineEvent)
+	// Query is applied to every request (optional). OSS uses it to carry the
+	// namespace filter ("namespaces=default") its RBAC layer expects.
+	Query url.Values
+
+	// Capabilities — the declared points of divergence.
+
+	// CursorKind is the server's cursor shape.
+	CursorKind CursorKind
+	// EmitsCoverage is true when the server emits coverage records for
+	// unanswerable window sub-ranges (hub yes, OSS no).
+	EmitsCoverage bool
+	// MaxRows is the server's per-response row cap; a larger requested limit
+	// clamps to it rather than erroring.
+	MaxRows int
+	// RejectsForeignCursor is true when a cursor from another store generation
+	// is a 400 (OSS); false when the server replays it instead (hub).
+	RejectsForeignCursor bool
+	// DefaultsWindow is true when an absent from/to defaults a window (hub, 24h);
+	// false when from/to are required (OSS).
+	DefaultsWindow bool
+}
+
+// Run drives the shared timeline wire contract against cfg's live handler.
+func Run(t *testing.T, cfg Config) {
+	t.Helper()
+
+	now := time.Now()
+	base := now.Add(-time.Minute)
+	mk := func(id string, off time.Duration) timeline.TimelineEvent {
+		return timeline.TimelineEvent{
+			ID: id, Timestamp: base.Add(off), Source: timeline.SourceInformer,
+			Kind: "Deployment", Namespace: "default", Name: id,
+			EventType: timeline.EventTypeUpdate,
+		}
+	}
+	cfg.Seed(t, []timeline.TimelineEvent{
+		mk("wc-0", 0), mk("wc-1", time.Second), mk("wc-2", 2*time.Second),
+	})
+
+	fromMs := strconv.FormatInt(base.Add(-time.Second).UnixMilli(), 10)
+	toMs := strconv.FormatInt(now.UnixMilli(), 10)
+
+	// coverage accumulates every coverage record seen across the suite, backing
+	// the EmitsCoverage=false negative assertion.
+	var coverageSeen []timelineapi.CoverageRecord
+	decode := func(t *testing.T, rr *httptest.ResponseRecorder) ([]json.RawMessage, *timelineapi.EndRecord, *timelineapi.ErrorRecord) {
+		t.Helper()
+		rows, end, errRec, cov, err := timelineapi.DecodeStream(rr.Body)
+		if err != nil {
+			t.Fatalf("DecodeStream: %v", err)
+		}
+		coverageSeen = append(coverageSeen, cov...)
+		return rows, end, errRec
+	}
+
+	// --- shared invariant: window load is framed NDJSON closed by a terminal ---
+	var frontier string
+	t.Run("window load frames NDJSON closed by a terminal record", func(t *testing.T) {
+		rr := cfg.request(t, map[string]string{"from": fromMs, "to": toMs})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("window status = %d, body %s", rr.Code, rr.Body.String())
+		}
+		if ct := rr.Header().Get("Content-Type"); ct != "application/x-ndjson" {
+			t.Fatalf("window Content-Type = %q, want application/x-ndjson", ct)
+		}
+		rows, end, errRec := decode(t, rr)
+		if errRec != nil {
+			t.Fatalf("window emitted an error record on success: %+v", errRec)
+		}
+		if end == nil {
+			t.Fatalf("window missing terminal end record")
+		}
+		if len(rows) != 3 {
+			t.Fatalf("window returned %d rows, want 3", len(rows))
+		}
+		if end.Cursor == "" {
+			t.Fatalf("terminal record carried no cursor")
+		}
+		assertCursorShape(t, cfg.CursorKind, end.Cursor)
+		if end.Truncated || end.More {
+			t.Fatalf("uncapped window terminal = %+v, want neither truncated nor more", end)
+		}
+		frontier = end.Cursor
+	})
+
+	// --- shared invariant: rows decode into the timeline row schema ---
+	t.Run("rows decode into timeline.TimelineEvent", func(t *testing.T) {
+		rr := cfg.request(t, map[string]string{"from": fromMs, "to": toMs})
+		rows, _, _ := decode(t, rr)
+		if len(rows) == 0 {
+			t.Fatalf("no rows to decode")
+		}
+		for _, raw := range rows {
+			var e timeline.TimelineEvent
+			if err := json.Unmarshal(raw, &e); err != nil {
+				t.Fatalf("row does not decode into timeline.TimelineEvent: %v (%s)", err, raw)
+			}
+			if e.ID == "" || e.Kind == "" {
+				t.Fatalf("row decoded but lost identity: %+v", e)
+			}
+		}
+	})
+
+	// --- shared invariant: an empty window still terminates with an end record ---
+	t.Run("empty window still terminates", func(t *testing.T) {
+		fromFuture := strconv.FormatInt(now.Add(time.Hour).UnixMilli(), 10)
+		toFuture := strconv.FormatInt(now.Add(2*time.Hour).UnixMilli(), 10)
+		rr := cfg.request(t, map[string]string{"from": fromFuture, "to": toFuture})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("empty window status = %d, body %s", rr.Code, rr.Body.String())
+		}
+		rows, end, _ := decode(t, rr)
+		if end == nil {
+			t.Fatalf("empty window missing terminal end record")
+		}
+		if len(rows) != 0 {
+			t.Fatalf("empty window returned %d rows, want 0", len(rows))
+		}
+	})
+
+	// --- shared invariant: a capped window sets truncated and cuts to the cap ---
+	t.Run("capped window is truncated to the row cap", func(t *testing.T) {
+		rr := cfg.request(t, map[string]string{"from": fromMs, "to": toMs, "limit": "2"})
+		rows, end, _ := decode(t, rr)
+		if end == nil {
+			t.Fatalf("capped window missing terminal end record")
+		}
+		if len(rows) != 2 || !end.Truncated {
+			t.Fatalf("capped window: %d rows, truncated=%v; want 2 rows, truncated", len(rows), end.Truncated)
+		}
+	})
+
+	// --- shared invariant: an over-cap limit clamps, never errors (gated on MaxRows) ---
+	t.Run("over-limit request clamps rather than errors", func(t *testing.T) {
+		over := strconv.Itoa(cfg.MaxRows + 5000)
+		rr := cfg.request(t, map[string]string{"from": fromMs, "to": toMs, "limit": over})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("over-limit status = %d, want 200 (clamp, not error); body %s", rr.Code, rr.Body.String())
+		}
+		rows, end, _ := decode(t, rr)
+		if end == nil {
+			t.Fatalf("over-limit window missing terminal end record")
+		}
+		if len(rows) > cfg.MaxRows {
+			t.Fatalf("over-limit returned %d rows, exceeds cap %d", len(rows), cfg.MaxRows)
+		}
+	})
+
+	// --- shared invariant: cursor round-trips — feed the end cursor back and the delta continues ---
+	t.Run("cursor round-trip continues the stream", func(t *testing.T) {
+		if frontier == "" {
+			t.Fatalf("no frontier cursor captured from the window load")
+		}
+		// At the frontier the delta is empty and terminates.
+		rr := cfg.request(t, map[string]string{"since": frontier})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("frontier delta status = %d, body %s", rr.Code, rr.Body.String())
+		}
+		rows, end, _ := decode(t, rr)
+		if end == nil {
+			t.Fatalf("frontier delta missing terminal end record")
+		}
+		if len(rows) != 0 {
+			t.Fatalf("frontier delta returned %d rows, want 0", len(rows))
+		}
+
+		// A new arrival after the cursor rides the next delta. Timestamp is set
+		// after the window's `to` so it advances a nanosecond-frontier cursor as
+		// well as an arrival-seq one.
+		cfg.Seed(t, []timeline.TimelineEvent{
+			mk("wc-new", time.Minute+time.Second), // base + 61s == now + 1s
+		})
+		rr = cfg.request(t, map[string]string{"since": frontier})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("continuation delta status = %d, body %s", rr.Code, rr.Body.String())
+		}
+		rows, end, _ = decode(t, rr)
+		if end == nil {
+			t.Fatalf("continuation delta missing terminal end record")
+		}
+		found := false
+		for _, raw := range rows {
+			var e timeline.TimelineEvent
+			if err := json.Unmarshal(raw, &e); err != nil {
+				t.Fatalf("continuation row decode: %v", err)
+			}
+			if e.ID == "wc-new" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("continuation delta did not deliver the new arrival: %d rows", len(rows))
+		}
+	})
+
+	// --- capability-gated: foreign cursor is 400 or replayed ---
+	t.Run("foreign cursor is rejected or replayed per capability", func(t *testing.T) {
+		rr := cfg.request(t, map[string]string{"since": foreignCursor(cfg.CursorKind)})
+		if cfg.RejectsForeignCursor {
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("foreign cursor status = %d, want 400", rr.Code)
+			}
+			return
+		}
+		if rr.Code != http.StatusOK {
+			t.Fatalf("foreign cursor status = %d, want 200 (replay), body %s", rr.Code, rr.Body.String())
+		}
+		_, end, _ := decode(t, rr)
+		if end == nil {
+			t.Fatalf("replayed foreign cursor missing terminal end record")
+		}
+	})
+
+	// --- capability-gated: absent window defaults or is required ---
+	t.Run("absent window defaults or is required per capability", func(t *testing.T) {
+		rr := cfg.request(t, nil)
+		if cfg.DefaultsWindow {
+			if rr.Code != http.StatusOK {
+				t.Fatalf("absent window status = %d, want 200 (default), body %s", rr.Code, rr.Body.String())
+			}
+			_, end, _ := decode(t, rr)
+			if end == nil {
+				t.Fatalf("defaulted window missing terminal end record")
+			}
+			return
+		}
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("absent window status = %d, want 400 (required)", rr.Code)
+		}
+	})
+
+	// --- capability-gated: coverage records appear only when declared ---
+	t.Run("coverage records absent unless declared", func(t *testing.T) {
+		// Positive coverage requires a retention/observation gap the shared suite
+		// cannot synthesize without server-specific internals, so the assertion
+		// is one-sided: a server that does NOT declare coverage must never emit
+		// it across any request the suite made.
+		if !cfg.EmitsCoverage && len(coverageSeen) != 0 {
+			t.Fatalf("server does not declare coverage yet emitted %d coverage record(s): %+v",
+				len(coverageSeen), coverageSeen)
+		}
+	})
+}
+
+// request drives one GET through the handler, merging cfg.Query with params.
+func (c Config) request(t *testing.T, params map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	q := url.Values{}
+	for k, vs := range c.Query {
+		q[k] = append([]string(nil), vs...)
+	}
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	target := c.PathFor(ModeEvents)
+	if enc := q.Encode(); enc != "" {
+		target += "?" + enc
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+	c.Handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// foreignCursor synthesizes a syntactically valid cursor that cannot belong to
+// the live store generation: an epoch of 1 never matches OSS's real
+// nanosecond epoch, and a frontier of 1ns is a stale position hub replays.
+func foreignCursor(kind CursorKind) string {
+	switch kind {
+	case CursorNanoFrontier:
+		return "1"
+	default:
+		return "1:5"
+	}
+}
+
+// assertCursorShape checks the terminal cursor has the structure the declared
+// CursorKind promises — a guard against a server silently changing cursor form.
+func assertCursorShape(t *testing.T, kind CursorKind, cursor string) {
+	t.Helper()
+	switch kind {
+	case CursorEpochSeq:
+		epoch, seq, ok := strings.Cut(cursor, ":")
+		if !ok || !isDigits(epoch) || !isDigits(seq) {
+			t.Fatalf("cursor %q is not <epoch>:<seq>", cursor)
+		}
+	case CursorNanoFrontier:
+		if !isDigits(cursor) {
+			t.Fatalf("cursor %q is not a bare nanosecond frontier", cursor)
+		}
+	}
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The timeline events endpoint (NDJSON rows + terminal record + cursor) is implemented independently in radar and radar-hub, held together only by a hand-written TS client - and it has already drifted in several small ways. Nothing pins the two live handlers to a shared contract.

This adds a shared, capability-parameterized conformance suite so both repos can certify their live handler against the same wire contract. This PR is the OSS-side, self-contained part.

## What is here
- **`pkg/timelineapi`** - shared wire types (`EndRecord` / `CoverageRecord` / `ErrorRecord`) plus a stdlib-only NDJSON `DecodeStream`. Kubernetes-free, ships in the existing `pkg` module.
- **`pkg/timelineapi/wiretest`** - exported `Run(t, Config)` mirroring the `storetest` idiom. Drives real HTTP requests through an injected `http.Handler` and asserts the shared invariants (NDJSON framing + content-type, terminal-record-on-success, empty window still terminates, `truncated` semantics, row schema decodes, cursor round-trip continuity), while gating the *deliberate* per-repo differences (cursor format, coverage emission, row caps, foreign-cursor handling) on declared capability flags.
- **`internal/server`** - wires radars own handler into the suite.
- **`timelineEndRecord`** is now a type alias of `timelineapi.EndRecord`, so the production terminal record and the shared wire type cannot drift at compile time.

## Follow-up (not in this PR)
Hub-side adoption: tag a new `pkg` module version, bump the `require` in radar-hub, and add a hub conformance test with the hub capability flags (nanosecond-frontier cursor, coverage emission, 50k cap, replay-on-foreign-cursor). Two record types (`CoverageRecord`/`ErrorRecord`) that radar never emits should be reconciled against the hubs actual output during that step.

## Tests
`cd pkg && go build ./... && go test ./timelineapi/...` and `go test ./internal/server/ -run Contract` all green.

Part of RAD-38.

https://claude.ai/code/session_018ea2h6ki1JweHcMU8F2LR8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new test/pkg surface; production change is a type alias with no handler behavior change.
> 
> **Overview**
> Introduces a **shared timeline events wire contract** in `pkg/timelineapi` (NDJSON control records + `DecodeStream`) and a **capability-parameterized HTTP conformance suite** in `pkg/timelineapi/wiretest`, so radar OSS and radar-hub can certify the same handler invariants while declaring intentional differences (cursor shape, coverage, row caps, foreign-cursor behavior, window defaults).
> 
> OSS now runs that suite against `handleTimelineEvents` via `TestHandleTimelineEvents_WireContract`, and **`timelineEndRecord` is a type alias of `timelineapi.EndRecord`** so the live terminal JSON shape cannot drift from the exported wire type at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab05e55790a9c8197cfbf355019a4e4a46ab4616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->