### PR TITLE
Enforce the single-workload app-scope invariant in the shared component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tmp/
 vt-shots/
 vt-audit-shots/
 vt-issues-shots/
+
+# Playwright e2e artifacts (never commit)
+web/test-results/

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.test.tsx
@@ -207,6 +207,52 @@ describe("ApplicationDetail shell", () => {
     expect(html).not.toContain("Application views");
   });
 
+  // A controlled host's only way to say "no workload in the URL" is null, so
+  // without this the application scope a single-workload app must not have
+  // becomes the default for every URL-driven host.
+  it("opens the workload directly for controlled single-workload apps with no workload in the URL", () => {
+    const singleApp: AppRow = {
+      ...app,
+      workloads: [app.workloads[0]],
+    };
+    const html = renderDetail({
+      app: singleApp,
+      selectedWorkloadKey: null,
+      onSelectWorkload: () => {},
+    });
+
+    expect(html).toContain("Runtime for");
+    expect(html).toContain("checkout-api");
+    expect(html).not.toContain("Application views");
+    expect(html).not.toContain('aria-haspopup="listbox"');
+  });
+
+  it("keeps workload scope for a controlled single-workload app whose URL names a workload it no longer has", () => {
+    const singleApp: AppRow = {
+      ...app,
+      workloads: [app.workloads[0]],
+    };
+    const html = renderDetail({
+      app: singleApp,
+      selectedWorkloadKey: workloadKey(app.workloads[1]),
+      onSelectWorkload: () => {},
+    });
+
+    expect(html).toContain("Runtime for");
+    expect(html).toContain("checkout-api");
+    expect(html).not.toContain("Application views");
+  });
+
+  it("keeps application scope for a controlled multi-workload app with no workload in the URL", () => {
+    const html = renderDetail({
+      selectedWorkloadKey: null,
+      onSelectWorkload: () => {},
+    });
+
+    expect(html).toContain("Application views");
+    expect(html).not.toContain("Runtime for");
+  });
+
   it("renders one filtered application chronology with workload and source actions", () => {
     const html = renderDetail({
       selectedView: "history",

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
@@ -71,6 +71,7 @@ import {
   sourceReportedHealth,
   sourceSyncHealth,
   servingReadiness,
+  resolveAppWorkloadSelection,
   worstHealth,
   appGroupLagMessage,
   compareVersions,
@@ -122,9 +123,10 @@ export interface AppIdentityInstance {
 
 /** Workload selection is either fully controlled (key + callback, the host
  *  wires it to the URL so back/forward works) or fully internal — providing
- *  only half silently freezes the selector, so the types forbid it. `null` means
- *  the application itself is selected; a key (see `workloadKey`) selects a
- *  workload scope. */
+ *  only half silently freezes the selector, so the types forbid it. A key (see
+ *  `workloadKey`) selects a workload scope; `null` asks for application scope,
+ *  which a single-workload app does not have — there the component resolves to
+ *  the sole workload regardless. See `rawSelected`. */
 type SelectionProps =
   | {
       selectedWorkloadKey: string | null;
@@ -407,12 +409,13 @@ export function ApplicationDetail({
   }, [app.key, selectedView]);
 
   const [internalSelected, setInternalSelected] = useState<string | null>(null);
-  const implicitSingleWorkloadKey =
-    workloads.length === 1 ? workloadKey(workloads[0]) : null;
-  const rawSelected =
-    selectedWorkloadKey !== undefined
-      ? selectedWorkloadKey
-      : (internalSelected ?? implicitSingleWorkloadKey);
+  const hostSelected =
+    selectedWorkloadKey !== undefined ? selectedWorkloadKey : internalSelected;
+  const { selected: rawSelected, hostKeyIsStale } = useMemo(
+    () =>
+      resolveAppWorkloadSelection(workloads.map(workloadKey), hostSelected),
+    [workloads, hostSelected],
+  );
   const setSelected = useCallback(
     (key: string | null, options?: AppWorkloadSelectionOptions) =>
       onSelectWorkload
@@ -425,14 +428,10 @@ export function ApplicationDetail({
     : undefined;
   const singleWorkloadScope = workloads.length === 1 && !!selectedWorkload;
   useEffect(() => {
-    if (
-      selectedWorkloadKey !== undefined &&
-      selectedWorkloadKey !== null &&
-      !selectedWorkload
-    ) {
+    if (selectedWorkloadKey !== undefined && hostKeyIsStale) {
       onSelectWorkload?.(null);
     }
-  }, [selectedWorkloadKey, selectedWorkload, onSelectWorkload]);
+  }, [selectedWorkloadKey, hostKeyIsStale, onSelectWorkload]);
   useEffect(() => {
     if (selectedWorkloadKey === undefined) setInternalSelected(null);
   }, [app.key, selectedWorkloadKey]);

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -1,5 +1,54 @@
 import { describe, it, expect } from 'vitest'
-import { compareVersions, appGroupingExplainer, APP_IDENTITY_ANNOTATION, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, worstHealth, buildAppMembershipIndex, batchActivityForApp, batchRuntimeForApp, servingReadiness, type AppGroupFoldEntry, type AppRow, type AppWorkload } from './applications'
+import { compareVersions, appGroupingExplainer, APP_IDENTITY_ANNOTATION, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, worstHealth, buildAppMembershipIndex, batchActivityForApp, batchRuntimeForApp, servingReadiness, resolveAppWorkloadSelection, type AppGroupFoldEntry, type AppRow, type AppWorkload } from './applications'
+
+describe('application workload scope resolution', () => {
+  const sole = ['Deployment/prod/api']
+  const many = ['Deployment/prod/api', 'Deployment/prod/worker']
+
+  it('resolves application scope to the sole workload — a one-workload app has none', () => {
+    expect(resolveAppWorkloadSelection(sole, null)).toEqual({
+      selected: 'Deployment/prod/api',
+      hostKeyIsStale: false,
+    })
+  })
+
+  it('keeps application scope for a multi-workload app', () => {
+    expect(resolveAppWorkloadSelection(many, null)).toEqual({
+      selected: null,
+      hostKeyIsStale: false,
+    })
+  })
+
+  it('passes a key that names a current workload straight through', () => {
+    expect(resolveAppWorkloadSelection(many, 'Deployment/prod/worker')).toEqual({
+      selected: 'Deployment/prod/worker',
+      hostKeyIsStale: false,
+    })
+  })
+
+  // The stale key still has to leave the URL even though the sole workload
+  // renders in its place — the two outcomes are deliberately independent.
+  it('renders the sole workload from a stale key and still reports the key stale', () => {
+    expect(resolveAppWorkloadSelection(sole, 'Deployment/prod/gone')).toEqual({
+      selected: 'Deployment/prod/api',
+      hostKeyIsStale: true,
+    })
+  })
+
+  it('falls back to application scope when a stale key has no sole workload to land on', () => {
+    expect(resolveAppWorkloadSelection(many, 'Deployment/prod/gone')).toEqual({
+      selected: null,
+      hostKeyIsStale: true,
+    })
+  })
+
+  it('reports no stale key when none was supplied', () => {
+    expect(resolveAppWorkloadSelection([], null)).toEqual({
+      selected: null,
+      hostKeyIsStale: false,
+    })
+  })
+})
 
 describe('batch application runtime', () => {
   it('uses the latest retained outcome instead of historical failure count', () => {

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -48,6 +48,19 @@ describe('application workload scope resolution', () => {
       hostKeyIsStale: false,
     })
   })
+
+  // A bare `?workload=` reaches a host as '' rather than null, and names no
+  // workload — it has to leave the URL like any other unusable key.
+  it('treats the empty string a bare query param yields as a stale key', () => {
+    expect(resolveAppWorkloadSelection(sole, '')).toEqual({
+      selected: 'Deployment/prod/api',
+      hostKeyIsStale: true,
+    })
+    expect(resolveAppWorkloadSelection(many, '')).toEqual({
+      selected: null,
+      hostKeyIsStale: true,
+    })
+  })
 })
 
 describe('batch application runtime', () => {

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -1384,7 +1384,10 @@ export function resolveAppWorkloadSelection(
   const soleWorkload = workloadKeys.length === 1 ? workloadKeys[0] : null;
   return {
     selected: matched ?? soleWorkload,
-    hostKeyIsStale: Boolean(hostSelected) && !matched,
+    // Any non-null value counts as a key the host supplied, including the empty
+    // string a bare `?workload=` yields — that names no workload either, and
+    // leaving it in the URL would strand a param nothing can act on.
+    hostKeyIsStale: hostSelected !== null && !matched,
   };
 }
 

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -1364,6 +1364,30 @@ export function applicationDisplayHealth(app: AppRow): AppHealth {
   ]);
 }
 
+/** Which workload an application detail view renders, and whether the host's
+ *  key should be dropped from the URL.
+ *
+ *  A single-workload app has no application scope, so it resolves to its sole
+ *  workload even when the caller asks for application scope (`null`) or names a
+ *  workload the app no longer has. Deciding this here rather than in each host
+ *  is the point: a controlled host's only way to say "no workload in the URL"
+ *  is `null`, so leaving the rule to hosts makes the forbidden state their
+ *  default. `hostKeyIsStale` stays independent of what gets rendered — a key
+ *  naming no current workload must leave the URL even when the sole workload
+ *  renders in its place. */
+export function resolveAppWorkloadSelection(
+  workloadKeys: readonly string[],
+  hostSelected: string | null,
+): { selected: string | null; hostKeyIsStale: boolean } {
+  const matched =
+    hostSelected && workloadKeys.includes(hostSelected) ? hostSelected : null;
+  const soleWorkload = workloadKeys.length === 1 ? workloadKeys[0] : null;
+  return {
+    selected: matched ?? soleWorkload,
+    hostKeyIsStale: Boolean(hostSelected) && !matched,
+  };
+}
+
 export function servingReadiness(workloads: AppWorkload[]): {
   ready: number;
   desired: number;

--- a/web/e2e/applications-scope.spec.ts
+++ b/web/e2e/applications-scope.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+
+// The seeded cluster has exactly one application (nginx) with exactly one
+// workload, which is the case the invariant governs: a single-workload app has
+// no application scope, so the detail page must land on the workload's runtime
+// and must not offer the application view tabs.
+const SINGLE_WORKLOAD_APP = 'default/Deployment/nginx'
+const SINGLE_WORKLOAD_KEY = 'Deployment/default/nginx'
+
+test.describe('Applications: single-workload scope', () => {
+  test('a single-workload app opens on its workload, not application scope', async ({ page }) => {
+    await page.goto(`/applications?app=${SINGLE_WORKLOAD_APP}`)
+
+    // The host canonicalizes the sole workload into the URL (replace navigation).
+    await expect(page).toHaveURL(/workload=/, { timeout: 15000 })
+    await expect(page.getByRole('tablist', { name: 'Application views' })).toHaveCount(0)
+  })
+
+  test('a workload key naming a workload the app no longer has still resolves to the sole workload', async ({
+    page,
+  }) => {
+    await page.goto(
+      `/applications?app=${SINGLE_WORKLOAD_APP}&workload=Deployment/default/removed`,
+    )
+
+    await expect(page).toHaveURL(/workload=Deployment(%2F|\/)default(%2F|\/)nginx/, {
+      timeout: 15000,
+    })
+    await expect(page.getByRole('tablist', { name: 'Application views' })).toHaveCount(0)
+  })
+
+  test('a valid workload deep link is preserved', async ({ page }) => {
+    await page.goto(
+      `/applications?app=${SINGLE_WORKLOAD_APP}&workload=${SINGLE_WORKLOAD_KEY}`,
+    )
+
+    await expect(page).toHaveURL(/workload=Deployment(%2F|\/)default(%2F|\/)nginx/, {
+      timeout: 15000,
+    })
+    await expect(page.getByRole('tablist', { name: 'Application views' })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## The bug

A single-workload application has no application scope — it opens directly on its workload. That is stated product intent (`web/src/components/applications/ApplicationsView.tsx:244-247`), but it lived **only in host code**.

`ApplicationDetail`'s own fallback keyed on `selectedWorkloadKey === undefined`, so it applied to *uncontrolled* hosts only. A controlled host's only way to express "no `?workload=` in the URL" is `null` — the type union requires `string | null` — so the fallback was bypassed for every URL-driven host, and `singleWorkloadScope` then went false and rendered the scope selector.

OSS compensated by enforcing the rule itself in four places. Radar Hub, which passes `searchParams.get('workload')` straight through, implemented none of them and shipped the bug: apps with one workload render the application shell wrapped around a one-row workload table.

Hub had actually reasoned about this invariant already — it hides the workload Back button for single-workload instances "which have no graph to return to" — it just never applied it to the selection derivation. A rule that each host has to re-implement is a rule that gets missed.

## The fix

Move the decision into `resolveAppWorkloadSelection`, a pure function over workload keys, and derive scope from it. A single-workload app resolves to its sole workload however the host asks, so hosts can no longer opt out of a product rule they didn't author.

`hostKeyIsStale` is deliberately independent of what renders: a key naming no current workload must still leave the URL even when the sole workload renders in its place. The reconcile effect previously keyed on the *rendered* workload, which would have stranded a bogus key in the URL once resolution started succeeding.

## Why the OSS host is unchanged

Its derivation looks redundant now, but the same value gates application-scope data fetching (`enabled: !selectedWorkloadKey` for history, retained timeline, and source inventory). Removing it would leave OSS fetching data the page no longer renders. OSS behavior is byte-identical after this change.

## Testing

- **Unit** — 6 cases on the pure resolver, including the stale-key case where the sole workload renders *and* the key is reported stale.
- **SSR** — controlled + `null`, controlled + stale key, and a multi-workload regression guard. Both single-workload cases were verified to fail without the fix.
- **e2e** — new `web/e2e/applications-scope.spec.ts` over the seeded single-workload app (scope, stale key, valid deep link).
- tsc clean · k8s-ui 1351 ✓ · web 390 ✓ · e2e 8 ✓ (`settings.spec.ts` has 5 failures that reproduce identically on `main` — unrelated and pre-existing).

## Rollout

This does not reach production on merge. Hub consumes `@skyhook-io/k8s-ui` and its lockfile pins `1.10.1`, so it needs a publish plus a Hub lockfile refresh and redeploy.

Semver: no exported type changes and the old behavior violated the documented invariant, so patch/minor is defensible — flagging it since it is an observable behavior change for a library consumer.

## Open question (not addressed here)

This restores the invariant; it does not ask whether the invariant is right. A one-workload Helm/Argo app loses the app-scope identity rail and History tab (provenance survives in the context strip). Worth deciding separately whether single-workload apps should keep a real application scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Observable library behavior change for controlled application detail hosts (URL workload selection and canonicalization); logic is well-tested but affects a shared UI package consumed by Hub after publish.
> 
> **Overview**
> **Single-workload apps no longer show application scope** when a URL-driven host passes `selectedWorkloadKey: null` (no `?workload=`). That invariant moves into shared `resolveAppWorkloadSelection` in `applications.ts`, and `ApplicationDetail` derives selection and stale-key cleanup from it instead of an uncontrolled-only implicit fallback.
> 
> For one workload, `null` or a missing/stale key resolves to the sole workload; `hostKeyIsStale` is separate so bogus or empty `?workload=` params still get cleared from the URL even when the UI already shows the right runtime view. Multi-workload apps keep application scope when no workload is selected.
> 
> Coverage adds unit tests for the resolver, SSR tests for controlled selection cases, Playwright e2e for the seeded nginx app, and `.gitignore` entries for Playwright artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae709af153c731618e25f32a373dfcb5f3c0886f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->