### PR TITLE
feat(timeline): expose retained floor as X-Radar-Timeline-Min-Seq on /api/changes

### DIFF
--- a/internal/server/changes_delta_test.go
+++ b/internal/server/changes_delta_test.go
@@ -204,6 +204,53 @@ func TestHandleChanges_MinSeqTracksEviction(t *testing.T) {
 	}
 }
 
+// The min-seq header is derived pre-RBAC-filter (pageMinSeq) but the retained
+// floor was historically re-read fresh after the slow, SAR-bound RBAC filter.
+// A ring evicting during that window raises the fresh floor above seqs still in
+// the response body, so the header could advertise a floor higher than a seq we
+// actually delivered — making the hub puller record a false coverage gap and
+// skip events it received. clampMinSeqToPage is the guard: whatever the floor
+// read reports, the emitted value can never exceed the lowest delivered seq.
+func TestClampMinSeqToPage(t *testing.T) {
+	cases := []struct {
+		name          string
+		retainedFloor int64
+		pageMinSeq    int64
+		want          int64
+	}{
+		// The race: a fresh floor read (10) has risen above a seq still on the
+		// delivered page (4) because the ring evicted mid-request. The emitted
+		// header must be the page floor, not the inflated store floor.
+		{"floor inflated above delivered page", 10, 4, 4},
+		// Genuine gap: low seqs were evicted before the query, so the page
+		// itself starts high (8) above the floor (5). min() keeps the true
+		// floor so the consumer still sees the gap below the page.
+		{"genuine gap preserved", 5, 8, 5},
+		// No skew: page floor equals the store floor.
+		{"floor matches page", 4, 4, 4},
+		// Empty page (all rows RBAC-filtered, or none matched): nothing in the
+		// body to contradict, so the raw floor stands.
+		{"empty page keeps floor", 7, 0, 7},
+		// Empty store: floor 0 → caller omits the header entirely.
+		{"empty store", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampMinSeqToPage(tc.retainedFloor, tc.pageMinSeq); got != tc.want {
+				t.Fatalf("clampMinSeqToPage(%d, %d) = %d, want %d",
+					tc.retainedFloor, tc.pageMinSeq, got, tc.want)
+			}
+			// The load-bearing invariant across every non-empty page: the
+			// emitted floor never exceeds a delivered seq.
+			if tc.pageMinSeq > 0 {
+				if got := clampMinSeqToPage(tc.retainedFloor, tc.pageMinSeq); got > tc.pageMinSeq {
+					t.Fatalf("emitted floor %d exceeds delivered page floor %d", got, tc.pageMinSeq)
+				}
+			}
+		})
+	}
+}
+
 // minEventSeq returns the smallest Seq in a page; the changes feed returns
 // events newest-first, so the oldest retained seq is the page minimum, not
 // events[0].

--- a/internal/server/changes_delta_test.go
+++ b/internal/server/changes_delta_test.go
@@ -81,6 +81,24 @@ func TestHandleChanges_DeltaContract(t *testing.T) {
 		t.Fatalf("full fetch returned %d events, want 3", len(full))
 	}
 
+	// Min-seq advertises the store's oldest retained seq so a consumer can tell
+	// its cursor fell below the retention floor. Nothing evicted here, so it is
+	// the seq of the oldest surviving event.
+	minSeqHeader := rr.Header().Get("X-Radar-Timeline-Min-Seq")
+	if minSeqHeader == "" {
+		t.Fatalf("missing X-Radar-Timeline-Min-Seq header")
+	}
+	minSeq, err := strconv.ParseInt(minSeqHeader, 10, 64)
+	if err != nil || minSeq <= 0 {
+		t.Fatalf("bad min-seq header %q", minSeqHeader)
+	}
+	if want := minEventSeq(full); minSeq != want {
+		t.Fatalf("min-seq header = %d, want oldest retained seq %d", minSeq, want)
+	}
+	if minSeq > maxSeq {
+		t.Fatalf("min-seq %d above max-seq %d", minSeq, maxSeq)
+	}
+
 	// Delta from the middle: ascending seq order, only events above the cursor.
 	middle := full[1].Seq
 	rr = get("/api/changes?namespaces=default&since_seq=" + strconv.FormatInt(middle, 10))
@@ -118,4 +136,83 @@ func TestHandleChanges_DeltaContract(t *testing.T) {
 			t.Fatalf("since_seq=%s status = %d, want 400", bad, rr.Code)
 		}
 	}
+}
+
+// After the ring evicts its oldest records, the min-seq header must advance
+// past the evicted floor so a consumer that pulled forward from a stale cursor
+// can detect the gap instead of reading an empty page as "caught up".
+func TestHandleChanges_MinSeqTracksEviction(t *testing.T) {
+	prev := k8s.GetConnectionStatus()
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{State: k8s.StateConnected})
+	t.Cleanup(func() { k8s.SetConnectionStatus(prev) })
+
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 3}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(func() {
+		timeline.ResetStore()
+		if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
+			t.Fatalf("re-init global store: %v", err)
+		}
+	})
+
+	store := timeline.GetStore()
+	base := time.Now().Add(-time.Minute)
+	// Six distinct resources into a 3-slot ring: the first three are evicted.
+	for i := 0; i < 6; i++ {
+		name := "r" + strconv.Itoa(i)
+		if err := store.Append(t.Context(), timeline.TimelineEvent{
+			ID: "ev-" + name, Timestamp: base.Add(time.Duration(i) * time.Second),
+			Source: timeline.SourceInformer, Kind: "Deployment", Namespace: "default",
+			Name: name, EventType: timeline.EventTypeUpdate,
+			ClusterContext: k8s.ActiveClusterContext(),
+		}); err != nil {
+			t.Fatalf("Append %s: %v", name, err)
+		}
+	}
+
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/changes?namespaces=default", nil)
+	rr := httptest.NewRecorder()
+	s.handleChanges(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rr.Code, rr.Body.String())
+	}
+
+	minSeqHeader := rr.Header().Get("X-Radar-Timeline-Min-Seq")
+	if minSeqHeader == "" {
+		t.Fatalf("missing X-Radar-Timeline-Min-Seq header")
+	}
+	minSeq, err := strconv.ParseInt(minSeqHeader, 10, 64)
+	if err != nil {
+		t.Fatalf("bad min-seq header %q", minSeqHeader)
+	}
+	// Seq 1 was evicted, so the retained floor must be above it.
+	if minSeq <= 1 {
+		t.Fatalf("min-seq header = %d, want floor above evicted seq 1", minSeq)
+	}
+	var events []timeline.TimelineEvent
+	if err := json.Unmarshal(rr.Body.Bytes(), &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("expected retained events after eviction")
+	}
+	if want := minEventSeq(events); minSeq != want {
+		t.Fatalf("min-seq header = %d, want oldest retained seq %d", minSeq, want)
+	}
+}
+
+// minEventSeq returns the smallest Seq in a page; the changes feed returns
+// events newest-first, so the oldest retained seq is the page minimum, not
+// events[0].
+func minEventSeq(events []timeline.TimelineEvent) int64 {
+	var min int64
+	for _, e := range events {
+		if min == 0 || e.Seq < min {
+			min = e.Seq
+		}
+	}
+	return min
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3264,6 +3264,22 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, events)
 }
 
+// clampMinSeqToPage bounds the advertised retention floor (the store's oldest
+// retained seq) to the lowest seq actually delivered on this page. pageMinSeq
+// is 0 for an empty page — nothing to be inconsistent with — so the raw floor
+// stands. A genuine gap (low seqs evicted before the query, so pageMinSeq is
+// already at or above the floor) is preserved, because min() keeps the floor.
+// The clamp only bites when a fresh floor read has risen above a seq still
+// present in the body (e.g. eviction during the slow RBAC filter), which would
+// otherwise make a consumer record a false coverage gap and skip delivered
+// events.
+func clampMinSeqToPage(retainedFloor, pageMinSeq int64) int64 {
+	if pageMinSeq > 0 && pageMinSeq < retainedFloor {
+		return pageMinSeq
+	}
+	return retainedFloor
+}
+
 // handleChanges returns timeline events using the unified timeline.TimelineEvent format.
 // This is the main timeline API endpoint - it queries the timeline store directly.
 func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
@@ -3386,12 +3402,24 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	// client only via its periodic full resync. A precise fix needs a
 	// same-snapshot store max-seq that ignores content filters; deferred as
 	// not worth the concurrency risk here.
-	var maxSeq int64
+	var maxSeq, pageMinSeq int64
 	for _, e := range events {
 		if e.Seq > maxSeq {
 			maxSeq = e.Seq
 		}
+		if pageMinSeq == 0 || e.Seq < pageMinSeq {
+			pageMinSeq = e.Seq
+		}
 	}
+	// Sample the retained floor here, from the same pre-filter moment maxSeq is
+	// taken — before filterEventsByRBAC below issues its (slow, SAR-bound)
+	// SubjectAccessReview round-trips. Reading it after the filter would let a
+	// busy ring evict mid-request and raise OldestSeq above seqs still in this
+	// response body, so the emitted floor could exceed a seq we actually
+	// deliver. The clamp below closes any residual skew, but sampling early
+	// keeps the two values consistent to begin with.
+	retainedFloor := store.Stats().OldestSeq
+
 	events = s.filterEventsByRBAC(r, events)
 
 	// The store epoch validates delta cursors: seq restarts from 1 when the
@@ -3404,11 +3432,16 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	}
 	// The store's oldest retained seq lets a consumer pulling forward from a
 	// cursor detect that events below its cursor were evicted while it was
-	// behind. Mirrors the Max-Seq header's marshaling and its skip-when-zero
-	// convention: an empty store (never recorded, nothing evicted) reports
-	// OldestSeq==0, so the header is omitted rather than sent as 0.
-	if oldestSeq := store.Stats().OldestSeq; oldestSeq > 0 {
-		w.Header().Set("X-Radar-Timeline-Min-Seq", strconv.FormatInt(oldestSeq, 10))
+	// behind. Clamp it to the lowest seq actually delivered in this response
+	// (pageMinSeq, computed pre-RBAC-filter so it aligns with maxSeq): the
+	// header must never claim a floor above a seq present in the body, or a
+	// consumer would record a false coverage gap and skip events it received.
+	// A genuine gap — low seqs evicted before this query, so pageMinSeq is
+	// already high — is preserved, since min() keeps the true floor. Mirrors
+	// the Max-Seq header's marshaling and its skip-when-zero convention: an
+	// empty store reports OldestSeq==0, so the header is omitted, not sent as 0.
+	if minSeq := clampMinSeqToPage(retainedFloor, pageMinSeq); minSeq > 0 {
+		w.Header().Set("X-Radar-Timeline-Min-Seq", strconv.FormatInt(minSeq, 10))
 	}
 	s.writeJSON(w, events)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -410,7 +410,7 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 		AllowedHeaders: []string{"Accept", "Content-Type"},
 		// Without an expose entry, cross-origin JS reads these as "" and the
 		// timeline client silently falls back to full-ring refetches.
-		ExposedHeaders:   []string{"X-Radar-Timeline-Epoch", "X-Radar-Timeline-Max-Seq"},
+		ExposedHeaders:   []string{"X-Radar-Timeline-Epoch", "X-Radar-Timeline-Max-Seq", "X-Radar-Timeline-Min-Seq"},
 		AllowCredentials: true,
 	}))
 
@@ -3401,6 +3401,14 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Radar-Timeline-Epoch", strconv.FormatInt(timeline.ObservationStart().UnixNano(), 10))
 	if maxSeq > 0 {
 		w.Header().Set("X-Radar-Timeline-Max-Seq", strconv.FormatInt(maxSeq, 10))
+	}
+	// The store's oldest retained seq lets a consumer pulling forward from a
+	// cursor detect that events below its cursor were evicted while it was
+	// behind. Mirrors the Max-Seq header's marshaling and its skip-when-zero
+	// convention: an empty store (never recorded, nothing evicted) reports
+	// OldestSeq==0, so the header is omitted rather than sent as 0.
+	if oldestSeq := store.Stats().OldestSeq; oldestSeq > 0 {
+		w.Header().Set("X-Radar-Timeline-Min-Seq", strconv.FormatInt(oldestSeq, 10))
 	}
 	s.writeJSON(w, events)
 }


### PR DESCRIPTION
The `/api/changes` response already advertises the newest seq (`X-Radar-Timeline-Max-Seq`) but not the **oldest retained** seq. A consumer that pulls forward from a cursor (the cloud hub´s timeline puller) therefore cannot tell that events *below* its cursor were evicted from radar´s local store while it was behind — so it silently skips the lost band.

This adds **`X-Radar-Timeline-Min-Seq`** (= the store´s oldest retained seq, `Stats().OldestSeq`) next to the existing Max-Seq header, and exposes it via CORS. The hub uses it to record an honest coverage gap instead of a silent one (companion radar-hub PR).

## Strictly additive
- New response header only; same value formatting as Max-Seq (`strconv.FormatInt`).
- Omitted when the store is empty (`OldestSeq == 0`), mirroring how Max-Seq is omitted when `0`.
- No change to status codes, body, cursor semantics, or existing headers. A client that ignores it sees no difference.

## Tests
- Extended the delta-contract test to assert the header is present, positive, equals the oldest retained seq, and sits at/below Max-Seq.
- New test: 6 events into a 3-slot ring → header advances past the evicted floor and equals the oldest surviving seq.
`go build ./...` and `go test ./internal/server/...` green.

Part of RAD-53 (the OSS half of the silent-gap backstop).

https://claude.ai/code/session_018ea2h6ki1JweHcMU8F2LR8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive response header and CORS only; body and cursor semantics unchanged. Logic is localized to `/api/changes` with thorough tests.
> 
> **Overview**
> **`/api/changes` now advertises the oldest retained timeline seq** via **`X-Radar-Timeline-Min-Seq`**, alongside the existing max-seq header, so pullers (e.g. the cloud hub) can tell when events below their cursor were evicted from the ring instead of treating an empty delta as caught up.
> 
> The handler samples `store.Stats().OldestSeq` **before** RBAC filtering (aligned with max-seq), computes the lowest seq on the returned page, and emits **`clampMinSeqToPage`** so the header never claims a retention floor **above** a seq still in the response body—avoiding false coverage gaps when the ring evicts during slow SAR filtering. The header is **omitted when zero** (empty store), same convention as max-seq. **CORS** exposes the new header name for cross-origin timeline clients.
> 
> Tests extend the delta contract, cover eviction in a small ring, and table-test the clamp helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0898bf7f9c575e617fa6f2be14f363c4146e681c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->