### PR TITLE
feat(auth): opt-in PKCE (S256) for the OIDC authorization-code flow

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -132,6 +132,7 @@ func main() {
 	authOIDCInsecureSkipVerify := flag.Bool("auth-oidc-insecure-skip-verify", false, "Skip TLS certificate verification for OIDC provider (insecure, dev/test only)")
 	authOIDCCACert := flag.String("auth-oidc-ca-cert", "", "Path to CA certificate file for OIDC provider TLS verification")
 	authOIDCBackchannelLogout := flag.Bool("auth-oidc-backchannel-logout", false, "Enable OIDC Back-Channel Logout endpoint (single-replica only)")
+	authOIDCEnablePKCE := flag.Bool("auth-oidc-enable-pkce", false, "Enable PKCE (S256) for the OIDC authorization-code flow (opt-in)")
 	// Radar Hub flags — enable connected mode when --cloud-url is set.
 	// Local-binary behavior is unchanged when these flags are empty. Each
 	// flag falls back to an env var so Kubernetes deployments can source
@@ -334,6 +335,7 @@ func main() {
 			OIDCInsecureSkipVerify:    *authOIDCInsecureSkipVerify,
 			OIDCCACert:                *authOIDCCACert,
 			OIDCBackchannelLogout:     *authOIDCBackchannelLogout,
+			OIDCEnablePKCE:            *authOIDCEnablePKCE,
 		},
 	}
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -167,6 +167,9 @@ spec:
             {{- if .Values.auth.oidc.backchannelLogout }}
             - --auth-oidc-backchannel-logout
             {{- end }}
+            {{- if .Values.auth.oidc.enablePKCE }}
+            - --auth-oidc-enable-pkce
+            {{- end }}
             {{- end }}
             {{- if .Values.cloud.enabled }}
             {{- if not (or .Values.cloud.token .Values.cloud.existingSecret) }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -247,7 +247,8 @@
             "groupsPrefix": { "type": "string" },
             "caCert": { "type": "string" },
             "insecureSkipVerify": { "type": "boolean" },
-            "backchannelLogout": { "type": "boolean", "description": "Single-replica only — revocations are in-memory." }
+            "backchannelLogout": { "type": "boolean", "description": "Single-replica only — revocations are in-memory." },
+            "enablePKCE": { "type": "boolean", "description": "Enable PKCE (S256) for the OIDC authorization-code flow (opt-in, default off)." }
           }
         }
       }

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -337,6 +337,10 @@ auth:
     # a signed logout_token to /auth/backchannel-logout to revoke sessions.
     # Single-replica only — revocations are stored in memory and lost on pod restart.
     backchannelLogout: false
+    # Enable PKCE (S256) for the OIDC authorization-code flow (opt-in). Default off —
+    # existing deployments are unaffected. Enable only if your IdP supports PKCE and
+    # you want the extra protection against authorization-code interception.
+    enablePKCE: false
 
 # Radar Cloud (hosted SaaS at radarhq.io) — outbound-only tunnel. When
 # enabled, this Radar instance dials out to the Cloud service over

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -23,6 +23,7 @@ import (
 )
 
 const oidcStateCookieName = "radar_oidc_state"
+const oidcVerifierCookieName = "radar_oidc_verifier"
 const oidcForceLoginCookieName = "radar_force_login"
 
 // OIDCHandler handles the OIDC login flow
@@ -34,6 +35,7 @@ type OIDCHandler struct {
 	endSessionEndpoint string                // from OIDC discovery; empty if IdP doesn't support RP-Initiated Logout
 	httpClient         *http.Client          // custom TLS client for OIDC provider calls; nil = default
 	revoker            *MemoryRevoker        // session revocation store; nil = backchannel logout disabled
+	pkceEnabled        bool                  // opt-in PKCE (S256) for the authorization-code flow
 
 	// basePath is the URL prefix Radar serves under ("" at the root). Where Radar
 	// is mounted is the server's concern, not part of the shared auth config, but
@@ -161,6 +163,11 @@ func NewOIDCHandler(ctx context.Context, cfg Config, basePath string) (*OIDCHand
 		httpClient:                        httpClient,
 		backchannelLogoutSupported:        providerClaims.BackchannelLogoutSupported,
 		backchannelLogoutSessionSupported: providerClaims.BackchannelLogoutSessionSupported,
+		pkceEnabled:                       cfg.OIDCEnablePKCE,
+	}
+
+	if h.pkceEnabled {
+		log.Printf("[oidc] PKCE (S256) enabled")
 	}
 
 	if cfg.OIDCBackchannelLogout {
@@ -395,6 +402,37 @@ func replaceOIDCURLBase(raw, fromBase, toBase string) string {
 	return raw
 }
 
+// newFlowCookie builds a short-lived (5 min) HttpOnly cookie for a login-flow
+// secret (state nonce, PKCE verifier). Secure is derived from the request so
+// HTTP/loopback logins can still return the cookie; both the state and verifier
+// cookies go through here so their attributes can't drift apart.
+func (h *OIDCHandler) newFlowCookie(name, value string, r *http.Request) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   300, // 5 minutes
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// clearFlowCookie builds the deletion cookie for a flow cookie. Path and Secure
+// must match the cookie being cleared — some browsers won't evict a Secure
+// cookie with a non-Secure deletion, so over HTTPS the secret would otherwise
+// linger until its own expiry.
+func (h *OIDCHandler) clearFlowCookie(name string, r *http.Request) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
 // HandleLogin redirects to the OIDC provider for authentication
 func (h *OIDCHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	// Generate random state nonce and store in a short-lived cookie for CSRF protection
@@ -406,15 +444,7 @@ func (h *OIDCHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	state := hex.EncodeToString(b)
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     oidcStateCookieName,
-		Value:    state,
-		Path:     "/",
-		MaxAge:   300, // 5 minutes
-		HttpOnly: true,
-		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
-		SameSite: http.SameSiteLaxMode,
-	})
+	http.SetCookie(w, h.newFlowCookie(oidcStateCookieName, state, r))
 
 	// If the user just logged out, force the IdP to show a login prompt instead
 	// of silently re-authenticating with an existing SSO session.
@@ -427,6 +457,14 @@ func (h *OIDCHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 			Path:   "/",
 			MaxAge: -1,
 		})
+	}
+
+	// PKCE (opt-in): generate a per-request verifier, stash it in a cookie for
+	// the callback, and send its S256 challenge to the IdP.
+	if h.pkceEnabled {
+		verifier := oauth2.GenerateVerifier()
+		http.SetCookie(w, h.newFlowCookie(oidcVerifierCookieName, verifier, r))
+		authOpts = append(authOpts, oauth2.S256ChallengeOption(verifier))
 	}
 
 	http.Redirect(w, r, h.oauth.AuthCodeURL(state, authOpts...), http.StatusFound)
@@ -452,12 +490,32 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid state parameter", http.StatusBadRequest)
 		return
 	}
-	// Clear the state cookie
+
+	// Read the PKCE verifier before clearing it. When PKCE is disabled this stays
+	// empty and the flow is byte-for-byte identical to the non-PKCE path.
+	var verifier string
+	if h.pkceEnabled {
+		if c, err := r.Cookie(oidcVerifierCookieName); err == nil {
+			verifier = c.Value
+		}
+	}
+
+	// Clear the state cookie. Clear the verifier cookie at the same point (after
+	// state is validated) so a stale PKCE secret never lingers past a successful
+	// state check, regardless of what happens next in the exchange.
 	http.SetCookie(w, &http.Cookie{
 		Name:   oidcStateCookieName,
 		Path:   "/",
 		MaxAge: -1,
 	})
+	if h.pkceEnabled {
+		http.SetCookie(w, h.clearFlowCookie(oidcVerifierCookieName, r))
+	}
+
+	if h.pkceEnabled && verifier == "" {
+		http.Error(w, "missing PKCE verifier — please retry login", http.StatusBadRequest)
+		return
+	}
 
 	// Exchange code for token
 	code := r.URL.Query().Get("code")
@@ -466,7 +524,11 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.oauth.Exchange(ctx, code)
+	var exchangeOpts []oauth2.AuthCodeOption
+	if h.pkceEnabled {
+		exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(verifier))
+	}
+	token, err := h.oauth.Exchange(ctx, code, exchangeOpts...)
 	if err != nil {
 		// The browser navigating away mid-login (common during a first-load 401
 		// burst) cancels this request's context. That's the client's doing, not a

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -149,6 +150,35 @@ func TestWarnIfInsecureOIDCOrigin(t *testing.T) {
 		if warned != wantWarn {
 			t.Errorf("warnIfInsecureOIDCOrigin(%q) warned=%v, want %v (log: %q)", redirectURL, warned, wantWarn, buf.String())
 		}
+	}
+}
+
+func TestHandleCallback_ClearsVerifierWithSecure(t *testing.T) {
+	h := newTestOIDCHandler()
+	h.pkceEnabled = true
+	h.oauth = oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: "http://127.0.0.1:1/token"}}
+
+	// Behind a TLS-terminating proxy: the verifier cookie was issued Secure, so
+	// its deletion must be Secure too or the browser may not evict it.
+	r := httptest.NewRequest("GET", "/auth/callback?state=abc&code=xyz", nil)
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: "abc"})
+	r.AddCookie(&http.Cookie{Name: oidcVerifierCookieName, Value: "some-verifier"})
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, r) // exchange fails (no IdP), but clears are written first
+
+	var cleared *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == oidcVerifierCookieName && c.MaxAge < 0 {
+			cleared = c
+		}
+	}
+	if cleared == nil {
+		t.Fatal("verifier cookie was not cleared")
+	}
+	if !cleared.Secure {
+		t.Error("verifier deletion cookie must be Secure to evict a Secure cookie over HTTPS")
 	}
 }
 
@@ -725,6 +755,7 @@ type fakeIDP struct {
 	tokenStatus int    // if >= 400, /token returns an error instead of a token
 	omitIDToken bool   // if true, /token omits the id_token from the response
 	claims      string // id_token claims JSON; empty means defaultClaims()
+	gotVerifier string // code_verifier the /token endpoint received (PKCE)
 }
 
 func newFakeIDP(t *testing.T, alg string) *fakeIDP {
@@ -747,6 +778,7 @@ func newFakeIDP(t *testing.T, alg string) *fakeIDP {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		idp.gotVerifier = r.FormValue("code_verifier")
 		if idp.tokenStatus >= 400 {
 			w.WriteHeader(idp.tokenStatus)
 			w.Write([]byte(`{"error":"invalid_grant"}`))
@@ -1115,5 +1147,162 @@ func TestHandleCallback_RedirectsUnderBasePath(t *testing.T) {
 				t.Errorf("Location = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+// cookieByName returns the cookie with the given name from a recorded response,
+// or nil if absent.
+func cookieByName(w *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range w.Result().Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// loginRedirectQuery runs HandleLogin and returns the parsed query of the
+// resulting authorization redirect URL.
+func loginRedirectQuery(t *testing.T, w *httptest.ResponseRecorder) url.Values {
+	t.Helper()
+	if w.Code != http.StatusFound {
+		t.Fatalf("HandleLogin status = %d, want 302", w.Code)
+	}
+	loc, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect Location: %v", err)
+	}
+	return loc.Query()
+}
+
+func TestHandleLogin_PKCEEnabled(t *testing.T) {
+	h := newTestOIDCHandler()
+	h.pkceEnabled = true
+	h.oauth = oauth2.Config{
+		ClientID:    "test-client",
+		Endpoint:    oauth2.Endpoint{AuthURL: "https://accounts.google.com/o/oauth2/v2/auth"},
+		RedirectURL: "http://localhost:9280/auth/callback",
+		Scopes:      []string{"openid"},
+	}
+
+	r := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	h.HandleLogin(w, r)
+
+	verifierCookie := cookieByName(w, oidcVerifierCookieName)
+	if verifierCookie == nil || verifierCookie.Value == "" {
+		t.Fatal("expected verifier cookie to be set when PKCE enabled")
+	}
+	// Verifier cookie must mirror the state cookie's flow attributes.
+	if verifierCookie.MaxAge != 300 || !verifierCookie.HttpOnly || verifierCookie.SameSite != http.SameSiteLaxMode || verifierCookie.Path != "/" {
+		t.Errorf("verifier cookie attributes drift from state cookie: %+v", verifierCookie)
+	}
+
+	q := loginRedirectQuery(t, w)
+	if got := q.Get("code_challenge_method"); got != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", got)
+	}
+	// The challenge must be derived from the exact verifier stored in the cookie.
+	want := oauth2.S256ChallengeFromVerifier(verifierCookie.Value)
+	if got := q.Get("code_challenge"); got != want {
+		t.Errorf("code_challenge = %q, want %q (S256 of cookie verifier)", got, want)
+	}
+}
+
+func TestHandleLogin_PKCEDisabled(t *testing.T) {
+	h := newTestOIDCHandler() // pkceEnabled defaults to false
+	h.oauth = oauth2.Config{
+		ClientID:    "test-client",
+		Endpoint:    oauth2.Endpoint{AuthURL: "https://accounts.google.com/o/oauth2/v2/auth"},
+		RedirectURL: "http://localhost:9280/auth/callback",
+		Scopes:      []string{"openid"},
+	}
+
+	r := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	h.HandleLogin(w, r)
+
+	if c := cookieByName(w, oidcVerifierCookieName); c != nil {
+		t.Errorf("no verifier cookie expected when PKCE disabled, got %+v", c)
+	}
+	q := loginRedirectQuery(t, w)
+	if q.Get("code_challenge") != "" || q.Get("code_challenge_method") != "" {
+		t.Errorf("no PKCE params expected when disabled, got challenge=%q method=%q", q.Get("code_challenge"), q.Get("code_challenge_method"))
+	}
+}
+
+func TestHandleCallback_PKCEMissingVerifier(t *testing.T) {
+	h := newTestOIDCHandler()
+	h.pkceEnabled = true
+
+	// Valid state, but no verifier cookie present.
+	r := httptest.NewRequest("GET", "/auth/callback?state=abc&code=xyz", nil)
+	r.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: "abc"})
+	w := httptest.NewRecorder()
+	h.HandleCallback(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "PKCE verifier") {
+		t.Errorf("expected PKCE verifier error, got %q", w.Body.String())
+	}
+}
+
+// TestPKCEFullFlow drives the real login→callback flow against a fake IdP with
+// PKCE enabled: HandleLogin mints the verifier + challenge, and the extracted
+// state + verifier cookie are fed back into HandleCallback. Asserts the exchange
+// succeeds AND the token endpoint received the code_verifier bound to the
+// challenge the browser was redirected with.
+func TestPKCEFullFlow(t *testing.T) {
+	idp := newFakeIDP(t, oidc.RS256)
+	h := idp.newHandler(t, Config{OIDCEnablePKCE: true})
+
+	// Drive HandleLogin to obtain the real state + verifier the handler generated.
+	lw := httptest.NewRecorder()
+	h.HandleLogin(lw, httptest.NewRequest("GET", "/auth/login", nil))
+	q := loginRedirectQuery(t, lw)
+	state := q.Get("state")
+	if state == "" {
+		t.Fatal("no state in login redirect")
+	}
+	verifierCookie := cookieByName(lw, oidcVerifierCookieName)
+	if verifierCookie == nil || verifierCookie.Value == "" {
+		t.Fatal("no verifier cookie from HandleLogin")
+	}
+	if got, want := q.Get("code_challenge"), oauth2.S256ChallengeFromVerifier(verifierCookie.Value); got != want {
+		t.Fatalf("login challenge %q not bound to verifier cookie (want %q)", got, want)
+	}
+
+	// Feed BOTH the state and the verifier cookie into HandleCallback.
+	cr := httptest.NewRequest("GET", "/auth/callback?state="+url.QueryEscape(state)+"&code=c", nil)
+	cr.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: state})
+	cr.AddCookie(verifierCookie)
+	cw := httptest.NewRecorder()
+	h.HandleCallback(cw, cr)
+
+	if cw.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want 302 (body: %s)", cw.Code, cw.Body.String())
+	}
+	if idp.gotVerifier != verifierCookie.Value {
+		t.Errorf("token endpoint code_verifier = %q, want %q", idp.gotVerifier, verifierCookie.Value)
+	}
+	// Verifier cookie must be cleared after a successful callback.
+	if c := cookieByName(cw, oidcVerifierCookieName); c == nil || c.MaxAge != -1 {
+		t.Errorf("verifier cookie should be cleared (MaxAge -1) after callback, got %+v", c)
+	}
+}
+
+// TestPKCEDisabledSendsNoVerifier confirms the opt-out path is byte-for-byte
+// unchanged: with PKCE off, the token endpoint receives no code_verifier.
+func TestPKCEDisabledSendsNoVerifier(t *testing.T) {
+	idp := newFakeIDP(t, oidc.RS256)
+	h := idp.newHandler(t, Config{}) // PKCE off
+	w := runCallback(h)
+	if w.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want 302 (body: %s)", w.Code, w.Body.String())
+	}
+	if idp.gotVerifier != "" {
+		t.Errorf("token endpoint received code_verifier %q with PKCE disabled", idp.gotVerifier)
 	}
 }

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -43,6 +43,7 @@ type Config struct {
 	OIDCInsecureSkipVerify    bool     // skip TLS verification for OIDC provider (dev/test only)
 	OIDCCACert                string   // path to CA certificate file for OIDC provider TLS
 	OIDCBackchannelLogout     bool     // enable backchannel logout endpoint
+	OIDCEnablePKCE            bool     // enable PKCE (S256) for the OIDC authorization-code flow (opt-in)
 }
 
 // SessionRevoker checks whether a session has been revoked (e.g., via OIDC


### PR DESCRIPTION
## Opt-in PKCE (S256) for OIDC — default OFF

Adds PKCE (RFC 7636, S256) to radar's OIDC authorization-code flow. Defense-in-depth against authorization-code injection; OAuth 2.1 baseline.

### Off by default — zero blast radius
Gated behind `--auth-oidc-enable-pkce` (Helm: `auth.oidc.enablePKCE`), default **false**. When disabled, the token exchange runs exactly as before (`Exchange(ctx, code)` with no options) — byte-for-byte unchanged. Existing deployments are unaffected on upgrade; you opt in only if you want PKCE. No auto-detection, so nothing changes for an IdP that doesn't support it unless you turn it on.

### When enabled
- `HandleLogin` generates a per-request verifier (`oauth2.GenerateVerifier`), stores it in a short-lived `radar_oidc_verifier` cookie, and sends the S256 challenge to the IdP.
- `HandleCallback` reads + clears the verifier at the same point as the state cookie (after state validation), then passes `code_verifier` to the token exchange. Missing verifier → `400` "please retry login".
- The verifier cookie mirrors the **state** cookie's attributes via a shared `newFlowCookie` helper — derived `Secure` (so HTTP/loopback logins still work), `HttpOnly`, `SameSite=Lax`, 5-minute expiry — so the two can't drift.

### Scope
Backend + Helm wiring only. Does **not** change multi-tab behavior (still one state/verifier cookie pair) — that's a separate concurrency-tolerant-state change.

### Tests
5 new tests in `internal/auth`: challenge↔verifier binding (`code_challenge == S256(verifier)`), a full `HandleLogin`→`HandleCallback` drive against a fake IdP asserting the token endpoint received the exact `code_verifier`, verifier-cookie cleared on callback, missing-verifier→`400`, and the disabled path sends no `code_verifier`. Full `internal/auth` suite green; `helm template` renders correctly in both default and opt-in modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OIDC login/callback path and cookie handling, but behavior is unchanged unless PKCE is explicitly enabled; misconfiguration could break login for IdPs that don’t support PKCE.
> 
> **Overview**
> Adds **opt-in PKCE (S256)** to Radar’s OIDC login flow, gated by `--auth-oidc-enable-pkce` / Helm `auth.oidc.enablePKCE` (default **off**). With PKCE disabled, token exchange stays unchanged.
> 
> When enabled, login stores a per-request verifier in `radar_oidc_verifier`, sends the S256 challenge to the IdP, and the callback passes `code_verifier` on exchange; a missing verifier returns **400**. State and verifier cookies share `newFlowCookie` / `clearFlowCookie` so attributes (including **Secure** behind TLS-terminating proxies) stay aligned.
> 
> `OIDCEnablePKCE` is wired through `pkg/auth` config, explorer flags, and Helm values/schema. New tests cover enabled/disabled login, full login→callback against a fake IdP, and verifier cookie clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08fdbd0ba00b6537ceb69364037ec6a0b4102eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->