### PR TITLE
Raise the Cloud funnel rollout to 20%

### DIFF
--- a/internal/server/cloud_funnel_rollout.go
+++ b/internal/server/cloud_funnel_rollout.go
@@ -12,12 +12,17 @@ import (
 	"github.com/skyhook-io/radar/internal/settings"
 )
 
-// cloudFunnelRolloutPercent stages the Cloud funnel's exposure. It is
-// compiled in and ramped by releases (10 → higher → 100, then this file is
-// deleted) — deliberately not a remote flag service, because Radar makes no
+// cloudFunnelRolloutPercent stages the Cloud funnel's exposure. It is compiled
+// in and raised by successive releases until it reaches 100 and this file is
+// deleted — deliberately not a remote flag service, because Radar makes no
 // network calls it doesn't announce and a rollout gate is not a reason to
 // start.
-const cloudFunnelRolloutPercent = 10
+//
+// Raising it only ever adds installs: the bucket is `hash % 100 < percent`, so
+// anyone already inside a lower percentage stays inside a higher one. Older
+// releases keep whatever value they were built with, so during a ramp the fleet
+// runs several percentages at once.
+const cloudFunnelRolloutPercent = 20
 
 // cloudFunnelInCohort decides whether this installation sees the Cloud
 // funnel during the staged rollout. RADAR_CLOUD_FUNNEL=on|off overrides in


### PR DESCRIPTION
## Summary

The gate has been at 10% since 1.9.0. This takes it to 20% for the next release.

Raising it only ever adds installs. The bucket is `hash % 100 < percent`, so anyone already inside a lower percentage is inside every higher one — nobody who can see the Cloud button today loses it. Simulated over 5,000 keys: 508 in at 10% → 1,008 at 20%, **0 dropped**.

## What changed

One constant, plus a comment recording the two properties that aren't obvious from the number:

- raising it is monotonic, so a ramp can't retract the feature from someone mid-flight
- older releases keep whatever value they were compiled with, so while 1.9.0 is still in the field the fleet is running both 10% and 20% simultaneously

Nothing else references the percentage — no docs, no tests pin it. `RADAR_CLOUD_FUNNEL=on|off` still overrides in either direction.

## Testing

`go build ./...` and `go test ./internal/server/` pass. The existing `TestCloudFunnelBucketing` already asserts monotonicity across every percentage from 1 to 100, so the 10 → 20 step is covered by construction rather than by a new case.

## Note on expected effect

Exposure is bounded by version adoption, not by this number. Over the last 14 days 1.9.0 accounts for roughly 187 records against ~2,800 across 1.8.5–1.8.7, so most of the fleet can't see the funnel at any percentage yet. Doubling the gate roughly doubles the cohort *within* 1.9.x — which is currently a small slice — so the sample grows mainly as 1.9.x adoption does.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single compile-time rollout percentage with no logic changes beyond exposure; overrides and bucketing behavior stay the same.
> 
> **Overview**
> **Raises the compiled-in Cloud funnel rollout gate from 10% to 20%** for the next release, expanding which local installs see the Cloud funnel via the existing `hash % 100 < percent` bucketing.
> 
> The change is limited to `cloudFunnelRolloutPercent` in `cloud_funnel_rollout.go`. Comment text is updated to spell out that **raising the percentage only adds cohort members** (no one drops out when the number goes up) and that **older binaries keep their baked-in percent**, so the fleet can run mixed rollout percentages during adoption. `RADAR_CLOUD_FUNNEL=on|off` behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6ec1ce258a40c11bc020120ab1204c88e72d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->