### PR TITLE
Clarify and declutter the Cloud funnel modal

### DIFF
--- a/web/src/components/CloudConnectFlow.tsx
+++ b/web/src/components/CloudConnectFlow.tsx
@@ -37,7 +37,7 @@ export function CloudConnectFlow({
   switch (status.state) {
     case 'preparing':
       return (
-        <div className="px-7 py-10 flex flex-col items-center gap-3 text-center">
+        <div className="px-8 py-10 flex flex-col items-center gap-3 text-center">
           <Loader2 className="w-5 h-5 animate-spin text-emerald-600 dark:text-emerald-400" />
           <p className="text-[13px] text-theme-text-secondary">
             Checking this cluster and preparing the install — this can take a moment on a slow link.
@@ -87,7 +87,7 @@ function BlockedView({
         ? 'Your Kubernetes identity can’t install this'
         : 'This cluster can’t be connected from here'
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <div className="card-inner-lg flex gap-2.5">
         {icon}
         <div className="min-w-0">
@@ -198,7 +198,7 @@ function PlanCard({
     (!!plan.sharedListener && !ackShared)
 
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <h4 className="text-[15px] font-semibold text-theme-text-primary mb-3">
         {adopt ? 'Adopt and connect this cluster' : 'Connect this cluster'}
       </h4>
@@ -356,7 +356,7 @@ function ApprovalCard({ status, onStatus }: { status: CloudInstallStatus; onStat
   const cancel = useCancelButton(status, onStatus)
   const starting = status.state === 'starting'
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <div className="flex items-center gap-2.5 mb-3">
         <Loader2 className="w-4 h-4 animate-spin text-emerald-600 dark:text-emerald-400" />
         <h4 className="text-[15px] font-semibold text-theme-text-primary">
@@ -394,7 +394,7 @@ function ProgressCard({ status, onStatus }: { status: CloudInstallStatus; onStat
     { label: 'Waiting for the agent to connect', state: provisioning ? 'todo' : 'active' },
   ]
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <h4 className="text-[15px] font-semibold text-theme-text-primary mb-3.5">
         Connecting {status.clusterName}
       </h4>
@@ -459,7 +459,7 @@ function ConnectedCard({
   const connected = status.connected
   if (!connected) return null
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <div className="flex items-center gap-2.5 mb-3">
         <span className="w-7 h-7 rounded-full bg-emerald-500/20 grid place-items-center">
           <Check className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
@@ -507,7 +507,7 @@ function FailedCard({
   const failure = status.failure
   if (!failure) return null
   return (
-    <div className="px-7 pt-6 pb-5">
+    <div className="px-8 pt-6 pb-5">
       <div className="flex items-start gap-2.5 mb-3">
         <AlertTriangle className="w-4 h-4 shrink-0 mt-1 text-amber-500" />
         <h4 className="text-[14px] font-semibold leading-snug text-theme-text-primary">{failure.message}</h4>

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState, type ReactNode } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
+import { Bell, Check, Globe, History, Sparkles, Users, X } from 'lucide-react'
+import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
 import { CloudConnectFlow } from './CloudConnectFlow'
@@ -261,14 +262,14 @@ function Fold({ summary, className = '', children }: { summary: string; classNam
         aria-controls={bodyId}
         className="flex items-center gap-1.5 text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
       >
-        <ChevronRight className={`w-3 h-3 shrink-0 transition-transform duration-200 ${open ? 'rotate-90' : ''}`} />
+        <CollapseChevron open={open} className="w-3 h-3" />
         {summary}
       </button>
-      <div id={bodyId} className={`issue-details-motion ${open ? 'issue-details-motion-open' : ''}`}>
-        <div className="overflow-hidden">
-          <p className="mt-2 pl-[18px] text-[11.5px] leading-relaxed text-theme-text-tertiary">{children}</p>
-        </div>
-      </div>
+      <Collapse open={open}>
+        <p id={bodyId} className="mt-2 pl-[18px] text-[11.5px] leading-relaxed text-theme-text-tertiary">
+          {children}
+        </p>
+      </Collapse>
     </div>
   )
 }

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState, type ReactNode } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Bell, Check, Globe, History, Sparkles, Users, X } from 'lucide-react'
+import { Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
 import { CloudConnectFlow } from './CloudConnectFlow'
@@ -34,6 +34,9 @@ const FALLBACK_APP_URL = 'https://app.radarhq.io'
 // offline laptop all render exactly what Radar rendered before this fetch
 // existed — the dialog never waits on the network and never shows a gap.
 const DEFAULT_ASSURANCES = ['Free for 3 clusters', 'No credit card', 'Your cluster data stays in your cluster']
+// A product fact, not funnel copy — appended even when the Hub supplies its
+// own assurances (deduped if the Hub starts sending it).
+const SOC2_ASSURANCE = 'SOC 2 compliant'
 const SIGNUP_QUERY = '?utm_source=radar-oss&utm_medium=app&utm_campaign=cloud-modal'
 const ABOUT_URL = 'https://radarhq.io/about'
 const SELF_HOSTED_DOCS_URL = 'https://radarhq.io/docs/cloud/self-hosted/'
@@ -193,7 +196,7 @@ export function CloudFunnelButton() {
       <DialogPortal
         open={open}
         onClose={() => setOpen(false)}
-        className="w-[500px] max-w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col"
+        className="w-[580px] max-w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col"
       >
         <button
           onClick={() => setOpen(false)}
@@ -245,6 +248,39 @@ export function CloudFunnelButton() {
   )
 }
 
+// Secondary copy the pitch shouldn't spend vertical space on until asked for.
+function Fold({ summary, className = '', children }: { summary: string; className?: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const bodyId = useId()
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        className="flex items-center gap-1.5 text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+      >
+        <ChevronRight className={`w-3 h-3 shrink-0 transition-transform duration-200 ${open ? 'rotate-90' : ''}`} />
+        {summary}
+      </button>
+      <div id={bodyId} className={`issue-details-motion ${open ? 'issue-details-motion-open' : ''}`}>
+        <div className="overflow-hidden">
+          <p className="mt-2 pl-[18px] text-[11.5px] leading-relaxed text-theme-text-tertiary">{children}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function assuranceItems(fromHub?: string[]): string[] {
+  const items = fromHub?.length ? fromHub : DEFAULT_ASSURANCES
+  if (items.some((item) => item.toLowerCase().includes('soc 2'))) return items
+  // Before the last item: the closer ("data stays in your cluster") is the
+  // longest line and wraps most naturally when it comes last.
+  return [...items.slice(0, -1), SOC2_ASSURANCE, items[items.length - 1]]
+}
+
 function RadarSweep() {
   return (
     <div
@@ -263,28 +299,9 @@ function RadarSweep() {
 
 function Eyebrow() {
   return (
-    <div className="flex items-center gap-2.5 mb-3.5">
+    <div className="flex items-center gap-3 mb-5">
       <RadarSweep />
       <span className="font-mono text-[10.5px] tracking-[0.16em] uppercase text-emerald-600 dark:text-emerald-400">Radar Cloud</span>
-    </div>
-  )
-}
-
-function Faces() {
-  return (
-    <div className="flex shrink-0" aria-hidden>
-      {[
-        ['R', 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-300'],
-        ['N', 'bg-sky-500/20 text-sky-700 dark:text-sky-300'],
-        ['E', 'bg-amber-500/20 text-amber-700 dark:text-amber-300'],
-      ].map(([initial, color], i) => (
-        <div
-          key={initial}
-          className={`w-6 h-6 text-[10px] ${color} rounded-full grid place-items-center font-bold border-2 border-theme-surface ${i > 0 ? '-ml-1.5' : ''}`}
-        >
-          {initial}
-        </div>
-      ))}
     </div>
   )
 }
@@ -328,9 +345,9 @@ function ModalFooter({
   // fast click would escape to signup before we could route this install.
   const selfPending = selfLoading === true
   return (
-    <div className="px-7 py-4 bg-theme-base border-t border-theme-border">
+    <div className="shrink-0 px-8 py-5 bg-theme-base border-t border-theme-border">
       {self && self.ownership !== 'unknown' && (
-        <div className="mb-3 card-inner text-[11.5px] leading-snug text-theme-text-secondary">
+        <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">
           {ambiguous ? (
             <>
               Radar found conflicting management metadata on this install, so it can't say whether a Helm
@@ -367,14 +384,20 @@ function ModalFooter({
         </div>
       )}
       {notice && (
-        <div className="mb-3 card-inner text-[11.5px] leading-snug text-theme-text-secondary">{notice}</div>
+        <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">{notice}</div>
       )}
-      <div className="flex items-center gap-4">
+      {lane === 'driver' && (
+        <p className="mb-3.5 text-[12px] leading-relaxed text-theme-text-secondary">
+          The guided setup runs right here in the app — Radar installs the Cloud agent on this cluster, and
+          you approve the connection in your browser.
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
         {lane === 'driver' ? (
           <>
             <button
               onClick={onConnect}
-              className="px-5 py-2 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[13.5px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+              className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
             >
               Connect this cluster
             </button>
@@ -382,9 +405,9 @@ function ModalFooter({
               href={driverEscapeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[12.5px] text-theme-text-secondary hover:text-theme-text-primary underline underline-offset-2 transition-colors"
+              className="whitespace-nowrap text-[13px] text-theme-text-secondary hover:text-theme-text-primary underline underline-offset-2 transition-colors"
             >
-              or start in the browser
+              or set up in the browser
             </a>
           </>
         ) : cliOnly ? null : (
@@ -399,33 +422,32 @@ function ModalFooter({
             {self?.ownership === 'helm' || gitops ? 'Connect this cluster' : 'Try Cloud free'}
           </a>
         )}
-        <button onClick={onLater} className="text-[12.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors">
+        <button onClick={onLater} className="whitespace-nowrap text-[13px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors">
           Maybe later
         </button>
       </div>
-      <div className="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-theme-text-tertiary">
-        {(assurances?.length ? assurances : DEFAULT_ASSURANCES).map((item) => (
-          <span key={item} className="flex items-center gap-1">
-            <Check className="w-3 h-3 text-emerald-600 dark:text-emerald-400" />
+      <div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-2 text-[11.5px] text-theme-text-tertiary">
+        {assuranceItems(assurances).map((item) => (
+          <span key={item} className="flex items-start gap-1.5">
+            <Check className="w-3 h-3 mt-[3px] shrink-0 text-emerald-600 dark:text-emerald-400" />
             {item}
           </span>
         ))}
       </div>
-      <p className="mt-3.5 text-[11px] text-theme-text-tertiary">
-        Prefer to run the control plane in your own VPC? Self-hosting is self-serve — 30-day trial, no sales
-        call.{' '}
+      <Fold summary="Prefer to run the control plane in your own VPC?" className="mt-3.5">
+        Self-hosting is fully self-serve — set it up yourself, whenever you're ready.{' '}
         <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
           Read the docs
         </a>
         .
-      </p>
+      </Fold>
     </div>
   )
 }
 
 // Headline defuses the paywall fear before anything is pitched; the grid
-// carries the concrete capabilities; the humans strip closes with the
-// anti-sell — the credibility beat that makes the sell land.
+// carries the concrete capabilities; the anti-sell closes — the credibility
+// beat that makes the sell land.
 function ModalBody() {
   const features = [
     {
@@ -456,43 +478,43 @@ function ModalBody() {
     },
   ]
   return (
-    <div className="px-7 pt-6 pb-1">
+    <div className="px-8 pt-7 pb-2">
       <Eyebrow />
-      <h3 className="text-[21px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-2.5 text-balance">
+      <h3 className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3 text-balance">
         First things first: Radar stays free.
       </h3>
-      <p className="text-[13.5px] leading-relaxed text-theme-text-secondary mb-4">
+      <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
         The app you're looking at is Apache&nbsp;2.0 — every feature, forever, no rug pulls.{' '}
         <b className="text-theme-text-primary font-semibold">Radar Cloud is how we keep the lights on:</b> the
         same Radar, plus the parts that are genuinely hard to run on your own.
       </p>
-      <div className="grid grid-cols-2 gap-2 mb-4">
+      <div className="grid grid-cols-2 gap-3 mb-5">
         {features.map(({ icon: Icon, title, body, wide }) => (
-          <div key={title} className={`card-inner-lg flex gap-2.5 ${wide ? 'col-span-2' : ''}`}>
+          <div
+            key={title}
+            className={`card-inner-lg p-3.5 flex gap-3 ${
+              wide ? 'col-span-2 bg-emerald-500/[0.06] border-emerald-500/25 dark:bg-emerald-500/[0.08]' : ''
+            }`}
+          >
             <Icon className="w-4 h-4 shrink-0 mt-0.5 text-emerald-600 dark:text-emerald-400" />
             <div>
-              <div className="text-[12.5px] font-semibold text-theme-text-primary">{title}</div>
-              <p className="mt-0.5 text-[11.5px] leading-snug text-theme-text-tertiary">{body}</p>
+              <div className="text-[13px] font-semibold text-theme-text-primary">{title}</div>
+              <p className="mt-1 text-[12px] leading-relaxed text-theme-text-tertiary">{body}</p>
             </div>
           </div>
         ))}
       </div>
-      <div className="flex items-start gap-2.5 mb-4">
-        <div className="mt-0.5">
-          <Faces />
-        </div>
-        <div className="min-w-0">
-          <p className="text-[12px] leading-snug text-theme-text-secondary">
-            If it's just you and one cluster — honestly, stay right here. This app is the product, not a demo.
-          </p>
-          <p className="mt-1 text-[11px] leading-snug text-theme-text-tertiary">
-            Radar is built in the open by many hands, and overseen by a small team of humans — the kind you can
-            actually talk to.{' '}
-            <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
-              Meet us →
-            </a>
-          </p>
-        </div>
+      <div className="mb-5 border-l-2 border-emerald-500/40 pl-3.5">
+        <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
+          If it's just you and one cluster — honestly, stay right here. This app is the product, not a demo.
+        </p>
+        <p className="mt-2 text-[11.5px] leading-relaxed text-theme-text-tertiary">
+          Radar is built in the open by many hands, and overseen by a small team of humans — the kind you
+          can actually talk to.{' '}
+          <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
+            Meet us →
+          </a>
+        </p>
       </div>
     </div>
   )

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -211,7 +211,7 @@ export function CloudFunnelButton() {
             more with the connect flow, whose plan card is the tallest state. */}
         {showFlow && flowForView ? (
           <div className="min-h-0 overflow-y-auto">
-            <div className="px-7 pt-6">
+            <div className="px-8 pt-7">
               <Eyebrow />
             </div>
             <CloudConnectFlow


### PR DESCRIPTION
Four copy and layout fixes from a review of the OSS → Cloud pitch modal.

**SOC 2.** Added "SOC 2 compliant" to the assurances row. Worth a look: the Hub serves that row live from `/api/connect/info`, so editing only the compiled-in fallback would never have reached production. The string is appended client-side instead, and dedupes itself if the Hub starts sending its own SOC 2 line.

Reviewed and kept deliberately: this asserts the claim unconditionally, including when the Hub fetch fails and when `RADAR_HUB_URL` points at an operator's self-hosted Hub, and an old binary can't honor a later server-side removal. If that trade stops being acceptable, the fix is to move the line into the Hub response and drop the client-side append.

**The R/N/E circles.** The initials didn't communicate anything, and the two-column layout they forced left the copy beneath them floating at an odd indent. Swapping in generic person icons just traded one meaningless glyph for another, so they're gone entirely — the anti-sell line now sits behind a quiet left rule.

**"Connect this cluster" vs "start in the browser."** Neither label said what it actually did. The driver lane now states up front that the guided setup runs in-app, installs the agent on this cluster, and that approval happens in the browser; the escape hatch reads "or set up in the browser."

No duration is promised. An earlier draft said "about two minutes" — the flow includes a human approval step Radar can't bound, and the server's own limits (5m prepare, 10m provision, 5m tunnel confirmation) admit successful paths well past any number worth printing.

**Self-hosted trial.** Dropped the 30-day claim — paid features are aligning to 14 days, and 30 was an airgapped licensing artifact — along with "no sales call," which read as though we'd rather not talk to people. Emphasis moves to self-serve.

**Layout.** The modal grows 500px → 580px with a looser vertical rhythm, since it was cramped. The self-hosting note folds away behind its own question ("Prefer to run the control plane in your own VPC?") so the extra breathing room doesn't become a wall of text — the reader who cares self-selects. The "who's behind Radar" backstory stays visible: it's the credibility beat the pitch leans on, so it shouldn't need a click.

The fold uses the Radar-standard expand/collapse motion (`issue-details-motion`, `grid-template-rows` 0fr↔1fr) rather than a native `<details>`, which snapped open with no animation.

The footer is pinned `shrink-0`. It sits outside the modal's only scroll region, so without it the now-taller footer could be squeezed and clipped on short viewports.

Verified in light and dark mode against a live cluster with `RADAR_CLOUD_FUNNEL=on`; `make tsc` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, copy, and layout only in the Cloud funnel modal; no auth, API, or install logic changes.
> 
> **Overview**
> **OSS → Cloud pitch modal** gets wider layout (500px → 580px), looser padding (`px-8`), and a pinned `shrink-0` footer so CTAs stay visible while the body scrolls. Connect-flow cards in `CloudConnectFlow` use the same horizontal padding.
> 
> **Copy and structure:** **SOC 2 compliant** is appended client-side via `assuranceItems()` (deduped if the Hub already sends it), shown in a two-column assurances grid. The decorative **R/N/E avatar strip** is removed; the anti-sell block uses a left border instead. **Driver lane** adds a line explaining in-app guided setup vs browser approval; the escape link reads **or set up in the browser**. Self-hosted footer copy drops the 30-day trial and “no sales call” claims and moves behind a **`Fold`** collapsible (shared `Collapse` animation). The wide AI feature card gets a subtle emerald highlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d923012165cd6df9ab3e084cac32f4fad087ca5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->