### PR TITLE
Feat/diagnose private sessions

### DIFF
--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -91,7 +91,8 @@ export interface RunSummary {
   kind: string;
   namespace: string;
   name: string;
-  /** The issue this session is for, on hosts that key sessions by issue. */
+  /** The issue this session is for, on hosts that key sessions by issue. Always
+   *  absent from Radar's own backend, which records no issue. */
   issueId?: string;
   context: string;
   agent?: string; // backend CLI that drove this run ("claude"/"codex")
@@ -146,9 +147,10 @@ export async function createRun(
     kind: string;
     namespace: string;
     name: string;
-    // Associates the session with the issue it was started from. Radar records
-    // it and hands it back on RunSummary; what a host does with it is the host's
-    // business.
+    // Associates the session with the issue it was started from, for hosts that
+    // group sessions that way. Inert for Radar's own backend, which neither reads
+    // it on start nor emits it on RunSummary — carried so both hosts share one
+    // request shape.
     issueId?: string;
     // Start a new session rather than continuing whatever the backend would
     // otherwise hand back for this target. Inert for Radar's own backend, which

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -91,6 +91,8 @@ export interface RunSummary {
   kind: string;
   namespace: string;
   name: string;
+  /** The issue this session is for, on hosts that key sessions by issue. */
+  issueId?: string;
   context: string;
   agent?: string; // backend CLI that drove this run ("claude"/"codex")
   profile?: ExecutionProfile;
@@ -144,6 +146,14 @@ export async function createRun(
     kind: string;
     namespace: string;
     name: string;
+    // Associates the session with the issue it was started from. Radar records
+    // it and hands it back on RunSummary; what a host does with it is the host's
+    // business.
+    issueId?: string;
+    // Start a new session rather than continuing whatever the backend would
+    // otherwise hand back for this target. Inert for Radar's own backend, which
+    // only ever continues an in-flight run — and that one is never bypassed.
+    fresh?: boolean;
   },
   opts?: {
     agent?: string;

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -32,6 +32,14 @@ export interface Target {
   kind: string;
   namespace: string;
   name: string;
+  /** The issue this investigation is for, when it came from an issue. Hosts
+   *  that group sessions by issue key on it; the rest carry it and ignore it. */
+  issueId?: string;
+  /** Start a new session instead of continuing one the backend would otherwise
+   *  return for this target. Rides here rather than as a separate argument so
+   *  the consent-deferred path replays one object — a parallel "was it fresh?"
+   *  state is a thing that can fall out of sync with the target it describes. */
+  fresh?: boolean;
 }
 export type DiagnoseView = "home" | "investigation";
 
@@ -475,8 +483,16 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
         setPendingTarget(null);
         if (t) startRunRef.current(t);
       })
-      .catch(() => {
-        setStartError("Couldn't record your consent — try again.");
+      .catch((e) => {
+        // The server's message, when it has one. A host that records consent
+        // above the individual refuses whoever isn't allowed to grant it, and
+        // only its message can say who is — "try again" sends them at something
+        // that can never succeed.
+        setStartError(
+          e instanceof DiagnoseError && e.message
+            ? e.message
+            : "Couldn't record your consent — try again.",
+        );
       })
       .finally(() => {
         consentBusyRef.current = false;

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -74,6 +74,10 @@ interface DiagnoseCtx {
   historyDegraded: boolean; // persistence broke — history won't survive a restart
   needsConsent: boolean; // a start is pending the one-time consent
   startError: string | null;
+  // Kept apart from startError: the consent card renders this as "why your
+  // approval was refused", and a run-start failure landing in the same slot
+  // would be read as exactly that — the two paths don't share a lifecycle.
+  consentError: string | null;
   openInvestigation: (t: Target) => void;
   openRun: (id: string) => void;
   openHome: () => void;
@@ -208,6 +212,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [historyDegraded, setHistoryDegraded] = useState(false);
   const [pendingTarget, setPendingTarget] = useState<Target | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
+  const [consentError, setConsentError] = useState<string | null>(null);
   const [width, setWidth] = useState<number>(() => {
     try {
       const v = Number(localStorage.getItem(WIDTH_KEY));
@@ -349,7 +354,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // panel closed — and only re-render when the set actually changes, not every poll.
   const runningSig = runs
     .filter((r) => r.status === "running")
-    .map((r) => `${r.kind}\x00${r.namespace}\x00${r.name}`)
+    .map((r) => runTargetKey(r.kind, r.namespace, r.name))
     .sort()
     .join("|");
   const runningKeys = useMemo(
@@ -406,6 +411,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const openInvestigation = useCallback(
     (t: Target) => {
       setStartError(null);
+      setConsentError(null);
       setOpen(true);
       if (!hosted && !consentSurface) {
         setPendingTarget(null);
@@ -457,21 +463,29 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     }
     if (id) openRun(id);
   }, [available, openRun]);
+  // Leaving the detail pane drops the failure that belonged to it. startError
+  // renders as the entire pane (maximized home still shows `detail`), where a
+  // message about a resource you just navigated away from has nothing to attach
+  // to and no way to be dismissed.
   const openHome = useCallback(() => {
     setView("home");
+    setStartError(null);
     setOpen(true);
   }, []);
-  const goHome = useCallback(() => setView("home"), []);
+  const goHome = useCallback(() => {
+    setView("home");
+    setStartError(null);
+  }, []);
   const close = useCallback(() => setOpen(false), []);
   const consentBusyRef = useRef(false);
   const approveConsent = useCallback(() => {
     if (consentBusyRef.current) return;
     if (!consentSurface) {
-      setStartError("Radar can’t record consent for this agent.");
+      setConsentError("Radar can’t record consent for this agent.");
       return;
     }
     consentBusyRef.current = true;
-    setStartError(null);
+    setConsentError(null);
     const t = pendingTarget;
     // The server ENFORCES consent at start, so the acknowledgment must land
     // before the run request — awaiting also makes it durable for the CLI.
@@ -488,7 +502,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
         // above the individual refuses whoever isn't allowed to grant it, and
         // only its message can say who is — "try again" sends them at something
         // that can never succeed.
-        setStartError(
+        setConsentError(
           e instanceof DiagnoseError && e.message
             ? e.message
             : "Couldn't record your consent — try again.",
@@ -500,6 +514,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   }, [consentSurface, pendingTarget]);
   const cancelConsent = useCallback(() => {
     setPendingTarget(null);
+    setConsentError(null);
     setOpen(false);
   }, []);
   const dismissError = useCallback(() => setStartError(null), []);
@@ -533,6 +548,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     // cleared on approve/cancel — so its presence is exactly "consent needed now".
     needsConsent: !!pendingTarget,
     startError,
+    consentError,
     openInvestigation,
     openRun,
     openHome,

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { canStartNewInvestigation } from "./DiagnoseSurface";
+import type { RunSummary } from "../../api/diagnose";
+
+// The "new investigation" button dispatches an agent and spends the user's own
+// tokens, so every one of these clauses is load-bearing rather than cosmetic.
+// Each case below is a way it misfired before the gate existed.
+function run(status: RunSummary["status"]): RunSummary {
+  return {
+    id: "r1",
+    kind: "Deployment",
+    namespace: "prod",
+    name: "payments",
+    context: "prod-cluster",
+    status,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("canStartNewInvestigation", () => {
+  it("offers a new investigation on a finished run", () => {
+    expect(canStartNewInvestigation("investigation", run("done"), false)).toBe(
+      true,
+    );
+  });
+
+  it("stays hidden on the investigations list", () => {
+    // goHome() leaves activeRunId set, so the header still has a run to read.
+    // Without the view check the click starts an agent on a resource the user
+    // navigated away from, over a list of unrelated investigations.
+    expect(canStartNewInvestigation("home", run("done"), false)).toBe(false);
+  });
+
+  it("stays hidden while a turn is in flight", () => {
+    // A start would be handed back the live run, so the button does nothing.
+    expect(canStartNewInvestigation("investigation", run("running"), false)).toBe(
+      false,
+    );
+  });
+
+  it("stays hidden on a stale run", () => {
+    // The body offers "Re-run on current cluster" WITH the context-changed
+    // warning. A bare + carries none of it, at a resource that may not exist in
+    // the context it would now run against.
+    expect(canStartNewInvestigation("investigation", run("stale"), false)).toBe(
+      false,
+    );
+  });
+
+  it("stays hidden while consent is pending", () => {
+    expect(canStartNewInvestigation("investigation", run("done"), true)).toBe(
+      false,
+    );
+  });
+
+  it("stays hidden with no focused run", () => {
+    expect(canStartNewInvestigation("investigation", null, false)).toBe(false);
+  });
+
+  it("offers one on an errored or stopped run", () => {
+    // Those are the runs a person most wants to start over from.
+    expect(canStartNewInvestigation("investigation", run("error"), false)).toBe(
+      true,
+    );
+    expect(canStartNewInvestigation("investigation", run("stopped"), false)).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -23,6 +23,7 @@ import {
   useDiagnoseLayout,
   agentLabelFor,
   openDiagnoseSettings,
+  type DiagnoseView,
 } from "./DiagnoseContext";
 import { useDiagnoseCustomization } from "../../context/DiagnoseCustomization";
 import { InvestigationView } from "./InvestigationView";
@@ -142,6 +143,33 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
 // header, right of the nav rail) — App renders it there and passes topInset (the
 // header height; 0 in chromeless embeds). It shares that frame with the resource/
 // Helm drawers, so it no longer floats viewport-fixed or DOM-measures the chrome.
+// Whether the header offers a new investigation on the focused run's resource.
+// Every clause is a failure this button actually had:
+//
+//   view          goHome() leaves activeRunId set, so the header keeps rendering
+//                 the last focused run. Without this the button dispatches an
+//                 agent — real tokens — from a screen showing an unrelated list.
+//   run           nothing to take a resource from.
+//   running       a start is handed back the live run, so the click does nothing
+//                 and the button reads as broken.
+//   stale         the body already offers "Re-run on current cluster" WITH the
+//                 warning that the context changed; a bare + carries none of it,
+//                 and the resource may not exist in the context it'd run against.
+//   needsConsent  the consent card owns the surface until it's answered.
+export function canStartNewInvestigation(
+  view: DiagnoseView,
+  run: RunSummary | null,
+  needsConsent: boolean,
+): boolean {
+  return (
+    view === "investigation" &&
+    !!run &&
+    run.status !== "running" &&
+    run.status !== "stale" &&
+    !needsConsent
+  );
+}
+
 export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
   const d = useDiagnose();
   // Injected settings action: undefined = Radar's own Settings dialog;
@@ -224,7 +252,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           profile={d.profile}
           copy={consentCopy}
           onOpenSettings={openSettings ?? undefined}
-          error={d.startError}
+          error={d.consentError}
           onApprove={d.approveConsent}
           onCancel={d.cancelConsent}
         />
@@ -343,10 +371,9 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
-          {/* Hidden while a turn is in flight: a start would only be handed back
-              the live run, so the button would read as broken. */}
-          {activeRun && activeRun.status !== "running" && !d.needsConsent && (
-            <Tooltip content="New session on this resource" position="bottom">
+          {activeRun &&
+            canStartNewInvestigation(d.view, activeRun, d.needsConsent) && (
+            <Tooltip content="New investigation on this resource" position="bottom">
               <button
                 onClick={() =>
                   d.openInvestigation({
@@ -358,7 +385,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
                   })
                 }
                 className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
-                aria-label="New session"
+                aria-label="New investigation on this resource"
               >
                 <Plus className="h-4 w-4" />
               </button>

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -15,6 +15,7 @@ import {
   TerminalSquare,
   Copy,
   Check,
+  Plus,
 } from "lucide-react";
 import { Tooltip } from "../ui/Tooltip";
 import {
@@ -223,6 +224,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           profile={d.profile}
           copy={consentCopy}
           onOpenSettings={openSettings ?? undefined}
+          error={d.startError}
           onApprove={d.approveConsent}
           onCancel={d.cancelConsent}
         />
@@ -341,6 +343,27 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
+          {/* Hidden while a turn is in flight: a start would only be handed back
+              the live run, so the button would read as broken. */}
+          {activeRun && activeRun.status !== "running" && !d.needsConsent && (
+            <Tooltip content="New session on this resource" position="bottom">
+              <button
+                onClick={() =>
+                  d.openInvestigation({
+                    kind: activeRun.kind,
+                    namespace: activeRun.namespace,
+                    name: activeRun.name,
+                    issueId: activeRun.issueId,
+                    fresh: true,
+                  })
+                }
+                className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+                aria-label="New session"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </Tooltip>
+          )}
           {activeRun && <InvestigationMenu run={activeRun} />}
           <Tooltip content={maximized ? "Restore" : "Expand"} position="bottom">
             <button

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -47,9 +47,19 @@ export function InvestigationView({
   // Apply is off for hosted agents (read-only server-side). Keyed on the selected
   // agent, which matches run.agent unless a deployment mixes hosted + local agents.
   const { refreshRuns, openInvestigation, startError, hosted } = useDiagnose();
+  // Re-run means look again, so it asks for a new session explicitly and only
+  // carries the issue forward — being handed the previous answer is the one
+  // thing someone clicking this doesn't want.
   const retryDiagnosis = useCallback(
-    () => openInvestigation({ kind, namespace, name }),
-    [openInvestigation, kind, namespace, name],
+    () =>
+      openInvestigation({
+        kind,
+        namespace,
+        name,
+        issueId: run.issueId,
+        fresh: true,
+      }),
+    [openInvestigation, kind, namespace, name, run.issueId],
   );
   const queryClient = useQueryClient();
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -470,7 +480,7 @@ export function InvestigationView({
                   </span>
                 </div>
                 <button
-                  onClick={() => openInvestigation({ kind, namespace, name })}
+                  onClick={retryDiagnosis}
                   className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/50 px-2.5 py-1 font-medium text-amber-600 hover:bg-amber-500/10 dark:text-amber-400"
                 >
                   <Send className="h-3 w-3" />
@@ -489,7 +499,7 @@ export function InvestigationView({
                   </span>
                 </div>
                 <button
-                  onClick={() => openInvestigation({ kind, namespace, name })}
+                  onClick={retryDiagnosis}
                   className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-theme-border px-2.5 py-1 font-medium text-theme-text-primary hover:bg-theme-hover"
                 >
                   <Send className="h-3 w-3" />

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -46,7 +46,8 @@ export function InvestigationView({
   const { kind, namespace, name } = run;
   // Apply is off for hosted agents (read-only server-side). Keyed on the selected
   // agent, which matches run.agent unless a deployment mixes hosted + local agents.
-  const { refreshRuns, openInvestigation, startError, hosted } = useDiagnose();
+  const { refreshRuns, openInvestigation, startError, dismissError, hosted } =
+    useDiagnose();
   // Re-run means look again, so it asks for a new session explicitly and only
   // carries the issue forward — being handed the previous answer is the one
   // thing someone clicking this doesn't want.
@@ -535,10 +536,36 @@ export function InvestigationView({
                 />
               );
             })}
-            {(actionError || startError) && (
+            {actionError && (
               <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
-                <span>{actionError || startError}</span>
+                <span>{actionError}</span>
+              </div>
+            )}
+            {/* A start that failed belongs to the investigation that never began,
+                not to the one on screen. Unlabelled at the foot of a finished
+                transcript — verdict directly above — it reads as "this
+                investigation failed". It also outlives the click that caused it,
+                and this is the only place it surfaces while a run is focused, so
+                it needs a way out. */}
+            {startError && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium">
+                    Couldn&apos;t start a new investigation
+                  </div>
+                  <div className="text-theme-text-secondary">{startError}</div>
+                </div>
+                <button
+                  onClick={dismissError}
+                  className="shrink-0 rounded px-1.5 py-0.5 text-xs text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+                >
+                  Dismiss
+                </button>
               </div>
             )}
           </div>

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -123,3 +123,42 @@ describe("ConsentCard execution profile treatment", () => {
     expect(html).not.toContain("Radar still enables the agent CLI");
   });
 });
+
+// The consent card's error box is the ONLY place a refused approval is
+// explained: the card stays mounted on failure, focus doesn't move, and nothing
+// else on screen changes. Red (not the card's own amber) and role="alert", or a
+// screen-reader user re-presses a button the server will never accept.
+describe("ConsentCard error", () => {
+  const base = {
+    agentName: "Claude",
+    profile: "safeguarded" as ExecutionProfile,
+    onApprove: noop,
+    onCancel: noop,
+  };
+
+  it("renders the server's refusal as an alert", () => {
+    const html = renderToStaticMarkup(
+      <ConsentCard {...base} error="An owner has to allow it once." />,
+    );
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("An owner has to allow it once.");
+  });
+
+  it("uses the error tone, not the card's warning tone", () => {
+    // full-local renders the card itself amber; an amber box on it reads as
+    // another paragraph of body copy rather than a failure.
+    const html = renderToStaticMarkup(
+      <ConsentCard
+        {...base}
+        profile={"full-local" as ExecutionProfile}
+        error="Refused."
+      />,
+    );
+    expect(html).toContain("border-red-500/30");
+  });
+
+  it("renders no alert when the approval hasn't failed", () => {
+    const html = renderToStaticMarkup(<ConsentCard {...base} />);
+    expect(html).not.toContain('role="alert"');
+  });
+});

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -704,9 +704,17 @@ function ConsentCardShell({
           {resolvedSettingsLabel}
         </button>
       )}
+      {/* Red, not amber: the full-local card is itself amber, so an amber box on
+          it reads as another paragraph of body copy. role="alert" because nothing
+          else moves on failure — focus stays on Approve, so without it a screen
+          reader says nothing and the user re-presses a button that cannot succeed. */}
       {error && (
-        <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-theme-text-secondary">
-          {error}
+        <div
+          role="alert"
+          className="mt-3 flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 p-2 text-xs text-theme-text-primary"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+          <span>{error}</span>
         </div>
       )}
       <div className="mt-4 flex gap-2">

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -649,11 +649,17 @@ function ConsentCardShell({
   settingsLabel,
   approveLabel = "Approve & investigate",
   warning = false,
+  error,
   onOpenSettings,
   onApprove,
   onCancel,
 }: DiagnoseConsentCopy & {
   warning?: boolean;
+  // Why the last approval failed, straight from the server. The card stays up on
+  // failure so retrying works in place, which means this is the ONLY chance to
+  // say why — a host that records consent above the individual refuses the
+  // wrong person here, and only its message knows who to ask.
+  error?: string | null;
   onOpenSettings?: () => void;
   onApprove: () => void;
   onCancel: () => void;
@@ -698,6 +704,11 @@ function ConsentCardShell({
           {resolvedSettingsLabel}
         </button>
       )}
+      {error && (
+        <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-theme-text-secondary">
+          {error}
+        </div>
+      )}
       <div className="mt-4 flex gap-2">
         <button
           onClick={onCancel}
@@ -731,6 +742,7 @@ export function ConsentCard({
   agent,
   profile,
   copy,
+  error,
   onOpenSettings,
   onApprove,
   onCancel,
@@ -739,11 +751,12 @@ export function ConsentCard({
   agent?: string;
   profile: ExecutionProfile;
   copy?: DiagnoseConsentCopy;
+  error?: string | null;
   onOpenSettings?: () => void;
   onApprove: () => void;
   onCancel: () => void;
 }) {
-  const chrome = { onOpenSettings, onApprove, onCancel };
+  const chrome = { onOpenSettings, onApprove, onCancel, error };
 
   // Tier 1: a host (e.g. radar-hub-web) supplied its own copy — use it verbatim.
   if (copy) return <ConsentCardShell {...copy} {...chrome} />;


### PR DESCRIPTION
## Description

  Frontend-only changes to the Diagnose panel. Two things:

  **1. Start a fresh investigation, and carry an issue id.** Two optional fields on the run-create contract (`issueId`, `fresh`), plus `issueId` echoed on `RunSummary`. Radar records and forwards them; it reads neither — its own backend only ever continues an in-flight run, and that one is never bypassed. A host that groups investigations by issue can key on the first. Both ride on `Target` rather than as separate arguments so the consent-deferred path
  replays a single object.

  The panel header gains a **New investigation** button on the focused run's resource, and both existing re-run affordances now go through the same `fresh: true` path — re-running means look again, not be handed the previous answer.

  **2. Failures now say whose they are.**

  - **Running indicator repaired.** `runningKeys` was built by joining fields with `\x00` while `runTargetKey` — what every consumer looks the key up with —  joins with spaces. The set could never match, so the per-resource "already investigating" indicator had never lit. Now built through `runTargetKey`.
  - **Consent refusals get their own state.** One `startError` was written by three paths (rejected `createRun`, missing consent surface, refused acknowledgment), and the consent card renders it as *why your approval failed* — so a capacity 409 could be presented as an administrator turning you down. Split into `consentError`.
  - **The consent card shows the server's message** instead of always "try again". A host that records consent above the individual refuses whoever isn't allowed to grant it, and only its message can name who is. Rendered red (not the amber it shared with the full-local card it sits inside) with `role="alert"` — the card stays mounted and focus doesn't move, so nothing was announced.
  - **A failed start no longer reads as the focused run's failure.** It shared an unlabelled banner with that run's own action errors, at the foot of a finished transcript with the verdict directly above. It now names itself and can be dismissed; leaving the detail pane clears it.
  - **The new-investigation button is gated on a named predicate** (`canStartNewInvestigation`) with a test per clause: view (`goHome()` leaves `activeRunId` set, so it was dispatching agents — real tokens — from the list screen), in-flight turn, stale context (the body already offers a re-run that explains which cluster it hits), pending consent.

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change
  - [ ] Documentation update

  Additive only — new fields are optional, new props are optional. No change for library consumers that don't pass them.

  ## How has this been tested?

  - [ ] Tested locally with minikube/kind
  - [ ] Tested against a remote cluster
  - [x] Added/updated unit tests

  `DiagnoseSurface.test.tsx` (7 cases, one per gate clause) and `parts.test.tsx` (consent-card error: alert role, error tone vs. the card's warning tone, absent when no failure).

  ## Checklist

  - [x] My code follows the project's coding standards
  - [x] I have performed a self-review of my code
  - [x] I have added comments where necessary
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged

  ## Related issues

  N/A