### PR TITLE
Fall back to the local timestamp when the in-cluster Deployment is unreadable

### DIFF
--- a/internal/server/cloud_funnel_rollout.go
+++ b/internal/server/cloud_funnel_rollout.go
@@ -41,42 +41,44 @@ func cloudFunnelInCohort() bool {
 	return cloudFunnelBucketVerdict()
 }
 
-// Memoized: the bucket verdict cannot change within a process (the ID is
+// Memoized: the bucket verdict cannot change within a process (the key is
 // sticky and the percent is compiled in), and capabilities are requested per
 // page load — no reason to re-read the settings file each time. The env
 // override above stays live deliberately.
 var cloudFunnelBucketVerdict = sync.OnceValue(func() bool {
-	return cloudFunnelBucketed(cloudFunnelRolloutPercent, rolloutIdentity())
+	return cloudFunnelBucketed(cloudFunnelRolloutPercent, bucketKey())
 })
 
-// rolloutIdentity is the value the cohort hashes on. In-cluster it comes from
-// the Radar Deployment's creation time, not ~/.radar: that directory sits on an
-// emptyDir that dies with the pod, so bucketing on it would re-roll the verdict
-// on every restart and rollout — and disagree between replicas — making the
-// funnel flicker in and out.
+// bucketKey is the value the rollout hashes on. In-cluster it prefers the Radar
+// Deployment's creation time over ~/.radar: that directory sits on an emptyDir
+// that dies with the pod, so bucketing on it re-rolls the verdict on every
+// restart and rollout — and disagrees between replicas — making the funnel
+// flicker in and out.
 //
-// Empty either way means no durable identity, which cloudFunnelBucketed treats
-// as out-of-cohort rather than re-rolling every start.
-func rolloutIdentity() string {
+// It still falls back to ~/.radar when the Deployment is unreadable (chart too
+// old to set the downward-API env vars, no cluster access, RBAC without
+// deployments). A flickering verdict is recoverable; returning nothing is not —
+// cloudFunnelBucketed pins an empty key out of every partial rollout, so those
+// installs would never see the funnel at any percentage below 100.
+func bucketKey() string {
 	if k8s.IsInCluster() {
 		if installed := k8s.InstalledAt(context.Background()); installed != 0 {
 			return strconv.FormatInt(installed, 10)
 		}
-		return ""
 	}
-	return settings.InstallID()
+	return settings.RolloutKey()
 }
 
-func cloudFunnelBucketed(percent uint32, installID string) bool {
+func cloudFunnelBucketed(percent uint32, key string) bool {
 	if percent >= 100 {
 		return true
 	}
-	// An empty ID means no persistable identity — stay out of a partial
-	// rollout rather than re-rolling a fresh bucket every start.
-	if percent == 0 || installID == "" {
+	// An empty key means nothing stable to hash — stay out of a partial rollout
+	// rather than re-rolling a fresh bucket every start.
+	if percent == 0 || key == "" {
 		return false
 	}
 	h := fnv.New32a()
-	h.Write([]byte(installID))
+	h.Write([]byte(key))
 	return h.Sum32()%100 < percent
 }

--- a/internal/server/cloud_funnel_rollout_test.go
+++ b/internal/server/cloud_funnel_rollout_test.go
@@ -35,6 +35,29 @@ func TestCloudFunnelBucketing(t *testing.T) {
 	}
 }
 
+// An in-cluster install whose Deployment can't be read (chart predating the
+// downward-API env vars, restricted RBAC) must still get a bucket key. Returning
+// "" would pin it out of every rollout below 100% permanently — the failure that
+// left ~17% of 1.9.0 in-cluster installs unable to reach the funnel at all.
+func TestBucketKeyFallsBackWhenDeploymentUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	// No cluster access in a test binary, so InstalledAt() is 0 — and
+	// IsInCluster() is true here because no kubeconfig path is configured.
+	key := bucketKey()
+	if key == "" {
+		t.Fatal("in-cluster install with an unreadable Deployment got no bucket key")
+	}
+	if !cloudFunnelBucketed(100, key) {
+		t.Fatal("the fallback key is not usable for bucketing")
+	}
+	if bucketKey() != key {
+		t.Fatal("fallback key is not stable across calls within a process")
+	}
+}
+
 func TestCloudFunnelEnvOverrideWins(t *testing.T) {
 	t.Setenv("RADAR_CLOUD_FUNNEL", "on")
 	if !cloudFunnelInCohort() {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -134,19 +134,23 @@ func Update(mutate func(*Settings)) (Settings, error) {
 	return s, Save(s)
 }
 
-// InstallID returns this installation's stable rollout identifier, minting
-// and persisting one on first use. Returns "" when it cannot be persisted
-// (no home directory, read-only filesystem) — a caller gating a partial
-// rollout must treat that as out-of-cohort rather than re-rolling a fresh
-// identity every start.
+// RolloutKey returns the local value staged rollouts hash on, minting and
+// persisting one on first use. It never leaves this machine. Returns "" when it
+// cannot be persisted (no home directory, read-only filesystem) — a caller
+// gating a partial rollout must treat that as out-of-cohort rather than
+// re-rolling a fresh key every start.
 //
-// The ID lives in its own file, deliberately NOT in the Settings struct:
+// The file name is load-bearing: changing it makes every existing install mint
+// a new key and land in a different bucket, so the rollout would visibly flip
+// for people on both sides of it.
+//
+// It lives in its own file, deliberately NOT in the Settings struct:
 // /api/settings serializes that struct verbatim (including through a Cloud
 // tunnel), and a settings PUT round-trip could silently drop a field the
-// client never saw. A random local identifier must be able to do neither.
+// client never saw. A random local value must be able to do neither.
 // The O_EXCL create makes a concurrent first mint (CLI and Desktop starting
 // together) resolve to one winner; losers adopt the winner's file.
-func InstallID() string {
+func RolloutKey() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -173,8 +177,8 @@ func InstallID() string {
 		return ""
 	}
 	// Any failure past the create must take the file with it. A stranded empty
-	// file is read back as a valid-but-empty id on every later call, which
-	// callers treat as "no identity" — pinning the install out of a staged
+	// file is read back as a valid-but-empty value on every later call, which
+	// callers treat as nothing to hash — pinning the install out of a staged
 	// rollout permanently, with no way to self-heal. Removing it lets the next
 	// start mint cleanly.
 	// Close is where a failed flush surfaces on some filesystems, so both it and

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -137,17 +137,17 @@ func TestSaveCreatesDirectory(t *testing.T) {
 	}
 }
 
-func TestInstallIDMintsOnceAndPersists(t *testing.T) {
+func TestRolloutKeyMintsOnceAndPersists(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
 
-	id := InstallID()
+	id := RolloutKey()
 	if id == "" {
-		t.Fatal("InstallID returned empty with a writable home")
+		t.Fatal("RolloutKey returned empty with a writable home")
 	}
-	if InstallID() != id {
-		t.Fatal("InstallID is not stable across calls")
+	if RolloutKey() != id {
+		t.Fatal("RolloutKey is not stable across calls")
 	}
 	// Its own file, never the settings struct: /api/settings serializes
 	// Settings verbatim, so the identifier must not be reachable from it.
@@ -160,7 +160,7 @@ func TestInstallIDMintsOnceAndPersists(t *testing.T) {
 	}
 }
 
-func TestInstallIDConcurrentMintResolvesToOneWinner(t *testing.T) {
+func TestRolloutKeyConcurrentMintResolvesToOneWinner(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
@@ -174,7 +174,7 @@ func TestInstallIDConcurrentMintResolvesToOneWinner(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ids[i] = InstallID()
+			ids[i] = RolloutKey()
 		}(i)
 	}
 	wg.Wait()
@@ -190,7 +190,7 @@ func TestInstallIDConcurrentMintResolvesToOneWinner(t *testing.T) {
 			t.Fatalf("racer %d minted %q while racer 0 got %q", i, id, ids[0])
 		}
 	}
-	if InstallID() == "" {
+	if RolloutKey() == "" {
 		t.Fatal("no identity persisted after the race")
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -145,14 +145,7 @@ func fetchLatestRelease(ctx context.Context) *UpdateInfo {
 		"method": {string(method)},
 		"mode":   {mode},
 	}
-	// In-cluster, ~/.radar is an emptyDir that dies with the pod, so its
-	// birthtime marks a pod lifetime rather than an installation. The Radar
-	// Deployment's creation time is the installation.
-	t := radarDirBirthtime()
-	if mode == "in-cluster" {
-		t = k8s.InstalledAt(ctx)
-	}
-	if t != 0 {
+	if t := installTimestamp(ctx, mode); t != 0 {
 		params.Set("t", strconv.FormatInt(t, 10))
 	}
 	proxyURL := fmt.Sprintf("%s?%s", releasesURL, params.Encode())
@@ -233,6 +226,19 @@ func truncateNotes(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// installTimestamp reports when this install was set up. In-cluster that is the
+// Deployment's creation time; ~/.radar is an emptyDir whose birthtime resets
+// with the pod. The birthtime is the weaker answer but still a better one than
+// none when the Deployment can't be read.
+func installTimestamp(ctx context.Context, mode string) int64 {
+	if mode == "in-cluster" {
+		if installed := k8s.InstalledAt(ctx); installed != 0 {
+			return installed
+		}
+	}
+	return radarDirBirthtime()
 }
 
 // radarDirBirthtime returns the creation timestamp of ~/.radar/ as Unix epoch

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,9 @@
 package version
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -118,5 +121,24 @@ func TestTruncateNotes(t *testing.T) {
 				t.Errorf("truncateNotes(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 			}
 		})
+	}
+}
+
+// When the Deployment is unreadable, in-cluster must report the same timestamp a
+// local install would rather than reporting none. Asserted as equality with the
+// local path so the test holds on filesystems that don't record a birthtime at
+// all (where both are legitimately 0).
+func TestInstallTimestampFallsBackInCluster(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".radar"), 0o755); err != nil {
+		t.Fatalf("seed ~/.radar: %v", err)
+	}
+
+	ctx := context.Background()
+	local := installTimestamp(ctx, "local")
+	if got := installTimestamp(ctx, "in-cluster"); got != local {
+		t.Fatalf("in-cluster timestamp %d did not fall back to the local timestamp %d", got, local)
 	}
 }


### PR DESCRIPTION
## Summary

In-cluster, Radar reads its own Deployment's `creationTimestamp` — it survives pod restarts, unlike anything under `~/.radar`, which sits on an emptyDir. When that Deployment can't be read the value was left empty, and empty is handled worse than approximate:

- `cloudFunnelBucketed` treats an empty value as out-of-cohort, so the install is excluded from **every** staged rollout below 100% — not unlucky in the hash, structurally out.
- The update check drops the value rather than using the one a local install would.

## What changed

Both call sites fall through instead of giving up:

- `bucketKey` (`cloud_funnel_rollout.go`) drops its `return ""`, so an unreadable Deployment falls through to the local value.
- `installTimestamp` (`version.go`, extracted from `fetchLatestRelease`) prefers `k8s.InstalledAt` and falls back to `radarDirBirthtime()`.

The fallback resets with the pod, so an affected install's rollout verdict can flip across restarts. That's the deliberate trade — a flickering verdict is recoverable, permanent exclusion isn't.

Alongside that, these values are now named for what they are and what they're for: `rolloutIdentity` → `bucketKey`, `settings.InstallID` → `settings.RolloutKey`, and the `installID` parameter on `cloudFunnelBucketed` → `key`. Pure rename, no behavior change.

**`~/.radar/install-id` keeps its file name.** Renaming the file would make every existing install mint a fresh key and land in a different bucket, flipping the rollout for people on both sides of it — the same churn this PR exists to avoid.

## Testing

`make test` green, `go vet` clean. Both new tests were verified against the bug — reverting the two source files to `main` and re-running produces:

```
--- FAIL: TestBucketKeyFallsBackWhenDeploymentUnreadable
--- FAIL: TestInstallTimestampFallsBackInCluster
```

`TestInstallTimestampFallsBackInCluster` asserts equality with the local path rather than a non-zero value, so it holds on filesystems that don't record a birthtime, where both are legitimately 0.

No visual test — Go-only, no rendered surface.

## Follow-up

`installedAtFrom` logs when the Deployment `Get` errors but returns 0 silently when the env vars are absent — the most likely cause emits no diagnostic at all. Worth a log line so an operator can tell why. Not in this PR.

The dominant cause is also a release-note fix rather than a code one: `helm upgrade` the chart, not just the image tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes staged rollout cohort assignment and release-check telemetry for in-cluster edge cases; behavior is intentional but can make funnel eligibility less stable across restarts for affected installs.
> 
> **Overview**
> Fixes in-cluster installs that cannot read the Radar Deployment (old chart, wrong workload, missing RBAC) being **permanently excluded** from staged Cloud funnel rollouts and sending **no install timestamp** on update checks.
> 
> **Cloud funnel:** `bucketKey()` (formerly `rolloutIdentity`) no longer returns an empty string when `k8s.InstalledAt()` is zero in-cluster; it falls through to the persisted local value via **`settings.RolloutKey()`** (rename of `InstallID()`). Bucketing helpers now talk about a generic **key** instead of install ID.
> 
> **Update check:** New **`installTimestamp()`** prefers Deployment creation time in-cluster, then falls back to **`~/.radar` birthtime**—same behavior local installs already used—so the `t` query param is still sent when possible.
> 
> The tradeoff is explicit: fallback keys/timestamps can **change across pod restarts** (emptyDir), so cohort membership may flicker; that is preferred over pinning ~17% of affected 1.9.0 in-cluster installs out of every partial rollout.
> 
> Tests cover unreadable-Deployment **`bucketKey`** stability and in-cluster **`installTimestamp`** matching the local path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3665afb60d4f9b4131b80c5d9326f22e569900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->