### PR TITLE
docs: correct three claims the published site inherits

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -393,7 +393,7 @@ When auth is enabled:
 - The **namespace selector** only shows namespaces the user can access
 - **Topology, resources, events, dashboard** are filtered to accessible namespaces
 - **Cluster-scoped resources** (Nodes, PersistentVolumes, StorageClasses) are gated per-kind via `SubjectAccessReview` — a user sees them only if their own RBAC permits listing that kind, independent of namespace access
-- **Helm releases** are visible to all authenticated users (reads use the ServiceAccount, not impersonation, because the K8s `view` role doesn't include `list secrets` which Helm requires). Write operations (install, upgrade, rollback, uninstall) are impersonated and require the user to have appropriate RBAC.
+- **Helm releases** are read with the user's own identity, like everything else. Helm stores releases as Secrets, so a user sees a release only where their RBAC grants `list secrets` in the storage namespace — and the K8s built-in `view` role deliberately does not. Radar resolves the namespaces the user can actually read release storage in and lists only there, returning 403 when there are none. Write operations (install, upgrade, rollback, uninstall) are impersonated and need the matching RBAC.
 - **Write buttons** (restart, scale, exec, Helm install, etc.) only appear if the user has permission
 - Write operations return **403** from K8s if RBAC denies them (shown as an error toast)
 - The **/api/auth/me** endpoint returns the current user info and whether auth is enabled

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,8 +184,8 @@ To connect a cluster from the command line, use `radar cloud install`
 
 ### What Radar sends
 
-Radar makes exactly two outbound requests, both to Skyhook, neither containing
-cluster data:
+Until you connect a cluster to Cloud, Radar makes exactly two outbound
+requests, both to Skyhook, neither containing cluster data:
 
 - **Update check** — periodically, to `releases.skyhook.io`, with the Radar
   version, OS/arch, install method, and whether it's running locally or
@@ -194,8 +194,14 @@ cluster data:
   current terms shown in it. No identifiers are sent. `RADAR_CLOUD_FUNNEL=off`
   stops this request from ever happening.
 
-Your cluster's data is never sent anywhere. Radar talks to your Kubernetes API
-directly and keeps everything it reads on your machine.
+A standalone Radar sends your cluster's data nowhere: it talks to your
+Kubernetes API directly and keeps everything it reads on your machine.
+
+Connecting a cluster to Cloud is what changes that, and it is the point of
+connecting — the cluster's agent opens an outbound tunnel to the Hub so the
+team can reach the same views without each person holding kubeconfig access.
+Deciding whether to connect is a separate question from the two requests
+above, which happen either way.
 
 ## Related Documentation
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -552,7 +552,7 @@ See the main [README](../README.md#gitops) for the user-facing overview. This se
 - **Operation-failure parser** recognizes 11 patterns: annotation-too-large, label-too-long, hook failure, admission webhook denial, RBAC, conflict, immutable field, schema migration, connectivity, etc.
 
 **Limitations**:
-- SSA-applied resources (`ServerSideApply=true` sync-option) lack the `last-applied-configuration` annotation; per-resource diff is unavailable for those rows. SSA fallback via `metadata.managedFields` and Argo API integration for canonical Git-rendered diffs are tracked in [#601](https://github.com/skyhook-io/radar/issues/601).
+- SSA-applied resources (`ServerSideApply=true` sync-option) lack the `last-applied-configuration` annotation, so the local diff described above is unavailable for those rows. Configuring the [Argo CD API integration](gitops.md#argo-cd-api-integration-deep-diff) covers them: Radar then asks argocd-server for the Git-rendered desired state and diffs against that, which is canonical rather than annotation-derived. An annotation-free local fallback via `metadata.managedFields` is still tracked in [#601](https://github.com/skyhook-io/radar/issues/601).
 - Single-cluster only: Application↔resource edges only render when Radar is connected to the cluster where the managed resources live (not necessarily the cluster running the Argo controller).
 
 ---


### PR DESCRIPTION
## Summary

`docs/*.md` is the source for docs.skyhook.io, so a wrong sentence here is published. Three were, and all three are contradicted by the code in this repo. Found while reviewing the first end-to-end run of the docs sync (skyhook-dev/radar-docs#74), which is blocked on these.

## The corrections

**Helm reads are impersonated.** `docs/authentication.md` said releases are "visible to all authenticated users (reads use the ServiceAccount, not impersonation)". `internal/helm/handlers.go` passes `userCreds(r)` into `ListReleasesAcrossNamespaces`, and `internal/server/packages.go` documents that an *empty* username is what selects the SA path. The doc described Radar as leakier than it is — the worst direction for an access-control claim.

**The Argo CD API deep-diff is shipped.** `docs/integrations.md` listed it under Limitations as "tracked in #601", alongside the genuinely-unbuilt `managedFields` fallback. It has routes (`PUT /api/integrations/argocd`, `GET /api/argo/applications/{ns}/{name}/resource-diff`) and its own section in `docs/gitops.md`. It is also the answer to the limitation that paragraph is about — SSA-applied resources — so burying it there hid the fix from the reader who most needs it.

**The privacy claims needed scoping.** "Radar makes exactly two outbound requests" and "your cluster's data is never sent anywhere" sit inside the Radar Cloud section, directly beneath the `radar cloud install` instructions. Both are true of a standalone Radar and false once a cluster is connected. Each now states which case it describes, and connecting is explained plainly instead of being contradicted a paragraph later.

## Not changed, deliberately

The docs site's older GitOps table carried a `Bucket` row and a `Fleet` column. Neither survives checking: `Bucket` appears nowhere in the topology or GitOps code, and the fleet view discovers all nine GitOps kinds rather than the subset the old column implied. Restoring them would republish claims the code doesn't support.

## Testing

Documentation only. Every claim above was verified against the referenced source files; the new `gitops.md` cross-reference resolves to an existing heading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to published user-facing pages; no runtime or security behavior changes.
> 
> **Overview**
> Published docs are updated so they match current behavior instead of overstating or understating access and features.
> 
> **`authentication.md`** replaces the claim that Helm release **reads** use the ServiceAccount with the actual model: reads run as the authenticated user, releases are backed by Secrets, listing is limited to namespaces where the user can `list secrets` (403 when none), and writes stay impersonated.
> 
> **`integrations.md`** moves the shipped **Argo CD API deep-diff** out of a “Limitations / #601” bullet and points readers at `gitops.md#argo-cd-api-integration-deep-diff` as the fix for SSA apps without `last-applied-configuration`; the `managedFields` fallback remains tracked in #601.
> 
> **`configuration.md`** scopes Radar Cloud copy: the “two Skyhook outbound requests” and “cluster data stays local” statements apply **until** a cluster is connected; connecting via the Hub tunnel is described as the intentional change to that model, separate from the always-on update-check/dialog requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d083eb21bfc58c2abf402c5492d9c0f1b8df11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->