### PR TITLE
test(timeline): add RejectsOverLimit capability to the wire-contract suite

### DIFF
--- a/internal/server/timeline_contract_test.go
+++ b/internal/server/timeline_contract_test.go
@@ -17,7 +17,8 @@ import (
 // servers prove they speak the one contract; each declares its capabilities and
 // the suite gates the deliberate divergences on them. OSS's capabilities:
 // "<epoch>:<seq>" cursors, foreign cursor → 400, no coverage records, a 10k row
-// cap, and a required (non-defaulted) window.
+// cap that clamps an over-cap limit rather than rejecting it, and a required
+// (non-defaulted) window.
 func TestHandleTimelineEvents_WireContract(t *testing.T) {
 	prev := k8s.GetConnectionStatus()
 	k8s.SetConnectionStatus(k8s.ConnectionStatus{State: k8s.StateConnected})
@@ -54,5 +55,6 @@ func TestHandleTimelineEvents_WireContract(t *testing.T) {
 		MaxRows:              10000,
 		RejectsForeignCursor: true,
 		DefaultsWindow:       false,
+		RejectsOverLimit:     false,
 	})
 }

--- a/pkg/timelineapi/wiretest/conformance.go
+++ b/pkg/timelineapi/wiretest/conformance.go
@@ -78,6 +78,18 @@ type Config struct {
 	// DefaultsWindow is true when an absent from/to defaults a window (hub, 24h);
 	// false when from/to are required (OSS).
 	DefaultsWindow bool
+	// RejectsOverLimit declares what the server does with a limit above MaxRows.
+	//
+	// false (default) = the server CLAMPS the over-cap limit to its max and
+	// returns 200. radar OSS is a local, single-user tool: an oversized limit
+	// costs nothing shared, so it forgives the caller and serves up to the cap.
+	//
+	// true = the server REJECTS limit > MaxRows with HTTP 400. radar-hub is a
+	// multi-tenant service where an oversized query reads shared storage on
+	// behalf of one tenant; it fails loud at the boundary rather than silently
+	// truncating, so the caller learns the request was too big instead of
+	// mistaking a capped page for the full result.
+	RejectsOverLimit bool
 }
 
 // Run drives the shared timeline wire contract against cfg's live handler.
@@ -190,10 +202,16 @@ func Run(t *testing.T, cfg Config) {
 		}
 	})
 
-	// --- shared invariant: an over-cap limit clamps, never errors (gated on MaxRows) ---
-	t.Run("over-limit request clamps rather than errors", func(t *testing.T) {
+	// --- capability-gated: an over-cap limit clamps (OSS) or is rejected 400 (hub) ---
+	t.Run("over-limit request clamps or is rejected per capability", func(t *testing.T) {
 		over := strconv.Itoa(cfg.MaxRows + 5000)
 		rr := cfg.request(t, map[string]string{"from": fromMs, "to": toMs, "limit": over})
+		if cfg.RejectsOverLimit {
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("over-limit status = %d, want 400 (reject: limit > MaxRows); body %s", rr.Code, rr.Body.String())
+			}
+			return
+		}
 		if rr.Code != http.StatusOK {
 			t.Fatalf("over-limit status = %d, want 200 (clamp, not error); body %s", rr.Code, rr.Body.String())
 		}


### PR DESCRIPTION
The shared wire-contract suite´s over-limit invariant assumed a server *clamps* an over-cap `limit`. radar-hub instead **rejects** `limit > MaxRows` with a 400 — an **intentional** divergence, not a bug:

- **radar OSS** is a local, single-user tool. An oversized limit costs nothing shared, so it forgives the caller and serves up to the cap (clamp + `truncated`).
- **radar-hub** is a multi-tenant service where an oversized query reads **shared** storage on behalf of one tenant. It fails **loud** at the boundary (400) rather than silently truncating, so the caller learns the request was too big instead of mistaking a capped page for the full result.

This adds a `RejectsOverLimit` capability so the suite **declares and tests both** behaviors instead of assuming one:
- `false` (default) → clamp + 200 (radar OSS)
- `true` → reject with 400 (radar-hub)

radar OSS´s own contract test now sets `RejectsOverLimit: false` explicitly, so the divergence is self-documenting. **No runtime/handler behavior changes** — test-harness + a new declared capability only.

## Tests
`cd pkg && go build ./... && go test ./timelineapi/...` and `go test ./internal/server/ -run Contract` — all green (incl. the over-limit subtest).

## Follow-up (after merge)
Tag `pkg/v1.10.1`, then radar-hub sets `RejectsOverLimit: true` to probe its real `>cap` 400 boundary (closes the last blind spot on radar-hub #184).

Part of RAD-38.

https://claude.ai/code/session_018ea2h6ki1JweHcMU8F2LR8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the wire conformance harness; no runtime timeline API behavior is modified.
> 
> **Overview**
> The shared timeline **wire-contract** suite no longer treats “`limit` above `MaxRows` always clamps with 200” as a universal invariant. It adds a **`RejectsOverLimit`** capability on `wiretest.Config` so each server declares whether over-cap limits are **clamped** (radar OSS) or **rejected with HTTP 400** (radar-hub).
> 
> The over-limit subtest is renamed and branches on that flag: expect **400** when `RejectsOverLimit` is true, otherwise keep asserting **200** and row count ≤ `MaxRows`. OSS’s contract test sets **`RejectsOverLimit: false`** explicitly and its comment now documents clamp-vs-reject behavior.
> 
> **No production handler changes**—only the conformance harness and declared capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e019ea12d25e021f7e9a2f5ce3481979df18e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->