### PR TITLE
fix(navigation): stop double-pluralizing CRD plurals before discovery lands (RAD-330)

### DIFF
--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterEach } from 'vitest'
+import { englishPlural } from './pluralize'
 import { kindToPlural, pluralToKind, refToSelectedResource, initNavigationMap, resetNavigationMap, laneId, laneResourceKey, groupQualifiesLaneId, parseLaneId } from './navigation'
 
 afterEach(() => {
@@ -64,6 +65,66 @@ describe('kindToPlural', () => {
     expect(kindToPlural('HorizontalPodAutoscaler')).toBe('horizontalpodautoscalers')
     expect(kindToPlural('pvc')).toBe('persistentvolumeclaims')
     expect(kindToPlural('PodGroup')).toBe('pods')
+  })
+
+  // A cold direct-URL load runs kindToPlural against the URL's plural slug one
+  // round-trip BEFORE initNavigationMap lands, so the discovered-plural guard
+  // can't fire for a CRD absent from BUILTIN_PLURAL_TO_KIND.
+  describe('CRD plurals before the discovery map arrives', () => {
+    test('idempotent on unknown lowercase plurals', () => {
+      expect(kindToPlural('schedules')).toBe('schedules')
+      expect(kindToPlural('validatingpolicies')).toBe('validatingpolicies')
+      expect(kindToPlural('virtualservices')).toBe('virtualservices')
+      expect(kindToPlural('clusters')).toBe('clusters')
+      expect(kindToPlural('backups')).toBe('backups')
+    })
+
+    // Plurals of `*se` singulars — Flux's HelmRelease and coordination.k8s.io's
+    // Lease are both kinds Radar handles, and both reach this cold path.
+    test('idempotent on plurals of *se singulars', () => {
+      expect(kindToPlural('helmreleases')).toBe('helmreleases')
+      expect(kindToPlural('leases')).toBe('leases')
+      expect(kindToPlural('databases')).toBe('databases')
+    })
+
+    test('still pluralizes singular PascalCase CRD kinds', () => {
+      expect(kindToPlural('Schedule')).toBe('schedules')
+      expect(kindToPlural('ValidatingPolicy')).toBe('validatingpolicies')
+      expect(kindToPlural('VirtualService')).toBe('virtualservices')
+      expect(kindToPlural('Cluster')).toBe('clusters')
+    })
+
+    // Lowercase does NOT imply plural. WorkloadViewRoute passes the URL segment
+    // through verbatim, so /workload/deployment/ns/name yields "deployment";
+    // pkg/topology's normalizeKind likewise returns its input unchanged when a
+    // kind resolves through neither its static map nor discovery, so a
+    // ResourceRef can carry "certificaterequest". Both must still pluralize —
+    // including the singulars that already end in 's'.
+    test('still pluralizes lowercase singular kinds', () => {
+      expect(kindToPlural('deployment')).toBe('deployments')
+      expect(kindToPlural('pod')).toBe('pods')
+      expect(kindToPlural('cronjob')).toBe('cronjobs')
+      expect(kindToPlural('certificaterequest')).toBe('certificaterequests')
+      expect(kindToPlural('validatingpolicy')).toBe('validatingpolicies')
+      expect(kindToPlural('ingress')).toBe('ingresses')
+      expect(kindToPlural('nodeclass')).toBe('nodeclasses')
+      expect(kindToPlural('ec2nodeclass')).toBe('ec2nodeclasses')
+      expect(kindToPlural('storageclass')).toBe('storageclasses')
+    })
+
+    test('leaves the empty-string result unchanged', () => {
+      expect(kindToPlural('')).toBe(englishPlural(''))
+    })
+
+    test('agrees with the post-discovery answer', () => {
+      const inputs = ['schedules', 'validatingpolicies', 'Schedule', 'ValidatingPolicy']
+      const cold = inputs.map(kindToPlural)
+      initNavigationMap([
+        { group: 'velero.io', version: 'v1', kind: 'Schedule', name: 'schedules', namespaced: true, isCrd: true, verbs: [] },
+        { group: 'kyverno.io', version: 'v1alpha1', kind: 'ValidatingPolicy', name: 'validatingpolicies', namespaced: false, isCrd: true, verbs: [] },
+      ])
+      expect(inputs.map(kindToPlural)).toEqual(cold)
+    })
   })
 })
 

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -1,5 +1,5 @@
 import type { SelectedResource, ResourceRef, APIResource } from '../types/core'
-import { englishPlural } from './pluralize'
+import { englishPlural, englishSingular, isEnglishPlural } from './pluralize'
 
 /**
  * Canonical callback type for navigating to a resource.
@@ -103,6 +103,15 @@ export function kindToPlural(kind: string): string {
   }
   if (aliases[kindLower]) return aliases[kindLower]
 
+  // Keep the idempotence contract alive for CRD plurals that neither map knows
+  // yet: the discovery map arrives one round-trip after a cold direct-URL load,
+  // and English-pluralizing an already-plural slug yields `scheduleses`. An
+  // all-lowercase input is an API resource name rather than a Kind (Kubernetes
+  // Kinds are PascalCase), and isEnglishPlural separates a real plural from a
+  // singular that merely ends in 's' — `ingress` and `nodeclass` must still be
+  // pluralized, `schedules` and `validatingpolicies` must not.
+  if (kind === kindLower && isEnglishPlural(kindLower)) return kindLower
+
   // Fallback: English pluralization rules (shared with pluralize() in
   // utils/pluralize.ts so a rule change updates both call paths).
   return englishPlural(kindLower)
@@ -125,14 +134,7 @@ export function pluralToKind(plural: string): string {
   }
 
   // Fallback: basic de-pluralization + capitalize first letter
-  let singular = lower
-  if (singular.endsWith('ies')) {
-    singular = singular.slice(0, -3) + 'y'
-  } else if (singular.endsWith('ses') || singular.endsWith('xes') || singular.endsWith('ches') || singular.endsWith('shes')) {
-    singular = singular.slice(0, -2)
-  } else if (singular.endsWith('s')) {
-    singular = singular.slice(0, -1)
-  }
+  const singular = englishSingular(lower)
   return singular.charAt(0).toUpperCase() + singular.slice(1)
 }
 

--- a/packages/k8s-ui/src/utils/pluralize.test.ts
+++ b/packages/k8s-ui/src/utils/pluralize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { englishPlural, pluralNoun, pluralize } from './pluralize'
+import { englishPlural, englishSingular, isEnglishPlural, pluralNoun, pluralize } from './pluralize'
 
 describe('englishPlural', () => {
   describe('default +s', () => {
@@ -94,5 +94,84 @@ describe('pluralize', () => {
     expect(pluralize(2, 'policy')).toBe('2 policies')
     expect(pluralize(2, 'class')).toBe('2 classes')
     expect(pluralize(2, 'box')).toBe('2 boxes')
+  })
+})
+
+describe('englishSingular', () => {
+  it('inverts englishPlural for regular plurals', () => {
+    expect(englishSingular('clusters')).toBe('cluster')
+    expect(englishSingular('policies')).toBe('policy')
+    expect(englishSingular('classes')).toBe('class')
+    expect(englishSingular('boxes')).toBe('box')
+    expect(englishSingular('batches')).toBe('batch')
+  })
+
+  it('leaves nouns with no plural ending alone', () => {
+    expect(englishSingular('cluster')).toBe('cluster')
+    expect(englishSingular('policy')).toBe('policy')
+  })
+
+  // The `-es` strip over-shortens a `*se` singular ('leases' → 'leas', not
+  // 'lease'), but englishPlural's `s → +es` rule inverts it exactly, so the
+  // round trip these two functions are used for still holds. Only the round
+  // trip is contractual — the intermediate stem is not.
+  it('over-strips *se stems but stays round-trip exact', () => {
+    expect(englishSingular('leases')).toBe('leas')
+    expect(englishPlural('leas')).toBe('leases')
+    expect(englishSingular('helmreleases')).toBe('helmreleas')
+    expect(englishPlural('helmreleas')).toBe('helmreleases')
+  })
+})
+
+describe('isEnglishPlural', () => {
+  it('recognizes regular plurals', () => {
+    expect(isEnglishPlural('schedules')).toBe(true)
+    expect(isEnglishPlural('validatingpolicies')).toBe(true)
+    expect(isEnglishPlural('virtualservices')).toBe(true)
+    expect(isEnglishPlural('gatewayclasses')).toBe(true)
+    expect(isEnglishPlural('endpoints')).toBe(true)
+  })
+
+  // Plurals whose singular ends in `se`. The stem englishSingular produces is
+  // wrong, but the round trip is not — see the englishSingular case above.
+  it('recognizes plurals of *se singulars', () => {
+    expect(isEnglishPlural('leases')).toBe(true)
+    expect(isEnglishPlural('helmreleases')).toBe(true)
+    expect(isEnglishPlural('releases')).toBe(true)
+    expect(isEnglishPlural('licenses')).toBe(true)
+    expect(isEnglishPlural('databases')).toBe(true)
+  })
+
+  // KNOWN LIMIT. A singular ending in a lone `s` whose stem doesn't end in
+  // s/x/ch/sh is indistinguishable from a plural by English rules alone
+  // ('status' → 'statu' → 'status' round-trips exactly like 'clusters' →
+  // 'cluster' → 'clusters'). No Kubernetes Kind Radar handles has this shape,
+  // and kindToPlural's discovered-map lookup takes over the moment discovery
+  // lands, so the mistake is confined to the cold window. Pinned so a future
+  // change to these rules surfaces the boundary rather than moving it silently.
+  it('cannot distinguish singulars ending in a lone s', () => {
+    expect(isEnglishPlural('status')).toBe(true)
+    expect(isEnglishPlural('alias')).toBe(true)
+    expect(isEnglishPlural('canvas')).toBe(true)
+  })
+
+  // The reason this predicate exists rather than a bare endsWith('s'): these
+  // are singular Kubernetes kinds that happen to end in 's'.
+  it('rejects singulars that merely end in s', () => {
+    expect(isEnglishPlural('ingress')).toBe(false)
+    expect(isEnglishPlural('nodeclass')).toBe(false)
+    expect(isEnglishPlural('ec2nodeclass')).toBe(false)
+    expect(isEnglishPlural('storageclass')).toBe(false)
+  })
+
+  it('rejects singulars with no plural ending', () => {
+    expect(isEnglishPlural('cluster')).toBe(false)
+    expect(isEnglishPlural('validatingpolicy')).toBe(false)
+  })
+
+  it('agrees with englishPlural on every round trip', () => {
+    for (const singular of ['cluster', 'policy', 'class', 'box', 'batch', 'schedule', 'service']) {
+      expect(isEnglishPlural(englishPlural(singular))).toBe(true)
+    }
   })
 })

--- a/packages/k8s-ui/src/utils/pluralize.ts
+++ b/packages/k8s-ui/src/utils/pluralize.ts
@@ -31,6 +31,40 @@ export function englishPlural(noun: string): string {
 }
 
 /**
+ * Undo englishPlural's regular rules.
+ *
+ *   englishSingular('classes')  → 'class'
+ *   englishSingular('policies') → 'policy'
+ *   englishSingular('clusters') → 'cluster'
+ *
+ * Lossy by construction — a noun that is already singular comes back mangled
+ * ('ingress' → 'ingres'). Use isEnglishPlural to find out which case you have.
+ */
+export function englishSingular(noun: string): string {
+  const lower = noun.toLowerCase();
+  if (lower.endsWith('ies')) return noun.slice(0, -3) + 'y';
+  if (lower.endsWith('ses') || lower.endsWith('xes') || lower.endsWith('ches') || lower.endsWith('shes')) {
+    return noun.slice(0, -2);
+  }
+  if (lower.endsWith('s')) return noun.slice(0, -1);
+  return noun;
+}
+
+/**
+ * Whether a noun is already the regular English plural of its own singular —
+ * i.e. whether englishPlural would reproduce it. Distinguishes a plural from a
+ * singular that merely ends in 's':
+ *
+ *   isEnglishPlural('schedules') → true   ('schedule' → 'schedules')
+ *   isEnglishPlural('policies')  → true   ('policy'   → 'policies')
+ *   isEnglishPlural('ingress')   → false  ('ingres'   → 'ingreses')
+ *   isEnglishPlural('nodeclass') → false  ('nodeclas' → 'nodeclases')
+ */
+export function isEnglishPlural(noun: string): boolean {
+  return englishPlural(englishSingular(noun)) === noun;
+}
+
+/**
  * Count-aware plural noun. Returns the singular when n===1, else the
  * plural form (passed-in or derived via englishPlural).
  *


### PR DESCRIPTION
Fixes [RAD-330](https://linear.app/skyhook-io/issue/RAD-330). Pre-existing; found during RAD-314 (Velero) and RAD-321 (Kyverno) live verification.

## The bug

`kindToPlural` already has a double-pluralization guard — it returns the input unchanged when it is a *known* plural. But "known" means `BUILTIN_PLURAL_TO_KIND` plus the map that `initNavigationMap` builds from API discovery, and on a **cold direct-URL load** the discovery response is still in flight when the detail drawer runs `kindToPlural` on the URL's plural slug. Any CRD plural absent from the small static map falls through to `englishPlural`, which pluralizes it a second time.

The drawer then fetches a nonexistent kind, and self-heals on the retry once discovery lands — which is why this has survived as a transient console error rather than a broken page. In-app navigation never hits it because the map is already warm.

## Root cause

Not a missing guard — an incomplete plural set at the moment the guard runs. So decide it structurally, with no round-trip required:

```ts
if (kind === kindLower && isEnglishPlural(kindLower)) return kindLower
```

Both halves are load-bearing:

- **`kind === kindLower`** — Kubernetes Kinds are PascalCase (`Schedule`), API resource names are lowercase (`schedules`). An all-lowercase input is a resource name.
- **`isEnglishPlural`** — a lowercase input can still be a *singular*. `pkg/topology/relationships.go`'s `normalizeKind` returns its input unchanged when a kind resolves through neither its static map nor discovery, so a `ResourceRef.Kind` can arrive as `validatingpolicy` or `certificaterequest`. The case check alone would have stopped pluralizing those — a regression this predicate prevents. It also keeps the singulars that merely *end* in 's' (`ingress`, `nodeclass`, `storageclass`, `ec2nodeclass`) pluralizing correctly, which a bare `endsWith('s')` would not.

`isEnglishPlural(n)` is `englishPlural(englishSingular(n)) === n` — a noun is plural iff the pluralizer reproduces it from its own singular. `englishSingular` is the new inverse of `englishPlural`; `pluralToKind` had hand-inlined the identical de-pluralization rules and now delegates to it so the two can't drift.

Ordering is preserved: the builtin-plural check, the discovered kind→plural lookup, and the lowercase alias map (`pvc`, `podgroup`, `horizontalpodautoscaler`) all run *before* the new branch.

## Verification

**Before** — cold load of `/resources/schedules?resource=demo/daily-backup` against a cluster with a `schedules.velero.io` CRD:

```
GET /api/resources/scheduleses/demo/daily-backup                 => 400 Bad Request
GET /api/resources/scheduleses/demo/daily-backup/cascade-preview => 200
GET /api/resources/schedules/demo/daily-backup                   => 200   (self-heal)
```

**After** — same cold load, same cluster:

```
GET /api/resources/schedules/demo/daily-backup                   => 200
GET /api/resources/schedules/demo/daily-backup/cascade-preview   => 200
```

`validatingpolicies` (cluster-scoped, `?resource=name` with no namespace) verified the same way: `validatingpolicieses` gone, no 4xx. `/resources/ingresses` re-checked as a core-kind regression guard.

## Tests

`navigation.test.ts`, under a cold (reset) map — the first two groups fail without this change with exactly `expected 'scheduleses' to be 'schedules'`:

- unknown lowercase plurals returned unchanged (`schedules`, `validatingpolicies`, `virtualservices`, `clusters`, `backups`)
- the cold answer equals the post-`initNavigationMap` answer for the same inputs
- singular PascalCase CRD kinds still pluralize
- **lowercase singular** kinds still pluralize (`certificaterequest`, `validatingpolicy`, `ingress`, `nodeclass`, `ec2nodeclass`, `storageclass`) — the guard-tightening case

`pluralize.test.ts` covers `englishSingular` and `isEnglishPlural` directly, including a round-trip property over `englishPlural`.

## Considered and skipped

RAD-330 asks for "a test that loads a CRD detail by cold direct URL". The Playwright e2e harness (`cmd/testserver`) is backed by a typed fake clientset with no dynamic client or discovery, so it cannot serve a CRD at all — adding that is a substantial change to shared test infrastructure. The unit tests pin the exact regression and the live-cluster trace above covers the cold-URL path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how resource API paths are built during the pre-discovery window; behavior is heuristic with known edge cases but is heavily tested and scoped to navigation pluralization.
> 
> **Overview**
> Fixes **cold direct-URL** loads where `kindToPlural` ran on a CRD plural slug (e.g. `schedules`) before API discovery filled the map, so `englishPlural` turned it into `scheduleses` and the first detail fetch 4xx’d until retry.
> 
> **`kindToPlural`** now returns lowercase inputs unchanged when `isEnglishPlural` says they’re already a regular plural (`kind === kindLower` + round-trip check), while still pluralizing lowercase **singulars** like `ingress`, `nodeclass`, and `certificaterequest`.
> 
> **`pluralize.ts`** adds `englishSingular` and `isEnglishPlural`; **`pluralToKind`** uses `englishSingular` instead of duplicated de-plural rules. Unit tests cover the cold-map CRD cases and the new helpers (including documented `*se` / lone-`s` limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c4a8896d118d3f3ff018e179a9446911c84659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->