### PR TITLE
fix(cnpg): CNPG v1 correctness repair — 8 shipped bugs + WAL-archiving/backup-failure detection

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -764,9 +764,11 @@ They roll up under two categories: `backup_failed` for runs, and `backup_target_
 - Storage configuration: data size, storage class, WAL storage
 - Backup configuration: destination, retention policy, last successful backup, recovery point
 - Monitoring: PodMonitor integration, custom query ConfigMaps
-- Replication settings (for replica clusters)
+- Replication settings (for replica clusters), with per-instance role and timeline ID
 - PostgreSQL parameters
 - Health detection (AlertBanner for degraded clusters, failover/switchover in progress)
+- **WAL archiving failure** — a first-class AlertBanner driven by the `ContinuousArchiving` condition. This is the classic silent CNPG incident: the cluster keeps serving traffic normally while the recovery point stops advancing. The condition proves the last archive attempt failed, so Radar reports "archiving failing since &lt;time&gt; — the recovery point may not be advancing" and deliberately does not claim an exact RPO
+- **Last-backup failure** — driven by the `LastBackupSucceeded` condition. CNPG also sets this condition False with reason `BackupStarted` while a backup is merely in flight; Radar ignores that state rather than alerting on every backup run
 
 **Backup Detail View:**
 - Phase, backup method, duration, start/stop timestamps
@@ -782,12 +784,34 @@ They roll up under two categories: `backup_failed` for runs, and `backup_target_
 
 **Pooler Detail View:**
 - Type (read-write/read-only) with colored badge, pool mode
-- Instances ready/desired
+- Instances scheduled/desired
 - Cluster reference with clickable link
 - PgBouncer parameters
-- Degraded state detection (AlertBanner when not all instances ready)
+- Degraded state detection (AlertBanner when not all instances are scheduled)
+
+Note `Pooler.status.instances` counts pods *trying to be scheduled*, not ready pods — a Pooler whose PgBouncer pods are all Pending still reports the full count. Radar therefore labels the healthy state **Scheduled** rather than Ready; actual readiness lives on the Deployment CNPG generates for the Pooler (same name, same namespace).
 
 **Resource Browser:** Smart columns show status, instance counts (with degraded highlighting), primary instance, image tag, storage size, cluster reference, and schedule expressions.
+
+### Phase classification
+
+Cluster phases are full English sentences (`Cluster is unrecoverable and needs manual intervention`), not enum tokens, and are matched on equality. They are bucketed as healthy / transient / failing / terminal / attention; terminal phases outrank instance counts, so an unrecoverable cluster whose pods happen to still be Ready is still rendered red. An unrecognized phase from a newer CNPG minor surfaces verbatim as unknown rather than being guessed at.
+
+Backup phases are lowercase tokens. `walArchivingFailing` is treated as a cluster-level signal, not an ordinary backup failure — archiving is broken upstream of that Backup, so the whole recovery window is affected.
+
+The taxonomy is defined twice — TypeScript for the badge, Go for the issue detector — and pinned by `TestCNPGPhaseTaxonomyMatchesFrontend`, which fails if the two drift.
+
+### Backup: in-tree vs the barman-cloud plugin
+
+In-tree `spec.backup.barmanObjectStore` is deprecated as of CNPG 1.26. Clusters migrated to the [barman-cloud plugin](https://github.com/cloudnative-pg/plugin-barman-cloud) keep their config in an `ObjectStore` CR (`barmancloud.cnpg.io/v1`), and CNPG stops populating `status.lastSuccessfulBackup` / `firstRecoverabilityPoint` by design. Radar detects the plugin from `spec.plugins[]`, names the ObjectStore and resolved server key, and says so explicitly — rather than rendering an empty backup section that reads identically to "no backups configured". Reading the ObjectStore's recovery window is not yet implemented.
+
+### Cluster Audit checks
+
+| Check | What it catches |
+|-------|-----------------|
+| `cnpgNoDeclarativeBackup` | A CNPG Cluster with no ScheduledBackup targeting it |
+
+Deliberately narrow: the absence of a ScheduledBackup does not prove a cluster is unprotected (on-demand Backups, volume snapshots and external schedulers all exist), so the finding asserts only that no schedule is *declared*, at posture severity. All three `spec.method` values — `barmanObjectStore`, `volumeSnapshot` and `plugin` — count as a declared schedule. Suspended schedules count as present, since suspension is deliberate operator intent. The check does not run at all unless a synced cluster-wide ScheduledBackup informer backs the inventory, because absence would otherwise be unprovable.
 
 ### Supported CRDs
 
@@ -797,6 +821,8 @@ They roll up under two categories: `backup_failed` for runs, and `backup_target_
 | Backup | `postgresql.cnpg.io/v1` | — | Yes | — |
 | ScheduledBackup | `postgresql.cnpg.io/v1` | — | Yes | — |
 | Pooler | `postgresql.cnpg.io/v1` | — | Yes | — |
+
+The `clusters` and `backups` plurals collide with Cluster API and Velero respectively. Radar resolves both with positive API-group guards, so a third operator's CRD sharing either plural (KubeBlocks, Redis/Valkey operators) falls through to the generic renderer instead of inheriting a fabricated PostgreSQL status.
 
 ---
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -784,7 +784,7 @@ They roll up under two categories: `backup_failed` for runs, and `backup_target_
 
 **Pooler Detail View:**
 - Type (read-write/read-only) with colored badge, pool mode
-- Instances scheduled/desired
+- Instances scheduled/desired (not readiness — see below)
 - Cluster reference with clickable link
 - PgBouncer parameters
 - Degraded state detection (AlertBanner when not all instances are scheduled)

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -65,6 +65,10 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 		input.AllServices = listNamespaced(cache.Services(), nil)
 	}
 
+	// CloudNativePG clusters + their backup schedules for the declarative-backup
+	// posture check. Nil inventory (CNPG absent / RBAC denied) → check no-ops.
+	input.CNPGClusters, input.CNPGScheduledBackups, input.CNPGScheduledBackupsAuthoritative = listCNPGDynamic(namespaces)
+
 	return bp.RunChecks(input)
 }
 
@@ -152,6 +156,64 @@ func listCrossplaneDynamic(namespaces []string) (mrs, xrs []*unstructured.Unstru
 		}
 	}
 	return mrs, xrs
+}
+
+const cnpgGroup = "postgresql.cnpg.io"
+
+// listCNPGDynamic gathers CNPG Clusters (scoped to the audited namespaces —
+// they're the subjects the check reports on) plus ScheduledBackups. A
+// ScheduledBackup always lives in its Cluster's namespace, so the targets need
+// no cross-namespace widening; what they DO need is absence-authority.
+//
+// `scheduledAuthoritative` is true only when a synced cluster-wide
+// ScheduledBackup informer backs the list. Under a namespace-scoped fallback the
+// cache knows a subset of namespaces, so "no schedule targets this cluster"
+// could just mean "not listed" — the check must not run at all there.
+func listCNPGDynamic(namespaces []string) (clusters, scheduledBackups []*unstructured.Unstructured, scheduledAuthoritative bool) {
+	cache := k8s.GetDynamicResourceCache()
+	if cache == nil {
+		return nil, nil, false
+	}
+
+	clustersGVR := schema.GroupVersionResource{Group: cnpgGroup, Version: "v1", Resource: "clusters"}
+	scheduledGVR := schema.GroupVersionResource{Group: cnpgGroup, Version: "v1", Resource: "scheduledbackups"}
+	_ = cache.EnsureWatching(clustersGVR) // best-effort; unserved/denied → no-op
+	_ = cache.EnsureWatching(scheduledGVR)
+
+	nsSet := make(map[string]bool, len(namespaces))
+	for _, ns := range namespaces {
+		nsSet[ns] = true
+	}
+	inScope := func(u *unstructured.Unstructured) bool {
+		if len(namespaces) == 0 {
+			return true
+		}
+		ns := u.GetNamespace()
+		return ns == "" || nsSet[ns]
+	}
+
+	list := func(gvr schema.GroupVersionResource) []*unstructured.Unstructured {
+		items, err := cache.ListWatched(gvr)
+		if err != nil {
+			if !apierrors.IsForbidden(err) && !apierrors.IsUnauthorized(err) {
+				log.Printf("[audit] CNPG scan: skipping %s: %v", gvr.GroupResource(), err)
+			}
+			return nil
+		}
+		var out []*unstructured.Unstructured
+		for _, u := range items {
+			if u == nil || !inScope(u) {
+				continue
+			}
+			out = append(out, u)
+		}
+		return out
+	}
+
+	clusters = list(clustersGVR)
+	scheduledBackups = list(scheduledGVR)
+	scheduledAuthoritative = cache.IsClusterWideSynced(scheduledGVR)
+	return clusters, scheduledBackups, scheduledAuthoritative
 }
 
 // traefikGroups are the two CRD groups Traefik has shipped — current and legacy.

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -1,0 +1,183 @@
+package issues
+
+import (
+	"fmt"
+
+	"github.com/skyhook-io/radar/pkg/conditions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CloudNativePG phase strings, copied verbatim from upstream
+// api/v1/cluster_types.go and api/v1/backup_types.go (verified against CNPG
+// 1.27). They are full English sentences, so they are matched on equality —
+// a substring match would misfile "Upgrading Postgres major version" under
+// "Upgrading cluster".
+//
+// This taxonomy is mirrored in the frontend at
+// packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts. The two must
+// agree: a divergence produces a red badge with no issue, or an issue with no
+// badge.
+const (
+	cnpgPhaseHealthy       = "Cluster in healthy state"
+	cnpgPhaseFailingOver   = "Failing over"
+	cnpgPhaseUnrecoverable = "Cluster is unrecoverable and needs manual intervention"
+	cnpgPhaseUnknownPlugin = "Cluster cannot proceed to reconciliation due to an unknown plugin being required"
+	cnpgPhaseFailurePlugin = "Cluster cannot proceed to reconciliation due to an error while interacting with plugins"
+)
+
+// cnpgTerminalPhases have stopped reconciling and do not self-heal.
+var cnpgTerminalPhases = map[string]bool{
+	cnpgPhaseUnrecoverable:                            true,
+	cnpgPhaseUnknownPlugin:                            true,
+	cnpgPhaseFailurePlugin:                            true,
+	"Unable to create required cluster objects":       true,
+	"Cluster has incomplete or invalid image catalog": true,
+	"Cluster cannot execute instance online upgrade due to missing architecture binary": true,
+}
+
+// cnpgAttentionPhases are stalled waiting on a human. Under
+// primaryUpdateStrategy: supervised this is the documented resting state, so it
+// only raises an issue under an unsupervised strategy.
+var cnpgAttentionPhases = map[string]bool{
+	"Waiting for user action": true,
+	"Cluster upgrade delayed": true,
+}
+
+func detectCNPGIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
+	switch kind {
+	case "Cluster":
+		return detectCNPGClusterIssues(gvr, kind, u)
+	case "Backup":
+		return detectCNPGBackupIssues(gvr, kind, u)
+	}
+	return nil
+}
+
+// Every CNPG issue carries a Fingerprint because one cluster genuinely has
+// several independent causes at once — WAL archiving can be failing WHILE the
+// phase is unrecoverable. Without one the issue ID is category-only (see
+// discriminator in identity.go) and all but one cause is dropped, which would
+// silently lose the archiving signal this detector exists to surface.
+//
+// The phase-derived issues deliberately SHARE a fingerprint: a cluster has
+// exactly one phase, so they are mutually exclusive, and a shared token keeps
+// the issue identity stable as the phase moves between buckets.
+func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
+	var out []Issue
+	ns, name := u.GetNamespace(), u.GetName()
+	created := u.GetCreationTimestamp().Time
+	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
+
+	// WAL archiving is the headline signal: the cluster keeps serving traffic
+	// normally while the recovery point stops advancing, so nothing else in the
+	// object looks wrong. Critical even though the cluster is "up".
+	//
+	// The condition proves the LAST ARCHIVE ATTEMPT failed — it is not an exact
+	// RPO, and the message deliberately doesn't claim one.
+	if _, reason, msg, since, ok := conditions.FindFalseCondition(u, "ContinuousArchiving"); ok {
+		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityCritical,
+			"CNPGWALArchivingFailing",
+			cnpgMessage("WAL archiving is failing; the recovery point may not be advancing", reason, msg),
+			since, "CNPGWALArchivingFailing", created))
+	}
+
+	// CNPG also sets LastBackupSucceeded=False with reason BackupStarted while a
+	// backup is merely in flight. Treating that as a failure would raise an issue
+	// on every backup run — the canonical alert-fatigue trap.
+	if _, reason, msg, since, ok := conditions.FindFalseCondition(u, "LastBackupSucceeded"); ok && reason != "BackupStarted" {
+		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
+			"CNPGLastBackupFailed",
+			cnpgMessage("The most recent backup attempt failed", reason, msg),
+			since, "CNPGLastBackupFailed", created))
+	}
+
+	switch {
+	case cnpgTerminalPhases[phase]:
+		reason := "CNPGClusterTerminal"
+		switch phase {
+		case cnpgPhaseUnrecoverable:
+			reason = "CNPGClusterUnrecoverable"
+		case cnpgPhaseUnknownPlugin, cnpgPhaseFailurePlugin:
+			reason = "CNPGClusterPluginFailure"
+		}
+		// Phase carries no lastTransitionTime, so since=0 — newConditionIssue
+		// omits issue_timing rather than inventing one from now().
+		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityCritical,
+			reason, phase, 0, "CNPGClusterPhase", created))
+
+	case phase == cnpgPhaseFailingOver:
+		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
+			"CNPGClusterFailingOver", phase, 0, "CNPGClusterPhase", created))
+
+	case cnpgAttentionPhases[phase]:
+		strategy, _, _ := unstructured.NestedString(u.Object, "spec", "primaryUpdateStrategy")
+		if strategy != "supervised" {
+			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
+				"CNPGClusterWaitingForUser", phase, 0, "CNPGClusterPhase", created))
+		}
+
+	case phase == cnpgPhaseHealthy || phase == "":
+		// Nothing phase-derived to report.
+
+	default:
+		// Unrecognized phase (a newer CNPG minor). Don't invent a severity —
+		// the degraded-instances check below still applies.
+	}
+
+	// Instance shortfall is only worth reporting when the phase hasn't already
+	// explained it; a transient phase like "Creating a new replica" legitimately
+	// runs below the desired count.
+	if len(out) == 0 && phase == cnpgPhaseHealthy {
+		desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
+		ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
+		if okD && okR && desired > 0 && ready < desired {
+			severity := SeverityWarning
+			if ready == 0 {
+				severity = SeverityCritical
+			}
+			out = append(out, newConditionIssue(gvr, kind, ns, name, severity,
+				"CNPGClusterDegraded",
+				fmt.Sprintf("Only %d of %d instances are ready", ready, desired),
+				0, "CNPGClusterDegraded", created))
+		}
+	}
+
+	return out
+}
+
+func detectCNPGBackupIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
+	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
+	ns, name := u.GetNamespace(), u.GetName()
+	created := u.GetCreationTimestamp().Time
+
+	switch phase {
+	case "walArchivingFailing":
+		// Archiving is broken upstream of this Backup, so every subsequent
+		// backup and the whole recovery window are affected — not one object.
+		msg := "WAL archiving is failing, so this backup and the cluster's recovery window are both affected"
+		if e, _, _ := unstructured.NestedString(u.Object, "status", "error"); e != "" {
+			msg += ": " + e
+		}
+		return []Issue{newConditionIssue(gvr, kind, ns, name, SeverityCritical,
+			"CNPGWALArchivingFailing", msg, 0, "CNPGWALArchivingFailing", created)}
+	case "failed":
+		msg := "Backup failed"
+		if e, _, _ := unstructured.NestedString(u.Object, "status", "error"); e != "" {
+			msg += ": " + e
+		}
+		return []Issue{newConditionIssue(gvr, kind, ns, name, SeverityWarning,
+			"CNPGBackupFailed", msg, 0, "CNPGBackupFailed", created)}
+	}
+	return nil
+}
+
+func cnpgMessage(base, reason, msg string) string {
+	if msg != "" {
+		return base + ": " + msg
+	}
+	if reason != "" {
+		return base + " (" + reason + ")"
+	}
+	return base
+}

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -41,7 +41,29 @@ var cnpgTerminalPhases = map[string]bool{
 // only raises an issue under an unsupervised strategy.
 var cnpgAttentionPhases = map[string]bool{
 	"Waiting for user action": true,
-	"Cluster upgrade delayed": true,
+}
+
+// cnpgTransientPhases are mid-operation and self-resolving. Enumerated (rather
+// than left to the unknown fallback) so the frontend parity test covers them
+// and a genuinely new phase is still distinguishable from a known transient.
+//
+// "Cluster upgrade delayed" belongs here, not in attention: upstream sets it
+// when an upgrade is postponed by the OPERATOR's own rollout-delay config and
+// requeued — no human is being waited on, and it has nothing to do with
+// primaryUpdateStrategy.
+var cnpgTransientPhases = map[string]bool{
+	"Setting up primary":                                       true,
+	"Creating a new replica":                                   true,
+	"Switchover in progress":                                   true,
+	"Upgrading cluster":                                        true,
+	"Upgrading Postgres major version":                         true,
+	"Online upgrade in progress":                               true,
+	"Applying configuration":                                   true,
+	"Primary instance is being restarted in-place":             true,
+	"Primary instance is being restarted without a switchover": true,
+	"Promoting to primary cluster":                             true,
+	"Waiting for the instances to become active":               true,
+	"Cluster upgrade delayed":                                  true,
 }
 
 func detectCNPGIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
@@ -78,7 +100,7 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	if _, reason, msg, since, ok := conditions.FindFalseCondition(u, "ContinuousArchiving"); ok {
 		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityCritical,
 			"CNPGWALArchivingFailing",
-			cnpgMessage("WAL archiving is failing; the recovery point may not be advancing", reason, msg),
+			cnpgMessage("The last WAL archival did not complete; recovery-point advancement is uncertain", reason, msg),
 			since, "CNPGWALArchivingFailing", created))
 	}
 
@@ -92,8 +114,10 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 			since, "CNPGLastBackupFailed", created))
 	}
 
+	phaseExplained := false
 	switch {
 	case cnpgTerminalPhases[phase]:
+		phaseExplained = true
 		reason := "CNPGClusterTerminal"
 		switch phase {
 		case cnpgPhaseUnrecoverable:
@@ -107,15 +131,22 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 			reason, phase, 0, "CNPGClusterPhase", created))
 
 	case phase == cnpgPhaseFailingOver:
+		phaseExplained = true
 		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 			"CNPGClusterFailingOver", phase, 0, "CNPGClusterPhase", created))
 
 	case cnpgAttentionPhases[phase]:
 		strategy, _, _ := unstructured.NestedString(u.Object, "spec", "primaryUpdateStrategy")
 		if strategy != "supervised" {
+			phaseExplained = true
 			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 				"CNPGClusterWaitingForUser", phase, 0, "CNPGClusterPhase", created))
 		}
+
+	case cnpgTransientPhases[phase]:
+		// Mid-operation: running below the desired instance count is expected,
+		// so the shortfall check below is suppressed without raising an issue.
+		phaseExplained = true
 
 	case phase == cnpgPhaseHealthy || phase == "":
 		// Nothing phase-derived to report.
@@ -125,10 +156,11 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 		// the degraded-instances check below still applies.
 	}
 
-	// Instance shortfall is only worth reporting when the phase hasn't already
-	// explained it; a transient phase like "Creating a new replica" legitimately
-	// runs below the desired count.
-	if len(out) == 0 && phase == cnpgPhaseHealthy {
+	// Instance shortfall is reported unless the PHASE already explains it. This
+	// must not key on len(out): a WAL-archiving or failed-backup issue is an
+	// unrelated cause, and letting either suppress the shortfall would hide a
+	// cluster with zero ready instances behind a backup warning.
+	if !phaseExplained {
 		desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
 		ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
 		if okD && okR && desired > 0 && ready < desired {

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -66,6 +66,27 @@ var cnpgTransientPhases = map[string]bool{
 	"Cluster upgrade delayed":                                  true,
 }
 
+// cnpgSuppressesGenericConditions reports whether the generic False-condition
+// walk must stay quiet for this object.
+//
+// The curated seam treats an empty result as "nothing to say", not "handled",
+// so the generic walk still runs after this detector deliberately stays silent.
+// During a switchover, replica creation or an upgrade CNPG sets Ready=False
+// with reason ClusterIsNotReady — which is NOT in conditions'
+// transientConditionReasons, so the noise floor doesn't catch it and a warning
+// leaks for the exact windows the phase buckets exist to silence.
+//
+// Deliberately scoped to the transient/attention phases rather than the whole
+// kind: outside those windows a False Ready is worth surfacing, and blanket
+// ownership would silence reasons like DetachedVolume on a settled cluster.
+func cnpgSuppressesGenericConditions(group, kind string, u *unstructured.Unstructured) bool {
+	if group != "postgresql.cnpg.io" || kind != "Cluster" {
+		return false
+	}
+	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
+	return cnpgTransientPhases[phase] || cnpgAttentionPhases[phase]
+}
+
 func detectCNPGIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
 	switch kind {
 	case "Cluster":
@@ -136,9 +157,15 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 			"CNPGClusterFailingOver", phase, 0, "CNPGClusterPhase", created))
 
 	case cnpgAttentionPhases[phase]:
+		// The phase explains the state either way — primaryUpdateStrategy only
+		// decides whether it is worth an issue. Leaving phaseExplained false
+		// under `supervised` let the shortfall check emit CNPGClusterDegraded
+		// while the badge showed the attention phase, and a supervised cluster
+		// waiting on a human is precisely when instances are legitimately below
+		// the desired count.
+		phaseExplained = true
 		strategy, _, _ := unstructured.NestedString(u.Object, "spec", "primaryUpdateStrategy")
 		if strategy != "supervised" {
-			phaseExplained = true
 			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 				"CNPGClusterWaitingForUser", phase, 0, "CNPGClusterPhase", created))
 		}

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -94,14 +94,25 @@ func cnpgSuppressesGenericConditions(group, kind string, u *unstructured.Unstruc
 		return false
 	}
 	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
-	if !cnpgTransientPhases[phase] && !cnpgAttentionPhases[phase] {
+
+	// Attention phases suppress WITHOUT an age bound. "Waiting for user action"
+	// under primaryUpdateStrategy: supervised is the documented resting state and
+	// legitimately persists until a human acts — bounding it would turn a
+	// supported configuration into a permanently-lit issue, the alert-fatigue
+	// trap this detector exists to avoid. (Under an unsupervised strategy the
+	// curated detector emits its own issue, so the generic walk is already
+	// skipped before this is consulted.)
+	if cnpgAttentionPhases[phase] {
+		return true
+	}
+	if !cnpgTransientPhases[phase] {
 		return false
 	}
-	// A phase that never advances is not transient. CNPG clusters do get stuck
-	// mid-operation (upstream #3365: "Creating a new replica" pinned at 2/3 with
-	// Ready=False indefinitely), and an unbounded suppression would keep that
-	// silent forever — worse than the noise it was added to remove. Bound it by
-	// the condition's own age so a genuinely stuck cluster surfaces.
+	// A transient phase that never advances is not transient. CNPG clusters do
+	// get stuck mid-operation (upstream #3365: "Creating a new replica" pinned at
+	// 2/3 with Ready=False indefinitely), and an unbounded suppression would keep
+	// that silent forever — worse than the noise it was added to remove. Bound it
+	// by the condition's own age so a genuinely stuck cluster surfaces.
 	if _, _, _, since, ok := conditions.FindFalseCondition(u); ok && since > cnpgTransientConditionGrace {
 		return false
 	}

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/skyhook-io/radar/pkg/conditions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,7 +35,16 @@ var cnpgTerminalPhases = map[string]bool{
 	"Unable to create required cluster objects":       true,
 	"Cluster has incomplete or invalid image catalog": true,
 	"Cluster cannot execute instance online upgrade due to missing architecture binary": true,
+	// Not in 1.27 or 1.28; added upstream after 1.28 (PhaseDefinitionInvalid).
+	// Matching is by equality, so a phase the running operator never emits is
+	// inert — carrying it costs nothing and keeps a future minor out of the
+	// unknown bucket.
+	"Invalid cluster definition": true,
 }
+
+// cnpgTransientConditionGrace bounds how long a False condition is written off
+// as "mid-operation" before the generic detector is allowed to report it.
+const cnpgTransientConditionGrace = 30 * time.Minute
 
 // cnpgAttentionPhases are stalled waiting on a human. Under
 // primaryUpdateStrategy: supervised this is the documented resting state, so it
@@ -84,7 +94,18 @@ func cnpgSuppressesGenericConditions(group, kind string, u *unstructured.Unstruc
 		return false
 	}
 	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
-	return cnpgTransientPhases[phase] || cnpgAttentionPhases[phase]
+	if !cnpgTransientPhases[phase] && !cnpgAttentionPhases[phase] {
+		return false
+	}
+	// A phase that never advances is not transient. CNPG clusters do get stuck
+	// mid-operation (upstream #3365: "Creating a new replica" pinned at 2/3 with
+	// Ready=False indefinitely), and an unbounded suppression would keep that
+	// silent forever — worse than the noise it was added to remove. Bound it by
+	// the condition's own age so a genuinely stuck cluster surfaces.
+	if _, _, _, since, ok := conditions.FindFalseCondition(u); ok && since > cnpgTransientConditionGrace {
+		return false
+	}
+	return true
 }
 
 func detectCNPGIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
@@ -162,7 +183,10 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 			reason, phase, 0, "CNPGClusterPhase", created))
 
 	case phase == cnpgPhaseFailingOver:
-		phaseExplained = true
+		// A failover explains a shortfall, but not a cluster with nothing
+		// serving — that is a total outage, and letting the phase absorb it
+		// downgraded it to this warning while the badge showed red.
+		phaseExplained = !allDown
 		out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 			"CNPGClusterFailingOver", phase, 0, "CNPGClusterPhase", created))
 

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -135,6 +135,16 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 			since, "CNPGLastBackupFailed", created))
 	}
 
+	desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
+	ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
+	// No phase excuses a database with nothing serving. "Waiting for user action"
+	// under a supervised strategy legitimately explains a PARTIAL shortfall, but
+	// not a cluster that is entirely down — that is an outage, not operator
+	// intent, and silencing it is how a total failure ends up with no issue at
+	// all. Mirrors the badge, which treats zero ready as hard-down ahead of
+	// every phase branch except terminal and failing-over.
+	allDown := okD && okR && desired > 0 && ready == 0
+
 	phaseExplained := false
 	switch {
 	case cnpgTerminalPhases[phase]:
@@ -163,7 +173,7 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 		// while the badge showed the attention phase, and a supervised cluster
 		// waiting on a human is precisely when instances are legitimately below
 		// the desired count.
-		phaseExplained = true
+		phaseExplained = !allDown
 		strategy, _, _ := unstructured.NestedString(u.Object, "spec", "primaryUpdateStrategy")
 		if strategy != "supervised" {
 			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
@@ -172,8 +182,9 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 
 	case cnpgTransientPhases[phase]:
 		// Mid-operation: running below the desired instance count is expected,
-		// so the shortfall check below is suppressed without raising an issue.
-		phaseExplained = true
+		// so the shortfall check below is suppressed without raising an issue —
+		// unless nothing is serving at all.
+		phaseExplained = !allDown
 
 	case phase == cnpgPhaseHealthy || phase == "":
 		// Nothing phase-derived to report.
@@ -188,8 +199,6 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	// unrelated cause, and letting either suppress the shortfall would hide a
 	// cluster with zero ready instances behind a backup warning.
 	if !phaseExplained {
-		desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
-		ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
 		if okD && okR && desired > 0 && ready < desired {
 			severity := SeverityWarning
 			if ready == 0 {

--- a/internal/issues/source_cnpg_golden_test.go
+++ b/internal/issues/source_cnpg_golden_test.go
@@ -1,0 +1,149 @@
+package issues
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const cnpgGoldenMatrixPath = "../../testdata/cnpg/badge-issue-matrix.json"
+
+type cnpgGoldenCase struct {
+	Name   string         `json:"name"`
+	Spec   map[string]any `json:"spec"`
+	Status map[string]any `json:"status"`
+	Badge  struct {
+		Text  string `json:"text"`
+		Level string `json:"level"`
+	} `json:"badge"`
+	Issues []string `json:"issues"`
+	Worst  string   `json:"worst"`
+}
+
+type cnpgGoldenFile struct {
+	Cases []cnpgGoldenCase `json:"cases"`
+}
+
+func loadCNPGGolden(t *testing.T) cnpgGoldenFile {
+	t.Helper()
+	raw, err := os.ReadFile(cnpgGoldenMatrixPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cnpgGoldenMatrixPath, err)
+	}
+	var f cnpgGoldenFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("parse %s: %v", cnpgGoldenMatrixPath, err)
+	}
+	if len(f.Cases) == 0 {
+		t.Fatalf("no cases in %s", cnpgGoldenMatrixPath)
+	}
+	return f
+}
+
+// TestCNPGGoldenMatrix asserts the Go detector against the shared specification
+// in testdata/cnpg/badge-issue-matrix.json. The TypeScript badge is asserted
+// against the SAME file in resource-utils-cnpg.golden.test.ts, so a change to
+// one language that the other does not mirror fails on both sides.
+//
+// The phase-spelling parity test cannot catch precedence, readiness-presence or
+// condition differences — every badge/issue disagreement found on this branch
+// slipped past it. This is the behavioural guard.
+func TestCNPGGoldenMatrix(t *testing.T) {
+	for _, tc := range loadCNPGGolden(t).Cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// JSON numbers decode as float64; the detector reads int64.
+			spec := normalizeJSONInts(tc.Spec)
+			status := normalizeJSONInts(tc.Status)
+			u := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "postgresql.cnpg.io/v1",
+				"kind":       "Cluster",
+				"metadata":   map[string]any{"name": "pg", "namespace": "pg"},
+				"spec":       spec,
+				"status":     status,
+			}}
+
+			issues := detectCNPGIssues(cnpgClusterGVR, "Cluster", u)
+			var got []string
+			worst := "none"
+			for _, i := range issues {
+				got = append(got, i.Reason)
+				switch {
+				case i.Severity == SeverityCritical:
+					worst = "critical"
+				case worst == "none":
+					worst = string(i.Severity)
+				}
+			}
+			want := append([]string(nil), tc.Issues...)
+			sort.Strings(got)
+			sort.Strings(want)
+			if strings.Join(got, ",") != strings.Join(want, ",") {
+				t.Errorf("issues = [%s], want [%s]", strings.Join(got, ","), strings.Join(want, ","))
+			}
+			if worst != tc.Worst {
+				t.Errorf("worst severity = %q, want %q", worst, tc.Worst)
+			}
+		})
+	}
+}
+
+// normalizeJSONInts converts float64 values decoded from JSON into int64 so
+// unstructured.NestedInt64 can read them, mirroring what the API server stores.
+func normalizeJSONInts(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		switch t := v.(type) {
+		case float64:
+			out[k] = int64(t)
+		case map[string]any:
+			out[k] = normalizeJSONInts(t)
+		case []any:
+			list := make([]any, 0, len(t))
+			for _, item := range t {
+				if im, ok := item.(map[string]any); ok {
+					list = append(list, normalizeJSONInts(im))
+					continue
+				}
+				list = append(list, item)
+			}
+			out[k] = list
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// Buckets must be disjoint. The two languages check them in different orders
+// (TS: transient before attention; Go: attention before transient), so a phase
+// in both maps would classify differently per language while the spelling
+// parity test still passed.
+func TestCNPGPhaseBucketsAreDisjoint(t *testing.T) {
+	buckets := map[string]map[string]bool{
+		"terminal":  cnpgTerminalPhases,
+		"transient": cnpgTransientPhases,
+		"attention": cnpgAttentionPhases,
+	}
+	seen := map[string]string{}
+	for name, set := range buckets {
+		for phase := range set {
+			if prev, dup := seen[phase]; dup {
+				t.Errorf("phase %q is in both %s and %s buckets", phase, prev, name)
+			}
+			seen[phase] = name
+		}
+	}
+	for _, single := range []struct{ name, phase string }{
+		{"healthy", cnpgPhaseHealthy},
+		{"failing", cnpgPhaseFailingOver},
+	} {
+		if prev, dup := seen[single.phase]; dup {
+			t.Errorf("phase %q is in both %s and %s buckets", single.phase, prev, single.name)
+		}
+		seen[single.phase] = single.name
+	}
+}

--- a/internal/issues/source_cnpg_parity_test.go
+++ b/internal/issues/source_cnpg_parity_test.go
@@ -13,6 +13,9 @@ const cnpgFrontendTaxonomyPath = "../../packages/k8s-ui/src/components/resources
 var (
 	cnpgTSConstBlock = regexp.MustCompile(`(?s)export const (CNPG_CLUSTER_PHASES_[A-Z]+) = \[(.*?)\] as const`)
 	cnpgTSEntry      = regexp.MustCompile(`'([^']*)'`)
+	// Prose in the block carries apostrophes and quoted phrases; strip comments
+	// before extracting entries or they parse as phases.
+	cnpgTSComment = regexp.MustCompile(`(?m)//.*$`)
 )
 
 // TestCNPGPhaseTaxonomyMatchesFrontend fails when the Go phase buckets and the
@@ -21,9 +24,10 @@ var (
 // detector. A divergence ships a red badge with no issue, or an issue with no
 // badge — the exact failure mode this integration was repaired for.
 //
-// Only the buckets Go actually enumerates are compared. Go has no transient
-// list: its degraded check fires only under the healthy phase, so transient
-// phases are excluded structurally rather than by enumeration.
+// All five buckets are compared. The transient bucket matters as much as the
+// rest: Go uses it to suppress the instance-shortfall issue during a legitimate
+// mid-operation shortfall, so a phase present on one side only would either
+// raise a spurious "degraded" issue or silently swallow a real one.
 func TestCNPGPhaseTaxonomyMatchesFrontend(t *testing.T) {
 	raw, err := os.ReadFile(cnpgFrontendTaxonomyPath)
 	if err != nil {
@@ -33,7 +37,7 @@ func TestCNPGPhaseTaxonomyMatchesFrontend(t *testing.T) {
 	ts := map[string][]string{}
 	for _, m := range cnpgTSConstBlock.FindAllStringSubmatch(string(raw), -1) {
 		var phases []string
-		for _, e := range cnpgTSEntry.FindAllStringSubmatch(m[2], -1) {
+		for _, e := range cnpgTSEntry.FindAllStringSubmatch(cnpgTSComment.ReplaceAllString(m[2], ""), -1) {
 			phases = append(phases, e[1])
 		}
 		ts[m[1]] = phases
@@ -48,6 +52,7 @@ func TestCNPGPhaseTaxonomyMatchesFrontend(t *testing.T) {
 	}{
 		{"CNPG_CLUSTER_PHASES_TERMINAL", cnpgTerminalPhases},
 		{"CNPG_CLUSTER_PHASES_ATTENTION", cnpgAttentionPhases},
+		{"CNPG_CLUSTER_PHASES_TRANSIENT", cnpgTransientPhases},
 		{"CNPG_CLUSTER_PHASES_HEALTHY", map[string]bool{cnpgPhaseHealthy: true}},
 		{"CNPG_CLUSTER_PHASES_FAILING", map[string]bool{cnpgPhaseFailingOver: true}},
 	}

--- a/internal/issues/source_cnpg_parity_test.go
+++ b/internal/issues/source_cnpg_parity_test.go
@@ -1,0 +1,86 @@
+package issues
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const cnpgFrontendTaxonomyPath = "../../packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts"
+
+var (
+	cnpgTSConstBlock = regexp.MustCompile(`(?s)export const (CNPG_CLUSTER_PHASES_[A-Z]+) = \[(.*?)\] as const`)
+	cnpgTSEntry      = regexp.MustCompile(`'([^']*)'`)
+)
+
+// TestCNPGPhaseTaxonomyMatchesFrontend fails when the Go phase buckets and the
+// TypeScript ones drift apart. They are the same taxonomy read by two
+// languages: the badge comes from the TS classifier, the issue from the Go
+// detector. A divergence ships a red badge with no issue, or an issue with no
+// badge — the exact failure mode this integration was repaired for.
+//
+// Only the buckets Go actually enumerates are compared. Go has no transient
+// list: its degraded check fires only under the healthy phase, so transient
+// phases are excluded structurally rather than by enumeration.
+func TestCNPGPhaseTaxonomyMatchesFrontend(t *testing.T) {
+	raw, err := os.ReadFile(cnpgFrontendTaxonomyPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cnpgFrontendTaxonomyPath, err)
+	}
+
+	ts := map[string][]string{}
+	for _, m := range cnpgTSConstBlock.FindAllStringSubmatch(string(raw), -1) {
+		var phases []string
+		for _, e := range cnpgTSEntry.FindAllStringSubmatch(m[2], -1) {
+			phases = append(phases, e[1])
+		}
+		ts[m[1]] = phases
+	}
+	if len(ts) == 0 {
+		t.Fatalf("no phase constants parsed from %s — did the export format change?", cnpgFrontendTaxonomyPath)
+	}
+
+	cases := []struct {
+		tsConst string
+		goSet   map[string]bool
+	}{
+		{"CNPG_CLUSTER_PHASES_TERMINAL", cnpgTerminalPhases},
+		{"CNPG_CLUSTER_PHASES_ATTENTION", cnpgAttentionPhases},
+		{"CNPG_CLUSTER_PHASES_HEALTHY", map[string]bool{cnpgPhaseHealthy: true}},
+		{"CNPG_CLUSTER_PHASES_FAILING", map[string]bool{cnpgPhaseFailingOver: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tsConst, func(t *testing.T) {
+			tsPhases, ok := ts[tc.tsConst]
+			if !ok {
+				t.Fatalf("%s not found in %s", tc.tsConst, cnpgFrontendTaxonomyPath)
+			}
+			var missingInGo, missingInTS []string
+			tsSet := map[string]bool{}
+			for _, p := range tsPhases {
+				tsSet[p] = true
+				if !tc.goSet[p] {
+					missingInGo = append(missingInGo, p)
+				}
+			}
+			for p := range tc.goSet {
+				if !tsSet[p] {
+					missingInTS = append(missingInTS, p)
+				}
+			}
+			sort.Strings(missingInGo)
+			sort.Strings(missingInTS)
+			if len(missingInGo) > 0 {
+				t.Errorf("phases in the TS %s but not the Go bucket — badge without issue: %s",
+					tc.tsConst, strings.Join(missingInGo, " | "))
+			}
+			if len(missingInTS) > 0 {
+				t.Errorf("phases in the Go bucket but not the TS %s — issue without badge: %s",
+					tc.tsConst, strings.Join(missingInTS, " | "))
+			}
+		})
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -1,0 +1,295 @@
+package issues
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var cnpgClusterGVR = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "clusters"}
+var cnpgBackupGVR = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "backups"}
+
+func cnpgCluster(spec, status map[string]any) *unstructured.Unstructured {
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	if status == nil {
+		status = map[string]any{}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Cluster",
+		"metadata":   map[string]any{"name": "pg-main", "namespace": "pg"},
+		"spec":       spec,
+		"status":     status,
+	}}
+}
+
+func cnpgCondition(condType, status, reason, message string) map[string]any {
+	return map[string]any{
+		"type": condType, "status": status, "reason": reason, "message": message,
+		"lastTransitionTime": "2026-04-28T10:00:00Z",
+	}
+}
+
+func reasonsOf(issues []Issue) []string {
+	out := make([]string, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, i.Reason)
+	}
+	return out
+}
+
+func findIssue(t *testing.T, issues []Issue, reason string) Issue {
+	t.Helper()
+	for _, i := range issues {
+		if i.Reason == reason {
+			return i
+		}
+	}
+	t.Fatalf("no issue with reason %q; got %v", reason, reasonsOf(issues))
+	return Issue{}
+}
+
+// The whole point of RAD-318: a cluster whose pods are all Ready but whose
+// phase says it is unrecoverable must not read as fine.
+func TestCNPGTerminalPhasesAreCriticalDespiteReadyInstances(t *testing.T) {
+	cases := []struct {
+		phase      string
+		wantReason string
+	}{
+		{"Cluster is unrecoverable and needs manual intervention", "CNPGClusterUnrecoverable"},
+		{"Cluster cannot proceed to reconciliation due to an unknown plugin being required", "CNPGClusterPluginFailure"},
+		{"Cluster cannot proceed to reconciliation due to an error while interacting with plugins", "CNPGClusterPluginFailure"},
+		{"Unable to create required cluster objects", "CNPGClusterTerminal"},
+		{"Cluster has incomplete or invalid image catalog", "CNPGClusterTerminal"},
+		{"Cluster cannot execute instance online upgrade due to missing architecture binary", "CNPGClusterTerminal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.phase, func(t *testing.T) {
+			u := cnpgCluster(
+				map[string]any{"instances": int64(3)},
+				map[string]any{"phase": tc.phase, "readyInstances": int64(3)},
+			)
+			issues := detectCNPGIssues(cnpgClusterGVR, "Cluster", u)
+			iss := findIssue(t, issues, tc.wantReason)
+			if iss.Severity != SeverityCritical {
+				t.Errorf("severity = %q, want critical", iss.Severity)
+			}
+			if iss.Message != tc.phase {
+				t.Errorf("message = %q, want the phase verbatim", iss.Message)
+			}
+		})
+	}
+}
+
+func TestCNPGWALArchivingFailureIsCritical(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(2)},
+		map[string]any{
+			"phase": "Cluster in healthy state", "readyInstances": int64(2),
+			"conditions": []any{
+				cnpgCondition("Ready", "True", "ClusterIsReady", "Cluster is Ready"),
+				cnpgCondition("ContinuousArchiving", "False", "ContinuousArchivingFailing", "unable to upload WAL"),
+			},
+		},
+	)
+	iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGWALArchivingFailing")
+	if iss.Severity != SeverityCritical {
+		t.Errorf("severity = %q, want critical — the cluster serves traffic while the recovery point stalls", iss.Severity)
+	}
+	if !strings.Contains(iss.Message, "unable to upload WAL") {
+		t.Errorf("message should carry the operator's own text, got %q", iss.Message)
+	}
+	// Must not claim an exact RPO — the condition only proves the last attempt failed.
+	if strings.Contains(strings.ToLower(iss.Message), "data loss") {
+		t.Errorf("message overclaims: %q", iss.Message)
+	}
+}
+
+func TestCNPGHealthyClusterRaisesNothing(t *testing.T) {
+	// Shape taken from a live CNPG 1.27 cluster.
+	u := cnpgCluster(
+		map[string]any{"instances": int64(2)},
+		map[string]any{
+			"phase": "Cluster in healthy state", "readyInstances": int64(2), "instances": int64(2),
+			"conditions": []any{
+				cnpgCondition("ConsistentSystemID", "True", "Unique", "A single, unique system ID was found across reporting instances."),
+				cnpgCondition("Ready", "True", "ClusterIsReady", "Cluster is Ready"),
+				cnpgCondition("ContinuousArchiving", "True", "ContinuousArchivingSuccess", "Continuous archiving is working"),
+			},
+		},
+	)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+		t.Fatalf("healthy cluster raised %v", reasonsOf(got))
+	}
+}
+
+// CNPG sets LastBackupSucceeded=False/BackupStarted while a backup is merely
+// starting up. Raising an issue there fires on every backup run.
+func TestCNPGBackupStartedIsNotAFailure(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(1)},
+		map[string]any{
+			"phase": "Cluster in healthy state", "readyInstances": int64(1),
+			"conditions": []any{cnpgCondition("LastBackupSucceeded", "False", "BackupStarted", "New Backup starting up")},
+		},
+	)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+		t.Fatalf("in-flight backup raised %v", reasonsOf(got))
+	}
+}
+
+func TestCNPGLastBackupFailedIsAWarning(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(1)},
+		map[string]any{
+			"phase": "Cluster in healthy state", "readyInstances": int64(1),
+			"conditions": []any{cnpgCondition("LastBackupSucceeded", "False", "LastBackupFailed", "no credentials")},
+		},
+	)
+	iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGLastBackupFailed")
+	if iss.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", iss.Severity)
+	}
+}
+
+// Under `supervised` the operator is SUPPOSED to wait for a human — flagging it
+// would light permanently on every supervised cluster.
+func TestCNPGWaitingForUserRespectsSupervisedStrategy(t *testing.T) {
+	status := map[string]any{"phase": "Waiting for user action", "readyInstances": int64(2)}
+
+	supervised := cnpgCluster(map[string]any{"instances": int64(2), "primaryUpdateStrategy": "supervised"}, status)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", supervised); len(got) != 0 {
+		t.Fatalf("supervised cluster raised %v", reasonsOf(got))
+	}
+
+	unsupervised := cnpgCluster(map[string]any{"instances": int64(2), "primaryUpdateStrategy": "unsupervised"}, status)
+	iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", unsupervised), "CNPGClusterWaitingForUser")
+	if iss.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", iss.Severity)
+	}
+}
+
+func TestCNPGTransientPhaseDoesNotRaiseDegraded(t *testing.T) {
+	// Mid-operation with fewer ready instances is expected, not a defect.
+	u := cnpgCluster(
+		map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Creating a new replica", "readyInstances": int64(2)},
+	)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+		t.Fatalf("transient phase raised %v", reasonsOf(got))
+	}
+}
+
+func TestCNPGDegradedInstancesUnderHealthyPhase(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Cluster in healthy state", "readyInstances": int64(1)},
+	)
+	iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGClusterDegraded")
+	if iss.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", iss.Severity)
+	}
+
+	down := cnpgCluster(
+		map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Cluster in healthy state", "readyInstances": int64(0)},
+	)
+	if got := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", down), "CNPGClusterDegraded"); got.Severity != SeverityCritical {
+		t.Errorf("all instances down: severity = %q, want critical", got.Severity)
+	}
+}
+
+func TestCNPGUnknownPhaseRaisesNothing(t *testing.T) {
+	// A phase from a future CNPG minor must not be guessed at.
+	u := cnpgCluster(
+		map[string]any{"instances": int64(1)},
+		map[string]any{"phase": "Reticulating splines", "readyInstances": int64(1)},
+	)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+		t.Fatalf("unknown phase raised %v", reasonsOf(got))
+	}
+}
+
+func TestCNPGBackupPhases(t *testing.T) {
+	backup := func(phase, errMsg string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Backup",
+			"metadata":   map[string]any{"name": "b1", "namespace": "pg"},
+			"status":     map[string]any{"phase": phase, "error": errMsg},
+		}}
+	}
+
+	walIssues := detectCNPGIssues(cnpgBackupGVR, "Backup", backup("walArchivingFailing", "S3 timeout"))
+	iss := findIssue(t, walIssues, "CNPGWALArchivingFailing")
+	if iss.Severity != SeverityCritical {
+		t.Errorf("walArchivingFailing severity = %q, want critical", iss.Severity)
+	}
+	if !strings.Contains(iss.Message, "S3 timeout") {
+		t.Errorf("message should carry status.error, got %q", iss.Message)
+	}
+
+	failed := findIssue(t, detectCNPGIssues(cnpgBackupGVR, "Backup", backup("failed", "boom")), "CNPGBackupFailed")
+	if failed.Severity != SeverityWarning {
+		t.Errorf("failed severity = %q, want warning", failed.Severity)
+	}
+
+	// Every non-failure phase CNPG 1.27 ships.
+	for _, phase := range []string{"pending", "started", "running", "finalizing", "completed", ""} {
+		if got := detectCNPGIssues(cnpgBackupGVR, "Backup", backup(phase, "")); len(got) != 0 {
+			t.Errorf("phase %q raised %v", phase, reasonsOf(got))
+		}
+	}
+}
+
+// Kinds without a curated detector must return nothing so the generic
+// condition path still gets its turn (detectCuratedConditionIssues skips the
+// generic walk only when the curated result is non-empty).
+func TestCNPGUncuratedKindsFallThrough(t *testing.T) {
+	for _, kind := range []string{"Pooler", "ScheduledBackup", "Database"} {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1", "kind": kind,
+			"metadata": map[string]any{"name": "x", "namespace": "pg"},
+			"status":   map[string]any{"phase": "whatever"},
+		}}
+		if got := detectCNPGIssues(cnpgClusterGVR, kind, u); got != nil {
+			t.Errorf("kind %s returned %v, want nil so the generic path runs", kind, reasonsOf(got))
+		}
+	}
+}
+
+// A cluster can be unrecoverable AND failing to archive WAL at the same time.
+// Issue IDs are category-only unless a Fingerprint is supplied, so without one
+// these two collapse into a single row and the archiving cause — the whole
+// point of the detector — is the one that gets dropped.
+func TestCNPGConcurrentCausesGetDistinctIdentities(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(2)},
+		map[string]any{
+			"phase": "Cluster is unrecoverable and needs manual intervention", "readyInstances": int64(2),
+			"conditions": []any{
+				cnpgCondition("ContinuousArchiving", "False", "ContinuousArchivingFailing", "unable to upload WAL"),
+				cnpgCondition("LastBackupSucceeded", "False", "LastBackupFailed", "no credentials"),
+			},
+		},
+	)
+	issues := detectCNPGIssues(cnpgClusterGVR, "Cluster", u)
+	if len(issues) != 3 {
+		t.Fatalf("expected 3 concurrent causes, got %d: %v", len(issues), reasonsOf(issues))
+	}
+
+	ids := map[string]string{}
+	for _, i := range issues {
+		if i.Fingerprint == "" {
+			t.Errorf("issue %q has no Fingerprint — it will collide on ID", i.Reason)
+		}
+		if prev, dup := ids[i.ID]; dup {
+			t.Errorf("issues %q and %q share ID %q — one will be dropped", prev, i.Reason, i.ID)
+		}
+		ids[i.ID] = i.Reason
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -419,6 +419,26 @@ func TestCNPGTransientPhasesSuppressGenericConditionWalk(t *testing.T) {
 		}
 	}
 
+	// The age bound applies to TRANSIENT phases only. A stuck mid-operation
+	// cluster must surface; a supervised cluster parked on "Waiting for user
+	// action" is the documented resting state and must stay quiet however long
+	// it lasts, or a supported configuration becomes permanently lit.
+	stale := []any{map[string]any{"type": "Ready", "status": "False",
+		"reason": "ClusterIsNotReady", "lastTransitionTime": "2020-01-01T00:00:00Z"}}
+
+	stuckTransient := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Creating a new replica", "readyInstances": int64(2), "conditions": stale})
+	if cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Cluster", stuckTransient) {
+		t.Error("a transient phase stuck past the grace must stop suppressing")
+	}
+
+	parkedSupervised := cnpgCluster(
+		map[string]any{"instances": int64(3), "primaryUpdateStrategy": "supervised"},
+		map[string]any{"phase": "Waiting for user action", "readyInstances": int64(2), "conditions": stale})
+	if !cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Cluster", parkedSupervised) {
+		t.Error("a supervised wait must keep suppressing however long it lasts")
+	}
+
 	// Scoped to CNPG Clusters only.
 	u := cnpgCluster(map[string]any{}, map[string]any{"phase": "Switchover in progress"})
 	if cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Pooler", u) {

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -368,3 +368,63 @@ func TestCNPGBadgeAndIssueAgreeOnReadiness(t *testing.T) {
 		})
 	}
 }
+
+// Under `supervised` the operator waits for a human, which is exactly when
+// instances sit below the desired count. The phase explains that, so the
+// shortfall must not fire — the badge shows the attention phase, and an issue
+// saying "degraded" alongside it is the disagreement this detector prevents.
+func TestCNPGSupervisedWaitSuppressesShortfall(t *testing.T) {
+	u := cnpgCluster(
+		map[string]any{"instances": int64(3), "primaryUpdateStrategy": "supervised"},
+		map[string]any{"phase": "Waiting for user action", "readyInstances": int64(1)},
+	)
+	if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+		t.Fatalf("supervised wait with a shortfall raised %v", reasonsOf(got))
+	}
+
+	// Unsupervised still reports the wait itself, and still only once.
+	un := cnpgCluster(
+		map[string]any{"instances": int64(3), "primaryUpdateStrategy": "unsupervised"},
+		map[string]any{"phase": "Waiting for user action", "readyInstances": int64(1)},
+	)
+	got := detectCNPGIssues(cnpgClusterGVR, "Cluster", un)
+	if len(got) != 1 || got[0].Reason != "CNPGClusterWaitingForUser" {
+		t.Fatalf("unsupervised wait = %v, want exactly CNPGClusterWaitingForUser", reasonsOf(got))
+	}
+}
+
+// CNPG reports Ready=False/ClusterIsNotReady throughout a switchover or replica
+// creation. That reason is not in conditions' transient set, so without an
+// explicit opt-out the generic CRD walk re-emits the warning the phase buckets
+// just suppressed.
+func TestCNPGTransientPhasesSuppressGenericConditionWalk(t *testing.T) {
+	for _, phase := range []string{
+		"Switchover in progress", "Creating a new replica", "Upgrading cluster",
+		"Upgrading Postgres major version", "Waiting for user action",
+	} {
+		u := cnpgCluster(map[string]any{"instances": int64(3)}, map[string]any{"phase": phase})
+		if !cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Cluster", u) {
+			t.Errorf("phase %q should suppress the generic condition walk", phase)
+		}
+	}
+
+	// Outside those windows a False Ready is still worth surfacing — blanket
+	// ownership would silence real reasons like DetachedVolume.
+	for _, phase := range []string{
+		"Cluster in healthy state", "Cluster is unrecoverable and needs manual intervention", "",
+	} {
+		u := cnpgCluster(map[string]any{"instances": int64(3)}, map[string]any{"phase": phase})
+		if cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Cluster", u) {
+			t.Errorf("phase %q must NOT suppress the generic walk", phase)
+		}
+	}
+
+	// Scoped to CNPG Clusters only.
+	u := cnpgCluster(map[string]any{}, map[string]any{"phase": "Switchover in progress"})
+	if cnpgSuppressesGenericConditions("postgresql.cnpg.io", "Pooler", u) {
+		t.Error("suppression must not extend to other CNPG kinds")
+	}
+	if cnpgSuppressesGenericConditions("cluster.x-k8s.io", "Cluster", u) {
+		t.Error("suppression must not extend to other groups' Cluster kinds")
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -293,3 +293,41 @@ func TestCNPGConcurrentCausesGetDistinctIdentities(t *testing.T) {
 		ids[i.ID] = i.Reason
 	}
 }
+
+// A backup-condition issue must never suppress the instance-shortfall issue:
+// they are unrelated causes, and letting a backup warning hide a cluster with
+// zero ready instances buries the actual outage.
+func TestCNPGBackupConditionDoesNotSuppressOutage(t *testing.T) {
+	for _, cond := range []map[string]any{
+		cnpgCondition("LastBackupSucceeded", "False", "LastBackupFailed", "no credentials"),
+		cnpgCondition("ContinuousArchiving", "False", "ContinuousArchivingFailing", "cannot upload"),
+	} {
+		u := cnpgCluster(
+			map[string]any{"instances": int64(3)},
+			map[string]any{
+				"phase": "Cluster in healthy state", "readyInstances": int64(0),
+				"conditions": []any{cond},
+			},
+		)
+		issues := detectCNPGIssues(cnpgClusterGVR, "Cluster", u)
+		degraded := findIssue(t, issues, "CNPGClusterDegraded")
+		if degraded.Severity != SeverityCritical {
+			t.Errorf("%v: outage severity = %q, want critical", cond["type"], degraded.Severity)
+		}
+	}
+}
+
+// Upstream sets PhaseUpgradeDelayed when the OPERATOR's rollout-delay config
+// postpones an upgrade and requeues — it is self-resolving and unrelated to
+// primaryUpdateStrategy, so it must not raise a waiting-for-user issue.
+func TestCNPGUpgradeDelayedIsTransientNotAttention(t *testing.T) {
+	for _, strategy := range []string{"unsupervised", "supervised", ""} {
+		u := cnpgCluster(
+			map[string]any{"instances": int64(2), "primaryUpdateStrategy": strategy},
+			map[string]any{"phase": "Cluster upgrade delayed", "readyInstances": int64(1)},
+		)
+		if got := detectCNPGIssues(cnpgClusterGVR, "Cluster", u); len(got) != 0 {
+			t.Errorf("strategy %q: rollout-delay raised %v", strategy, reasonsOf(got))
+		}
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -331,3 +331,40 @@ func TestCNPGUpgradeDelayedIsTransientNotAttention(t *testing.T) {
 		}
 	}
 }
+
+// Mirror of the TS "badge/issue agreement on instance readiness" suite in
+// resource-utils-cnpg.test.ts. Same fixtures, asserted from the detector side:
+// a green badge with a Degraded issue (or the reverse) is the drift this
+// integration was repaired to prevent.
+func TestCNPGBadgeAndIssueAgreeOnReadiness(t *testing.T) {
+	cases := []struct {
+		name      string
+		phase     string
+		desired   int64
+		ready     int64
+		wantIssue bool
+	}{
+		{"healthy phase, shortfall — badge Degraded", "Cluster in healthy state", 3, 1, true},
+		{"healthy phase, count met — badge Healthy", "Cluster in healthy state", 3, 3, false},
+		{"transient phase explains the shortfall — badge shows the phase", "Creating a new replica", 3, 1, false},
+		{"unrecognized phase, shortfall — badge Degraded", "Some future phase", 3, 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := cnpgCluster(
+				map[string]any{"instances": tc.desired},
+				map[string]any{"phase": tc.phase, "readyInstances": tc.ready},
+			)
+			issues := detectCNPGIssues(cnpgClusterGVR, "Cluster", u)
+			var degraded bool
+			for _, i := range issues {
+				if i.Reason == "CNPGClusterDegraded" {
+					degraded = true
+				}
+			}
+			if degraded != tc.wantIssue {
+				t.Errorf("CNPGClusterDegraded = %v, want %v (issues: %v)", degraded, tc.wantIssue, reasonsOf(issues))
+			}
+		})
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -428,3 +428,49 @@ func TestCNPGTransientPhasesSuppressGenericConditionWalk(t *testing.T) {
 		t.Error("suppression must not extend to other groups' Cluster kinds")
 	}
 }
+
+// No phase excuses a database with nothing serving. Suppressing the shortfall
+// for attention/transient phases is right for a PARTIAL shortfall, but a
+// cluster with zero ready instances is an outage — and once the generic
+// condition walk is also suppressed for those phases, silence here means no
+// signal anywhere.
+func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
+	cases := []struct {
+		phase    string
+		strategy string
+	}{
+		{"Waiting for user action", "supervised"},
+		{"Waiting for user action", "unsupervised"},
+		{"Cluster upgrade delayed", ""},
+		{"Switchover in progress", ""},
+		{"Creating a new replica", ""},
+		{"Upgrading Postgres major version", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.phase+"/"+tc.strategy, func(t *testing.T) {
+			spec := map[string]any{"instances": int64(3)}
+			if tc.strategy != "" {
+				spec["primaryUpdateStrategy"] = tc.strategy
+			}
+			u := cnpgCluster(spec, map[string]any{"phase": tc.phase, "readyInstances": int64(0)})
+			iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGClusterDegraded")
+			if iss.Severity != SeverityCritical {
+				t.Errorf("severity = %q, want critical for a fully-down cluster", iss.Severity)
+			}
+		})
+	}
+
+	// A partial shortfall under the same phases stays suppressed — that is the
+	// legitimate operator-workflow case.
+	for _, phase := range []string{"Waiting for user action", "Switchover in progress"} {
+		u := cnpgCluster(
+			map[string]any{"instances": int64(3), "primaryUpdateStrategy": "supervised"},
+			map[string]any{"phase": phase, "readyInstances": int64(2)},
+		)
+		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
+			if i.Reason == "CNPGClusterDegraded" {
+				t.Errorf("phase %q: partial shortfall should stay suppressed", phase)
+			}
+		}
+	}
+}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -34,14 +34,6 @@ func cnpgCondition(condType, status, reason, message string) map[string]any {
 	}
 }
 
-func reasonsOf(issues []Issue) []string {
-	out := make([]string, 0, len(issues))
-	for _, i := range issues {
-		out = append(out, i.Reason)
-	}
-	return out
-}
-
 func findIssue(t *testing.T, issues []Issue, reason string) Issue {
 	t.Helper()
 	for _, i := range issues {

--- a/internal/issues/source_conditions.go
+++ b/internal/issues/source_conditions.go
@@ -196,6 +196,8 @@ func detectCuratedConditionIssues(gvr schema.GroupVersionResource, kind string, 
 		if kind == "CustomResourceDefinition" {
 			return detectObjectConditionIssues(gvr, kind, u, SeverityCritical, "Established", "NamesAccepted")
 		}
+	case "postgresql.cnpg.io":
+		return detectCNPGIssues(gvr, kind, u)
 	}
 	return nil
 }

--- a/internal/issues/source_conditions.go
+++ b/internal/issues/source_conditions.go
@@ -110,6 +110,14 @@ func detectGenericCRDIssues(p Provider, f Filters, ownedSubjects map[string]bool
 				out = append(out, curated...)
 				continue
 			}
+			// An empty curated result means "nothing to say", not "handled", so
+			// the generic walk below still runs. A curated detector that stays
+			// silent ON PURPOSE — because the object is mid-operation and its
+			// False Ready is expected — has to say so explicitly, or the noise
+			// it just suppressed comes straight back through the generic path.
+			if cnpgSuppressesGenericConditions(gvr.Group, kind, u) {
+				continue
+			}
 			condType, reason, msg, since, ok := conditions.FindFalseCondition(u)
 			if !ok {
 				continue

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -276,6 +276,8 @@ var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "projectcontour.io", Versions: []string{"v1"}, Resource: "httpproxies", Kind: "HTTPProxy", Namespaced: true},
 	{Group: "postgresql.cnpg.io", Versions: []string{"v1"}, Resource: "clusters", Kind: "Cluster", Namespaced: true},
 	{Group: "postgresql.cnpg.io", Versions: []string{"v1"}, Resource: "poolers", Kind: "Pooler", Namespaced: true},
+	{Group: "postgresql.cnpg.io", Versions: []string{"v1"}, Resource: "backups", Kind: "Backup", Namespaced: true},
+	{Group: "postgresql.cnpg.io", Versions: []string{"v1"}, Resource: "scheduledbackups", Kind: "ScheduledBackup", Namespaced: true},
 	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "clusters", Kind: "Cluster", Namespaced: true},
 	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinedeployments", Kind: "MachineDeployment", Namespaced: true},
 	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinesets", Kind: "MachineSet", Namespaced: true},

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -107,7 +107,7 @@ interface ResourceTypeButtonProps {
 
 const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps>(
   function ResourceTypeButton({ resource, count, isSelected, isHighlighted, isForbidden: forbidden, isPinned, onTogglePin, onClick }, ref) {
-    const Icon = getResourceIcon(resource.kind)
+    const Icon = getResourceIcon(resource.kind, resource.group)
     return (
       <button
         ref={ref}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -160,6 +160,7 @@ import { ExternalSecretCell, ClusterExternalSecretCell, SecretStoreCell, Cluster
 import { BackupCell, RestoreCell, ScheduleCell, BackupStorageLocationCell, VolumeSnapshotLocationCell, BackupRepositoryCell } from './renderers/velero-cells'
 import { isVeleroResource } from './resource-utils-velero'
 import { CNPGClusterCell, CNPGBackupCell, CNPGScheduledBackupCell, CNPGPoolerCell } from './renderers/cnpg-cells'
+import { isApiGroup, CNPG_GROUP } from './resource-utils-cnpg'
 import { ManagedResourceCell, CompositeResourceCell, CrossplaneProviderCell, CrossplaneProviderConfigCell, CompositionCell, XRDCell } from './renderers/crossplane-cells'
 import { isManagedResource, isComposite } from './resource-utils-crossplane'
 import { VirtualServiceCell, DestinationRuleCell, IstioGatewayCell, ServiceEntryCell, PeerAuthenticationCell, AuthorizationPolicyCell } from './renderers/istio-cells'
@@ -5830,10 +5831,10 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       // Reached only when the group is unknown to normalizeKindToPlural. Both
       // engines are matched positively so a third `backups` CRD renders generic
       // rather than inheriting whichever branch happened to be the fallback.
-      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+      if (isApiGroup(resource.apiVersion, CNPG_GROUP)) {
         return <CNPGBackupCell resource={resource} column={column} />
       }
-      if (resource.apiVersion?.includes('velero.io')) {
+      if (isApiGroup(resource.apiVersion, 'velero.io')) {
         return <BackupCell resource={resource} column={column} />
       }
       return <GenericCell resource={resource} column={column} />
@@ -5857,17 +5858,17 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       // Positive guard: `clusters` is one of the most collided CRD plurals
       // (CNPG, CAPI, KubeBlocks, Redis/Valkey operators). Anything else gets
       // the generic cell instead of a fabricated Postgres status.
-      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+      if (isApiGroup(resource.apiVersion, CNPG_GROUP)) {
         return <CNPGClusterCell resource={resource} column={column} />
       }
       return <GenericCell resource={resource} column={column} />
     case 'scheduledbackups':
-      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+      if (isApiGroup(resource.apiVersion, CNPG_GROUP)) {
         return <CNPGScheduledBackupCell resource={resource} column={column} />
       }
       return <GenericCell resource={resource} column={column} />
     case 'poolers':
-      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+      if (isApiGroup(resource.apiVersion, CNPG_GROUP)) {
         return <CNPGPoolerCell resource={resource} column={column} />
       }
       return <GenericCell resource={resource} column={column} />

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1285,7 +1285,12 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   cnpgclusters: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-28' },
+    // w-28 leaves the "Status" label 0.23px short once the sort AND filter
+    // affordances are both present, which renders "STAT…" — a sub-pixel miss
+    // costs two characters because the ellipsis needs its own room. The filter
+    // icon appears as soon as a column holds more than one distinct value, so
+    // this is latent on any status column, not specific to the current data.
+    { key: 'status', label: 'Status', width: 'w-32' },
     { key: 'instances', label: 'Instances', width: 'w-28', tooltip: 'Ready/Total' },
     { key: 'primary', label: 'Primary', width: 'w-36' },
     { key: 'image', label: 'Image', width: 'w-28' },
@@ -1295,9 +1300,11 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   cnpgbackups: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'status', label: 'Status', width: 'w-32' },
     { key: 'cluster', label: 'Cluster', width: 'w-36' },
-    { key: 'method', label: 'Method', width: 'w-36' },
+    // `barmanObjectStore` is the longest method and the field that decides how
+    // the rest of the row reads; at w-36 it was permanently ellipsised.
+    { key: 'method', label: 'Method', width: 'w-40' },
     { key: 'started', label: 'Started', width: 'w-24' },
     { key: 'duration', label: 'Duration', width: 'w-24' },
     { key: 'age', label: 'Age', width: 'w-24' },
@@ -1315,9 +1322,15 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   poolers: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
+    // "Not Scheduled" measures ~100px and wrapped at w-24 (96px). Sized to the
+    // widest value the column can hold, not the one the current data happens to
+    // show — and to w-32 for the header, per the note on cnpgclusters.status.
+    { key: 'status', label: 'Status', width: 'w-32' },
     { key: 'cluster', label: 'Cluster', width: 'w-36' },
-    { key: 'type', label: 'Type', width: 'w-16' },
+    // Sized for the HEADER, not the value: `rw`/`ro` need 27px, but "Type" plus
+    // the sort affordance needs more than w-16 leaves, and the label rendered
+    // as "T…".
+    { key: 'type', label: 'Type', width: 'w-24' },
     { key: 'poolMode', label: 'Pool Mode', width: 'w-32' },
     // status.instances counts pods trying to be scheduled, not ready ones.
     { key: 'instances', label: 'Instances', width: 'w-28', tooltip: 'Scheduled/Total' },

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1291,6 +1291,16 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'storage', label: 'Storage', width: 'w-28' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
+  cnpgbackups: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'cluster', label: 'Cluster', width: 'w-36' },
+    { key: 'method', label: 'Method', width: 'w-36' },
+    { key: 'started', label: 'Started', width: 'w-24' },
+    { key: 'duration', label: 'Duration', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
   scheduledbackups: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
@@ -1836,6 +1846,9 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
 // Map (plural, group) → KNOWN_COLUMNS key for kinds that collide with core K8s
 const GROUP_QUALIFIED_COLUMN_KEYS: Record<string, Record<string, string>> = {
   clusters: { 'postgresql.cnpg.io': 'cnpgclusters', 'cluster.x-k8s.io': 'capiclusters' },
+  // Velero owns the unqualified `backups` column set; CNPG Backups carry a
+  // completely different shape (cluster + method, no storage location/expiry).
+  backups: { 'postgresql.cnpg.io': 'cnpgbackups' },
   clusterpolicies: { 'nvidia.com': 'nvidiaclusterpolicies' },
   services: { 'serving.knative.dev': 'knativeservices' },
   configurations: { 'serving.knative.dev': 'knativeconfigurations' },
@@ -5811,12 +5824,19 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
     case 'clustersecretstores':
       return <ClusterSecretStoreCell resource={resource} column={column} />
     // Velero
+    case 'cnpgbackups':
+      return <CNPGBackupCell resource={resource} column={column} />
     case 'backups':
-      // Disambiguate CNPG vs Velero backups by apiVersion
-      if (resource.apiVersion?.includes('cnpg.io')) {
+      // Reached only when the group is unknown to normalizeKindToPlural. Both
+      // engines are matched positively so a third `backups` CRD renders generic
+      // rather than inheriting whichever branch happened to be the fallback.
+      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
         return <CNPGBackupCell resource={resource} column={column} />
       }
-      return <BackupCell resource={resource} column={column} />
+      if (resource.apiVersion?.includes('velero.io')) {
+        return <BackupCell resource={resource} column={column} />
+      }
+      return <GenericCell resource={resource} column={column} />
     case 'velerorestores':
       return <RestoreCell resource={resource} column={column} />
     case 'veleroschedules':
@@ -5832,12 +5852,25 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       return <BackupRepositoryCell resource={resource} column={column} />
     // CloudNativePG
     case 'cnpgclusters':
-    case 'clusters':
       return <CNPGClusterCell resource={resource} column={column} />
+    case 'clusters':
+      // Positive guard: `clusters` is one of the most collided CRD plurals
+      // (CNPG, CAPI, KubeBlocks, Redis/Valkey operators). Anything else gets
+      // the generic cell instead of a fabricated Postgres status.
+      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+        return <CNPGClusterCell resource={resource} column={column} />
+      }
+      return <GenericCell resource={resource} column={column} />
     case 'scheduledbackups':
-      return <CNPGScheduledBackupCell resource={resource} column={column} />
+      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+        return <CNPGScheduledBackupCell resource={resource} column={column} />
+      }
+      return <GenericCell resource={resource} column={column} />
     case 'poolers':
-      return <CNPGPoolerCell resource={resource} column={column} />
+      if (resource.apiVersion?.includes('postgresql.cnpg.io')) {
+        return <CNPGPoolerCell resource={resource} column={column} />
+      }
+      return <GenericCell resource={resource} column={column} />
     // Istio Service Mesh
     case 'virtualservices':
       return <VirtualServiceCell resource={resource} column={column} />

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1290,17 +1290,23 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     // costs two characters because the ellipsis needs its own room. The filter
     // icon appears as soon as a column holds more than one distinct value, so
     // this is latent on any status column, not specific to the current data.
-    { key: 'status', label: 'Status', width: 'w-32' },
+    // w-44 fits "WAL Archiving Failing" (120.2px against a 127px label budget).
+    // CNPG's own phases are mapped to short display states — see
+    // getCNPGClusterDisplayState; a 315px sentence fits no column at all.
+    { key: 'status', label: 'Status', width: 'w-44' },
     { key: 'instances', label: 'Instances', width: 'w-28', tooltip: 'Ready/Total' },
     { key: 'primary', label: 'Primary', width: 'w-36' },
     { key: 'image', label: 'Image', width: 'w-28' },
-    { key: 'storage', label: 'Storage', width: 'w-28' },
+    // No Storage column: it rendered spec.storage.size, the configured REQUEST.
+    // The useful number is actual usage (kubectl cnpg status shows "Size: 158M")
+    // and that isn't in the CR. A plausible-but-wrong-meaning number is worse
+    // than an absent one — the reader can't tell which meaning they're getting.
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   cnpgbackups: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-32' },
+    { key: 'status', label: 'Status', width: 'w-44' },
     { key: 'cluster', label: 'Cluster', width: 'w-36' },
     // `barmanObjectStore` is the longest method and the field that decides how
     // the rest of the row reads; at w-36 it was permanently ellipsised.
@@ -1322,10 +1328,11 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   poolers: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    // "Not Scheduled" measures ~100px and wrapped at w-24 (96px). Sized to the
-    // widest value the column can hold, not the one the current data happens to
-    // show — and to w-32 for the header, per the note on cnpgclusters.status.
-    { key: 'status', label: 'Status', width: 'w-32' },
+    // "Not Scheduled" (83.5px) is kept rather than shortened to "Unscheduled":
+    // ScheduledBackup also renders a literal "Scheduled" badge in this same
+    // column, so a standalone adjective would read as "has no cron" — a claim
+    // about a field Poolers don't have. w-36 buys the words.
+    { key: 'status', label: 'Status', width: 'w-36' },
     { key: 'cluster', label: 'Cluster', width: 'w-36' },
     // Sized for the HEADER, not the value: `rw`/`ro` need 27px, but "Type" plus
     // the sort affordance needs more than w-16 leaves, and the label rendered

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1319,7 +1319,8 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'cluster', label: 'Cluster', width: 'w-36' },
     { key: 'type', label: 'Type', width: 'w-16' },
     { key: 'poolMode', label: 'Pool Mode', width: 'w-32' },
-    { key: 'instances', label: 'Instances', width: 'w-28', tooltip: 'Ready/Total' },
+    // status.instances counts pods trying to be scheduled, not ready ones.
+    { key: 'instances', label: 'Instances', width: 'w-28', tooltip: 'Scheduled/Total' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   // ============================================================================

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { CNPGClusterRenderer } from './CNPGClusterRenderer'
+import { getCNPGClusterStatus } from '../resource-utils-cnpg'
+
+const cluster = (phase: string, readyInstances: number, extra: any = {}) => ({
+  apiVersion: 'postgresql.cnpg.io/v1',
+  kind: 'Cluster',
+  metadata: { name: 'pg', namespace: 'db' },
+  spec: { instances: 3 },
+  status: { phase, readyInstances, ...extra },
+})
+
+const html = (resource: any) => renderToString(<CNPGClusterRenderer data={resource} />)
+
+describe('CNPGClusterRenderer — the drawer must not contradict the badge', () => {
+  it('does not raise Degraded for a shortfall the phase already explains', () => {
+    // Mid-switchover at 2/3 is the operation, not a fault. The badge says
+    // "Switchover"; the drawer used to say "Degraded Cluster" beside it.
+    const switching = cluster('Switchover in progress', 2)
+    expect(getCNPGClusterStatus(switching).text).toBe('Switchover')
+    expect(html(switching)).not.toContain('Degraded Cluster')
+  })
+
+  it.each([
+    ['Upgrading cluster', 'transient'],
+    ['Waiting for user action', 'attention'],
+    ['Failing over', 'failing'],
+    ['Cluster is unrecoverable and needs manual intervention', 'terminal'],
+  ])('suppresses the Degraded banner during %s (%s)', (phase) => {
+    expect(html(cluster(phase, 2))).not.toContain('Degraded Cluster')
+  })
+
+  it('still raises Degraded when the phase does NOT explain the shortfall', () => {
+    // The regression guard for the fix: a settled cluster missing an instance
+    // is a genuine problem, and both surfaces must say so.
+    const settled = cluster('Cluster in healthy state', 2)
+    expect(getCNPGClusterStatus(settled).text).toBe('Degraded')
+    expect(html(settled)).toContain('Degraded Cluster')
+  })
+
+  it('still raises Cluster Down at zero ready, whatever the phase', () => {
+    // No phase excuses a database with nothing serving.
+    expect(html(cluster('Upgrading cluster', 0))).toContain('Cluster Down')
+  })
+
+  it('renders a failed last backup at the same tier as the badge and detector', () => {
+    // Three surfaces, one severity: badge `degraded`, Go SeverityWarning, and
+    // the banner. An error banner made the drawer the loudest of the three.
+    const failed = cluster('Cluster in healthy state', 3, {
+      conditions: [{ type: 'LastBackupSucceeded', status: 'False', reason: 'BackupFailed', message: 'upload rejected' }],
+    })
+    const out = html(failed)
+    expect(out).toContain('Last backup failed')
+    expect(getCNPGClusterStatus(failed).level).toBe('degraded')
+    // AlertBanner keys its tone off the variant; the error tone must be absent
+    // for this banner while the warning tone is present.
+    const banner = out.slice(out.indexOf('Last backup failed') - 400, out.indexOf('Last backup failed'))
+    expect(banner).not.toMatch(/status-unhealthy|text-red-/)
+  })
+})
+
+describe('the WAL banner must not claim nothing else looks wrong when something does', () => {
+  const walFailing = (phase: string, ready: number) => cluster(phase, ready, {
+    conditions: [{ type: 'ContinuousArchiving', status: 'False', reason: 'ContinuousArchivingFailing' }],
+  })
+  const CLAIM = 'otherwise serving normally'
+
+  it('makes the claim on a genuinely healthy cluster', () => {
+    expect(html(walFailing('Cluster in healthy state', 3))).toContain(CLAIM)
+  })
+
+  it('drops it mid-switchover, where a Switchover banner sits right above', () => {
+    // Regression guard for a sibling the phase gate itself introduced: this
+    // clause used to be suppressed by isDegraded, which a phase-explained
+    // shortfall no longer sets.
+    const out = html(walFailing('Switchover in progress', 2))
+    expect(out).toContain('Switchover in Progress')
+    expect(out).not.toContain(CLAIM)
+  })
+
+  it.each(['Waiting for user action', 'Upgrading cluster', 'Failing over'])('drops it during %s', (phase) => {
+    expect(html(walFailing(phase, 2))).not.toContain(CLAIM)
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -32,7 +32,12 @@ interface CNPGClusterRendererProps {
 export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererProps) {
   const conditions = data.status?.conditions || []
   const instances = data.spec?.instances ?? 0
-  const readyInstances = data.status?.readyInstances ?? 0
+  // Presence matters — see getCNPGClusterStatus. A cluster whose status has no
+  // readyInstances yet is unknown, not zero; defaulting to 0 raised a "Cluster
+  // Down" banner on a cluster that had simply not reported yet.
+  const readyKnown = typeof data.status?.readyInstances === 'number'
+  const readyInstances: number = readyKnown ? data.status.readyInstances : 0
+  const countsKnown = instances > 0 && readyKnown
   const phase = getCNPGClusterPhase(data)
   const backupConfig = getCNPGClusterBackupConfig(data)
   const monitoring = getCNPGClusterMonitoring(data)
@@ -67,14 +72,22 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   const phaseBucket = classifyCNPGClusterPhase(phase)
 
   // Problem detection
-  const isDown = instances > 0 && readyInstances === 0
-  const isDegraded = instances > 0 && readyInstances < instances && readyInstances > 0
-  const isFailover = phase.toLowerCase().includes('failing over')
-  const isSwitchover = phase.toLowerCase().includes('switchover')
+  const isDown = countsKnown && readyInstances === 0
+  const isDegraded = countsKnown && readyInstances < instances && readyInstances > 0
+  const isFailover = phaseBucket === 'failing'
+  const isSwitchover = phase === 'Switchover in progress'
+  const isTerminal = phaseBucket === 'terminal'
 
   return (
     <>
       {/* Problem alerts */}
+      {isTerminal && (
+        <AlertBanner
+          variant="error"
+          title="Reconciliation has stopped"
+          message={`${phase}. This state does not resolve on its own — the operator has stopped reconciling this cluster and it needs manual intervention.`}
+        />
+      )}
       {hasSplitBrain && (
         <AlertBanner
           variant="error"
@@ -97,8 +110,13 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
         />
       )}
       {isFailover && (
+        // Warning, not error: the badge renders failover at the alert tier and
+        // the issue detector reports it as a warning. A failover that has also
+        // taken every instance down still gets the red "Cluster Down" banner
+        // above, so severity is not lost — this just stops one surface shouting
+        // louder than the other two about the same event.
         <AlertBanner
-          variant="error"
+          variant="warning"
           title="Failover in Progress"
           message={`Cluster is performing a failover. Current phase: ${phase}`}
         />
@@ -130,7 +148,7 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
             // Cluster Down banner would be plainly false.
             `CNPG reports that the last WAL archival did not complete${walArchivingFailure.lastTransitionTime ? `, and archiving has been in this state for ${formatAge(walArchivingFailure.lastTransitionTime)}` : ''}. ` +
             'Recovery-point advancement is uncertain — check the backup destination before relying on point-in-time recovery.' +
-            (isDown || isDegraded || isFailover || phaseBucket === 'terminal'
+            (isDown || isDegraded || isFailover || isTerminal
               ? ''
               : ' The cluster is otherwise serving normally, so nothing else here will look wrong.') +
             (walArchivingFailure.message ? ` Operator reported: ${walArchivingFailure.message}` : '')

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -18,7 +18,10 @@ import {
   getCNPGClusterPostgresParams,
   getCNPGClusterInstancesReportedState,
   getCNPGClusterCertificateExpirations,
+  getCNPGWALArchivingFailure,
+  getCNPGLastBackupFailure,
 } from '../resource-utils-cnpg'
+import { formatAge } from '../resource-utils'
 
 interface CNPGClusterRendererProps {
   data: any
@@ -56,6 +59,10 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
 
   // Last failed backup
   const lastFailedBackup = data.status?.lastFailedBackup
+
+  // WAL archiving / backup health, straight from the operator's own conditions.
+  const walArchivingFailure = getCNPGWALArchivingFailure(data)
+  const lastBackupFailure = getCNPGLastBackupFailure(data)
 
   // Problem detection
   const isDown = instances > 0 && readyInstances === 0
@@ -108,11 +115,26 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
           message={`Target primary is ${targetPrimary} but current primary is ${currentPrimary}.`}
         />
       )}
-      {lastFailedBackup && (
+      {walArchivingFailure && (
         <AlertBanner
           variant="error"
-          title="Last Backup Failed"
-          message={`Last backup failed at ${lastFailedBackup}. WAL archiving may be impacted and RPO is growing.`}
+          title="WAL archiving is failing"
+          message={
+            `Continuous archiving has been failing${walArchivingFailure.lastTransitionTime ? ` for ${formatAge(walArchivingFailure.lastTransitionTime)}` : ''}. ` +
+            'The cluster keeps serving traffic normally, but the recovery point may not be advancing — ' +
+            'check the backup destination before relying on point-in-time recovery.' +
+            (walArchivingFailure.message ? ` Operator reported: ${walArchivingFailure.message}` : '')
+          }
+        />
+      )}
+      {lastBackupFailure && (
+        <AlertBanner
+          variant="error"
+          title="Last backup failed"
+          message={
+            `The most recent backup attempt failed${lastBackupFailure.lastTransitionTime ? ` ${formatAge(lastBackupFailure.lastTransitionTime)} ago` : ''}.` +
+            (lastBackupFailure.message ? ` Operator reported: ${lastBackupFailure.message}` : '')
+          }
         />
       )}
       {expiredCerts.length > 0 && (
@@ -242,6 +264,22 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
       {backupConfig.configured && (
         <Section title="Backup" icon={Clock} defaultExpanded>
           <PropertyList>
+            {backupConfig.plugin && (
+              <Property label="Managed By" value="barman-cloud plugin" />
+            )}
+            {backupConfig.plugin?.barmanObjectName && (
+              <Property label="Object Store" value={
+                <ResourceLink
+                  name={backupConfig.plugin.barmanObjectName}
+                  kind="objectstores"
+                  namespace={data.metadata?.namespace || ''}
+                  onNavigate={onNavigate}
+                />
+              } />
+            )}
+            {backupConfig.plugin?.isWALArchiver && (
+              <Property label="WAL Archiver" value="This plugin" />
+            )}
             {backupConfig.destinationPath && (
               <Property label="Destination" value={backupConfig.destinationPath} />
             )}
@@ -258,6 +296,17 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
               <Property label="First Recoverability" value={backupConfig.firstRecoverabilityPoint} />
             )}
           </PropertyList>
+          {/* Without this note the section renders empty on plugin-migrated
+              clusters, which is indistinguishable from "no backups configured" —
+              the worst possible ambiguity for a recovery-point display. */}
+          {backupConfig.rpoTrackedOnObjectStore && (
+            <div className="mt-2 pt-2 border-t border-theme-border text-xs text-theme-text-secondary">
+              Recovery-point fields are not published on the Cluster when backups run through the
+              barman-cloud plugin. The recovery window is tracked on the ObjectStore
+              {backupConfig.plugin?.barmanObjectName ? ` "${backupConfig.plugin.barmanObjectName}"` : ''}
+              {backupConfig.plugin?.serverName ? `, under server "${backupConfig.plugin.serverName}"` : ''}.
+            </div>
+          )}
         </Section>
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -73,10 +73,28 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
 
   // Problem detection
   const isDown = countsKnown && readyInstances === 0
-  const isDegraded = countsKnown && readyInstances < instances && readyInstances > 0
+  // A shortfall the PHASE already explains is not a separate problem. Mirrors
+  // source_cnpg.go's phaseExplained gate and the badge's ordering, both of
+  // which check the phase before the instance counts: mid-switchover or waiting
+  // on a supervised update, running below the desired count is the operation,
+  // not a fault. Without this the drawer raised "Degraded Cluster" while the
+  // badge deliberately said "Switchover" — the same two-surfaces-one-cluster
+  // disagreement this integration exists to remove, inverted.
+  const phaseExplainsShortfall =
+    phaseBucket === 'terminal' || phaseBucket === 'failing'
+    || phaseBucket === 'attention' || phaseBucket === 'transient'
+  const isDegraded = countsKnown && readyInstances < instances && readyInstances > 0 && !phaseExplainsShortfall
   const isFailover = phaseBucket === 'failing'
   const isSwitchover = phase === 'Switchover in progress'
   const isTerminal = phaseBucket === 'terminal'
+  // "The cluster is otherwise serving normally, so nothing else here will look
+  // wrong" is a claim about the REST OF THIS DRAWER, so any other banner
+  // falsifies it. It can no longer lean on isDegraded now that a
+  // phase-explained shortfall doesn't set it: a cluster mid-switchover at 2/3
+  // would assert nothing else looks wrong directly beneath a Switchover banner.
+  const hasOtherProblemBanner =
+    isDown || isDegraded || primaryMismatch || hasSplitBrain
+    || (phaseBucket !== 'healthy' && phaseBucket !== 'unknown')
 
   return (
     <>
@@ -148,7 +166,7 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
             // Cluster Down banner would be plainly false.
             `CNPG reports that the last WAL archival did not complete${walArchivingFailure.lastTransitionTime ? `, and archiving has been in this state for ${formatAge(walArchivingFailure.lastTransitionTime)}` : ''}. ` +
             'Recovery-point advancement is uncertain — check the backup destination before relying on point-in-time recovery.' +
-            (isDown || isDegraded || isFailover || isTerminal
+            (hasOtherProblemBanner
               ? ''
               : ' The cluster is otherwise serving normally, so nothing else here will look wrong.') +
             (walArchivingFailure.message ? ` Operator reported: ${walArchivingFailure.message}` : '')
@@ -156,8 +174,13 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
         />
       )}
       {lastBackupFailure && (
+        // Warning, not error: the badge renders this at the degraded tier and
+        // the issue detector reports SeverityWarning. One failed attempt puts
+        // the recovery window at risk and CNPG will retry — unlike the
+        // archiving failure above, which is continuous and stays red on all
+        // three surfaces.
         <AlertBanner
-          variant="error"
+          variant="warning"
           title="Last backup failed"
           message={
             `The most recent backup attempt failed${lastBackupFailure.lastTransitionTime ? ` ${formatAge(lastBackupFailure.lastTransitionTime)} ago` : ''}.` +

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -20,6 +20,7 @@ import {
   getCNPGClusterCertificateExpirations,
   getCNPGWALArchivingFailure,
   getCNPGLastBackupFailure,
+  classifyCNPGClusterPhase,
 } from '../resource-utils-cnpg'
 import { formatAge } from '../resource-utils'
 
@@ -63,6 +64,7 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   // WAL archiving / backup health, straight from the operator's own conditions.
   const walArchivingFailure = getCNPGWALArchivingFailure(data)
   const lastBackupFailure = getCNPGLastBackupFailure(data)
+  const phaseBucket = classifyCNPGClusterPhase(phase)
 
   // Problem detection
   const isDown = instances > 0 && readyInstances === 0
@@ -120,9 +122,17 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
           variant="error"
           title="WAL archiving is failing"
           message={
-            `Continuous archiving has been failing${walArchivingFailure.lastTransitionTime ? ` for ${formatAge(walArchivingFailure.lastTransitionTime)}` : ''}. ` +
-            'The cluster keeps serving traffic normally, but the recovery point may not be advancing — ' +
-            'check the backup destination before relying on point-in-time recovery.' +
+            // Precision matters here. The condition proves the last archival
+            // attempt did not complete and has stayed False since its
+            // transition — it does not prove a continuous run of failures, and
+            // it says nothing about an exact RPO. The "still serving" framing
+            // is gated on the cluster actually being up: asserting it next to a
+            // Cluster Down banner would be plainly false.
+            `CNPG reports that the last WAL archival did not complete${walArchivingFailure.lastTransitionTime ? `, and archiving has been in this state for ${formatAge(walArchivingFailure.lastTransitionTime)}` : ''}. ` +
+            'Recovery-point advancement is uncertain — check the backup destination before relying on point-in-time recovery.' +
+            (isDown || isDegraded || isFailover || phaseBucket === 'terminal'
+              ? ''
+              : ' The cluster is otherwise serving normally, so nothing else here will look wrong.') +
             (walArchivingFailure.message ? ` Operator reported: ${walArchivingFailure.message}` : '')
           }
         />

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
@@ -17,8 +17,12 @@ interface CNPGPoolerRendererProps {
 
 export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps) {
   const desired = data.spec?.instances ?? 0
-  const ready = data.status?.instances ?? 0
-  const isDegraded = desired > 0 && ready < desired
+  // status.instances is the number of pods trying to be SCHEDULED, not ready
+  // pods — a Pooler whose PgBouncer pods are all Pending still reports the full
+  // count. Naming it `ready` here is what let the banner claim a readiness the
+  // CR never establishes.
+  const scheduled = data.status?.instances ?? 0
+  const isDegraded = desired > 0 && scheduled < desired
   const clusterName = getCNPGPoolerCluster(data)
   const parameters = getCNPGPoolerParameters(data)
   const authQuery = getCNPGPoolerAuthQuery(data)
@@ -31,7 +35,7 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
         <AlertBanner
           variant="warning"
           title="Pooler Degraded"
-          message={`Only ${ready} of ${desired} pooler instances are ready.`}
+          message={`Only ${scheduled} of ${desired} pooler instances are scheduled. Readiness is tracked on the "${data.metadata?.name}" Deployment, not on the Pooler.`}
         />
       )}
 
@@ -40,7 +44,7 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
         <PropertyList>
           <Property label="Type" value={getCNPGPoolerType(data)} />
           <Property label="Pool Mode" value={getCNPGPoolerMode(data)} />
-          <Property label="Instances" value={getCNPGPoolerInstances(data)} />
+          <Property label="Instances Scheduled" value={getCNPGPoolerInstances(data)} />
         </PropertyList>
       </Section>
 

--- a/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
@@ -1,8 +1,10 @@
 // CloudNativePG cell components for ResourcesView table
 
 import { clsx } from 'clsx'
+import { Tooltip } from '../../ui/Tooltip'
 import {
   getCNPGClusterStatus,
+  classifyCNPGClusterPhase,
   getCNPGClusterInstances,
   getCNPGClusterPrimary,
   getCNPGClusterImageTag,
@@ -24,6 +26,11 @@ import {
   getCNPGPoolerInstances,
 } from '../resource-utils-cnpg'
 
+/** Terminal = the operator has stopped reconciling; neighbouring cells are stale. */
+function isTerminalPhase(resource: any): boolean {
+  return classifyCNPGClusterPhase(resource?.status?.phase || '') === 'terminal'
+}
+
 export function CNPGClusterCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status': {
@@ -37,15 +44,38 @@ export function CNPGClusterCell({ resource, column }: { resource: any; column: s
     case 'instances': {
       const instances = getCNPGClusterInstances(resource)
       const desired = resource.spec?.instances ?? 0
-      const ready = resource.status?.readyInstances ?? 0
+      const readyKnown = typeof resource.status?.readyInstances === 'number'
+      const ready = readyKnown ? resource.status.readyInstances : 0
+      // A terminal cluster still reports a ready count, and the count is true —
+      // unrecoverable at 2/2 means the data is probably intact, at 0/2 it is down
+      // too. That distinction is worth keeping, so the cell is muted rather than
+      // hidden. Muting alone reads as "less important"; the tooltip is what says
+      // "this does not mean what you think".
+      if (isTerminalPhase(resource)) {
+        return (
+          <Tooltip content="Reconciliation has stopped — this count reflects the pods still running, not a working cluster.">
+            <span className="text-sm text-theme-text-tertiary">{instances}</span>
+          </Tooltip>
+        )
+      }
       return (
-        <span className={clsx('text-sm', ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary')}>
+        <span className={clsx('text-sm', readyKnown && ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary')}>
           {instances}
         </span>
       )
     }
     case 'primary': {
       const primary = getCNPGClusterPrimary(resource)
+      // status.currentPrimary is LAST KNOWN — CNPG never clears it. Naming a
+      // primary on a cluster that cannot elect one is an assertion Radar makes,
+      // not one CNPG makes, so say so rather than presenting it as current.
+      if (isTerminalPhase(resource)) {
+        return (
+          <Tooltip content="Last known primary — this cluster cannot currently elect one.">
+            <span className="text-sm text-theme-text-tertiary truncate block">{primary}</span>
+          </Tooltip>
+        )
+      }
       return <span className="text-sm text-theme-text-secondary truncate block">{primary}</span>
     }
     case 'image': {

--- a/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
@@ -11,6 +11,7 @@ import {
   getCNPGBackupCluster,
   getCNPGBackupMethod,
   getCNPGBackupDuration,
+  getCNPGBackupStartedAt,
   getCNPGScheduledBackupStatus,
   getCNPGScheduledBackupCluster,
   getCNPGScheduleCron,
@@ -77,6 +78,10 @@ export function CNPGBackupCell({ resource, column }: { resource: any; column: st
     case 'method': {
       const method = getCNPGBackupMethod(resource)
       return <span className="text-sm text-theme-text-secondary">{method}</span>
+    }
+    case 'started': {
+      const started = getCNPGBackupStartedAt(resource)
+      return <span className="text-sm text-theme-text-secondary">{started}</span>
     }
     case 'duration': {
       const duration = getCNPGBackupDuration(resource)

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import {
   getCNPGClusterStatus,
+  getCNPGClusterInstances,
   classifyCNPGClusterPhase,
   CNPG_CLUSTER_PHASES_HEALTHY,
   CNPG_CLUSTER_PHASES_TRANSIENT,
@@ -56,6 +57,28 @@ describe('CNPG golden matrix — badge side', () => {
       if (badge.level === 'unhealthy') {
         expect(tc.worst, 'an unhealthy badge must not sit next to silence').not.toBe('none')
       }
+    },
+  )
+
+  // The Instances CELL, derived from the same cases rather than specified in
+  // them. The matrix stays a Go/TS parity spec — Go has no instances cell, so a
+  // `cell` field would add a column only one language can assert to a file
+  // whose whole purpose is that both do. Deriving costs no schema change and
+  // covers every case added later for badge reasons.
+  //
+  // This is the gap that let the bug through: the matrix already pinned
+  // "readyInstances absent — unknown, not zero; must not fabricate an outage"
+  // for the badge, and the cell rendered 0/N on that very case.
+  it.each(cases.map((c) => [c.name, c] as const))(
+    'instances cell does not claim an outage the badge denies — %s',
+    (_name, tc) => {
+      const cell = getCNPGClusterInstances({ spec: tc.spec, status: tc.status })
+      const ready = cell.split('/')[0]
+      const readyReported = typeof tc.status.readyInstances === 'number'
+      expect(
+        ready === '-',
+        `readyInstances ${readyReported ? 'is reported' : 'is absent'} but the cell reads ${cell}`,
+      ).toBe(!readyReported)
     },
   )
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import {
+  getCNPGClusterStatus,
+  classifyCNPGClusterPhase,
+  CNPG_CLUSTER_PHASES_HEALTHY,
+  CNPG_CLUSTER_PHASES_TRANSIENT,
+  CNPG_CLUSTER_PHASES_FAILING,
+  CNPG_CLUSTER_PHASES_TERMINAL,
+  CNPG_CLUSTER_PHASES_ATTENTION,
+} from './resource-utils-cnpg'
+
+// Shared specification, also asserted from Go in
+// internal/issues/source_cnpg_golden_test.go. The sibling parity test compares
+// only phase SPELLING between the two languages, which cannot catch a
+// precedence, readiness-presence or condition difference — every badge/issue
+// disagreement found on this branch slipped past it.
+const GOLDEN = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../../testdata/cnpg/badge-issue-matrix.json',
+)
+
+interface GoldenCase {
+  name: string
+  spec: Record<string, unknown>
+  status: Record<string, unknown>
+  badge: { text: string; level: string }
+  issues: string[]
+  worst: string
+}
+
+const cases: GoldenCase[] = JSON.parse(readFileSync(GOLDEN, 'utf8')).cases
+
+describe('CNPG golden matrix — badge side', () => {
+  it('loads the shared specification', () => {
+    expect(cases.length).toBeGreaterThan(0)
+  })
+
+  it.each(cases.map((c) => [c.name, c] as const))('%s', (_name, tc) => {
+    const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+    expect({ text: badge.text, level: badge.level }).toEqual(tc.badge)
+  })
+
+  // The invariant itself, stated directly against the spec rather than inferred:
+  // a green badge must never accompany an issue, and a red badge must never
+  // accompany silence.
+  it.each(cases.map((c) => [c.name, c] as const))(
+    'badge and issues do not contradict — %s',
+    (_name, tc) => {
+      const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+      if (badge.level === 'healthy') {
+        expect(tc.issues, 'a healthy badge must not sit next to an issue').toEqual([])
+      }
+      if (badge.level === 'unhealthy') {
+        expect(tc.worst, 'an unhealthy badge must not sit next to silence').not.toBe('none')
+      }
+    },
+  )
+})
+
+describe('CNPG phase buckets', () => {
+  // TS checks transient before attention; Go checks attention before transient.
+  // A phase in both would classify differently per language while the spelling
+  // parity test still passed.
+  it('are disjoint', () => {
+    const seen = new Map<string, string>()
+    const buckets: Record<string, readonly string[]> = {
+      healthy: CNPG_CLUSTER_PHASES_HEALTHY,
+      transient: CNPG_CLUSTER_PHASES_TRANSIENT,
+      failing: CNPG_CLUSTER_PHASES_FAILING,
+      terminal: CNPG_CLUSTER_PHASES_TERMINAL,
+      attention: CNPG_CLUSTER_PHASES_ATTENTION,
+    }
+    for (const [bucket, phases] of Object.entries(buckets)) {
+      for (const phase of phases) {
+        expect(seen.has(phase), `${phase} is in both ${seen.get(phase)} and ${bucket}`).toBe(false)
+        seen.set(phase, bucket)
+      }
+    }
+  })
+
+  it('classify every listed phase into its own bucket', () => {
+    for (const p of CNPG_CLUSTER_PHASES_TERMINAL) expect(classifyCNPGClusterPhase(p)).toBe('terminal')
+    for (const p of CNPG_CLUSTER_PHASES_TRANSIENT) expect(classifyCNPGClusterPhase(p)).toBe('transient')
+    for (const p of CNPG_CLUSTER_PHASES_ATTENTION) expect(classifyCNPGClusterPhase(p)).toBe('attention')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -386,3 +386,33 @@ describe('CNPG_CLUSTER_PHASES_ATTENTION', () => {
     expect(classifyCNPGClusterPhase('Cluster upgrade delayed')).toBe('transient')
   })
 })
+
+// The badge and the Go issue detector must agree on the same object. These
+// fixtures are mirrored in internal/issues/source_cnpg_test.go
+// (TestCNPGBadgeAndIssueAgreeOnReadiness) — change one, change both.
+describe('badge/issue agreement on instance readiness', () => {
+  it('does not render Healthy while the detector reports a shortfall', () => {
+    // CNPG sets "Cluster in healthy state" once reconciliation settles, which
+    // can be true while instances are still missing. Returning Healthy here put
+    // a green badge on a cluster the Go side flags CNPGClusterDegraded.
+    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 1 }, { instances: 3 }))
+    expect(s.level).toBe('degraded')
+    expect(s.text).toBe('Degraded')
+  })
+
+  it('still renders Healthy only when the count is actually met', () => {
+    expect(getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 3 }, { instances: 3 })).level).toBe('healthy')
+  })
+
+  it('lets a transient phase explain a legitimate shortfall', () => {
+    // Go marks these phaseExplained and raises no issue, so the badge must not
+    // say "Degraded" either — it shows the phase, at the same amber tier.
+    const s = getCNPGClusterStatus(cluster({ phase: 'Creating a new replica', readyInstances: 1 }, { instances: 3 }))
+    expect(s.level).toBe('degraded')
+    expect(s.text).toBe('Creating a new replica')
+  })
+
+  it('flags a shortfall under an unrecognized phase, matching the Go fallthrough', () => {
+    expect(getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 1 }, { instances: 3 })).level).toBe('degraded')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -530,3 +530,35 @@ describe('status column filter reads the badge, not the raw phase', () => {
     )).toBe('Running')
   })
 })
+
+describe('an unknown phase outranks the Ready condition', () => {
+  // The decision this pins: a phase from a newer CNPG minor renders verbatim.
+  // A Ready=True condition read first would turn it into a green "Ready" badge
+  // — health asserted from a signal that does not establish it.
+  const withPhase = (phase: string, ready?: string) => ({
+    spec: { instances: 2 },
+    status: {
+      phase,
+      readyInstances: 2,
+      ...(ready ? { conditions: [{ type: 'Ready', status: ready, reason: 'ClusterIsReady' }] } : {}),
+    },
+  })
+
+  it('shows the operator words, not Ready, when Ready=True', () => {
+    const s = getCNPGClusterStatus(withPhase('Rebalancing shards across zones', 'True'))
+    expect(s.text).toBe('Rebalancing shards across zones')
+    expect(s.level).toBe('unknown')
+  })
+
+  it('keeps the red when Ready=False, still showing the phase', () => {
+    const s = getCNPGClusterStatus(withPhase('Rebalancing shards across zones', 'False'))
+    expect(s.text).toBe('Rebalancing shards across zones')
+    expect(s.level).toBe('unhealthy')
+  })
+
+  it('falls back to the condition only when there is no phase at all', () => {
+    expect(getCNPGClusterStatus(withPhase('', 'True')).text).toBe('Ready')
+    expect(getCNPGClusterStatus(withPhase('', 'False')).text).toBe('ClusterIsReady')
+    expect(getCNPGClusterStatus({ spec: {}, status: {} }).text).toBe('Unknown')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -20,6 +20,7 @@ import {
   CNPG_BARMAN_PLUGIN_NAME,
   CNPG_GROUP,
   isApiGroup,
+  getCNPGClusterDisplayState,
 } from './resource-utils-cnpg'
 
 describe('getCNPGClusterCertificateExpirations', () => {
@@ -146,7 +147,7 @@ describe('getCNPGClusterStatus', () => {
       { instances: 3 },
     ))
     expect(s.level).toBe('unhealthy')
-    expect(s.text).toBe('Cluster is unrecoverable and needs manual intervention')
+    expect(s.text).toBe('Unrecoverable')
   })
 
   it('renders both plugin-failure phases red', () => {
@@ -161,7 +162,7 @@ describe('getCNPGClusterStatus', () => {
   it('renders a major-version upgrade as transient, not unknown', () => {
     const s = getCNPGClusterStatus(cluster({ phase: 'Upgrading Postgres major version', readyInstances: 1 }, { instances: 3 }))
     expect(s.level).toBe('degraded')
-    expect(s.text).toBe('Upgrading Postgres major version')
+    expect(s.text).toBe('Major Upgrade')
   })
 
   it('uses the alert tier for failover, between degraded and unhealthy', () => {
@@ -412,7 +413,7 @@ describe('badge/issue agreement on instance readiness', () => {
     // say "Degraded" either — it shows the phase, at the same amber tier.
     const s = getCNPGClusterStatus(cluster({ phase: 'Creating a new replica', readyInstances: 1 }, { instances: 3 }))
     expect(s.level).toBe('degraded')
-    expect(s.text).toBe('Creating a new replica')
+    expect(s.text).toBe('Creating Replica')
   })
 
   it('lets an attention phase explain a shortfall, matching the supervised Go path', () => {
@@ -421,10 +422,56 @@ describe('badge/issue agreement on instance readiness', () => {
     // the badge must show the phase, not "Degraded".
     const s = getCNPGClusterStatus(cluster({ phase: 'Waiting for user action', readyInstances: 1 }, { instances: 3 }))
     expect(s.level).toBe('degraded')
-    expect(s.text).toBe('Waiting for user action')
+    expect(s.text).toBe('Needs Action')
   })
 
   it('flags a shortfall under an unrecognized phase, matching the Go fallthrough', () => {
     expect(getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 1 }, { instances: 3 })).level).toBe('degraded')
+  })
+})
+
+// ============================================================================
+// DISPLAY STATES — a badge carries a state, the drawer carries the prose
+// ============================================================================
+
+describe('getCNPGClusterDisplayState', () => {
+  it('maps every mapped phase to something a badge can hold', () => {
+    // 127px is the label budget at w-44. The longest state must clear it with
+    // real headroom — not the 0.2px kind that has bitten three times.
+    const all = [
+      ...CNPG_CLUSTER_PHASES_TERMINAL,
+      ...CNPG_CLUSTER_PHASES_TRANSIENT,
+      ...CNPG_CLUSTER_PHASES_ATTENTION,
+    ]
+    for (const phase of all) {
+      const state = getCNPGClusterDisplayState(phase)
+      expect(state, `${phase} has no display state`).not.toBe(phase)
+      // Rough proxy for width in a unit test; the real measurement is in the
+      // PR. 22 chars ≈ 120px at this typography.
+      expect(state.length, `${state} is too long for a badge`).toBeLessThanOrEqual(22)
+    }
+  })
+
+  it('passes an unmapped phase through verbatim rather than inventing one', () => {
+    // A phase from a newer CNPG minor. Inventing a state for a string we have
+    // never seen would be worse than showing the operator's words.
+    expect(getCNPGClusterDisplayState('Reticulating splines')).toBe('Reticulating splines')
+    expect(getCNPGClusterDisplayState('')).toBe('')
+  })
+
+  it('collapses both restart phases to one state — a documented loss', () => {
+    // You cannot tell from the table which restart mechanism is in play. The
+    // exact phase stays in the drawer; splitting them needs ~140px.
+    expect(getCNPGClusterDisplayState('Primary instance is being restarted in-place')).toBe('Restarting Primary')
+    expect(getCNPGClusterDisplayState('Primary instance is being restarted without a switchover')).toBe('Restarting Primary')
+  })
+
+  it('renders the state, not the sentence, on the badge', () => {
+    const s = getCNPGClusterStatus(cluster(
+      { phase: 'Cluster is unrecoverable and needs manual intervention', readyInstances: 2 },
+      { instances: 2 },
+    ))
+    expect(s.text).toBe('Unrecoverable')
+    expect(s.level).toBe('unhealthy')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -18,6 +18,8 @@ import {
   CNPG_CLUSTER_PHASES_ATTENTION,
   CNPG_BACKUP_PHASES_TRANSIENT,
   CNPG_BARMAN_PLUGIN_NAME,
+  CNPG_GROUP,
+  isApiGroup,
 } from './resource-utils-cnpg'
 
 describe('getCNPGClusterCertificateExpirations', () => {
@@ -354,5 +356,33 @@ describe('getCNPGClusterBackupConfig', () => {
 
   it('reports not-configured when neither path is present', () => {
     expect(getCNPGClusterBackupConfig({ spec: {}, status: {} }).configured).toBe(false)
+  })
+})
+
+describe('isApiGroup', () => {
+  it('matches the exact group, not a substring of it', () => {
+    expect(isApiGroup('postgresql.cnpg.io/v1', CNPG_GROUP)).toBe(true)
+    // A vendor sub-group contains the CNPG group as a substring but is not it.
+    expect(isApiGroup('extension.postgresql.cnpg.io/v1', CNPG_GROUP)).toBe(false)
+    expect(isApiGroup('barmancloud.cnpg.io/v1', CNPG_GROUP)).toBe(false)
+    expect(isApiGroup('backup.velero.io/v1', 'velero.io')).toBe(false)
+    expect(isApiGroup('velero.io/v1', 'velero.io')).toBe(true)
+  })
+
+  it('rejects core-group and malformed apiVersions', () => {
+    expect(isApiGroup('v1', CNPG_GROUP)).toBe(false)
+    expect(isApiGroup('/v1', CNPG_GROUP)).toBe(false)
+    expect(isApiGroup(undefined, CNPG_GROUP)).toBe(false)
+    expect(isApiGroup(null, CNPG_GROUP)).toBe(false)
+  })
+})
+
+describe('CNPG_CLUSTER_PHASES_ATTENTION', () => {
+  it('excludes the operator-driven rollout delay', () => {
+    // "Cluster upgrade delayed" is postponed by the operator's own config and
+    // requeued — nothing waits on a human.
+    expect(CNPG_CLUSTER_PHASES_ATTENTION).not.toContain('Cluster upgrade delayed')
+    expect(CNPG_CLUSTER_PHASES_TRANSIENT).toContain('Cluster upgrade delayed')
+    expect(classifyCNPGClusterPhase('Cluster upgrade delayed')).toBe('transient')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -21,6 +21,8 @@ import {
   CNPG_GROUP,
   isApiGroup,
   getCNPGClusterDisplayState,
+  getCNPGClusterInstances,
+  getCNPGPoolerInstances,
 } from './resource-utils-cnpg'
 import { getCellFilterValue } from './resource-utils'
 
@@ -560,5 +562,40 @@ describe('an unknown phase outranks the Ready condition', () => {
     expect(getCNPGClusterStatus(withPhase('', 'True')).text).toBe('Ready')
     expect(getCNPGClusterStatus(withPhase('', 'False')).text).toBe('ClusterIsReady')
     expect(getCNPGClusterStatus({ spec: {}, status: {} }).text).toBe('Unknown')
+  })
+})
+
+describe('an absent count is unknown, never zero', () => {
+  // The window this covers is ordinary: between creation and the operator's
+  // first status write. Brief, common, and exactly when someone is watching.
+  it('Cluster instances cell renders a dash, not 0', () => {
+    expect(getCNPGClusterInstances({ spec: { instances: 3 }, status: {} })).toBe('-/3')
+    expect(getCNPGClusterInstances({ spec: {}, status: {} })).toBe('-/-')
+    expect(getCNPGClusterInstances({ spec: { instances: 3 }, status: { readyInstances: 0 } })).toBe('0/3')
+    expect(getCNPGClusterInstances({ spec: { instances: 3 }, status: { readyInstances: 3 } })).toBe('3/3')
+  })
+
+  it('does not contradict the badge during that window', () => {
+    // The pairing IS the claim: a cell reading 0/3 beside a badge that does not
+    // say degraded is the contradiction this integration exists to remove.
+    const fresh = { spec: { instances: 3 }, status: { phase: 'Setting up primary' } }
+    expect(getCNPGClusterInstances(fresh)).toBe('-/3')
+    expect(getCNPGClusterStatus(fresh).level).not.toBe('unhealthy')
+  })
+
+  it('Pooler instances cell renders a dash, not 0', () => {
+    expect(getCNPGPoolerInstances({ spec: { instances: 2 }, status: {} })).toBe('-/2')
+    expect(getCNPGPoolerInstances({ spec: { instances: 2 }, status: { instances: 0 } })).toBe('0/2')
+  })
+
+  it('Pooler badge says Unknown, not a red Not Scheduled', () => {
+    // Sharper than the cell: reading absence as 0 fabricated a FAILURE, so an
+    // unreconciled Pooler went red on a state nobody had reported yet.
+    const fresh = { spec: { instances: 2 }, status: {} }
+    expect(getCNPGPoolerStatus(fresh)).toMatchObject({ text: 'Unknown', level: 'unknown' })
+    expect(getCNPGPoolerStatus({ spec: { instances: 2 }, status: { instances: 0 } }))
+      .toMatchObject({ text: 'Not Scheduled', level: 'unhealthy' })
+    expect(getCNPGPoolerStatus({ spec: { instances: 2 }, status: { instances: 2 } }))
+      .toMatchObject({ text: 'Scheduled', level: 'healthy' })
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { getCNPGClusterCertificateExpirations } from './resource-utils-cnpg'
+import {
+  getCNPGClusterCertificateExpirations,
+  getCNPGClusterStatus,
+  getCNPGBackupStatus,
+  getCNPGPoolerStatus,
+  getCNPGClusterInstancesReportedState,
+  getCNPGClusterBackupConfig,
+  getCNPGClusterBarmanPlugin,
+  getCNPGWALArchivingFailure,
+  getCNPGLastBackupFailure,
+  classifyCNPGClusterPhase,
+  classifyCNPGBackupPhase,
+  CNPG_CLUSTER_PHASES_HEALTHY,
+  CNPG_CLUSTER_PHASES_TRANSIENT,
+  CNPG_CLUSTER_PHASES_FAILING,
+  CNPG_CLUSTER_PHASES_TERMINAL,
+  CNPG_CLUSTER_PHASES_ATTENTION,
+  CNPG_BACKUP_PHASES_TRANSIENT,
+  CNPG_BARMAN_PLUGIN_NAME,
+} from './resource-utils-cnpg'
 
 describe('getCNPGClusterCertificateExpirations', () => {
   beforeEach(() => {
@@ -71,5 +90,269 @@ describe('getCNPGClusterCertificateExpirations', () => {
   it('returns empty list when no expirations are present', () => {
     expect(getCNPGClusterCertificateExpirations({})).toEqual([])
     expect(getCNPGClusterCertificateExpirations({ status: {} })).toEqual([])
+  })
+})
+
+// ============================================================================
+// PHASE TAXONOMY
+// ============================================================================
+
+const cluster = (status: any = {}, spec: any = {}) => ({ spec, status })
+
+describe('classifyCNPGClusterPhase', () => {
+  it('buckets every phase constant shipped by CNPG 1.27', () => {
+    for (const p of CNPG_CLUSTER_PHASES_HEALTHY) expect(classifyCNPGClusterPhase(p)).toBe('healthy')
+    for (const p of CNPG_CLUSTER_PHASES_TRANSIENT) expect(classifyCNPGClusterPhase(p)).toBe('transient')
+    for (const p of CNPG_CLUSTER_PHASES_FAILING) expect(classifyCNPGClusterPhase(p)).toBe('failing')
+    for (const p of CNPG_CLUSTER_PHASES_TERMINAL) expect(classifyCNPGClusterPhase(p)).toBe('terminal')
+    for (const p of CNPG_CLUSTER_PHASES_ATTENTION) expect(classifyCNPGClusterPhase(p)).toBe('attention')
+  })
+
+  it('matches on equality, not substring', () => {
+    // The bug this pins: "Upgrading Postgres major version" contains neither
+    // "Upgrading cluster" nor vice versa, but a sloppy includes() over the
+    // transient list would still have to enumerate it. Both must classify.
+    expect(classifyCNPGClusterPhase('Upgrading cluster')).toBe('transient')
+    expect(classifyCNPGClusterPhase('Upgrading Postgres major version')).toBe('transient')
+    // A phase that merely CONTAINS a known one must not inherit its bucket.
+    expect(classifyCNPGClusterPhase('Cluster in healthy state (probably)')).toBe('unknown')
+  })
+
+  it('classifies an unknown phase from a future CNPG minor as unknown', () => {
+    expect(classifyCNPGClusterPhase('Reticulating splines')).toBe('unknown')
+    expect(classifyCNPGClusterPhase('')).toBe('unknown')
+  })
+
+  it('has no dead entries — every listed phase is a real CNPG constant', () => {
+    // "Creating replica" was the shipped typo; CNPG emits "Creating a new replica".
+    expect(CNPG_CLUSTER_PHASES_TRANSIENT).toContain('Creating a new replica')
+    expect(CNPG_CLUSTER_PHASES_TRANSIENT).not.toContain('Creating replica')
+    // "Invalid cluster definition" does not exist in CNPG 1.27's cluster_types.go.
+    expect(CNPG_CLUSTER_PHASES_TERMINAL).not.toContain('Invalid cluster definition')
+  })
+})
+
+describe('getCNPGClusterStatus', () => {
+  it('renders an unrecoverable cluster red even when all pods are ready', () => {
+    // The shipped bug: readiness was checked first, so this fell through every
+    // phase list and landed on the neutral-grey fallback.
+    const s = getCNPGClusterStatus(cluster(
+      { phase: 'Cluster is unrecoverable and needs manual intervention', readyInstances: 3 },
+      { instances: 3 },
+    ))
+    expect(s.level).toBe('unhealthy')
+    expect(s.text).toBe('Cluster is unrecoverable and needs manual intervention')
+  })
+
+  it('renders both plugin-failure phases red', () => {
+    for (const phase of [
+      'Cluster cannot proceed to reconciliation due to an unknown plugin being required',
+      'Cluster cannot proceed to reconciliation due to an error while interacting with plugins',
+    ]) {
+      expect(getCNPGClusterStatus(cluster({ phase, readyInstances: 2 }, { instances: 2 })).level).toBe('unhealthy')
+    }
+  })
+
+  it('renders a major-version upgrade as transient, not unknown', () => {
+    const s = getCNPGClusterStatus(cluster({ phase: 'Upgrading Postgres major version', readyInstances: 1 }, { instances: 3 }))
+    expect(s.level).toBe('degraded')
+    expect(s.text).toBe('Upgrading Postgres major version')
+  })
+
+  it('uses the alert tier for failover, between degraded and unhealthy', () => {
+    expect(getCNPGClusterStatus(cluster({ phase: 'Failing over', readyInstances: 2 }, { instances: 3 })).level).toBe('alert')
+  })
+
+  it('treats zero ready instances as down regardless of phase', () => {
+    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 0 }, { instances: 3 }))
+    expect(s.level).toBe('unhealthy')
+    expect(s.text).toBe('Not Ready')
+  })
+
+  it('is healthy when the phase is healthy and all instances are ready', () => {
+    expect(getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 2 }, { instances: 2 })).level).toBe('healthy')
+  })
+
+  it('surfaces an unrecognized phase verbatim at unknown rather than guessing', () => {
+    const s = getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 2 }, { instances: 2 }))
+    expect(s.level).toBe('unknown')
+    expect(s.text).toBe('Some future phase')
+  })
+})
+
+describe('getCNPGBackupStatus', () => {
+  it('escalates walArchivingFailing instead of rendering it neutral', () => {
+    // The shipped bug: this phase hit the default branch and rendered grey,
+    // while it is CNPG telling you the recovery point is drifting.
+    const s = getCNPGBackupStatus({ status: { phase: 'walArchivingFailing' } })
+    expect(s.level).toBe('unhealthy')
+    expect(s.text).toBe('WAL Archiving Failing')
+  })
+
+  it('classifies every backup phase constant shipped by CNPG 1.27', () => {
+    expect(classifyCNPGBackupPhase('completed')).toBe('healthy')
+    expect(classifyCNPGBackupPhase('failed')).toBe('failed')
+    expect(classifyCNPGBackupPhase('walArchivingFailing')).toBe('walArchivingFailing')
+    for (const p of CNPG_BACKUP_PHASES_TRANSIENT) expect(classifyCNPGBackupPhase(p)).toBe('transient')
+  })
+
+  it('handles started and finalizing, which previously fell through to unknown', () => {
+    expect(getCNPGBackupStatus({ status: { phase: 'started' } }).level).toBe('degraded')
+    expect(getCNPGBackupStatus({ status: { phase: 'finalizing' } }).level).toBe('degraded')
+  })
+
+  it('leaves an unrecognized phase at unknown', () => {
+    expect(getCNPGBackupStatus({ status: { phase: 'wat' } }).level).toBe('unknown')
+    expect(getCNPGBackupStatus({}).level).toBe('unknown')
+  })
+})
+
+// ============================================================================
+// CONDITIONS — WAL ARCHIVING / LAST BACKUP
+// ============================================================================
+
+const withConditions = (...conds: any[]) => ({ status: { conditions: conds } })
+
+describe('getCNPGWALArchivingFailure', () => {
+  it('fires only when ContinuousArchiving is False', () => {
+    expect(getCNPGWALArchivingFailure(withConditions(
+      { type: 'ContinuousArchiving', status: 'True', reason: 'ContinuousArchivingSuccess' },
+    ))).toBeNull()
+
+    const f = getCNPGWALArchivingFailure(withConditions(
+      { type: 'ContinuousArchiving', status: 'False', reason: 'ContinuousArchivingFailing', message: 'boom', lastTransitionTime: '2026-04-28T10:00:00Z' },
+    ))
+    expect(f?.reason).toBe('ContinuousArchivingFailing')
+    expect(f?.lastTransitionTime).toBe('2026-04-28T10:00:00Z')
+  })
+
+  it('returns null when the condition is absent', () => {
+    expect(getCNPGWALArchivingFailure({})).toBeNull()
+    expect(getCNPGWALArchivingFailure(withConditions({ type: 'Ready', status: 'True' }))).toBeNull()
+  })
+})
+
+describe('getCNPGLastBackupFailure', () => {
+  it('ignores the in-flight BackupStarted state', () => {
+    // CNPG sets LastBackupSucceeded=False/BackupStarted while a backup is merely
+    // starting. Alerting on it would light the banner on every backup run.
+    expect(getCNPGLastBackupFailure(withConditions(
+      { type: 'LastBackupSucceeded', status: 'False', reason: 'BackupStarted' },
+    ))).toBeNull()
+  })
+
+  it('fires on a real LastBackupFailed', () => {
+    const f = getCNPGLastBackupFailure(withConditions(
+      { type: 'LastBackupSucceeded', status: 'False', reason: 'LastBackupFailed', message: 'no credentials' },
+    ))
+    expect(f?.reason).toBe('LastBackupFailed')
+    expect(f?.message).toBe('no credentials')
+  })
+})
+
+// ============================================================================
+// BUG 7 — timeLineID
+// ============================================================================
+
+describe('getCNPGClusterInstancesReportedState', () => {
+  it('reads CNPG\'s timeLineID spelling (capital L)', () => {
+    const state = getCNPGClusterInstancesReportedState({
+      status: {
+        instancesReportedState: {
+          'pg-main-1': { ip: '10.244.0.9', isPrimary: true, timeLineID: 3 },
+          'pg-main-2': { ip: '10.244.0.12', isPrimary: false, timeLineID: 3 },
+        },
+      },
+    })
+    expect(state).toHaveLength(2)
+    expect(state[0]).toMatchObject({ podName: 'pg-main-1', isPrimary: true, timelineID: 3, ip: '10.244.0.9' })
+    expect(state[1].timelineID).toBe(3)
+  })
+
+  it('does not read the lowercase timelineID spelling, which CNPG never emits', () => {
+    const state = getCNPGClusterInstancesReportedState({
+      status: { instancesReportedState: { 'pg-1': { isPrimary: true, timelineID: 9 } } },
+    })
+    expect(state[0].timelineID).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// POOLER
+// ============================================================================
+
+describe('getCNPGPoolerStatus', () => {
+  it('does not claim readiness from status.instances, which counts scheduled pods', () => {
+    // Verified live: a Pooler whose 2 PgBouncer pods are both Pending (0/1
+    // ready) still reports status.instances=2. Calling that "Ready" renders a
+    // broken Pooler green.
+    const s = getCNPGPoolerStatus({ spec: { instances: 2 }, status: { instances: 2 } })
+    expect(s.level).toBe('healthy')
+    expect(s.text).toBe('Scheduled')
+    expect(s.text).not.toBe('Ready')
+  })
+
+  it('flags a shortfall in scheduled pods', () => {
+    expect(getCNPGPoolerStatus({ spec: { instances: 3 }, status: { instances: 1 } })).toMatchObject({ level: 'degraded' })
+    expect(getCNPGPoolerStatus({ spec: { instances: 3 }, status: { instances: 0 } })).toMatchObject({ level: 'unhealthy', text: 'Not Scheduled' })
+  })
+})
+
+// ============================================================================
+// BUG 6 — PLUGIN-AWARE BACKUP
+// ============================================================================
+
+describe('getCNPGClusterBarmanPlugin', () => {
+  it('detects the barman-cloud plugin and resolves the ObjectStore + server key', () => {
+    const p = getCNPGClusterBarmanPlugin({
+      metadata: { name: 'pg-main' },
+      spec: { plugins: [{ name: CNPG_BARMAN_PLUGIN_NAME, isWALArchiver: true, parameters: { barmanObjectName: 'store-a' } }] },
+    })
+    expect(p).toMatchObject({ barmanObjectName: 'store-a', isWALArchiver: true, serverName: 'pg-main' })
+  })
+
+  it('prefers an explicit serverName parameter over the cluster name', () => {
+    const p = getCNPGClusterBarmanPlugin({
+      metadata: { name: 'pg-main' },
+      spec: { plugins: [{ name: CNPG_BARMAN_PLUGIN_NAME, parameters: { barmanObjectName: 'store-a', serverName: 'custom' } }] },
+    })
+    expect(p?.serverName).toBe('custom')
+  })
+
+  it('ignores an explicitly disabled plugin and unrelated plugins', () => {
+    expect(getCNPGClusterBarmanPlugin({
+      spec: { plugins: [{ name: CNPG_BARMAN_PLUGIN_NAME, enabled: false }] },
+    })).toBeNull()
+    expect(getCNPGClusterBarmanPlugin({
+      spec: { plugins: [{ name: 'some-other.plugin.io' }] },
+    })).toBeNull()
+    expect(getCNPGClusterBarmanPlugin({ spec: {} })).toBeNull()
+  })
+})
+
+describe('getCNPGClusterBackupConfig', () => {
+  it('reports configured for a plugin-managed cluster with no in-tree stanza', () => {
+    // The shipped bug: plugin-migrated clusters render the whole backup section
+    // blank, indistinguishable from "no backups configured".
+    const cfg = getCNPGClusterBackupConfig({
+      metadata: { name: 'pg-main' },
+      spec: { plugins: [{ name: CNPG_BARMAN_PLUGIN_NAME, parameters: { barmanObjectName: 'store-a' } }] },
+      status: {},
+    })
+    expect(cfg.configured).toBe(true)
+    expect(cfg.rpoTrackedOnObjectStore).toBe(true)
+    expect(cfg.plugin?.barmanObjectName).toBe('store-a')
+  })
+
+  it('still reports in-tree config the old way', () => {
+    const cfg = getCNPGClusterBackupConfig({
+      spec: { backup: { barmanObjectStore: { destinationPath: 's3://b' }, retentionPolicy: '30d' } },
+      status: { lastSuccessfulBackup: '2026-04-28T00:00:00Z' },
+    })
+    expect(cfg).toMatchObject({ configured: true, destinationPath: 's3://b', retentionPolicy: '30d', plugin: null, rpoTrackedOnObjectStore: false })
+  })
+
+  it('reports not-configured when neither path is present', () => {
+    expect(getCNPGClusterBackupConfig({ spec: {}, status: {} }).configured).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -412,6 +412,15 @@ describe('badge/issue agreement on instance readiness', () => {
     expect(s.text).toBe('Creating a new replica')
   })
 
+  it('lets an attention phase explain a shortfall, matching the supervised Go path', () => {
+    // Go marks attention phases phaseExplained regardless of update strategy,
+    // so a supervised cluster waiting on a human raises no shortfall issue —
+    // the badge must show the phase, not "Degraded".
+    const s = getCNPGClusterStatus(cluster({ phase: 'Waiting for user action', readyInstances: 1 }, { instances: 3 }))
+    expect(s.level).toBe('degraded')
+    expect(s.text).toBe('Waiting for user action')
+  })
+
   it('flags a shortfall under an unrecognized phase, matching the Go fallthrough', () => {
     expect(getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 1 }, { instances: 3 })).level).toBe('degraded')
   })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -125,12 +125,15 @@ describe('classifyCNPGClusterPhase', () => {
     expect(classifyCNPGClusterPhase('')).toBe('unknown')
   })
 
-  it('has no dead entries — every listed phase is a real CNPG constant', () => {
+  it('has no invented entries — every listed phase is a real CNPG constant', () => {
     // "Creating replica" was the shipped typo; CNPG emits "Creating a new replica".
     expect(CNPG_CLUSTER_PHASES_TRANSIENT).toContain('Creating a new replica')
     expect(CNPG_CLUSTER_PHASES_TRANSIENT).not.toContain('Creating replica')
-    // "Invalid cluster definition" does not exist in CNPG 1.27's cluster_types.go.
-    expect(CNPG_CLUSTER_PHASES_TERMINAL).not.toContain('Invalid cluster definition')
+    // PhaseDefinitionInvalid is absent from 1.27 and 1.28 but present upstream
+    // after 1.28. Matching is by equality, so carrying it is inert against an
+    // operator that never emits it, and correct once one does.
+    expect(CNPG_CLUSTER_PHASES_TERMINAL).toContain('Invalid cluster definition')
+    expect(classifyCNPGClusterPhase('Invalid cluster definition')).toBe('terminal')
   })
 })
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -22,6 +22,7 @@ import {
   isApiGroup,
   getCNPGClusterDisplayState,
 } from './resource-utils-cnpg'
+import { getCellFilterValue } from './resource-utils'
 
 describe('getCNPGClusterCertificateExpirations', () => {
   beforeEach(() => {
@@ -473,5 +474,59 @@ describe('getCNPGClusterDisplayState', () => {
     ))
     expect(s.text).toBe('Unrecoverable')
     expect(s.level).toBe('unhealthy')
+  })
+})
+
+describe('status column filter reads the badge, not the raw phase', () => {
+  // Deliberately asserts LITERAL strings rather than comparing against
+  // getCNPGClusterStatus(...).text — both sides would call the same reader and
+  // the test would pass while both were wrong. These are the strings a user
+  // sees on a badge, so the dropdown must offer exactly them.
+  const CLUSTER = 'cnpgclusters'
+
+  it('offers the short state, not CNPG prose', () => {
+    expect(getCellFilterValue(
+      cluster({ phase: 'Cluster is unrecoverable and needs manual intervention', readyInstances: 2 }, { instances: 2 }),
+      'status', CLUSTER,
+    )).toBe('Unrecoverable')
+
+    expect(getCellFilterValue(
+      cluster({ phase: 'Cluster in healthy state', readyInstances: 2 }, { instances: 2 }),
+      'status', CLUSTER,
+    )).toBe('Healthy')
+  })
+
+  it('separates a WAL-archiving failure from healthy — they share a phase', () => {
+    // The defect this pins: both clusters report `Cluster in healthy state`,
+    // so filtering on the raw phase collapsed them into one option and the
+    // headline state of this integration could not be filtered for at all.
+    const healthy = cluster({ phase: 'Cluster in healthy state', readyInstances: 2 }, { instances: 2 })
+    const walFailing = cluster({
+      phase: 'Cluster in healthy state',
+      readyInstances: 2,
+      conditions: [{ type: 'ContinuousArchiving', status: 'False', reason: 'ContinuousArchivingFailing' }],
+    }, { instances: 2 })
+
+    expect(healthy.status.phase).toBe(walFailing.status.phase)
+    expect(getCellFilterValue(healthy, 'status', CLUSTER)).toBe('Healthy')
+    expect(getCellFilterValue(walFailing, 'status', CLUSTER)).toBe('WAL Archiving Failing')
+  })
+
+  it('covers the other three CNPG kinds', () => {
+    expect(getCellFilterValue({ status: { phase: 'completed' } }, 'status', 'cnpgbackups')).toBe('Completed')
+    expect(getCellFilterValue(
+      { apiVersion: 'postgresql.cnpg.io/v1', spec: { suspend: true } }, 'status', 'scheduledbackups',
+    )).toBe('Suspended')
+    expect(getCellFilterValue(
+      { apiVersion: 'postgresql.cnpg.io/v1', spec: { instances: 2 }, status: { instances: 2 } }, 'status', 'poolers',
+    )).toBe('Scheduled')
+  })
+
+  it('leaves a foreign CRD sharing the plural on the generic path', () => {
+    // `poolers`/`scheduledbackups` are bare plurals — another operator could
+    // ship them, and it must not be read through a CNPG accessor.
+    expect(getCellFilterValue(
+      { apiVersion: 'pooling.example.com/v1', status: { phase: 'Running' } }, 'status', 'poolers',
+    )).toBe('Running')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -8,44 +8,94 @@ import { parseGoTimeString } from '../../utils/parse-go-time'
 // CNPG CLUSTER UTILITIES
 // ============================================================================
 
+// Phase strings are full English sentences copied verbatim from CNPG's
+// api/v1/cluster_types.go — match on equality, never substring. Verified
+// against CNPG 1.27. Radar's Go issue detection mirrors these buckets in
+// internal/issues/source_cnpg.go; the two must not drift, or a cluster gets
+// a red badge and no issue (or the reverse).
+
+/** Cluster is reconciled and serving. */
+export const CNPG_CLUSTER_PHASES_HEALTHY = ['Cluster in healthy state'] as const
+
+/** Operator is mid-operation. Expected to resolve on its own. */
+export const CNPG_CLUSTER_PHASES_TRANSIENT = [
+  'Setting up primary',
+  'Creating a new replica',
+  'Switchover in progress',
+  'Upgrading cluster',
+  'Upgrading Postgres major version',
+  'Online upgrade in progress',
+  'Applying configuration',
+  'Primary instance is being restarted in-place',
+  'Primary instance is being restarted without a switchover',
+  'Promoting to primary cluster',
+  'Waiting for the instances to become active',
+] as const
+
+/** Losing the primary — degraded now, self-resolving only if a replica can take over. */
+export const CNPG_CLUSTER_PHASES_FAILING = ['Failing over'] as const
+
+/** Reconciliation has stopped. These need a human; none of them self-heal. */
+export const CNPG_CLUSTER_PHASES_TERMINAL = [
+  'Cluster is unrecoverable and needs manual intervention',
+  'Unable to create required cluster objects',
+  'Cluster has incomplete or invalid image catalog',
+  'Cluster cannot proceed to reconciliation due to an unknown plugin being required',
+  'Cluster cannot proceed to reconciliation due to an error while interacting with plugins',
+  'Cluster cannot execute instance online upgrade due to missing architecture binary',
+] as const
+
+/**
+ * Stalled waiting on a human. Under `primaryUpdateStrategy: supervised` this is
+ * the documented, expected resting state, so it is styled as attention rather
+ * than failure and the Go side suppresses the issue entirely.
+ */
+export const CNPG_CLUSTER_PHASES_ATTENTION = [
+  'Waiting for user action',
+  'Cluster upgrade delayed',
+] as const
+
+export type CNPGPhaseBucket = 'healthy' | 'transient' | 'failing' | 'terminal' | 'attention' | 'unknown'
+
+export function classifyCNPGClusterPhase(phase: string): CNPGPhaseBucket {
+  if (!phase) return 'unknown'
+  if ((CNPG_CLUSTER_PHASES_HEALTHY as readonly string[]).includes(phase)) return 'healthy'
+  if ((CNPG_CLUSTER_PHASES_TERMINAL as readonly string[]).includes(phase)) return 'terminal'
+  if ((CNPG_CLUSTER_PHASES_FAILING as readonly string[]).includes(phase)) return 'failing'
+  if ((CNPG_CLUSTER_PHASES_TRANSIENT as readonly string[]).includes(phase)) return 'transient'
+  if ((CNPG_CLUSTER_PHASES_ATTENTION as readonly string[]).includes(phase)) return 'attention'
+  return 'unknown'
+}
+
 export function getCNPGClusterStatus(resource: any): StatusBadge {
   const status = resource.status || {}
   const phase = status.phase || ''
   const instances = resource.spec?.instances ?? 0
   const readyInstances = status.readyInstances ?? 0
+  const bucket = classifyCNPGClusterPhase(phase)
 
-  // Check for degraded instances first
-  if (instances > 0 && readyInstances < instances) {
-    // Distinguish between total failure and partial degradation
-    if (readyInstances === 0) {
-      return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
-    }
-    return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
+  // Terminal phases outrank instance counts: an unrecoverable cluster whose pods
+  // happen to still be Ready is still unrecoverable, and reading the counts first
+  // is what used to render it neutral.
+  if (bucket === 'terminal') {
+    return { text: phase, color: healthColors.unhealthy, level: 'unhealthy' }
   }
-
-  // Phase-based status
-  const healthyPhases = ['Cluster in healthy state', 'Healthy']
-  const transientPhases = [
-    'Setting up primary',
-    'Creating replica',
-    'Switchover in progress',
-    'Upgrading cluster',
-    'Online upgrade in progress',
-  ]
-  const unhealthyPhases = [
-    'Failing over',
-    'Failing over (streaming)',
-    'Failing over (designated primary)',
-  ]
-
-  if (healthyPhases.some(p => phase.includes(p))) {
+  if (bucket === 'failing') {
+    return { text: 'Failing Over', color: healthColors.alert, level: 'alert' }
+  }
+  // Zero ready instances is a hard down regardless of what the phase claims.
+  if (instances > 0 && readyInstances === 0) {
+    return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (bucket === 'healthy') {
     return { text: 'Healthy', color: healthColors.healthy, level: 'healthy' }
   }
-  if (unhealthyPhases.some(p => phase.includes(p))) {
-    return { text: 'Failing Over', color: healthColors.unhealthy, level: 'unhealthy' }
-  }
-  if (transientPhases.some(p => phase.includes(p))) {
+  // A transient phase explains partial readiness better than a bare "Degraded".
+  if (bucket === 'transient' || bucket === 'attention') {
     return { text: phase, color: healthColors.degraded, level: 'degraded' }
+  }
+  if (instances > 0 && readyInstances < instances) {
+    return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
 
   // Conditions fallback
@@ -58,6 +108,8 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
     return { text: readyCond.reason || 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
+  // Unrecognized phase — surface the operator's own words rather than inventing
+  // a health level. A new CNPG minor adding a phase lands here, not in "Healthy".
   if (phase) {
     return { text: phase, color: healthColors.unknown, level: 'unknown' }
   }
@@ -118,21 +170,66 @@ export function getCNPGClusterUpdateStrategy(resource: any): string {
   return resource.spec?.primaryUpdateStrategy || 'unsupervised'
 }
 
+export const CNPG_BARMAN_PLUGIN_NAME = 'barman-cloud.cloudnative-pg.io'
+
+export interface CNPGBarmanPlugin {
+  name: string
+  /** ObjectStore CR (barmancloud.cnpg.io/v1) holding the real destination + recovery window. */
+  barmanObjectName?: string
+  /** Resolved server key inside ObjectStore.status.serverRecoveryWindow. */
+  serverName?: string
+  isWALArchiver: boolean
+}
+
+/**
+ * Detects the barman-cloud CNPG-I plugin. In-tree `spec.backup.barmanObjectStore`
+ * is deprecated as of CNPG 1.26 and the migration moves config into an
+ * `ObjectStore` CR in a different API group — at which point CNPG stops setting
+ * status.lastSuccessfulBackup / firstRecoverabilityPoint entirely.
+ */
+export function getCNPGClusterBarmanPlugin(resource: any): CNPGBarmanPlugin | null {
+  const plugins = resource.spec?.plugins
+  if (!Array.isArray(plugins)) return null
+  const plugin = plugins.find(
+    (p: any) => p?.name === CNPG_BARMAN_PLUGIN_NAME && p?.enabled !== false
+  )
+  if (!plugin) return null
+  return {
+    name: plugin.name,
+    barmanObjectName: plugin.parameters?.barmanObjectName,
+    // ObjectStore keys the recovery window by the plugin's serverName when set,
+    // otherwise by the cluster name.
+    serverName: plugin.parameters?.serverName || resource.metadata?.name,
+    isWALArchiver: plugin.isWALArchiver === true,
+  }
+}
+
 export function getCNPGClusterBackupConfig(resource: any): {
   configured: boolean
   destinationPath?: string
   retentionPolicy?: string
   lastSuccessfulBackup?: string
   firstRecoverabilityPoint?: string
+  /** Non-null when backup is managed by the barman-cloud plugin. */
+  plugin: CNPGBarmanPlugin | null
+  /**
+   * True when the status RPO fields are deprecated-and-unset by design (plugin
+   * mode) rather than genuinely absent. Distinguishes "tracked elsewhere" from
+   * "no backups configured" — the ambiguity that made this section render blank.
+   */
+  rpoTrackedOnObjectStore: boolean
 } {
   const backup = resource.spec?.backup
   const barman = backup?.barmanObjectStore
+  const plugin = getCNPGClusterBarmanPlugin(resource)
   return {
-    configured: !!barman,
+    configured: !!barman || !!plugin,
     destinationPath: barman?.destinationPath,
     retentionPolicy: backup?.retentionPolicy,
     lastSuccessfulBackup: resource.status?.lastSuccessfulBackup,
     firstRecoverabilityPoint: resource.status?.firstRecoverabilityPoint,
+    plugin,
+    rpoTrackedOnObjectStore: !!plugin && !resource.status?.lastSuccessfulBackup,
   }
 }
 
@@ -172,6 +269,7 @@ export interface CNPGInstanceReportedState {
   podName: string
   isPrimary: boolean
   timelineID?: number
+  ip?: string
 }
 
 export function getCNPGClusterInstancesReportedState(resource: any): CNPGInstanceReportedState[] {
@@ -180,7 +278,9 @@ export function getCNPGClusterInstancesReportedState(resource: any): CNPGInstanc
   return Object.entries(reported).map(([podName, state]: [string, any]) => ({
     podName,
     isPrimary: state?.isPrimary === true,
-    timelineID: state?.timelineID,
+    // CNPG serializes this as timeLineID (capital L).
+    timelineID: state?.timeLineID,
+    ip: state?.ip,
   }))
 }
 
@@ -205,21 +305,97 @@ export function getCNPGClusterCertificateExpirations(resource: any): CNPGCertifi
 }
 
 // ============================================================================
+// CNPG CLUSTER CONDITIONS — WAL ARCHIVING / BACKUP HEALTH
+// ============================================================================
+
+export interface CNPGCondition {
+  type: string
+  status: string
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+}
+
+export function getCNPGClusterCondition(resource: any, type: string): CNPGCondition | null {
+  const conditions = resource.status?.conditions
+  if (!Array.isArray(conditions)) return null
+  const cond = conditions.find((c: any) => c?.type === type)
+  if (!cond) return null
+  return {
+    type: cond.type,
+    status: String(cond.status ?? ''),
+    reason: cond.reason,
+    message: cond.message,
+    lastTransitionTime: cond.lastTransitionTime,
+  }
+}
+
+/**
+ * WAL archiving failure — the classic silent CNPG incident. The cluster keeps
+ * serving traffic normally while the recovery point stops advancing.
+ *
+ * The condition proves the LAST ARCHIVE ATTEMPT failed, not an exact RPO, so
+ * callers must not turn `since` into a data-loss window.
+ */
+export function getCNPGWALArchivingFailure(resource: any): CNPGCondition | null {
+  const cond = getCNPGClusterCondition(resource, 'ContinuousArchiving')
+  if (!cond || cond.status !== 'False') return null
+  return cond
+}
+
+/**
+ * Last-backup failure. CNPG also sets LastBackupSucceeded=False with reason
+ * `BackupStarted` while a backup is merely in flight — treating that as a
+ * failure would light the banner on every backup run, so only an explicit
+ * LastBackupFailed reason counts.
+ */
+export function getCNPGLastBackupFailure(resource: any): CNPGCondition | null {
+  const cond = getCNPGClusterCondition(resource, 'LastBackupSucceeded')
+  if (!cond || cond.status !== 'False') return null
+  if (cond.reason === 'BackupStarted') return null
+  return cond
+}
+
+// ============================================================================
 // CNPG BACKUP UTILITIES
 // ============================================================================
+
+// Backup phases are lowercase tokens from CNPG's api/v1/backup_types.go,
+// verified against CNPG 1.27. Unlike cluster phases these are stable enum
+// tokens, but they are still matched exactly — an unrecognized phase must
+// surface as unknown rather than be swallowed by a prefix match.
+export const CNPG_BACKUP_PHASES_TRANSIENT = ['pending', 'started', 'running', 'finalizing'] as const
+
+/**
+ * WAL archiving is broken upstream of this Backup, so the recovery window for
+ * the whole cluster is affected — not just this one object. Kept separate from
+ * a plain `failed` so callers can escalate it to the cluster level.
+ */
+export const CNPG_BACKUP_PHASE_WAL_ARCHIVING_FAILING = 'walArchivingFailing'
+
+export type CNPGBackupPhaseBucket = 'healthy' | 'transient' | 'failed' | 'walArchivingFailing' | 'unknown'
+
+export function classifyCNPGBackupPhase(phase: string): CNPGBackupPhaseBucket {
+  if (!phase) return 'unknown'
+  if (phase === CNPG_BACKUP_PHASE_WAL_ARCHIVING_FAILING) return 'walArchivingFailing'
+  if (phase === 'completed') return 'healthy'
+  if (phase === 'failed') return 'failed'
+  if ((CNPG_BACKUP_PHASES_TRANSIENT as readonly string[]).includes(phase)) return 'transient'
+  return 'unknown'
+}
 
 export function getCNPGBackupStatus(resource: any): StatusBadge {
   const phase = resource.status?.phase || ''
 
-  switch (phase.toLowerCase()) {
-    case 'completed':
+  switch (classifyCNPGBackupPhase(phase)) {
+    case 'healthy':
       return { text: 'Completed', color: healthColors.healthy, level: 'healthy' }
-    case 'running':
-      return { text: 'Running', color: healthColors.degraded, level: 'degraded' }
-    case 'pending':
-      return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+    case 'transient':
+      return { text: phase.charAt(0).toUpperCase() + phase.slice(1), color: healthColors.degraded, level: 'degraded' }
     case 'failed':
       return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+    case 'walArchivingFailing':
+      return { text: 'WAL Archiving Failing', color: healthColors.unhealthy, level: 'unhealthy' }
     default:
       if (phase) return { text: phase, color: healthColors.unknown, level: 'unknown' }
       return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
@@ -341,22 +517,35 @@ export function getCNPGScheduledBackupOwnerRef(resource: any): string {
 // CNPG POOLER UTILITIES
 // ============================================================================
 
+/**
+ * Pooler.status.instances is "the number of pods trying to be scheduled" — NOT
+ * ready pods. A Pooler whose PgBouncer pods are all Pending still reports
+ * status.instances == spec.instances, so reading it as readiness renders a
+ * broken Pooler green. Readiness lives on the generated Deployment (same name,
+ * same namespace), which the Pooler CR alone cannot see — so the positive state
+ * is labelled "Scheduled", not "Ready".
+ */
 export function getCNPGPoolerStatus(resource: any): StatusBadge {
   const desired = resource.spec?.instances ?? 0
-  const ready = resource.status?.instances ?? 0
+  const scheduled = resource.status?.instances ?? 0
 
-  if (desired > 0 && ready < desired) {
-    if (ready === 0) {
-      return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
+  if (desired > 0 && scheduled < desired) {
+    if (scheduled === 0) {
+      return { text: 'Not Scheduled', color: healthColors.unhealthy, level: 'unhealthy' }
     }
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
 
-  if (desired > 0 && ready >= desired) {
-    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  if (desired > 0 && scheduled >= desired) {
+    return { text: 'Scheduled', color: healthColors.healthy, level: 'healthy' }
   }
 
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+/** Name of the Deployment CNPG generates for this Pooler — where real readiness lives. */
+export function getCNPGPoolerDeploymentName(resource: any): string {
+  return resource.metadata?.name || ''
 }
 
 export function getCNPGPoolerCluster(resource: any): string {

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -234,10 +234,14 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
 }
 
+// Absence is not zero — same rule the badge follows via readyKnown. Between
+// creation and the operator's first status write there is no readyInstances,
+// and defaulting it to 0 rendered "0/3" next to a badge that (correctly) did
+// not say degraded: the cell claimed a total outage the badge denied.
+const countOrDash = (n: unknown): string => (typeof n === 'number' ? String(n) : '-')
+
 export function getCNPGClusterInstances(resource: any): string {
-  const desired = resource.spec?.instances ?? 0
-  const ready = resource.status?.readyInstances ?? 0
-  return `${ready}/${desired}`
+  return `${countOrDash(resource.status?.readyInstances)}/${countOrDash(resource.spec?.instances)}`
 }
 
 export function getCNPGClusterPrimary(resource: any): string {
@@ -644,7 +648,16 @@ export function getCNPGScheduledBackupOwnerRef(resource: any): string {
  */
 export function getCNPGPoolerStatus(resource: any): StatusBadge {
   const desired = resource.spec?.instances ?? 0
-  const scheduled = resource.status?.instances ?? 0
+  // Presence, not value — the same distinction getCNPGClusterStatus makes. A
+  // Pooler the controller has not reconciled yet has no status.instances at
+  // all, and reading that as 0 rendered a red "Not Scheduled" on a Pooler that
+  // may be perfectly healthy: a fabricated failure, not merely a wrong count.
+  const scheduledKnown = typeof resource.status?.instances === 'number'
+  const scheduled = scheduledKnown ? resource.status.instances : 0
+
+  if (!scheduledKnown) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
 
   if (desired > 0 && scheduled < desired) {
     if (scheduled === 0) {
@@ -678,9 +691,7 @@ export function getCNPGPoolerMode(resource: any): string {
 }
 
 export function getCNPGPoolerInstances(resource: any): string {
-  const desired = resource.spec?.instances ?? 0
-  const ready = resource.status?.instances ?? 0
-  return `${ready}/${desired}`
+  return `${countOrDash(resource.status?.instances)}/${countOrDash(resource.spec?.instances)}`
 }
 
 export function getCNPGPoolerParameters(resource: any): Record<string, string> {

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -203,20 +203,32 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
     return { text: 'Healthy', color: healthColors.healthy, level: 'healthy' }
   }
 
-  // Conditions fallback
   const conditions = status.conditions || []
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
+
+  // Unrecognized phase — surface the operator's own words rather than inventing
+  // a health level. A new CNPG minor adding a phase lands here, not in "Healthy".
+  //
+  // This must outrank the Ready condition below. Ready=True says the instances
+  // are serving; it does not say the cluster is fine, and CNPG sets it during
+  // phases we have never seen. Reading it first turned an unknown phase into a
+  // green "Ready" badge — asserting health from a signal that doesn't establish
+  // it, and defeating the pass-through this branch exists for. Ready=False
+  // still colors the phase red: showing the operator's words in red loses
+  // nothing and keeps a real failure signal.
+  if (phase) {
+    if (readyCond?.status === 'False') {
+      return { text: phase, color: healthColors.unhealthy, level: 'unhealthy' }
+    }
+    return { text: phase, color: healthColors.unknown, level: 'unknown' }
+  }
+
+  // No phase at all — conditions are the only signal left.
   if (readyCond?.status === 'True') {
     return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
   }
   if (readyCond?.status === 'False') {
     return { text: readyCond.reason || 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
-  }
-
-  // Unrecognized phase — surface the operator's own words rather than inventing
-  // a health level. A new CNPG minor adding a phase lands here, not in "Healthy".
-  if (phase) {
-    return { text: phase, color: healthColors.unknown, level: 'unknown' }
   }
 
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -80,6 +80,59 @@ export const CNPG_CLUSTER_PHASES_ATTENTION = [
   'Waiting for user action',
 ] as const
 
+/**
+ * Short display states for the table badge.
+ *
+ * CNPG's phases are prose, not tokens — "Cluster is unrecoverable and needs
+ * manual intervention" is banner copy. At 315px it fits no defensible column,
+ * so this is about badge semantics rather than width: a badge carries a state,
+ * the drawer and the `title` carry the operator's exact words.
+ *
+ * Radar's own labels (Healthy, WAL Archiving Failing, …) are not in here —
+ * those are already states and are produced directly by getCNPGClusterStatus.
+ *
+ * Both in-place and without-a-switchover restarts collapse to "Restarting
+ * Primary". The distinction is about the operator's mechanism, not about what a
+ * scanning operator needs; the exact phase remains in the drawer. Splitting
+ * them honestly would need ~140px and a wider column than the rest earns.
+ */
+const CNPG_PHASE_DISPLAY_STATE: Record<string, string> = {
+  // Terminal
+  'Cluster is unrecoverable and needs manual intervention': 'Unrecoverable',
+  'Invalid cluster definition': 'Invalid Spec',
+  'Unable to create required cluster objects': 'Setup Failed',
+  'Cluster has incomplete or invalid image catalog': 'Image Catalog Error',
+  'Cluster cannot proceed to reconciliation due to an unknown plugin being required': 'Unknown Plugin',
+  'Cluster cannot proceed to reconciliation due to an error while interacting with plugins': 'Plugin Error',
+  'Cluster cannot execute instance online upgrade due to missing architecture binary': 'Arch Binary Missing',
+  // Transient
+  'Setting up primary': 'Setting Up Primary',
+  'Creating a new replica': 'Creating Replica',
+  'Switchover in progress': 'Switchover',
+  'Upgrading cluster': 'Upgrading',
+  'Upgrading Postgres major version': 'Major Upgrade',
+  'Online upgrade in progress': 'Online Upgrade',
+  'Applying configuration': 'Configuring',
+  'Primary instance is being restarted in-place': 'Restarting Primary',
+  'Primary instance is being restarted without a switchover': 'Restarting Primary',
+  'Promoting to primary cluster': 'Promoting',
+  'Waiting for the instances to become active': 'Starting Instances',
+  'Cluster upgrade delayed': 'Upgrade Delayed',
+  // Attention
+  'Waiting for user action': 'Needs Action',
+}
+
+/**
+ * The short state for a phase, or the phase itself when we have no mapping.
+ *
+ * An unrecognized phase from a newer CNPG minor passes through verbatim —
+ * inventing a state for a string we have never seen would be worse than showing
+ * the operator's words, and that is the case badge truncation exists for.
+ */
+export function getCNPGClusterDisplayState(phase: string): string {
+  return CNPG_PHASE_DISPLAY_STATE[phase] || phase
+}
+
 export type CNPGPhaseBucket = 'healthy' | 'transient' | 'failing' | 'terminal' | 'attention' | 'unknown'
 
 export function classifyCNPGClusterPhase(phase: string): CNPGPhaseBucket {
@@ -110,7 +163,7 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   // to still be Ready is still unrecoverable, and reading the counts first is
   // what used to render it neutral.
   if (bucket === 'terminal') {
-    return { text: phase, color: healthColors.unhealthy, level: 'unhealthy' }
+    return { text: getCNPGClusterDisplayState(phase), color: healthColors.unhealthy, level: 'unhealthy' }
   }
   // Zero ready instances is a hard down that no phase excuses — including a
   // failover, where the phase alone would otherwise downgrade a total outage to
@@ -133,7 +186,7 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   // so it is checked BEFORE the shortfall — mid-operation the cluster is
   // legitimately below its desired count.
   if (bucket === 'transient' || bucket === 'attention') {
-    return { text: phase, color: healthColors.degraded, level: 'degraded' }
+    return { text: getCNPGClusterDisplayState(phase), color: healthColors.degraded, level: 'degraded' }
   }
   // The shortfall must be checked BEFORE the healthy phase, not after. CNPG
   // reports "Cluster in healthy state" the moment reconciliation is settled,

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -59,6 +59,11 @@ export const CNPG_CLUSTER_PHASES_FAILING = ['Failing over'] as const
 /** Reconciliation has stopped. These need a human; none of them self-heal. */
 export const CNPG_CLUSTER_PHASES_TERMINAL = [
   'Cluster is unrecoverable and needs manual intervention',
+  // Not in 1.27 or 1.28; added upstream after 1.28 (PhaseDefinitionInvalid).
+  // Listed early because matching is by equality — a phase string the running
+  // operator never emits is inert, so carrying it costs nothing and stops a
+  // future minor from landing in the unknown bucket.
+  'Invalid cluster definition',
   'Unable to create required cluster objects',
   'Cluster has incomplete or invalid image catalog',
   'Cluster cannot proceed to reconciliation due to an unknown plugin being required',
@@ -91,21 +96,38 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   const status = resource.status || {}
   const phase = status.phase || ''
   const instances = resource.spec?.instances ?? 0
-  const readyInstances = status.readyInstances ?? 0
+  // Readiness PRESENCE matters. A cluster whose status has no readyInstances yet
+  // (freshly created, operator hasn't written status) is unknown, not zero —
+  // defaulting to 0 fabricated a red "Not Ready" badge for a cluster the issue
+  // detector correctly said nothing about.
+  const readyKnown = typeof status.readyInstances === 'number'
+  const readyInstances: number = readyKnown ? status.readyInstances : 0
+  const countsKnown = instances > 0 && readyKnown
   const bucket = classifyCNPGClusterPhase(phase)
 
-  // Terminal phases outrank instance counts: an unrecoverable cluster whose pods
-  // happen to still be Ready is still unrecoverable, and reading the counts first
-  // is what used to render it neutral.
+  // Ordered by descending severity, and mirrored by source_cnpg.go. Terminal
+  // phases outrank instance counts: an unrecoverable cluster whose pods happen
+  // to still be Ready is still unrecoverable, and reading the counts first is
+  // what used to render it neutral.
   if (bucket === 'terminal') {
     return { text: phase, color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  // Zero ready instances is a hard down that no phase excuses — including a
+  // failover, where the phase alone would otherwise downgrade a total outage to
+  // orange.
+  if (countsKnown && readyInstances === 0) {
+    return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
   if (bucket === 'failing') {
     return { text: 'Failing Over', color: healthColors.alert, level: 'alert' }
   }
-  // Zero ready instances is a hard down regardless of what the phase claims.
-  if (instances > 0 && readyInstances === 0) {
-    return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
+  // Data-durability failures don't move any instance count, so a cluster with a
+  // broken recovery point looks perfectly healthy on availability alone — which
+  // is precisely how it stays invisible until a restore. The detail drawer has
+  // always shown this; the list badge must too, or the headline signal of this
+  // integration reads green.
+  if (getCNPGWALArchivingFailure(resource)) {
+    return { text: 'WAL Archiving Failing', color: healthColors.alert, level: 'alert' }
   }
   // A transient phase explains partial readiness better than a bare "Degraded",
   // so it is checked BEFORE the shortfall — mid-operation the cluster is
@@ -118,8 +140,11 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   // which can be true while instances are still missing — returning Healthy
   // there paints a green badge on a cluster the Go detector flags as
   // CNPGClusterDegraded. Mirrors source_cnpg.go's !phaseExplained gate.
-  if (instances > 0 && readyInstances < instances) {
+  if (countsKnown && readyInstances < instances) {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (getCNPGLastBackupFailure(resource)) {
+    return { text: 'Backup Failed', color: healthColors.degraded, level: 'degraded' }
   }
   if (bucket === 'healthy') {
     return { text: 'Healthy', color: healthColors.healthy, level: 'healthy' }

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -8,6 +8,23 @@ import { parseGoTimeString } from '../../utils/parse-go-time'
 // CNPG CLUSTER UTILITIES
 // ============================================================================
 
+export const CNPG_GROUP = 'postgresql.cnpg.io'
+
+/**
+ * Exact API-group match for a resource's `apiVersion` ("group/version").
+ *
+ * Used for the `clusters` and `backups` plurals, where several operators ship
+ * the same kind and a wrong guess fabricates a status. A substring test is not
+ * a group guard — `extension.postgresql.cnpg.io/v1` contains `postgresql.cnpg.io`
+ * — and these are exactly the plurals where that would misfire.
+ */
+export function isApiGroup(apiVersion: unknown, group: string): boolean {
+  if (typeof apiVersion !== 'string') return false
+  const slash = apiVersion.lastIndexOf('/')
+  // A core-group resource ("v1") has no slash and belongs to no CRD group.
+  return slash > 0 && apiVersion.slice(0, slash) === group
+}
+
 // Phase strings are full English sentences copied verbatim from CNPG's
 // api/v1/cluster_types.go — match on equality, never substring. Verified
 // against CNPG 1.27. Radar's Go issue detection mirrors these buckets in
@@ -30,6 +47,10 @@ export const CNPG_CLUSTER_PHASES_TRANSIENT = [
   'Primary instance is being restarted without a switchover',
   'Promoting to primary cluster',
   'Waiting for the instances to become active',
+  // Upstream sets this when an upgrade is postponed by the OPERATOR's own
+  // rollout-delay config and requeued — nothing is waiting on a human, so it
+  // does not belong with 'Waiting for user action'.
+  'Cluster upgrade delayed',
 ] as const
 
 /** Losing the primary — degraded now, self-resolving only if a replica can take over. */
@@ -52,7 +73,6 @@ export const CNPG_CLUSTER_PHASES_TERMINAL = [
  */
 export const CNPG_CLUSTER_PHASES_ATTENTION = [
   'Waiting for user action',
-  'Cluster upgrade delayed',
 ] as const
 
 export type CNPGPhaseBucket = 'healthy' | 'transient' | 'failing' | 'terminal' | 'attention' | 'unknown'

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -107,15 +107,22 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   if (instances > 0 && readyInstances === 0) {
     return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
-  if (bucket === 'healthy') {
-    return { text: 'Healthy', color: healthColors.healthy, level: 'healthy' }
-  }
-  // A transient phase explains partial readiness better than a bare "Degraded".
+  // A transient phase explains partial readiness better than a bare "Degraded",
+  // so it is checked BEFORE the shortfall — mid-operation the cluster is
+  // legitimately below its desired count.
   if (bucket === 'transient' || bucket === 'attention') {
     return { text: phase, color: healthColors.degraded, level: 'degraded' }
   }
+  // The shortfall must be checked BEFORE the healthy phase, not after. CNPG
+  // reports "Cluster in healthy state" the moment reconciliation is settled,
+  // which can be true while instances are still missing — returning Healthy
+  // there paints a green badge on a cluster the Go detector flags as
+  // CNPGClusterDegraded. Mirrors source_cnpg.go's !phaseExplained gate.
   if (instances > 0 && readyInstances < instances) {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (bucket === 'healthy') {
+    return { text: 'Healthy', color: healthColors.healthy, level: 'healthy' }
   }
 
   // Conditions fallback

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -15,6 +15,7 @@ import { getNvidiaClusterPolicyStatus as _getNvidiaClusterPolicyStatus, getNvidi
 import { getBackupStatus as _getBackupStatus, getRestoreStatus as _getRestoreStatus, getScheduleStatus as _getScheduleStatus, getBSLStatus as _getBSLStatus, getBackupRepositoryStatus as _getBackupRepositoryStatus } from './resource-utils-velero'
 import { getExternalSecretStatus as _getExternalSecretStatus, getClusterExternalSecretStatus as _getClusterExternalSecretStatus, getSecretStoreStatus as _getSecretStoreStatus, getClusterSecretStoreStatus as _getClusterSecretStoreStatus, getSecretStoreProviderType as _getSecretStoreProviderType } from './resource-utils-eso'
 import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
+import { getCNPGClusterStatus as _getCNPGClusterStatus, getCNPGBackupStatus as _getCNPGBackupStatus, getCNPGScheduledBackupStatus as _getCNPGScheduledBackupStatus, getCNPGPoolerStatus as _getCNPGPoolerStatus, isApiGroup as _isApiGroup, CNPG_GROUP as _CNPG_GROUP } from './resource-utils-cnpg'
 
 // ============================================================================
 // STATUS & HEALTH UTILITIES
@@ -2104,6 +2105,18 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       if (kindLower === 'clusterexternalsecrets') return _getClusterExternalSecretStatus(resource).text
       if (kindLower === 'secretstores') return _getSecretStoreStatus(resource).text
       if (kindLower === 'clustersecretstores') return _getClusterSecretStoreStatus(resource).text
+      // CNPG. The filter must read the same text the cell renders, or the
+      // dropdown offers strings that appear on no row: CNPG's phase is prose
+      // ("Cluster in healthy state") while the badge is a short state
+      // ("Healthy"). Worse for `cnpgclusters` — a WAL-archiving failure leaves
+      // the phase healthy, so filtering on the raw phase cannot express the
+      // badge at all. `cnpgclusters`/`cnpgbackups` arrive group-qualified;
+      // `scheduledbackups`/`poolers` are bare plurals, so gate those on the
+      // group rather than assume nobody else ships the name.
+      if (kindLower === 'cnpgclusters') return _getCNPGClusterStatus(resource).text
+      if (kindLower === 'cnpgbackups') return _getCNPGBackupStatus(resource).text
+      if (kindLower === 'scheduledbackups' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGScheduledBackupStatus(resource).text
+      if (kindLower === 'poolers' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGPoolerStatus(resource).text
       // Generic CRDs: try status.phase, then Ready condition
       if (resource.status?.phase) return resource.status.phase
       {

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -166,10 +166,15 @@ function renderCollidingKind(kind: string, apiVersion: string): string {
 }
 
 describe('getResourceStatus — colliding plurals', () => {
-  it('fabricates no status badge for a third-party clusters CRD', () => {
-    // KubeBlocks, Redis/Valkey operators and friends all ship `clusters`.
+  it('fabricates no PostgreSQL status for a third-party clusters CRD', () => {
+    // KubeBlocks, Redis/Valkey operators and friends all ship `clusters`. With
+    // no status of their own they get nothing; with a phase they get the
+    // generic phase badge, never a CNPG-derived one.
     expect(getResourceStatus('clusters', { apiVersion: 'apps.kubeblocks.io/v1alpha1', status: {} })).toBeNull()
-    expect(getResourceStatus('clusters', { apiVersion: 'redis.redis.opstreelabs.in/v1beta2', status: {} })).toBeNull()
+    expect(getResourceStatus('clusters', { apiVersion: 'apps.kubeblocks.io/v1alpha1', status: { phase: 'Running' } }))
+      .toMatchObject({ text: 'Running' })
+    // CNPG would have rendered "Not Ready" from the absent instance counts.
+    expect(getResourceStatus('clusters', { apiVersion: 'redis.redis.opstreelabs.in/v1beta2', spec: { instances: 3 }, status: {} })).toBeNull()
   })
 
   it('still resolves both known clusters engines positively', () => {
@@ -185,8 +190,10 @@ describe('getResourceStatus — colliding plurals', () => {
     })).not.toBeNull()
   })
 
-  it('fabricates no status badge for a third-party backups CRD', () => {
+  it('fabricates no engine status for a third-party backups CRD', () => {
     expect(getResourceStatus('backups', { apiVersion: 'kubevirt.io/v1', status: {} })).toBeNull()
+    expect(getResourceStatus('backups', { apiVersion: 'kubevirt.io/v1', status: { phase: 'Running' } }))
+      .toMatchObject({ text: 'Running' })
   })
 
   it('still resolves both known backups engines positively', () => {
@@ -201,9 +208,10 @@ describe('getResourceStatus — colliding plurals', () => {
     })).not.toBeNull()
   })
 
-  it('gives no badge to third-party scheduledbackups and poolers', () => {
+  it('gives no CNPG badge to third-party scheduledbackups and poolers', () => {
+    // CNPG's Pooler getter would have said "Not Scheduled" from spec.instances.
+    expect(getResourceStatus('poolers', { apiVersion: 'other.io/v1', spec: { instances: 2 }, status: {} })).toBeNull()
     expect(getResourceStatus('scheduledbackups', { apiVersion: 'other.io/v1', spec: {}, status: {} })).toBeNull()
-    expect(getResourceStatus('poolers', { apiVersion: 'other.io/v1', spec: {}, status: {} })).toBeNull()
   })
 })
 
@@ -226,5 +234,33 @@ describe('ResourceRendererDispatch — colliding plurals fall through', () => {
     expect(html).toContain('Cluster Overview')
     // The generic renderer's raw-spec dump must not appear alongside it.
     expect(html.match(/Cluster Overview/g)).toHaveLength(1)
+  })
+})
+
+describe('colliding plurals — near-match API groups', () => {
+  // A substring guard would hand these to CNPG/Velero. They are different groups.
+  it.each([
+    ['clusters', 'extension.postgresql.cnpg.io/v1'],
+    ['clusters', 'barmancloud.cnpg.io/v1'],
+    ['backups', 'extension.postgresql.cnpg.io/v1'],
+    ['backups', 'backup.velero.io/v1'],
+    ['poolers', 'sub.postgresql.cnpg.io/v1'],
+    ['scheduledbackups', 'sub.postgresql.cnpg.io/v1'],
+  ])('does not give %s/%s an engine-specific status', (kind, apiVersion) => {
+    const s = getResourceStatus(kind, { apiVersion, spec: { instances: 2 }, status: { phase: 'completed' } })
+    // The generic fallback echoes the phase verbatim; the CNPG/Velero getters
+    // would have mapped it to "Completed" or read the instance counts.
+    expect(s?.text).not.toBe('Completed')
+    expect(s?.text).not.toBe('Not Scheduled')
+    expect(s?.text).not.toBe('Not Ready')
+  })
+
+  it.each([
+    ['clusters', 'extension.postgresql.cnpg.io/v1'],
+    ['backups', 'backup.velero.io/v1'],
+  ])('falls %s/%s through to the generic renderer', (kind, apiVersion) => {
+    const html = renderCollidingKind(kind, apiVersion)
+    expect(html.trim()).not.toBe('')
+    expect(html).not.toContain('Cluster Overview')
   })
 })

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { renderToString } from 'react-dom/server'
-import { ResourceRendererDispatch, type RendererOverrides } from './ResourceRendererDispatch'
+import { ResourceRendererDispatch, getResourceStatus, type RendererOverrides } from './ResourceRendererDispatch'
 import type { ResourceRef } from '../../types'
 
 function renderWithScalers(scalers: ResourceRef[]): string {
@@ -144,5 +144,87 @@ describe('DRA renderers dispatch', () => {
     })
     expect(html).toContain('Selectors (1)')
     expect(html).toContain('device.driver')
+  })
+})
+
+// ============================================================================
+// COLLIDING CRD PLURALS — `clusters` (CNPG / CAPI / third parties) and
+// `backups` (CNPG / Velero). Both used to be resolved with a negative guard,
+// so any third operator's CRD inherited whichever branch was the fallback.
+// ============================================================================
+
+function renderCollidingKind(kind: string, apiVersion: string): string {
+  return renderToString(
+    <ResourceRendererDispatch
+      resource={{ kind, namespace: 'default', name: 'thing' }}
+      data={{ apiVersion, kind: 'Cluster', metadata: { name: 'thing', namespace: 'default' }, spec: {}, status: {} }}
+      onCopy={() => {}}
+      copied={null}
+      showCommonSections={false}
+    />,
+  )
+}
+
+describe('getResourceStatus — colliding plurals', () => {
+  it('fabricates no status badge for a third-party clusters CRD', () => {
+    // KubeBlocks, Redis/Valkey operators and friends all ship `clusters`.
+    expect(getResourceStatus('clusters', { apiVersion: 'apps.kubeblocks.io/v1alpha1', status: {} })).toBeNull()
+    expect(getResourceStatus('clusters', { apiVersion: 'redis.redis.opstreelabs.in/v1beta2', status: {} })).toBeNull()
+  })
+
+  it('still resolves both known clusters engines positively', () => {
+    expect(getResourceStatus('clusters', {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      spec: { instances: 2 },
+      status: { phase: 'Cluster in healthy state', readyInstances: 2 },
+    })).toMatchObject({ text: 'Healthy' })
+
+    expect(getResourceStatus('clusters', {
+      apiVersion: 'cluster.x-k8s.io/v1beta1',
+      status: { phase: 'Provisioned' },
+    })).not.toBeNull()
+  })
+
+  it('fabricates no status badge for a third-party backups CRD', () => {
+    expect(getResourceStatus('backups', { apiVersion: 'kubevirt.io/v1', status: {} })).toBeNull()
+  })
+
+  it('still resolves both known backups engines positively', () => {
+    expect(getResourceStatus('backups', {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      status: { phase: 'completed' },
+    })).toMatchObject({ text: 'Completed' })
+
+    expect(getResourceStatus('backups', {
+      apiVersion: 'velero.io/v1',
+      status: { phase: 'Completed' },
+    })).not.toBeNull()
+  })
+
+  it('gives no badge to third-party scheduledbackups and poolers', () => {
+    expect(getResourceStatus('scheduledbackups', { apiVersion: 'other.io/v1', spec: {}, status: {} })).toBeNull()
+    expect(getResourceStatus('poolers', { apiVersion: 'other.io/v1', spec: {}, status: {} })).toBeNull()
+  })
+})
+
+describe('ResourceRendererDispatch — colliding plurals fall through', () => {
+  // These plurals are in KNOWN_KINDS, which suppresses the generic renderer.
+  // Making every render line apiVersion-gated without an explicit fall-through
+  // renders a blank drawer for a foreign CRD — the trap the Crossplane
+  // collision block documents.
+  it.each([
+    ['clusters', 'apps.kubeblocks.io/v1alpha1'],
+    ['backups', 'kubevirt.io/v1'],
+    ['scheduledbackups', 'other.io/v1'],
+    ['poolers', 'other.io/v1'],
+  ])('renders something for a foreign %s CRD', (kind, apiVersion) => {
+    expect(renderCollidingKind(kind, apiVersion).trim()).not.toBe('')
+  })
+
+  it('does not double-render when a known engine matches', () => {
+    const html = renderCollidingKind('clusters', 'postgresql.cnpg.io/v1')
+    expect(html).toContain('Cluster Overview')
+    // The generic renderer's raw-spec dump must not appear alongside it.
+    expect(html.match(/Cluster Overview/g)).toHaveLength(1)
   })
 })

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -538,12 +538,27 @@ export function ResourceRendererDispatch({
   // a foreign CR with the same plural (rancher/backup-restore-operator ships
   // restores.resources.cattle.io; several operators ship `schedules`) matches
   // no renderer AND is suppressed from GenericRenderer — i.e. renders blank.
-  // `backups` is deliberately absent: its render lines are still keyed on the
-  // CNPG-vs-Velero split, not a positive velero.io guard.
+  // `backups` is deliberately absent here — it is shared with CNPG, so both of
+  // its render lines are positively group-gated and it falls through via
+  // isGroupGatedKind below rather than through this Velero-only check.
   const isVeleroCollisionGatedKind =
     kind === 'restores' || kind === 'schedules'
     || kind === 'backupstoragelocations' || kind === 'volumesnapshotlocations'
   const veleroCollisionFallthrough = isVeleroCollisionGatedKind && !isVeleroResource(data)
+
+  // Same rule as the Crossplane block above, for the plurals shared by two
+  // named operators: `clusters` (CNPG / CAPI — plus KubeBlocks, Redis/Valkey
+  // and friends in the wild) and `backups` (CNPG / Velero). Both render lines
+  // are positively apiVersion-gated, so a third CRD with the plural matches
+  // neither and needs an explicit fall-through or the drawer renders blank.
+  const isGroupGatedKind =
+    kind === 'clusters' || kind === 'backups' || kind === 'scheduledbackups' || kind === 'poolers'
+  const isCNPGApiVersion = data?.apiVersion?.includes('postgresql.cnpg.io') === true
+  const groupGatedMatched =
+    (kind === 'clusters' && (isCNPGApiVersion || data?.apiVersion?.includes('cluster.x-k8s.io') === true))
+    || (kind === 'backups' && (isCNPGApiVersion || data?.apiVersion?.includes('velero.io') === true))
+    || ((kind === 'scheduledbackups' || kind === 'poolers') && isCNPGApiVersion)
+  const groupGatedFallthrough = isGroupGatedKind && !groupGatedMatched
 
   const isKnownKind = KNOWN_KINDS.has(kind) || isCrossplaneMR || isCrossplaneClaim || isCrossplaneXR
 
@@ -666,8 +681,8 @@ export function ResourceRendererDispatch({
         {kind === 'resourceclaimtemplates' && <ResourceClaimTemplateRenderer data={data} />}
         {kind === 'deviceclasses' && <DeviceClassRenderer data={data} />}
         {kind === 'resourceslices' && <ResourceSliceRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'backups' && data.apiVersion?.includes('cnpg.io') && <CNPGBackupRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'backups' && !data.apiVersion?.includes('cnpg.io') && <VeleroBackupRenderer data={data} />}
+        {kind === 'backups' && data.apiVersion?.includes('postgresql.cnpg.io') && <CNPGBackupRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'backups' && data.apiVersion?.includes('velero.io') && <VeleroBackupRenderer data={data} />}
         {kind === 'restores' && isVeleroResource(data) && <VeleroRestoreRenderer data={data} />}
         {kind === 'schedules' && isVeleroResource(data) && <VeleroScheduleRenderer data={data} />}
         {kind === 'backupstoragelocations' && isVeleroResource(data) && <VeleroBSLRenderer data={data} />}
@@ -675,10 +690,10 @@ export function ResourceRendererDispatch({
         {kind === 'externalsecrets' && <ExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusterexternalsecrets' && <ClusterExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {(kind === 'secretstores' || kind === 'clustersecretstores') && <SecretStoreRenderer data={data} />}
-        {kind === 'clusters' && !data?.apiVersion?.includes('cluster.x-k8s.io') && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'clusters' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusters' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIClusterRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'scheduledbackups' && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'poolers' && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'scheduledbackups' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'poolers' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
         {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && data?.apiVersion?.includes('cluster.x-k8s.io') && (
           <AlertBanner
@@ -772,7 +787,7 @@ export function ResourceRendererDispatch({
             for known-plural collisions where no apiVersion-gated renderer
             matched (e.g. a Knative Configuration sharing the `configurations`
             plural with Crossplane Configuration). */}
-        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough) && <GenericRenderer data={data} />}
+        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough || groupGatedFallthrough) && <GenericRenderer data={data} />}
 
         {/* Common sections - can be disabled when parent handles them separately */}
         {showCommonSections && (
@@ -912,9 +927,12 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'resourceclaimtemplates') return getResourceClaimTemplateStatus(data)
   if (k === 'deviceclasses') return getDeviceClassStatus(data)
   if (k === 'resourceslices') return getResourceSliceStatus(data)
+  // Positive guards both ways — a third `backups` CRD gets no badge rather than
+  // a fabricated one from whichever engine happened to be the fallback.
   if (k === 'backups') {
-    if (data.apiVersion?.includes('cnpg.io')) return getCNPGBackupStatus(data)
-    return getBackupStatus(data)
+    if (data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGBackupStatus(data)
+    if (data.apiVersion?.includes('velero.io')) return getBackupStatus(data)
+    return null
   }
   if (k === 'restores' && isVeleroResource(data)) return getRestoreStatus(data)
   if (k === 'schedules' && isVeleroResource(data)) return getScheduleStatus(data)
@@ -925,7 +943,8 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'clustersecretstores') return getClusterSecretStoreStatus(data)
   if (k === 'clusters') {
     if (data.apiVersion?.includes('cluster.x-k8s.io')) return getCAPIClusterStatus(data)
-    return getCNPGClusterStatus(data)
+    if (data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGClusterStatus(data)
+    return null
   }
   if (k === 'machines' && data.apiVersion?.includes('cluster.x-k8s.io')) return getMachineStatus(data)
   if (k === 'machinedeployments') return getMachineDeploymentStatus(data)
@@ -949,8 +968,8 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'azuremanagedmachinepools') return getAzureMMPStatus(data)
   if (k === 'azuremachines') return getAzureMachineStatus(data)
   if (k === 'azuremanagedclusters') return getAzureManagedClusterStatus(data)
-  if (k === 'scheduledbackups') return getCNPGScheduledBackupStatus(data)
-  if (k === 'poolers') return getCNPGPoolerStatus(data)
+  if (k === 'scheduledbackups' && data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGScheduledBackupStatus(data)
+  if (k === 'poolers' && data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGPoolerStatus(data)
   if (k === 'virtualservices') return getVirtualServiceStatus(data)
   if (k === 'destinationrules') return getDestinationRuleStatus(data)
   if (k === 'serviceentries') return getServiceEntryStatus(data)

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -691,7 +691,7 @@ export function ResourceRendererDispatch({
         {kind === 'clusterexternalsecrets' && <ClusterExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {(kind === 'secretstores' || kind === 'clustersecretstores') && <SecretStoreRenderer data={data} />}
         {kind === 'clusters' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'clusters' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIClusterRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'clusters' && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && <CAPIClusterRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'scheduledbackups' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'poolers' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
@@ -942,7 +942,7 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'secretstores') return getSecretStoreStatus(data)
   if (k === 'clustersecretstores') return getClusterSecretStoreStatus(data)
   if (k === 'clusters') {
-    if (data.apiVersion?.includes('cluster.x-k8s.io')) return getCAPIClusterStatus(data)
+    if (isApiGroup(data.apiVersion, 'cluster.x-k8s.io')) return getCAPIClusterStatus(data)
     if (isApiGroup(data.apiVersion, CNPG_GROUP)) return getCNPGClusterStatus(data)
     // Third-party `clusters` CRDs (KubeBlocks, Redis/Valkey) fall through to the
     // generic handling below instead of getting a fabricated PostgreSQL status.

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -72,7 +72,7 @@ import {
   getPeerAuthenticationStatus,
   getAuthorizationPolicyStatus,
 } from '../resources/resource-utils-istio'
-import { getCNPGClusterStatus, getCNPGBackupStatus, getCNPGScheduledBackupStatus, getCNPGPoolerStatus } from '../resources/resource-utils-cnpg'
+import { getCNPGClusterStatus, getCNPGBackupStatus, getCNPGScheduledBackupStatus, getCNPGPoolerStatus, isApiGroup, CNPG_GROUP } from '../resources/resource-utils-cnpg'
 import { getExternalSecretStatus, getClusterExternalSecretStatus, getSecretStoreStatus, getClusterSecretStoreStatus } from '../resources/resource-utils-eso'
 import {
   getKnativeConditionStatus,
@@ -553,10 +553,10 @@ export function ResourceRendererDispatch({
   // neither and needs an explicit fall-through or the drawer renders blank.
   const isGroupGatedKind =
     kind === 'clusters' || kind === 'backups' || kind === 'scheduledbackups' || kind === 'poolers'
-  const isCNPGApiVersion = data?.apiVersion?.includes('postgresql.cnpg.io') === true
+  const isCNPGApiVersion = isApiGroup(data?.apiVersion, CNPG_GROUP)
   const groupGatedMatched =
-    (kind === 'clusters' && (isCNPGApiVersion || data?.apiVersion?.includes('cluster.x-k8s.io') === true))
-    || (kind === 'backups' && (isCNPGApiVersion || data?.apiVersion?.includes('velero.io') === true))
+    (kind === 'clusters' && (isCNPGApiVersion || isApiGroup(data?.apiVersion, 'cluster.x-k8s.io')))
+    || (kind === 'backups' && (isCNPGApiVersion || isApiGroup(data?.apiVersion, 'velero.io')))
     || ((kind === 'scheduledbackups' || kind === 'poolers') && isCNPGApiVersion)
   const groupGatedFallthrough = isGroupGatedKind && !groupGatedMatched
 
@@ -681,8 +681,8 @@ export function ResourceRendererDispatch({
         {kind === 'resourceclaimtemplates' && <ResourceClaimTemplateRenderer data={data} />}
         {kind === 'deviceclasses' && <DeviceClassRenderer data={data} />}
         {kind === 'resourceslices' && <ResourceSliceRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'backups' && data.apiVersion?.includes('postgresql.cnpg.io') && <CNPGBackupRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'backups' && data.apiVersion?.includes('velero.io') && <VeleroBackupRenderer data={data} />}
+        {kind === 'backups' && isApiGroup(data.apiVersion, CNPG_GROUP) && <CNPGBackupRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'backups' && isApiGroup(data.apiVersion, 'velero.io') && <VeleroBackupRenderer data={data} />}
         {kind === 'restores' && isVeleroResource(data) && <VeleroRestoreRenderer data={data} />}
         {kind === 'schedules' && isVeleroResource(data) && <VeleroScheduleRenderer data={data} />}
         {kind === 'backupstoragelocations' && isVeleroResource(data) && <VeleroBSLRenderer data={data} />}
@@ -690,10 +690,10 @@ export function ResourceRendererDispatch({
         {kind === 'externalsecrets' && <ExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusterexternalsecrets' && <ClusterExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {(kind === 'secretstores' || kind === 'clustersecretstores') && <SecretStoreRenderer data={data} />}
-        {kind === 'clusters' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'clusters' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusters' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIClusterRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'scheduledbackups' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'poolers' && data?.apiVersion?.includes('postgresql.cnpg.io') && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'scheduledbackups' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'poolers' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
         {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && data?.apiVersion?.includes('cluster.x-k8s.io') && (
           <AlertBanner
@@ -927,12 +927,12 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'resourceclaimtemplates') return getResourceClaimTemplateStatus(data)
   if (k === 'deviceclasses') return getDeviceClassStatus(data)
   if (k === 'resourceslices') return getResourceSliceStatus(data)
-  // Positive guards both ways — a third `backups` CRD gets no badge rather than
-  // a fabricated one from whichever engine happened to be the fallback.
+  // Positive guards both ways. A third `backups` CRD matches neither and falls
+  // through to the generic phase/conditions handling at the end of this
+  // function, rather than borrowing whichever engine used to be the fallback.
   if (k === 'backups') {
-    if (data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGBackupStatus(data)
-    if (data.apiVersion?.includes('velero.io')) return getBackupStatus(data)
-    return null
+    if (isApiGroup(data.apiVersion, CNPG_GROUP)) return getCNPGBackupStatus(data)
+    if (isApiGroup(data.apiVersion, 'velero.io')) return getBackupStatus(data)
   }
   if (k === 'restores' && isVeleroResource(data)) return getRestoreStatus(data)
   if (k === 'schedules' && isVeleroResource(data)) return getScheduleStatus(data)
@@ -943,8 +943,9 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'clustersecretstores') return getClusterSecretStoreStatus(data)
   if (k === 'clusters') {
     if (data.apiVersion?.includes('cluster.x-k8s.io')) return getCAPIClusterStatus(data)
-    if (data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGClusterStatus(data)
-    return null
+    if (isApiGroup(data.apiVersion, CNPG_GROUP)) return getCNPGClusterStatus(data)
+    // Third-party `clusters` CRDs (KubeBlocks, Redis/Valkey) fall through to the
+    // generic handling below instead of getting a fabricated PostgreSQL status.
   }
   if (k === 'machines' && data.apiVersion?.includes('cluster.x-k8s.io')) return getMachineStatus(data)
   if (k === 'machinedeployments') return getMachineDeploymentStatus(data)
@@ -968,8 +969,8 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
   if (k === 'azuremanagedmachinepools') return getAzureMMPStatus(data)
   if (k === 'azuremachines') return getAzureMachineStatus(data)
   if (k === 'azuremanagedclusters') return getAzureManagedClusterStatus(data)
-  if (k === 'scheduledbackups' && data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGScheduledBackupStatus(data)
-  if (k === 'poolers' && data.apiVersion?.includes('postgresql.cnpg.io')) return getCNPGPoolerStatus(data)
+  if (k === 'scheduledbackups' && isApiGroup(data.apiVersion, CNPG_GROUP)) return getCNPGScheduledBackupStatus(data)
+  if (k === 'poolers' && isApiGroup(data.apiVersion, CNPG_GROUP)) return getCNPGPoolerStatus(data)
   if (k === 'virtualservices') return getVirtualServiceStatus(data)
   if (k === 'destinationrules') return getDestinationRuleStatus(data)
   if (k === 'serviceentries') return getServiceEntryStatus(data)

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -163,7 +163,14 @@ const KIND: Record<string, string> = {
   // Contour
   HTTPProxy:            'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
 
-  // CloudNativePG
+  // CloudNativePG. CNPGCluster/CNPGBackup/CNPGScheduledBackup are topology
+  // pseudo-kinds (same convention as CAPICluster above) — getKindColorClass is
+  // keyed on the kind string alone, and the resource browser passes the real
+  // API kind, so those three are only reachable from topology. They are
+  // deliberately NOT registered under bare `Cluster`/`Backup`: those collide
+  // with CAPI and Velero, and Badge has no API group to disambiguate with, so
+  // a bare key would paint another operator's resource in Postgres colors.
+  // `Pooler` is unambiguous, so it resolves everywhere.
   CNPGCluster:          'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
   CNPGBackup:           'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
   CNPGScheduledBackup:  'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -163,6 +163,12 @@ const KIND: Record<string, string> = {
   // Contour
   HTTPProxy:            'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
 
+  // CloudNativePG
+  CNPGCluster:          'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  CNPGBackup:           'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  CNPGScheduledBackup:  'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  Pooler:               'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+
   // Cluster API
   CAPICluster:          'bg-indigo-100 text-indigo-700 border-indigo-300 dark:bg-indigo-950/50 dark:text-indigo-400 dark:border-indigo-700/40',
   MachineDeployment:    'bg-indigo-100 text-indigo-700 border-indigo-300 dark:bg-indigo-950/50 dark:text-indigo-400 dark:border-indigo-700/40',

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -163,17 +163,12 @@ const KIND: Record<string, string> = {
   // Contour
   HTTPProxy:            'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
 
-  // CloudNativePG. CNPGCluster/CNPGBackup/CNPGScheduledBackup are topology
-  // pseudo-kinds (same convention as CAPICluster above) — getKindColorClass is
-  // keyed on the kind string alone, and the resource browser passes the real
-  // API kind, so those three are only reachable from topology. They are
-  // deliberately NOT registered under bare `Cluster`/`Backup`: those collide
-  // with CAPI and Velero, and Badge has no API group to disambiguate with, so
-  // a bare key would paint another operator's resource in Postgres colors.
-  // `Pooler` is unambiguous, so it resolves everywhere.
-  CNPGCluster:          'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
-  CNPGBackup:           'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
-  CNPGScheduledBackup:  'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  // CloudNativePG. Only Pooler is keyed here. getKindColorClass takes the kind
+  // string alone, and CNPG's other kinds arrive as bare `Cluster` / `Backup` /
+  // `ScheduledBackup`, which collide with CAPI and Velero — keying those would
+  // paint another operator's resource in Postgres colors, the exact collision
+  // class this integration fixes elsewhere. Coloring them needs the API group
+  // threaded through Badge; until then they take the default.
   Pooler:               'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
 
   // Cluster API

--- a/packages/k8s-ui/src/utils/api-resources.ts
+++ b/packages/k8s-ui/src/utils/api-resources.ts
@@ -207,6 +207,8 @@ export function formatGroupName(group: string): string {
     'eks.amazonaws.com': 'EKS',
     'networking.k8s.aws': 'AWS Networking',
     'acid.zalan.do': 'Zalando Postgres',
+    'postgresql.cnpg.io': 'CloudNativePG',
+    'barmancloud.cnpg.io': 'CloudNativePG',
     'serving.kserve.io': 'KServe',
     'ray.io': 'KubeRay',
     'leaderworkerset.x-k8s.io': 'LeaderWorkerSet',

--- a/packages/k8s-ui/src/utils/resource-icons.test.ts
+++ b/packages/k8s-ui/src/utils/resource-icons.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { Database, Server, Puzzle } from 'lucide-react'
+import { getResourceIcon, DEFAULT_RESOURCE_ICON } from './resource-icons'
+
+describe('getResourceIcon', () => {
+  it('disambiguates colliding kinds by API group', () => {
+    // `Cluster` is shipped by CNPG, Cluster API, KubeBlocks and others. Without
+    // the group there is nothing to pick on, so the browser passes it.
+    expect(getResourceIcon('Cluster', 'postgresql.cnpg.io')).toBe(Database)
+    expect(getResourceIcon('Cluster', 'cluster.x-k8s.io')).toBe(Server)
+  })
+
+  it('falls back to the default for an unmapped group', () => {
+    // A third operator's `clusters` CRD must not inherit a Postgres icon.
+    expect(getResourceIcon('Cluster', 'apps.kubeblocks.io')).toBe(DEFAULT_RESOURCE_ICON)
+    expect(getResourceIcon('Backup', 'kubevirt.io')).toBe(DEFAULT_RESOURCE_ICON)
+  })
+
+  it('ignores the group for kinds that do not collide', () => {
+    expect(getResourceIcon('Pod')).not.toBe(Puzzle)
+    expect(getResourceIcon('Pod', 'postgresql.cnpg.io')).toBe(getResourceIcon('Pod'))
+  })
+
+  it('resolves unambiguous CNPG kinds without a group', () => {
+    // Pooler is CNPG-only, so it keys directly and works everywhere.
+    expect(getResourceIcon('Pooler')).not.toBe(DEFAULT_RESOURCE_ICON)
+    expect(getResourceIcon('Pooler')).toBe(getResourceIcon('Pooler', 'postgresql.cnpg.io'))
+  })
+
+  it('returns the default for an entirely unknown kind', () => {
+    expect(getResourceIcon('Widget')).toBe(DEFAULT_RESOURCE_ICON)
+  })
+})

--- a/packages/k8s-ui/src/utils/resource-icons.ts
+++ b/packages/k8s-ui/src/utils/resource-icons.ts
@@ -208,11 +208,10 @@ const KIND_ICON_MAP: Record<string, LucideIcon> = {
   // Contour
   httpproxy: Globe,
 
-  // CloudNativePG — pseudo-kinds for topology; the resource browser resolves
-  // the real API kinds through GROUP_QUALIFIED_KIND_ICONS below.
-  cnpgcluster: Database,
-  cnpgbackup: DatabaseBackup,
-  cnpgscheduledbackup: DatabaseBackup,
+  // CloudNativePG. Pooler is unambiguous so it keys directly; CNPG's colliding
+  // kinds resolve through GROUP_QUALIFIED_KIND_ICONS below. Topology
+  // pseudo-kinds (cnpgcluster/…) belong here only once pkg/topology's
+  // KindForGVK emits them — it has no CNPG case today.
   pooler: Waypoints,
 
   // Cluster API

--- a/packages/k8s-ui/src/utils/resource-icons.ts
+++ b/packages/k8s-ui/src/utils/resource-icons.ts
@@ -29,6 +29,8 @@ import {
   HardDrive,
   Cylinder,
   Database,
+  DatabaseBackup,
+  Waypoints,
   FileSearch,
   Fingerprint,
   Wand2,
@@ -206,6 +208,13 @@ const KIND_ICON_MAP: Record<string, LucideIcon> = {
   // Contour
   httpproxy: Globe,
 
+  // CloudNativePG — pseudo-kinds for topology; the resource browser resolves
+  // the real API kinds through GROUP_QUALIFIED_KIND_ICONS below.
+  cnpgcluster: Database,
+  cnpgbackup: DatabaseBackup,
+  cnpgscheduledbackup: DatabaseBackup,
+  pooler: Waypoints,
+
   // Cluster API
   capicluster: Server,
   machinedeployment: Layers,
@@ -273,8 +282,25 @@ const KIND_ICON_MAP: Record<string, LucideIcon> = {
 }
 
 /** Get the icon for a Kubernetes resource kind (case-insensitive). */
-export function getResourceIcon(kind: string): LucideIcon {
-  return KIND_ICON_MAP[kind.toLowerCase()] ?? Puzzle
+/**
+ * Kinds shared by more than one operator, where the icon can only be chosen
+ * once the API group is known. The resource browser passes the group; callers
+ * that don't have one fall through to the ungrouped map.
+ */
+const GROUP_QUALIFIED_KIND_ICONS: Record<string, Record<string, LucideIcon>> = {
+  cluster: { 'postgresql.cnpg.io': Database, 'cluster.x-k8s.io': Server },
+  backup: { 'postgresql.cnpg.io': DatabaseBackup },
+  scheduledbackup: { 'postgresql.cnpg.io': DatabaseBackup },
+  pooler: { 'postgresql.cnpg.io': Waypoints },
+}
+
+export function getResourceIcon(kind: string, group?: string): LucideIcon {
+  const k = kind.toLowerCase()
+  if (group) {
+    const byGroup = GROUP_QUALIFIED_KIND_ICONS[k]?.[group]
+    if (byGroup) return byGroup
+  }
+  return KIND_ICON_MAP[k] ?? Puzzle
 }
 
 /** Get the icon for a topology node kind, including virtual kinds (Internet, PodGroup). */

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -153,6 +153,12 @@ func RunChecks(input *CheckInput) *ScanResults {
 	// missing input (the gate is "not applicable here", not "couldn't list").
 	findings = append(findings, checkGitOpsCoverage(tr, input)...)
 
+	// --- CloudNativePG: clusters with no declarative backup schedule ---
+	// Self-gates on a nil Cluster inventory (CNPG not installed / RBAC denied)
+	// and on ScheduledBackup absence-authority — records nothing rather than
+	// reporting a missing input.
+	findings = append(findings, checkCNPGDeclarativeBackup(tr, input)...)
+
 	return buildResults(findings, tr, missingInputs)
 }
 

--- a/pkg/audit/cnpg.go
+++ b/pkg/audit/cnpg.go
@@ -1,0 +1,112 @@
+package audit
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const checkCNPGNoDeclarativeBackup = "cnpgNoDeclarativeBackup"
+
+// cnpgBarmanPluginName is the barman-cloud CNPG-I plugin. Clusters that have
+// migrated to it keep their backup config in an ObjectStore CR in a different
+// API group, and CNPG stops publishing the in-tree RPO status fields.
+const cnpgBarmanPluginName = "barman-cloud.cloudnative-pg.io"
+
+// checkCNPGDeclarativeBackup flags CNPG Clusters with no ScheduledBackup
+// targeting them.
+//
+// Deliberately narrow: the absence of a ScheduledBackup does NOT prove a
+// cluster is unprotected — on-demand Backups, volume snapshots and
+// plugin-external schedulers all exist — so the finding asserts only what is
+// observable ("no declarative backup schedule"), at posture severity.
+//
+// Suspended schedules count as present. Suspension is a deliberate operator
+// action, and re-reporting it here would duplicate intent as a defect.
+func checkCNPGDeclarativeBackup(tr *evalTracker, input *CheckInput) []Finding {
+	if input == nil || len(input.CNPGClusters) == 0 {
+		return nil
+	}
+	// Without a synced cluster-wide ScheduledBackup informer the inventory may
+	// cover only a subset of namespaces, so "no schedule found" could simply
+	// mean "not listed". Assert nothing, and record nothing — a check that
+	// couldn't run must not inflate its own passed count.
+	if !input.CNPGScheduledBackupsAuthoritative {
+		return nil
+	}
+
+	// A ScheduledBackup and the Cluster it targets are always in the same
+	// namespace; spec.method may be barmanObjectStore, volumeSnapshot or plugin,
+	// and all three are declarative schedules.
+	scheduled := map[string]bool{}
+	for _, sb := range input.CNPGScheduledBackups {
+		if sb == nil {
+			continue
+		}
+		target, _, _ := unstructured.NestedString(sb.Object, "spec", "cluster", "name")
+		if target == "" {
+			continue
+		}
+		scheduled[sb.GetNamespace()+"\x00"+target] = true
+	}
+
+	var findings []Finding
+	for _, c := range input.CNPGClusters {
+		if c == nil {
+			continue
+		}
+		ns, name := c.GetNamespace(), c.GetName()
+		tr.record(checkCNPGNoDeclarativeBackup, ns)
+		if scheduled[ns+"\x00"+name] {
+			continue
+		}
+		findings = append(findings, Finding{
+			Kind:      "Cluster",
+			Namespace: ns,
+			Name:      name,
+			CheckID:   checkCNPGNoDeclarativeBackup,
+			Category:  CategoryReliability,
+			Severity:  SeverityWarning,
+			Message:   cnpgNoScheduleMessage(c),
+		})
+	}
+	return findings
+}
+
+func cnpgNoScheduleMessage(c *unstructured.Unstructured) string {
+	const base = "No ScheduledBackup targets this PostgreSQL cluster, so no backup schedule is declared in the cluster. " +
+		"On-demand Backups or an external scheduler may still cover it — this reports what is declared, not whether backups exist."
+	switch {
+	case cnpgHasBarmanPlugin(c):
+		return base + " Backup for this cluster runs through the barman-cloud plugin; a ScheduledBackup with spec.method: plugin is what schedules it."
+	case cnpgHasInTreeBackup(c):
+		return base + " A backup destination is configured (spec.backup.barmanObjectStore), but nothing triggers it on a schedule."
+	default:
+		return base + " No backup destination is configured on the cluster either."
+	}
+}
+
+func cnpgHasBarmanPlugin(c *unstructured.Unstructured) bool {
+	plugins, found, _ := unstructured.NestedSlice(c.Object, "spec", "plugins")
+	if !found {
+		return false
+	}
+	for _, raw := range plugins {
+		p, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := p["name"].(string); name != cnpgBarmanPluginName {
+			continue
+		}
+		// `enabled` is CRD-defaulted to true, so only an explicit false disables.
+		if enabled, present := p["enabled"].(bool); present && !enabled {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func cnpgHasInTreeBackup(c *unstructured.Unstructured) bool {
+	_, found, _ := unstructured.NestedMap(c.Object, "spec", "backup", "barmanObjectStore")
+	return found
+}

--- a/pkg/audit/cnpg_test.go
+++ b/pkg/audit/cnpg_test.go
@@ -1,0 +1,213 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func cnpgObj(kind, ns, name string, spec map[string]any) *unstructured.Unstructured {
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       kind,
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec":       spec,
+	}}
+}
+
+func cnpgScheduledBackup(ns, name, clusterName, method string) *unstructured.Unstructured {
+	return cnpgObj("ScheduledBackup", ns, name, map[string]any{
+		"cluster":  map[string]any{"name": clusterName},
+		"schedule": "0 0 2 * * *", // CNPG crons are six-field
+		"method":   method,
+	})
+}
+
+func TestCNPGDeclarativeBackup_FlagsClusterWithNoSchedule(t *testing.T) {
+	input := &CheckInput{
+		CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "unprotected", nil)},
+		CNPGScheduledBackups:              nil,
+		CNPGScheduledBackupsAuthoritative: true,
+	}
+	tr := newEvalTracker()
+	findings := checkCNPGDeclarativeBackup(tr, input)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.CheckID != checkCNPGNoDeclarativeBackup {
+		t.Errorf("CheckID = %q, want %q", f.CheckID, checkCNPGNoDeclarativeBackup)
+	}
+	if f.Severity != SeverityWarning {
+		t.Errorf("Severity = %q, want %q (posture, not breakage)", f.Severity, SeverityWarning)
+	}
+	if f.Category != CategoryReliability {
+		t.Errorf("Category = %q, want %q", f.Category, CategoryReliability)
+	}
+	if f.Kind != "Cluster" || f.Namespace != "pg" || f.Name != "unprotected" {
+		t.Errorf("wrong subject: %+v", f)
+	}
+	// Group must stay empty — the audit backfills it, and the per-resource
+	// drill-down looks CRDs up under "".
+	if f.Group != "" {
+		t.Errorf("Group = %q, want empty", f.Group)
+	}
+	if tr.counts[checkCNPGNoDeclarativeBackup]["pg"] != 1 {
+		t.Errorf("expected the cluster to be counted as evaluated once")
+	}
+}
+
+func TestCNPGDeclarativeBackup_ScheduleSatisfiesCheck(t *testing.T) {
+	// All three methods are declarative schedules; the plugin one is the case
+	// that a barmanObjectStore-only heuristic would miss.
+	for _, method := range []string{"barmanObjectStore", "volumeSnapshot", "plugin"} {
+		t.Run(method, func(t *testing.T) {
+			input := &CheckInput{
+				CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "protected", nil)},
+				CNPGScheduledBackups:              []*unstructured.Unstructured{cnpgScheduledBackup("pg", "nightly", "protected", method)},
+				CNPGScheduledBackupsAuthoritative: true,
+			}
+			tr := newEvalTracker()
+			if findings := checkCNPGDeclarativeBackup(tr, input); len(findings) != 0 {
+				t.Fatalf("expected no findings, got %+v", findings)
+			}
+			if tr.counts[checkCNPGNoDeclarativeBackup]["pg"] != 1 {
+				t.Errorf("a passing cluster must still count as evaluated")
+			}
+		})
+	}
+}
+
+func TestCNPGDeclarativeBackup_SuspendedScheduleStillCounts(t *testing.T) {
+	// Suspension is deliberate operator intent; re-reporting it here would
+	// duplicate intent as a defect.
+	sb := cnpgScheduledBackup("pg", "nightly", "protected", "barmanObjectStore")
+	_ = unstructured.SetNestedField(sb.Object, true, "spec", "suspend")
+	input := &CheckInput{
+		CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "protected", nil)},
+		CNPGScheduledBackups:              []*unstructured.Unstructured{sb},
+		CNPGScheduledBackupsAuthoritative: true,
+	}
+	if findings := checkCNPGDeclarativeBackup(newEvalTracker(), input); len(findings) != 0 {
+		t.Fatalf("suspended schedule should still count as declared, got %+v", findings)
+	}
+}
+
+func TestCNPGDeclarativeBackup_ScheduleInOtherNamespaceDoesNotCount(t *testing.T) {
+	input := &CheckInput{
+		CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "app", nil)},
+		CNPGScheduledBackups:              []*unstructured.Unstructured{cnpgScheduledBackup("other", "nightly", "app", "barmanObjectStore")},
+		CNPGScheduledBackupsAuthoritative: true,
+	}
+	if findings := checkCNPGDeclarativeBackup(newEvalTracker(), input); len(findings) != 1 {
+		t.Fatalf("a schedule in a different namespace targets a different cluster, got %+v", findings)
+	}
+}
+
+// The coverage gate: without a synced cluster-wide ScheduledBackup informer the
+// inventory may cover a subset of namespaces, so absence proves nothing.
+func TestCNPGDeclarativeBackup_NonAuthoritativeInventoryIsNotEvaluated(t *testing.T) {
+	input := &CheckInput{
+		CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "unprotected", nil)},
+		CNPGScheduledBackups:              nil,
+		CNPGScheduledBackupsAuthoritative: false,
+	}
+	tr := newEvalTracker()
+	if findings := checkCNPGDeclarativeBackup(tr, input); len(findings) != 0 {
+		t.Fatalf("expected no findings when absence isn't provable, got %+v", findings)
+	}
+	if len(tr.counts) != 0 {
+		t.Fatalf("a check that couldn't run must not record evaluations, got %+v", tr.counts)
+	}
+}
+
+func TestCNPGDeclarativeBackup_NoClustersIsNotEvaluated(t *testing.T) {
+	tr := newEvalTracker()
+	if findings := checkCNPGDeclarativeBackup(tr, &CheckInput{CNPGScheduledBackupsAuthoritative: true}); len(findings) != 0 {
+		t.Fatalf("expected no findings without CNPG, got %+v", findings)
+	}
+	if len(tr.counts) != 0 {
+		t.Fatalf("CNPG-absent cluster must record nothing, got %+v", tr.counts)
+	}
+}
+
+func TestCNPGDeclarativeBackup_MessageNamesTheBackupMode(t *testing.T) {
+	cases := []struct {
+		name string
+		spec map[string]any
+		want string
+	}{
+		{
+			name: "plugin",
+			spec: map[string]any{"plugins": []any{map[string]any{"name": cnpgBarmanPluginName}}},
+			want: "spec.method: plugin",
+		},
+		{
+			name: "in-tree",
+			spec: map[string]any{"backup": map[string]any{"barmanObjectStore": map[string]any{"destinationPath": "s3://b"}}},
+			want: "spec.backup.barmanObjectStore",
+		},
+		{
+			name: "nothing configured",
+			spec: map[string]any{},
+			want: "No backup destination is configured",
+		},
+		{
+			name: "explicitly disabled plugin reads as unconfigured",
+			spec: map[string]any{"plugins": []any{map[string]any{"name": cnpgBarmanPluginName, "enabled": false}}},
+			want: "No backup destination is configured",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := &CheckInput{
+				CNPGClusters:                      []*unstructured.Unstructured{cnpgObj("Cluster", "pg", "c", tc.spec)},
+				CNPGScheduledBackupsAuthoritative: true,
+			}
+			findings := checkCNPGDeclarativeBackup(newEvalTracker(), input)
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding, got %+v", findings)
+			}
+			if !strings.Contains(findings[0].Message, tc.want) {
+				t.Errorf("message %q should mention %q", findings[0].Message, tc.want)
+			}
+			// Never assert backups don't exist — only that none is declared.
+			if strings.Contains(findings[0].Message, "is not backed up") {
+				t.Errorf("message overclaims: %q", findings[0].Message)
+			}
+		})
+	}
+}
+
+func TestCNPGDeclarativeBackup_CountsRollupAndRegistry(t *testing.T) {
+	input := &CheckInput{
+		CNPGClusters: []*unstructured.Unstructured{
+			cnpgObj("Cluster", "pg", "protected", nil),
+			cnpgObj("Cluster", "pg", "unprotected", nil),
+		},
+		CNPGScheduledBackups:              []*unstructured.Unstructured{cnpgScheduledBackup("pg", "nightly", "protected", "plugin")},
+		CNPGScheduledBackupsAuthoritative: true,
+	}
+	results := RunChecks(input)
+
+	got, ok := results.CheckCounts[checkCNPGNoDeclarativeBackup]
+	if !ok {
+		t.Fatalf("check missing from CheckCounts: %+v", results.CheckCounts)
+	}
+	if got.Evaluated != 2 || got.Passed != 1 {
+		t.Errorf("counts = %+v, want Evaluated 2 / Passed 1", got)
+	}
+	if _, ok := CheckRegistry[checkCNPGNoDeclarativeBackup]; !ok {
+		t.Errorf("check has no CheckRegistry entry — it would be untoggleable and uncatalogued")
+	}
+	for _, in := range results.MissingInputs {
+		if strings.Contains(strings.ToLower(in), "cnpg") {
+			t.Errorf("a self-gated check must not report a missing input, got %q", in)
+		}
+	}
+}

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -48,6 +48,7 @@ var (
 	refOpenGitOps      = Reference{Label: "OpenGitOps: Principles", URL: "https://opengitops.dev/"}
 	refArgoCD          = Reference{Label: "Argo CD: Declarative GitOps", URL: "https://argo-cd.readthedocs.io/en/stable/"}
 	refHelm            = Reference{Label: "Helm: Charts", URL: "https://helm.sh/docs/topics/charts/"}
+	refCNPGBackup      = Reference{Label: "CloudNativePG: Backup", URL: "https://cloudnative-pg.io/documentation/current/backup/"}
 )
 
 // CheckRegistry maps checkID → metadata for all built-in checks.
@@ -381,6 +382,18 @@ var CheckRegistry = map[string]CheckMeta{
 		Description: "A Crossplane Managed Resource, Composite Resource, or Claim has been reporting Ready=False or Synced=False past the reconciliation window. Synced=False usually means a configuration error (bad ProviderConfig, malformed forProvider spec, missing IAM permissions, quota exceeded, schema mismatch). Ready=False usually means the provider accepted the spec but can't reach a desired state (target cloud API rejected, dependency missing, eventual-consistency lag past the threshold).",
 		Remediation: "Open the resource and read the latest condition's message — Crossplane providers almost always include the upstream cloud error verbatim. Common fixes: (1) check the linked Provider's Healthy condition; the package controller crashlooping starves every MR it manages. (2) verify the ProviderConfig credentials Secret still exists and is current (rotated keys, expired tokens). (3) check IAM/RBAC at the target cloud — Synced=False with auth errors needs a credentials fix, not a Crossplane fix. (4) look at quota/limit errors in the cloud provider console. (5) for paused resources (crossplane.io/paused annotation), this finding is intentionally suppressed — remove the annotation to resume reconciliation.",
 		References:  []Reference{refCrossplane},
+	},
+
+	// ── CloudNativePG ─────────────────────────────────────────────────
+	// Posture, not breakage: absence of a schedule doesn't prove a cluster is
+	// unprotected, so this stays at the default Medium and is not BadgeWorthy.
+	checkCNPGNoDeclarativeBackup: {
+		ID:          checkCNPGNoDeclarativeBackup,
+		Title:       "PostgreSQL cluster has no declarative backup schedule",
+		Category:    CategoryReliability,
+		Description: "No ScheduledBackup targets this CloudNativePG cluster, so nothing in the cluster declares when its backups run. Backups may still be taken on demand or by an external scheduler — this reports what is declared, not whether backups exist. Without a declared schedule there is no in-cluster record of the intended backup cadence, and no signal when backups silently stop.",
+		Remediation: "Create a ScheduledBackup in the cluster's namespace referencing it by spec.cluster.name, with the schedule and the method that matches how backups run (barmanObjectStore, volumeSnapshot, or plugin for barman-cloud). Note CNPG schedules are six-field cron expressions — they include a leading seconds field.",
+		References:  []Reference{refCNPGBackup},
 	},
 
 	// ── GitOps coverage (emit under Reliability) ───────────────────────

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -74,6 +74,17 @@ type CheckInput struct {
 	// Traefik route → Service references, including cross-namespace ones.
 	AllServices []*corev1.Service
 
+	// CloudNativePG CRDs arrive unstructured (no shared typed schema). Clusters
+	// are the subjects of the declarative-backup check; ScheduledBackups are the
+	// targets it looks for. Both nil when CNPG isn't installed or RBAC denies it.
+	CNPGClusters         []*unstructured.Unstructured
+	CNPGScheduledBackups []*unstructured.Unstructured
+	// CNPGScheduledBackupsAuthoritative is true only when a synced cluster-wide
+	// ScheduledBackup informer backs the inventory. False → the cache may know a
+	// subset of namespaces, so "no schedule found" doesn't prove "none exists"
+	// and the check must not run at all.
+	CNPGScheduledBackupsAuthoritative bool
+
 	// GitOpsToolsPresent gates the GitOps coverage check (checkGitOpsCoverage).
 	// True when at least one GitOps root OBJECT exists (Argo CD Application,
 	// Flux Kustomization, or Flux HelmRelease) — not merely the CRDs, which

--- a/testdata/cnpg/badge-issue-matrix.json
+++ b/testdata/cnpg/badge-issue-matrix.json
@@ -1,0 +1,232 @@
+{
+  "_comment": [
+    "Shared golden matrix for the CNPG cluster health invariant.",
+    "",
+    "The status badge (TypeScript, getCNPGClusterStatus) and the issue detector",
+    "(Go, detectCNPGClusterIssues) are two implementations of one decision. This",
+    "file is the single specification both are tested against:",
+    "  internal/issues/source_cnpg_golden_test.go",
+    "  packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts",
+    "",
+    "The sibling parity test only compares phase SPELLING between the two files.",
+    "That cannot catch a precedence, readiness-presence or condition difference —",
+    "every badge/issue disagreement found on this branch slipped past it. This",
+    "file pins observable behaviour instead, so a change to one language that the",
+    "other doesn't mirror fails in both.",
+    "",
+    "`issues` is an unordered set of Reason values. `worst` is the highest issue",
+    "severity (critical > warning > none). Adding a case is cheap — do it every",
+    "time a state turns out to be ambiguous."
+  ],
+  "cases": [
+    {
+      "name": "healthy and fully ready",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Cluster in healthy state", "readyInstances": 3 },
+      "badge": { "text": "Healthy", "level": "healthy" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "healthy phase but a partial shortfall — the phase settles before instances do",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Cluster in healthy state", "readyInstances": 1 },
+      "badge": { "text": "Degraded", "level": "degraded" },
+      "issues": ["CNPGClusterDegraded"],
+      "worst": "warning"
+    },
+    {
+      "name": "healthy phase with nothing serving",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Cluster in healthy state", "readyInstances": 0 },
+      "badge": { "text": "Not Ready", "level": "unhealthy" },
+      "issues": ["CNPGClusterDegraded"],
+      "worst": "critical"
+    },
+    {
+      "name": "readyInstances absent — unknown, not zero; must not fabricate an outage",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster in healthy state",
+        "conditions": [{ "type": "Ready", "status": "True", "reason": "ClusterIsReady" }]
+      },
+      "badge": { "text": "Healthy", "level": "healthy" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "WAL archiving failing on a fully-ready cluster — availability hides it",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster in healthy state",
+        "readyInstances": 3,
+        "conditions": [
+          { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing", "message": "cannot upload WAL" }
+        ]
+      },
+      "badge": { "text": "WAL Archiving Failing", "level": "alert" },
+      "issues": ["CNPGWALArchivingFailing"],
+      "worst": "critical"
+    },
+    {
+      "name": "last backup failed on a fully-ready cluster",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster in healthy state",
+        "readyInstances": 3,
+        "conditions": [
+          { "type": "LastBackupSucceeded", "status": "False", "reason": "LastBackupFailed", "message": "no credentials" }
+        ]
+      },
+      "badge": { "text": "Backup Failed", "level": "degraded" },
+      "issues": ["CNPGLastBackupFailed"],
+      "worst": "warning"
+    },
+    {
+      "name": "a backup merely in flight is not a failure on either side",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster in healthy state",
+        "readyInstances": 3,
+        "conditions": [
+          { "type": "LastBackupSucceeded", "status": "False", "reason": "BackupStarted", "message": "New Backup starting up" }
+        ]
+      },
+      "badge": { "text": "Healthy", "level": "healthy" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "unrecoverable while every pod is still Ready",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "readyInstances": 3 },
+      "badge": { "text": "Cluster is unrecoverable and needs manual intervention", "level": "unhealthy" },
+      "issues": ["CNPGClusterUnrecoverable"],
+      "worst": "critical"
+    },
+    {
+      "name": "plugin failure is terminal, not unknown",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster cannot proceed to reconciliation due to an unknown plugin being required",
+        "readyInstances": 3
+      },
+      "badge": {
+        "text": "Cluster cannot proceed to reconciliation due to an unknown plugin being required",
+        "level": "unhealthy"
+      },
+      "issues": ["CNPGClusterPluginFailure"],
+      "worst": "critical"
+    },
+    {
+      "name": "post-1.28 PhaseDefinitionInvalid is carried ahead of the release that emits it",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Invalid cluster definition", "readyInstances": 3 },
+      "badge": { "text": "Invalid cluster definition", "level": "unhealthy" },
+      "issues": ["CNPGClusterTerminal"],
+      "worst": "critical"
+    },
+    {
+      "name": "failover with a surviving replica",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Failing over", "readyInstances": 2 },
+      "badge": { "text": "Failing Over", "level": "alert" },
+      "issues": ["CNPGClusterFailingOver"],
+      "worst": "warning"
+    },
+    {
+      "name": "failover with nothing serving is a total outage, not an orange warning",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Failing over", "readyInstances": 0 },
+      "badge": { "text": "Not Ready", "level": "unhealthy" },
+      "issues": ["CNPGClusterFailingOver", "CNPGClusterDegraded"],
+      "worst": "critical"
+    },
+    {
+      "name": "mid-operation shortfall is expected and stays quiet",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Creating a new replica", "readyInstances": 2 },
+      "badge": { "text": "Creating a new replica", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "no transient phase excuses a fully-down cluster",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Switchover in progress", "readyInstances": 0 },
+      "badge": { "text": "Not Ready", "level": "unhealthy" },
+      "issues": ["CNPGClusterDegraded"],
+      "worst": "critical"
+    },
+    {
+      "name": "rollout delay is operator-driven, not a wait on a human",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Cluster upgrade delayed", "readyInstances": 2 },
+      "badge": { "text": "Cluster upgrade delayed", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "supervised wait — a shortfall is the documented resting state",
+      "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
+      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "badge": { "text": "Waiting for user action", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "unsupervised wait is worth reporting",
+      "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
+      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "badge": { "text": "Waiting for user action", "level": "degraded" },
+      "issues": ["CNPGClusterWaitingForUser"],
+      "worst": "warning"
+    },
+    {
+      "name": "supervised wait with nothing serving is still an outage",
+      "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
+      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "badge": { "text": "Not Ready", "level": "unhealthy" },
+      "issues": ["CNPGClusterDegraded"],
+      "worst": "critical"
+    },
+    {
+      "name": "unsupervised wait with nothing serving reports both true causes",
+      "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
+      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "badge": { "text": "Not Ready", "level": "unhealthy" },
+      "issues": ["CNPGClusterWaitingForUser", "CNPGClusterDegraded"],
+      "worst": "critical"
+    },
+    {
+      "name": "a phase from a newer minor is surfaced verbatim, never guessed at",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Reticulating splines", "readyInstances": 3 },
+      "badge": { "text": "Reticulating splines", "level": "unknown" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "an unknown phase still gets its shortfall reported",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Reticulating splines", "readyInstances": 1 },
+      "badge": { "text": "Degraded", "level": "degraded" },
+      "issues": ["CNPGClusterDegraded"],
+      "worst": "warning"
+    },
+    {
+      "name": "terminal outranks WAL archiving on the badge; both are reported as issues",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Cluster is unrecoverable and needs manual intervention",
+        "readyInstances": 3,
+        "conditions": [
+          { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing" }
+        ]
+      },
+      "badge": { "text": "Cluster is unrecoverable and needs manual intervention", "level": "unhealthy" },
+      "issues": ["CNPGWALArchivingFailing", "CNPGClusterUnrecoverable"],
+      "worst": "critical"
+    }
+  ]
+}

--- a/testdata/cnpg/badge-issue-matrix.json
+++ b/testdata/cnpg/badge-issue-matrix.json
@@ -100,7 +100,7 @@
       "name": "unrecoverable while every pod is still Ready",
       "spec": { "instances": 3 },
       "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "readyInstances": 3 },
-      "badge": { "text": "Cluster is unrecoverable and needs manual intervention", "level": "unhealthy" },
+      "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGClusterUnrecoverable"],
       "worst": "critical"
     },
@@ -112,7 +112,7 @@
         "readyInstances": 3
       },
       "badge": {
-        "text": "Cluster cannot proceed to reconciliation due to an unknown plugin being required",
+        "text": "Unknown Plugin",
         "level": "unhealthy"
       },
       "issues": ["CNPGClusterPluginFailure"],
@@ -122,7 +122,7 @@
       "name": "post-1.28 PhaseDefinitionInvalid is carried ahead of the release that emits it",
       "spec": { "instances": 3 },
       "status": { "phase": "Invalid cluster definition", "readyInstances": 3 },
-      "badge": { "text": "Invalid cluster definition", "level": "unhealthy" },
+      "badge": { "text": "Invalid Spec", "level": "unhealthy" },
       "issues": ["CNPGClusterTerminal"],
       "worst": "critical"
     },
@@ -146,7 +146,7 @@
       "name": "mid-operation shortfall is expected and stays quiet",
       "spec": { "instances": 3 },
       "status": { "phase": "Creating a new replica", "readyInstances": 2 },
-      "badge": { "text": "Creating a new replica", "level": "degraded" },
+      "badge": { "text": "Creating Replica", "level": "degraded" },
       "issues": [],
       "worst": "none"
     },
@@ -162,7 +162,7 @@
       "name": "rollout delay is operator-driven, not a wait on a human",
       "spec": { "instances": 3 },
       "status": { "phase": "Cluster upgrade delayed", "readyInstances": 2 },
-      "badge": { "text": "Cluster upgrade delayed", "level": "degraded" },
+      "badge": { "text": "Upgrade Delayed", "level": "degraded" },
       "issues": [],
       "worst": "none"
     },
@@ -170,7 +170,7 @@
       "name": "supervised wait — a shortfall is the documented resting state",
       "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
       "status": { "phase": "Waiting for user action", "readyInstances": 2 },
-      "badge": { "text": "Waiting for user action", "level": "degraded" },
+      "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": [],
       "worst": "none"
     },
@@ -178,7 +178,7 @@
       "name": "unsupervised wait is worth reporting",
       "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
       "status": { "phase": "Waiting for user action", "readyInstances": 2 },
-      "badge": { "text": "Waiting for user action", "level": "degraded" },
+      "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": ["CNPGClusterWaitingForUser"],
       "worst": "warning"
     },
@@ -224,7 +224,7 @@
           { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing" }
         ]
       },
-      "badge": { "text": "Cluster is unrecoverable and needs manual intervention", "level": "unhealthy" },
+      "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGWALArchivingFailing", "CNPGClusterUnrecoverable"],
       "worst": "critical"
     }


### PR DESCRIPTION
Radar already had the most detailed CloudNativePG renderer of any general-purpose Kubernetes UI. It was also wrong in exactly the states that matter: a cluster losing its recovery point rendered green, an unrecoverable cluster rendered neutral grey, and the failures were invisible from the resource list, the Problems queue and an AI agent's context alike.

This makes CNPG state honest. A Postgres cluster whose WAL archiving is failing, whose phase is terminal, or whose last backup failed now says so — in the badge, in the drawer, as an Issue, in Cluster Audit, and in the filter — and says the same thing in each.

## The headline: WAL archiving

`ContinuousArchiving=False` means WAL segments are not reaching object storage. The database serves normally, every pod is Ready, and the recovery point is silently drifting — so instance-count reasoning renders it perfect. This was the state Radar was least able to see and the one an operator most needs.

It is now a `critical` Issue (`CNPGWALArchivingFailing`), an orange badge in the list, and a drawer banner that says what is at risk rather than which condition is false.

## Detection

Issues emitted, all with fingerprints so concurrent causes survive independently — a cluster can be both unrecoverable *and* failing to archive, and both rows appear:

| Reason | Severity |
|---|---|
| `CNPGWALArchivingFailing` | critical |
| `CNPGClusterUnrecoverable` · `CNPGClusterTerminal` · `CNPGClusterPluginFailure` | critical |
| `CNPGClusterDegraded` · `CNPGClusterFailingOver` · `CNPGClusterWaitingForUser` | warning |
| `CNPGBackupFailed` · `CNPGLastBackupFailed` | warning |

Phase handling is the load-bearing part. CNPG phases are full English sentences, matched on **equality** against upstream 1.27 and bucketed healthy / transient / failing / terminal / attention. Terminal phases outrank instance counts, so an unrecoverable cluster whose pods are still Ready renders red rather than neutral. Transient and attention phases suppress the generic `Ready=False` walk — a switchover or a supervised `Waiting for user action` is not a fault — bounded by a 30-minute age gate for transient phases only, since a mid-operation phase that never advances is not transient. Unrecognised phases from a future minor pass through verbatim rather than being asserted healthy.

`internal/audit` gains `cnpgNoDeclarativeBackup`, gated on coverage: a cluster with no declarative backup configuration is reported only when the inventory is complete enough to prove it.

## The row tells one story

The Clusters list previously showed a badge saying one thing and its neighbours saying another. Now:

- **Status** carries a short display state (`Unrecoverable`, `WAL Archiving Failing`, `Needs Action`, `Switchover`) — CNPG's own sentence-length phases reach 315px and fit no column; the exact phase is in the drawer and the `title`. Twenty phases are mapped; anything unmapped renders verbatim.
- **Instances** and **Primary** are muted, with tooltips, when the phase is terminal. `2/2` on an unrecoverable cluster is literally true and diagnostically useful — unrecoverable at 2/2 means the data is probably intact, at 0/2 it is down too — so it is de-emphasised rather than hidden. `status.currentPrimary` is *last known* and CNPG never clears it, so naming a primary on a cluster that cannot elect one is an assertion Radar makes; the tooltip says so.
- **An absent count renders as `-`, never `0`.** Readiness is read for **presence**, not value, everywhere it is read: the badge, the Instances cell, and the Pooler equivalents. Between creation and the operator's first status write there is no `readyInstances`, and treating that as zero would put `0/3` next to a badge that correctly says nothing is wrong — the same contradiction this section exists to remove, and `-/3` states what is actually known. The Pooler badge follows the same rule for a sharper reason: reading an absent `status.instances` as zero would satisfy `scheduled < desired` and paint a red **Not Scheduled** on a Pooler nobody has reported on yet, fabricating a failure rather than a count.
- **Storage** is dropped. It rendered `spec.storage.size` — the configured request, not usage — under a label that reads like consumption. A plausible-but-wrong-meaning number is worse than an absent one.
- **Column widths** are sized to their **headers**, not their values. A header needs its space after padding and the sort/filter affordances, and the filter icon appears as soon as a column holds more than one distinct value — so an under-sized column is latent until real data arrives.

The status **filter** derives from the same curated reader as the badge. Previously it fell through to raw `status.phase`, which for CNPG is prose — so the dropdown offered strings appearing on no row, and WAL-archiving failure was inexpressible entirely, since that state leaves `phase` at `Cluster in healthy state`.

## Colliding plurals

`backups` and `clusters` are shared with Velero, CAPI, KubeBlocks and others. Every render line, `getResourceStatus` branch and cell dispatch is gated on an **exact** API-group match (`extension.postgresql.cnpg.io` satisfies a substring test), with an explicit fall-through so a third-party CRD sharing a plural gets the generic renderer rather than a blank drawer or a fabricated Postgres status.

## Drawer and detail

Backup failure and WAL-archiving banners; barman-cloud plugin backups (`method: plugin`) recognised rather than reported as missing; Pooler's positive state labelled **Scheduled** — `status.instances` counts pods *trying* to be scheduled, which cannot support a readiness claim; `timeLineID` corrected so per-instance timelines render; group-aware icons and badge tones.

## What a reviewer should look at

**`detectCNPGClusterIssues` and `getCNPGClusterStatus`.** They carry four interacting concerns — `phaseExplained`, `allDown`, the attention/transient split, and the grace bound — and that interaction is where the residual risk is.

**`testdata/cnpg/badge-issue-matrix.json`** is one specification consumed by both languages: Go asserts the detector against it, Vitest asserts the badge, and the TS side additionally asserts the invariant directly — no healthy badge beside an issue, no unhealthy badge beside silence. The taxonomy is defined twice (TypeScript for display, Go for detection) and `TestCNPGPhaseTaxonomyMatchesFrontend` fails on drift in either direction.

## Testing

`make tsc` · `go test ./...` clean in **both** modules · k8s-ui **2131** · web **400**

Verified against a real **CNPG 1.27.0** operator running real Postgres on `kind`, with terminal and failure states hand-crafted by patching status behind a frozen operator, and WAL-archiving failure induced genuinely by pointing at an unreachable object store.

- Four clusters at 2/2 ready, three outcomes: `Healthy`, `WAL Archiving Failing`, `Unrecoverable` ×2. Rows one and two differ only by the `ContinuousArchiving` condition — the first is what the second used to look like.
- Badge, drawer banner and `/api/issues` agree on the same cluster; concurrent causes appear as two rows.
- Filter dropdown options match the badges on the rows, for all four kinds, with the affordance present.
- `/api/ai/resources/...` reports `issueSummary: {count: 1, highestSeverity: critical, topReason: CNPGWALArchivingFailing}`.
- Audit reports `evaluated 2 / passed 1`.
- Collisions checked against a real third-party CRD: a KubeBlocks `clusters` CR renders a generic drawer, and Velero `backups` and CNPG `backups` render different column sets on one cluster.

**visual-test: ran.** Clusters list before/after, the four-banner drawer, the filter dropdowns, and the KubeBlocks fall-through.

Two limits worth stating: the operator is scaled to zero for the hand-patched states, so those are static; and CNPG's instance manager writes cluster status independently of the operator, so any fixture built by patching conditions alone reverts within ~10 minutes.

## Surface integration

| Surface | |
|---|---|
| Resource browser · Issues · Cluster Audit · Sidebar | integrated |
| MCP / AI context | integrated — issue summaries reach resource context generically |
| Topology (traffic view) | works today via selector matching |
| **Topology (resources view)** | **gap** — CNPG sets ownerReferences on Pods, PVCs, Services and Secrets, but `pkg/topology` has no CNPG `NodeKind`, so they render as orphans. Tracked in RAD-319 |
| Timeline | records all four kinds; failover/switchover transitions collapse to "resource changed". Tracked in RAD-319 |
| Upgrade readiness | N/A — scans deprecated Kubernetes APIs; `postgresql.cnpg.io/v1` is current |

## Follow-ups

- **RAD-320** — recovery-point *freshness*. `kubectl cnpg status` reports WAL backlog depth and last-archived timestamp; this PR reports a boolean. The data is not in the CR, so it needs the instance manager or Prometheus.
- **RAD-362** — the status-filter drift fixed here for CNPG's four kinds exists on ~62 others.
- **RAD-352** — `Scheduled` means "cron is active" on ScheduledBackup and "pods are placed" on Pooler.
- `Error` on Backup and `Next Run` on ScheduledBackup lost only to the column budget and are first in line if width work frees space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting change to status/issue semantics and plural collision routing; mitigated by extensive golden/parity tests and conservative audit gating when inventory is incomplete.
> 
> **Overview**
> Makes **CloudNativePG** state honest end-to-end: clusters that look healthy while WAL archiving fails or reconciliation has stopped no longer render green in the list, drawer, Problems queue, filters, and audit.
> 
> **Backend issues** add a curated CNPG detector (`internal/issues/source_cnpg.go`) with phase buckets matched on **equality** to upstream 1.27 sentences, critical **`CNPGWALArchivingFailing`** from `ContinuousArchiving=False`, backup/last-backup handling that ignores in-flight `BackupStarted`, and fingerprints so concurrent causes (e.g. unrecoverable + archiving) stay separate rows. Transient/attention phases suppress generic `Ready=False` noise with a 30-minute grace on transient only; zero ready instances still surfaces as critical.
> 
> **Cluster audit** adds `cnpgNoDeclarativeBackup`, fed by `listCNPGDynamic` in the audit runner, only when cluster-wide ScheduledBackup inventory is authoritative.
> 
> **UI** rewrites `getCNPGClusterStatus` and related utils: short badge states, `-` instead of fabricated `0` when counts are absent, WAL/backup on the badge, barman-cloud plugin backup section, Pooler **Scheduled** (not Ready), `timeLineID` fix, and drawer banners aligned with badge severity. **Colliding plurals** (`clusters`, `backups`, etc.) use exact `isApiGroup` guards and generic fall-through so third-party CRDs do not get Postgres/Velero treatment.
> 
> **Parity tests**: shared `testdata/cnpg/badge-issue-matrix.json`, `TestCNPGPhaseTaxonomyMatchesFrontend`, and golden matrix tests on both Go and TypeScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd8a83891a40e26d3fef022b729b8a5b6b51dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->