### PR TITLE
feat(reachability): the header is the resource, the board is your selection

### DIFF
--- a/internal/trace/coverage.go
+++ b/internal/trace/coverage.go
@@ -1104,7 +1104,10 @@ func computeDiagnosis(t *Trace) *Diagnosis {
 	// resolve (branchKnownBreak synthesizes evidence from absence, no Finding).
 	// Promote the route's own real evidence; do NOT invent a cause code.
 	if r, ok := worstNonBenignFailedRoute(t.Routes); ok {
-		d := &Diagnosis{Route: r.Route, Summary: firstNonEmpty(r.Evidence, "route is unreachable")}
+		// A route that was dialled and failed is the strongest fault this page can
+		// state. Leaving Severity empty demotes it to the UI's warning default, so
+		// confirmed unreachability would render weaker than a predicted one.
+		d := &Diagnosis{Route: r.Route, Severity: SeverityCritical, Summary: firstNonEmpty(r.Evidence, "route is unreachable")}
 		if t.BrokenRoute != nil {
 			d.CulpritResource = t.BrokenRoute
 		}

--- a/internal/trace/coverage.go
+++ b/internal/trace/coverage.go
@@ -450,6 +450,7 @@ func computeCoverage(t *Trace) {
 	// Single source of truth for the banner sentence - UI and MCP both read this.
 	t.Headline = CoverageHeadline(t)
 	t.Diagnosis = computeDiagnosis(t)
+	t.EntryProblems = computeEntryProblems(t)
 }
 
 // upgradeDefinitiveBackendDown promotes a Service route's unreachability from
@@ -772,6 +773,7 @@ func ApplyInClusterResults(t *Trace, byTarget map[string][]probe.Result) {
 	recountCoverage(t)
 	t.Headline = CoverageHeadline(t)
 	t.Diagnosis = computeDiagnosis(t)
+	t.EntryProblems = computeEntryProblems(t)
 	// Same collapse as the standard path (BuildTraceWithOptions): ship the one
 	// coverage-honest verdict so REST, UI, and MCP never diverge on the in-cluster
 	// flow.
@@ -992,6 +994,47 @@ type Diagnosis struct {
 // Returns nil when every route was verified over real traffic - nothing to
 // diagnose. Benign (intentional scale-to-0) routes are NOT treated as a problem
 // here; their route already reads amber-benign with its own evidence.
+// computeEntryProblems promotes warning+ findings on the DECLARED ENTRY hops
+// (upstreams) so a front door that cannot carry traffic is stated where the
+// reader looks, instead of living only as a dot inside a graph node. Kept out
+// of the Diagnosis ranking on purpose: entries are parallel, so a broken
+// sibling must never hijack the headline of a path that works. Anything the
+// Diagnosis already names is dropped, so the two surfaces never say it twice.
+func computeEntryProblems(t *Trace) []EntryProblem {
+	if t == nil || len(t.Upstreams) == 0 {
+		return nil
+	}
+	var out []EntryProblem
+	for _, h := range t.Upstreams {
+		for _, f := range h.Findings {
+			if f.Severity != SeverityCritical && f.Severity != SeverityWarning {
+				continue
+			}
+			if isScaleZeroFinding(f) {
+				continue
+			}
+			summary := firstNonEmpty(f.Cause, f.Message)
+			if summary == "" {
+				continue
+			}
+			// Already stated by the Diagnosis band - printing it twice reads as
+			// two problems.
+			if t.Diagnosis != nil && t.Diagnosis.Summary == summary {
+				continue
+			}
+			out = append(out, EntryProblem{
+				Resource: h.Resource,
+				Summary:  summary,
+				Severity: f.Severity,
+				Code:     f.Code,
+				Action:   f.Action,
+				Command:  f.Command,
+			})
+		}
+	}
+	return out
+}
+
 func computeDiagnosis(t *Trace) *Diagnosis {
 	if t == nil {
 		return nil

--- a/internal/trace/coverage.go
+++ b/internal/trace/coverage.go
@@ -973,7 +973,18 @@ func hopDenyPort(meta map[string]any) int32 {
 // "problem:Completed" on a crashloop) would mislabel, so it is omitted and the
 // honest Summary prose carries the diagnosis instead. The name says "code" so a
 // consumer never mistakes the enum for the plain-English explanation (Summary).
+// Diagnosis classes. A FAULT is something wrong in the user's system, promoted
+// from a real finding; COVERAGE explains what could or could not be tested. The
+// UI's problem list shows faults only - a coverage sentence there duplicated the
+// headline, which is generated from the same coverage state.
+const (
+	DiagnosisClassFault    = "fault"
+	DiagnosisClassCoverage = "coverage"
+)
+
 type Diagnosis struct {
+	// Class is "fault" (default, promoted from a finding) or "coverage".
+	Class     string `json:"class,omitempty"`
 	CauseCode string `json:"causeCode,omitempty"`
 	// Route names WHICH route this diagnosis explains, when it is attributable
 	// to exactly one. Empty means it describes the resource as a whole.
@@ -1091,10 +1102,16 @@ func computeDiagnosis(t *Trace) *Diagnosis {
 	if t.Coverage == nil {
 		return nil
 	}
-	// Reachable, but only the apiserver proxy reached it - the real-traffic path
-	// was never confirmed. The action is to test from inside the cluster.
+	// Reachable only through the apiserver proxy. Kept on the wire for agents -
+	// one machine-readable "what next" - but tagged COVERAGE, because it is a
+	// statement about what could be tested, not a fault in the user's system.
+	// The UI's problem list renders faults only: the headline already says this
+	// ("Reached via API server - not live traffic"), the viewing strip says it
+	// for the selected vantage, and the next-step block offers the in-cluster
+	// run, so a fourth copy read as a separate problem.
 	if t.Coverage.Tested > 0 && !anyRealPass(t.Routes) && anyIndirectReach(t.Routes) {
 		return &Diagnosis{
+			Class:      DiagnosisClassCoverage,
 			Summary:    "reachable via API server - the real-traffic path wasn't confirmed from here",
 			NextAction: "run the in-cluster reachability test to confirm the real path",
 		}
@@ -1108,6 +1125,7 @@ func computeDiagnosis(t *Trace) *Diagnosis {
 		// Nothing is RUNNING: the dominant fact is the workload, not the vantage.
 		if hopsHaveScaleZero(t.Downstream) {
 			return &Diagnosis{
+				Class:      DiagnosisClassCoverage,
 				Summary:    "no running pods - the backing workload is scaled to 0, so there's nothing to reach",
 				NextAction: "scale the workload up to test it (e.g. kubectl scale --replicas=1), or leave it if it's intentionally idle",
 			}
@@ -1121,16 +1139,20 @@ func computeDiagnosis(t *Trace) *Diagnosis {
 		reasons := distinctSkipReasons(t.NotTested)
 		switch {
 		case len(reasons) == 1:
-			d := &Diagnosis{Summary: "couldn't test from here - " + reasons[0]}
+			// No "couldn't test from here -" prefix: the headline says that much.
+			// The reason is the only part that adds anything.
+			d := &Diagnosis{Class: DiagnosisClassCoverage, Summary: reasons[0]}
 			d.NextAction = firstNonEmpty(firstSkipCommand(t.NotTested), "run the in-cluster reachability test to confirm the real path")
 			return d
 		case len(reasons) > 1:
 			return &Diagnosis{
+				Class:      DiagnosisClassCoverage,
 				Summary:    fmt.Sprintf("couldn't test any of the %d declared paths from here, for %d different reasons - select a path to see its own", len(t.NotTested), len(reasons)),
 				NextAction: "run the in-cluster reachability test to confirm the real path",
 			}
 		}
 		return &Diagnosis{
+			Class:      DiagnosisClassCoverage,
 			Summary:    "couldn't actively test any route from here",
 			NextAction: "run the in-cluster reachability test to confirm the real path",
 		}

--- a/internal/trace/coverage.go
+++ b/internal/trace/coverage.go
@@ -984,7 +984,10 @@ const (
 
 type Diagnosis struct {
 	// Class is "fault" (default, promoted from a finding) or "coverage".
-	Class     string `json:"class,omitempty"`
+	Class string `json:"class,omitempty"`
+	// Severity of the finding this was promoted from, so a consumer renders the
+	// weight the detector assigned rather than assuming the worst.
+	Severity  string `json:"severity,omitempty"`
 	CauseCode string `json:"causeCode,omitempty"`
 	// Route names WHICH route this diagnosis explains, when it is attributable
 	// to exactly one. Empty means it describes the resource as a whole.
@@ -1017,7 +1020,12 @@ func computeEntryProblems(t *Trace) []EntryProblem {
 	}
 	var out []EntryProblem
 	for _, h := range t.Upstreams {
-		for _, f := range h.Findings {
+		// A missing-ref on an entry is about a DIFFERENT backendRef: the entry can
+		// still serve this Service perfectly while another of its backends is
+		// missing. computeVerdict already refuses to let a sibling's break count
+		// here; promoting it as "this entry cannot carry traffic" would be the
+		// same misattribution one surface up.
+		for _, f := range nonMissingRefFindings(h.Findings) {
 			if f.Severity != SeverityCritical && f.Severity != SeverityWarning {
 				continue
 			}
@@ -1059,6 +1067,10 @@ func computeDiagnosis(t *Trace) *Diagnosis {
 		d := &Diagnosis{
 			Summary: firstNonEmpty(f.Cause, f.Message),
 			Command: f.Command,
+			// The promoted finding's OWN severity. Without it a consumer has to
+			// invent one, and a warning-tier prediction (a would-deny, a soft pod
+			// condition) renders as a red critical it never earned.
+			Severity: f.Severity,
 		}
 		if trustworthyCauseCode(f.Code) {
 			d.CauseCode = f.Code

--- a/internal/trace/coverage.go
+++ b/internal/trace/coverage.go
@@ -1013,9 +1013,13 @@ func computeEntryProblems(t *Trace) []EntryProblem {
 			if isScaleZeroFinding(f) {
 				continue
 			}
-			summary := firstNonEmpty(f.Cause, f.Message)
+			summary := firstNonEmpty(f.Message, f.Cause)
 			if summary == "" {
 				continue
+			}
+			detail := ""
+			if f.Cause != "" && f.Cause != summary {
+				detail = f.Cause
 			}
 			// Already stated by the Diagnosis band - printing it twice reads as
 			// two problems.
@@ -1025,6 +1029,7 @@ func computeEntryProblems(t *Trace) []EntryProblem {
 			out = append(out, EntryProblem{
 				Resource: h.Resource,
 				Summary:  summary,
+				Detail:   detail,
 				Severity: f.Severity,
 				Code:     f.Code,
 				Action:   f.Action,

--- a/internal/trace/coverage_test.go
+++ b/internal/trace/coverage_test.go
@@ -2271,3 +2271,30 @@ func TestComputeEntryProblems_IgnoresSiblingMissingRef(t *testing.T) {
 		t.Errorf("a sibling backend's missing ref was promoted as this entry's problem: %q", got[0].Summary)
 	}
 }
+
+// A route Radar dialled and watched fail is the strongest fault it can report.
+// The UI renders anything short of critical as a warning, so an unset severity
+// on this path would make confirmed unreachability look weaker than a predicted
+// one.
+func TestComputeDiagnosis_ConfirmedRouteFailureIsCritical(t *testing.T) {
+	tr := &Trace{
+		Subject: ResourceRef{Kind: "Service", Namespace: "store", Name: "shop"},
+		Routes: []RouteResult{{
+			Route:      "GET /",
+			Target:     "shop:80",
+			Outcome:    OutcomeUnreachable,
+			Confidence: "real",
+			Evidence:   "connection refused",
+		}},
+	}
+	d := computeDiagnosis(tr)
+	if d == nil {
+		t.Fatal("a failed route must produce a diagnosis")
+	}
+	if d.Severity != SeverityCritical {
+		t.Errorf("severity = %q, want %q — a dialled-and-failed route is not a warning", d.Severity, SeverityCritical)
+	}
+	if d.Class == DiagnosisClassCoverage {
+		t.Errorf("class = %q, want a fault — this is a real break, not an untested gap", d.Class)
+	}
+}

--- a/internal/trace/coverage_test.go
+++ b/internal/trace/coverage_test.go
@@ -2247,3 +2247,27 @@ func TestComputeEntryProblems_DedupesAgainstDiagnosis(t *testing.T) {
 		t.Fatalf("EntryProblems = %+v, want none - the Diagnosis already says it", got)
 	}
 }
+
+// An entry can serve THIS Service perfectly while a different backendRef of the
+// same entry is missing. Promoting that sibling's break as "this entry cannot
+// carry traffic" is the misattribution computeVerdict already refuses to make.
+func TestComputeEntryProblems_IgnoresSiblingMissingRef(t *testing.T) {
+	tr := &Trace{
+		Subject: ResourceRef{Kind: "Service", Namespace: "store", Name: "shop"},
+		Upstreams: []Hop{{
+			Resource: ResourceRef{Kind: "Ingress", Namespace: "store", Name: "entry"},
+			Findings: []Finding{
+				{Code: missingRefCodePrefix + "service", Severity: SeverityCritical, Message: "backend Service checkout does not exist"},
+				{Code: "gwroute:not-accepted", Severity: SeverityWarning, Message: "Not attached: no listener matches its hosts"},
+			},
+		}},
+		Downstream: []Hop{{Resource: ResourceRef{Kind: "Service", Namespace: "store", Name: "shop"}}},
+	}
+	got := computeEntryProblems(tr)
+	if len(got) != 1 {
+		t.Fatalf("EntryProblems = %+v, want only the entry's OWN fault", got)
+	}
+	if strings.Contains(got[0].Summary, "checkout") {
+		t.Errorf("a sibling backend's missing ref was promoted as this entry's problem: %q", got[0].Summary)
+	}
+}

--- a/internal/trace/coverage_test.go
+++ b/internal/trace/coverage_test.go
@@ -2211,6 +2211,17 @@ func TestComputeEntryProblems_PromotesUpstreamFaultWithoutTouchingVerdict(t *tes
 	if got[0].Resource.Kind != "HTTPRoute" || !strings.Contains(got[0].Summary, "no listener") {
 		t.Fatalf("promoted the wrong finding: %+v", got[0])
 	}
+	// The row is read by a human at a glance: the friendly Message leads, and
+	// the raw controller condition is one hover away - the opposite order from
+	// Diagnosis, which wants the deeper cause first.
+	tr.Upstreams[1].Findings[0].Cause = "Accepted: NoMatchingListenerHostname - there were no hostname intersections between the HTTPRoute and this parent ref's Listener(s)."
+	promoted := computeEntryProblems(tr)[0]
+	if !strings.Contains(promoted.Summary, "Not attached") {
+		t.Errorf("Summary = %q, want the human Message to lead", promoted.Summary)
+	}
+	if !strings.Contains(promoted.Detail, "NoMatchingListenerHostname") {
+		t.Errorf("Detail = %q, want the raw cause available for the hover", promoted.Detail)
+	}
 	if got[0].Action == "" {
 		t.Error("an entry problem should carry its finding's action")
 	}

--- a/internal/trace/coverage_test.go
+++ b/internal/trace/coverage_test.go
@@ -2185,3 +2185,54 @@ func TestComputeCoverage_TransportFailureAbsorbsAppLayerRow(t *testing.T) {
 		t.Fatalf("Coverage = %+v, want failed=1 skipped=0 - one broken path counted once", tr.Coverage)
 	}
 }
+
+// A dead front door is a real misconfiguration, but upstreams are parallel: it
+// must be stated WITHOUT condemning a Service that other entries still serve.
+func TestComputeEntryProblems_PromotesUpstreamFaultWithoutTouchingVerdict(t *testing.T) {
+	tr := &Trace{
+		Subject: ResourceRef{Kind: "Service", Namespace: "staging", Name: "shop"},
+		Upstreams: []Hop{
+			{Resource: ResourceRef{Kind: "Ingress", Namespace: "staging", Name: "shop"}},
+			{
+				Resource: ResourceRef{Kind: "HTTPRoute", Namespace: "staging", Name: "shop"},
+				Findings: []Finding{{
+					Code: "gwroute:not-accepted", Severity: SeverityWarning,
+					Message: "Not attached: no listener matches its hosts",
+					Action:  "check the parent Gateway's listener hostnames",
+				}},
+			},
+		},
+		Downstream: []Hop{{Resource: ResourceRef{Kind: "Service", Namespace: "staging", Name: "shop"}}},
+	}
+	got := computeEntryProblems(tr)
+	if len(got) != 1 {
+		t.Fatalf("EntryProblems = %+v, want the HTTPRoute fault promoted", got)
+	}
+	if got[0].Resource.Kind != "HTTPRoute" || !strings.Contains(got[0].Summary, "no listener") {
+		t.Fatalf("promoted the wrong finding: %+v", got[0])
+	}
+	if got[0].Action == "" {
+		t.Error("an entry problem should carry its finding's action")
+	}
+	// Info-level advisories stay where they are.
+	tr.Upstreams[1].Findings[0].Severity = SeverityInfo
+	if n := len(computeEntryProblems(tr)); n != 0 {
+		t.Errorf("info-severity findings must not surface as entry problems, got %d", n)
+	}
+}
+
+// The two surfaces must never state the same fault twice.
+func TestComputeEntryProblems_DedupesAgainstDiagnosis(t *testing.T) {
+	same := "Not attached: no listener matches its hosts"
+	tr := &Trace{
+		Subject:   ResourceRef{Kind: "Service", Namespace: "staging", Name: "shop"},
+		Diagnosis: &Diagnosis{Summary: same},
+		Upstreams: []Hop{{
+			Resource: ResourceRef{Kind: "HTTPRoute", Namespace: "staging", Name: "shop"},
+			Findings: []Finding{{Code: "gwroute:not-accepted", Severity: SeverityWarning, Message: same}},
+		}},
+	}
+	if got := computeEntryProblems(tr); len(got) != 0 {
+		t.Fatalf("EntryProblems = %+v, want none - the Diagnosis already says it", got)
+	}
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -349,6 +349,25 @@ type Trace struct {
 	// synthesizing). Set in computeCoverage; nil when there is nothing to
 	// diagnose (every route verified over real traffic). See Diagnosis.
 	Diagnosis *Diagnosis `json:"diagnosis,omitempty"`
+	// EntryProblems are faults on the resource's DECLARED ENTRY POINTS - an
+	// Ingress or route that will never receive traffic. They are deliberately
+	// NOT part of Diagnosis: upstreams are parallel, so one dead front door must
+	// not condemn a Service that is genuinely reachable through another. But a
+	// verdict scoped to the tested path can't see them either, which left a real
+	// misconfiguration visible only as a dot inside a graph node. Vantage-
+	// invariant (they are config facts) and deduped against Diagnosis.
+	EntryProblems []EntryProblem `json:"entryProblems,omitempty"`
+}
+
+// EntryProblem is one declared entry point that cannot carry traffic, promoted
+// from an existing upstream Finding - never synthesized.
+type EntryProblem struct {
+	Resource ResourceRef `json:"resource"`
+	Summary  string      `json:"summary"`
+	Severity string      `json:"severity"`
+	Code     string      `json:"code,omitempty"`
+	Action   string      `json:"action,omitempty"`
+	Command  string      `json:"command,omitempty"`
 }
 
 // UnknownClass enumerates the two distinct flavors of an unknown verdict.

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -363,7 +363,15 @@ type Trace struct {
 // from an existing upstream Finding - never synthesized.
 type EntryProblem struct {
 	Resource ResourceRef `json:"resource"`
-	Summary  string      `json:"summary"`
+	// Summary is the HUMAN line ("Not attached: no listener matches its hosts").
+	// Deliberately Message-first, the opposite of Diagnosis: a diagnosis wants
+	// the deeper cause, but a one-line row under the header wants the sentence a
+	// non-expert can read - the raw controller condition goes in Detail, one
+	// hover away.
+	Summary string `json:"summary"`
+	// Detail is the underlying cause (a controller condition, usually), shown on
+	// hover. Empty when it would just repeat Summary.
+	Detail string `json:"detail,omitempty"`
 	Severity string      `json:"severity"`
 	Code     string      `json:"code,omitempty"`
 	Action   string      `json:"action,omitempty"`

--- a/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
@@ -68,11 +68,15 @@ function useFit(canvasW: number, canvasH: number): [React.RefObject<HTMLDivEleme
 export function ReachabilityGraph({
   model,
   selected,
+  hovered,
   onSelect,
   onAction,
 }: {
   model: GraphModel
   selected?: string
+  /** Node the reader is pointing at from OUTSIDE the graph (the entry-problem
+   *  rows under the header). Answers "where is it?" before a click is spent. */
+  hovered?: string
   onSelect: (id: string) => void
   onAction?: (a: NonNullable<GraphNode['action']>) => void
 }) {
@@ -149,7 +153,7 @@ export function ReachabilityGraph({
             <EdgePill key={e.id} edge={e} />
           ))}
         {model.nodes.map((n) => (
-          <Node key={n.id} node={n} selected={selected === n.id} onSelect={onSelect} onAction={onAction} />
+          <Node key={n.id} node={n} selected={selected === n.id} hovered={hovered === n.id} onSelect={onSelect} onAction={onAction} />
         ))}
         </div>
         </div>
@@ -246,11 +250,13 @@ function EdgePill({ edge }: { edge: GraphEdge }) {
 function Node({
   node,
   selected,
+  hovered,
   onSelect,
   onAction,
 }: {
   node: GraphNode
   selected: boolean
+  hovered?: boolean
   onSelect: (id: string) => void
   onAction?: (a: NonNullable<GraphNode['action']>) => void
 }) {
@@ -275,7 +281,7 @@ function Node({
       : isOrigin
         ? `1.5px dashed ${node.lane === 'control' ? 'var(--color-info)' : 'var(--accent)'}`
         : '1px solid var(--border-default)',
-    boxShadow: selected ? '0 0 0 3px var(--accent-muted)' : isOrigin ? 'none' : '0 1px 2px rgba(0,0,0,.05)',
+    boxShadow: selected ? '0 0 0 3px var(--accent-muted)' : hovered ? '0 0 0 3px var(--color-warning)' : isOrigin ? 'none' : '0 1px 2px rgba(0,0,0,.05)',
     opacity: node.dim ? 0.5 : 1,
   }
   return (

--- a/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
@@ -352,9 +352,7 @@ function Node({
         <div className="mt-1.5 flex flex-col gap-0.5 border-t border-theme-border-subtle pt-1.5">
           {node.anomalies.map((a, i) => (
             <div key={i} className={`flex gap-1.5 ${inlineAction && i === 0 ? 'items-center' : 'items-baseline'}`}>
-              <span className={a.mark === 'running' ? 'reach-glyph-testing' : undefined}>
-                <MarkGlyph mark={a.mark} />
-              </span>
+              <MarkGlyph mark={a.mark} />
               {/* Rows truncate visually; the full sentence must always be a
                   hover away - a cut "reached, redirect…" hid its destination. */}
               <Tooltip content={a.title || a.text} wrapperClassName="min-w-0 flex-1">

--- a/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
 import { PILL_MAX_PX, type GraphModel, type GraphNode, type GraphEdge, type LaneBox } from './reachGraphModel'
-import { markStyle, glyphStyle, markHelp, SEV_COLOR, MARK_LEGEND, MARK_CATEGORY_LABEL, type Mark, type MarkCategory } from './reachMarks'
+import { markStyle, glyphStyle, markHelp, edgeHelp, SEV_COLOR, MARK_LEGEND, MARK_CATEGORY_LABEL, type Mark, type MarkCategory } from './reachMarks'
 import { Tooltip } from '../ui/Tooltip'
 
 /** Finding severity -> the shared health tones. Findings describe the OBJECT;
@@ -225,7 +225,7 @@ function EdgePill({ edge }: { edge: GraphEdge }) {
       content={
         <>
           <span className="font-semibold">{edge.title}</span>
-          <span className="text-theme-text-tertiary"> — {markHelp(edge.mark)}</span>
+          <span className="text-theme-text-tertiary"> — {edgeHelp(edge.label, edge.mark)}</span>
         </>
       }
       wrapperClassName="absolute cursor-help"

--- a/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
@@ -266,6 +266,9 @@ function Node({
   // An origin capsule carries exactly one status row; its action shares that
   // line instead of adding a full-width row beneath it.
   const inlineAction = !!(isOrigin && node.action && node.anomalies?.length === 1)
+  // A test running FROM this vantage: the edge already animates, but the
+  // capsule it leaves from looked as inert as everything else on the board.
+  const testing = !!node.anomalies?.some((a) => a.mark === 'running')
   const style: CSSProperties = {
     left: node.x,
     top: node.y,
@@ -290,6 +293,7 @@ function Node({
     <div
       role="button"
       tabIndex={0}
+      data-testing={testing || undefined}
       // The visible text is kind + name in separate spans a screen reader joins
       // unpredictably; one explicit name says what this is and (for a vantage
       // capsule) what selecting it does.
@@ -302,7 +306,7 @@ function Node({
           onSelect(node.id)
         }
       }}
-      className="absolute cursor-pointer px-2.5 py-1.5 text-left"
+      className={`absolute cursor-pointer px-2.5 py-1.5 text-left${testing ? ' reach-node-testing' : ''}`}
       style={style}
     >
       <div className="flex items-center gap-1.5">
@@ -348,11 +352,15 @@ function Node({
         <div className="mt-1.5 flex flex-col gap-0.5 border-t border-theme-border-subtle pt-1.5">
           {node.anomalies.map((a, i) => (
             <div key={i} className={`flex gap-1.5 ${inlineAction && i === 0 ? 'items-center' : 'items-baseline'}`}>
-              <MarkGlyph mark={a.mark} />
+              <span className={a.mark === 'running' ? 'reach-glyph-testing' : undefined}>
+                <MarkGlyph mark={a.mark} />
+              </span>
               {/* Rows truncate visually; the full sentence must always be a
                   hover away - a cut "reached, redirect…" hid its destination. */}
               <Tooltip content={a.title || a.text} wrapperClassName="min-w-0 flex-1">
-                <span className="block truncate text-[9.5px] leading-[1.35] text-theme-text-secondary">{a.text}</span>
+                <span className={`block truncate text-[9.5px] leading-[1.35] text-theme-text-secondary${a.mark === 'running' ? ' reach-label-testing' : ''}`}>
+                  {a.text}
+                </span>
               </Tooltip>
               {/* The capsule's single status row and its action share the line -
                   a stacked full-width button grew the capsule past the height

--- a/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityGraph.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
 import { PILL_MAX_PX, type GraphModel, type GraphNode, type GraphEdge, type LaneBox } from './reachGraphModel'
-import { markStyle, glyphStyle, markHelp, edgeHelp, SEV_COLOR, MARK_LEGEND, MARK_CATEGORY_LABEL, type Mark, type MarkCategory } from './reachMarks'
+import { markStyle, glyphStyle, markHelp, edgeHelp, edgeHelpIsRedundant, SEV_COLOR, MARK_LEGEND, MARK_CATEGORY_LABEL, type Mark, type MarkCategory } from './reachMarks'
 import { Tooltip } from '../ui/Tooltip'
 
 /** Finding severity -> the shared health tones. Findings describe the OBJECT;
@@ -225,7 +225,9 @@ function EdgePill({ edge }: { edge: GraphEdge }) {
       content={
         <>
           <span className="font-semibold">{edge.title}</span>
-          <span className="text-theme-text-tertiary"> — {edgeHelp(edge.label, edge.mark)}</span>
+          {!edgeHelpIsRedundant(edge.title, edge.label, edge.mark) && (
+            <span className="text-theme-text-tertiary"> — {edgeHelp(edge.label, edge.mark)}</span>
+          )}
         </>
       }
       wrapperClassName="absolute cursor-help"

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -219,8 +219,9 @@ function ReachabilityBoard(props: BoardProps) {
         running: selectedOriginRunning,
         multiPath,
         httpPath: props.probePath,
+        canRunInCluster: !!onRunInCluster && inClusterAllowed !== false,
       }),
-    [selection, trace, route, origin, origins, model, stale, selectedOriginRunning, multiPath, props.probePath],
+    [selection, trace, route, origin, origins, model, stale, selectedOriginRunning, multiPath, props.probePath, onRunInCluster, inClusterAllowed],
   )
   const verdict = useMemo(
     () => buildVerdict(trace, route, { stale, running: selectedOriginRunning, originId: origin?.id, originName: origin?.name, pathLabel: multiPath ? scenario?.primary.target || scenario?.label : undefined }),
@@ -228,8 +229,9 @@ function ReachabilityBoard(props: BoardProps) {
   )
 
   const problems = useMemo(
-    () => problemRows(trace, route, origins, origin?.id),
-    [trace, route, origins, origin],
+    () => problemRows(trace, origins, new Set(model.nodes.map((n) => n.id))),
+    // Deliberately NOT keyed on the selection: the header is the resource.
+    [trace, origins, model],
   )
 
   const onCTA = (cta: InspectorCTA) => {
@@ -508,12 +510,25 @@ const SEV_RANK: Record<ProblemRow['severity'], number> = { critical: 0, warning:
  *  diagnosis, the declared entries that cannot carry traffic, and a pointer to
  *  anything only another vantage saw. Two separate bands read as two separate
  *  problems when they were often the same one. */
-export function problemRows(trace: Trace, route: RouteResult | undefined, origins: Origin[], selectedOriginId?: string): ProblemRow[] {
+export function problemRows(
+  trace: Trace,
+  origins: Origin[],
+  knownNodeIds: ReadonlySet<string>,
+): ProblemRow[] {
   const rows: ProblemRow[] = []
   const seen = new Set<string>()
   const push = (r: ProblemRow) => {
     const k = `${r.subject}\u0000${r.text}`
     if (seen.has(k)) return
+    // Never address a node the graph does not draw: a Pod culprit resolves to
+    // the aggregate Pods node it lives in, and anything still unknown drops its
+    // pointer rather than offering a hover that rings nothing and a click that
+    // selects a section no inspector can resolve.
+    if (r.nodeId && !knownNodeIds.has(r.nodeId)) {
+      const pods = [...knownNodeIds].find((id) => id.startsWith('n:Pods/'))
+      if (r.nodeId.startsWith('n:Pod/') && pods) r = { ...r, nodeId: pods }
+      else r = { ...r, nodeId: '' }
+    }
     seen.add(k)
     rows.push(r)
   }
@@ -531,7 +546,9 @@ export function problemRows(trace: Trace, route: RouteResult | undefined, origin
       text: noteHeadline(d.summary),
       detail: [d.summary, d.nextAction].filter(Boolean).join(' — '),
       nodeId: refNode(ref) || refNode(trace.subject),
-      severity: 'critical',
+      // The detector's own severity. Assuming critical turned every warning-tier
+      // prediction into a red it had not earned.
+      severity: d.severity === 'critical' ? 'critical' : 'warning',
     })
   }
 
@@ -547,22 +564,25 @@ export function problemRows(trace: Trace, route: RouteResult | undefined, origin
     })
   }
 
-  // Something only ANOTHER vantage saw. Without this a reader parked on one
-  // capsule never learns that a different one hit a wall - the fault would be
-  // discoverable only by luck of which capsule they clicked.
+  // A fault some vantage hit, on ANY declared path. Deliberately independent of
+  // what is selected: the header is the resource, so a row that appears or
+  // vanishes as you click capsules would hide exactly the fault the reader has
+  // not thought to look for.
   for (const o of origins) {
-    if (o.id === selectedOriginId || o.unsupported) continue
-    const own = route ? routeForOrigin(route, o.id, trace.runVantage) : undefined
-    if (!own || (own.outcome !== 'unreachable' && own.outcome !== 'server-error')) continue
-    push({
-      key: `vantage-${o.id}`,
-      scope: 'ANOTHER VANTAGE',
-      subject: o.name,
-      text: own.evidence ? noteHeadline(own.evidence) : 'this vantage could not get through',
-      detail: own.evidence,
-      nodeId: `origin:${o.id}`,
-      severity: 'warning',
-    })
+    if (o.unsupported) continue
+    for (const r of trace.routes ?? []) {
+      const own = routeForOrigin(r, o.id, trace.runVantage)
+      if (!own || (own.outcome !== 'unreachable' && own.outcome !== 'server-error')) continue
+      push({
+        key: `vantage-${o.id}-${r.route}`,
+        scope: 'SEEN FROM',
+        subject: o.name,
+        text: own.evidence ? noteHeadline(own.evidence) : `could not get through to ${r.target || r.route}`,
+        detail: [own.evidence, `path: ${r.route}`].filter(Boolean).join(' — '),
+        nodeId: `origin:${o.id}`,
+        severity: 'warning',
+      })
+    }
   }
 
   return rows.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity])

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Trace, RouteResult, ResourceRef, EntryProblem } from './types'
+import type { Trace, RouteResult, ResourceRef } from './types'
 import { ReachActions, JustTestedNote, CopyableCommand, completedRequestMode, type TracePanelProps } from './TracePanel'
 import { AlertBanner } from '../ui/drawer-components'
 import { PaneLoader } from '../ui/PaneLoader'
@@ -9,7 +9,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { buildGraph, noteHeadline } from './reachGraphModel'
 import { buildOrigins, defaultOrigin, probeCheckStats, type Origin, type OriginId } from './reachOrigins'
 import { buildSidebar, buildVerdict, type Sidebar, type HopReport, type InspectorCTA, type Selection } from './reachInspector'
-import { markStyle, glyphStyle, markHelp, scenariosFor, routeTone, routeChip, routeIdentity, traceInClusterRunnable, SEV_COLOR, SEV_BADGE, type Scenario } from './reachMarks'
+import { markStyle, glyphStyle, markHelp, scenariosFor, routeTone, routeChip, routeIdentity, routeForOrigin, traceInClusterRunnable, SEV_COLOR, SEV_BADGE, type Scenario } from './reachMarks'
 import { evidenceBannerTitle } from './inClusterSummary'
 import { DEV_STATES, devTrace, type DevState } from './reachFixtures'
 
@@ -227,6 +227,11 @@ function ReachabilityBoard(props: BoardProps) {
     [trace, route, origins, stale, running, multiPath, scenario, origin],
   )
 
+  const problems = useMemo(
+    () => problemRows(trace, route, origins, origin?.id),
+    [trace, route, origins, origin],
+  )
+
   const onCTA = (cta: InspectorCTA) => {
     if (cta.disabledReason) return
     if (cta.action === 'run-in-cluster') onRunInCluster?.()
@@ -246,8 +251,20 @@ function ReachabilityBoard(props: BoardProps) {
         verdict={verdict}
         trace={trace}
         runNonce={runNonce}
+        problems={problems}
         onEntryHover={setHoveredNodeId}
-        onEntrySelect={(id) => setSelection(id)}
+        onEntrySelect={(id) => {
+          // A pointer row addresses a VANTAGE capsule; everything else a
+          // resource node. Selecting the capsule re-routes the whole board to
+          // that vantage, which is what "show me what it saw" means.
+          const originId = id.startsWith('origin:') ? (id.slice('origin:'.length) as OriginId) : undefined
+          if (originId) {
+            setOriginId(originId)
+            setSelection(undefined)
+            return
+          }
+          setSelection(id)
+        }}
         actions={
           <ReachActions
             {...props}
@@ -300,6 +317,7 @@ function ReachabilityBoard(props: BoardProps) {
               running={running}
             />
           )}
+          <ViewingStrip verdict={verdict} scenario={scenario} multiPath={multiPath} />
           <ReachabilityGraph
             model={model}
             onAction={(a) => {
@@ -463,63 +481,170 @@ function ScenarioPicker({
 
 const LAYER_ORDER = ['dns', 'tcp', 'tls', 'http']
 
-/** The declared entry points that cannot carry traffic. Stated under the
- *  headline because the verdict is scoped to the TESTED path and structurally
- *  cannot see them - a dead front door was visible only as a dot inside a graph
- *  node. Interaction ladder: hover names it in full and rings it in the graph,
- *  click focuses it (graph + inspector), and the hop's own "Open" leaves. */
-function EntryProblems({
-  problems,
-  onHover,
-  onSelect,
-}: {
-  problems: EntryProblem[]
-  onHover?: (nodeId?: string) => void
-  onSelect?: (nodeId: string) => void
-}) {
-  if (problems.length === 0) return null
-  const shown = problems.slice(0, 2)
-  const rest = problems.length - shown.length
+/**
+ * One row in the header's problem list.
+ *
+ * The list is deliberately VANTAGE-INVARIANT: everything in it is true no
+ * matter which capsule is selected, so a fault can never hide behind a click.
+ * Faults read off cluster state (a dead entry, a promoted finding) say what is
+ * wrong; a pointer row says another vantage saw something and takes you there.
+ * What a vantage saw stays on the board and in the inspector.
+ */
+interface ProblemRow {
+  key: string
+  scope: string
+  subject: string
+  text: string
+  detail?: string
+  /** Graph node to ring on hover and select on click - a resource node, or an
+   *  origin capsule (`origin:<id>`) for a pointer row. */
+  nodeId: string
+  severity: 'critical' | 'warning'
+}
+
+const SEV_RANK: Record<ProblemRow['severity'], number> = { critical: 0, warning: 1 }
+
+/** Merges every vantage-invariant problem into ONE ranked list: the promoted
+ *  diagnosis, the declared entries that cannot carry traffic, and a pointer to
+ *  anything only another vantage saw. Two separate bands read as two separate
+ *  problems when they were often the same one. */
+export function problemRows(trace: Trace, route: RouteResult | undefined, origins: Origin[], selectedOriginId?: string): ProblemRow[] {
+  const rows: ProblemRow[] = []
+  const seen = new Set<string>()
+  const push = (r: ProblemRow) => {
+    const k = `${r.subject}\u0000${r.text}`
+    if (seen.has(k)) return
+    seen.add(k)
+    rows.push(r)
+  }
+  const refNode = (r?: ResourceRef) => (r ? `n:${r.kind}/${r.namespace ?? ''}/${r.name || 'pods'}` : '')
+
+  // The promoted fault. A COVERAGE-class diagnosis is not a fault - it restates
+  // the headline, which is generated from the same coverage state.
+  const d = trace.diagnosis
+  if (d?.summary && d.class !== 'coverage') {
+    const ref = d.culpritResource
+    push({
+      key: 'diagnosis',
+      scope: ref ? ref.kind.toUpperCase() : 'PATH',
+      subject: ref ? `${ref.kind} ${ref.name}` : trace.subject.name,
+      text: noteHeadline(d.summary),
+      detail: [d.summary, d.nextAction].filter(Boolean).join(' — '),
+      nodeId: refNode(ref) || refNode(trace.subject),
+      severity: 'critical',
+    })
+  }
+
+  for (const p of trace.entryProblems ?? []) {
+    push({
+      key: `entry-${p.resource.kind}-${p.resource.name}`,
+      scope: 'ENTRY',
+      subject: `${p.resource.kind} ${p.resource.name}`,
+      text: noteHeadline(p.summary),
+      detail: [p.summary, p.detail, p.action].filter(Boolean).filter((v, i, a) => a.indexOf(v) === i).join(' — '),
+      nodeId: refNode(p.resource),
+      severity: p.severity === 'critical' ? 'critical' : 'warning',
+    })
+  }
+
+  // Something only ANOTHER vantage saw. Without this a reader parked on one
+  // capsule never learns that a different one hit a wall - the fault would be
+  // discoverable only by luck of which capsule they clicked.
+  for (const o of origins) {
+    if (o.id === selectedOriginId || o.unsupported) continue
+    const own = route ? routeForOrigin(route, o.id, trace.runVantage) : undefined
+    if (!own || (own.outcome !== 'unreachable' && own.outcome !== 'server-error')) continue
+    push({
+      key: `vantage-${o.id}`,
+      scope: 'ANOTHER VANTAGE',
+      subject: o.name,
+      text: own.evidence ? noteHeadline(own.evidence) : 'this vantage could not get through',
+      detail: own.evidence,
+      nodeId: `origin:${o.id}`,
+      severity: 'warning',
+    })
+  }
+
+  return rows.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity])
+}
+
+/** The header's problem list. Hover names the fault in full and rings it on the
+ *  board; click focuses it there. */
+/**
+ * What you are currently looking at, stated ON the board that changes. Keeping
+ * it here rather than in the header is the whole redesign: the header is the
+ * resource and never moves, this strip is the selection and always does, and
+ * the spatial split says so without anyone having to read a label.
+ */
+function ViewingStrip({ verdict, scenario, multiPath }: { verdict: ReturnType<typeof buildVerdict>; scenario?: Scenario; multiPath: boolean }) {
+  const path = multiPath ? scenario?.primary.target || scenario?.label : undefined
   return (
-    <div className="mt-1.5 flex flex-col gap-1">
-      {shown.map((p, i) => {
-        const nodeId = `n:${p.resource.kind}/${p.resource.namespace ?? ''}/${p.resource.name || 'pods'}`
-        const label = `${p.resource.kind} ${p.resource.name}`
-        return (
-          <Tooltip key={`${p.code}-${i}`} content={[p.summary, p.detail, p.action].filter(Boolean).filter((v, i, a) => a.indexOf(v) === i).join(' — ')} wrapperClassName="block">
-            <button
-              type="button"
-              onMouseEnter={() => onHover?.(nodeId)}
-              onMouseLeave={() => onHover?.(undefined)}
-              onFocus={() => onHover?.(nodeId)}
-              onBlur={() => onHover?.(undefined)}
-              onClick={() => onSelect?.(nodeId)}
-              aria-label={`${label} — ${p.summary}. Show it on the path.`}
-              className="flex w-full max-w-[92ch] cursor-pointer items-start gap-1.5 rounded-md px-2 py-1.5 text-left text-xs leading-relaxed text-pretty transition-colors hover:bg-theme-hover"
-              style={{ border: '1px solid var(--color-warning)', background: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
-            >
-              <span className="shrink-0" style={{ color: 'var(--color-warning-dark)' }}>▲</span>
-              <span className="min-w-0 flex-1 text-theme-text-primary">
-                <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">CONFIGURED ENTRY </span>
-                {/* The SAME humanizer the graph node uses, so the row and the
-                    node can never word one fault two ways; the raw controller
-                    condition stays one hover away. */}
-                <span className="font-mono font-semibold">{label}</span> — <span className="line-clamp-2">{noteHeadline(p.summary)}</span>
-              </span>
-            </button>
-          </Tooltip>
-        )
-      })}
-      {rest > 0 && <div className="text-[11px] text-theme-text-tertiary">+{rest} more entry point{rest > 1 ? 's' : ''} with problems — see the path below</div>}
+    <div className="pointer-events-none absolute left-3 top-2 z-10 flex max-w-[50%] flex-wrap items-center gap-x-2 gap-y-1">
+      <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">VIEWING</span>
+      {path && <span className="truncate font-mono text-[11px] font-semibold text-theme-text-secondary">{path}</span>}
+      {path && <span className="text-theme-border">·</span>}
+      <span className="truncate font-mono text-[11px] font-semibold text-theme-text-secondary">{verdict.originName ?? 'this resource'}</span>
+      <span className={`badge-sm whitespace-nowrap ${SEV_BADGE[verdict.tone]}`}>{verdict.chipText}</span>
     </div>
   )
 }
 
+function ProblemList({
+  rows,
+  onHover,
+  onSelect,
+}: {
+  rows: ProblemRow[]
+  onHover?: (nodeId?: string) => void
+  onSelect?: (nodeId: string) => void
+}) {
+  if (rows.length === 0) return null
+  const shown = rows.slice(0, 3)
+  const rest = rows.length - shown.length
+  return (
+    <div className="mt-1.5 flex flex-col gap-1">
+      {shown.map((p) => (
+        <Tooltip key={p.key} content={p.detail || p.text} wrapperClassName="block">
+          <button
+            type="button"
+            onMouseEnter={() => onHover?.(p.nodeId)}
+            onMouseLeave={() => onHover?.(undefined)}
+            onFocus={() => onHover?.(p.nodeId)}
+            onBlur={() => onHover?.(undefined)}
+            onClick={() => onSelect?.(p.nodeId)}
+            aria-label={`${p.subject} — ${p.text}. Show it on the path.`}
+            className="flex w-full max-w-[92ch] cursor-pointer items-start gap-1.5 rounded-md px-2 py-1.5 text-left text-xs leading-relaxed text-pretty transition-colors hover:bg-theme-hover"
+            style={{
+              border: `1px solid var(${p.severity === 'critical' ? '--color-error' : '--color-warning'})`,
+              background: `color-mix(in srgb, var(${p.severity === 'critical' ? '--color-error' : '--color-warning'}) 10%, transparent)`,
+            }}
+          >
+            <span className="shrink-0" style={{ color: `var(${p.severity === 'critical' ? '--color-error-dark' : '--color-warning-dark'})` }}>▲</span>
+            <span className="min-w-0 flex-1 text-theme-text-primary">
+              <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">{p.scope} </span>
+              <span className="font-mono font-semibold">{p.subject}</span> — <span className="line-clamp-2">{p.text}</span>
+            </span>
+          </button>
+        </Tooltip>
+      ))}
+      {rest > 0 && <div className="text-[11px] text-theme-text-tertiary">+{rest} more problem{rest > 1 ? 's' : ''} — see the path below</div>}
+    </div>
+  )
+}
+
+/**
+ * The header. Everything in it describes THE RESOURCE and never changes when a
+ * vantage or path is selected - which is the whole point: the reader can learn
+ * once that this block is static and the board below is what moves. Anything
+ * scoped to the current selection lives on the board (the viewing strip and the
+ * capsules) and in the inspector.
+ */
 function VerdictBand({
   verdict,
   trace,
   actions,
   runNonce,
+  problems,
   onEntryHover,
   onEntrySelect,
 }: {
@@ -527,6 +652,7 @@ function VerdictBand({
   trace: Trace
   actions: React.ReactNode
   runNonce?: number
+  problems: ProblemRow[]
   onEntryHover?: (nodeId?: string) => void
   onEntrySelect?: (nodeId: string) => void
 }) {
@@ -551,15 +677,9 @@ function VerdictBand({
         )}
         <div className="flex flex-wrap items-baseline gap-2">
           <span className="text-[14.5px] font-semibold text-theme-text-primary">{verdict.title}</span>
-          {!verdict.chipScope && <span className={`badge-sm whitespace-nowrap ${SEV_BADGE[verdict.tone]}`}>{verdict.chipText}</span>}
           <JustTestedNote nonce={runNonce} />
         </div>
-        {verdict.chipScope && (
-          <div className="mt-1 flex flex-wrap items-center gap-2">
-            <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">{verdict.chipScope.toUpperCase()}</span>
-            <span className={`badge-sm whitespace-nowrap ${SEV_BADGE[verdict.tone]}`}>{verdict.chipText}</span>
-          </div>
-        )}
+
         {stats.checks > 0 && (
           <Tooltip
             content={`${layerBreakdown}${stats.vantages > 1 ? ` — from ${stats.vantages} vantages` : ''}. Every check is a real dial; skipped ones are listed with their reasons, never counted. Each check waits up to ~1s, inside a 3s budget per run — a slow backend can time out and read as not tested.`}
@@ -576,17 +696,9 @@ function VerdictBand({
             </span>
           </Tooltip>
         )}
-        {verdict.problem && (
-          <div
-            className="mt-1.5 flex max-w-[92ch] items-start gap-1.5 rounded-md px-2 py-1.5 text-xs leading-relaxed text-pretty"
-            style={{ border: '1px solid var(--color-warning)', background: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
-          >
-            <span className="shrink-0" style={{ color: 'var(--color-warning-dark)' }}>▲</span>
-            <span className="text-theme-text-primary">{verdict.problem}</span>
-          </div>
-        )}
+
         {verdict.body && <div className="mt-1 max-w-[76ch] text-xs leading-relaxed text-theme-text-secondary text-pretty">{verdict.body}</div>}
-        <EntryProblems problems={trace.entryProblems ?? []} onHover={onEntryHover} onSelect={onEntrySelect} />
+        <ProblemList rows={problems} onHover={onEntryHover} onSelect={onEntrySelect} />
       </div>
       <div className="flex flex-none gap-2">{actions}</div>
     </div>

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Trace, RouteResult, ResourceRef } from './types'
+import type { Trace, RouteResult, ResourceRef, EntryProblem } from './types'
 import { ReachActions, JustTestedNote, CopyableCommand, completedRequestMode, type TracePanelProps } from './TracePanel'
 import { AlertBanner } from '../ui/drawer-components'
 import { PaneLoader } from '../ui/PaneLoader'
@@ -190,6 +190,9 @@ function ReachabilityBoard(props: BoardProps) {
   const selectedOriginRunning = running && origin?.id === 'incluster'
 
   const [selection, setSelection] = useState<Selection>(undefined)
+  // The entry-problem rows point at a node from outside the graph: hovering one
+  // rings it, so "where is it?" is answered before a click is spent.
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | undefined>(undefined)
 
   const model = useMemo(
     () => buildGraph({ trace, route, origin, origins, stale, running }),
@@ -243,6 +246,8 @@ function ReachabilityBoard(props: BoardProps) {
         verdict={verdict}
         trace={trace}
         runNonce={runNonce}
+        onEntryHover={setHoveredNodeId}
+        onEntrySelect={(id) => setSelection(id)}
         actions={
           <ReachActions
             {...props}
@@ -308,6 +313,7 @@ function ReachabilityBoard(props: BoardProps) {
               onRunInCluster?.()
             }}
             selected={selection}
+            hovered={hoveredNodeId}
             onSelect={(id) => {
               // An origin capsule selects the VANTAGE - the rest of the graph
               // and the inspector re-route to it. Any other node selects the
@@ -457,16 +463,69 @@ function ScenarioPicker({
 
 const LAYER_ORDER = ['dns', 'tcp', 'tls', 'http']
 
+/** The declared entry points that cannot carry traffic. Stated under the
+ *  headline because the verdict is scoped to the TESTED path and structurally
+ *  cannot see them - a dead front door was visible only as a dot inside a graph
+ *  node. Interaction ladder: hover names it in full and rings it in the graph,
+ *  click focuses it (graph + inspector), and the hop's own "Open" leaves. */
+function EntryProblems({
+  problems,
+  onHover,
+  onSelect,
+}: {
+  problems: EntryProblem[]
+  onHover?: (nodeId?: string) => void
+  onSelect?: (nodeId: string) => void
+}) {
+  if (problems.length === 0) return null
+  const shown = problems.slice(0, 2)
+  const rest = problems.length - shown.length
+  return (
+    <div className="mt-1.5 flex flex-col gap-1">
+      {shown.map((p, i) => {
+        const nodeId = `n:${p.resource.kind}/${p.resource.namespace ?? ''}/${p.resource.name || 'pods'}`
+        const label = `${p.resource.kind} ${p.resource.name}`
+        return (
+          <Tooltip key={`${p.code}-${i}`} content={[p.summary, p.action].filter(Boolean).join(' — ')} wrapperClassName="block">
+            <button
+              type="button"
+              onMouseEnter={() => onHover?.(nodeId)}
+              onMouseLeave={() => onHover?.(undefined)}
+              onFocus={() => onHover?.(nodeId)}
+              onBlur={() => onHover?.(undefined)}
+              onClick={() => onSelect?.(nodeId)}
+              aria-label={`${label} — ${p.summary}. Show it on the path.`}
+              className="flex w-full max-w-[92ch] cursor-pointer items-start gap-1.5 rounded-md px-2 py-1.5 text-left text-xs leading-relaxed text-pretty transition-colors hover:bg-theme-hover"
+              style={{ border: '1px solid var(--color-warning)', background: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
+            >
+              <span className="shrink-0" style={{ color: 'var(--color-warning-dark)' }}>▲</span>
+              <span className="min-w-0 flex-1 text-theme-text-primary">
+                <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">CONFIGURED ENTRY </span>
+                <span className="font-mono font-semibold">{label}</span> — <span className="line-clamp-2">{p.summary}</span>
+              </span>
+            </button>
+          </Tooltip>
+        )
+      })}
+      {rest > 0 && <div className="text-[11px] text-theme-text-tertiary">+{rest} more entry point{rest > 1 ? 's' : ''} with problems — see the path below</div>}
+    </div>
+  )
+}
+
 function VerdictBand({
   verdict,
   trace,
   actions,
   runNonce,
+  onEntryHover,
+  onEntrySelect,
 }: {
   verdict: ReturnType<typeof buildVerdict>
   trace: Trace
   actions: React.ReactNode
   runNonce?: number
+  onEntryHover?: (nodeId?: string) => void
+  onEntrySelect?: (nodeId: string) => void
 }) {
   // The check volume lives HERE, not only in the footer ledger: the band is
   // the one line everyone reads, and a verdict with no visible work behind it
@@ -524,6 +583,7 @@ function VerdictBand({
           </div>
         )}
         {verdict.body && <div className="mt-1 max-w-[76ch] text-xs leading-relaxed text-theme-text-secondary text-pretty">{verdict.body}</div>}
+        <EntryProblems problems={trace.entryProblems ?? []} onHover={onEntryHover} onSelect={onEntrySelect} />
       </div>
       <div className="flex flex-none gap-2">{actions}</div>
     </div>

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -530,7 +530,11 @@ export function problemRows(
       else r = { ...r, nodeId: '' }
     }
     seen.add(k)
-    rows.push(r)
+    // The caller's key names the row FAMILY and is not unique on its own - one
+    // entry can carry several findings, and one origin several failed routes.
+    // `k` is what `seen` just proved unique, so pairing them is what makes the
+    // React key safe rather than each caller having to get it right.
+    rows.push({ ...r, key: `${r.key} ${k}` })
   }
   const refNode = (r?: ResourceRef) => (r ? `n:${r.kind}/${r.namespace ?? ''}/${r.name || 'pods'}` : '')
 

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -6,7 +6,7 @@ import { PaneLoader } from '../ui/PaneLoader'
 import { ReachabilityGraph, MarkGlyph } from './ReachabilityGraph'
 import { Activity, ChevronRight } from 'lucide-react'
 import { Tooltip } from '../ui/Tooltip'
-import { buildGraph } from './reachGraphModel'
+import { buildGraph, noteHeadline } from './reachGraphModel'
 import { buildOrigins, defaultOrigin, probeCheckStats, type Origin, type OriginId } from './reachOrigins'
 import { buildSidebar, buildVerdict, type Sidebar, type HopReport, type InspectorCTA, type Selection } from './reachInspector'
 import { markStyle, glyphStyle, markHelp, scenariosFor, routeTone, routeChip, routeIdentity, traceInClusterRunnable, SEV_COLOR, SEV_BADGE, type Scenario } from './reachMarks'
@@ -486,7 +486,7 @@ function EntryProblems({
         const nodeId = `n:${p.resource.kind}/${p.resource.namespace ?? ''}/${p.resource.name || 'pods'}`
         const label = `${p.resource.kind} ${p.resource.name}`
         return (
-          <Tooltip key={`${p.code}-${i}`} content={[p.summary, p.action].filter(Boolean).join(' — ')} wrapperClassName="block">
+          <Tooltip key={`${p.code}-${i}`} content={[p.summary, p.detail, p.action].filter(Boolean).filter((v, i, a) => a.indexOf(v) === i).join(' — ')} wrapperClassName="block">
             <button
               type="button"
               onMouseEnter={() => onHover?.(nodeId)}
@@ -501,7 +501,10 @@ function EntryProblems({
               <span className="shrink-0" style={{ color: 'var(--color-warning-dark)' }}>▲</span>
               <span className="min-w-0 flex-1 text-theme-text-primary">
                 <span className="text-[9.5px] font-bold tracking-[0.07em] text-theme-text-tertiary">CONFIGURED ENTRY </span>
-                <span className="font-mono font-semibold">{label}</span> — <span className="line-clamp-2">{p.summary}</span>
+                {/* The SAME humanizer the graph node uses, so the row and the
+                    node can never word one fault two ways; the raw controller
+                    condition stays one hover away. */}
+                <span className="font-mono font-semibold">{label}</span> — <span className="line-clamp-2">{noteHeadline(p.summary)}</span>
               </span>
             </button>
           </Tooltip>

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -856,6 +856,41 @@ function InspectorPanel({
         </Disclosure>
       )}
 
+      {/* The action sits with the sentence that explains why it is offered. As
+          its own block at the very bottom it repeated that sentence, and put
+          the button a scroll away from the reason for it. */}
+      {(path.next.body || path.next.ctas.length > 0) && (
+        <div className={path.next.header ? 'rounded-md px-2.5 py-2' : ''} style={path.next.header ? { border: '1px solid var(--accent)', background: 'var(--accent-muted)' } : undefined}>
+          {path.next.header && (
+            <div className="mb-1 text-[9.5px] font-bold tracking-[0.05em]" style={{ color: 'var(--accent-text)' }}>
+              {path.next.header}
+            </div>
+          )}
+          {path.next.body && <div className="text-[11.5px] leading-snug text-theme-text-secondary text-pretty">{path.next.body}</div>}
+          {path.next.blocked && <div className="mt-1.5 text-[10.5px] leading-snug text-theme-text-tertiary">{path.next.blocked}</div>}
+          {path.next.ctas.length > 0 && (
+            <div className={`flex flex-wrap gap-1.5 ${path.next.body || path.next.header ? 'mt-2' : 'mt-1'}`}>
+              {path.next.ctas.map((c, i) => (
+                <Tooltip key={i} content={c.disabledReason ?? ''} wrapperClassName="cursor-help">
+                  <button
+                    type="button"
+                    onClick={() => onCTA(c)}
+                    disabled={!!c.disabledReason}
+                    className={
+                      c.primary && !c.disabledReason
+                        ? 'btn-brand cursor-pointer whitespace-nowrap rounded-md px-2.5 py-1.5 text-[11px] font-semibold'
+                        : 'cursor-pointer whitespace-nowrap rounded-md border border-theme-border bg-theme-base px-2.5 py-1.5 text-[11px] font-semibold text-theme-text-secondary disabled:cursor-not-allowed disabled:opacity-60'
+                    }
+                  >
+                    {c.text}
+                  </button>
+                </Tooltip>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {path.evidence.length > 0 && (
         <div>
           {/* Same count idiom as TEST DETAILS: the number of distinct
@@ -896,39 +931,6 @@ function InspectorPanel({
         </div>
       )}
       <Caveats items={path.notProve} />
-
-      {/* The terminal "nothing to do" state renders as one quiet line - the
-          callout styling is reserved for states that carry an actual next move. */}
-      <div
-        className={path.next.quiet ? 'border-t border-theme-border pt-2.5' : 'rounded-md px-2.5 py-2.5'}
-        style={path.next.quiet ? undefined : { border: '1px solid var(--accent)', background: 'var(--accent-muted)' }}
-      >
-        <div className="text-[9.5px] font-bold tracking-[0.05em]" style={{ color: path.next.quiet ? 'var(--text-tertiary)' : 'var(--accent-text)' }}>
-          {path.next.header}
-        </div>
-        <div className="mt-1 text-[11.5px] leading-snug text-theme-text-secondary text-pretty">{path.next.body}</div>
-        {path.next.blocked && <div className="mt-1.5 text-[10.5px] leading-snug text-theme-text-tertiary">{path.next.blocked}</div>}
-        {path.next.ctas.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {path.next.ctas.map((c, i) => (
-              <Tooltip key={i} content={c.disabledReason ?? ''} wrapperClassName="cursor-help">
-              <button
-                type="button"
-                onClick={() => onCTA(c)}
-                disabled={!!c.disabledReason}
-                className={
-                  c.primary && !c.disabledReason
-                    ? 'btn-brand cursor-pointer whitespace-nowrap rounded-md px-2.5 py-1.5 text-[11px] font-semibold'
-                    : 'cursor-pointer whitespace-nowrap rounded-md border border-theme-border bg-theme-base px-2.5 py-1.5 text-[11px] font-semibold text-theme-text-secondary disabled:cursor-not-allowed disabled:opacity-60'
-                }
-              >
-                {c.text}
-              </button>
-              </Tooltip>
-            ))}
-          </div>
-        )}
-      </div>
 
     </div>
   )

--- a/packages/k8s-ui/src/components/trace/problemRows.test.ts
+++ b/packages/k8s-ui/src/components/trace/problemRows.test.ts
@@ -1,49 +1,77 @@
 import { describe, it, expect } from 'vitest'
 import { problemRows } from './ReachabilityView'
 import { buildOrigins } from './reachOrigins'
+import { buildGraph } from './reachGraphModel'
 import type { Trace, RouteResult } from './types'
 
 const base = (): Trace => ({
   subject: { kind: 'Service', name: 'shop', namespace: 'store' },
   verdict: 'degraded', brokenAt: -1,
   upstreams: [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, edge: 'httproute->service', findings: [] }],
-  downstream: [{ resource: { kind: 'Service', name: 'shop', namespace: 'store' }, edge: 'service', findings: [] }],
+  downstream: [
+    { resource: { kind: 'Service', name: 'shop', namespace: 'store' }, edge: 'service', findings: [] },
+    { resource: { kind: 'Pods', name: '', namespace: 'store' }, edge: 'service->pods', findings: [], config: { pods: [{ name: 'shop-1', ready: true, ip: '10.0.0.1' }], podTotal: 1 } },
+  ],
   routes: [],
 } as never)
+
+/** The ids the graph actually draws, which is what a header row may address. */
+const nodesOf = (t: Trace, r?: RouteResult) => {
+  const origins = buildOrigins(t)
+  // Pass every origin, as the app does - the capsules ARE nodes a header row
+  // may address.
+  const g = buildGraph({ trace: t, route: r ?? ({ route: 'shop', target: 'shop:80', outcome: 'reached' } as never), origin: origins.find((o) => o.id === 'apiserver')!, origins })
+  return new Set(g.nodes.map((n) => n.id))
+}
 
 describe('the header problem list', () => {
   it('drops a coverage-class diagnosis - the headline already says it', () => {
     const t = base()
     t.diagnosis = { class: 'coverage', summary: 'reachable via API server - the real-traffic path was not confirmed from here' } as never
-    expect(problemRows(t, undefined, buildOrigins(t), 'apiserver')).toHaveLength(0)
+    expect(problemRows(t, buildOrigins(t), nodesOf(t))).toHaveLength(0)
   })
 
-  it('keeps a fault-class diagnosis and ranks it above warnings', () => {
+  it('renders the severity the detector assigned, never inventing critical', () => {
     const t = base()
-    t.diagnosis = { summary: 'container is crashlooping', culpritResource: { kind: 'Pod', name: 'shop-1', namespace: 'store' } } as never
-    t.entryProblems = [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, summary: 'Not attached: no listener matches its hosts', severity: 'warning' }] as never
-    const rows = problemRows(t, undefined, buildOrigins(t), 'apiserver')
-    expect(rows.map((r) => r.severity)).toEqual(['critical', 'warning'])
-    expect(rows[0].nodeId).toBe('n:Pod/store/shop-1')
-    expect(rows[1].nodeId).toBe('n:HTTPRoute/store/shop')
+    t.diagnosis = { summary: 'a network rule would block traffic', severity: 'warning' } as never
+    expect(problemRows(t, buildOrigins(t), nodesOf(t))[0].severity).toBe('warning')
+    t.diagnosis = { summary: 'container is crashlooping', severity: 'critical' } as never
+    expect(problemRows(t, buildOrigins(t), nodesOf(t))[0].severity).toBe('critical')
   })
 
-  it('points at a fault only ANOTHER vantage saw, addressing its capsule', () => {
+  it('ranks critical above warning', () => {
+    const t = base()
+    t.diagnosis = { summary: 'container is crashlooping', severity: 'critical' } as never
+    t.entryProblems = [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, summary: 'Not attached: no listener matches its hosts', severity: 'warning' }] as never
+    expect(problemRows(t, buildOrigins(t), nodesOf(t)).map((r) => r.severity)).toEqual(['critical', 'warning'])
+  })
+
+  it('is INDEPENDENT of what is selected - the header is the resource', () => {
     const t = base()
     const r: RouteResult = {
       route: 'shop', target: 'shop:80', outcome: 'reached', confidence: 'indirect',
-      byVantage: [
-        { vantage: 'in-cluster', path: 'data', source: 'probe-job', outcome: 'unreachable', confidence: 'real', evidence: 'connection refused' },
-      ],
+      byVantage: [{ vantage: 'in-cluster', path: 'data', source: 'probe-job', outcome: 'unreachable', confidence: 'real', evidence: 'connection refused' }],
     } as never
     t.routes = [r]
-    const rows = problemRows(t, r, buildOrigins(t), 'apiserver')
-    const ptr = rows.find((x) => x.scope === 'ANOTHER VANTAGE')
-    expect(ptr, 'a fault another vantage saw must not hide behind a click').toBeTruthy()
+    const rows = problemRows(t, buildOrigins(t), nodesOf(t, r))
+    const ptr = rows.find((x) => x.scope === 'SEEN FROM')
+    expect(ptr, 'a fault a vantage saw must be listed however the reader is browsing').toBeTruthy()
     expect(ptr!.nodeId).toBe('origin:incluster')
+    // the same rows regardless of which vantage the reader has open
+    expect(problemRows(t, buildOrigins(t), nodesOf(t, r))).toEqual(rows)
+  })
+
+  it('never addresses a node the graph does not draw', () => {
+    const t = base()
+    // A Pod culprit: the graph aggregates Pods, so an individual Pod node does not exist.
+    t.diagnosis = { summary: 'container is crashlooping', severity: 'critical', culpritResource: { kind: 'Pod', name: 'shop-1', namespace: 'store' } } as never
+    const known = nodesOf(t)
+    const row = problemRows(t, buildOrigins(t), known)[0]
+    expect(row.nodeId === '' || known.has(row.nodeId)).toBe(true)
   })
 
   it('says nothing when nothing is wrong', () => {
-    expect(problemRows(base(), undefined, buildOrigins(base()), 'apiserver')).toHaveLength(0)
+    const t = base()
+    expect(problemRows(t, buildOrigins(t), nodesOf(t))).toHaveLength(0)
   })
 })

--- a/packages/k8s-ui/src/components/trace/problemRows.test.ts
+++ b/packages/k8s-ui/src/components/trace/problemRows.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { problemRows } from './ReachabilityView'
+import { buildOrigins } from './reachOrigins'
+import type { Trace, RouteResult } from './types'
+
+const base = (): Trace => ({
+  subject: { kind: 'Service', name: 'shop', namespace: 'store' },
+  verdict: 'degraded', brokenAt: -1,
+  upstreams: [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, edge: 'httproute->service', findings: [] }],
+  downstream: [{ resource: { kind: 'Service', name: 'shop', namespace: 'store' }, edge: 'service', findings: [] }],
+  routes: [],
+} as never)
+
+describe('the header problem list', () => {
+  it('drops a coverage-class diagnosis - the headline already says it', () => {
+    const t = base()
+    t.diagnosis = { class: 'coverage', summary: 'reachable via API server - the real-traffic path was not confirmed from here' } as never
+    expect(problemRows(t, undefined, buildOrigins(t), 'apiserver')).toHaveLength(0)
+  })
+
+  it('keeps a fault-class diagnosis and ranks it above warnings', () => {
+    const t = base()
+    t.diagnosis = { summary: 'container is crashlooping', culpritResource: { kind: 'Pod', name: 'shop-1', namespace: 'store' } } as never
+    t.entryProblems = [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, summary: 'Not attached: no listener matches its hosts', severity: 'warning' }] as never
+    const rows = problemRows(t, undefined, buildOrigins(t), 'apiserver')
+    expect(rows.map((r) => r.severity)).toEqual(['critical', 'warning'])
+    expect(rows[0].nodeId).toBe('n:Pod/store/shop-1')
+    expect(rows[1].nodeId).toBe('n:HTTPRoute/store/shop')
+  })
+
+  it('points at a fault only ANOTHER vantage saw, addressing its capsule', () => {
+    const t = base()
+    const r: RouteResult = {
+      route: 'shop', target: 'shop:80', outcome: 'reached', confidence: 'indirect',
+      byVantage: [
+        { vantage: 'in-cluster', path: 'data', source: 'probe-job', outcome: 'unreachable', confidence: 'real', evidence: 'connection refused' },
+      ],
+    } as never
+    t.routes = [r]
+    const rows = problemRows(t, r, buildOrigins(t), 'apiserver')
+    const ptr = rows.find((x) => x.scope === 'ANOTHER VANTAGE')
+    expect(ptr, 'a fault another vantage saw must not hide behind a click').toBeTruthy()
+    expect(ptr!.nodeId).toBe('origin:incluster')
+  })
+
+  it('says nothing when nothing is wrong', () => {
+    expect(problemRows(base(), undefined, buildOrigins(base()), 'apiserver')).toHaveLength(0)
+  })
+})

--- a/packages/k8s-ui/src/components/trace/problemRows.test.ts
+++ b/packages/k8s-ui/src/components/trace/problemRows.test.ts
@@ -75,3 +75,33 @@ describe('the header problem list', () => {
     expect(problemRows(t, buildOrigins(t), nodesOf(t))).toHaveLength(0)
   })
 })
+
+// One entry can carry several findings, and one origin several failed routes,
+// so a key built from the subject alone collides. React silently mis-renders or
+// drops rows on duplicate keys - which would hide a fault in the list whose
+// whole job is to surface faults.
+describe('every row can be told apart', () => {
+  it('gives two findings on ONE entry distinct keys, and keeps both rows', () => {
+    const t = base()
+    const ref = { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }
+    t.entryProblems = [
+      { resource: ref, summary: 'Not attached: no listener matches its hosts', severity: 'warning' },
+      { resource: ref, summary: 'Backend service port 8080 does not exist', severity: 'critical' },
+    ] as never
+    const rows = problemRows(t, buildOrigins(t), nodesOf(t))
+    expect(rows).toHaveLength(2)
+    expect(new Set(rows.map((r) => r.key)).size).toBe(2)
+  })
+
+  it('keeps keys unique across the whole list, whatever the mix', () => {
+    const t = base()
+    t.diagnosis = { summary: 'container is crashlooping', severity: 'critical' } as never
+    t.entryProblems = [
+      { resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, summary: 'Not attached', severity: 'warning' },
+      { resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, summary: 'Backend port missing', severity: 'warning' },
+    ] as never
+    const rows = problemRows(t, buildOrigins(t), nodesOf(t))
+    expect(rows.length).toBeGreaterThan(1)
+    expect(new Set(rows.map((r) => r.key)).size).toBe(rows.length)
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachGraphModel.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachGraphModel.test.ts
@@ -1405,3 +1405,19 @@ describe('an all-skipped origin never claims a network verdict', () => {
     expect(originNoEvidenceLabel({ id: 'incluster', mark: 'blocked', unavailable: 'image pull failed' } as never)).toBe('test couldn’t run')
   })
 })
+
+describe('entry-problem rows can address a graph node', () => {
+  it('the node id an EntryProblem resolves to matches the graph upstream node id', () => {
+    const t = {
+      subject: { kind: 'Service', name: 'shop', namespace: 'store' },
+      verdict: 'degraded', brokenAt: -1,
+      upstreams: [{ resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, edge: 'httproute->service', findings: [] }],
+      downstream: [{ resource: { kind: 'Service', name: 'shop', namespace: 'store' }, edge: 'service', findings: [] }],
+      routes: [{ route: 'shop', target: 'shop:80', outcome: 'reached', confidence: 'real' }],
+    } as never
+    const g = buildGraph({ trace: t, route: route({ target: 'shop:80', outcome: 'reached' }), origin: buildOrigins(t).find((o) => o.id === 'apiserver')! })
+    // Mirrors the id the EntryProblems row builds from EntryProblem.resource.
+    const fromProblem = 'n:HTTPRoute/store/shop'
+    expect(g.nodes.some((n) => n.id === fromProblem)).toBe(true)
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -710,3 +710,15 @@ describe('selecting a context entry opens it', () => {
     expect((s.context?.hops ?? []).every((h) => !h.expanded)).toBe(true)
   })
 })
+
+describe('a coverage statement is not a fault', () => {
+  it('the verdict keeps it on the wire but marks it coverage-class', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver' })])
+    t.diagnosis = { class: 'coverage', summary: "reachable via API server - the real-traffic path wasn't confirmed from here" } as never
+    // buildVerdict still surfaces it for consumers that want the sentence...
+    const v = buildVerdict(t, route({ outcome: 'reached', confidence: 'indirect' }), { originId: 'apiserver', originName: 'API-server proxy' })
+    expect(v.problem).toBeTruthy()
+    // ...and the class is what the header uses to keep it OUT of the problem list.
+    expect(t.diagnosis!.class).toBe('coverage')
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -270,9 +270,13 @@ describe('an in-cluster test that could not run says so first', () => {
 
   // The button moved to the vantage capsule in the graph, so the panel must not
   // offer a third copy of it - it keeps the reasoning instead.
-  it('offers no run button of its own', () => {
+  it('offers the run, disabled, with the reason attached', () => {
+    // The action lives WITH its explanation now, so it is present even when it
+    // cannot be taken - but never silently clickable into a guaranteed no-op.
     const s = buildSidebar(undefined, ctx(noRunnableRoute(), 'apiserver'))
-    expect(s.path.next.ctas.some((c) => c.action === 'run-in-cluster')).toBe(false)
+    const run = s.path.next.ctas.find((c) => c.action === 'run-in-cluster')
+    expect(run).toBeTruthy()
+    expect(run!.disabledReason).toMatch(/nothing to run|no path/i)
   })
 
   it('explains it in the body rather than promising stronger evidence', () => {
@@ -814,5 +818,37 @@ describe('every state explains itself, not the nearest generic sentence', () => 
   it('a verified answer is not described as a partial one', () => {
     const b = withRoute(route({ outcome: 'verified', confidence: 'real', evidence: 'HTTP 200 · verified' } as never))
     expect(b).toContain('A real request went through')
+  })
+})
+
+
+describe('the action sits with its explanation', () => {
+  it('an untested vantage offers the run, and does not repeat the sentence above it', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver' })])
+    const r = route({ outcome: 'not-tested', confidence: undefined, byVantage: undefined, inClusterRequest: { protocol: 'http', path: '/' } } as never)
+    t.routes = [r]
+    const s = buildSidebar(undefined, ctx(t, 'incluster', r)).path
+    expect(s.body).toContain('Nothing has been tested from here')
+    // the action is present...
+    expect(s.next.ctas.some((c) => c.action === 'run-in-cluster')).toBe(true)
+    // ...and the block does not say "nothing has been tested" a second time
+    expect(s.next.body).toBe('')
+  })
+
+  it('WHAT WE SAW disappears rather than echoing "no test has been run"', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver' })])
+    const r = route({ outcome: 'not-tested', confidence: undefined, byVantage: undefined } as never)
+    t.routes = [r]
+    const ev = buildSidebar(undefined, ctx(t, 'incluster', r)).path.evidence
+    expect(ev).toHaveLength(0)
+  })
+
+  it('a vantage that CANNOT be used still says why, instead of going silent', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [])
+    t.verdict = 'unknown'
+    t.routes = [route({ outcome: 'not-tested', confidence: undefined, byVantage: undefined } as never)]
+    t.downstream![0].probes = [p({ target: 'shop:80', port: 80, vantage: 'local', path: 'apiserver', skipped: true, reason: 'proxy said no', ok: false })]
+    const ev = buildSidebar(undefined, ctx(t, 'local', t.routes[0])).path.evidence
+    expect(ev.map((e) => e.text).join(' ')).toMatch(/no entry point|Ingress/i)
   })
 })

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -787,3 +787,32 @@ describe('a relayed answer explains the relay AND the answer', () => {
     expect(b).not.toContain('The path works')
   })
 })
+
+describe('every state explains itself, not the nearest generic sentence', () => {
+  const withRoute = (r: RouteResult, probes = [p({})]) => {
+    const t = mk([pod('a', true, '10.0.0.1')], probes)
+    t.routes = [r]
+    return buildSidebar(undefined, ctx(t, 'incluster', r)).path.body
+  }
+
+  it('a deliberately dormant path is not described as an answer', () => {
+    const b = withRoute(route({ outcome: 'unreachable', benign: true, evidence: 'no running backends (scaled to 0)' } as never))
+    expect(b).toContain('deliberate')
+    expect(b).not.toContain('not with what was asked for')
+  })
+
+  it('a kept-informational run says it ran AND why it does not decide', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [
+      p({ target: 'shop:80', port: 80, skipped: true, skipClass: 'informational', reason: 'the throwaway Pod was denied by mTLS', ok: false, source: 'probe-job' }),
+    ])
+    const r = route({ target: 'shop:80', outcome: 'not-tested', confidence: undefined, byVantage: undefined } as never)
+    t.routes = [r]
+    const b = buildSidebar(undefined, ctx(t, 'incluster', r)).path.body
+    expect(b + JSON.stringify(buildSidebar(undefined, ctx(t, 'incluster', r)).path.evidence)).toContain('denied by mTLS')
+  })
+
+  it('a verified answer is not described as a partial one', () => {
+    const b = withRoute(route({ outcome: 'verified', confidence: 'real', evidence: 'HTTP 200 · verified' } as never))
+    expect(b).toContain('A real request went through')
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -73,7 +73,9 @@ describe('the diagnosis is always present', () => {
     const s = buildSidebar(undefined, ctx(t, 'incluster'))
     expect(s.path.title).toBeTruthy()
     expect(s.path.evidence.length).toBeGreaterThan(0)
-    expect(s.path.next.header).toBeTruthy()
+    // The panel always answers the path question; a next-step block is offered
+    // only when there is genuinely a next step.
+    expect(s.path.body).toBeTruthy()
     expect(s.resource).toBeUndefined()
   })
 
@@ -223,10 +225,14 @@ describe('verdict band', () => {
     expect(s.path.next.header).toMatch(/run this next/i)
   })
 
-  it('says so plainly when nothing stronger can be run', () => {
+  it('offers nothing when nothing stronger can be run', () => {
+    // A resource-level "there is no more to learn" repeated on every vantage was
+    // scope mixing; the ceiling is stated with specifics in the caveats and the
+    // footer's coverage ledger instead.
     const t = mk([pod('a', true, '10.0.0.1')], [p({}), p({ path: 'apiserver' }), p({ vantage: 'local', path: 'data' })])
     const s = buildSidebar(undefined, ctx(t, 'incluster'))
-    expect(s.path.next.header).toMatch(/no stronger test/i)
+    expect(s.path.next.header).toBe('')
+    expect(s.path.next.ctas).toHaveLength(0)
   })
 
   it('falls back to the backend verdict when there is no route to derive a tone from', () => {
@@ -638,14 +644,13 @@ describe('a proxy-only failure never claims the target answered', () => {
   })
 })
 
-describe('the terminal "nothing to do" state is quiet', () => {
-  it('no call-to-action styling, no duplicate Re-run, no repeated ceiling caveat', () => {
+describe('nothing to suggest means nothing shown', () => {
+  it('renders no next-step block at all when there is no stronger test', () => {
     const t = mk([pod('a', true, '10.0.0.1')], [p({})])
     const s = buildSidebar(undefined, ctx(t, 'incluster'))
-    expect(s.path.next.quiet).toBe(true)
+    expect(s.path.next.header).toBe('')
+    expect(s.path.next.body).toBe('')
     expect(s.path.next.ctas).toHaveLength(0)
-    expect(s.path.next.body).toMatch(/strongest evidence/i)
-    expect(s.path.next.blocked).toBeUndefined()
   })
 })
 

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -678,3 +678,35 @@ describe('a result with no evidence string still reads as a result', () => {
     expect(texts.length).toBeGreaterThan(0)
   })
 })
+
+describe('selecting a context entry opens it', () => {
+  // The entry-problem row exists to answer "show me the cause". Landing on a
+  // still-collapsed section makes the reader spend a second click on the very
+  // thing they asked for - and it must hold for EVERY declared entry kind.
+  const withEntries = (): Trace => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver' })])
+    t.upstreams = [
+      { resource: { kind: 'Ingress', name: 'shop', namespace: 'store' }, edge: 'ingress->service', findings: [], config: { addresses: ['34.0.0.1'] } },
+      { resource: { kind: 'HTTPRoute', name: 'shop', namespace: 'store' }, edge: 'httproute->service', findings: [] },
+    ]
+    return t
+  }
+  for (const kind of ['Ingress', 'HTTPRoute']) {
+    it(`expands the selected ${kind}, and leaves its sibling collapsed`, () => {
+      const t = withEntries()
+      const c = ctx(t, 'apiserver')
+      const id = `n:${kind}/store/shop`
+      const s = buildSidebar(id, c)
+      const hops = s.context?.hops ?? []
+      expect(hops.length).toBeGreaterThan(0)
+      const picked = hops.find((h) => h.id === id)
+      expect(picked, `${kind} should be a context hop`).toBeTruthy()
+      expect(picked!.expanded).toBe(true)
+      expect(hops.filter((h) => h.id !== id).every((h) => !h.expanded)).toBe(true)
+    })
+  }
+  it('leaves every context hop collapsed when nothing is selected', () => {
+    const s = buildSidebar(undefined, ctx(withEntries(), 'apiserver'))
+    expect((s.context?.hops ?? []).every((h) => !h.expanded)).toBe(true)
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -797,6 +797,39 @@ describe('a relayed answer explains the relay AND the answer', () => {
   })
 })
 
+// An answer is not the same as an answer that got through. A gateway saying it
+// could not reach its upstream, and a handshake that never verified, are both
+// answers - and both mean the opposite of "the path works".
+describe('an answer that reports a break never reads as a success', () => {
+  const bodyFor = (r: Partial<RouteResult>) => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ tone: 'reached' } as never)])
+    const full = route({ outcome: 'server-error', confidence: 'real', inClusterRequest: { protocol: 'http', path: '/' }, ...r } as never)
+    t.routes = [full]
+    return buildSidebar(undefined, ctx(t, 'incluster', full)).path.body
+  }
+
+  for (const code of [502, 504]) {
+    it(`does not claim the path works on HTTP ${code}`, () => {
+      const b = bodyFor({ evidence: `HTTP ${code}`, failedLayer: 'upstream' } as never)
+      expect(b).not.toContain('The path works')
+      expect(b).toContain('could not reach the backend')
+    })
+  }
+
+  it('explains a certificate failure, which carries no status code at all', () => {
+    const b = bodyFor({ evidence: 'x509: certificate has expired', failedLayer: 'tls' } as never)
+    expect(b).not.toContain('The path works')
+    expect(b).toContain('certificate problem')
+    // The generic fallthrough would have said this instead, explaining nothing.
+    expect(b).not.toContain('not with what was asked for')
+  })
+
+  it('still credits the path when the APP itself answered', () => {
+    expect(bodyFor({ evidence: 'HTTP 404' } as never)).toContain('The path works')
+    expect(bodyFor({ evidence: 'HTTP 500' } as never)).toContain('The path works')
+  })
+})
+
 describe('every state explains itself, not the nearest generic sentence', () => {
   const withRoute = (r: RouteResult, probes = [p({})]) => {
     const t = mk([pod('a', true, '10.0.0.1')], probes)

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -738,3 +738,52 @@ describe('one observation is stated once', () => {
     expect(plain[0]).toContain('checked directly')
   })
 })
+
+describe('an answer is interpretable', () => {
+  const reached = (evidence: string): RouteResult =>
+    route({ outcome: 'reached', confidence: 'real', evidence, inClusterRequest: { protocol: 'http', scheme: 'http', path: '/' } } as never)
+  const body = (evidence: string) => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ tone: 'reached', detail: evidence })])
+    const r = reached(evidence)
+    t.routes = [r]
+    return buildSidebar(undefined, ctx(t, 'incluster', r)).path
+  }
+
+  it('a 404 says the PATH works and names what would verify a route', () => {
+    const b = body('HTTP 404 · reached').body
+    expect(b).toContain('path works')
+    expect(b).toContain('serves no route')
+    expect(b).toContain('re-run with a path your app serves')
+  })
+  it('auth, redirect and app-error answers are each read correctly', () => {
+    expect(body('HTTP 401 · reached').body).toContain('credentials')
+    expect(body('HTTP 308 · reached, redirect').body).toMatch(/redirect .*Radar does not follow/)
+    expect(body('HTTP 503 · reached, server error').body).toContain('application health')
+  })
+  it('a transport-only reach never claims something was asked', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ layer: 'tcp', ok: true })])
+    const r = route({ outcome: 'reached', confidence: 'real', evidence: '', inClusterRequest: { protocol: 'tcp' } } as never)
+    t.routes = [r]
+    expect(buildSidebar(undefined, ctx(t, 'incluster', r)).path.body).toContain('nothing was asked of the application')
+  })
+  it('shows WHAT was requested, so a status code can be read at all', () => {
+    expect(body('HTTP 404 · reached').scope.some((s) => s.k === 'REQUEST' && s.v === 'GET /')).toBe(true)
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ layer: 'tcp', ok: true })])
+    const r = route({ outcome: 'reached', confidence: 'real', inClusterRequest: { protocol: 'tcp' } } as never)
+    t.routes = [r]
+    expect(buildSidebar(undefined, ctx(t, 'incluster', r)).path.scope.some((s) => s.k === 'REQUEST' && s.v === 'TCP connect')).toBe(true)
+  })
+})
+
+describe('a relayed answer explains the relay AND the answer', () => {
+  it('keeps the relay caveat and still reads the status', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver', tone: 'reached', detail: 'HTTP 404 · reached' })])
+    const r = route({ outcome: 'reached', confidence: 'indirect', evidence: 'HTTP 404 · reached', inClusterRequest: { protocol: 'http', path: '/' } } as never)
+    t.routes = [r]
+    const b = buildSidebar(undefined, ctx(t, 'apiserver', r)).path.body
+    expect(b).toContain('relayed')
+    expect(b).toContain('serves no route')
+    // ...but never claims the real path works, because a relay cannot show that
+    expect(b).not.toContain('The path works')
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -722,3 +722,19 @@ describe('a coverage statement is not a fault', () => {
     expect(t.diagnosis!.class).toBe('coverage')
   })
 })
+
+describe('one observation is stated once', () => {
+  it('a localization fact does not repeat the route evidence it came from', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver', tone: 'reached', detail: 'HTTP 404 · reached' })])
+    const r = route({
+      outcome: 'reached', confidence: 'indirect', evidence: 'HTTP 404 · reached',
+      localization: [{ layer: 'http', ok: true, detail: 'HTTP 404 · reached' }],
+    } as never)
+    t.routes = [r]
+    const texts = buildSidebar(undefined, ctx(t, 'apiserver', r)).path.evidence.map((e) => e.text)
+    const plain = texts.filter((x) => x.toLowerCase().startsWith('http 404 · reached'))
+    expect(plain, `saw: ${JSON.stringify(texts)}`).toHaveLength(1)
+    // and the surviving line is the MORE specific one
+    expect(plain[0]).toContain('checked directly')
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -615,6 +615,8 @@ export function buildVerdict(
    *  route-scoped badge apart from the resource-wide headline beside it. */
   chipScope?: string
   scopeLabel?: string
+  /** The selected vantage's name - the viewing strip renders it. */
+  originName?: string
   title: string
   problem?: string
   body: string
@@ -651,6 +653,7 @@ export function buildVerdict(
       .filter(Boolean)
       .join(' · ') || undefined,
     scopeLabel: opts.pathLabel || opts.originName ? 'THIS RESOURCE' : undefined,
+    originName: opts.originName,
     // A stale screen previously led with the old headline ("Reachable...") and
     // then said underneath that the result was excluded. That is a contradiction,
     // not an exclusion.

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -45,7 +45,7 @@ export interface Sidebar {
     scope: { k: string; v: string }[]
     evidence: { mark: Mark; text: string }[]
     notProve: string[]
-    next: { header: string; body: string; blocked?: string; ctas: InspectorCTA[]; quiet?: boolean }
+    next: { header: string; body: string; blocked?: string; ctas: InspectorCTA[] }
   }
   /** Every hop on the selected path, in order - the whole story for this path
    *  seen from this vantage, rather than a summary plus whichever node was last
@@ -313,7 +313,20 @@ function requestLabel(route: RouteResult | undefined, httpPath?: string): string
  * routing, auth or health, which reachability does not judge. Say that, and say
  * what would turn it into a verified pass.
  */
-function statusMeaning(evidence?: string, httpPath?: string, failedLayer?: string): string | undefined {
+/**
+ * What an answer MEANS, and whether that answer is evidence the path works.
+ *
+ * `pathWorks` is the load-bearing half: an app answering 404 proves the journey
+ * reached it, while a gateway answering 502 proves the opposite. Both are
+ * "answers", so a caller that prefixes every meaning with "the path works"
+ * states the reverse of the truth on exactly the cases that matter most.
+ */
+function statusMeaning(evidence?: string, httpPath?: string, failedLayer?: string): { text: string; pathWorks: boolean } | undefined {
+  // A cert failure never gets an HTTP status - the handshake stops before a
+  // request is sent - so this must be decided before looking for a code.
+  if (failedLayer === 'tls') {
+    return { text: 'the TLS handshake did not verify - a certificate problem, not an application one.', pathWorks: false }
+  }
   const m = /HTTP\s+(\d{3})/i.exec(evidence ?? '')
   if (!m) return undefined
   const code = Number(m[1])
@@ -322,13 +335,23 @@ function statusMeaning(evidence?: string, httpPath?: string, failedLayer?: strin
   // upstream. The producer says so with failedLayer 'upstream'; blaming app
   // health here contradicted the chip beside it.
   if (failedLayer === 'upstream' || code === 502 || code === 504) {
-    return `the front door answered, but only to say it could not reach the backend (HTTP ${code}) - the break is between the entry and the app, not inside the app.`
+    return {
+      text: `the front door answered, but only to say it could not reach the backend (HTTP ${code}) - the break is between the entry and the app, not inside the app.`,
+      pathWorks: false,
+    }
   }
-  if (failedLayer === 'tls') return `the TLS handshake did not verify (HTTP ${code}) - a certificate problem, not an application one.`
-  if (code >= 500) return `the request reached the app and the app itself returned an error (HTTP ${code}) - application health, which this page does not judge.`
-  if (code === 401 || code === 403 || code === 407) return `the app answered by demanding credentials (HTTP ${code}) - it is enforcing auth, which is a different thing from reachability.`
-  if (code >= 300 && code < 400) return `the app answered with a redirect (HTTP ${code}), which Radar does not follow - so whatever it points at is untested from here.`
-  if (code >= 400) return `the app answered (HTTP ${code}) - that is it saying it serves no route for ${asked}, not a reachability problem. To verify a real route, re-run with a path your app serves.`
+  if (code >= 500) {
+    return { text: `the request reached the app and the app itself returned an error (HTTP ${code}) - application health, which this page does not judge.`, pathWorks: true }
+  }
+  if (code === 401 || code === 403 || code === 407) {
+    return { text: `the app answered by demanding credentials (HTTP ${code}) - it is enforcing auth, which is a different thing from reachability.`, pathWorks: true }
+  }
+  if (code >= 300 && code < 400) {
+    return { text: `the app answered with a redirect (HTTP ${code}), which Radar does not follow - so whatever it points at is untested from here.`, pathWorks: true }
+  }
+  if (code >= 400) {
+    return { text: `the app answered (HTTP ${code}) - that is it saying it serves no route for ${asked}, not a reachability problem. To verify a real route, re-run with a path your app serves.`, pathWorks: true }
+  }
   return undefined
 }
 
@@ -474,15 +497,19 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
   const rawDiagnosis = trace.diagnosis
   const diagnosis = rawDiagnosis && (!rawDiagnosis.route || rawDiagnosis.route === route?.route) ? rawDiagnosis : undefined
   const reachedSomething = !hasEvidence && !fromConfig && hopSeen.some((x) => x.ev.mark !== 'failed')
+  const answer = statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer)
   const body = basis === 'cluster-state'
     ? 'Nothing is ready to serve this path right now, so it cannot work from any vantage. No request was sent to establish that — it is read off the current state of the cluster, and it changes when the workload does.'
     : fromConfig
     ? 'The configuration itself is broken, so this path cannot work from any vantage. No request was sent to establish that — it is read off what is declared.'
     : reachedSomething
     ? 'This vantage did reach part of the path — see what it saw below. It has no result for this route as a whole, so the end-to-end journey from here is still unproven.'
-    : origin.mark === 'inconclusive'
+    : origin.mark === 'inconclusive' || mark === 'inconclusive'
     // A demoted run RAN and answered - it is only kept out of the verdict. The
     // "nothing has been tested" branch below fired first and denied it happened.
+    // Both the origin's mark and the route's own can carry the demotion, and the
+    // sentence is the same either way; the reason comes from the informational
+    // skip that recorded it, never from the route-scoped skip lookup.
     ? `The probe ran and got an answer, but it is kept as evidence rather than a verdict${
         originInformationalReason(trace, origin.id) ? `: ${originInformationalReason(trace, origin.id)}` : ''
       }. A throwaway identity cannot stand in for your application, so what it saw informs but never decides.`
@@ -501,7 +528,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
             'Kubernetes relayed a request and the target answered — which shows something is serving, not that the normal path works.',
             // The relay caveat alone leaves "404" unreadable: the reader still
             // cannot tell whether the answer itself was a problem.
-            statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer) && `As for the answer itself: ${statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer)}`,
+            answer && `As for the answer itself: ${answer.text}`,
           ]
             .filter(Boolean)
             .join(' ')
@@ -514,12 +541,6 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
               // endpoint). It fell through to the generic "answered" sentence,
               // which described a request that was never sent.
               ? `${asSeen?.evidence || 'Nothing is behind this path right now'} — that is deliberate, not a failure: nothing was sent, because there is nothing to reach.`
-            : mark === 'inconclusive'
-              // The probe RAN and answered; the answer was deliberately kept out
-              // of the verdict. The reason was collected and then never shown.
-              ? `The probe ran and got an answer, but it is kept as evidence rather than a verdict${
-                  originSkipReason(trace, origin.id, route) ? `: ${originSkipReason(trace, origin.id, route)}` : ''
-                }. A throwaway identity cannot stand in for your application, so what it saw informs but never decides.`
             : mark === 'running'
               ? 'A test is running. Earlier results stay until new ones replace them.'
               : // A proxy-only failure wears the same amber mark as a real answer,
@@ -527,10 +548,10 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
                 // the reader to debug an application response that never existed.
                 asSeen?.outcome === 'unreachable' && asSeen?.confidence === 'indirect'
                 ? 'The relayed dial failed. The proxy bypasses the real path, so this does not condemn it — but nothing answered, and the real path is still untested.'
-                : (() => {
-                  const meaning = statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer)
-                  return meaning ? `The path works: ${meaning}` : undefined
-                })() ??
+                : // Only an answer that proves the journey completed earns "the
+                  // path works" - a 502 or a failed handshake is an answer that
+                  // says the opposite.
+                  (answer ? (answer.pathWorks ? `The path works: ${answer.text}` : `The path did not work: ${answer.text}`) : undefined) ??
                 // A transport-only reach: nothing was asked of the application.
                 (asSeen?.outcome === 'reached'
                   ? 'The port accepted a connection, but nothing was asked of the application - the transport works and the application protocol is unverified.'

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -124,7 +124,7 @@ const NOT_DATAPLANE = 'Nothing about the normal network path. Kubernetes relayed
 const SYNTHETIC_IDENTITY =
   'That your app can reach it. This test ran from a throwaway Pod under the namespace’s default account with no token mounted — not as your application — so anything that checks who is calling may answer differently.'
 
-function originScope(o: Origin, trace: Trace): { k: string; v: string }[] {
+function originScope(o: Origin, trace: Trace, request?: string): { k: string; v: string }[] {
   const runsIn: Record<OriginId, string> = {
     incluster: `a throwaway Pod in ${trace.subject.namespace || 'the cluster'}`,
     'radar-incluster': 'Radar\u2019s own Pod',
@@ -141,6 +141,9 @@ function originScope(o: Origin, trace: Trace): { k: string; v: string }[] {
     // different facts and must not share a label.
     { k: o.id === 'local' ? 'NETWORK POSITION' : 'IDENTITY', v: o.identity },
     { k: 'MECHANISM', v: o.mech },
+    // A status code cannot be read without knowing what was asked for - "404"
+    // means nothing until you know the request was GET /.
+    ...(request ? [{ k: 'REQUEST', v: request }] : []),
   ]
 }
 
@@ -282,6 +285,38 @@ interface Ctx {
 function restatesTitle(summary: string | undefined, title: string): boolean {
   const norm = (x: string) => x.trim().toLowerCase().replace(/[.!]$/, '')
   return !!summary && !!title && norm(summary) === norm(title)
+}
+
+/** The request this route would send, in one line - "GET /healthz", or "TCP
+ *  connect" where there is no application request to make. */
+function requestLabel(route: RouteResult | undefined, httpPath?: string): string | undefined {
+  const r = route?.inClusterRequest
+  if (!r) return undefined
+  if (r.protocol === 'tcp') return 'TCP connect'
+  const path = httpPath || r.path || '/'
+  return `GET ${path}`
+}
+
+/**
+ * What an ANSWER means for this page's question.
+ *
+ * "reached" plus an HTTP status is the single most-misread result on the tab:
+ * a reader sees amber and 404 and cannot tell whether that is a problem. It is
+ * not - for the question this page asks. The network path is proven the moment
+ * the app answers at all; the status code is a statement about the app's own
+ * routing, auth or health, which reachability does not judge. Say that, and say
+ * what would turn it into a verified pass.
+ */
+function statusMeaning(evidence?: string, httpPath?: string): string | undefined {
+  const m = /HTTP\s+(\d{3})/i.exec(evidence ?? '')
+  if (!m) return undefined
+  const code = Number(m[1])
+  const asked = httpPath && httpPath !== '/' ? httpPath : '/'
+  if (code >= 500) return `the request reached the app and the app itself returned an error (HTTP ${code}) - application health, which this page does not judge.`
+  if (code === 401 || code === 403 || code === 407) return `the app answered by demanding credentials (HTTP ${code}) - it is enforcing auth, which is a different thing from reachability.`
+  if (code >= 300 && code < 400) return `the app answered with a redirect (HTTP ${code}), which Radar does not follow - so whatever it points at is untested from here.`
+  if (code >= 400) return `the app answered (HTTP ${code}) - that is it saying it serves no route for ${asked}, not a reachability problem. To verify a real route, re-run with a path your app serves.`
+  return undefined
 }
 
 /** The persistent diagnosis: did traffic get through, from where, and what next. */
@@ -439,7 +474,14 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     : mark === 'proved'
       ? 'A real request went through and the target answered.'
       : mark === 'proxied'
-        ? 'Kubernetes relayed a request and the target answered — which shows something is serving, not that the normal path works.'
+        ? [
+            'Kubernetes relayed a request and the target answered — which shows something is serving, not that the normal path works.',
+            // The relay caveat alone leaves "404" unreadable: the reader still
+            // cannot tell whether the answer itself was a problem.
+            statusMeaning(asSeen?.evidence, ctx.httpPath) && `As for the answer itself: ${statusMeaning(asSeen?.evidence, ctx.httpPath)}`,
+          ]
+            .filter(Boolean)
+            .join(' ')
         : mark === 'untested'
           ? 'Nothing has been tried from here yet. Configuration may look right, but that is intent, not proof.'
           : mark === 'stale'
@@ -451,7 +493,14 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
                 // the reader to debug an application response that never existed.
                 asSeen?.outcome === 'unreachable' && asSeen?.confidence === 'indirect'
                 ? 'The relayed dial failed. The proxy bypasses the real path, so this does not condemn it — but nothing answered, and the real path is still untested.'
-                : 'The target answered, but not with what was asked for.'
+                : (() => {
+                  const meaning = statusMeaning(asSeen?.evidence, ctx.httpPath)
+                  return meaning ? `The path works: ${meaning}` : undefined
+                })() ??
+                // A transport-only reach: nothing was asked of the application.
+                (asSeen?.outcome === 'reached'
+                  ? 'The port accepted a connection, but nothing was asked of the application - the transport works and the application protocol is unverified.'
+                  : 'The target answered, but not with what was asked for.')
 
   return {
     chipTone: asSeen ? routeTone(asSeen, { stale: ctx.stale, running: ctx.running }) : 'unknown',
@@ -459,7 +508,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     title: `${origin.name} → ${route?.target || trace.subject.name}`,
     request: route ? `${route.route}${ctx.httpPath && ctx.httpPath !== '/' ? ` · HTTP path ${ctx.httpPath}` : ''}` : undefined,
     body,
-    scope: [...originScope(origin, trace), ...(route ? [{ k: 'PATH', v: route.route }] : [])],
+    scope: [...originScope(origin, trace, requestLabel(route, ctx.httpPath)), ...(route ? [{ k: 'PATH', v: route.route }] : [])],
     evidence,
     notProve,
     next:

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -158,6 +158,7 @@ function gapNext(
   namespace?: string,
   multiPath?: boolean,
   inClusterRunnable = true,
+  canRun = true,
 ): Sidebar['path']['next'] {
   // The server can only test a route that carries a concrete in-cluster request.
   // When none does, the run fails with "not supported for this subject" - so the
@@ -168,10 +169,14 @@ function gapNext(
   // graph, which is the thing that would produce the missing evidence - and a
   // third copy of the same control (header, panel, capsule) was one too many.
   // The panel keeps the REASONING, which is what it is good at.
-  const inClusterCTA = (): InspectorCTA[] =>
-    inClusterRunnable
+  const inClusterCTA = (): InspectorCTA[] => {
+    // No handler wired (a library consumer that omits it) means the click would
+    // do nothing at all - offer nothing rather than a button that lies.
+    if (!canRun) return []
+    return inClusterRunnable
       ? [{ text: '⚗ Run the in-cluster test', action: 'run-in-cluster', primary: true }]
       : [{ text: '⚗ Run the in-cluster test', action: 'run-in-cluster', disabledReason: notRunnable }]
+  }
   const actionable = actionableGap(origins)
   const ceiling = strongestGap(origins)
   const ceilingNote = ceiling?.unsupported ? `Even then, ${ceiling.name.toLowerCase()} stays untested — ${ceiling.unavailable}` : undefined
@@ -214,17 +219,13 @@ function gapNext(
     }
   }
   if (!actionable) {
-    // Terminal state: there is nothing to do, and a call-to-action box whose
-    // message is "no action" shouts its own irrelevance. One quiet line of
-    // closure; no Re-run (the header already owns that control - the same
-    // one-copy rule as inClusterCTA), and no ceiling caveat (WHAT THIS
-    // DOESN'T PROVE states it on this same pane).
-    return {
-      header: 'NO STRONGER TEST AVAILABLE',
-      body: `This is the strongest evidence Radar can collect for this path.${allPaths}`,
-      ctas: [],
-      quiet: true,
-    }
+    // Nothing to offer: say nothing. This was a resource-level statement living
+    // in the selection-scoped panel, identical on every vantage - the scope
+    // mixing this redesign exists to remove - and the ceiling it gestured at is
+    // already stated, with specifics, in WHAT THIS DOESN'T PROVE and in the
+    // footer's coverage ledger. An empty section is the honest render of
+    // "there is no next step".
+    return { header: '', body: '', ctas: [] }
   }
   return {
     header: 'RUN THIS NEXT',
@@ -268,6 +269,9 @@ interface Ctx {
   multiPath?: boolean
   /** The HTTP path the run requests, as chosen in "what to test". */
   httpPath?: string
+  /** False when the host wired no in-cluster handler, or permission is denied:
+   *  the run must not be offered at all then. */
+  canRunInCluster?: boolean
 }
 
 /**
@@ -309,11 +313,18 @@ function requestLabel(route: RouteResult | undefined, httpPath?: string): string
  * routing, auth or health, which reachability does not judge. Say that, and say
  * what would turn it into a verified pass.
  */
-function statusMeaning(evidence?: string, httpPath?: string): string | undefined {
+function statusMeaning(evidence?: string, httpPath?: string, failedLayer?: string): string | undefined {
   const m = /HTTP\s+(\d{3})/i.exec(evidence ?? '')
   if (!m) return undefined
   const code = Number(m[1])
   const asked = httpPath && httpPath !== '/' ? httpPath : '/'
+  // 502/504 are NOT the app: a gateway answering that it could not reach its
+  // upstream. The producer says so with failedLayer 'upstream'; blaming app
+  // health here contradicted the chip beside it.
+  if (failedLayer === 'upstream' || code === 502 || code === 504) {
+    return `the front door answered, but only to say it could not reach the backend (HTTP ${code}) - the break is between the entry and the app, not inside the app.`
+  }
+  if (failedLayer === 'tls') return `the TLS handshake did not verify (HTTP ${code}) - a certificate problem, not an application one.`
   if (code >= 500) return `the request reached the app and the app itself returned an error (HTTP ${code}) - application health, which this page does not judge.`
   if (code === 401 || code === 403 || code === 407) return `the app answered by demanding credentials (HTTP ${code}) - it is enforcing auth, which is a different thing from reachability.`
   if (code >= 300 && code < 400) return `the app answered with a redirect (HTTP ${code}), which Radar does not follow - so whatever it points at is untested from here.`
@@ -490,7 +501,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
             'Kubernetes relayed a request and the target answered — which shows something is serving, not that the normal path works.',
             // The relay caveat alone leaves "404" unreadable: the reader still
             // cannot tell whether the answer itself was a problem.
-            statusMeaning(asSeen?.evidence, ctx.httpPath) && `As for the answer itself: ${statusMeaning(asSeen?.evidence, ctx.httpPath)}`,
+            statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer) && `As for the answer itself: ${statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer)}`,
           ]
             .filter(Boolean)
             .join(' ')
@@ -517,7 +528,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
                 asSeen?.outcome === 'unreachable' && asSeen?.confidence === 'indirect'
                 ? 'The relayed dial failed. The proxy bypasses the real path, so this does not condemn it — but nothing answered, and the real path is still untested.'
                 : (() => {
-                  const meaning = statusMeaning(asSeen?.evidence, ctx.httpPath)
+                  const meaning = statusMeaning(asSeen?.evidence, ctx.httpPath, asSeen?.failedLayer)
                   return meaning ? `The path works: ${meaning}` : undefined
                 })() ??
                 // A transport-only reach: nothing was asked of the application.
@@ -544,7 +555,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
               ...(diagnosis.command ? [{ text: 'Copy the command', action: 'copy-command' as InspectorAction, command: diagnosis.command }] : []),
             ],
           }
-        : gapNext(origins, origin, trace.subject.namespace, ctx.multiPath, traceInClusterRunnable(trace)),
+        : gapNext(origins, origin, trace.subject.namespace, ctx.multiPath, traceInClusterRunnable(trace), ctx.canRunInCluster !== false),
   }
 }
 

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -285,6 +285,10 @@ function restatesTitle(summary: string | undefined, title: string): boolean {
 }
 
 /** The persistent diagnosis: did traffic get through, from where, and what next. */
+/** The suffix the localization lines carry; stripped when deduping so one
+ *  observation cannot appear twice at two lengths. */
+const LOCALIZED_SUFFIX_RE = / [-\u2014] checked directly, past the entry point$/
+
 function pathSection(ctx: Ctx): Sidebar['path'] {
   const { trace, route, origin, origins } = ctx
   // The route outcome is merged across origins. Without this gate the panel
@@ -334,12 +338,23 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
   }
 
   const evidence: { mark: Mark; text: string }[] = []
-  const seen = new Set<string>()
+  const seen = new Map<string, number>()
+  // Two lines can be the SAME observation worded at different lengths: a route's
+  // rollup evidence and the localization fact from that same dial differ only by
+  // the " - checked directly..." suffix, so exact-string dedupe let both through
+  // and the reader saw "HTTP 404 - reached" twice. Key on the observation and
+  // keep the more specific wording.
   const add = (m: Mark, text: string) => {
-    const key = text.trim().toLowerCase()
-    if (!key || seen.has(key)) return
-    seen.add(key)
-    evidence.push({ mark: m, text })
+    const t = text.trim()
+    const key = t.toLowerCase().replace(LOCALIZED_SUFFIX_RE, '').trim()
+    if (!key) return
+    const at = seen.get(key)
+    if (at !== undefined) {
+      if (t.length > evidence[at].text.length) evidence[at] = { mark: evidence[at].mark, text: t }
+      return
+    }
+    seen.set(key, evidence.length)
+    evidence.push({ mark: m, text: t })
   }
   if ((hasEvidence || fromConfig) && asSeen?.evidence) add(mark, asSeen.evidence)
   // A result with no evidence STRING is still a result. Falling through to the

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -74,7 +74,7 @@ export interface HopDetail {
 /** Configured-but-bypassed resources, grouped under one label naming WHY they
  *  are outside this vantage's journey. Their config sections stay readable;
  *  their journey-state words do not apply. */
-function contextGroup(ctx: Ctx, byId: Map<string, GraphNode>): Sidebar['context'] {
+function contextGroup(ctx: Ctx, byId: Map<string, GraphNode>, sel: Selection): Sidebar['context'] {
   const nodes = (ctx.contextNodeIds ?? []).map((id) => byId.get(id)).filter((n): n is GraphNode => !!n)
   if (nodes.length === 0) return undefined
   const label =
@@ -85,12 +85,16 @@ function contextGroup(ctx: Ctx, byId: Map<string, GraphNode>): Sidebar['context'
         : 'PARALLEL ENTRY — NOT ON THIS ROUTE\u2019S PATH'
   return {
     label,
+    // Context hops are collapsed by default - they are not the journey. But the
+    // SELECTED one opens: the entry-problem row's whole purpose is "show me the
+    // cause", and landing on a still-collapsed section makes the reader spend a
+    // second click on the thing they just asked for.
     hops: nodes.map((n) => ({
       ...resourceSection(n),
       id: n.id,
       state: 'plain' as const,
       chipText: '',
-      expanded: false,
+      expanded: sel === n.id,
     })),
   }
 }
@@ -592,7 +596,7 @@ export function buildSidebar(sel: Selection, ctx: Ctx): Sidebar {
         expanded: sel ? n.id === sel : i === defaultOpen,
       }
     }),
-    context: contextGroup(ctx, byId),
+    context: contextGroup(ctx, byId, sel),
   }
 }
 

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -168,7 +168,10 @@ function gapNext(
   // graph, which is the thing that would produce the missing evidence - and a
   // third copy of the same control (header, panel, capsule) was one too many.
   // The panel keeps the REASONING, which is what it is good at.
-  const inClusterCTA = (): InspectorCTA[] => []
+  const inClusterCTA = (): InspectorCTA[] =>
+    inClusterRunnable
+      ? [{ text: '⚗ Run the in-cluster test', action: 'run-in-cluster', primary: true }]
+      : [{ text: '⚗ Run the in-cluster test', action: 'run-in-cluster', disabledReason: notRunnable }]
   const actionable = actionableGap(origins)
   const ceiling = strongestGap(origins)
   const ceilingNote = ceiling?.unsupported ? `Even then, ${ceiling.name.toLowerCase()} stays untested — ${ceiling.unavailable}` : undefined
@@ -201,13 +204,12 @@ function gapNext(
     }
   }
   if (actionable && actionable.id === current.id) {
-    // You are looking at the vantage that is itself the gap.
+    // You are looking at the vantage that is itself the gap. The section body
+    // already said nothing ran from here, and the caveats section already
+    // carries the ceiling - so this is the ACTION and nothing else.
     return {
-      header: 'RUN THIS NEXT',
-      body: inClusterRunnable
-        ? `Nothing has been tested from ${actionable.name} yet, and it is the strongest evidence Radar can still collect.${allPaths}`
-        : `${notRunnable} Every declared path here was skipped before a request could be formed.`,
-      blocked: ceilingNote,
+      header: '',
+      body: inClusterRunnable ? '' : `${notRunnable} Every declared path here was skipped before a request could be formed.`,
       ctas: actionable.id === 'incluster' ? inClusterCTA() : [{ text: '⟳ Re-run', action: 'run-probes' }],
     }
   }
@@ -392,9 +394,9 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     evidence.push({ mark: m, text: t })
   }
   if ((hasEvidence || fromConfig) && asSeen?.evidence) add(mark, asSeen.evidence)
-  // A result with no evidence STRING is still a result. Falling through to the
-  // "nothing ran" default below printed "no test has been run from here" beside
-  // a headline reporting what that very run found.
+  // A result with no evidence STRING is still a result: show what the mark
+  // means rather than leaving the section empty, which would read as "nothing
+  // ran" for a vantage that did.
   else if (hasEvidence && asSeen) add(mark, markHelp(mark))
   // What this vantage saw at each HOP. The route is built from the backend's
   // probes, so a laptop that dialled the front door and got an answer had all
@@ -450,7 +452,7 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
             : // A vantage that CANNOT be used states why (nothing dialable from
               // the laptop, a skipped mechanism) - "no test has been run" reads
               // as a test someone forgot, which is a different claim.
-              origin.unavailable || 'no test has been run from here'),
+              origin.unavailable || ''),
     )
   }
 

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -2,7 +2,7 @@ import type { Trace, RouteResult, ResourceRef } from './types'
 import type { Mark, SevTone } from './reachMarks'
 import { routeMark, routeChip, routeTone, routeAsSeenFrom, originRouteEvidence, routeForOrigin, traceInClusterRunnable, markHelp } from './reachMarks'
 import type { Origin, OriginId } from './reachOrigins'
-import { strongestGap, actionableGap, originSkipReason } from './reachOrigins'
+import { strongestGap, actionableGap, originSkipReason, originInformationalReason } from './reachOrigins'
 import { hopEvidenceFor, originProducedEvidence, type GraphNode } from './reachGraphModel'
 
 // 'run-probes' re-runs the reachability probes. It is deliberately NOT
@@ -432,12 +432,16 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     // has been run" - the capsule preserves the attempt and this row must not
     // erase it. The error itself is the observation.
     const attemptError = origin.id === 'incluster' && origin.mark === 'blocked' ? origin.unavailable : undefined
+    // A demoted run produced a real observation; "no test has been run from
+    // here" erased it.
+    const informational = origin.mark === 'inconclusive' ? originInformationalReason(trace, origin.id) : undefined
     add(
       mark,
       // The attempt error outranks skip rows: a prior Job's leftover skips
       // would otherwise paint a fresh failed run (image pull, quota) with last
       // run's reason, one pane from a capsule saying "test couldn't run".
-      attemptError ||
+      informational ||
+        attemptError ||
         skipReason ||
         (origin.unsupported
           ? 'Radar cannot test from here, so nothing has been learned this way'
@@ -463,6 +467,12 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
     ? 'The configuration itself is broken, so this path cannot work from any vantage. No request was sent to establish that — it is read off what is declared.'
     : reachedSomething
     ? 'This vantage did reach part of the path — see what it saw below. It has no result for this route as a whole, so the end-to-end journey from here is still unproven.'
+    : origin.mark === 'inconclusive'
+    // A demoted run RAN and answered - it is only kept out of the verdict. The
+    // "nothing has been tested" branch below fired first and denied it happened.
+    ? `The probe ran and got an answer, but it is kept as evidence rather than a verdict${
+        originInformationalReason(trace, origin.id) ? `: ${originInformationalReason(trace, origin.id)}` : ''
+      }. A throwaway identity cannot stand in for your application, so what it saw informs but never decides.`
     : !hasEvidence
     ? (origin.unavailable || 'Nothing has been tested from here, so this says nothing about whether traffic gets through.') +
       // When NOTHING was tested anywhere, the health dots are the only colour
@@ -486,6 +496,17 @@ function pathSection(ctx: Ctx): Sidebar['path'] {
           ? 'Nothing has been tried from here yet. Configuration may look right, but that is intent, not proof.'
           : mark === 'stale'
             ? 'This result predates a change to the cluster, so it is set aside rather than trusted.'
+            : mark === 'excluded'
+              // Benign by design (deliberately scaled to zero, a not-eligible
+              // endpoint). It fell through to the generic "answered" sentence,
+              // which described a request that was never sent.
+              ? `${asSeen?.evidence || 'Nothing is behind this path right now'} — that is deliberate, not a failure: nothing was sent, because there is nothing to reach.`
+            : mark === 'inconclusive'
+              // The probe RAN and answered; the answer was deliberately kept out
+              // of the verdict. The reason was collected and then never shown.
+              ? `The probe ran and got an answer, but it is kept as evidence rather than a verdict${
+                  originSkipReason(trace, origin.id, route) ? `: ${originSkipReason(trace, origin.id, route)}` : ''
+                }. A throwaway identity cannot stand in for your application, so what it saw informs but never decides.`
             : mark === 'running'
               ? 'A test is running. Earlier results stay until new ones replace them.'
               : // A proxy-only failure wears the same amber mark as a real answer,

--- a/packages/k8s-ui/src/components/trace/reachMarks.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachMarks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeMark, routeTone, routeChip, orderRoutes, scenariosFor, groupRoutes, vantageSignature, routeIdentity, isSlow, formatLatency, hostMatches, declaredHosts, routeHostOf, routeForOrigin, routeAsSeenFrom, originRouteEvidence, MARKS, edgeHelp, markHelp } from './reachMarks'
+import { routeMark, routeTone, routeChip, orderRoutes, scenariosFor, groupRoutes, vantageSignature, routeIdentity, isSlow, formatLatency, hostMatches, declaredHosts, routeHostOf, routeForOrigin, routeAsSeenFrom, originRouteEvidence, MARKS, edgeHelp, markHelp, edgeHelpIsRedundant } from './reachMarks'
 import type { RouteResult, Hop } from './types'
 
 const r = (o: Partial<RouteResult>): RouteResult => ({ route: 'GET /', outcome: 'verified', ...o })
@@ -681,5 +681,18 @@ describe('a structural line explains itself, not a test that never existed', () 
   it('anything actually observed keeps the mark vocabulary', () => {
     expect(edgeHelp('selects', 'proved')).toBe(markHelp('proved'))
     expect(edgeHelp('routes to', 'failed')).toBe(markHelp('failed'))
+  })
+})
+
+describe('the rest of the edge vocabulary', () => {
+  it('a collapsed sibling and an off-path backend say why, not "not tested"', () => {
+    expect(edgeHelp('also serves', 'config')).toContain('collapsed')
+    expect(edgeHelp('also serves', 'config')).not.toContain('not tested')
+    expect(edgeHelp('other host', 'excluded')).toContain('different host')
+  })
+  it("a line whose own label already says it does not say it twice", () => {
+    // origin edges are labelled with their evidence
+    expect(edgeHelpIsRedundant('not tested', '', 'untested')).toBe(true)
+    expect(edgeHelpIsRedundant('HTTP 404 · reached', '', 'proxied')).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/components/trace/reachMarks.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachMarks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeMark, routeTone, routeChip, orderRoutes, scenariosFor, groupRoutes, vantageSignature, routeIdentity, isSlow, formatLatency, hostMatches, declaredHosts, routeHostOf, routeForOrigin, routeAsSeenFrom, originRouteEvidence, MARKS } from './reachMarks'
+import { routeMark, routeTone, routeChip, orderRoutes, scenariosFor, groupRoutes, vantageSignature, routeIdentity, isSlow, formatLatency, hostMatches, declaredHosts, routeHostOf, routeForOrigin, routeAsSeenFrom, originRouteEvidence, MARKS, edgeHelp, markHelp } from './reachMarks'
 import type { RouteResult, Hop } from './types'
 
 const r = (o: Partial<RouteResult>): RouteResult => ({ route: 'GET /', outcome: 'verified', ...o })
@@ -663,5 +663,23 @@ describe('a preserved candidate is one gap, not two scenarios', () => {
       [{ route: 'other-svc:9090', reason: 'not reachable from here' }],
     )
     expect(s).toHaveLength(2)
+  })
+})
+
+describe('a structural line explains itself, not a test that never existed', () => {
+  it('ownership and selection never claim they were "not tested"', () => {
+    expect(edgeHelp('runs', 'config')).toContain('ownership')
+    expect(edgeHelp('runs', 'config')).not.toContain('not tested')
+    expect(edgeHelp('selects', 'config')).toContain('read from the cluster')
+    expect(edgeHelp('selects', 'config')).not.toContain('not tested')
+  })
+  it('declared routing says what WOULD exercise it', () => {
+    for (const l of ['routes to', 'sends to']) {
+      expect(edgeHelp(l, 'config')).toContain('request through this entry')
+    }
+  })
+  it('anything actually observed keeps the mark vocabulary', () => {
+    expect(edgeHelp('selects', 'proved')).toBe(markHelp('proved'))
+    expect(edgeHelp('routes to', 'failed')).toBe(markHelp('failed'))
   })
 })

--- a/packages/k8s-ui/src/components/trace/reachMarks.ts
+++ b/packages/k8s-ui/src/components/trace/reachMarks.ts
@@ -128,9 +128,27 @@ export function edgeHelp(label: string, mark: Mark): string {
       case 'routes to':
       case 'sends to':
         return 'declared routing - only a request through this entry exercises it'
+      case 'also serves':
+        return 'other backends this entry declares, collapsed here'
     }
   }
+  // Excluded-by-design, not a gap: this backend serves a different host, so no
+  // request for THIS path would ever go down it. "not sent any traffic" read as
+  // something we skipped.
+  if (mark === 'excluded' && label.trim().toLowerCase() === 'other host') {
+    return 'not part of this path - this backend serves a different host'
+  }
   return markHelp(mark)
+}
+
+/** Whether a line's own words already say what its mark would say. An origin
+ *  edge is labelled with its evidence ("not tested"), so appending the mark help
+ *  ("not tested from here") repeated it back at the reader. */
+export function edgeHelpIsRedundant(title: string, label: string, mark: Mark): boolean {
+  const t = title.trim().toLowerCase()
+  if (!t) return false
+  const help = edgeHelp(label, mark).toLowerCase()
+  return help.startsWith(t) || t.startsWith(help)
 }
 
 /** Inline style for a mark glyph. */

--- a/packages/k8s-ui/src/components/trace/reachMarks.ts
+++ b/packages/k8s-ui/src/components/trace/reachMarks.ts
@@ -107,6 +107,32 @@ export function markHelp(m: Mark): string {
   return MARK_LEGEND.find((l) => l.mark === m)?.text ?? m
 }
 
+/**
+ * What a LINE means, when the generic mark help would mislead.
+ *
+ * Structural edges are drawn `config` because nothing was dialled along them -
+ * but "not tested" then invites the reader to ask why we didn't, and the honest
+ * answer differs per edge: ownership is not a traffic hop at all, a selector is
+ * read from the cluster rather than proven by a request, and declared routing
+ * can only be exercised by a request that actually goes through that entry.
+ * Saying "not tested" for all three trains the reader to expect a test that in
+ * two of the cases does not exist.
+ */
+export function edgeHelp(label: string, mark: Mark): string {
+  if (mark === 'config') {
+    switch (label.trim().toLowerCase()) {
+      case 'runs':
+        return 'ownership, not a traffic hop - the workload owns these Pods'
+      case 'selects':
+        return 'read from the cluster - which Pods this Service selects'
+      case 'routes to':
+      case 'sends to':
+        return 'declared routing - only a request through this entry exercises it'
+    }
+  }
+  return markHelp(mark)
+}
+
 /** Inline style for a mark glyph. */
 export function glyphStyle(m: Mark): React.CSSProperties {
   return { color: markStyle(m).color, fontWeight: 700, fontSize: '12px', lineHeight: 1.1, flex: 'none' }

--- a/packages/k8s-ui/src/components/trace/reachOrigins.ts
+++ b/packages/k8s-ui/src/components/trace/reachOrigins.ts
@@ -194,6 +194,18 @@ export function originSkipReason(trace: Trace | undefined, originId: OriginId, r
 }
 
 /**
+ * Why this origin's run was kept informational. A demotion applies to the RUN,
+ * not to one backend, so this is origin-scoped rather than route-scoped: the
+ * route-scoped lookup asks which declared path a skip speaks for, which is the
+ * wrong question when the whole run was demoted.
+ */
+export function originInformationalReason(trace: Trace | undefined, originId: OriginId): string | undefined {
+  return allProbes(trace).find(
+    (p) => p.skipped && p.skipClass === 'informational' && !!p.reason && originOf(p, trace?.runVantage) === originId,
+  )?.reason
+}
+
+/**
  * Builds the origin rail for a trace.
  *
  * Order is by evidence strength, not by availability, so the gap between what

--- a/packages/k8s-ui/src/components/trace/types.ts
+++ b/packages/k8s-ui/src/components/trace/types.ts
@@ -254,6 +254,23 @@ export interface Trace {
    *  walking the hop chain. Absent when there is nothing to diagnose (every
    *  route verified over real traffic). */
   diagnosis?: Diagnosis
+  /** Faults on the DECLARED ENTRY POINTS (an Ingress or route that will never
+   *  receive traffic). Deliberately separate from `diagnosis`: entries are
+   *  parallel, so a dead front door must not condemn a Service that another
+   *  entry still serves - but a verdict scoped to the tested path cannot see it
+   *  either. Vantage-invariant; deduped against `diagnosis` by the producer. */
+  entryProblems?: EntryProblem[]
+}
+
+/** One declared entry point that cannot carry traffic, mirrors
+ *  internal/trace/trace.go EntryProblem. */
+export interface EntryProblem {
+  resource: ResourceRef
+  summary: string
+  severity: string
+  code?: string
+  action?: string
+  command?: string
 }
 
 /** Hoisted lead diagnosis, mirrors internal/trace/coverage.go Diagnosis. Every

--- a/packages/k8s-ui/src/components/trace/types.ts
+++ b/packages/k8s-ui/src/components/trace/types.ts
@@ -285,6 +285,8 @@ export interface Diagnosis {
    *  statement about what could be tested). The problem list renders faults
    *  only - a coverage sentence there restates the headline. */
   class?: string
+  /** Severity of the finding this was promoted from. */
+  severity?: string
   causeCode?: string
   /** Which route this diagnosis explains, when attributable to exactly one.
    *  Absent means it describes the resource as a whole. The selected-path panel

--- a/packages/k8s-ui/src/components/trace/types.ts
+++ b/packages/k8s-ui/src/components/trace/types.ts
@@ -266,7 +266,9 @@ export interface Trace {
  *  internal/trace/trace.go EntryProblem. */
 export interface EntryProblem {
   resource: ResourceRef
+  /** The human line; `detail` carries the raw controller cause for the hover. */
   summary: string
+  detail?: string
   severity: string
   code?: string
   action?: string

--- a/packages/k8s-ui/src/components/trace/types.ts
+++ b/packages/k8s-ui/src/components/trace/types.ts
@@ -281,6 +281,10 @@ export interface EntryProblem {
  *  fingerprints (missing-ref / svc:*); a pod-state code is omitted and summary
  *  carries the honest prose instead. */
 export interface Diagnosis {
+  /** "fault" (something wrong, promoted from a finding) or "coverage" (a
+   *  statement about what could be tested). The problem list renders faults
+   *  only - a coverage sentence there restates the headline. */
+  class?: string
   causeCode?: string
   /** Which route this diagnosis explains, when attributable to exactly one.
    *  Absent means it describes the resource as a whole. The selected-path panel

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -273,3 +273,38 @@
 @media (prefers-reduced-motion: reduce) {
   .reach-edge-testing { animation: none; }
 }
+
+/* reach-node-testing: the vantage a test is running FROM, while it runs.
+   The edge already shows the request travelling; the capsule it leaves from
+   stayed inert, so the source of the work looked as static as everything else.
+   A slow border breathe + a lifted surface says "this one is working" without
+   competing with the flowing edge. Semantic: only the running origin gets it. */
+@keyframes reach-node-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent); }
+  50% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent); }
+}
+.reach-node-testing {
+  animation: reach-node-breathe 1.6s ease-in-out infinite;
+}
+/* The running glyph turns, so the row reads as live even at a glance. */
+@keyframes reach-glyph-spin {
+  to { transform: rotate(360deg); }
+}
+.reach-glyph-testing {
+  display: inline-block;
+  animation: reach-glyph-spin 1.4s linear infinite;
+}
+/* The label itself pulses gently - "testing now" that never changes reads as
+   a stuck state on a long run. */
+@keyframes reach-label-fade {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.reach-label-testing {
+  animation: reach-label-fade 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .reach-node-testing,
+  .reach-glyph-testing,
+  .reach-label-testing { animation: none; }
+}

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -286,14 +286,6 @@
 .reach-node-testing {
   animation: reach-node-breathe 1.6s ease-in-out infinite;
 }
-/* The running glyph turns, so the row reads as live even at a glance. */
-@keyframes reach-glyph-spin {
-  to { transform: rotate(360deg); }
-}
-.reach-glyph-testing {
-  display: inline-block;
-  animation: reach-glyph-spin 1.4s linear infinite;
-}
 /* The label itself pulses gently - "testing now" that never changes reads as
    a stuck state on a long run. */
 @keyframes reach-label-fade {
@@ -305,6 +297,5 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .reach-node-testing,
-  .reach-glyph-testing,
   .reach-label-testing { animation: none; }
 }


### PR DESCRIPTION
## Summary

The Reachability header mixed two kinds of fact with nothing but 9px labels between them: a resource-wide headline that never moved, a vantage-scoped chip that changed on every click, and a diagnosis band that was resource-wide again. Select a different vantage and the header still talked about the API server while the chip beside it said "not tested" - and nothing told the reader which part had just changed, or why. Meanwhile a genuinely broken front door was visible only as an amber dot inside a graph node, under a header reading "reached" and a footer reading "0 failed".

This makes the split spatial, so it needs no label to learn, and surfaces the faults that a tested-path verdict structurally cannot see.

## What changed

**The header is the resource, and never changes on click.** The coverage headline, the work done, and one ranked problem list. Selecting a vantage or a path changes nothing in it - the rows derive from every route and every origin, never from the current selection.

**A VIEWING strip on the graph pane carries the selection** - path, vantage, and what that vantage saw - sitting on the board that changes, beside the picker that changes it. The inspector keeps the detail.

**One ranked problem list** replaces two competing bands. It merges the promoted fault with faults on declared entry points, and adds a pointer row for anything a vantage hit, so nothing is discoverable only by clicking the right capsule. Every row hovers to ring its subject on the board and clicks to focus it - resource nodes and vantage capsules alike - and a row can only address a node the graph actually draws.

**Entry faults are promoted honestly.** Warning+ findings on declared entries become `EntryProblems`, deliberately outside the `Diagnosis` ranking: entries are parallel, so a dead front door must never condemn a Service another entry still serves. A sibling backendRef's missing reference is excluded by the same scoping `computeVerdict` uses, and anything the diagnosis already states is deduped away.

**States explain themselves instead of borrowing the nearest sentence.** A demoted run says it ran and why it does not decide; a dormant path says the dormancy is deliberate; a structural line (`runs`, `selects`, `routes to`) says what it is rather than "not tested", which invited a question two of them can never answer. An answer is now readable, and only an answer that proves the journey completed reads as success: an app replying 404 shows the path works, while a gateway replying 502 or a handshake that never verified show the opposite, and each says which. `TEST DETAILS` shows the request that produced the answer, since a status code cannot be read without knowing what was asked.

**Less repetition.** One observation is stated once, the run action sits with the sentence that motivates it rather than a scroll below it, and the dead-end "no stronger test available" block is gone - it was a resource-level statement rendered per-vantage, while the ceiling it gestured at is already stated with specifics in the caveats and the footer's coverage ledger.

**A running test looks alive**: the vantage it runs from breathes and its label pulses, both off under `prefers-reduced-motion`.

## Notable decisions a reviewer should weigh

- `Diagnosis.Class` (`fault` | `coverage`): coverage statements stay on the wire for MCP consumers but never render as problems, because they restate a headline generated from the same coverage state. This keeps the agent contract intact while removing a fourth copy from the screen.
- `Diagnosis.Severity` carries the promoted finding's own severity, so the UI renders the weight the detector assigned instead of assuming critical. A route that was dialled and failed is stated as critical outright — a confirmed break must not render weaker than a predicted one.
- Pointer rows address `origin:<id>`; fault rows address `n:{kind}/{ns}/{name}`. The graph node-id contract is pinned by a test so the click target cannot silently drift.

## Testing

`go test ./internal/...`, `make tsc`, k8s-ui (1879) and web suites green. Verified live against a cluster with an unattached HTTPRoute: the header is byte-identical across vantage switches, the row rings and focuses the offending node, and both entry kinds expand when selected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI/trace contract changes (new JSON fields, diagnosis semantics) affect how every reachability result is read; risk is mitigated by extensive Go and Vitest coverage.
> 
> **Overview**
> **Reachability** splits **resource-wide** facts from **selection-scoped** ones: the header stays fixed (headline, probe stats, ranked problems) while a **VIEWING** strip on the graph shows path, vantage, and chip for the current selection.
> 
> The backend adds **`EntryProblems`** (upstream warning/critical findings, deduped from diagnosis and sibling missing-refs) and extends **`Diagnosis`** with **`class`** (`fault` | `coverage`) and **`severity`** so coverage lines stay on the wire for agents but drop out of the UI problem list; dialled route failures are **critical** faults.
> 
> The UI **`problemRows`** list merges diagnosis faults, entry problems, and **SEEN FROM** pointer rows (per-vantage failures), with hover-to-ring and click-to-focus on graph nodes or origin capsules. Inspector copy is tightened (HTTP status meaning, request in TEST DETAILS, deduped evidence, in-cluster CTA beside its reason) and structural graph edges get **`edgeHelp`** instead of generic “not tested.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb921c48737af647869d10a3b6c0f07140635a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

