### PR TITLE
Fix Event detail contrast in light mode (RAD-351)

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/EventRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/EventRenderer.test.tsx
@@ -1,0 +1,23 @@
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { EventRenderer } from './EventRenderer'
+
+describe('EventRenderer', () => {
+  it.each([
+    ['Warning', 'status-degraded'],
+    ['Normal', 'status-neutral'],
+  ])('uses the theme-aware status tone for %s events', (type, statusClass) => {
+    const html = renderToString(<EventRenderer data={{
+      type,
+      reason: 'FailedScheduling',
+      message: 'No nodes are available',
+    }} />)
+
+    expect(html).toContain(statusClass)
+    expect(html).toContain('FailedScheduling')
+    expect(html).toContain('No nodes are available')
+    expect(html).not.toMatch(/text-(?:amber|blue)-(?:200|300|400)/)
+    expect(html).not.toContain('opacity-')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/EventRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/EventRenderer.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Info, Clock, Target, Server, Hash } from 'lucide-react'
 import { clsx } from 'clsx'
+import { Badge } from '../../ui/Badge'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import type { NavigateToResource } from '../../../utils/navigation'
@@ -20,35 +21,29 @@ export function EventRenderer({ data, onNavigate }: EventRendererProps) {
   const source = data.source || {}
   const firstTimestamp = data.firstTimestamp
   const lastTimestamp = data.lastTimestamp || data.metadata?.creationTimestamp
+  const statusClass = isWarning ? 'status-degraded' : 'status-neutral'
+  const badgeSeverity = isWarning ? 'warning' : 'info'
 
   return (
     <>
       {/* Event Type Banner */}
       <div className={clsx(
         'mb-4 p-4 rounded-lg border',
-        isWarning
-          ? 'bg-amber-500/10 border-amber-500/30'
-          : 'bg-blue-500/10 border-blue-500/30'
+        statusClass,
       )}>
         <div className="flex items-start gap-3">
           {isWarning ? (
-            <AlertTriangle className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
+            <AlertTriangle className="w-5 h-5 mt-0.5 shrink-0" />
           ) : (
-            <Info className="w-5 h-5 text-blue-400 mt-0.5 shrink-0" />
+            <Info className="w-5 h-5 mt-0.5 shrink-0" />
           )}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <span className={clsx(
-                'badge',
-                isWarning ? 'bg-amber-500/20 text-amber-400' : 'bg-blue-500/20 text-blue-400'
-              )}>
+              <Badge severity={badgeSeverity}>
                 {eventType}
-              </span>
+              </Badge>
               {reason && (
-                <span className={clsx(
-                  'text-sm font-semibold',
-                  isWarning ? 'text-amber-300' : 'text-blue-300'
-                )}>
+                <span className="text-sm font-semibold">
                   {reason}
                 </span>
               )}
@@ -59,10 +54,7 @@ export function EventRenderer({ data, onNavigate }: EventRendererProps) {
               )}
             </div>
             {message && (
-              <p className={clsx(
-                'text-sm break-all',
-                isWarning ? 'text-amber-200/90' : 'text-blue-200/90'
-              )}>
+              <p className="text-sm break-all">
                 {message}
               </p>
             )}

--- a/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
@@ -23,7 +23,7 @@ const BASELINE = new Set<string>([
   'AlertRenderer.tsx', 'ArgoApplicationRenderer.tsx', 'CertificateRenderer.tsx',
   'CertificateRequestRenderer.tsx', 'ChallengeRenderer.tsx', 'CiliumNetworkPolicyRenderer.tsx',
   'ClusterExternalSecretRenderer.tsx', 'ClusterIssuerRenderer.tsx', 'ClusterNetworkPolicyRenderer.tsx',
-  'cnpg-cells.tsx', 'CNPGClusterRenderer.tsx', 'EventRenderer.tsx', 'GatewayRenderer.tsx',
+  'cnpg-cells.tsx', 'CNPGClusterRenderer.tsx', 'GatewayRenderer.tsx',
   'GenericRenderer.tsx', 'IngressClassRenderer.tsx', 'IstioPeerAuthenticationRenderer.tsx',
   'IstioServiceEntryRenderer.tsx', 'KarpenterNodeClaimRenderer.tsx', 'knative-cells.tsx',
   'KnativeEventingRenderer.tsx', 'KnativeRevisionRenderer.tsx', 'kyverno-cells.tsx',


### PR DESCRIPTION
## Summary

Event detail banners now use Radar's semantic status palette, making Warning and Normal event messages readable in both light and dark mode.

Linear: [RAD-351](https://linear.app/skyhook-io/issue/RAD-351/eventrenderer-is-unreadable-in-light-mode-dark-mode-first-amberblue)

## What changed

- Map Warning events to the degraded status tone and Normal events to the neutral tone.
- Use the canonical Badge component for the event type and inherit theme-aware banner colors for the icon, reason, and message.
- Add EventRenderer regression coverage and remove it from the hand-rolled badge-color baseline.

## Testing

- `make build`
- `make tsc`
- `make test`
- `npm test --workspace=@skyhook-io/k8s-ui -- EventRenderer.test.tsx badge-no-handrolled.test.tsx`
- Visual verification against a real Kubernetes cluster at 1920x1080 in both themes. Light-mode message contrast measured 6.37:1 for Warning and 5.17:1 for Normal, with no console errors.

## Visual verification

| Event | Light mode | Dark mode |
| --- | --- | --- |
| Warning | ![Warning event in light mode](https://uploads.linear.app/be499cef-c3e8-4139-b897-0b1b9dc7c840/7232e237-42fb-4d1e-8bb4-e3089139f268/50130b71-f13d-4b99-9c56-cacd2299a92a) | ![Warning event in dark mode](https://uploads.linear.app/be499cef-c3e8-4139-b897-0b1b9dc7c840/730c2cd3-c0ba-4795-9b10-b7d94300c8b3/1991e79a-27be-4dc8-8eda-e25be1559721) |
| Normal | ![Normal event in light mode](https://uploads.linear.app/be499cef-c3e8-4139-b897-0b1b9dc7c840/31d7c037-6c9c-4c90-8556-3d2f94afaf6a/ca34eace-421a-4628-83df-b4c873ab5d78) | ![Normal event in dark mode](https://uploads.linear.app/be499cef-c3e8-4139-b897-0b1b9dc7c840/24323102-a675-443e-bedf-f086c32c4e2c/c0596b7b-14c8-41d4-b55a-9911f44b5532) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/theming change in one resource renderer with regression tests; no auth, data, or API impact.
> 
> **Overview**
> **Event detail banners** now use Radar’s semantic status styling instead of fixed amber/blue Tailwind colors, so Warning and Normal events stay readable in light and dark themes.
> 
> Warning maps to `status-degraded` and Normal to `status-neutral`; the event type chip uses `<Badge severity={…}>` instead of hand-rolled `bg-*/text-*` classes. Reason and message text inherit theme-aware colors from the banner (no per-type text color classes).
> 
> Adds `EventRenderer` regression tests (status classes, no legacy amber/blue text utilities) and drops `EventRenderer.tsx` from the hand-rolled badge-color ratchet baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf54e29b0d1960837fd9f85bbbb25f9dd13ccfc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->