### PR TITLE
fix(auth): don't 500 on cancelled token exchange; warn on insecure OIDC origin

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -73,6 +74,26 @@ var supportedOIDCSigningAlgorithms = map[string]bool{
 // served under ("" at the root), which the post-login redirect must target.
 // Returns an error if the provider cannot be discovered (network error, invalid
 // issuer URL, etc.).
+// warnIfInsecureOIDCOrigin logs a prominent warning when OIDC is configured on a
+// non-secure origin. Session cookies are issued Secure, so the browser silently
+// drops them over plain HTTP and the user loops on login with no server-side
+// error. localhost is exempt — browsers treat it as a secure context.
+func warnIfInsecureOIDCOrigin(redirectURL string) {
+	u, err := url.Parse(redirectURL)
+	if err != nil || u.Scheme != "http" || isLoopbackHost(u.Hostname()) {
+		return
+	}
+	log.Printf("[oidc] WARNING: redirect URL %s is not HTTPS — the browser will drop the Secure session cookie and login will loop. Serve Radar over HTTPS, or ensure your TLS-terminating proxy sets X-Forwarded-Proto: https.", redirectURL)
+}
+
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return strings.HasSuffix(host, ".localhost")
+}
+
 func NewOIDCHandler(ctx context.Context, cfg Config, basePath string) (*OIDCHandler, error) {
 	// Build a custom HTTP client for OIDC provider TLS when configured
 	var httpClient *http.Client
@@ -102,6 +123,8 @@ func NewOIDCHandler(ctx context.Context, cfg Config, basePath string) (*OIDCHand
 	if httpClient != nil {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 	}
+
+	warnIfInsecureOIDCOrigin(cfg.OIDCRedirectURL)
 
 	provider, providerClaims, err := newOIDCProvider(ctx, cfg)
 	if err != nil {
@@ -445,6 +468,14 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	token, err := h.oauth.Exchange(ctx, code)
 	if err != nil {
+		// The browser navigating away mid-login (common during a first-load 401
+		// burst) cancels this request's context. That's the client's doing, not a
+		// server fault — don't log it as an error or return 500. A deadline
+		// (context.DeadlineExceeded) is a real IdP timeout and still falls through.
+		if errors.Is(err, context.Canceled) {
+			log.Printf("[oidc] Token exchange canceled (client disconnected)")
+			return
+		}
 		log.Printf("[oidc] Token exchange failed: %v", err)
 		http.Error(w, "authentication failed", http.StatusInternalServerError)
 		return

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -10,6 +11,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -87,6 +89,66 @@ func TestOIDCCallback_MissingCode(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestOIDCCallback_ContextCanceledIsNot500(t *testing.T) {
+	h := newTestOIDCHandler()
+	// Unreachable token endpoint; the canceled context makes Exchange fail with
+	// context.Canceled before any network round-trip completes.
+	h.oauth = oauth2.Config{
+		ClientID: "radar",
+		Endpoint: oauth2.Endpoint{TokenURL: "http://127.0.0.1:1/token"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client already gone
+
+	r := httptest.NewRequest("GET", "/auth/callback?state=abc&code=xyz", nil).WithContext(ctx)
+	r.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: "abc"})
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, r)
+
+	if w.Code == http.StatusInternalServerError {
+		t.Errorf("a client-canceled token exchange must not return 500, got %d", w.Code)
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	cases := map[string]bool{
+		"localhost":       true,
+		"127.0.0.1":       true,
+		"::1":             true,
+		"radar.localhost": true,
+		"example.com":     false,
+		"10.0.0.5":        false,
+		"":                false,
+	}
+	for host, want := range cases {
+		if got := isLoopbackHost(host); got != want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestWarnIfInsecureOIDCOrigin(t *testing.T) {
+	cases := map[string]bool{
+		"http://radar.example.com/auth/callback":    true,  // non-secure, non-local → warn
+		"https://radar.example.com/auth/callback":   false, // secure → no warn
+		"http://localhost:8080/auth/callback":       false, // loopback exempt
+		"http://radar.localhost:4962/auth/callback": false,
+	}
+	for redirectURL, wantWarn := range cases {
+		var buf bytes.Buffer
+		orig := log.Writer()
+		log.SetOutput(&buf)
+		warnIfInsecureOIDCOrigin(redirectURL)
+		log.SetOutput(orig)
+
+		warned := strings.Contains(buf.String(), "not HTTPS")
+		if warned != wantWarn {
+			t.Errorf("warnIfInsecureOIDCOrigin(%q) warned=%v, want %v (log: %q)", redirectURL, warned, wantWarn, buf.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## Two small OIDC robustness fixes

Both surfaced while debugging the OIDC login loop (#1100). Neither is the loop fix itself (that's #1348) — these clean up rough edges seen in that investigation.

### 1. Don't return HTTP 500 for a client-cancelled token exchange
When the browser navigates away mid-login (common during a first-load 401 burst), the request context is cancelled and `oauth.Exchange` returns `context.Canceled`. Previously this logged `[oidc] Token exchange failed` and returned `500` — misleading noise for a client-side disconnect (it shows up in #1100's logs). Now it logs quietly and returns. A real IdP timeout (`context.DeadlineExceeded`) still falls through to the error path.

### 2. Warn at startup when OIDC runs on a non-secure origin
Session cookies are issued `Secure`, so a browser on a plain-`http://` origin silently drops them and the user loops on login with **no server-side error** — a genuinely baffling failure to debug. Now, when the OIDC redirect URL is `http://` and not loopback, Radar logs a clear warning at startup pointing the operator at HTTPS / `X-Forwarded-Proto`. `localhost` / `*.localhost` / `127.0.0.1` / `::1` are exempt (browsers treat them as secure contexts).

### Tests
- Cancelled token exchange returns non-500.
- Loopback-host classification.
- Startup warning fires only for non-secure, non-loopback origins.

Full `internal/auth` suite green.

### Not included (follow-ups)
The deeper `Secure`-derivation cleanup — making all auth cookies derive `Secure` from one signal (state/session/delete currently disagree, so logout can fail to evict over HTTP) — is intentionally left for a separate, reviewed change. This PR is just the two safe, self-contained fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth edge-case handling and operator logging only; no change to successful login or cookie issuance.
> 
> **Overview**
> Two small OIDC robustness improvements in `HandleCallback` and `NewOIDCHandler`.
> 
> **Token exchange when the client disconnects:** If `oauth.Exchange` fails with `context.Canceled` (e.g. the browser navigates away mid-login), the callback now logs a quiet message and returns without a **500** or error-level log. Real IdP timeouts (`context.DeadlineExceeded`) still use the existing error path.
> 
> **Startup warning for HTTP OIDC:** When the configured redirect URL is plain `http://` and not loopback (`localhost`, `127.0.0.1`, `::1`, `*.localhost`), Radar logs a startup warning that **Secure** session cookies will be dropped and login may loop, with guidance on HTTPS or `X-Forwarded-Proto`.
> 
> Tests cover canceled exchange (non-500), loopback classification, and when the insecure-origin warning fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9aea75f66557e85d90b341f4633cc61a39fb1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->