### PR TITLE
Require a Prometheus-family signal, not a bare port, to admit a discovery candidate

### DIFF
--- a/pkg/prom/discovery.go
+++ b/pkg/prom/discovery.go
@@ -376,11 +376,12 @@ func promPortScore(port int32) int {
 // ScoreService computes a heuristic score for a service being
 // Prometheus-compatible. It returns the ranking score, an inferred BasePath for
 // vmselect-style services, and whether the service carries a Prometheus-family
-// *identity* signal (a name/label/port match). identity gates admission:
-// namespace membership alone contributes to the score for ranking but must not,
-// on its own, make an unrelated Service a candidate — discovery probes
-// candidates with the operator's configured Prometheus headers, so an
-// unrecognized neighbor must not be admitted just for sharing a namespace.
+// *identity* signal (a name, label, or port-NAME match — NOT a bare port number).
+// identity gates admission: a matched port number and namespace membership
+// contribute to the score for ranking but must not, on their own, make an
+// unrelated Service a candidate — discovery probes candidates with the operator's
+// configured Prometheus headers, so a neighbor that merely shares a popular port
+// (9090 is a common gRPC/plugin default too) or a namespace must not be admitted.
 func ScoreService(svc corev1.Service) (score int, basePath string, identity bool) {
 	if svc.Spec.Type == corev1.ServiceTypeExternalName {
 		return 0, "", false
@@ -400,23 +401,30 @@ func ScoreService(svc corev1.Service) (score int, basePath string, identity bool
 	switch appName {
 	case "prometheus":
 		score += 100
+		identity = true
 	case "victoria-metrics-single", "vmsingle":
 		score += 100
+		identity = true
 	case "vmselect":
 		score += 90
 		basePath = "/select/0/prometheus"
+		identity = true
 	case "thanos-query", "thanos-querier":
 		score += 80
+		identity = true
 	}
 
 	switch appLabel {
 	case "prometheus", "prometheus-server":
 		score += 80
+		identity = true
 	case "vmsingle":
 		score += 80
+		identity = true
 	case "vmselect":
 		score += 80
 		basePath = "/select/0/prometheus"
+		identity = true
 	}
 
 	if score > 0 && component == "server" {
@@ -426,7 +434,12 @@ func ScoreService(svc corev1.Service) (score int, basePath string, identity bool
 	for _, p := range svc.Spec.Ports {
 		// Credit a recognized port on either the service port or the container
 		// targetPort — a real Prometheus is often fronted by a service port of
-		// 80/http with targetPort 9090 — but only once per port entry.
+		// 80/http with targetPort 9090 — but only once per port entry. A bare port
+		// NUMBER is a ranking signal only: it must NOT set identity, because
+		// popular defaults like 9090 are shared with unrelated components (e.g. a
+		// gRPC plugin), and admitting on the number alone sends the operator's
+		// Prometheus headers to — and wastes a doomed port-forward on — that
+		// neighbor. A port explicitly NAMED "prometheus" is a genuine family signal.
 		if s := promPortScore(p.Port); s > 0 {
 			score += s
 		} else {
@@ -434,27 +447,32 @@ func ScoreService(svc corev1.Service) (score int, basePath string, identity bool
 		}
 		if strings.Contains(strings.ToLower(p.Name), "prometheus") {
 			score += 10
+			identity = true
 		}
 	}
 
 	nameLower := strings.ToLower(svc.Name)
 	if strings.Contains(nameLower, "prometheus") {
 		score += 20
+		identity = true
 	}
 	if strings.Contains(nameLower, "victoria") || strings.Contains(nameLower, "vmsingle") || strings.Contains(nameLower, "vmselect") {
 		score += 20
+		identity = true
 		if strings.Contains(nameLower, "vmselect") && basePath == "" {
 			basePath = "/select/0/prometheus"
 		}
 	}
 	if strings.Contains(nameLower, "thanos") {
 		score += 15
+		identity = true
 	}
 
-	// Everything above is a Prometheus-family identity signal; the namespace
-	// bonus below only nudges ranking and must not admit on its own.
-	identity = score > 0
-
+	// identity is set above only by a name, label, or port-name signal — genuine
+	// Prometheus-family membership. A bare port number and the metrics-namespace
+	// bonus below rank a candidate but must never admit one on their own, so the
+	// caller never probes (and never sends the operator's configured Prometheus
+	// headers to) an unrelated neighbor that merely shares port 9090 or a namespace.
 	if metricsNamespaces[svc.Namespace] {
 		score += 10
 	}

--- a/pkg/prom/discovery_test.go
+++ b/pkg/prom/discovery_test.go
@@ -700,3 +700,83 @@ func TestDiscover_CarettaVMLastEvenWithNonStandardServicePort(t *testing.T) {
 		t.Fatalf("caretta-vm at idx %d, want last (%d): %+v", carettaIdx, len(cands)-1, cands)
 	}
 }
+
+// TestDiscover_ExcludesPortOnlyPortMatch reproduces issue #1356: a Service that
+// matches only on a well-known port NUMBER (9090 here, shared with gRPC plugins
+// such as CloudNativePG's barman-cloud) carries no Prometheus-family identity —
+// no name, label, or port-name signal — and must NOT be admitted as a candidate.
+// Admitting it wastes a doomed port-forward that, in-cluster on a read-only
+// ServiceAccount, surfaces to the user as a confusing "Prometheus not connected".
+func TestDiscover_ExcludesPortOnlyPortMatch(t *testing.T) {
+	barman := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "barman-cloud",
+			Namespace:   "cnpg-system",
+			Annotations: map[string]string{"cnpg.io/pluginPort": "9090"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.20",
+			Ports:     []corev1.ServicePort{{Port: 9090}},
+		},
+	}
+
+	// Ranking signal is present (port scores) but identity must be false.
+	score, _, identity := ScoreService(*barman)
+	if identity {
+		t.Fatalf("barman-cloud identity=true (a bare port number must not admit); score=%d", score)
+	}
+	if score == 0 {
+		t.Fatalf("expected a non-zero ranking score from the port number, got 0")
+	}
+
+	k8s := fake.NewSimpleClientset(barman)
+	cands, err := Discover(context.Background(), k8s, DiscoverOptions{IncludeDynamic: true, MaxDynamic: 5})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, c := range cands {
+		if c.Name == "barman-cloud" {
+			t.Fatalf("port-only gRPC service admitted as a Prometheus candidate: %+v", cands)
+		}
+	}
+}
+
+// TestScoreService_IdentityRequiresFamilySignal locks the issue #1356 contract at
+// the scoring layer: identity is set by a name/label/port-name signal, never by a
+// bare port number.
+func TestScoreService_IdentityRequiresFamilySignal(t *testing.T) {
+	cases := []struct {
+		name      string
+		svc       corev1.Service
+		wantIdent bool
+	}{
+		{"port-number only", corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "some-grpc-svc", Namespace: "apps"},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090}}},
+		}, false},
+		{"metrics namespace + port only", corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "some-grpc-svc", Namespace: "monitoring"},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8428}}},
+		}, false},
+		{"label signal admits", corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "apps", Labels: map[string]string{"app.kubernetes.io/name": "prometheus"}},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090}}},
+		}, true},
+		{"name signal admits", corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "team-prometheus", Namespace: "apps"},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090}}},
+		}, true},
+		{"port-name signal admits", corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "apps"},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 9090, Name: "prometheus"}}},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, identity := ScoreService(tc.svc)
+			if identity != tc.wantIdent {
+				t.Fatalf("identity=%v, want %v", identity, tc.wantIdent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #1356. `prom.Discover()`'s dynamic layer admits a Service as a Prometheus candidate when the **port number alone** matches a well-known value. `ScoreService()` set `identity = score > 0`, and `promPortScore(9090) == 30`, so any Service exposing 9090 (or 8428/8481/9009/10902) was admitted — no name or label signal required.

In a real cluster this surfaces on the CloudNativePG **barman-cloud** plugin: its Service exposes a single gRPC port `9090`, carries no `prometheus` name substring and none of the labels `ScoreService` inspects. Radar admits it, then (in-cluster, default `rbac.portForward: false`) attempts a port-forward that can only fail:

```
port-forward to cnpg-system/barman-cloud failed: ... pods "barman-cloud-..." is forbidden:
User "system:serviceaccount:radar:radar" cannot create resource "pods/portforward" in ... "cnpg-system"
```

which reads to the user as `Prometheus not connected` naming an unrelated namespace — looks like an RBAC misconfig, is actually a discovery mismatch.

## Fix

Set `identity` only from a **name, label, or port-NAME** signal — genuine Prometheus-family membership. A bare port **number** and the metrics-namespace bonus still contribute to the ranking `score`, but no longer admit a candidate on their own. This mirrors the guard already applied to namespace membership (a namespace-only match ranks but never admits).

- Real Prometheus/VictoriaMetrics/Thanos query services carry `app.kubernetes.io/name`, `app`, or a recognizable name substring, so they still admit.
- Operator-managed installs are covered by the Layer-1 well-known list regardless of dynamic scoring.
- A Service whose only Prometheus-ish trait is `:9090` (barman-cloud) is no longer probed.

## Tests

- `TestDiscover_ExcludesPortOnlyPortMatch` — reproduces the barman-cloud case: `identity=false`, non-zero ranking score, and the service is absent from `Discover()` candidates.
- `TestScoreService_IdentityRequiresFamilySignal` — table: port-number-only and metrics-namespace+port-only → `identity=false`; label / name / port-name → `identity=true`.
- Existing `TestScoreService_TableDriven`, `TestDiscover_KeepsUnlabeledCustomPrometheus`, `TestDiscover_KeepsUnlabeledThanosQuery` (all name-signal cases) still pass.

## Scope

The issue also suggests skipping `appProtocol: grpc/h2c` services and preferring the in-cluster ClusterIP over a port-forward. Both are reasonable independent hardening, but the identity-gate fix here resolves the reported case at the root (a port number is a convention, not a family identity); the others can follow separately if wanted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes discovery admission logic for all clusters using dynamic scan; mis-tuned identity rules could hide a lightly labeled Prometheus, though name/label/port-name paths and well-known layer remain.
> 
> **Overview**
> Fixes **#1356** by tightening how dynamic Prometheus discovery decides to **admit** a Service. **`ScoreService`** no longer treats `identity = score > 0`; it sets **`identity` only** from Prometheus-family **labels**, **service name** substrings, or a port **named** `prometheus`. Well-known port numbers (e.g. **9090**) and the metrics-namespace score bonus still **rank** candidates but **cannot admit** one by themselves.
> 
> That stops unrelated gRPC/plugin Services (e.g. CloudNativePG **barman-cloud** on 9090) from being probed and triggering misleading failed port-forwards / “Prometheus not connected” noise. Real Prometheus, VictoriaMetrics, and Thanos query endpoints with conventional labels or names are unchanged.
> 
> Adds **`TestDiscover_ExcludesPortOnlyPortMatch`** and **`TestScoreService_IdentityRequiresFamilySignal`** to lock the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b3e706a6abdd072d18158debe49e19c84d6de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->