### PR TITLE
Use canonical Radar group names

### DIFF
--- a/deploy/helm/radar/templates/cloud-rbac-cluster-read.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-cluster-read.yaml
@@ -8,7 +8,7 @@ flow-control configuration). For a cluster-wide observability tool that means
 owners and viewers can't see core infrastructure or complete those checks. This
 add-on grants get/list/watch on infrastructure and list-only access to Upgrade
 impact evidence through EXPLICIT
-bindings to the cloud:* groups — deliberately NOT via `aggregate-to-view` labels,
+bindings to the radar:* groups — deliberately NOT via `aggregate-to-view` labels,
 which would widen the shared built-in `view`/`edit` roles cluster-wide for every
 other subject bound to them (mirrors the radar-helm add-on pattern).
 
@@ -29,7 +29,7 @@ Scoping — cluster-scoped read is its own axis, per tier:
     own that tier's RBAC entirely.
   - Want a DIFFERENT cluster-read set for a tier (e.g. Nodes but not PVs)? Don't
     fork this role: set clusterScopedRead.<tier>=false and bind your own ClusterRole
-    to the cloud:<tier> group. The cloud:* groups are injected by Cloud regardless,
+    to the radar:<tier> group. The radar:* groups are injected by Cloud regardless,
     so your binding composes with the built-in namespaced one.
 */}}
 {{- /*

--- a/deploy/helm/radar/templates/cloud-rbac-helm.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-helm.yaml
@@ -1,7 +1,9 @@
 {{- /*
-Bind Helm add-on ClusterRoles to cloud tiers. radar-helm goes to owner +
+Bind Helm add-on ClusterRoles to Radar tiers. radar-helm goes to owner +
 member; radar-helm-admin goes to owner only — see clusterrole-helm-admin.yaml
 for the rationale. Viewer is intentionally not bound; viewers never install.
+The cloud:* subjects below keep rolling hub and chart upgrades compatible
+until v2.
 
 Gating note: cloud.enabled is sufficient (matches sibling cloud-rbac.yaml
 and the upstream clusterrole-helm.yaml which uses
@@ -10,7 +12,7 @@ and the upstream clusterrole-helm.yaml which uses
 installs that set cloud.enabled=true but left auth.mode at the default —
 which is the shape produced by the cloud install wizard. The underlying
 ClusterRoles still rendered, so it looked like Helm RBAC was wired up
-when in fact cloud:owner/cloud:member groups had no path to them.
+when in fact radar:owner/radar:member groups had no path to them.
 Runtime forces --auth-mode=proxy via RADAR_CLOUD_MODE when cloud.enabled
 is set, so the bindings are always meaningful here regardless of the
 chart-values auth.mode.

--- a/deploy/helm/radar/templates/cloud-rbac.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac.yaml
@@ -4,20 +4,23 @@ when cloud.enabled=true and cloud.defaultRbac.create=true (the default).
 
 Cloud injects identity headers on every proxied request:
   X-Forwarded-User:   <workos user id>
-  X-Forwarded-Groups: cloud:<role>,cloud:org:<org_id>,cloud:user:<user_id>
+  X-Forwarded-Groups: radar:<role>,radar:org:<org_id>,radar:user:<user_id>
 
 Radar runs with --auth-mode=proxy under cloud-mode, so K8s sees the request
 as that impersonated identity and enforces RBAC on it. These bindings map
 the Cloud role tiers to standard K8s ClusterRoles:
 
-  cloud:owner   → K8s "admin" role (namespace-everything, no cluster-scoped writes)
-  cloud:member  → K8s "edit" role (read+write on standard resources, no RBAC)
-  cloud:viewer  → K8s "view" role (read-only)
+  radar:owner   → K8s "admin" role (namespace-everything, no cluster-scoped writes)
+  radar:member  → K8s "edit" role (read+write on standard resources, no RBAC)
+  radar:viewer  → K8s "view" role (read-only)
 
 Cluster operators can disable any of these (set cloud.defaultRbac.<role>=false)
 and author their own bindings — e.g., per-namespace RoleBindings, or bindings
-for cloud:user:<id> groups to grant individuals extra access. Set
+for radar:user:<id> groups to grant individuals extra access. Set
 cloud.defaultRbac.ownerClusterRole=cluster-admin to grant cluster-wide admin.
+
+Each binding also includes its pre-rename cloud:* subject so rolling hub and
+chart upgrades remain compatible. Remove those subjects in v2.
 */}}
 {{- if and .Values.cloud.enabled .Values.cloud.defaultRbac.create -}}
 {{- if .Values.cloud.defaultRbac.owner -}}
@@ -32,8 +35,6 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.cloud.defaultRbac.ownerClusterRole }}
 subjects:
-  # radar:* is the canonical group vocabulary; the cloud:* subject is the
-  # pre-rename legacy kept for older hubs during the deprecation window.
   - kind: Group
     name: radar:owner
     apiGroup: rbac.authorization.k8s.io
@@ -54,8 +55,6 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.cloud.defaultRbac.memberClusterRole }}
 subjects:
-  # radar:* is the canonical group vocabulary; the cloud:* subject is the
-  # pre-rename legacy kept for older hubs during the deprecation window.
   - kind: Group
     name: radar:member
     apiGroup: rbac.authorization.k8s.io
@@ -76,8 +75,6 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.cloud.defaultRbac.viewerClusterRole }}
 subjects:
-  # radar:* is the canonical group vocabulary; the cloud:* subject is the
-  # pre-rename legacy kept for older hubs during the deprecation window.
   - kind: Group
     name: radar:viewer
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/radar/templates/clusterrole-helm-admin.yaml
+++ b/deploy/helm/radar/templates/clusterrole-helm-admin.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Cluster-admin-equivalent add-on ClusterRole. Emitted under the same gate as
-radar-helm but bound only to cloud:owner — never cloud:member.
+radar-helm but bound only to radar:owner — never radar:member.
 
 The verbs in this role are individually sufficient for self-promotion to
 cluster-admin or for bypassing admission control:

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -368,8 +368,8 @@ cloud:
   insecureSkipVerify: false
   # Default ClusterRoleBindings for Radar Cloud identity groups.
   #
-  # How it works: Cloud injects X-Forwarded-Groups: cloud:<role>,
-  # cloud:org:<id>, cloud:user:<id> on every proxied request. Radar
+  # How it works: Cloud injects X-Forwarded-Groups: radar:<role>,
+  # radar:org:<id>, radar:user:<id> on every proxied request. Radar
   # impersonates that identity against the K8s API on EVERY user-initiated
   # call (REST, MCP, Helm reads and writes, workload logs, node ops, pod
   # file browse, CAPI kubeconfig), so K8s RBAC enforces the tier — no
@@ -378,17 +378,17 @@ cloud:
   # Defaults map Cloud's tiers onto standard K8s ClusterRoles. These are
   # ClusterRoleBindings (not namespace-scoped RoleBindings), so the grant
   # applies in EVERY namespace:
-  #   cloud:owner   → "admin"  (full read+write in every namespace, including
+  #   radar:owner   → "admin"  (full read+write in every namespace, including
   #                            RBAC within namespaces; no writes on cluster-
   #                            scoped resources like Nodes, CRDs, ClusterRoles)
-  #   cloud:member  → "edit"   (read+write on standard resources, no RBAC)
-  #   cloud:viewer  → "view"   (read-only)
+  #   radar:member  → "edit"   (read+write on standard resources, no RBAC)
+  #   radar:viewer  → "view"   (read-only)
   #
   # These are starting-point grants, not "fallbacks that kick in when the
   # user has nothing else" — K8s RBAC is strictly ADDITIVE. Operator bindings
   # stack on top of ours, they can't override or deny. To tighten a tier,
   # set its boolean below to false (suppresses our binding) and author your
-  # own. To give an individual user extra access, bind cloud:user:<id> to
+  # own. To give an individual user extra access, bind radar:user:<id> to
   # an extra Role/ClusterRole — it will union with their tier's permissions.
   # To loosen owner, set ownerClusterRole=cluster-admin.
   defaultRbac:
@@ -426,7 +426,7 @@ cloud:
     # Independent of *ClusterRole above: a custom namespaced role does NOT
     # disable cluster-read (they're separate bindings). Want a tier to read a
     # DIFFERENT cluster-scoped set (e.g. Nodes but not PVs)? Set its flag false
-    # and bind your own ClusterRole to the cloud:<tier> group — the cloud:*
+    # and bind your own ClusterRole to the radar:<tier> group — the radar:*
     # groups exist regardless of this chart, so your binding composes cleanly.
     clusterScopedRead:
       viewer: true

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -213,7 +213,7 @@ If you see `RADAR_CLOUD_MODE` or `cloud.*` values in the chart, they control a s
 Under cloud-mode (`RADAR_CLOUD_MODE=true`, set automatically by the chart when `cloud.enabled=true`), Radar:
 
 - Forces `--auth-mode=proxy` with pinned `X-Forwarded-User` / `X-Forwarded-Groups` headers. Radar accepts those headers only on requests marked in-process by its authenticated Cloud tunnel; the ordinary pod TCP listener cannot assert Cloud identity.
-- Ships three default ClusterRoleBindings mapping Cloud's `radar:owner` / `radar:member` / `radar:viewer` groups (canonical; the legacy `cloud:*` equivalents are still emitted and bound during the deprecation window) to the standard K8s `admin` / `edit` / `view` ClusterRoles. Configurable via `cloud.defaultRbac.*` in `values.yaml`.
+- Ships three default ClusterRoleBindings mapping Cloud's `radar:owner` / `radar:member` / `radar:viewer` groups to the standard K8s `admin` / `edit` / `view` ClusterRoles. Configurable via `cloud.defaultRbac.*` in `values.yaml`.
 - Adds a **cluster-read add-on** (`cloud.defaultRbac.clusterScopedRead.{viewer,member,owner}`, each default on) granting `get/list/watch` on infrastructure the built-in `view`/`edit`/`admin` roles exclude — Nodes, PersistentVolumes, StorageClasses, IngressClasses, PriorityClasses, RuntimeClasses, CRDs, and admission webhook configurations — plus list-only Upgrade impact source evidence for CSIStorageCapacities, legacy PodSecurityPolicies, and API flow-control configuration. When the matching collection is enabled, it also grants APIServices, PrometheusRules, Karpenter kinds, and node metrics. It does not grant Secrets, RBAC objects, API-server metrics, or kubelet proxy access. It's an independent axis per tier: set a tier `false` to make it namespaced-only (e.g. `clusterScopedRead.viewer: false`). Owner node cordon/drain is a separate cluster-scoped *write*, off by default (`cloud.defaultRbac.nodeOps`).
 - Restricts the ordinary pod/ClusterIP TCP listener to `/api/health`; the full handler is served only over yamux streams from the outbound Cloud tunnel. Cloud mode also omits `/debug/pprof/*` and narrows auth exemptions to health only.
 
@@ -222,10 +222,10 @@ Under cloud-mode (`RADAR_CLOUD_MODE=true`, set automatically by the chart when `
 
 **Helm-specific bindings (when `rbac.helm=true`).** Helm's pre-flight existence check needs cluster-scoped reads/writes that the K8s built-in `admin`/`edit`/`view` ClusterRoles don't grant. The chart emits two add-on ClusterRoles, split by trust tier:
 
-- `radar-helm` — CRDs, StorageClasses, RuntimeClasses, PriorityClasses, PodDisruptionBudgets, Namespaces. Bound to `cloud:owner` AND `cloud:member`.
-- `radar-helm-admin` — RBAC objects (Roles/Bindings, Cluster variants), validating/mutating webhooks, ApiServices. Bound to `cloud:owner` ONLY. Granting these to a tier weaker than owner would let a member self-promote to cluster-admin in one `ClusterRoleBinding` write, collapsing the owner/member distinction.
+- `radar-helm` — CRDs, StorageClasses, RuntimeClasses, PriorityClasses, PodDisruptionBudgets, Namespaces. Bound to `radar:owner` AND `radar:member`.
+- `radar-helm-admin` — RBAC objects (Roles/Bindings, Cluster variants), validating/mutating webhooks, ApiServices. Bound to `radar:owner` ONLY. Granting these to a tier weaker than owner would let a member self-promote to cluster-admin in one `ClusterRoleBinding` write, collapsing the owner/member distinction.
 
-A `cloud:member` attempting to install a chart that bundles its own RBAC will get a typed `rbac_preflight` 403 with an actionable "ask an owner" message. Day-to-day app charts and operator-CRD installs still work for members.
+A `radar:member` attempting to install a chart that bundles its own RBAC will get a typed `rbac_preflight` 403 with an actionable "ask an owner" message. Day-to-day app charts and operator-CRD installs still work for members.
 
 Customer-facing documentation for Radar Cloud lives on [radarhq.io](https://radarhq.io). The authoritative reference for the Cloud-mode chart values is the comment block in [`deploy/helm/radar/values.yaml`](../deploy/helm/radar/values.yaml) under `cloud:`.
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -215,13 +215,13 @@ func TestMiddleware_CloudProxyHeadersOverrideSessionWithoutSettingCookie(t *test
 	handler := cloud.AuthenticatedTunnelHandler(Authenticate(cfg)(http.HandlerFunc(echoUser)))
 
 	cookie := CreateSessionCookie(
-		&User{Username: "stale-user", Groups: []string{"cloud:owner"}},
+		&User{Username: "stale-user", Groups: []string{"radar:owner"}},
 		NewSessionID(), "", cfg.Secret, cfg.CookieTTL, false,
 	)[0]
 	req := httptest.NewRequest(http.MethodGet, "/api/topology", nil)
 	req.AddCookie(cookie)
 	req.Header.Set(cfg.UserHeader, "current-user")
-	req.Header.Set(cfg.GroupsHeader, "cloud:viewer, cloud:org:org-1")
+	req.Header.Set(cfg.GroupsHeader, "radar:viewer, radar:org:org-1")
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -236,7 +236,7 @@ func TestMiddleware_CloudProxyHeadersOverrideSessionWithoutSettingCookie(t *test
 	if got.Username != "current-user" {
 		t.Fatalf("username = %q, want current Hub header identity", got.Username)
 	}
-	if len(got.Groups) != 2 || got.Groups[0] != "cloud:viewer" || got.Groups[1] != "cloud:org:org-1" {
+	if len(got.Groups) != 2 || got.Groups[0] != "radar:viewer" || got.Groups[1] != "radar:org:org-1" {
 		t.Fatalf("groups = %v, want current Hub header groups", got.Groups)
 	}
 	if values := rec.Header().Values("Set-Cookie"); len(values) != 0 {
@@ -271,7 +271,7 @@ func TestMiddleware_CloudProxyRejectsSpoofedHeadersOutsideTunnel(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/topology", nil)
 	req.Header.Set(cfg.UserHeader, "attacker")
-	req.Header.Set(cfg.GroupsHeader, "cloud:owner")
+	req.Header.Set(cfg.GroupsHeader, "radar:owner")
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/internal/cloudinstall/adoption_preflight_test.go
+++ b/internal/cloudinstall/adoption_preflight_test.go
@@ -77,7 +77,7 @@ roleRef:
   name: admin
 subjects:
 - kind: Group
-  name: cloud:owner
+  name: radar:owner
   apiGroup: rbac.authorization.k8s.io
 `
 
@@ -205,7 +205,7 @@ roleRef:
   name: admin
 subjects:
 - kind: Group
-  name: cloud:owner
+  name: radar:owner
   apiGroup: rbac.authorization.k8s.io`,
 			live: []*unstructured.Unstructured{
 				adoptionObject("v1", "ConfigMap", "radar", "radar-config", nil),

--- a/internal/cloudinstall/fresh_preflight_test.go
+++ b/internal/cloudinstall/fresh_preflight_test.go
@@ -43,7 +43,7 @@ roleRef:
   name: admin
 subjects:
 - kind: Group
-  name: cloud:owner
+  name: radar:owner
   apiGroup: rbac.authorization.k8s.io
 `
 

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -181,7 +181,7 @@ func (h *Handlers) handleGetRelease(w http.ResponseWriter, r *http.Request) {
 
 // handleGetManifest returns the rendered manifest for a release.
 // Member+ only — manifests can inline literal Secret resources with
-// base64-encoded data, which K8s 'view' (the default cloud:viewer
+// base64-encoded data, which K8s 'view' (the default radar:viewer
 // binding) excludes.
 func (h *Handlers) handleGetManifest(w http.ResponseWriter, r *http.Request) {
 	if !requireCloudRole(w, r, auth.RoleMember, "view Helm release manifests") {

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -32,22 +32,22 @@ func TestRequireCloudRole(t *testing.T) {
 		// CloudRole is RoleNone, AtLeast bypasses. This is permissive
 		// by design — the assumption is that radar-hub guarantees the
 		// role group when forwarding.
-		{name: "user without cloud:* — bypass", groups: []string{"developers"}, min: auth.RoleOwner, wantOK: true},
+		{name: "user without radar:* — bypass", groups: []string{"developers"}, min: auth.RoleOwner, wantOK: true},
 
 		// Cloud-attributed users — gate enforces.
-		{name: "viewer denied member-required op", groups: []string{"cloud:viewer"}, min: auth.RoleMember,
+		{name: "viewer denied member-required op", groups: []string{"radar:viewer"}, min: auth.RoleMember,
 			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
-		{name: "viewer denied owner-required op", groups: []string{"cloud:viewer"}, min: auth.RoleOwner,
+		{name: "viewer denied owner-required op", groups: []string{"radar:viewer"}, min: auth.RoleOwner,
 			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
-		{name: "viewer allowed viewer-required op", groups: []string{"cloud:viewer"}, min: auth.RoleViewer, wantOK: true},
-		{name: "member allowed member-required op", groups: []string{"cloud:member"}, min: auth.RoleMember, wantOK: true},
-		{name: "member denied owner-required op", groups: []string{"cloud:member"}, min: auth.RoleOwner,
+		{name: "viewer allowed viewer-required op", groups: []string{"radar:viewer"}, min: auth.RoleViewer, wantOK: true},
+		{name: "member allowed member-required op", groups: []string{"radar:member"}, min: auth.RoleMember, wantOK: true},
+		{name: "member denied owner-required op", groups: []string{"radar:member"}, min: auth.RoleOwner,
 			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
-		{name: "owner allowed owner-required op", groups: []string{"cloud:owner"}, min: auth.RoleOwner, wantOK: true},
+		{name: "owner allowed owner-required op", groups: []string{"radar:owner"}, min: auth.RoleOwner, wantOK: true},
 
 		// Defensive: a stuffed lower tier alongside owner shouldn't
 		// downgrade the user. CloudRoleFromGroups picks the highest.
-		{name: "stuffed viewer + owner — allowed", groups: []string{"cloud:viewer", "cloud:owner"}, min: auth.RoleOwner, wantOK: true},
+		{name: "stuffed viewer + owner — allowed", groups: []string{"radar:viewer", "radar:owner"}, min: auth.RoleOwner, wantOK: true},
 	}
 
 	for _, tc := range cases {
@@ -174,7 +174,7 @@ func TestSensitiveHelmHandlers_GateOnViewer(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "/test", nil)
 			req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{
 				Username: "viewer-test",
-				Groups:   []string{"cloud:viewer"},
+				Groups:   []string{"radar:viewer"},
 			}))
 			rec := httptest.NewRecorder()
 

--- a/internal/k8s/context_client_test.go
+++ b/internal/k8s/context_client_test.go
@@ -35,7 +35,7 @@ func swapGlobals(t *testing.T, cfg *rest.Config) {
 func TestClientFromContext_Impersonation(t *testing.T) {
 	swapGlobals(t, &rest.Config{Host: "https://example.invalid"})
 
-	user := &pkgauth.User{Username: "alice", Groups: []string{"cloud:owner"}}
+	user := &pkgauth.User{Username: "alice", Groups: []string{"radar:owner"}}
 	ctx := pkgauth.ContextWithUser(context.Background(), user)
 
 	client := ClientFromContext(ctx)
@@ -51,8 +51,8 @@ func TestClientFromContext_Impersonation(t *testing.T) {
 	if cfg.Impersonate.UserName != "alice" {
 		t.Errorf("Impersonate.UserName = %q, want %q", cfg.Impersonate.UserName, "alice")
 	}
-	if len(cfg.Impersonate.Groups) != 1 || cfg.Impersonate.Groups[0] != "cloud:owner" {
-		t.Errorf("Impersonate.Groups = %v, want [cloud:owner]", cfg.Impersonate.Groups)
+	if len(cfg.Impersonate.Groups) != 1 || cfg.Impersonate.Groups[0] != "radar:owner" {
+		t.Errorf("Impersonate.Groups = %v, want [radar:owner]", cfg.Impersonate.Groups)
 	}
 }
 
@@ -86,7 +86,7 @@ func TestConfigSnapshotKeepsContextAndConfigTogether(t *testing.T) {
 func TestClientFromContext_ImpersonationFailureReturnsNil(t *testing.T) {
 	swapGlobals(t, nil) // no base config
 
-	user := &pkgauth.User{Username: "alice", Groups: []string{"cloud:viewer"}}
+	user := &pkgauth.User{Username: "alice", Groups: []string{"radar:viewer"}}
 	ctx := pkgauth.ContextWithUser(context.Background(), user)
 
 	if client := ClientFromContext(ctx); client != nil {
@@ -120,7 +120,7 @@ func TestClientFromContext_TypedNilGuard(t *testing.T) {
 func TestDynamicClientFromContext_Impersonation(t *testing.T) {
 	swapGlobals(t, &rest.Config{Host: "https://example.invalid"})
 
-	user := &pkgauth.User{Username: "alice", Groups: []string{"cloud:owner"}}
+	user := &pkgauth.User{Username: "alice", Groups: []string{"radar:owner"}}
 	ctx := pkgauth.ContextWithUser(context.Background(), user)
 
 	if client := DynamicClientFromContext(ctx); client == nil {
@@ -138,7 +138,7 @@ func TestDynamicClientFromContext_Impersonation(t *testing.T) {
 func TestDynamicClientFromContext_FailsClosedOnNoConfig(t *testing.T) {
 	swapGlobals(t, nil)
 
-	user := &pkgauth.User{Username: "alice", Groups: []string{"cloud:viewer"}}
+	user := &pkgauth.User{Username: "alice", Groups: []string{"radar:viewer"}}
 	ctx := pkgauth.ContextWithUser(context.Background(), user)
 
 	if client := DynamicClientFromContext(ctx); client != nil {

--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -35,7 +35,7 @@ type CertExpiry = topology.CertExpiry
 // lives in pkg/certs so the hub stays a thin pivot.
 //
 // Read pattern mirrors handleListPackages: the ServiceAccount-backed cache
-// performs the read (so cert hygiene survives cloud:viewer, whose K8s `view`
+// performs the read (so cert hygiene survives radar:viewer, whose K8s `view`
 // role excludes secrets), but the response is post-filtered to the caller's
 // RBAC-allowed namespaces. Only public certificate metadata (issuer / domains
 // / expiry) is emitted — never tls.key. A cluster without cert-manager simply

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -361,7 +361,7 @@ func computePackagesInternal(ctx context.Context, namespaces []string) ([]packag
 
 	// Helm releases (source H). Inventory reads pass empty user/groups
 	// so the SA does the read — see deploy/helm/radar/templates/clusterrole.yaml
-	// for the secrets-rule rationale (cloud:viewer → K8s `view` excludes
+	// for the secrets-rule rationale (radar:viewer → K8s `view` excludes
 	// secrets, so impersonating would 403 viewers on inventory metadata
 	// that isn't credential data). Sensitive Helm reads (GetValues,
 	// GetManifest) and all writes still impersonate.

--- a/internal/server/reachability_run.go
+++ b/internal/server/reachability_run.go
@@ -68,7 +68,7 @@ func (s *Server) handleProbeInClusterCapability(w http.ResponseWriter, r *http.R
 	}
 	// The POST gate is additive: K8s RBAC AND the Cloud-role tier (Member). Mirror
 	// the Cloud-role half here (without the 403) so the capability answer matches
-	// what the POST will actually do - a cloud:viewer with the right RBAC must not
+	// what the POST will actually do - a radar:viewer with the right RBAC must not
 	// see allowed=true and then get a 403 cloud_role_insufficient on submit.
 	if !auth.CloudRoleFromContext(r.Context()).AtLeast(auth.RoleMember) {
 		resp.Reason = "your Radar Cloud role cannot run an in-cluster reachability test"

--- a/internal/server/reachability_run_test.go
+++ b/internal/server/reachability_run_test.go
@@ -172,7 +172,7 @@ func TestTraceInClusterDoesNotLeakExistenceAcrossNamespaces(t *testing.T) {
 	rctx.URLParams.Add("namespace", "ns-b")
 	rctx.URLParams.Add("name", "secret-svc")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	req = req.WithContext(auth.ContextWithUser(req.Context(), userWithGroups("cloud:member")))
+	req = req.WithContext(auth.ContextWithUser(req.Context(), userWithGroups("radar:member")))
 	rec := httptest.NewRecorder()
 
 	s.handleTraceInCluster(rec, req)

--- a/internal/server/selfupgrade_test.go
+++ b/internal/server/selfupgrade_test.go
@@ -29,7 +29,7 @@ func TestSelfUpgradeRequiresCloudOwner(t *testing.T) {
 	t.Setenv("MY_POD_NAMESPACE", "")
 	t.Setenv("MY_DEPLOYMENT_NAME", "")
 
-	for _, tier := range []string{"cloud:viewer", "cloud:member", "cloud:unknown", ""} {
+	for _, tier := range []string{"radar:viewer", "radar:member", "radar:unknown", ""} {
 		t.Run(tier, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/api/agent/self-upgrade", strings.NewReader(`{"image":"ghcr.io/skyhook-io/radar:1.9.0"}`))
 			req = req.WithContext(auth.ContextWithUser(req.Context(), userWithGroups(tier)))
@@ -93,7 +93,7 @@ func TestSelfUpgradeCloudOwnerPassesRoleGate(t *testing.T) {
 	t.Setenv("MY_POD_NAMESPACE", "")
 	t.Setenv("MY_DEPLOYMENT_NAME", "")
 	req := httptest.NewRequest(http.MethodPost, "/api/agent/self-upgrade", strings.NewReader(`{"image":"ghcr.io/skyhook-io/radar:1.9.0"}`))
-	req = req.WithContext(auth.ContextWithUser(req.Context(), userWithGroups("cloud:owner")))
+	req = req.WithContext(auth.ContextWithUser(req.Context(), userWithGroups("radar:owner")))
 	rec := httptest.NewRecorder()
 
 	(&Server{}).handleSelfUpgrade(rec, req)

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -101,7 +101,7 @@ func TestHandleAuthMe_CloudUser_ExposesCloudRole(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := requestWithUser("GET", "/api/auth/me", &auth.User{
 		Username: "bob",
-		Groups:   []string{"cloud:viewer", "cloud:org:abc"},
+		Groups:   []string{"radar:viewer", "radar:org:abc"},
 	})
 	s.handleAuthMe(w, r)
 

--- a/internal/server/server_listener_test.go
+++ b/internal/server/server_listener_test.go
@@ -28,7 +28,7 @@ func TestLocalTCPHandlerCloudModeExposesExactHealthOnly(t *testing.T) {
 		t.Run(tc.path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			req.Header.Set("X-Forwarded-User", "attacker")
-			req.Header.Set("X-Forwarded-Groups", "cloud:owner")
+			req.Header.Set("X-Forwarded-Groups", "radar:owner")
 			rec := httptest.NewRecorder()
 
 			handler.ServeHTTP(rec, req)

--- a/internal/server/settings_role_test.go
+++ b/internal/server/settings_role_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // userWithGroups builds an authenticated user carrying the given groups, used
-// to drive the Cloud-role gate (cloud:<tier> prefix).
+// to drive the Cloud-role gate (radar:<tier> prefix).
 func userWithGroups(groups ...string) *auth.User {
 	return &auth.User{Username: "u@example.com", Groups: groups}
 }
@@ -35,7 +35,7 @@ func putConfigStatus(t *testing.T, user *auth.User) (int, string) {
 func TestPutConfig_RoleGate(t *testing.T) {
 	// Non-owner Cloud roles are rejected with the stable error_code so the
 	// frontend can branch on it.
-	for _, tier := range []string{"cloud:viewer", "cloud:member"} {
+	for _, tier := range []string{"radar:viewer", "radar:member"} {
 		code, body := putConfigStatus(t, userWithGroups(tier))
 		if code != http.StatusForbidden {
 			t.Errorf("%s: status = %d, want 403; body=%s", tier, code, body)
@@ -59,7 +59,7 @@ func TestPutConfig_OwnerAndOSSBypassRoleGate(t *testing.T) {
 		name string
 		user *auth.User
 	}{
-		{"owner", userWithGroups("cloud:owner")},
+		{"owner", userWithGroups("radar:owner")},
 		{"no-role-groups", userWithGroups("devs")},
 		{"no-user", nil},
 	}

--- a/pkg/auth/cloud_role_test.go
+++ b/pkg/auth/cloud_role_test.go
@@ -33,20 +33,20 @@ func TestCloudRoleFromGroups(t *testing.T) {
 		want   CloudRole
 	}{
 		{"empty groups", nil, RoleNone},
-		{"no cloud prefix", []string{"developers", "sre"}, RoleNone},
-		{"viewer", []string{"cloud:viewer"}, RoleViewer},
-		{"member", []string{"cloud:member"}, RoleMember},
-		{"owner", []string{"cloud:owner"}, RoleOwner},
-		{"unknown cloud tier", []string{"cloud:superuser"}, RoleNone},
-		{"viewer + non-cloud", []string{"cloud:viewer", "team:platform"}, RoleViewer},
-		// Cloud injects multiple cloud:* groups (cloud:<tier>, cloud:org:<id>,
-		// cloud:user:<id>). Only the tier should drive the role.
-		{"multiple cloud groups", []string{"cloud:viewer", "cloud:org:abc", "cloud:user:xyz"}, RoleViewer},
+		{"no Radar prefix", []string{"developers", "sre"}, RoleNone},
+		{"viewer", []string{"radar:viewer"}, RoleViewer},
+		{"member", []string{"radar:member"}, RoleMember},
+		{"owner", []string{"radar:owner"}, RoleOwner},
+		{"unknown Radar tier", []string{"radar:superuser"}, RoleNone},
+		{"viewer + unrelated group", []string{"radar:viewer", "team:platform"}, RoleViewer},
+		// Cloud injects multiple radar:* groups (radar:<tier>, radar:org:<id>,
+		// radar:user:<id>). Only the tier should drive the role.
+		{"multiple Radar groups", []string{"radar:viewer", "radar:org:abc", "radar:user:xyz"}, RoleViewer},
 		// If two tiers are present (shouldn't happen in practice), prefer
 		// the highest. Defensive: a header-stuffing attempt to downgrade
 		// shouldn't succeed by adding a lower-tier alongside.
-		{"two tiers — pick highest", []string{"cloud:viewer", "cloud:owner"}, RoleOwner},
-		{"member + viewer", []string{"cloud:member", "cloud:viewer"}, RoleMember},
+		{"two tiers — pick highest", []string{"radar:viewer", "radar:owner"}, RoleOwner},
+		{"member + viewer", []string{"radar:member", "radar:viewer"}, RoleMember},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestCloudRoleFromContext(t *testing.T) {
 	t.Run("user with Cloud groups", func(t *testing.T) {
 		ctx := ContextWithUser(context.Background(), &User{
 			Username: "alice",
-			Groups:   []string{"cloud:member", "cloud:org:abc"},
+			Groups:   []string{"radar:member", "radar:org:abc"},
 		})
 		if got := CloudRoleFromContext(ctx); got != RoleMember {
 			t.Errorf("CloudRoleFromContext = %q, want member", got)
@@ -107,7 +107,7 @@ func TestCloudRoleFromContext(t *testing.T) {
 			Groups:   []string{"sre", "platform-team"},
 		})
 		if got := CloudRoleFromContext(ctx); got != RoleNone {
-			t.Errorf("CloudRoleFromContext = %q, want RoleNone (no cloud: prefix)", got)
+			t.Errorf("CloudRoleFromContext = %q, want RoleNone (no radar: prefix)", got)
 		}
 	})
 }

--- a/pkg/auth/identity_filter.go
+++ b/pkg/auth/identity_filter.go
@@ -22,7 +22,7 @@ var reservedPrincipalPrefixes = []string{
 
 // IsReservedPrincipal reports whether a username or group falls in a reserved
 // Kubernetes namespace. Matched as an exact leading prefix so Radar's own
-// namespaced synthetic principals (e.g. "cloud:system:alerts:…") are
+// namespaced synthetic principals (e.g. "radar:system:alerts:…") are
 // unaffected — only leading "system:" is reserved.
 func IsReservedPrincipal(principal string) bool {
 	for _, p := range reservedPrincipalPrefixes {
@@ -79,7 +79,7 @@ func ForwardedIdentityAllowed(username string, groups []string, cloudMode bool) 
 // isCloudUsername reports whether a username is one the Radar Cloud control
 // plane legitimately injects: the opaque per-user id the hub sets as
 // X-Forwarded-User, or an internal synthetic principal namespaced under
-// "cloud:system:". The hub never forwards a K8s-reserved username, so
+// "radar:system:". The hub never forwards a K8s-reserved username, so
 // rejecting reserved is the meaningful check; the opaque WorkOS id has no
 // fixed prefix to match beyond "non-empty and not reserved".
 func isCloudUsername(username string) bool {

--- a/pkg/auth/identity_filter_test.go
+++ b/pkg/auth/identity_filter_test.go
@@ -28,7 +28,7 @@ func TestForwardedIdentityAllowed(t *testing.T) {
 		{"cloud: radar:email allowed", "user_01ABC", []string{"radar:email:a@b.com"}, true, true},
 		{"cloud: non-vocabulary group rejected", "user_01ABC", []string{"radar:owner", "sre-team"}, true, false},
 		{"cloud: empty username rejected", "", []string{"radar:owner"}, true, false},
-		{"cloud: internal synthetic username allowed", "cloud:system:alerts:o1", []string{"radar:owner"}, true, true},
+		{"cloud mode internal synthetic username allowed", "radar:system:alerts:o1", []string{"radar:owner"}, true, true},
 		{"cloud: no groups, valid user, allowed", "user_01ABC", nil, true, true},
 	}
 	for _, tc := range cases {
@@ -50,7 +50,7 @@ func TestIsReservedPrincipal(t *testing.T) {
 		}
 	}
 	// Radar's own namespaced synthetic principals must NOT be treated as reserved.
-	notReserved := []string{"cloud:system:alerts:o1", "cloud:system", "radar:owner", "alice@company.com", "sre-team", ""}
+	notReserved := []string{"radar:system:alerts:o1", "radar:system", "radar:owner", "alice@company.com", "sre-team", ""}
 	for _, p := range notReserved {
 		if IsReservedPrincipal(p) {
 			t.Errorf("IsReservedPrincipal(%q) = true, want false", p)


### PR DESCRIPTION
Summary:
- use radar:* in chart guidance, docs, comments, and normal test fixtures
- retain cloud:* only in compatibility bindings and explicit compatibility tests

Testing:
- go test for changed auth, Helm, Kubernetes, cloud-install, and server packages
- ./scripts/test-chart.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster RBAC bindings and Cloud identity group naming; dual subjects limit breakage, but mismatched hub/chart versions or custom bindings keyed only on `cloud:*` could cause authorization gaps until aligned.
> 
> **Overview**
> Renames Radar Cloud’s **canonical** forwarded identity vocabulary from `cloud:*` to `radar:*` (`radar:owner` / `radar:member` / `radar:viewer`, plus `radar:org:*` and `radar:user:*` in docs and chart comments).
> 
> Helm **ClusterRoleBindings** now bind both `radar:<tier>` and the legacy `cloud:<tier>` subject on default Cloud RBAC, cluster-scoped read, and Helm add-on roles so rolling hub/chart upgrades keep working until v2. Comments and `values.yaml` describe the new header shape; synthetic principals move from `cloud:system:` to `radar:system:` in identity-filter docs/tests.
> 
> Tests, cloud-install preflight fixtures, and inline comments across auth, Helm, and server packages use `radar:*` as the normal case; compatibility tests still cover legacy `cloud:*` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85b6596fc7a38d663f4ff147b62f3317c95a065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->