### PR TITLE
Report what kubectl reports, and stop claiming healthy on in-flight work

### DIFF
--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -749,29 +749,19 @@ export function getContainerSquareStates(pod: any): ContainerSquareState[] {
 // WORKLOAD UTILITIES (Deployment, StatefulSet, DaemonSet, ReplicaSet)
 // ============================================================================
 
-/** How long a freshly created workload may take to converge before we grade it.
- *  Mirrors pkg/health.workloadConvergenceGrace. */
-const CONVERGENCE_GRACE_MS = 5 * 60 * 1000
-
 /**
- * Whether a workload has not yet had a fair chance to reach its target. Two
- * ways that happens: the controller has not observed the current spec
- * generation yet (which is what covers scale-ups on long-lived workloads,
- * where the creation timestamp is months old but the target moved a second
- * ago), or the object was created inside the grace window.
+ * Whether the controller has not yet acted on this workload's current spec, so
+ * grading against that spec would report controller lag as an outage. The
+ * scale-up case: spec says 10, the controller is still working from the previous
+ * generation and has created 3.
  *
- * Mirrors pkg/health.converging — keep the two in step.
+ * Deliberately NOT age-based — "created recently" guesses wrong exactly when a
+ * deploy is broken on arrival. Mirrors pkg/health.converging; keep in step.
  */
 function isConverging(resource: any): boolean {
   const generation = resource?.metadata?.generation
   const observed = resource?.status?.observedGeneration
-  if (typeof generation === 'number' && typeof observed === 'number' && observed > 0 && observed < generation) {
-    return true
-  }
-  const created = resource?.metadata?.creationTimestamp
-  if (!created) return false
-  const age = Date.now() - new Date(created).getTime()
-  return Number.isFinite(age) && age >= 0 && age < CONVERGENCE_GRACE_MS
+  return typeof generation === 'number' && typeof observed === 'number' && observed > 0 && observed < generation
 }
 
 /** Whether the pod was created by a batch Job. The owner's API group is checked

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -291,6 +291,14 @@ export function getPodStatus(pod: any): StatusBadge {
       if (unsettled > 0) {
         return { text: `Running (${ready}/${total})`, color: healthColors.degraded, level: 'degraded' }
       }
+      // Batch work in flight is not an all-clear. The Job itself already grades
+      // neutral while running; without the same call here its pods would read
+      // healthy — one piece of work graded two ways. Last, after every failure
+      // check above, so a broken Job pod keeps its real verdict.
+      // Mirrors pkg/health.classifyPodLevel.
+      if (isOwnedByJob(pod)) {
+        return { text: 'Running', color: healthColors.neutral, level: 'neutral' }
+      }
       return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
     }
     case 'Succeeded':
@@ -741,6 +749,40 @@ export function getContainerSquareStates(pod: any): ContainerSquareState[] {
 // WORKLOAD UTILITIES (Deployment, StatefulSet, DaemonSet, ReplicaSet)
 // ============================================================================
 
+/** How long a freshly created workload may take to converge before we grade it.
+ *  Mirrors pkg/health.workloadConvergenceGrace. */
+const CONVERGENCE_GRACE_MS = 5 * 60 * 1000
+
+/**
+ * Whether a workload has not yet had a fair chance to reach its target. Two
+ * ways that happens: the controller has not observed the current spec
+ * generation yet (which is what covers scale-ups on long-lived workloads,
+ * where the creation timestamp is months old but the target moved a second
+ * ago), or the object was created inside the grace window.
+ *
+ * Mirrors pkg/health.converging — keep the two in step.
+ */
+function isConverging(resource: any): boolean {
+  const generation = resource?.metadata?.generation
+  const observed = resource?.status?.observedGeneration
+  if (typeof generation === 'number' && typeof observed === 'number' && observed > 0 && observed < generation) {
+    return true
+  }
+  const created = resource?.metadata?.creationTimestamp
+  if (!created) return false
+  const age = Date.now() - new Date(created).getTime()
+  return Number.isFinite(age) && age >= 0 && age < CONVERGENCE_GRACE_MS
+}
+
+/** Whether the pod was created by a batch Job. The owner's API group is checked
+ *  so a CRD that merely uses Kind "Job" doesn't match. Mirrors
+ *  pkg/health.isOwnedByJob. */
+function isOwnedByJob(pod: any): boolean {
+  const refs = pod?.metadata?.ownerReferences
+  if (!Array.isArray(refs)) return false
+  return refs.some((r: any) => r?.kind === 'Job' && typeof r?.apiVersion === 'string' && r.apiVersion.startsWith('batch/'))
+}
+
 export function getWorkloadStatus(resource: any, kind: string): StatusBadge {
   const status = resource.status || {}
   const spec = resource.spec || {}
@@ -770,6 +812,16 @@ export function getWorkloadStatus(resource: any, kind: string): StatusBadge {
 
   if (desired === 0) {
     return { text: 'Scaled to 0', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  // Convergence grace — mirrors pkg/health.replicaVerdict. A workload whose
+  // spec just changed (or that was created moments ago) has not had a chance to
+  // reach its target, so grading against that target reports controller lag as
+  // an outage. Neutral, never healthy: declining to call it broken is not the
+  // same as calling it fine. Guarded on "not already fully ready" so a
+  // converged workload still takes the healthy path below, matching Go's order.
+  if (isConverging(resource) && !(ready === desired && available === desired)) {
+    return { text: `${ready}/${desired}`, color: healthColors.neutral, level: 'neutral' }
   }
 
   // Check if updating

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -788,6 +788,12 @@ export function getWorkloadStatus(resource: any, kind: string): StatusBadge {
     if (ready === desired && updated === desired) {
       return { text: `${ready}/${desired}`, color: healthColors.healthy, level: 'healthy' }
     }
+    // Convergence grace, same as the replica kinds below. pkg/health.Workload
+    // passes this signal for DaemonSets too, so omitting it here would render a
+    // mid-reconcile DaemonSet unhealthy while the backend calls it neutral.
+    if (isConverging(resource)) {
+      return { text: `${ready}/${desired}`, color: healthColors.neutral, level: 'neutral' }
+    }
     if (ready > 0) {
       return { text: `${ready}/${desired}`, color: healthColors.degraded, level: 'degraded' }
     }

--- a/pkg/ai/context/summary.go
+++ b/pkg/ai/context/summary.go
@@ -26,9 +26,17 @@ type ResourceSummary struct {
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
 	Namespace string `json:"namespace,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Ready     string `json:"ready,omitempty"`
-	Issue     string `json:"issue,omitempty"`
+	// Status is the DISPLAY state, computed the way `kubectl get` computes its
+	// STATUS column: what is true about this object right now.
+	Status string `json:"status,omitempty"`
+	Ready  string `json:"ready,omitempty"`
+	// Issue is the diagnostic hint — a reason worth looking at. It is
+	// deliberately NOT the same concept as Status and is allowed to be broader:
+	// it surfaces recent history too, so a pod that OOMKilled and recovered
+	// reports Status "Running" with Issue "OOMKilled". Read it as "notable,
+	// worth a look", never as "currently broken" — the health level
+	// (summaryContext.health, from pkg/health) is the authority on that.
+	Issue string `json:"issue,omitempty"`
 	Age       string `json:"age,omitempty"`
 	// Terminating signals that metadata.deletionTimestamp is set on the
 	// resource. AI agents need this signal to avoid suggesting
@@ -52,7 +60,17 @@ type ResourceSummary struct {
 	ClusterIP     string   `json:"clusterIP,omitempty"`
 	Hosts         []string `json:"hosts,omitempty"`
 	Restarts      int32    `json:"restarts,omitempty"`
-	Node          string   `json:"node,omitempty"`
+	// LastTerminatedReason is why the most recently terminated container
+	// exited (OOMKilled, Error, ...). It is HISTORY, not an active fault: a
+	// pod OOMKilled an hour ago that has been Ready since is healthy, and
+	// Status says so. Carried separately so an agent can tell "crashing now"
+	// from "crashed once, weeks ago" — a distinction a bare restart count
+	// destroys. Mirrors what `kubectl describe` shows as "Last State".
+	LastTerminatedReason string `json:"lastTerminatedReason,omitempty"`
+	// LastRestartedAge is how long ago that termination happened, mirroring
+	// kubectl's "2 (5m ago)" RESTARTS column. Empty when nothing restarted.
+	LastRestartedAge string `json:"lastRestartedAge,omitempty"`
+	Node             string `json:"node,omitempty"`
 	Strategy      string   `json:"strategy,omitempty"`
 	Completions   string   `json:"completions,omitempty"`
 	Duration      string   `json:"duration,omitempty"`
@@ -218,25 +236,29 @@ func summarizePod(pod *corev1.Pod) *ResourceSummary {
 		s.Image = pod.Spec.Containers[0].Image
 	}
 
-	// Ready count and restarts
-	ready, total := int32(0), int32(len(pod.Status.ContainerStatuses))
-	var restarts int32
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Ready {
-			ready++
-		}
-		restarts += cs.RestartCount
+	// STATUS / READY / RESTARTS come from the kubectl-equivalent computation.
+	// Status is a DISPLAY string describing the pod's current state; Issue
+	// below is the separate diagnostic signal. Keeping them apart matters:
+	// routing display through getPodIssue would turn every display refinement
+	// (Completed, SchedulingGated) into a serialized "issue", which is a
+	// different, load-bearing concept.
+	d := computePodDisplay(pod)
+	s.Status = d.Status
+	s.Ready = d.Ready
+	s.Restarts = d.Restarts
+	// Termination history, deliberately NOT folded into Status: a pod
+	// OOMKilled an hour ago that has been Ready since is healthy now, and
+	// Status says "Running". The history is still worth carrying — a bare
+	// restart count can't distinguish "crashing right now" from "crashed once,
+	// weeks ago". This mirrors kubectl, which keeps STATUS current and shows
+	// the reason under "Last State" in describe.
+	s.LastTerminatedReason = d.LastTerminatedBy
+	if !d.LastRestartedAt.IsZero() {
+		s.LastRestartedAge = age(d.LastRestartedAt)
 	}
-	if total > 0 {
-		s.Ready = fmt.Sprintf("%d/%d", ready, total)
-	}
-	s.Restarts = restarts
 
-	// Detect issue
+	// Diagnostic issue — independent of the display status above.
 	s.Issue = getPodIssue(pod)
-	if s.Issue != "" {
-		s.Status = s.Issue
-	}
 
 	return s
 }
@@ -246,16 +268,23 @@ func summarizeDeployment(dep *appsv1.Deployment) *ResourceSummary {
 		Kind:      "Deployment",
 		Name:      dep.Name,
 		Namespace: dep.Namespace,
-		Ready:     fmt.Sprintf("%d/%d", dep.Status.ReadyReplicas, dep.Status.Replicas),
+		Ready:     fmt.Sprintf("%d/%d", dep.Status.ReadyReplicas, specReplicas(dep.Spec.Replicas)),
 		Strategy:  string(dep.Spec.Strategy.Type),
 		Age:       age(dep.CreationTimestamp.Time),
 	}
 
-	if dep.Status.ReadyReplicas == dep.Status.Replicas && dep.Status.Replicas > 0 {
-		s.Status = "Running"
-	} else if dep.Status.Replicas == 0 {
+	// Denominate by SPEC, not status. status.Replicas is what the controller
+	// has created so far; on a 3->10 scale-up it still reads 3 until the
+	// controller catches up, so a status-denominated row shows "3/3 Running"
+	// for a workload that is 7 replicas short of its target. kubectl uses
+	// spec.Replicas for exactly this reason.
+	desired := specReplicas(dep.Spec.Replicas)
+	switch {
+	case desired == 0:
 		s.Status = "Scaled to 0"
-	} else {
+	case dep.Status.ReadyReplicas == desired:
+		s.Status = "Running"
+	default:
 		s.Status = "Progressing"
 	}
 
@@ -384,13 +413,33 @@ func summarizeJob(job *batchv1.Job) *ResourceSummary {
 		Age:       age(job.CreationTimestamp.Time),
 	}
 
-	// Status from conditions
+	// Status from conditions. Terminal conditions win over spec intent: a Job
+	// that failed and was then suspended is still a failure, so Complete /
+	// Failed are checked before Suspended — mirroring health.jobVerdict
+	// (pkg/health/workload.go:63) so the two surfaces agree.
 	s.Status = "Running"
+	terminal := false
 	for _, c := range job.Status.Conditions {
 		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
-			s.Status = "Complete"
+			s.Status, terminal = "Complete", true
 		} else if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
-			s.Status = "Failed"
+			s.Status, terminal = "Failed", true
+			// Preserve WHY it failed (BackoffLimitExceeded / DeadlineExceeded);
+			// "Failed" alone sends a reader back to the API for the reason.
+			if c.Reason != "" {
+				s.Issue = c.Reason
+			}
+		}
+	}
+
+	// Suspension is operator intent, not a fault — surfaced as its own field
+	// rather than folded into Status. CronJob already did this
+	// (s.Suspended below); Job did not, so a deliberately paused Job read as
+	// "Running" here while health.jobVerdict correctly called it Suspended.
+	if job.Spec.Suspend != nil && *job.Spec.Suspend {
+		s.Suspended = job.Spec.Suspend
+		if !terminal {
+			s.Status = "Suspended"
 		}
 	}
 
@@ -575,8 +624,9 @@ func summarizeReplicaSet(rs *appsv1.ReplicaSet) *ResourceSummary {
 		Kind:      "ReplicaSet",
 		Name:      rs.Name,
 		Namespace: rs.Namespace,
-		Ready:     fmt.Sprintf("%d/%d", rs.Status.ReadyReplicas, rs.Status.Replicas),
-		Age:       age(rs.CreationTimestamp.Time),
+		// Spec-denominated, same reasoning as summarizeDeployment.
+		Ready: fmt.Sprintf("%d/%d", rs.Status.ReadyReplicas, specReplicas(rs.Spec.Replicas)),
+		Age:   age(rs.CreationTimestamp.Time),
 	}
 
 	if len(rs.Spec.Template.Spec.Containers) > 0 {
@@ -597,6 +647,216 @@ func summarizeNamespace(ns *corev1.Namespace) *ResourceSummary {
 		Status: string(ns.Status.Phase),
 		Age:    age(ns.CreationTimestamp.Time),
 	}
+}
+
+// podDisplay is the `kubectl get pods` view of a pod — its STATUS, READY and
+// RESTARTS columns. The three are computed together because upstream derives
+// all of them from a single walk over the container statuses; splitting them
+// would duplicate that walk and let them drift apart.
+//
+// WHY THIS EXISTS: pod.Status.Phase alone is nearly useless as a status. It has
+// five values, and a Job pod whose main container finished while a sidecar
+// keeps running reports phase Running forever. Radar used to emit the bare
+// phase here, so such a pod read "Running" with no hint anything was wrong,
+// while `kubectl get pods` read "NotReady". This is a deliberate port of
+// upstream printPod (k8s.io/kubernetes/pkg/printers/internalversion).
+//
+// Two deliberate divergences from upstream, both retaining strictly more
+// information than upstream does:
+//   - No Terminating override. kubectl replaces STATUS wholesale with
+//     "Terminating" when deletionTimestamp is set; radar carries Terminating
+//     and Finalizers as dedicated fields, so overriding would DISCARD the
+//     underlying state during every routine rollout.
+//   - No NodeUnreachable -> "Unknown" branch. It is gated on a legacy
+//     pod.Status.Reason that modern kubelets rarely set; radar's health
+//     classifier keys on phase Unknown instead (pkg/health/pod.go:75).
+type podDisplay struct {
+	Status           string
+	Ready            string
+	Restarts         int32
+	LastRestartedAt  time.Time
+	LastTerminatedBy string
+}
+
+// isRestartableInitContainer reports whether an init container is a native
+// (KEP-753) sidecar — restartPolicy: Always — which runs alongside the main
+// containers rather than gating them.
+func isRestartableInitContainer(c *corev1.Container) bool {
+	return c != nil && c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+func computePodDisplay(pod *corev1.Pod) podDisplay {
+	var d podDisplay
+
+	// Native sidecars count toward the READY denominator: they are real
+	// containers the pod depends on, not setup steps that finish.
+	totalContainers := len(pod.Spec.Containers)
+	initSpecs := make(map[string]*corev1.Container, len(pod.Spec.InitContainers))
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		initSpecs[c.Name] = c
+		if isRestartableInitContainer(c) {
+			totalContainers++
+		}
+	}
+
+	reason := string(pod.Status.Phase)
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason // Evicted, NodeAffinity, ...
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodScheduled && cond.Reason == corev1.PodReasonSchedulingGated {
+			reason = corev1.PodReasonSchedulingGated
+		}
+	}
+
+	readyContainers := 0
+	var restarts, sidecarRestarts int32
+	var lastRestart, lastSidecarRestart time.Time
+	var lastReason, lastSidecarReason string
+
+	noteTermination := func(t *corev1.ContainerStateTerminated, at *time.Time, who *string) {
+		if t == nil {
+			return
+		}
+		// A kubelet always stamps FinishedAt, but an unstamped termination
+		// still tells us WHY the container died — keep the reason and simply
+		// report no age for it, rather than dropping the fact entirely.
+		if t.FinishedAt.IsZero() {
+			if *who == "" {
+				*who = t.Reason
+			}
+			return
+		}
+		if at.IsZero() || t.FinishedAt.Time.After(*at) {
+			*at, *who = t.FinishedAt.Time, t.Reason
+		}
+	}
+
+	initializing := false
+	for i := range pod.Status.InitContainerStatuses {
+		cs := pod.Status.InitContainerStatuses[i]
+		spec := initSpecs[cs.Name]
+		restarts += cs.RestartCount
+		noteTermination(cs.LastTerminationState.Terminated, &lastRestart, &lastReason)
+		if isRestartableInitContainer(spec) {
+			sidecarRestarts += cs.RestartCount
+			noteTermination(cs.LastTerminationState.Terminated, &lastSidecarRestart, &lastSidecarReason)
+		}
+
+		switch {
+		case cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0:
+			continue // a completed init step: move on
+		case isRestartableInitContainer(spec) && cs.Started != nil && *cs.Started:
+			if cs.Ready {
+				readyContainers++
+			}
+			continue // native sidecar: running alongside, doesn't gate init
+		case cs.State.Terminated != nil:
+			switch {
+			case cs.State.Terminated.Reason != "":
+				reason = "Init:" + cs.State.Terminated.Reason
+			case cs.State.Terminated.Signal != 0:
+				reason = fmt.Sprintf("Init:Signal:%d", cs.State.Terminated.Signal)
+			default:
+				reason = fmt.Sprintf("Init:ExitCode:%d", cs.State.Terminated.ExitCode)
+			}
+			initializing = true
+		case cs.State.Waiting != nil && cs.State.Waiting.Reason != "" && cs.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + cs.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break // upstream stops at the first init container that isn't done
+	}
+
+	if !initializing || isPodInitialized(pod) {
+		// Init restarts stop counting once initialization is done; only native
+		// sidecars keep contributing, matching upstream.
+		restarts, lastRestart, lastReason = sidecarRestarts, lastSidecarRestart, lastSidecarReason
+		hasRunning := false
+		errorReason := ""
+		// Reverse order is upstream's: the FIRST container in spec order wins
+		// the reason, because later iterations overwrite earlier ones.
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			cs := pod.Status.ContainerStatuses[i]
+			restarts += cs.RestartCount
+			noteTermination(cs.LastTerminationState.Terminated, &lastRestart, &lastReason)
+
+			switch {
+			case cs.State.Waiting != nil && cs.State.Waiting.Reason != "":
+				reason = cs.State.Waiting.Reason
+			case cs.State.Terminated != nil:
+				switch {
+				case cs.State.Terminated.Reason != "":
+					reason = cs.State.Terminated.Reason
+				case cs.State.Terminated.Signal != 0:
+					reason = fmt.Sprintf("Signal:%d", cs.State.Terminated.Signal)
+				default:
+					reason = fmt.Sprintf("ExitCode:%d", cs.State.Terminated.ExitCode)
+				}
+				if cs.State.Terminated.ExitCode != 0 {
+					errorReason = reason
+				}
+			case cs.Ready && cs.State.Running != nil:
+				hasRunning = true
+				readyContainers++
+			}
+		}
+
+		// THE CASE THAT MATTERS: a container reported Completed while another
+		// is still running. If the pod is Ready it is genuinely fine; if not,
+		// something finished and left the pod wedged — a Job whose sidecar
+		// never exits is the canonical example.
+		if reason == "Completed" {
+			switch {
+			case hasRunning && hasPodReadyCondition(pod):
+				reason = "Running"
+			case errorReason != "":
+				reason = errorReason
+			case hasRunning:
+				reason = "NotReady"
+			}
+		}
+	}
+
+	d.Status = reason
+	d.Restarts = restarts
+	d.LastRestartedAt = lastRestart
+	d.LastTerminatedBy = lastReason
+	if totalContainers > 0 {
+		d.Ready = fmt.Sprintf("%d/%d", readyContainers, totalContainers)
+	}
+	return d
+}
+
+// specReplicas resolves a workload's desired replica count. A nil pointer
+// means "unset", which Kubernetes defaults to 1 — not 0.
+func specReplicas(r *int32) int32 {
+	if r == nil {
+		return 1
+	}
+	return *r
+}
+
+func hasPodReadyCondition(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isPodInitialized(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodInitialized && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // getPodIssue extracts the primary issue from a pod's status.

--- a/pkg/ai/context/summary.go
+++ b/pkg/ai/context/summary.go
@@ -252,9 +252,22 @@ func summarizePod(pod *corev1.Pod) *ResourceSummary {
 	// restart count can't distinguish "crashing right now" from "crashed once,
 	// weeks ago". This mirrors kubectl, which keeps STATUS current and shows
 	// the reason under "Last State" in describe.
-	s.LastTerminatedReason = d.LastTerminatedBy
-	if !d.LastRestartedAt.IsZero() {
-		s.LastRestartedAge = age(d.LastRestartedAt)
+	// Only when something actually restarted, which is the rule kubectl applies
+	// to its own RESTARTS column ("7 (16h ago)" for a non-zero count, a bare
+	// "0" otherwise). Termination history without a restart would describe a
+	// container that ended and stayed ended — the pod's current state already
+	// says that, so the history adds nothing.
+	//
+	// A 4,355-resource sweep across five clusters found no row violating this,
+	// so the guard is an invariant made explicit rather than a fix for observed
+	// breakage. Note "Completed" IS legitimate history here: redis-master-0 in
+	// that sweep had 7 restarts each ending cleanly, which kubectl reports too —
+	// a service quietly exiting and being restarted is worth seeing.
+	if d.Restarts > 0 {
+		s.LastTerminatedReason = d.LastTerminatedBy
+		if !d.LastRestartedAt.IsZero() {
+			s.LastRestartedAge = age(d.LastRestartedAt)
+		}
 	}
 
 	// Diagnostic issue — independent of the display status above.

--- a/pkg/ai/context/summary_test.go
+++ b/pkg/ai/context/summary_test.go
@@ -115,12 +115,18 @@ func withSchedulingGate() podOption {
 	}
 }
 
+// withLastTerminationOOM builds a container that was OOMKilled and came back.
+// RestartCount is non-zero because that is the only shape a kubelet produces: a
+// container cannot have a LastTerminationState and zero restarts. Termination
+// history is reported only when something actually restarted, so a fixture
+// without the count would exercise a state that cannot occur.
 func withLastTerminationOOM() podOption {
 	return func(p *corev1.Pod) {
 		p.Status.ContainerStatuses = []corev1.ContainerStatus{{
-			Name:  "app",
-			Ready: false,
-			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Name:         "app",
+			Ready:        false,
+			RestartCount: 2,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 			LastTerminationState: corev1.ContainerState{
 				Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"},
 			},

--- a/pkg/ai/context/summary_test.go
+++ b/pkg/ai/context/summary_test.go
@@ -73,6 +73,48 @@ func withContainerTerminated(reason string) podOption {
 	}
 }
 
+// withExtraRunningReadyContainer appends a second container that is running and
+// ready — the sidecar half of the "main container finished, sidecar didn't"
+// shape. Added to spec as well as status so the READY denominator is right.
+func withExtraRunningReadyContainer(name string) podOption {
+	return func(p *corev1.Pod) {
+		p.Spec.Containers = append(p.Spec.Containers, corev1.Container{Name: name, Image: "fluent-bit:2"})
+		p.Status.ContainerStatuses = append(p.Status.ContainerStatuses, corev1.ContainerStatus{
+			Name:  name,
+			Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		})
+	}
+}
+
+func withPodReady(ready bool) podOption {
+	return func(p *corev1.Pod) {
+		status := corev1.ConditionFalse
+		if ready {
+			status = corev1.ConditionTrue
+		}
+		p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+			Type: corev1.PodReady, Status: status,
+		})
+	}
+}
+
+// withPodReason sets the pod-level reason (Evicted, NodeAffinity, ...), which
+// lives on the pod rather than on any container.
+func withPodReason(reason string) podOption {
+	return func(p *corev1.Pod) { p.Status.Reason = reason }
+}
+
+func withSchedulingGate() podOption {
+	return func(p *corev1.Pod) {
+		p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+			Type:   corev1.PodScheduled,
+			Status: corev1.ConditionFalse,
+			Reason: corev1.PodReasonSchedulingGated,
+		})
+	}
+}
+
 func withLastTerminationOOM() podOption {
 	return func(p *corev1.Pod) {
 		p.Status.ContainerStatuses = []corev1.ContainerStatus{{
@@ -100,10 +142,15 @@ func withInitContainerWaiting(reason string) podOption {
 
 // --- Workload helpers ---
 
+// makeDeployment builds a converged Deployment: `total` is the DESIRED count,
+// so it is set on spec as well as status. Real Deployments always carry
+// spec.replicas; a fixture that set only status let the status-denominated
+// READY bug pass unnoticed.
 func makeDeployment(name string, ready, total int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
 		Spec: appsv1.DeploymentSpec{
+			Replicas: &total,
 			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -161,6 +208,11 @@ func TestSummary_PodStatus(t *testing.T) {
 		wantStatus string
 		wantIssue  string
 		wantReady  string
+		// wantLastTerminated is the termination HISTORY field, asserted apart
+		// from Status on purpose: a pod OOMKilled an hour ago that has been
+		// Ready since is Running now, and the reason belongs in history rather
+		// than masquerading as the current state.
+		wantLastTerminated string
 	}{
 		{
 			name:       "running healthy",
@@ -184,11 +236,18 @@ func TestSummary_PodStatus(t *testing.T) {
 			wantReady:  "0/1",
 		},
 		{
-			name:       "OOMKilled via lastTerminationState",
-			pod:        makePod("oom-last", withLastTerminationOOM()),
-			wantStatus: "OOMKilled",
-			wantIssue:  "OOMKilled",
-			wantReady:  "0/1",
+			// A PAST OOM kill is not the current status. kubectl keeps STATUS
+			// on the live state and reports the reason under "Last State";
+			// health.Pod agrees (pkg/health/pod_test.go: "recovered
+			// LastTerminationState OOMKilled is healthy"). Before this split
+			// the row claimed Status "OOMKilled" for a pod that was running
+			// fine, contradicting the health verdict on the very same object.
+			name:               "recovered OOM reports as running, with history",
+			pod:                makePod("oom-last", withLastTerminationOOM()),
+			wantStatus:         "Running",
+			wantIssue:          "OOMKilled", // getPodIssue is the diagnostic signal; unchanged
+			wantReady:          "0/1",
+			wantLastTerminated: "OOMKilled",
 		},
 		{
 			name:       "ImagePullBackOff",
@@ -198,24 +257,71 @@ func TestSummary_PodStatus(t *testing.T) {
 			wantReady:  "0/1",
 		},
 		{
-			name:       "init container failing",
+			// The Init: prefix is load-bearing — it tells a reader the failure
+			// is in initialization, not the main workload, which points at a
+			// different fix. kubectl has carried it for years.
+			name:       "init container failing is attributed to init",
 			pod:        makePod("init-fail", withPhase(corev1.PodPending), withInitContainerWaiting("CrashLoopBackOff")),
-			wantStatus: "CrashLoopBackOff",
+			wantStatus: "Init:CrashLoopBackOff",
 			wantIssue:  "CrashLoopBackOff",
-			wantReady:  "",
+			wantReady:  "0/1", // denominator is spec containers, as kubectl does
 		},
 		{
 			name:       "completed",
 			pod:        makePod("done", withPhase(corev1.PodSucceeded)),
 			wantStatus: "Succeeded",
 			wantIssue:  "",
-			wantReady:  "",
+			wantReady:  "0/1",
 		},
 		{
-			name:       "terminated Completed is not an issue",
+			// Nothing else is running, so "Completed" is the whole truth —
+			// this is the branch that does NOT become NotReady.
+			name:       "terminated Completed with nothing else running",
 			pod:        makePod("completed-term", withContainerTerminated("Completed")),
-			wantStatus: "Running",
+			wantStatus: "Completed",
 			wantIssue:  "",
+			wantReady:  "0/1",
+		},
+		{
+			// THE case this work exists for. A Job pod whose main container
+			// finished while a sidecar keeps running: phase stays Running
+			// forever, so the bare phase said "Running" and radar called it
+			// healthy. kubectl reports NotReady, which is what let other tools
+			// spot a CronJob wedged by a non-exiting sidecar.
+			name: "completed main container with a lingering sidecar is NotReady",
+			pod: makePod("job-sidecar",
+				withContainerTerminated("Completed"),
+				withExtraRunningReadyContainer("sidecar"),
+				withPodReady(false)),
+			wantStatus: "NotReady",
+			wantReady:  "1/2",
+		},
+		{
+			// Same shape, but the pod IS Ready — a legitimately healthy pod
+			// that happens to have a finished container. Must stay Running or
+			// the fix would false-positive on every such pod.
+			name: "completed container but pod is Ready stays Running",
+			pod: makePod("job-ready",
+				withContainerTerminated("Completed"),
+				withExtraRunningReadyContainer("sidecar"),
+				withPodReady(true)),
+			wantStatus: "Running",
+			wantReady:  "1/2",
+		},
+		{
+			// Node pressure evicted it. The reason lives on the pod, not on any
+			// container, so a container-only walk loses it entirely.
+			name:       "evicted pod names the eviction",
+			pod:        makePod("eviction", withPhase(corev1.PodFailed), withPodReason("Evicted")),
+			wantStatus: "Evicted",
+			wantReady:  "0/1",
+		},
+		{
+			// Intentionally parked (quota gate, Kueue). Worth naming so an
+			// agent doesn't chase it as slow scheduling.
+			name:       "scheduling gated is named, not generic Pending",
+			pod:        makePod("gated", withPhase(corev1.PodPending), withSchedulingGate()),
+			wantStatus: "SchedulingGated",
 			wantReady:  "0/1",
 		},
 	}
@@ -236,6 +342,9 @@ func TestSummary_PodStatus(t *testing.T) {
 			}
 			if s.Ready != tt.wantReady {
 				t.Errorf("Ready = %q, want %q", s.Ready, tt.wantReady)
+			}
+			if s.LastTerminatedReason != tt.wantLastTerminated {
+				t.Errorf("LastTerminatedReason = %q, want %q", s.LastTerminatedReason, tt.wantLastTerminated)
 			}
 		})
 	}
@@ -268,6 +377,22 @@ func TestSummary_WorkloadStatus(t *testing.T) {
 			obj:        makeDeployment("web", 0, 0),
 			wantStatus: "Scaled to 0",
 			wantReady:  "0/0",
+			wantImage:  "myapp:v1",
+		},
+		{
+			// Scale-up before the controller reacts: spec says 10, status still
+			// says 3. Denominating by status reported "3/3 Running" for a
+			// workload 7 replicas short of target — worse than kubectl, which
+			// denominates by spec and shows 3/10.
+			name: "Deployment scaled up before the controller reacts",
+			obj: func() *appsv1.Deployment {
+				d := makeDeployment("web", 3, 3)
+				ten := int32(10)
+				d.Spec.Replicas = &ten
+				return d
+			}(),
+			wantStatus: "Progressing",
+			wantReady:  "3/10",
 			wantImage:  "myapp:v1",
 		},
 		{

--- a/pkg/cronsched/cronsched.go
+++ b/pkg/cronsched/cronsched.go
@@ -53,7 +53,13 @@ func MinInterval(schedule string) (time.Duration, bool) {
 		}
 		return 28 * day, true
 	case dom != "*":
-		// Specific day(s)-of-month → monthly cadence.
+		// Specific day(s)-of-month → take the real largest gap, not a flat
+		// month. "1,15" fires twice monthly; calling that a 28-day cadence gave
+		// it a 42-day staleness grace, so it could miss two consecutive runs
+		// and still read healthy for six weeks.
+		if gap, ok := maxDomGapDays(dom); ok {
+			return gap, true
+		}
 		return 28 * day, true
 	case dow != "*":
 		// Specific day(s)-of-week → weekly is the conservative lower bound.
@@ -65,6 +71,48 @@ func MinInterval(schedule string) (time.Duration, bool) {
 		// Intra-day cadence (every minute / */n minutes or hours).
 		return time.Hour, true
 	}
+}
+
+// maxDomGapDays returns the longest stretch (in days) a day-of-month field can
+// go between firings. Unlike months, days-of-month are not uniform units: the
+// wrap from the last firing day of one month to the first of the next depends
+// on month length, and a day past 29 is skipped entirely in short months.
+//
+// Both are resolved upward so the estimate stays an upper bound — a staleness
+// threshold must never trip on a healthy rare-cadence job:
+//   - the wrap gap uses a 31-day month,
+//   - any day above 29 is treated as possibly skipping a whole month.
+//
+// ok=false when the field can't be parsed, so the caller falls back rather than
+// trusting a partial set.
+func maxDomGapDays(field string) (time.Duration, bool) {
+	days, ok := cronFieldValues(field, 1, 31)
+	if !ok || len(days) == 0 {
+		return 0, false
+	}
+	// Only days that exist in EVERY month can be relied on to fire. The 29th
+	// through 31st are skipped in short months, so a schedule firing solely on
+	// those can pass a whole month without running.
+	reliable := make([]int, 0, len(days))
+	for _, d := range days {
+		if d <= 28 {
+			reliable = append(reliable, d)
+		}
+	}
+	if len(reliable) == 0 {
+		return 62 * day, true // e.g. the 31st: Jan 31 → Mar 31
+	}
+	// Wrap from the last reliable day to the first of the next month, measured
+	// against the SHORTEST month. Longer months only add firings, which can
+	// only narrow gaps, so this stays an upper bound. A single day yields a
+	// full 28-day cycle, which is the monthly case.
+	maxGap := (28 - reliable[len(reliable)-1]) + reliable[0]
+	for i := 1; i < len(reliable); i++ {
+		if g := reliable[i] - reliable[i-1]; g > maxGap {
+			maxGap = g
+		}
+	}
+	return time.Duration(maxGap) * day, true
 }
 
 // maxMonthGapDays returns the longest stretch (in days) the schedule can go

--- a/pkg/cronsched/cronsched.go
+++ b/pkg/cronsched/cronsched.go
@@ -102,11 +102,14 @@ func maxDomGapDays(field string) (time.Duration, bool) {
 	if len(reliable) == 0 {
 		return 62 * day, true // e.g. the 31st: Jan 31 → Mar 31
 	}
-	// Wrap from the last reliable day to the first of the next month, measured
-	// against the SHORTEST month. Longer months only add firings, which can
-	// only narrow gaps, so this stays an upper bound. A single day yields a
-	// full 28-day cycle, which is the monthly case.
-	maxGap := (28 - reliable[len(reliable)-1]) + reliable[0]
+	// Wrap from the last reliable day to the first of the following month,
+	// measured against the LONGEST month. A 31-day month only adds firings if
+	// those extra days are in the set — and 29-31 were filtered out above
+	// precisely because they aren't dependable — so a long month simply
+	// stretches the wrap rather than narrowing it. A single day therefore
+	// yields a 31-day cycle, which is the true monthly case: Jan 1 -> Feb 1 is
+	// 31 days, not 28.
+	maxGap := (31 - reliable[len(reliable)-1]) + reliable[0]
 	for i := 1; i < len(reliable); i++ {
 		if g := reliable[i] - reliable[i-1]; g > maxGap {
 			maxGap = g

--- a/pkg/cronsched/cronsched_test.go
+++ b/pkg/cronsched/cronsched_test.go
@@ -39,6 +39,48 @@ func TestMinInterval(t *testing.T) {
 	}
 }
 
+// TestMinInterval_MultiDayOfMonth pins day-of-month cadence to the real gap
+// between firings. Any constrained day-of-month used to collapse to a flat 28
+// days, so a twice-monthly job inherited a 42-day staleness grace and could miss
+// two consecutive runs while still reading healthy for six weeks.
+//
+// This needs an UPPER bound — the main table asserts only a lower one, which is
+// why the bug survived there.
+func TestMinInterval_MultiDayOfMonth(t *testing.T) {
+	day := 24 * time.Hour
+	cases := []struct {
+		schedule string
+		atMost   time.Duration
+		why      string
+	}{
+		// 1st and 15th: the widest gap is the 15th to the 1st of next month.
+		{"0 0 1,15 * *", 18 * day, "twice monthly"},
+		// Every fifth day: gaps of 5, plus the wrap off the 26th.
+		{"0 0 */5 * *", 11 * day, "every fifth day"},
+		// A contiguous run fires daily inside the window; the wrap off the 7th
+		// is the widest gap.
+		{"0 0 1-7 * *", 26 * day, "first week of each month"},
+	}
+	for _, c := range cases {
+		got, ok := MinInterval(c.schedule)
+		if !ok {
+			t.Errorf("%q (%s): could not parse", c.schedule, c.why)
+			continue
+		}
+		if got > c.atMost {
+			t.Errorf("%q (%s): interval=%s, want <= %s — too wide a cadence grants "+
+				"an unearned staleness grace", c.schedule, c.why, got, c.atMost)
+		}
+	}
+
+	// A day that doesn't exist in every month must stay conservative rather
+	// than alarm every February.
+	if got, _ := MinInterval("0 0 31 * *"); got < 60*day {
+		t.Errorf("dom=31: interval=%s, want >= 60d — the 31st is skipped in short "+
+			"months, so the real gap can span two months", got)
+	}
+}
+
 func TestStaleThreshold(t *testing.T) {
 	day := 24 * time.Hour
 	cases := []struct {

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,7 @@ import (
 //	Pending > 5m         → degraded ; Pending < 5m → healthy (startup grace)
 //	readiness probe fail → degraded
 //	active thrash        → degraded
+//	owned by a Job       → neutral  (batch work in flight; not an all-clear)
 //	default              → healthy
 //
 // Unschedulable and stuck-termination are NOT folded in here: they are detected
@@ -126,7 +128,37 @@ func classifyPodLevel(pod *corev1.Pod, now time.Time) Level {
 		return LevelDegraded
 	}
 
+	// Batch work is in-flight, not "healthy". Workload() already draws exactly
+	// this line for the Job itself — jobVerdict returns Neutral/"Running" for an
+	// active Job (workload.go), documented there as "in-progress, not healthy".
+	// Without this, the same work gets two answers: the Job reads Neutral while
+	// every one of its pods reads Healthy. A Job pod sitting at 1/2 ready
+	// because its sidecar outlived the main container then reads as an
+	// affirmative all-clear, which is the claim we most want not to make.
+	//
+	// LAST, after every failure check, so a crashlooping / OOMKilled / fatally
+	// waiting Job pod keeps its real verdict — Neutral must never mask a
+	// failure. From here we can see the owner reference but not the Job's
+	// status, so the honest claim is "this is batch work", not "the Job is
+	// in-flight" — which is why it is Neutral (no assertion) rather than
+	// Degraded (an assertion of impairment).
+	if isOwnedByJob(pod) {
+		return LevelNeutral
+	}
+
 	return LevelHealthy
+}
+
+// isOwnedByJob reports whether the pod was created by a batch Job. The
+// APIVersion group is checked so a CRD that happens to be Kind "Job" doesn't
+// match.
+func isOwnedByJob(pod *corev1.Pod) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "Job" && strings.HasPrefix(ref.APIVersion, "batch/") {
+			return true
+		}
+	}
+	return false
 }
 
 // PodProblemReason returns a short reason token for a problematic pod. Walks

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -40,6 +40,62 @@ func TestPodGoldenVectors(t *testing.T) {
 			wantReason: "Completed",
 		},
 		{
+			// Batch work in flight is not an all-clear. Workload() already says
+			// this for the Job itself (jobVerdict returns Neutral/"Running");
+			// without the same call here the Job read Neutral while its own pods
+			// read Healthy — one piece of work graded two ways.
+			name: "job-owned pod is neutral, not an affirmative healthy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Job", APIVersion: "batch/v1", Name: "archiver-123"},
+				}},
+				Status: corev1.PodStatus{
+					Phase:             corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+				},
+			},
+			wantLevel: LevelNeutral,
+		},
+		{
+			// The masking guard. Neutral sits after every failure check, so a
+			// genuinely broken Job pod keeps its real verdict. If this ever
+			// returns Neutral the ordering has regressed and failing batch
+			// workloads have gone silent.
+			name: "crashlooping job-owned pod stays unhealthy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Job", APIVersion: "batch/v1", Name: "archiver-123"},
+				}},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Ready:        false,
+						RestartCount: 6,
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+					}},
+				},
+			},
+			wantLevel:  LevelUnhealthy,
+			wantReason: "CrashLoopBackOff",
+		},
+		{
+			// A CRD that merely happens to be Kind "Job" must not match; the
+			// owner's API group is checked, not just the kind string.
+			name: "non-batch Job kind does not trigger the neutral branch",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Job", APIVersion: "acme.example.com/v1", Name: "not-a-batch-job"},
+				}},
+				Status: corev1.PodStatus{
+					Phase:             corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+				},
+			},
+			wantLevel: LevelHealthy,
+		},
+		{
 			name:      "failed pod is unhealthy",
 			pod:       &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
 			wantLevel: LevelUnhealthy,

--- a/pkg/health/testdata/golden_vectors.json
+++ b/pkg/health/testdata/golden_vectors.json
@@ -156,6 +156,30 @@
       "kind": "PersistentVolumeClaim",
       "level": "unhealthy",
       "object": { "status": { "phase": "Lost" } }
+    },
+    {
+      "name": "pod owned by a batch Job is neutral, not an affirmative healthy",
+      "kind": "Pod",
+      "level": "neutral",
+      "object": { "metadata": { "ownerReferences": [{ "kind": "Job", "apiVersion": "batch/v1", "name": "archiver-1" }] }, "status": { "phase": "Running", "containerStatuses": [{ "ready": true }] } }
+    },
+    {
+      "name": "pod owned by a non-batch Job kind stays healthy",
+      "kind": "Pod",
+      "level": "healthy",
+      "object": { "metadata": { "ownerReferences": [{ "kind": "Job", "apiVersion": "acme.example.com/v1", "name": "nope" }] }, "status": { "phase": "Running", "containerStatuses": [{ "ready": true }] } }
+    },
+    {
+      "name": "deployment whose controller has not observed the new spec is converging, not down",
+      "kind": "Deployment",
+      "level": "neutral",
+      "object": { "metadata": { "generation": 7 }, "spec": { "replicas": 10 }, "status": { "observedGeneration": 6, "replicas": 3, "readyReplicas": 3, "availableReplicas": 3 } }
+    },
+    {
+      "name": "deployment settled with zero ready is unhealthy",
+      "kind": "Deployment",
+      "level": "unhealthy",
+      "object": { "metadata": { "generation": 7 }, "spec": { "replicas": 3 }, "status": { "observedGeneration": 7, "replicas": 3, "readyReplicas": 0, "availableReplicas": 0 } }
     }
   ]
 }

--- a/pkg/health/testdata/golden_vectors.json
+++ b/pkg/health/testdata/golden_vectors.json
@@ -180,6 +180,18 @@
       "kind": "Deployment",
       "level": "unhealthy",
       "object": { "metadata": { "generation": 7 }, "spec": { "replicas": 3 }, "status": { "observedGeneration": 7, "replicas": 3, "readyReplicas": 0, "availableReplicas": 0 } }
+    },
+    {
+      "name": "daemonset whose controller has not observed the new spec is converging",
+      "kind": "DaemonSet",
+      "level": "neutral",
+      "object": { "metadata": { "generation": 5 }, "status": { "observedGeneration": 4, "desiredNumberScheduled": 3, "numberReady": 1, "updatedNumberScheduled": 1 } }
+    },
+    {
+      "name": "daemonset settled with none ready is unhealthy",
+      "kind": "DaemonSet",
+      "level": "unhealthy",
+      "object": { "metadata": { "generation": 5 }, "status": { "observedGeneration": 5, "desiredNumberScheduled": 3, "numberReady": 0, "updatedNumberScheduled": 3 } }
     }
   ]
 }

--- a/pkg/health/workload.go
+++ b/pkg/health/workload.go
@@ -25,18 +25,18 @@ func Workload(obj any, now time.Time) Verdict {
 	switch o := obj.(type) {
 	case *appsv1.Deployment:
 		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, o.Status.AvailableReplicas, true,
-			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
+			converging(o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.ReplicaSet:
 		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false,
-			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
+			converging(o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.StatefulSet:
 		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false,
-			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
+			converging(o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.DaemonSet:
 		// DesiredNumberScheduled 0 means the selector matches no nodes — benign,
 		// nothing to run, not unhealthy.
 		return replicaVerdict(o.Status.DesiredNumberScheduled, o.Status.NumberReady, 0, false,
-			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
+			converging(o.Generation, o.Status.ObservedGeneration))
 	case *batchv1.Job:
 		return jobVerdict(o)
 	case *batchv1.CronJob:
@@ -78,22 +78,21 @@ func replicaVerdict(desired, ready, available int32, requireAvailable, convergin
 	return Verdict{Level: LevelUnhealthy, Reason: "NoneReady"}
 }
 
-// workloadConvergenceGrace is how long a freshly created workload may take to
-// reach its target before we grade it. Matches the 5-minute window Pending pods
-// and unassigned LoadBalancers already get elsewhere in the codebase, so the
-// product has one startup-tolerance story rather than three.
-const workloadConvergenceGrace = 5 * time.Minute
-
-// converging reports whether a workload has not yet had a fair chance to reach
-// its target — either because it was created moments ago, or because its spec
-// changed and the controller has not observed that generation yet. The
-// generation check is what covers scale-ups on long-lived workloads, where the
-// creation timestamp is months old but the target moved a second ago.
-func converging(created, now time.Time, generation, observedGeneration int64) bool {
-	if observedGeneration > 0 && observedGeneration < generation {
-		return true
-	}
-	return now.Sub(created) < workloadConvergenceGrace
+// converging reports whether the controller has not yet acted on the workload's
+// current spec, so grading against that spec would report controller lag as an
+// outage. This is the scale-up case: spec says 10, the controller is still
+// working from generation N-1 and has created 3, so ready-vs-desired looks like
+// a 70% outage for as long as the reconcile takes.
+//
+// Deliberately NOT age-based. An earlier revision also granted grace to any
+// workload created within five minutes, which softened genuinely broken
+// workloads: an unschedulable Deployment at 0/3 read neutral while the object's
+// own issues said [critical] workload_degraded. Generation skew is evidence —
+// the controller has demonstrably not looked at this spec yet. "Created
+// recently" is only a guess, and it guesses wrong exactly when a deploy is
+// broken on arrival, which is when it matters most.
+func converging(generation, observedGeneration int64) bool {
+	return observedGeneration > 0 && observedGeneration < generation
 }
 
 func jobVerdict(j *batchv1.Job) Verdict {

--- a/pkg/health/workload.go
+++ b/pkg/health/workload.go
@@ -24,15 +24,19 @@ import (
 func Workload(obj any, now time.Time) Verdict {
 	switch o := obj.(type) {
 	case *appsv1.Deployment:
-		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, o.Status.AvailableReplicas, true)
+		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, o.Status.AvailableReplicas, true,
+			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.ReplicaSet:
-		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false)
+		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false,
+			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.StatefulSet:
-		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false)
+		return replicaVerdict(specReplicas(o.Spec.Replicas), o.Status.ReadyReplicas, 0, false,
+			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
 	case *appsv1.DaemonSet:
 		// DesiredNumberScheduled 0 means the selector matches no nodes — benign,
 		// nothing to run, not unhealthy.
-		return replicaVerdict(o.Status.DesiredNumberScheduled, o.Status.NumberReady, 0, false)
+		return replicaVerdict(o.Status.DesiredNumberScheduled, o.Status.NumberReady, 0, false,
+			converging(o.CreationTimestamp.Time, now, o.Generation, o.Status.ObservedGeneration))
 	case *batchv1.Job:
 		return jobVerdict(o)
 	case *batchv1.CronJob:
@@ -46,17 +50,50 @@ func Workload(obj any, now time.Time) Verdict {
 // replicaVerdict grades a replica-based workload. requireAvailable additionally
 // demands available==desired (Deployment tracks availability; ReplicaSet /
 // StatefulSet / DaemonSet don't expose it the same way).
-func replicaVerdict(desired, ready, available int32, requireAvailable bool) Verdict {
+func replicaVerdict(desired, ready, available int32, requireAvailable, converging bool) Verdict {
 	if desired == 0 {
 		return Verdict{Level: LevelNeutral, Reason: "ScaledToZero"}
 	}
 	if ready == desired && (!requireAvailable || available == desired) {
 		return Verdict{Level: LevelHealthy}
 	}
+	// Convergence grace. Without it every ordinary rollout and every scale-up
+	// grades as impaired for its whole duration — a Deployment scaled 3->10
+	// reads NoneReady/PartiallyReady the instant the spec changes, before the
+	// controller has created a single pod, which is controller lag rather than
+	// an outage.
+	//
+	// Neutral, never Healthy: we are declining to call it broken, not claiming
+	// it is fine. And this only softens the WORKLOAD verdict — a pod that is
+	// genuinely failing (ImagePullBackOff, CrashLoopBackOff) is classified
+	// unhealthy on its own by Pod(), so real breakage during the window still
+	// surfaces; it just surfaces on the pod rather than as a premature verdict
+	// on the controller.
+	if converging {
+		return Verdict{Level: LevelNeutral, Reason: "Converging"}
+	}
 	if ready > 0 {
 		return Verdict{Level: LevelDegraded, Reason: "PartiallyReady"}
 	}
 	return Verdict{Level: LevelUnhealthy, Reason: "NoneReady"}
+}
+
+// workloadConvergenceGrace is how long a freshly created workload may take to
+// reach its target before we grade it. Matches the 5-minute window Pending pods
+// and unassigned LoadBalancers already get elsewhere in the codebase, so the
+// product has one startup-tolerance story rather than three.
+const workloadConvergenceGrace = 5 * time.Minute
+
+// converging reports whether a workload has not yet had a fair chance to reach
+// its target — either because it was created moments ago, or because its spec
+// changed and the controller has not observed that generation yet. The
+// generation check is what covers scale-ups on long-lived workloads, where the
+// creation timestamp is months old but the target moved a second ago.
+func converging(created, now time.Time, generation, observedGeneration int64) bool {
+	if observedGeneration > 0 && observedGeneration < generation {
+		return true
+	}
+	return now.Sub(created) < workloadConvergenceGrace
 }
 
 func jobVerdict(j *batchv1.Job) Verdict {

--- a/pkg/health/workload_test.go
+++ b/pkg/health/workload_test.go
@@ -172,13 +172,18 @@ func TestWorkloadConvergenceGrace(t *testing.T) {
 			wantLevel: LevelNeutral,
 		},
 		{
-			name: "freshly created deployment with nothing ready yet",
+			// Age alone must NOT buy grace. A deploy that is broken on arrival is
+			// still broken, and softening it is worst exactly when it matters
+			// most: an earlier revision granted every workload a 5-minute window
+			// and reported an unschedulable Deployment as neutral while that same
+			// object carried a critical workload_degraded issue.
+			name: "freshly created but controller caught up is graded normally",
 			dep: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: fresh, Generation: 1},
 				Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
 				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
 			},
-			wantLevel: LevelNeutral,
+			wantLevel: LevelUnhealthy,
 		},
 		{
 			// Past the window with the controller caught up and still nothing

--- a/pkg/health/workload_test.go
+++ b/pkg/health/workload_test.go
@@ -140,3 +140,76 @@ func TestWorkloadGoldenVectors(t *testing.T) {
 		})
 	}
 }
+
+// TestWorkloadConvergenceGrace covers the window between a spec change and the
+// controller acting on it. Without it, replicaVerdict graded purely on
+// ready-vs-desired, so a Deployment scaled 3->10 read NoneReady/PartiallyReady
+// the instant the spec changed — before the controller had created a single
+// pod. That is controller lag, not an outage.
+//
+// The contract is Neutral, never Healthy: radar declines to call it broken
+// without claiming it is fine.
+func TestWorkloadConvergenceGrace(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	old := metav1.NewTime(now.Add(-30 * 24 * time.Hour))
+	fresh := metav1.NewTime(now.Add(-30 * time.Second))
+
+	tests := []struct {
+		name      string
+		dep       *appsv1.Deployment
+		wantLevel Level
+	}{
+		{
+			name: "long-lived deployment scaled up, controller has not observed the new spec",
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old, Generation: 7},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr32(10)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 6, // one behind: spec moved, controller hasn't
+					ReadyReplicas:      3, AvailableReplicas: 3,
+				},
+			},
+			wantLevel: LevelNeutral,
+		},
+		{
+			name: "freshly created deployment with nothing ready yet",
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: fresh, Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+			},
+			wantLevel: LevelNeutral,
+		},
+		{
+			// Past the window with the controller caught up and still nothing
+			// ready — this is a real outage and must not be softened.
+			name: "settled deployment with zero ready is unhealthy",
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old, Generation: 7},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 7},
+			},
+			wantLevel: LevelUnhealthy,
+		},
+		{
+			// Converged: grace must never downgrade a genuinely healthy result.
+			name: "settled and fully ready is healthy",
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old, Generation: 7},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 7, ReadyReplicas: 3, AvailableReplicas: 3,
+				},
+			},
+			wantLevel: LevelHealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Workload(tt.dep, now).Level; got != tt.wantLevel {
+				t.Errorf("Level = %v, want %v", got, tt.wantLevel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Radar's resource rows carried the raw `pod.Status.Phase` as their status. That field has five values and says almost nothing about a pod: one whose main container finished while a sidecar keeps running reports phase `Running` indefinitely. A CronJob wedged by a non-exiting sidecar — twelve concurrent Job pods, one per minute, none completing — showed twelve rows reading `Running` with `health: healthy`, while `kubectl get pods` showed the same pods as `NotReady`.

kubectl's printer spends ~80 lines turning phase, container states and conditions into a status worth reading. This adopts that computation, and fixes the adjacent places where radar either dropped information kubectl keeps or asserted health it couldn't support.

Concrete effect on live clusters: a `metrics-server` pod that was OOMKilled two days ago and has run cleanly since no longer reports `OOMKilled`; `netd` DaemonSet pods that read `2/2` now read `3/3` because native sidecars are counted; and a Deployment scaled 3→10 reads `3/10` instead of `3/3 Running`.

## What changed

**Display status is computed, not copied from the phase.** A port of upstream `printPod` covering: `Completed` + still-running + not-Ready → `NotReady`; pod-level reasons such as `Evicted`; the `Init:` prefix that attributes a failure to initialization rather than the main workload; `SchedulingGated`; and counting native (KEP-753) sidecars toward the READY denominator, which is spec containers rather than reported statuses.

Two deliberate divergences from upstream, both retaining more information than it does. No `Terminating` override — radar carries `terminating` and `finalizers` as dedicated fields, so replacing the status would discard the underlying state on every routine rollout. No legacy `NodeUnreachable` → `Unknown` branch, which is gated on a `pod.Status.Reason` that modern kubelets rarely set.

**Termination history is a separate concern from current state.** `lastTerminatedReason` and `lastRestartedAge` carry why a container last died and how long ago, while `status` stays on what is true now. Reported only when a container has actually restarted, mirroring kubectl's RESTARTS column (`7 (16h ago)` for a non-zero count, a bare `0` otherwise) — history without a restart would describe a container that ended and stayed ended, which the pod's state already says. `Issue` remains the diagnostic hint and is allowed to be broader than `status`, including recent history; the health level is the authority on whether something is currently wrong.

**Replica rows denominate by spec.** `status.replicas` is what the controller has created so far, so a scale-up read `3/3 Running` until it caught up. Both the READY fraction and the status comparison use `spec.replicas`, matching kubectl. Same on ReplicaSet.

**Job summaries carry suspension and failure reason.** A suspended Job read `Running`, contradicting `health.jobVerdict` on the same object. Terminal conditions take precedence over suspension, and `BackoffLimitExceeded` / `DeadlineExceeded` survive instead of flattening to `Failed`.

**In-flight batch work grades neutral, not healthy.** `health.Workload` already returns Neutral for a running Job; its pods returned Healthy, so one piece of work was graded two ways. The branch sits after every failure check, so a crashlooping or OOMKilled Job pod keeps its real verdict, and the owner's API group is checked so a CRD named `Job` doesn't match.

**Workload convergence keys on controller lag.** A workload is treated as converging when `observedGeneration` is behind `generation` — the controller demonstrably has not read the current spec, so grading against it reports reconcile lag as an outage. Neutral, never Healthy. Deliberately not age-based: recency is a guess that fails exactly when a deploy is broken on arrival, and pod-level failures surface independently either way.

**Day-of-month cron cadence is computed.** Any constrained day-of-month collapsed to a flat 28 days, giving a 42-day staleness grace, so a `1,15` job could miss two consecutive runs and read healthy for six weeks. The maximum gap is derived from days present in every month, with 29–31 handled conservatively since short months skip them.

## Reviewer notes

The two health-level changes flow into the TypeScript classifiers, so `resource-utils.ts` moves in step and four vectors were added to `pkg/health/testdata/golden_vectors.json` — the shared fixture that `golden_crosslang_test.go` and the vitest mirror both load. The new vectors are generation-based rather than age-based, since that fixture must stay time-independent (the TS classifier has no injected clock).

Worth focusing on: the ordering of the neutral branch in `classifyPodLevel`, which must stay last or it masks failures (there is a test pinning that); the convergence predicate, the one change that softens an existing verdict; and the two documented divergences from `printPod` above.

## Testing

`make tsc`, `make test`, `make build` green; `pkg` module suite green; cross-language golden contract green on both sides.

Beyond unit tests, the tool output was verified against a control build compiled from the same base commit: both queried one cluster at the same instant, so differences isolate this change. Extended to a differential sweep of **4,355 resources across five clusters** (2 GKE, 2 EKS; non-prod, infra and management) comparing every pod, deployment, statefulset, daemonset, replicaset, job and cronjob row field-by-field. Every difference falls in a field this PR intends to change; none unexplained.

New unit coverage: the Job-sidecar split in both directions (pod Ready vs not), evicted, scheduling-gated, init attribution, recovered-OOM history, scale-up before the controller reacts, convergence in all four states, and day-of-month cadence with an upper bound — the existing cron table asserted only a lower bound.

`visual-test` not run. Badge colours change for in-flight Job pods and converging workloads, so a fixture-backed capture is worth taking before merge.

## Notes

Day-of-month cadence rests on unit tests alone — no cluster in the sweep uses such a schedule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core health classification, AI-facing status fields, and UI badges across pods and workloads; convergence softens verdicts during rollouts but real pod failures still surface, and Job-neutral ordering is test-pinned to avoid masking crashes.
> 
> **Overview**
> **Pod and workload display/health now match `kubectl get` and stop treating in-flight work as healthy.**
> 
> AI resource summaries no longer emit raw `pod.Status.Phase` as **status**. They use a `computePodDisplay` port of upstream `printPod` (e.g. main **Completed** + lingering sidecar → **NotReady**, `Init:` failures, **SchedulingGated**, native sidecars in READY). **Status** stays current state; **Issue** stays diagnostic; **lastTerminatedReason** / **lastRestartedAge** carry restart history only when restarts &gt; 0. Deployments/ReplicaSets use **spec.replicas** for READY and status; Job summaries respect terminal conditions, suspension, and failure reasons.
> 
> **Backend and UI health classifiers move in lockstep.** Batch Job-owned pods grade **neutral** after failure checks (`isOwnedByJob` requires `batch/` API group). Deployments/DaemonSets get **converging** grace when `observedGeneration` &lt; `generation` (not age-based). `resource-utils.ts` mirrors the same rules; four time-independent golden vectors were added.
> 
> **Cron staleness:** day-of-month schedules use real max gap (`maxDomGapDays`) instead of a flat 28-day interval so twice-monthly jobs don’t get a ~6-week healthy window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8837c8098a27800f555d6023c18875edf2696ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->