### PR TITLE
fix(reachability): a successful TCP test stops reading as "nothing ran"

### DIFF
--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -667,3 +667,14 @@ describe('a fresh failed attempt outranks leftover skip rows', () => {
     expect(texts).not.toContain('stale skip')
   })
 })
+
+describe('a result with no evidence string still reads as a result', () => {
+  it('never says "no test has been run" beside an outcome that ran', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ layer: 'tcp', path: 'data', ok: true })])
+    const r = route({ route: 'redis', target: 'redis:6379', outcome: 'reached', confidence: 'real', evidence: undefined })
+    t.routes = [r]
+    const texts = buildSidebar(undefined, ctx(t, 'incluster', r)).path.evidence.map((e) => e.text).join('\n')
+    expect(texts).not.toContain('no test has been run from here')
+    expect(texts.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -1,6 +1,6 @@
 import type { Trace, RouteResult, ResourceRef } from './types'
 import type { Mark, SevTone } from './reachMarks'
-import { routeMark, routeChip, routeTone, routeAsSeenFrom, originRouteEvidence, routeForOrigin, traceInClusterRunnable } from './reachMarks'
+import { routeMark, routeChip, routeTone, routeAsSeenFrom, originRouteEvidence, routeForOrigin, traceInClusterRunnable, markHelp } from './reachMarks'
 import type { Origin, OriginId } from './reachOrigins'
 import { strongestGap, actionableGap, originSkipReason } from './reachOrigins'
 import { hopEvidenceFor, originProducedEvidence, type GraphNode } from './reachGraphModel'
@@ -338,6 +338,10 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     evidence.push({ mark: m, text })
   }
   if ((hasEvidence || fromConfig) && asSeen?.evidence) add(mark, asSeen.evidence)
+  // A result with no evidence STRING is still a result. Falling through to the
+  // "nothing ran" default below printed "no test has been run from here" beside
+  // a headline reporting what that very run found.
+  else if (hasEvidence && asSeen) add(mark, markHelp(mark))
   // What this vantage saw at each HOP. The route is built from the backend's
   // probes, so a laptop that dialled the front door and got an answer had all
   // of it discarded and read as "no test has been run from here" - beside a

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -395,6 +395,12 @@ func TCP(ctx context.Context, addr string, vantage Vantage) Result {
 	}
 	_ = conn.Close()
 	r.OK = true
+	// Every other layer names what it observed (DNS "resolved to ...", TLS
+	// "valid · ...", HTTP "HTTP 200 ..."). A silent TCP success left the route's
+	// evidence empty, and an empty evidence string reads downstream as "no test
+	// has been run from here" - the exact contradiction beside a passing result
+	// that this view exists to prevent.
+	r.Detail = "TCP connection succeeded"
 	return r
 }
 

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -485,3 +485,29 @@ func TestIsAPIServerTunnelDown(t *testing.T) {
 		t.Error("nil is not a tunnel-down")
 	}
 }
+
+// A successful TCP dial must name what it observed: an empty Detail leaves the
+// route's evidence blank, which downstream renders as "no test has been run".
+func TestTCP_SuccessCarriesDetail(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			_ = c.Close()
+		}
+	}()
+	orig := dialControl
+	dialControl = nil // the SSRF guard blocks loopback; this test is about the success Detail
+	defer func() { dialControl = orig }()
+	r := TCP(context.Background(), ln.Addr().String(), VantageLocal)
+	if !r.OK {
+		t.Fatalf("dial failed: %+v", r)
+	}
+	if r.Detail == "" {
+		t.Error("a successful TCP probe must carry a Detail - empty evidence reads as 'nothing ran'")
+	}
+}


### PR DESCRIPTION
Found while capturing docs screenshots against v1.9.1: after a **successful** in-cluster TCP test on a Redis Service, the inspector said **"no test has been run from here"** beside a headline reading "Reachable - server reached, route not verified" and a footer reading "1 got through".

**Cause:** `probe.TCP` set no `Detail` on success, so the route folded from that run with an empty evidence string; the inspector's no-evidence fallback then claimed nothing ran.

**Fix, at both layers:**
- `pkg/probe` - a successful TCP dial names what it observed, like every other layer already does (DNS "resolved to …", TLS "valid · …", HTTP "HTTP 200 …").
- `reachInspector` - a result that exists but carries no evidence *string* is still a result: it renders the mark's meaning rather than falling through to the "nothing ran" default, so this contradiction class can't reappear from another empty-evidence path.

Regression tests on both sides. Affects the headline non-HTTP journey shipped in v1.9.1 (#1271).

## Testing
`go test ./internal/... pkg/probe`, `make tsc`, k8s-ui vitest (1847 passed) - green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UX/copy fix in probe detail and inspector evidence fallback; no auth, security, or data-path behavior changes beyond filling missing evidence text.
> 
> **Overview**
> Fixes a contradiction where a **successful** in-cluster TCP check (e.g. Redis) could still show **"no test has been run from here"** next to a reachable headline.
> 
> **`pkg/probe`:** On TCP success, `Detail` is set to `"TCP connection succeeded"` so route evidence is populated like DNS/TLS/HTTP already do.
> 
> **`reachInspector`:** When this vantage has a real result but `evidence` is empty, the sidebar adds **`markHelp(mark)`** instead of falling through to the generic "nothing ran" copy.
> 
> Regression tests cover both the probe `Detail` and the inspector path evidence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de14881ab0df51bc24e87d310754885d9554c51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->