### PR TITLE
Add UI load-test harness: synthetic fake cluster with live pod-count control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean dev frontend backend test test-e2e test-chart lint help restart restart-fe kill watch-backend watch-frontend
+.PHONY: build install clean dev frontend backend test test-e2e test-chart lint help restart restart-fe kill watch-backend watch-frontend loadtest
 .PHONY: release release-binaries-dry docker docker-test docker-multiarch docker-push
 .PHONY: desktop desktop-binary desktop-dev desktop-package-darwin desktop-package-windows desktop-package-linux
 
@@ -169,6 +169,19 @@ crossplane-demo-down:
 
 crossplane-demo-status:
 	./scripts/crossplane-demo.sh status
+
+# Load-test the UI at high object counts against a synthetic, resource-free fake
+# cluster (no real workloads, no kubelet, no etcd). Radar treats the fakes as a
+# real cluster. Seeds a topology-realistic Deployment->ReplicaSet->Pod population
+# with matching Services/ConfigMaps/Secrets, spread across nodes and namespaces.
+# The pod count is live-controllable via the admin listener (default <port>+1):
+#   curl -XPOST localhost:9282/loadtest/scale -d '{"pods":10000}'
+#   curl localhost:9282/loadtest/status
+# Override the count with PODS and the port with LOADTEST_PORT.
+LOADTEST_PORT ?= 9281
+PODS ?= 50000
+loadtest: frontend embed
+	go run ./cmd/testserver -port $(LOADTEST_PORT) -pods $(PODS)
 
 # Run linter
 lint:

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -4,29 +4,47 @@
 //
 // Usage:
 //
-//	go run ./cmd/testserver            # port 9281
+//	go run ./cmd/testserver                 # port 9281, small nginx fixture
 //	go run ./cmd/testserver -port 9999
+//	go run ./cmd/testserver -pods 50000     # load-test population (see below)
 //
-// Intended for Playwright / e2e tests — no real cluster required.
+// Load-test mode (-pods > 0): instead of the small nginx fixture, the server
+// seeds a topology-realistic synthetic population (Deployments -> ReplicaSets
+// -> Pods with matching Services, spread across nodes and namespaces) so
+// Radar's UI can be driven at high object counts with no real cluster. The
+// count is live-controllable via a small admin listener (default port+1):
+//
+//	curl -XPOST localhost:9282/loadtest/scale -d '{"pods":10000}'
+//	curl localhost:9282/loadtest/status
+//
+// Intended for Playwright / e2e tests and UI load testing — no real cluster
+// required.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/skyhook-io/radar/internal/config"
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/loadtest"
 	"github.com/skyhook-io/radar/internal/server"
 	"github.com/skyhook-io/radar/internal/static"
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -34,6 +52,11 @@ import (
 
 func main() {
 	port := flag.Int("port", 9281, "port to listen on")
+	pods := flag.Int("pods", 0, "load-test: number of synthetic pods to seed (0 = small nginx fixture)")
+	nodes := flag.Int("nodes", 0, "load-test: number of fake nodes (0 = default)")
+	namespaces := flag.Int("namespaces", 0, "load-test: number of namespaces to spread apps across (0 = default)")
+	podsPerApp := flag.Int("pods-per-app", 0, "load-test: pods per Deployment/ReplicaSet (0 = default)")
+	adminPort := flag.Int("admin-port", 0, "load-test: admin listener port for live scaling (0 = <port>+1)")
 	flag.Parse()
 
 	// Isolate config/settings writes to a temp directory so e2e tests
@@ -47,12 +70,162 @@ func main() {
 
 	// --- Fake K8s client with seed data ---
 
+	var (
+		fakeClient *fake.Clientset
+		gen        *loadtest.Generator
+	)
+	if *pods > 0 {
+		gen = loadtest.New(loadtest.Config{
+			Pods: *pods, Nodes: *nodes, Namespaces: *namespaces, PodsPerApp: *podsPerApp,
+		})
+		start := time.Now()
+		objs := gen.SeedObjects()
+		fakeClient = fake.NewClientset(objs...)
+		cfg := gen.Config()
+		fmt.Fprintf(os.Stderr, "Seeding %d pods across %d apps / %d namespaces / %d nodes (%d objects, %s)\n",
+			cfg.Pods, gen.AppCount(), cfg.Namespaces, cfg.Nodes, len(objs), time.Since(start).Round(time.Millisecond))
+	} else {
+		fakeClient = fake.NewClientset(seedObjects()...)
+	}
+
+	// --- Initialize subsystems ---
+
+	if err := k8s.InitTestResourceCache(fakeClient); err != nil {
+		log.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{
+		State:   k8s.StateConnected,
+		Context: "fake-test",
+	})
+
+	if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
+		log.Fatalf("InitStore: %v", err)
+	}
+
+	// --- Start server ---
+
+	effectiveCfg := &config.Config{Port: *port}
+
+	srv := server.New(server.Config{
+		Port:            *port,
+		ListenAddress:   server.DefaultListenAddress,
+		StaticFS:        static.FS,
+		StaticRoot:      "dist",
+		EffectiveConfig: effectiveCfg,
+	})
+
+	ready := make(chan struct{})
+	go func() {
+		if err := srv.StartWithReady(ready); err != nil {
+			log.Fatalf("Server error: %v", err)
+		}
+	}()
+	<-ready
+
+	fmt.Fprintf(os.Stderr, "Test server ready on http://localhost:%d (fake k8s)\n", *port)
+
+	var adminSrv *http.Server
+	if gen != nil {
+		ap := *adminPort
+		if ap == 0 {
+			ap = *port + 1
+		}
+		adminSrv = startAdminServer(ap, gen, fakeClient)
+	}
+
+	// Wait for interrupt
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	if adminSrv != nil {
+		_ = adminSrv.Close()
+	}
+	srv.Stop()
+	timeline.ResetStore()
+	k8s.ResetTestState()
+}
+
+// informerCount reports the object count Radar's informer cache currently holds
+// for a Kind ("Pod", "Deployment", …) — the count the UI sees. It is the drain
+// signal the scaler paces every watched kind against, and the source of truth
+// for the post-scale convergence check.
+func informerCount(kind string) int {
+	rc := k8s.GetResourceCache()
+	if rc == nil {
+		return 0
+	}
+	return rc.GetKindObjectCounts()[kind]
+}
+
+func startAdminServer(port int, gen *loadtest.Generator, client kubernetes.Interface) *http.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/loadtest/status", func(w http.ResponseWriter, r *http.Request) {
+		cfg := gen.Config()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"pods":         informerCount("Pod"),
+			"target":       gen.Current(),
+			"nodes":        cfg.Nodes,
+			"namespaces":   cfg.Namespaces,
+			"pods_per_app": cfg.PodsPerApp,
+		})
+	})
+
+	mux.HandleFunc("/loadtest/scale", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "POST only"})
+			return
+		}
+		var body struct {
+			Pods *int `json:"pods"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Pods == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body must be {\"pods\": N}"})
+			return
+		}
+		res, err := gen.ScaleTo(r.Context(), client, *body.Pods, informerCount)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+
+	// Bind synchronously so a failed bind (e.g. port already in use) is surfaced
+	// here rather than swallowed in a goroutine after we've claimed the admin
+	// endpoint is ready.
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Printf("[loadtest] admin listener unavailable on %s: %v (live scaling disabled)", addr, err)
+		return nil
+	}
+	adminSrv := &http.Server{Handler: mux}
+	go func() {
+		if err := adminSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("[loadtest] admin server error: %v", err)
+		}
+	}()
+	fmt.Fprintf(os.Stderr, "Load-test admin on http://localhost:%d  (POST /loadtest/scale {\"pods\":N}, GET /loadtest/status)\n", port)
+	return adminSrv
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// seedObjects returns the default small nginx fixture used when -pods is unset,
+// preserving the fixture Playwright and manual smoke runs expect.
+func seedObjects() []runtime.Object {
 	replicas := int32(2)
 	deployUID := "deploy-uid-1234"
 	rsUID := "rs-uid-5678"
 
-	fakeClient := fake.NewClientset(
-		// Namespaces
+	return []runtime.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
 			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -62,7 +235,6 @@ func main() {
 			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		},
 
-		// Deployment
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nginx",
@@ -72,9 +244,7 @@ func main() {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": "nginx"},
-				},
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
 					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.25"}}},
@@ -83,7 +253,6 @@ func main() {
 			Status: appsv1.DeploymentStatus{Replicas: 2, ReadyReplicas: 2},
 		},
 
-		// ReplicaSet
 		&appsv1.ReplicaSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nginx-abc",
@@ -100,9 +269,7 @@ func main() {
 			},
 			Spec: appsv1.ReplicaSetSpec{
 				Replicas: &replicas,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": "nginx"},
-				},
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
 					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.25"}}},
@@ -111,7 +278,6 @@ func main() {
 			Status: appsv1.ReplicaSetStatus{Replicas: 2, ReadyReplicas: 2},
 		},
 
-		// Pods
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nginx-abc-111",
@@ -161,7 +327,6 @@ func main() {
 			},
 		},
 
-		// Service
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nginx",
@@ -174,7 +339,6 @@ func main() {
 			},
 		},
 
-		// Node
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"},
 			Status: corev1.NodeStatus{
@@ -183,53 +347,7 @@ func main() {
 				},
 			},
 		},
-	)
-
-	// --- Initialize subsystems ---
-
-	if err := k8s.InitTestResourceCache(fakeClient); err != nil {
-		log.Fatalf("InitTestResourceCache: %v", err)
 	}
-
-	k8s.SetConnectionStatus(k8s.ConnectionStatus{
-		State:   k8s.StateConnected,
-		Context: "fake-test",
-	})
-
-	if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
-		log.Fatalf("InitStore: %v", err)
-	}
-
-	// --- Start server ---
-
-	effectiveCfg := &config.Config{Port: *port}
-
-	srv := server.New(server.Config{
-		Port:            *port,
-		ListenAddress:   server.DefaultListenAddress,
-		StaticFS:        static.FS,
-		StaticRoot:      "dist",
-		EffectiveConfig: effectiveCfg,
-	})
-
-	ready := make(chan struct{})
-	go func() {
-		if err := srv.StartWithReady(ready); err != nil {
-			log.Fatalf("Server error: %v", err)
-		}
-	}()
-	<-ready
-
-	fmt.Fprintf(os.Stderr, "Test server ready on http://localhost:%d (fake k8s)\n", *port)
-
-	// Wait for interrupt
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	<-sig
-
-	srv.Stop()
-	timeline.ResetStore()
-	k8s.ResetTestState()
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/docs/loadtest.md
+++ b/docs/loadtest.md
@@ -1,0 +1,85 @@
+# UI load testing (synthetic fake cluster)
+
+Drive Radar's UI at high object counts — tens of thousands of pods — without a
+real cluster, real workloads, a kubelet, or etcd. Radar connects to an in-process
+fake Kubernetes client and treats the synthetic objects exactly as it would a
+real cluster: the same informer cache, topology builder, SSE broadcaster and
+React render path all run unchanged.
+
+This is the leanest realization of the industry pattern behind
+[KWOK](https://kwok.sigs.k8s.io/) ("Kubernetes WithOut Kubelet") — fake objects,
+no containers — but with no separate control-plane process at all: the objects
+live only as Go values in the test server's memory.
+
+## Run
+
+```bash
+make loadtest                 # 50,000 pods on :9281, admin on :9282
+make loadtest PODS=10000      # 10,000 pods
+make loadtest PODS=50000 LOADTEST_PORT=9351
+```
+
+Or directly:
+
+```bash
+go run ./cmd/testserver -pods 50000 [-port 9281] [-admin-port 9282] \
+  [-nodes 50] [-namespaces 10] [-pods-per-app 200]
+```
+
+With `-pods 0` (the default) the server seeds the small nginx fixture instead —
+the fixture the Playwright e2e suite relies on.
+
+## What gets generated
+
+A topology-realistic population, not a flat pile of orphan pods:
+
+- `N` pods, grouped into apps of `pods-per-app` (default 200)
+- one Deployment → ReplicaSet → Pods chain per app, with correct ownerReferences
+- a matching Service, ConfigMap and Secret per app (the pod template references
+  the ConfigMap and Secret, so topology shows the "Configures" edges)
+- pods spread round-robin across `nodes` fake Nodes
+- apps spread round-robin across `namespaces` namespaces
+
+Names are deterministic (`app-0004-000817`, `loadtest-node-042`, `loadtest-03`),
+so the same count always produces the same objects.
+
+## Control the pod count live
+
+The admin listener (default `<port>+1`) adjusts the count at runtime. Radar's
+informers observe the create/delete events and the UI updates over SSE with no
+reload:
+
+```bash
+curl -XPOST localhost:9282/loadtest/scale -d '{"pods":10000}'
+curl localhost:9282/loadtest/status
+# {"pods":10000,"target":10000,"nodes":50,"namespaces":10,"pods_per_app":200}
+```
+
+`scale` returns once the informer cache has converged on the target
+(`"converged": true`).
+
+## How it stays honest at scale
+
+The initial population is handed to the fake clientset at construction, so it
+arrives through the informers' initial **LIST** — safe at any count. Live scaling
+travels the fake clientset's **watch** channel, which panics if more than 100
+events queue before the informer drains them. The scaler therefore mutates in
+batches below that bound and blocks on the informer's observed count between
+batches, so it never overflows and always converges.
+
+## Scope and limits
+
+- This exercises everything **at and above** Radar's informer store — informer
+  memory, topology CPU, SSE fan-out, virtualized render. It deliberately does
+  **not** exercise the real network transport, client-go decode, or a real
+  apiserver; for that fidelity, point Radar at a KWOK cluster instead (the
+  generated object shapes are standard Kubernetes objects and feed KWOK as-is).
+- The test server does not initialize API discovery, so the sidebar count badges
+  for **grouped** kinds (Deployments, ReplicaSets, Jobs, …) render as "–" even
+  though the data is present (`/api/resource-counts` returns the real numbers).
+  Core-group kinds (Pods, Services, ConfigMaps, Secrets) show counts. Wiring
+  discovery (via `InitTestDynamicResourceCache`) is the same step CRD kinds such
+  as HTTPRoutes need, and is the natural next extension.
+- Above ~25,000 pods in scope the Pods table shows a "too many to show" guard and
+  asks you to narrow the namespace — a real Radar responsiveness limit this
+  harness is well suited to exercise.

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -1,0 +1,556 @@
+// Package loadtest generates topology-realistic synthetic Kubernetes objects
+// for driving Radar's UI at high object counts without a real cluster.
+//
+// The objects form a coherent Deployment -> ReplicaSet -> Pod hierarchy with
+// matching Service selectors, spread across namespaces and nodes, so the
+// resources browser, topology graph and workload views all render meaningful
+// relationships rather than a flat pile of orphan pods.
+//
+// A Generator both seeds an initial population (delivered through the fake
+// clientset's initial LIST) and scales the live population up or down through
+// the fake clientset's Create/Delete paths. Live mutations travel over the
+// fake clientset's watch channel, which panics if more than
+// watch.DefaultChanSize (100) events queue before the informer drains them, so
+// scaling is batched below that bound and paced against the informer's observed
+// count between batches.
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Defaults for a Config. Chosen so a 50k-pod population produces a plausible
+// cluster shape (~250 apps over 10 namespaces on 50 nodes) rather than one
+// giant workload.
+const (
+	DefaultNodes      = 50
+	DefaultNamespaces = 10
+	DefaultPodsPerApp = 200
+	DefaultImage      = "registry.k8s.io/pause:3.9"
+
+	// batchSize keeps live mutations per drain-cycle below the fake watch
+	// channel's DefaultChanSize (100) so it never panics with "channel full".
+	batchSize = 90
+
+	// appBatchSize bounds how many apps are created/deleted per drain-cycle.
+	// Each app touches five distinct watchers with one event apiece, so the
+	// per-watcher burst equals appBatchSize — kept below the 100 buffer.
+	appBatchSize = 80
+
+	// hardMaxPods bounds a single scale request so a fat-fingered value can't
+	// try to allocate an unbounded number of objects.
+	hardMaxPods = 2_000_000
+)
+
+// Config describes the synthetic population.
+type Config struct {
+	Pods       int    // number of pods to materialize
+	Nodes      int    // number of fake nodes to spread pods across
+	Namespaces int    // number of namespaces to spread apps across
+	PodsPerApp int    // pods per Deployment/ReplicaSet (sets the app count)
+	Image      string // container image reported on every pod
+}
+
+func (c Config) withDefaults() Config {
+	if c.Nodes <= 0 {
+		c.Nodes = DefaultNodes
+	}
+	if c.Namespaces <= 0 {
+		c.Namespaces = DefaultNamespaces
+	}
+	if c.PodsPerApp <= 0 {
+		c.PodsPerApp = DefaultPodsPerApp
+	}
+	if c.Image == "" {
+		c.Image = DefaultImage
+	}
+	if c.Pods < 0 {
+		c.Pods = 0
+	}
+	return c
+}
+
+// Generator produces and mutates a deterministic synthetic population. The set
+// of objects is a pure function of the target pod count, so scaling is a diff
+// against the previous target rather than stateful bookkeeping.
+type Generator struct {
+	cfg     Config
+	mu      sync.Mutex
+	current int // pods materialized after the last Seed/ScaleTo
+}
+
+// New returns a Generator for cfg (with defaults applied).
+func New(cfg Config) *Generator {
+	return &Generator{cfg: cfg.withDefaults()}
+}
+
+// Config returns the effective (defaulted) configuration.
+func (g *Generator) Config() Config { return g.cfg }
+
+// AppCount returns the number of Deployment/ReplicaSet/Service apps materialized
+// for the current pod count.
+func (g *Generator) AppCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return appsFor(g.current, g.cfg.PodsPerApp)
+}
+
+// Result reports the outcome of a scale operation.
+type Result struct {
+	From       int  `json:"from"`
+	To         int  `json:"to"`
+	Apps       int  `json:"apps"`
+	Nodes      int  `json:"nodes"`
+	Namespaces int  `json:"namespaces"`
+	Converged  bool `json:"converged"`
+}
+
+// ---- deterministic naming / layout ----
+
+func appsFor(pods, perApp int) int {
+	if pods <= 0 {
+		return 0
+	}
+	return (pods + perApp - 1) / perApp
+}
+
+func podsInApp(app, pods, perApp int) int {
+	base := app * perApp
+	if base >= pods {
+		return 0
+	}
+	if pods-base < perApp {
+		return pods - base
+	}
+	return perApp
+}
+
+func (g *Generator) appIndex(pod int) int   { return pod / g.cfg.PodsPerApp }
+func (g *Generator) nsName(app int) string  { return fmt.Sprintf("loadtest-%02d", app%g.cfg.Namespaces) }
+func (g *Generator) appName(app int) string    { return fmt.Sprintf("app-%04d", app) }
+func (g *Generator) rsName(app int) string     { return fmt.Sprintf("app-%04d-rs", app) }
+func (g *Generator) cmName(app int) string     { return fmt.Sprintf("app-%04d-config", app) }
+func (g *Generator) secretName(app int) string { return fmt.Sprintf("app-%04d-secret", app) }
+func (g *Generator) nodeName(i int) string  { return fmt.Sprintf("loadtest-node-%03d", i%g.cfg.Nodes) }
+func (g *Generator) podName(pod int) string { return fmt.Sprintf("app-%04d-%06d", g.appIndex(pod), pod) }
+func (g *Generator) deployUID(app int) types.UID {
+	return types.UID(fmt.Sprintf("loadtest-deploy-%04d", app))
+}
+func (g *Generator) rsUID(app int) types.UID {
+	return types.UID(fmt.Sprintf("loadtest-rs-%04d", app))
+}
+func (g *Generator) appLabels(app int) map[string]string {
+	return map[string]string{"app": g.appName(app), "loadtest": "true"}
+}
+
+// ---- object builders ----
+
+func (g *Generator) buildNamespace(i int) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("loadtest-%02d", i), Labels: map[string]string{"loadtest": "true"}},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+}
+
+func (g *Generator) buildNode(i int) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("loadtest-node-%03d", i), Labels: map[string]string{"loadtest": "true"}},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("1100"),
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("1100"),
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+		},
+	}
+}
+
+func (g *Generator) podTemplate(app int) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: g.appLabels(app)},
+		Spec:       g.podSpec(0, app),
+	}
+}
+
+func (g *Generator) buildDeployment(app, replicas int) *appsv1.Deployment {
+	r := int32(replicas)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.appName(app),
+			Namespace: g.nsName(app),
+			UID:       g.deployUID(app),
+			Labels:    g.appLabels(app),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &r,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": g.appName(app)}},
+			Template: g.podTemplate(app),
+		},
+		Status: appsv1.DeploymentStatus{Replicas: r, ReadyReplicas: r, AvailableReplicas: r, UpdatedReplicas: r},
+	}
+}
+
+func (g *Generator) buildReplicaSet(app, replicas int) *appsv1.ReplicaSet {
+	r := int32(replicas)
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.rsName(app),
+			Namespace: g.nsName(app),
+			UID:       g.rsUID(app),
+			Labels:    g.appLabels(app),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: g.appName(app),
+				UID: g.deployUID(app), Controller: boolPtr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &r,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": g.appName(app)}},
+			Template: g.podTemplate(app),
+		},
+		Status: appsv1.ReplicaSetStatus{Replicas: r, ReadyReplicas: r, AvailableReplicas: r},
+	}
+}
+
+func (g *Generator) buildConfigMap(app int) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: g.cmName(app), Namespace: g.nsName(app), Labels: g.appLabels(app)},
+		Data:       map[string]string{"app.conf": fmt.Sprintf("name=%s\nreplicas=%d\n", g.appName(app), g.cfg.PodsPerApp)},
+	}
+}
+
+func (g *Generator) buildSecret(app int) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: g.secretName(app), Namespace: g.nsName(app), Labels: g.appLabels(app)},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"token": []byte("c3ludGhldGljLWxvYWR0ZXN0")},
+	}
+}
+
+func (g *Generator) buildService(app int) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.appName(app),
+			Namespace: g.nsName(app),
+			Labels:    g.appLabels(app),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": g.appName(app)},
+			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(80)}},
+		},
+	}
+}
+
+func (g *Generator) podSpec(pod, app int) corev1.PodSpec {
+	return corev1.PodSpec{
+		NodeName: g.nodeName(pod),
+		Containers: []corev1.Container{{
+			Name:  "app",
+			Image: g.cfg.Image,
+			EnvFrom: []corev1.EnvFromSource{{
+				SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: g.secretName(app)}},
+			}},
+			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			}},
+		}},
+		Volumes: []corev1.Volume{{
+			Name: "config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: g.cmName(app)}},
+			},
+		}},
+	}
+}
+
+func (g *Generator) buildPod(pod int) *corev1.Pod {
+	app := g.appIndex(pod)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      g.podName(pod),
+			Namespace: g.nsName(app),
+			Labels:    g.appLabels(app),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: g.rsName(app),
+				UID: g.rsUID(app), Controller: boolPtr(true),
+			}},
+		},
+		Spec: g.podSpec(pod, app),
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app", Ready: true, Started: boolPtr(true),
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+}
+
+// SeedObjects returns the full object population for the configured pod count.
+// These are handed to fake.NewClientset, so they arrive through the informers'
+// initial LIST (never the watch channel) and are safe at any count.
+func (g *Generator) SeedObjects() []runtime.Object {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	objs := make([]runtime.Object, 0, g.cfg.Namespaces+g.cfg.Nodes+g.cfg.Pods+appsFor(g.cfg.Pods, g.cfg.PodsPerApp)*5)
+	for i := 0; i < g.cfg.Namespaces; i++ {
+		objs = append(objs, g.buildNamespace(i))
+	}
+	for i := 0; i < g.cfg.Nodes; i++ {
+		objs = append(objs, g.buildNode(i))
+	}
+	apps := appsFor(g.cfg.Pods, g.cfg.PodsPerApp)
+	for j := 0; j < apps; j++ {
+		r := podsInApp(j, g.cfg.Pods, g.cfg.PodsPerApp)
+		objs = append(objs, g.buildConfigMap(j), g.buildSecret(j), g.buildDeployment(j, r), g.buildReplicaSet(j, r), g.buildService(j))
+	}
+	for i := 0; i < g.cfg.Pods; i++ {
+		objs = append(objs, g.buildPod(i))
+	}
+	g.current = g.cfg.Pods
+	return objs
+}
+
+// Current returns the pod count materialized after the last operation.
+func (g *Generator) Current() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.current
+}
+
+// ScaleTo brings the live pod population to target by creating or deleting
+// objects through client, pacing each batch against the informer so the fake
+// watch channel never overflows. count reports the object count the informer
+// cache currently holds for a Kind ("Pod", "Deployment"); it is the drain
+// signal every watched kind is paced against. It returns once the Pod informer
+// has converged on target (Converged=true) or the settle timeout elapses.
+func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, target int, count func(kind string) int) (Result, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if target < 0 {
+		target = 0
+	}
+	if target > hardMaxPods {
+		return Result{}, fmt.Errorf("target %d exceeds max %d", target, hardMaxPods)
+	}
+
+	from := g.current
+	appsHave := appsFor(from, g.cfg.PodsPerApp)
+	appsWant := appsFor(target, g.cfg.PodsPerApp)
+
+	if appsWant > appsHave {
+		if err := g.createApps(ctx, client, appsHave, appsWant, target, count); err != nil {
+			return Result{}, err
+		}
+	}
+
+	switch {
+	case target > from:
+		if err := g.createPods(ctx, client, from, target, count); err != nil {
+			return Result{}, err
+		}
+	case target < from:
+		if err := g.deletePods(ctx, client, target, from, count); err != nil {
+			return Result{}, err
+		}
+	}
+
+	if err := g.reconcileBoundaryApps(ctx, client, appsHave, appsWant, target); err != nil {
+		return Result{}, err
+	}
+
+	if appsWant < appsHave {
+		if err := g.deleteApps(ctx, client, appsWant, appsHave, count); err != nil {
+			return Result{}, err
+		}
+	}
+
+	g.current = target
+	converged := waitFor(ctx, func() bool { return count("Pod") == target }, 60*time.Second)
+
+	return Result{
+		From: from, To: target, Apps: appsWant,
+		Nodes: g.cfg.Nodes, Namespaces: g.cfg.Namespaces, Converged: converged,
+	}, nil
+}
+
+// createApps materializes app skeletons (ConfigMap/Secret/Deployment/ReplicaSet/
+// Service) for indices [first, last). Each app touches five distinct watchers
+// with one event apiece, so it batches below the fake watch buffer and paces
+// against the Deployment informer between batches — the same drain discipline
+// as pods, extended to every watched kind.
+func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface, first, last, target int, count func(kind string) int) error {
+	j := first
+	for j < last {
+		end := min(j+appBatchSize, last)
+		for ; j < end; j++ {
+			r := podsInApp(j, target, g.cfg.PodsPerApp)
+			ns := g.nsName(j)
+			if _, err := client.CoreV1().ConfigMaps(ns).Create(ctx, g.buildConfigMap(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			if _, err := client.CoreV1().Secrets(ns).Create(ctx, g.buildSecret(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			if _, err := client.AppsV1().Deployments(ns).Create(ctx, g.buildDeployment(j, r), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			if _, err := client.AppsV1().ReplicaSets(ns).Create(ctx, g.buildReplicaSet(j, r), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			if _, err := client.CoreV1().Services(ns).Create(ctx, g.buildService(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+		created := j
+		if !waitFor(ctx, func() bool { return count("Deployment") >= created }, 30*time.Second) {
+			return fmt.Errorf("informer did not drain after creating %d apps (Deployment=%d)", created, count("Deployment"))
+		}
+	}
+	return nil
+}
+
+// deleteApps removes app skeletons for indices [first, last), from the top down,
+// batched and paced against the Deployment informer so no watcher overflows.
+func (g *Generator) deleteApps(ctx context.Context, client kubernetes.Interface, first, last int, count func(kind string) int) error {
+	j := last
+	for j > first {
+		start := max(j-appBatchSize, first)
+		for ; j > start; j-- {
+			ns := g.nsName(j - 1)
+			_ = client.CoreV1().Services(ns).Delete(ctx, g.appName(j-1), metav1.DeleteOptions{})
+			_ = client.AppsV1().ReplicaSets(ns).Delete(ctx, g.rsName(j-1), metav1.DeleteOptions{})
+			_ = client.AppsV1().Deployments(ns).Delete(ctx, g.appName(j-1), metav1.DeleteOptions{})
+			_ = client.CoreV1().Secrets(ns).Delete(ctx, g.secretName(j-1), metav1.DeleteOptions{})
+			_ = client.CoreV1().ConfigMaps(ns).Delete(ctx, g.cmName(j-1), metav1.DeleteOptions{})
+		}
+		remaining := j
+		if !waitFor(ctx, func() bool { return count("Deployment") <= remaining }, 30*time.Second) {
+			return fmt.Errorf("informer did not drain after deleting apps down to %d (Deployment=%d)", remaining, count("Deployment"))
+		}
+	}
+	return nil
+}
+
+// reconcileBoundaryApps fixes the replica counts of the (at most two) apps whose
+// pod share changed but that still exist after the scale: the old last app (now
+// possibly full) and the new last app (now the partial boundary). Fully-
+// populated interior apps keep PodsPerApp and newly-created apps were already
+// set correctly at creation, so neither is touched.
+func (g *Generator) reconcileBoundaryApps(ctx context.Context, client kubernetes.Interface, appsHave, appsWant, target int) error {
+	boundary := map[int]bool{}
+	if j := appsHave - 1; j >= 0 && j < appsWant {
+		boundary[j] = true
+	}
+	if j := appsWant - 1; j >= 0 {
+		boundary[j] = true
+	}
+	for j := range boundary {
+		r := podsInApp(j, target, g.cfg.PodsPerApp)
+		if err := patchReplicas(ctx, client, g.nsName(j), g.appName(j), g.rsName(j), r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func patchReplicas(ctx context.Context, client kubernetes.Interface, ns, deploy, rs string, replicas int) error {
+	r := int32(replicas)
+	if d, err := client.AppsV1().Deployments(ns).Get(ctx, deploy, metav1.GetOptions{}); err == nil {
+		d.Spec.Replicas = &r
+		d.Status.Replicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UpdatedReplicas = r, r, r, r
+		if _, err := client.AppsV1().Deployments(ns).Update(ctx, d, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	if s, err := client.AppsV1().ReplicaSets(ns).Get(ctx, rs, metav1.GetOptions{}); err == nil {
+		s.Spec.Replicas = &r
+		s.Status.Replicas, s.Status.ReadyReplicas, s.Status.AvailableReplicas = r, r, r
+		if _, err := client.AppsV1().ReplicaSets(ns).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createPods materializes pods [from, to), batched below the fake watch buffer
+// and paced against the Pod informer. g.current advances per drained batch so a
+// mid-scale failure leaves the generator's idea of the population consistent
+// with what the client actually holds.
+func (g *Generator) createPods(ctx context.Context, client kubernetes.Interface, from, to int, count func(kind string) int) error {
+	i := from
+	for i < to {
+		end := min(i+batchSize, to)
+		for ; i < end; i++ {
+			if _, err := client.CoreV1().Pods(g.nsName(g.appIndex(i))).Create(ctx, g.buildPod(i), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+		}
+		created := i
+		if !waitFor(ctx, func() bool { return count("Pod") >= created }, 30*time.Second) {
+			return fmt.Errorf("informer did not drain after creating %d pods (observed %d)", created, count("Pod"))
+		}
+		g.current = created
+	}
+	return nil
+}
+
+// deletePods removes pods [from, to) — the tail above the new target — batched
+// and paced against the Pod informer, advancing g.current per drained batch.
+func (g *Generator) deletePods(ctx context.Context, client kubernetes.Interface, from, to int, count func(kind string) int) error {
+	i := to
+	for i > from {
+		start := max(i-batchSize, from)
+		for ; i > start; i-- {
+			if err := client.CoreV1().Pods(g.nsName(g.appIndex(i-1))).Delete(ctx, g.podName(i-1), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		remaining := i
+		if !waitFor(ctx, func() bool { return count("Pod") <= remaining }, 30*time.Second) {
+			return fmt.Errorf("informer did not drain after deleting down to %d pods (observed %d)", remaining, count("Pod"))
+		}
+		g.current = remaining
+	}
+	return nil
+}
+
+// waitFor polls cond until it returns true or the timeout elapses. Returns
+// whether cond became true. The poll interval is deliberately short so the
+// scaler paces tightly against the informer draining the watch channel.
+func waitFor(ctx context.Context, cond func() bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return true
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			return false
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -408,12 +408,15 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 // Service) for indices [first, last). Each app touches five distinct watchers
 // with one event apiece, so it batches below the fake watch buffer and paces
 // against the Deployment informer between batches — the same drain discipline
-// as pods, extended to every watched kind.
+// as pods, extended to every watched kind. currentApps is advanced to cover app
+// j BEFORE its objects are written, so a mid-app failure still leaves the app in
+// the cleanup range and nothing is orphaned.
 func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface, first, last, target int, count func(kind string) int) error {
 	j := first
 	for j < last {
 		end := min(j+appBatchSize, last)
 		for ; j < end; j++ {
+			g.currentApps = j + 1
 			r := podsInApp(j, target, g.cfg.PodsPerApp)
 			ns := g.nsName(j)
 			if _, err := client.CoreV1().ConfigMaps(ns).Create(ctx, g.buildConfigMap(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
@@ -436,7 +439,6 @@ func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface,
 		if !waitFor(ctx, func() bool { return count("Deployment") >= created }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after creating %d apps (Deployment=%d)", created, count("Deployment"))
 		}
-		g.currentApps = created
 	}
 	return nil
 }
@@ -454,12 +456,12 @@ func (g *Generator) deleteApps(ctx context.Context, client kubernetes.Interface,
 			_ = client.AppsV1().Deployments(ns).Delete(ctx, g.appName(j-1), metav1.DeleteOptions{})
 			_ = client.CoreV1().Secrets(ns).Delete(ctx, g.secretName(j-1), metav1.DeleteOptions{})
 			_ = client.CoreV1().ConfigMaps(ns).Delete(ctx, g.cmName(j-1), metav1.DeleteOptions{})
+			g.currentApps = j - 1
 		}
 		remaining := j
 		if !waitFor(ctx, func() bool { return count("Deployment") <= remaining }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after deleting apps down to %d (Deployment=%d)", remaining, count("Deployment"))
 		}
-		g.currentApps = remaining
 	}
 	return nil
 }
@@ -506,9 +508,9 @@ func patchReplicas(ctx context.Context, client kubernetes.Interface, ns, deploy,
 }
 
 // createPods materializes pods [from, to), batched below the fake watch buffer
-// and paced against the Pod informer. g.current advances per drained batch so a
-// mid-scale failure leaves the generator's idea of the population consistent
-// with what the client actually holds.
+// and paced against the Pod informer. g.current advances per pod actually
+// written, so a mid-batch failure leaves the generator's idea of the population
+// consistent with what the client holds (and cleanup covers every written pod).
 func (g *Generator) createPods(ctx context.Context, client kubernetes.Interface, from, to int, count func(kind string) int) error {
 	i := from
 	for i < to {
@@ -517,18 +519,19 @@ func (g *Generator) createPods(ctx context.Context, client kubernetes.Interface,
 			if _, err := client.CoreV1().Pods(g.nsName(g.appIndex(i))).Create(ctx, g.buildPod(i), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
+			g.current = i + 1
 		}
 		created := i
 		if !waitFor(ctx, func() bool { return count("Pod") >= created }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after creating %d pods (observed %d)", created, count("Pod"))
 		}
-		g.current = created
 	}
 	return nil
 }
 
 // deletePods removes pods [from, to) — the tail above the new target — batched
-// and paced against the Pod informer, advancing g.current per drained batch.
+// and paced against the Pod informer, advancing g.current per pod actually
+// removed.
 func (g *Generator) deletePods(ctx context.Context, client kubernetes.Interface, from, to int, count func(kind string) int) error {
 	i := to
 	for i > from {
@@ -537,12 +540,12 @@ func (g *Generator) deletePods(ctx context.Context, client kubernetes.Interface,
 			if err := client.CoreV1().Pods(g.nsName(g.appIndex(i-1))).Delete(ctx, g.podName(i-1), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
+			g.current = i - 1
 		}
 		remaining := i
 		if !waitFor(ctx, func() bool { return count("Pod") <= remaining }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after deleting down to %d pods (observed %d)", remaining, count("Pod"))
 		}
-		g.current = remaining
 	}
 	return nil
 }

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -90,6 +90,12 @@ type Generator struct {
 	cfg     Config
 	mu      sync.Mutex
 	current int // pods materialized after the last Seed/ScaleTo
+	// currentApps is the number of app skeletons (Deployment/ReplicaSet/Service/
+	// ConfigMap/Secret) actually materialized. Tracked independently of current
+	// because a scale that fails after mutating pods but before mutating apps
+	// leaves the two out of step; deriving the app count from current would then
+	// skip cleanup and orphan skeletons on retry.
+	currentApps int
 }
 
 // New returns a Generator for cfg (with defaults applied).
@@ -100,12 +106,12 @@ func New(cfg Config) *Generator {
 // Config returns the effective (defaulted) configuration.
 func (g *Generator) Config() Config { return g.cfg }
 
-// AppCount returns the number of Deployment/ReplicaSet/Service apps materialized
-// for the current pod count.
+// AppCount returns the number of Deployment/ReplicaSet/Service/ConfigMap/Secret
+// apps currently materialized.
 func (g *Generator) AppCount() int {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return appsFor(g.current, g.cfg.PodsPerApp)
+	return g.currentApps
 }
 
 // Result reports the outcome of a scale operation.
@@ -329,6 +335,7 @@ func (g *Generator) SeedObjects() []runtime.Object {
 		objs = append(objs, g.buildPod(i))
 	}
 	g.current = g.cfg.Pods
+	g.currentApps = apps
 	return objs
 }
 
@@ -357,7 +364,7 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 	}
 
 	from := g.current
-	appsHave := appsFor(from, g.cfg.PodsPerApp)
+	appsHave := g.currentApps
 	appsWant := appsFor(target, g.cfg.PodsPerApp)
 
 	if appsWant > appsHave {
@@ -388,6 +395,7 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 	}
 
 	g.current = target
+	g.currentApps = appsWant
 	converged := waitFor(ctx, func() bool { return count("Pod") == target }, 60*time.Second)
 
 	return Result{
@@ -428,6 +436,7 @@ func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface,
 		if !waitFor(ctx, func() bool { return count("Deployment") >= created }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after creating %d apps (Deployment=%d)", created, count("Deployment"))
 		}
+		g.currentApps = created
 	}
 	return nil
 }
@@ -450,6 +459,7 @@ func (g *Generator) deleteApps(ctx context.Context, client kubernetes.Interface,
 		if !waitFor(ctx, func() bool { return count("Deployment") <= remaining }, 30*time.Second) {
 			return fmt.Errorf("informer did not drain after deleting apps down to %d (Deployment=%d)", remaining, count("Deployment"))
 		}
+		g.currentApps = remaining
 	}
 	return nil
 }

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -372,6 +372,11 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 
 	from := g.current
 	appsWant := appsFor(target, g.cfg.PodsPerApp)
+	// The app count before this scale's mutations — the correct basis for
+	// reconciling the old boundary app's replica count. Derived from the tracked
+	// app mark, not appsFor(from): pods can lag the app count after a partial
+	// failure, which would otherwise point the reconcile at the wrong app.
+	prevApps := g.appsCompleted
 
 	// Create resumes from the last fully-completed app, so a partially-written
 	// app from an earlier failed attempt is finished rather than skipped.
@@ -392,7 +397,7 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 		}
 	}
 
-	if err := g.reconcileBoundaryApps(ctx, client, appsFor(from, g.cfg.PodsPerApp), appsWant, target); err != nil {
+	if err := g.reconcileBoundaryApps(ctx, client, prevApps, appsWant, target); err != nil {
 		return Result{}, err
 	}
 

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -90,12 +90,18 @@ type Generator struct {
 	cfg     Config
 	mu      sync.Mutex
 	current int // pods materialized after the last Seed/ScaleTo
-	// currentApps is the number of app skeletons (Deployment/ReplicaSet/Service/
-	// ConfigMap/Secret) actually materialized. Tracked independently of current
-	// because a scale that fails after mutating pods but before mutating apps
-	// leaves the two out of step; deriving the app count from current would then
-	// skip cleanup and orphan skeletons on retry.
-	currentApps int
+	// App skeletons need two high-water marks because a partially-written app
+	// (some of its five objects created, then a failure) must be handled two
+	// different ways: cleanup must delete it, but a create retry must finish it.
+	//   appsCompleted   — apps whose five objects all succeeded; where a create
+	//                     resumes, so a partial app is re-completed rather than
+	//                     skipped.
+	//   appsMaterialized — the furthest app index any object was written for; the
+	//                     upper bound cleanup deletes down from, so a partial
+	//                     app's stray objects are never orphaned.
+	// On success both equal the app count; they only diverge after a failure.
+	appsCompleted    int
+	appsMaterialized int
 }
 
 // New returns a Generator for cfg (with defaults applied).
@@ -106,12 +112,12 @@ func New(cfg Config) *Generator {
 // Config returns the effective (defaulted) configuration.
 func (g *Generator) Config() Config { return g.cfg }
 
-// AppCount returns the number of Deployment/ReplicaSet/Service/ConfigMap/Secret
-// apps currently materialized.
+// AppCount returns the number of fully-created Deployment/ReplicaSet/Service/
+// ConfigMap/Secret apps.
 func (g *Generator) AppCount() int {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.currentApps
+	return g.appsCompleted
 }
 
 // Result reports the outcome of a scale operation.
@@ -335,7 +341,8 @@ func (g *Generator) SeedObjects() []runtime.Object {
 		objs = append(objs, g.buildPod(i))
 	}
 	g.current = g.cfg.Pods
-	g.currentApps = apps
+	g.appsCompleted = apps
+	g.appsMaterialized = apps
 	return objs
 }
 
@@ -364,11 +371,12 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 	}
 
 	from := g.current
-	appsHave := g.currentApps
 	appsWant := appsFor(target, g.cfg.PodsPerApp)
 
-	if appsWant > appsHave {
-		if err := g.createApps(ctx, client, appsHave, appsWant, target, count); err != nil {
+	// Create resumes from the last fully-completed app, so a partially-written
+	// app from an earlier failed attempt is finished rather than skipped.
+	if appsWant > g.appsCompleted {
+		if err := g.createApps(ctx, client, g.appsCompleted, appsWant, target, count); err != nil {
 			return Result{}, err
 		}
 	}
@@ -384,18 +392,21 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 		}
 	}
 
-	if err := g.reconcileBoundaryApps(ctx, client, appsHave, appsWant, target); err != nil {
+	if err := g.reconcileBoundaryApps(ctx, client, appsFor(from, g.cfg.PodsPerApp), appsWant, target); err != nil {
 		return Result{}, err
 	}
 
-	if appsWant < appsHave {
-		if err := g.deleteApps(ctx, client, appsWant, appsHave, count); err != nil {
+	// Cleanup deletes down from the furthest app any object was written for, so a
+	// partial app's stray objects are removed, not orphaned.
+	if g.appsMaterialized > appsWant {
+		if err := g.deleteApps(ctx, client, appsWant, g.appsMaterialized, count); err != nil {
 			return Result{}, err
 		}
 	}
 
 	g.current = target
-	g.currentApps = appsWant
+	g.appsCompleted = appsWant
+	g.appsMaterialized = appsWant
 	converged := waitFor(ctx, func() bool { return count("Pod") == target }, 60*time.Second)
 
 	return Result{
@@ -408,15 +419,19 @@ func (g *Generator) ScaleTo(ctx context.Context, client kubernetes.Interface, ta
 // Service) for indices [first, last). Each app touches five distinct watchers
 // with one event apiece, so it batches below the fake watch buffer and paces
 // against the Deployment informer between batches — the same drain discipline
-// as pods, extended to every watched kind. currentApps is advanced to cover app
-// j BEFORE its objects are written, so a mid-app failure still leaves the app in
-// the cleanup range and nothing is orphaned.
+// as pods, extended to every watched kind. appsMaterialized is bumped to cover
+// app j BEFORE its objects are written (so a mid-app failure still leaves the
+// app in the cleanup range) and appsCompleted only AFTER all five succeed (so a
+// retry resumes on the unfinished app rather than skipping it). Creates are
+// idempotent, so re-running over an already-complete app is a no-op.
 func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface, first, last, target int, count func(kind string) int) error {
 	j := first
 	for j < last {
 		end := min(j+appBatchSize, last)
 		for ; j < end; j++ {
-			g.currentApps = j + 1
+			if j+1 > g.appsMaterialized {
+				g.appsMaterialized = j + 1
+			}
 			r := podsInApp(j, target, g.cfg.PodsPerApp)
 			ns := g.nsName(j)
 			if _, err := client.CoreV1().ConfigMaps(ns).Create(ctx, g.buildConfigMap(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
@@ -434,6 +449,7 @@ func (g *Generator) createApps(ctx context.Context, client kubernetes.Interface,
 			if _, err := client.CoreV1().Services(ns).Create(ctx, g.buildService(j), metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
+			g.appsCompleted = j + 1
 		}
 		created := j
 		if !waitFor(ctx, func() bool { return count("Deployment") >= created }, 30*time.Second) {
@@ -456,7 +472,10 @@ func (g *Generator) deleteApps(ctx context.Context, client kubernetes.Interface,
 			_ = client.AppsV1().Deployments(ns).Delete(ctx, g.appName(j-1), metav1.DeleteOptions{})
 			_ = client.CoreV1().Secrets(ns).Delete(ctx, g.secretName(j-1), metav1.DeleteOptions{})
 			_ = client.CoreV1().ConfigMaps(ns).Delete(ctx, g.cmName(j-1), metav1.DeleteOptions{})
-			g.currentApps = j - 1
+			if g.appsCompleted > j-1 {
+				g.appsCompleted = j - 1
+			}
+			g.appsMaterialized = j - 1
 		}
 		remaining := j
 		if !waitFor(ctx, func() bool { return count("Deployment") <= remaining }, 30*time.Second) {

--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -353,6 +353,60 @@ func TestScaleUpRetryCompletesPartialApp(t *testing.T) {
 	}
 }
 
+// TestReconcileFixesFormerBoundaryReplicasAfterPodDivergence covers the case
+// where a scale created a partial boundary app but the pod count then diverged
+// from the app count; a later scale-up must still bring that former-boundary
+// Deployment's replica count up to full rather than leave it stale.
+func TestReconcileFixesFormerBoundaryReplicasAfterPodDivergence(t *testing.T) {
+	g := New(Config{Pods: 0, Nodes: 4, Namespaces: 2, PodsPerApp: 10})
+	client := fake.NewClientset(g.SeedObjects()...)
+
+	factory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := factory.Core().V1().Pods().Informer()
+	deployInformer := factory.Apps().V1().Deployments().Informer()
+	stop := make(chan struct{})
+	defer close(stop)
+	factory.Start(stop)
+	if !cache.WaitForCacheSync(stop, podInformer.HasSynced, deployInformer.HasSynced) {
+		t.Fatal("informer failed to sync")
+	}
+	count := func(kind string) int {
+		switch kind {
+		case "Pod":
+			return len(podInformer.GetStore().ListKeys())
+		case "Deployment":
+			return len(deployInformer.GetStore().ListKeys())
+		}
+		return 0
+	}
+
+	ctx := context.Background()
+	// 45 pods over PodsPerApp=10 => 5 apps, app 4 partial (5 replicas).
+	if _, err := g.ScaleTo(ctx, client, 45, count); err != nil {
+		t.Fatalf("ScaleTo(45): %v", err)
+	}
+	d, _ := client.AppsV1().Deployments("loadtest-00").Get(ctx, "app-0004", metav1.GetOptions{})
+	if *d.Spec.Replicas != 5 {
+		t.Fatalf("app 4 replicas=%d want 5 (partial boundary)", *d.Spec.Replicas)
+	}
+
+	// Simulate pods diverging below the app count (as after a partial pod
+	// failure): the pod counter drops but the 5 apps remain.
+	g.mu.Lock()
+	g.current = 5
+	g.mu.Unlock()
+
+	// Grow to 250 pods (25 apps). App 4 is now a full interior app and its
+	// replica count must be corrected to PodsPerApp, not left at 5.
+	if _, err := g.ScaleTo(ctx, client, 250, count); err != nil {
+		t.Fatalf("ScaleTo(250): %v", err)
+	}
+	d, _ = client.AppsV1().Deployments("loadtest-00").Get(ctx, "app-0004", metav1.GetOptions{})
+	if *d.Spec.Replicas != 10 {
+		t.Fatalf("app 4 replicas=%d want 10 (former boundary must be re-fulled)", *d.Spec.Replicas)
+	}
+}
+
 func waitCount(count func() int, want int, timeout time.Duration) int {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -2,13 +2,17 @@ package loadtest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -199,6 +203,95 @@ func TestScaleDownAfterPartialProgressLeavesNoOrphanApps(t *testing.T) {
 			t.Fatalf("orphan %s skeletons: %s=%d want 1", kind, kind, got)
 		}
 	}
+}
+
+// TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps reproduces a scale-up
+// that fails partway through creating app skeletons: the app count must still
+// reflect what was written, so a later scale-down cleans up every skeleton
+// (including the partially-written app whose Deployment create failed).
+func TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps(t *testing.T) {
+	g := New(Config{Pods: 0, Nodes: 4, Namespaces: 2, PodsPerApp: 200})
+	client := fake.NewClientset(g.SeedObjects()...)
+
+	// Fail the Deployment create for app index 2 exactly once, mid scale-up.
+	failed := false
+	client.PrependReactor("create", "deployments", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		d := a.(clienttesting.CreateAction).GetObject().(*appsv1.Deployment)
+		if d.Name == "app-0002" && !failed {
+			failed = true
+			return true, nil, fmt.Errorf("injected create failure")
+		}
+		return false, nil, nil
+	})
+
+	factory := informers.NewSharedInformerFactory(client, 0)
+	deployInformer := factory.Apps().V1().Deployments().Informer()
+	svcInformer := factory.Core().V1().Services().Informer()
+	cmInformer := factory.Core().V1().ConfigMaps().Informer()
+	stop := make(chan struct{})
+	defer close(stop)
+	factory.Start(stop)
+	if !cache.WaitForCacheSync(stop, deployInformer.HasSynced, svcInformer.HasSynced, cmInformer.HasSynced) {
+		t.Fatal("informer failed to sync")
+	}
+	count := func(kind string) int {
+		switch kind {
+		case "Deployment":
+			return len(deployInformer.GetStore().ListKeys())
+		case "Service":
+			return len(svcInformer.GetStore().ListKeys())
+		case "ConfigMap":
+			return len(cmInformer.GetStore().ListKeys())
+		}
+		return 0
+	}
+
+	ctx := context.Background()
+	// Scale up to 1000 pods (5 apps). createApps fails at app 2's Deployment.
+	if _, err := g.ScaleTo(ctx, client, 1000, count); err == nil {
+		t.Fatal("expected ScaleTo to fail on injected create error")
+	}
+	// The high-water mark must include the partially-written app 2 (>=3), else
+	// its ConfigMap/Secret would be orphaned by cleanup.
+	if g.AppCount() < 3 {
+		t.Fatalf("AppCount=%d want >=3 (partial app must be recorded)", g.AppCount())
+	}
+
+	// Scale back down to 0; every skeleton — including the partial app — must go.
+	if _, err := g.ScaleTo(ctx, client, 0, count); err != nil {
+		t.Fatalf("cleanup ScaleTo(0): %v", err)
+	}
+	// Assert against the client (authoritative truth, no informer lag): no app
+	// skeleton of any kind may survive.
+	assertNoneInClient := func(kind string, list func() (int, error)) {
+		n, err := list()
+		if err != nil {
+			t.Fatalf("list %s: %v", kind, err)
+		}
+		if n != 0 {
+			t.Fatalf("orphan %s skeletons in client after cleanup: %d want 0", kind, n)
+		}
+	}
+	assertNoneInClient("Deployment", func() (int, error) {
+		l, e := client.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertNoneInClient("ReplicaSet", func() (int, error) {
+		l, e := client.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertNoneInClient("Service", func() (int, error) {
+		l, e := client.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertNoneInClient("ConfigMap", func() (int, error) {
+		l, e := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertNoneInClient("Secret", func() (int, error) {
+		l, e := client.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
 }
 
 func waitCount(count func() int, want int, timeout time.Duration) int {

--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -251,10 +251,10 @@ func TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps(t *testing.T) {
 	if _, err := g.ScaleTo(ctx, client, 1000, count); err == nil {
 		t.Fatal("expected ScaleTo to fail on injected create error")
 	}
-	// The high-water mark must include the partially-written app 2 (>=3), else
-	// its ConfigMap/Secret would be orphaned by cleanup.
-	if g.AppCount() < 3 {
-		t.Fatalf("AppCount=%d want >=3 (partial app must be recorded)", g.AppCount())
+	// Precondition: app 2 is partially written (its ConfigMap exists, its
+	// Deployment does not) — the state cleanup must fully remove.
+	if _, err := client.CoreV1().ConfigMaps("loadtest-00").Get(ctx, "app-0002-config", metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected partial app 2 ConfigMap to exist: %v", err)
 	}
 
 	// Scale back down to 0; every skeleton — including the partial app — must go.
@@ -292,6 +292,65 @@ func TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps(t *testing.T) {
 		l, e := client.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
 		return len(l.Items), e
 	})
+}
+
+// TestScaleUpRetryCompletesPartialApp reproduces a scale-up that fails partway
+// through an app, then retries: the retry must finish the partially-written app
+// (create its missing Deployment/ReplicaSet/Service) rather than skip it, so no
+// pod ends up referencing a nonexistent workload.
+func TestScaleUpRetryCompletesPartialApp(t *testing.T) {
+	g := New(Config{Pods: 0, Nodes: 4, Namespaces: 2, PodsPerApp: 200})
+	client := fake.NewClientset(g.SeedObjects()...)
+
+	failed := false
+	client.PrependReactor("create", "deployments", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		d := a.(clienttesting.CreateAction).GetObject().(*appsv1.Deployment)
+		if d.Name == "app-0002" && !failed {
+			failed = true
+			return true, nil, fmt.Errorf("injected create failure")
+		}
+		return false, nil, nil
+	})
+
+	factory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := factory.Core().V1().Pods().Informer()
+	deployInformer := factory.Apps().V1().Deployments().Informer()
+	stop := make(chan struct{})
+	defer close(stop)
+	factory.Start(stop)
+	if !cache.WaitForCacheSync(stop, podInformer.HasSynced, deployInformer.HasSynced) {
+		t.Fatal("informer failed to sync")
+	}
+	count := func(kind string) int {
+		switch kind {
+		case "Pod":
+			return len(podInformer.GetStore().ListKeys())
+		case "Deployment":
+			return len(deployInformer.GetStore().ListKeys())
+		}
+		return 0
+	}
+
+	ctx := context.Background()
+	if _, err := g.ScaleTo(ctx, client, 1000, count); err == nil {
+		t.Fatal("expected first ScaleTo to fail on injected error")
+	}
+	// Retry the same target; the reactor now passes, so app 2 must be finished.
+	res, err := g.ScaleTo(ctx, client, 1000, count)
+	if err != nil {
+		t.Fatalf("retry ScaleTo: %v", err)
+	}
+	if !res.Converged || count("Pod") != 1000 {
+		t.Fatalf("pods=%d converged=%v want 1000/true", count("Pod"), res.Converged)
+	}
+	// The previously-partial app 2 must now have its Deployment, and all 5 apps
+	// must be fully present — no pod references a missing workload.
+	if _, err := client.AppsV1().Deployments("loadtest-00").Get(ctx, "app-0002", metav1.GetOptions{}); err != nil {
+		t.Fatalf("app 2 Deployment missing after retry: %v", err)
+	}
+	if got := count("Deployment"); got != 5 {
+		t.Fatalf("deployments=%d want 5 (all apps complete)", got)
+	}
 }
 
 func waitCount(count func() int, want int, timeout time.Duration) int {

--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -1,0 +1,152 @@
+package loadtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestAppsForAndPodsInApp(t *testing.T) {
+	cases := []struct {
+		pods, perApp, wantApps int
+	}{
+		{0, 200, 0},
+		{1, 200, 1},
+		{200, 200, 1},
+		{201, 200, 2},
+		{50000, 200, 250},
+	}
+	for _, c := range cases {
+		if got := appsFor(c.pods, c.perApp); got != c.wantApps {
+			t.Errorf("appsFor(%d,%d)=%d want %d", c.pods, c.perApp, got, c.wantApps)
+		}
+	}
+	// pod distribution sums back to the total
+	perApp, total := 200, 50000
+	sum := 0
+	for j := 0; j < appsFor(total, perApp); j++ {
+		sum += podsInApp(j, total, perApp)
+	}
+	if sum != total {
+		t.Fatalf("podsInApp sum=%d want %d", sum, total)
+	}
+}
+
+func TestSeedObjectsTopology(t *testing.T) {
+	g := New(Config{Pods: 1005, Nodes: 5, Namespaces: 3, PodsPerApp: 100})
+	objs := g.SeedObjects()
+
+	var pods, deploys, rss, svcs, nodes, nss, cms, secrets int
+	deployUIDs := map[string]bool{}
+	rsUIDs := map[string]bool{}
+	for _, o := range objs {
+		switch v := o.(type) {
+		case *corev1.ConfigMap:
+			cms++
+		case *corev1.Secret:
+			secrets++
+		case *appsv1.Deployment:
+			deploys++
+			deployUIDs[string(v.UID)] = true
+		case *appsv1.ReplicaSet:
+			rss++
+			rsUIDs[string(v.UID)] = true
+			if len(v.OwnerReferences) != 1 || !deployUIDs[string(v.OwnerReferences[0].UID)] {
+				t.Fatalf("replicaset %s not owned by a generated deployment", v.Name)
+			}
+		case *corev1.Pod:
+			pods++
+			if len(v.OwnerReferences) != 1 || v.OwnerReferences[0].Kind != "ReplicaSet" || !rsUIDs[string(v.OwnerReferences[0].UID)] {
+				t.Fatalf("pod %s not owned by a generated replicaset", v.Name)
+			}
+			if v.Spec.NodeName == "" {
+				t.Fatalf("pod %s not scheduled to a node", v.Name)
+			}
+		case *corev1.Service:
+			svcs++
+		case *corev1.Node:
+			nodes++
+		case *corev1.Namespace:
+			nss++
+		}
+	}
+
+	wantApps := appsFor(1005, 100) // 11
+	if pods != 1005 {
+		t.Errorf("pods=%d want 1005", pods)
+	}
+	if deploys != wantApps || rss != wantApps || svcs != wantApps || cms != wantApps || secrets != wantApps {
+		t.Errorf("apps: deploy=%d rs=%d svc=%d cm=%d secret=%d want %d each", deploys, rss, svcs, cms, secrets, wantApps)
+	}
+	if nodes != 5 || nss != 3 {
+		t.Errorf("nodes=%d nss=%d want 5/3", nodes, nss)
+	}
+}
+
+// TestScaleRoundTripThroughInformer exercises the real fake-clientset watch
+// path: a running informer consumes Create/Delete events while the scaler
+// paces against the informer's store. It asserts convergence up and down and,
+// implicitly, that batching keeps the fake watch channel from panicking.
+func TestScaleRoundTripThroughInformer(t *testing.T) {
+	g := New(Config{Pods: 300, Nodes: 4, Namespaces: 2, PodsPerApp: 100})
+	client := fake.NewClientset(g.SeedObjects()...)
+
+	factory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := factory.Core().V1().Pods().Informer()
+	deployInformer := factory.Apps().V1().Deployments().Informer()
+	stop := make(chan struct{})
+	defer close(stop)
+	factory.Start(stop)
+	if !cache.WaitForCacheSync(stop, podInformer.HasSynced, deployInformer.HasSynced) {
+		t.Fatal("informer failed to sync")
+	}
+
+	count := func(kind string) int {
+		switch kind {
+		case "Pod":
+			return len(podInformer.GetStore().ListKeys())
+		case "Deployment":
+			return len(deployInformer.GetStore().ListKeys())
+		}
+		return 0
+	}
+	if got := waitCount(func() int { return count("Pod") }, 300, 5*time.Second); got != 300 {
+		t.Fatalf("seed count=%d want 300", got)
+	}
+
+	ctx := context.Background()
+	for _, target := range []int{900, 50, 450, 0, 250} {
+		res, err := g.ScaleTo(ctx, client, target, count)
+		if err != nil {
+			t.Fatalf("ScaleTo(%d): %v", target, err)
+		}
+		if !res.Converged {
+			t.Fatalf("ScaleTo(%d) did not converge; informer=%d", target, count("Pod"))
+		}
+		if got := count("Pod"); got != target {
+			t.Fatalf("after ScaleTo(%d) informer store=%d", target, got)
+		}
+		// apps track pods: one Deployment per app of PodsPerApp
+		wantApps := appsFor(target, g.Config().PodsPerApp)
+		if got := count("Deployment"); got != wantApps {
+			t.Fatalf("after ScaleTo(%d) deployments=%d want %d", target, got, wantApps)
+		}
+	}
+}
+
+func waitCount(count func() int, want int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if count() == want {
+			return want
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return count()
+}

--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -140,6 +140,67 @@ func TestScaleRoundTripThroughInformer(t *testing.T) {
 	}
 }
 
+// TestScaleDownAfterPartialProgressLeavesNoOrphanApps reproduces the case where
+// a scale-down deletes pods (advancing the pod counter) but fails before
+// deleting the app skeletons. A retry must still remove every orphaned
+// Deployment/ReplicaSet/Service/ConfigMap/Secret — it must not derive the app
+// count from pod progress.
+func TestScaleDownAfterPartialProgressLeavesNoOrphanApps(t *testing.T) {
+	g := New(Config{Pods: 1000, Nodes: 4, Namespaces: 2, PodsPerApp: 200}) // 5 apps
+	client := fake.NewClientset(g.SeedObjects()...)
+
+	factory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := factory.Core().V1().Pods().Informer()
+	deployInformer := factory.Apps().V1().Deployments().Informer()
+	svcInformer := factory.Core().V1().Services().Informer()
+	cmInformer := factory.Core().V1().ConfigMaps().Informer()
+	stop := make(chan struct{})
+	defer close(stop)
+	factory.Start(stop)
+	if !cache.WaitForCacheSync(stop, podInformer.HasSynced, deployInformer.HasSynced, svcInformer.HasSynced, cmInformer.HasSynced) {
+		t.Fatal("informer failed to sync")
+	}
+	count := func(kind string) int {
+		switch kind {
+		case "Pod":
+			return len(podInformer.GetStore().ListKeys())
+		case "Deployment":
+			return len(deployInformer.GetStore().ListKeys())
+		case "Service":
+			return len(svcInformer.GetStore().ListKeys())
+		case "ConfigMap":
+			return len(cmInformer.GetStore().ListKeys())
+		}
+		return 0
+	}
+	waitCount(func() int { return count("Pod") }, 1000, 5*time.Second)
+
+	ctx := context.Background()
+	// Simulate the partial failure: pods deleted down to 400 (current advances),
+	// but the app skeletons are left untouched (currentApps stays 5).
+	if err := g.deletePods(ctx, client, 400, 1000, count); err != nil {
+		t.Fatalf("setup deletePods: %v", err)
+	}
+	if g.AppCount() != 5 {
+		t.Fatalf("precondition: AppCount=%d want 5 (apps must be untouched)", g.AppCount())
+	}
+
+	// Retry the scale-down; it must clean up the orphaned apps.
+	res, err := g.ScaleTo(ctx, client, 200, count)
+	if err != nil {
+		t.Fatalf("ScaleTo: %v", err)
+	}
+	if !res.Converged || count("Pod") != 200 {
+		t.Fatalf("pods=%d converged=%v want 200/true", count("Pod"), res.Converged)
+	}
+	// 200 pods / 200 per app = 1 app. Every other app kind must match — no orphans.
+	for _, kind := range []string{"Deployment", "Service", "ConfigMap"} {
+		if got := count(kind); got != 1 {
+			t.Fatalf("orphan %s skeletons: %s=%d want 1", kind, kind, got)
+		}
+	}
+}
+
 func waitCount(count func() int, want int, timeout time.Duration) int {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## What

Lets developers drive Radar's UI at tens of thousands of pods with a **live-controllable** pod count, without a real cluster, real workloads, a kubelet, or etcd. Radar connects to an in-process fake Kubernetes client and runs its real informer → topology → SSE → React render pipeline, treating the synthetic objects exactly as it would a real cluster.

This is the leanest realization of the industry pattern behind [KWOK](https://kwok.sigs.k8s.io/) ("Kubernetes WithOut Kubelet") — fake objects, no containers — but with no separate control-plane process: the objects live only as Go values in the test server's memory. The generated objects are standard Kubernetes objects, so the same generator feeds a KWOK cluster as-is if real-wire fidelity is ever wanted.

## How

- **`internal/loadtest`** — a generator producing a coherent `Deployment → ReplicaSet → Pod` population with a matching `Service`/`ConfigMap`/`Secret` per app (the pod template references the ConfigMap and Secret, so topology shows the "Configures" edges), spread across fake nodes and namespaces. Names are deterministic; the object set is a pure function of the pod count.
- **`cmd/testserver`** — new `-pods` / `-nodes` / `-namespaces` / `-pods-per-app` flags seed the population at construction, so it arrives through the informers' initial **LIST** (safe at any count). With `-pods 0` the existing nginx fixture is unchanged (Playwright e2e unaffected). A small admin listener (default `<port>+1`) exposes `POST /loadtest/scale {"pods":N}` and `GET /loadtest/status`.
- **Live scaling** mutates the fake client through its **watch** path, whose `RaceFreeFakeWatcher` has a 100-event buffer that panics on overflow. Mutations are therefore batched below that bound and paced against the informer's observed count between batches — for **every** watched kind, not just pods — advancing progress per drained batch so a mid-scale failure stays consistent. `scale` returns once the Pod informer has converged.
- `make loadtest` target + `docs/loadtest.md`.

## Verification

- 50,000 pods: informer store complete (`Pod:50000`, plus 250 each of Deployment/ReplicaSet/Service/ConfigMap/Secret), ~800 MB RSS, `/api/resources/pods` returns all 50k in ~0.2s.
- Live scale up/down (50k→200→8000→0) all converge with **zero** watch panics; in-browser the Pods count updates live over SSE with no reload.
- Unit tests cover the topology math and a scale round-trip through a live informer (`-race` clean).

A cross-model review (cursor/gpt-5.5-high) flagged that non-pod app mutations were initially unbatched (panic risk), the boundary reconcile over-patched, progress state could go stale on partial failure, and the admin bind was silent on failure — all fixed in this branch.

## Known limits (documented in docs/loadtest.md)

- Exercises everything **at and above** the informer store (informer memory, topology CPU, SSE fan-out, virtualized render); deliberately not the real network transport / client-go decode / apiserver.
- The test server doesn't initialize API discovery, so sidebar count badges for **grouped** kinds (Deployments, Jobs, …) render as "–" though the data is present (`/api/resource-counts` returns real numbers). Wiring discovery is the same step CRD kinds (HTTPRoutes, etc.) will need — the natural next extension.
- Above ~25k pods in scope the Pods table shows Radar's built-in "too many to show" guard — a real responsiveness limit this harness is well suited to exercise.

https://claude.ai/code/session_01LFEw9hKzrvDUfVMf7p38SJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to dev/test tooling (`testserver`, `loadtest`, Makefile, docs) and do not alter production cluster connectivity or auth paths.
> 
> **Overview**
> Adds a **UI load-testing path** that runs Radar against a large, topology-realistic fake cluster (no real kubelet/etcd), with optional **live pod count control** over HTTP.
> 
> A new **`internal/loadtest`** package seeds and mutates deterministic `Deployment → ReplicaSet → Pod` graphs plus per-app Services, ConfigMaps, and Secrets across fake nodes/namespaces. **`ScaleTo`** batches creates/deletes and waits on informer counts so the fake client-go watch buffer (100 events) does not panic; partial-failure handling avoids orphan app skeletons.
> 
> **`cmd/testserver`** gains `-pods` / `-nodes` / `-namespaces` / `-pods-per-app` (load-test mode) while **`-pods 0`** keeps the existing nginx Playwright fixture. When load-test mode is on, an admin listener on `<port>+1` exposes **`GET /loadtest/status`** and **`POST /loadtest/scale`**, pacing against Radar’s resource cache via `informerCount`.
> 
> **`make loadtest`** (default 50k pods) and **`docs/loadtest.md`** document usage, live scaling, and known limits (e.g. no API discovery for grouped-kind sidebar badges). Unit tests cover topology math, informer round-trips, and failure/retry/orphan cleanup scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67abbc953faa31d150238aa819edd6543f9b1fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->