### PR TITLE
fix: index all current PolicyReports

### DIFF
--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -192,8 +192,9 @@ var (
 // The reason isn't tracked yet because there's no consumer to need it;
 // adding it speculatively is YAGNI surface.
 //
-// Returned indexes are safe for concurrent reads; the index swaps its
-// internal state atomically during rebuilds.
+// Returned indexes are safe for concurrent reads. Rebuilds publish a new
+// index snapshot atomically, so a caller that already loaded an index sees a
+// stable snapshot for the rest of its synchronous computation.
 func GetPolicyReportIndex() *policyreports.Index {
 	return policyReportIndex.Load()
 }
@@ -632,11 +633,12 @@ func listPolicyReportsAll(gvrs []schema.GroupVersionResource) []*unstructured.Un
 // scheduleRebuild coalesces back-to-back informer events into a single
 // rebuild. The first event in a burst arms a timer; subsequent events
 // during the debounce window do nothing (the pending flag is already
-// set). When the timer fires, we re-list and Replace the index contents.
+// set). When the timer fires, we re-list and publish a replacement index
+// snapshot.
 //
-// The debounce window (rebuildDebounce) is well under any realistic
-// staleness budget: agents reading the index see at most ~500ms-stale
-// data, which is well below Kyverno's own reconcile cadence.
+// The first rebuild starts after rebuildDebounce. Under sustained churn, a
+// follow-up also waits at least as long as the preceding rebuild took so index
+// maintenance cannot monopolize a core.
 func scheduleRebuild() {
 	if !policyReportPending.CompareAndSwap(false, true) {
 		return // rebuild already scheduled
@@ -704,14 +706,14 @@ func rebuildPolicyReportIndexOnce(listReports func([]schema.GroupVersionResource
 		return
 	}
 	reports := listReports(gvrs)
+	next := policyreports.BuildIndex(reports)
 
 	policyReportMu.Lock()
-	stale := kyvernoWarmupGen.Load() != generation
-	policyReportMu.Unlock()
-	if stale {
+	defer policyReportMu.Unlock()
+	if kyvernoWarmupGen.Load() != generation || policyReportIndex.Load() != idx {
 		return
 	}
-	idx.Replace(reports)
+	policyReportIndex.Store(next)
 }
 
 // ResetPolicyReportIndex clears the index and re-arms warmup-once. Called
@@ -730,6 +732,9 @@ func ResetPolicyReportIndex() {
 	policyReportIndex.Store(nil)
 	policyReportWatched = nil
 	policyReportPending.Store(false)
+	// The rebuild coordinator deliberately survives reset. Clearing its active
+	// flag while the old loop still owns it could start a second loop in parallel;
+	// generation and pointer validation make the old iteration harmless.
 	// Clear the warmup decision too — the new cluster gets a fresh
 	// detection pass, and GetKyvernoStatus should report "warmup" until
 	// the new pass completes (not whatever the previous cluster decided).

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -15,11 +15,9 @@ import (
 )
 
 // KyvernoStatus reports why the PolicyReport index is (or isn't) populated.
-// Callers that need to distinguish "Kyverno not installed" from "warmup
-// deferred (cluster too large)" from "warmup in flight" from "ready but
-// empty" use GetKyvernoStatus to surface the reason to the operator/agent
-// — otherwise an empty PolicyReport response is indistinguishable from a
-// transient one.
+// Callers that need lifecycle and coverage details use GetPolicyReportStatus;
+// the bare enum only distinguishes absence, deferred warmup, active warmup,
+// and a live index.
 type KyvernoStatus string
 
 const (
@@ -27,26 +25,25 @@ const (
 	// not present in discovery. The PolicyReport source is unavailable;
 	// nothing to do.
 	KyvernoStatusNotInstalled KyvernoStatus = "not_installed"
-	// KyvernoStatusDeferred — Kyverno is installed but warmup decided not
-	// to track PolicyReports (cluster aggregate exceeds the warmup cap, or
-	// the probe was denied/errored). Findings are NOT being indexed.
+	// KyvernoStatusDeferred — Kyverno is installed but warmup could not
+	// track PolicyReports because the probe was denied or failed. Findings
+	// are NOT being indexed.
 	// Callers wanting them must fall back to a direct fetch.
 	KyvernoStatusDeferred KyvernoStatus = "deferred"
 	// KyvernoStatusWarmup — Kyverno is installed and warmup is presumed
 	// in-flight (discovery has named the CRDs but the index hasn't been
 	// published yet). Narrow window; expect to become "ready" shortly.
 	KyvernoStatusWarmup KyvernoStatus = "warmup"
-	// KyvernoStatusReady — PolicyReport index is populated and live. An
-	// empty findings list with this status means "no policy violations",
-	// not "data unavailable".
+	// KyvernoStatusReady — PolicyReport index is populated and live. Consumers
+	// must inspect its structured coverage fields before treating an empty
+	// findings list as complete.
 	KyvernoStatusReady KyvernoStatus = "ready"
 )
 
 // Reason codes explaining a non-ready status. The bare four-state enum
-// collapses RBAC denial, probe failure and over-cap into "deferred", which
-// leaves an operator with an empty policy view and no way to tell "nothing is
-// violating" from "Radar cannot see". The reason code is what makes that
-// distinction sayable.
+// collapses RBAC denial and probe failure into "deferred", which leaves an
+// operator with an empty policy view and no way to tell "nothing is violating"
+// from "Radar cannot see". The reason code makes that distinction sayable.
 const (
 	ReasonNoDiscovery  = "discovery_unavailable"
 	ReasonNotInstalled = "kyverno_not_installed"
@@ -54,31 +51,21 @@ const (
 	ReasonCacheDown    = "cache_unavailable"
 	ReasonRBACDenied   = "rbac_denied"
 	ReasonProbeFailed  = "probe_failed"
-	ReasonOverCap      = "over_cap"
 )
 
 // PolicyReportStatus is the structured contract behind the PolicyReport
-// index. Status alone cannot answer "why is this empty"; ObservedCount and
-// Cap turn "deferred" into a sentence an operator can act on ("1,842 reports
-// exceeds the 500-report cap"), and WatchedGroups names which API family the
-// data actually came from — load-bearing on a cluster mid-migration from
-// wgpolicyk8s.io to openreports.io.
+// index. Status alone cannot answer "why is this empty"; WatchedGroups names
+// which API family the data actually came from, which is load-bearing on a
+// cluster mid-migration from wgpolicyk8s.io to openreports.io.
 type PolicyReportStatus struct {
 	Status     KyvernoStatus `json:"status"`
 	ReasonCode string        `json:"reasonCode,omitempty"`
 	// ObservedCount is the number of report objects the pre-warmup probe
 	// counted across the selected groups. -1 when the probe could not run.
 	//
-	// It is a BOOT-TIME SNAPSHOT and does not track growth. The probe runs
-	// once, inside warmup's sync.Once; the debounced rebuild re-lists and
-	// lets Index.Replace truncate to the cap without re-counting. So a
-	// cluster that starts under the cap and later grows past it keeps
-	// reporting `ready` with a stale count while findings are silently
-	// dropped. Don't render this as a live number, and don't infer
-	// "under the cap" from it. Making post-warmup truncation observable is
-	// the actual fix and belongs with the multi-engine retention work.
+	// It is a boot-time snapshot for diagnostics and does not track growth.
+	// Do not render it as a live count.
 	ObservedCount int `json:"observedCount"`
-	Cap           int `json:"cap"`
 	// WatchedGroups are the API groups actually being watched, e.g.
 	// ["openreports.io"]. Empty when nothing is watched.
 	WatchedGroups []string `json:"watchedGroups,omitempty"`
@@ -164,13 +151,6 @@ var reportGroups = []reportGroup{
 	},
 }
 
-// kyvernoReportWarmupCap caps how many PolicyReport documents the index
-// keeps in memory. The pkg/policyreports.MaxIndexedReports constant is the
-// authoritative number; this re-export lives here for easy operator-side
-// tuning at the integration boundary (so anyone grepping the codebase for
-// "Kyverno" finds the tunable without having to know the package layout).
-const kyvernoReportWarmupCap = policyreports.MaxIndexedReports
-
 // policyReportIndex is the singleton index instance, populated when
 // Kyverno is detected and kept up to date by PolicyReport informer
 // events. Nil when Kyverno is absent — callers must nil-check.
@@ -181,10 +161,13 @@ var (
 	// value-type sync.Once whose mutex is currently held by a concurrent
 	// Do() crashes with "unlock of unlocked mutex". Every other sync.Once
 	// in internal/k8s/ uses this same pointer pattern for the same reason.
-	policyReportInit    = new(sync.Once)
-	policyReportWatched []schema.GroupVersionResource // guarded by policyReportMu
-	policyReportMu      sync.Mutex                    // guards policyReportWatched + serializes rebuild
-	policyReportPending atomic.Bool                   // true when a rebuild is already queued
+	policyReportInit         = new(sync.Once)
+	policyReportWatched      []schema.GroupVersionResource // guarded by policyReportMu
+	policyReportMu           sync.Mutex                    // guards policyReportWatched + warmup/reset publication
+	policyReportRebuildMu    sync.Mutex
+	policyReportRebuilding   bool        // guarded by policyReportRebuildMu
+	policyReportRebuildAgain bool        // guarded by policyReportRebuildMu
+	policyReportPending      atomic.Bool // true when a rebuild is already queued
 
 	// debounceDelay is how long after an informer event we wait before
 	// rebuilding the index. PolicyReport updates often arrive in bursts
@@ -199,10 +182,9 @@ var (
 // "Nil" collapses several distinct conditions today — discovery not
 // available, Kyverno not installed, dynamic cache not initialized, no
 // PolicyReport CRDs registered, RBAC denied on the count probe, or the
-// aggregate report count exceeded the warmup cap (deferred). Callers
-// that need to distinguish these — e.g. to emit the correct
-// `resourcecontext.OmittedReason` (not_installed vs rbac_denied vs
-// budget_exceeded vs cache_cold) — cannot do so today.
+// report probe was denied or failed. Callers that need to distinguish
+// these — e.g. to emit the correct `resourcecontext.OmittedReason`
+// (not_installed vs rbac_denied vs cache_cold) — cannot do so today.
 //
 // TODO(T10): when the diagnostic `policySummary.kyverno` consumer
 // arrives, introduce a sibling accessor that returns an enum status
@@ -265,7 +247,6 @@ func WarmupKyvernoPolicyReports() {
 				Status:        s,
 				ReasonCode:    reason,
 				ObservedCount: observed,
-				Cap:           kyvernoReportWarmupCap,
 				WatchedGroups: groups,
 			})
 		}
@@ -281,7 +262,6 @@ func WarmupKyvernoPolicyReports() {
 			kyvernoWarmupReason.Store(PolicyReportStatus{
 				Status:        KyvernoStatusReady,
 				ObservedCount: observed,
-				Cap:           kyvernoReportWarmupCap,
 				WatchedGroups: groups,
 				DeniedGroups:  denied,
 				LiveUpdates:   live,
@@ -331,19 +311,7 @@ func WarmupKyvernoPolicyReports() {
 			return
 		}
 
-		// The index caps what it keeps in memory (MaxIndexedReports), but the
-		// informers themselves list/watch/cache every report object
-		// cluster-wide — on a Kyverno-heavy cluster with tens of thousands of
-		// reports that is exactly the high-cardinality cost we're avoiding.
-		// Over the cap, leave reports in the deferred-fetch tier and say so
-		// with the count, so the operator can tell over-cap from empty.
-		if selection.total > kyvernoReportWarmupCap {
-			log.Printf("[policy-reports] Cluster has %d reports across %v (cap=%d); leaving deferred to avoid full-cluster watch cost", selection.total, selection.groups, kyvernoReportWarmupCap)
-			setStatus(KyvernoStatusDeferred, ReasonOverCap, selection.total, selection.groups)
-			return
-		}
-
-		log.Printf("[policy-reports] Kyverno detected; warming up %d report CRDs from %v (probed %d reports, cap=%d)", len(watched), selection.groups, selection.total, kyvernoReportWarmupCap)
+		log.Printf("[policy-reports] Kyverno detected; warming up %d report CRDs from %v (probed %d reports)", len(watched), selection.groups, selection.total)
 		cache.WarmupParallel(watched, 30*time.Second)
 
 		// Initialize the index from current cache contents so the first
@@ -357,8 +325,7 @@ func WarmupKyvernoPolicyReports() {
 		// critical section sees the new policyReportWatched value. Each
 		// handler does a debounced rebuild — PolicyReport events arrive
 		// in bursts when Kyverno re-evaluates a policy, and rebuilding
-		// once per burst is cheaper than per-event incremental updates
-		// given how small the index is (≤500 reports).
+		// once per burst is cheaper than rebuilding once per event.
 		handlersRegistered := true
 		handler := toolscache.ResourceEventHandlerFuncs{
 			AddFunc:    func(_ any) { scheduleRebuild() },
@@ -392,14 +359,14 @@ func WarmupKyvernoPolicyReports() {
 //
 //	not_installed — discovery decided Kyverno is absent (or the reporting
 //	                CRDs are missing); findings will never appear.
-//	deferred      — warmup ran but skipped indexing (cluster exceeded the
-//	                cap, or RBAC/probe error). Findings won't appear from
-//	                this index; callers may fall back to on-demand.
+//	deferred      — warmup ran but skipped indexing after an RBAC/probe
+//	                error. Findings won't appear from this index; callers
+//	                may fall back to on-demand.
 //	warmup        — warmup hasn't completed its decision pass yet (typical
 //	                for the first second or two after subsystem init); the
 //	                index is uninitialized.
-//	ready         — index is live. An empty findings list under this
-//	                status means "no violations", not "data unavailable".
+//	ready         — index is live. GetPolicyReportStatus carries the
+//	                coverage fields needed to interpret an empty lookup.
 //
 // Cheap: a single atomic.Value Load. Safe to call from request paths.
 func GetKyvernoStatus() KyvernoStatus {
@@ -419,12 +386,12 @@ func GetKyvernoStatus() KyvernoStatus {
 
 // GetPolicyReportStatus returns the structured status behind the PolicyReport
 // index: the lifecycle phase plus why it is in that phase, how many report
-// objects were observed, the cap they were measured against, and which API
-// groups are actually being watched.
+// objects were observed at boot, and which API groups are actually being
+// watched.
 //
 // Consumers rendering an empty policy view must use this rather than
-// GetKyvernoStatus alone — "deferred" collapses RBAC denial, probe failure and
-// over-cap, and those need different words in front of an operator.
+// GetKyvernoStatus alone — "deferred" collapses RBAC denial and probe failure,
+// and those need different words in front of an operator.
 func GetPolicyReportStatus() PolicyReportStatus {
 	status, _ := kyvernoWarmupReason.Load().(PolicyReportStatus)
 	// Ready is authoritative for the same reason GetKyvernoStatus treats it
@@ -441,9 +408,6 @@ func GetPolicyReportStatus() PolicyReportStatus {
 		}
 		status.Status = KyvernoStatusReady
 		status.ReasonCode = ""
-		if status.Cap == 0 {
-			status.Cap = kyvernoReportWarmupCap
-		}
 		return status
 	}
 	if status.Status == "" {
@@ -463,12 +427,12 @@ func GetPolicyReportStatus() PolicyReportStatus {
 		d := GetResourceDiscovery()
 		if d == nil || d.ResourceDiscovery == nil {
 			// No discovery yet — we haven't looked, so we can't claim absence.
-			return PolicyReportStatus{Status: KyvernoStatusNotInstalled, ReasonCode: ReasonNoDiscovery, Cap: kyvernoReportWarmupCap}
+			return PolicyReportStatus{Status: KyvernoStatusNotInstalled, ReasonCode: ReasonNoDiscovery}
 		}
 		if d.IsKyvernoInstalled() {
-			return PolicyReportStatus{Status: KyvernoStatusWarmup, Cap: kyvernoReportWarmupCap}
+			return PolicyReportStatus{Status: KyvernoStatusWarmup}
 		}
-		return PolicyReportStatus{Status: KyvernoStatusNotInstalled, ReasonCode: ReasonNotInstalled, Cap: kyvernoReportWarmupCap}
+		return PolicyReportStatus{Status: KyvernoStatusNotInstalled, ReasonCode: ReasonNotInstalled}
 	}
 	return status
 }
@@ -565,8 +529,7 @@ func selectReportGVRs(served func(schema.GroupVersionResource) bool, probeCount 
 				groupDenied = true
 			default:
 				// Readable, including a legitimately empty sibling — keep it
-				// watched so a report created later still appears live. Its
-				// cost is bounded precisely because the probe succeeded.
+				// watched so a report created later still appears live.
 				readable = append(readable, gvr)
 				groupTotal += count
 			}
@@ -643,8 +606,6 @@ func (s PolicyReportStatus) OmittedReason() (resourcecontext.OmittedReason, bool
 	switch s.ReasonCode {
 	case ReasonRBACDenied:
 		return resourcecontext.OmittedRBACDenied, true
-	case ReasonOverCap:
-		return resourcecontext.OmittedBudgetExceeded, true
 	}
 	return resourcecontext.OmittedCacheCold, true
 }
@@ -658,7 +619,7 @@ func listPolicyReportsAll(gvrs []schema.GroupVersionResource) []*unstructured.Un
 	}
 	var all []*unstructured.Unstructured
 	for _, gvr := range gvrs {
-		items, err := cache.ListWatched(gvr)
+		items, err := cache.ListWatchedReadOnly(gvr)
 		if err != nil {
 			log.Printf("[policy-reports] list %s: %v", gvr, err)
 			continue
@@ -688,28 +649,69 @@ func scheduleRebuild() {
 		// fresh timer (CAS would fail while pending=true), and would
 		// only be picked up when *some later* event happened to fire.
 		// Clearing first means any event during the rebuild always
-		// either lands in the current rebuild's snapshot OR arms a
-		// fresh timer. The cost is one extra rebuild per event that
-		// arrives during the rebuild window — cheaper than chasing
-		// silent staleness.
+		// either lands in the current rebuild's snapshot or arms a
+		// fresh timer. Concurrent timer expirations collapse into one
+		// follow-up rebuild.
 		policyReportPending.Store(false)
 		rebuildPolicyReportIndex()
 	})
 }
 
-// rebuildPolicyReportIndex re-lists all watched PolicyReport GVRs from
-// the dynamic cache and atomically swaps the index contents. Serialized
-// by policyReportMu so concurrent triggers don't waste CPU rebuilding
-// the same data.
 func rebuildPolicyReportIndex() {
-	policyReportMu.Lock()
-	defer policyReportMu.Unlock()
+	rebuildPolicyReportIndexUsing(listPolicyReportsAll)
+}
 
-	idx := policyReportIndex.Load()
-	if idx == nil {
-		return // index was reset (context switch) — drop event
+func rebuildPolicyReportIndexUsing(listReports func([]schema.GroupVersionResource) []*unstructured.Unstructured) {
+	policyReportRebuildMu.Lock()
+	if policyReportRebuilding {
+		policyReportRebuildAgain = true
+		policyReportRebuildMu.Unlock()
+		return
 	}
-	idx.Replace(listPolicyReportsAll(policyReportWatched))
+	policyReportRebuilding = true
+	policyReportRebuildMu.Unlock()
+
+	for {
+		started := time.Now()
+		rebuildPolicyReportIndexOnce(listReports)
+		rebuildDuration := time.Since(started)
+
+		policyReportRebuildMu.Lock()
+		if !policyReportRebuildAgain {
+			policyReportRebuilding = false
+			policyReportRebuildMu.Unlock()
+			return
+		}
+		policyReportRebuildMu.Unlock()
+
+		// A sustained report storm must not consume more than roughly half
+		// of one core rebuilding the same full snapshot repeatedly.
+		time.Sleep(max(rebuildDebounce, rebuildDuration))
+		policyReportRebuildMu.Lock()
+		policyReportRebuildAgain = false
+		policyReportRebuildMu.Unlock()
+	}
+}
+
+func rebuildPolicyReportIndexOnce(listReports func([]schema.GroupVersionResource) []*unstructured.Unstructured) {
+	policyReportMu.Lock()
+	idx := policyReportIndex.Load()
+	gvrs := append([]schema.GroupVersionResource(nil), policyReportWatched...)
+	generation := kyvernoWarmupGen.Load()
+	policyReportMu.Unlock()
+
+	if idx == nil {
+		return
+	}
+	reports := listReports(gvrs)
+
+	policyReportMu.Lock()
+	stale := kyvernoWarmupGen.Load() != generation
+	policyReportMu.Unlock()
+	if stale {
+		return
+	}
+	idx.Replace(reports)
 }
 
 // ResetPolicyReportIndex clears the index and re-arms warmup-once. Called

--- a/internal/k8s/policy_reports_selection_test.go
+++ b/internal/k8s/policy_reports_selection_test.go
@@ -101,6 +101,21 @@ func TestSelectReportGVRs_WatchesBothWhenBothHoldData(t *testing.T) {
 	}
 }
 
+func TestSelectReportGVRs_PreservesLargeObservedCount(t *testing.T) {
+	const reportCount = 20_000
+	sel := selectReportGVRs(
+		servedSet(orReports),
+		counts(map[schema.GroupVersionResource]int{orReports: reportCount}),
+	)
+
+	if !hasGVR(sel, orReports) {
+		t.Fatalf("expected large readable report collection to be watched, got %v", sel.gvrs)
+	}
+	if sel.total != reportCount {
+		t.Errorf("total = %d, want %d", sel.total, reportCount)
+	}
+}
+
 // Within one group the versions are the same resource; watching two would
 // double-count every finding.
 func TestSelectReportGVRs_WatchesOneVersionPerGroup(t *testing.T) {
@@ -145,7 +160,7 @@ func TestSelectReportGVRs_ReportsRBACDenialDistinctly(t *testing.T) {
 	)
 
 	if len(sel.gvrs) != 0 {
-		t.Errorf("must not watch a GVR whose cost could not be bounded, got %v", sel.gvrs)
+		t.Errorf("must not watch a GVR the current identity cannot read, got %v", sel.gvrs)
 	}
 	if sel.reason != ReasonRBACDenied {
 		t.Errorf("reason = %q, want %q", sel.reason, ReasonRBACDenied)
@@ -206,7 +221,6 @@ func TestPolicyReportStatusOmittedReason(t *testing.T) {
 		// non-Kyverno cluster would be noise, not honesty.
 		{"not installed stays silent", PolicyReportStatus{Status: KyvernoStatusNotInstalled}, "", false},
 		{"warmup is cache cold", PolicyReportStatus{Status: KyvernoStatusWarmup}, "cache_cold", true},
-		{"over cap is budget exceeded", PolicyReportStatus{Status: KyvernoStatusDeferred, ReasonCode: ReasonOverCap}, "budget_exceeded", true},
 		{"rbac denial is reported as such", PolicyReportStatus{Status: KyvernoStatusDeferred, ReasonCode: ReasonRBACDenied}, "rbac_denied", true},
 		{"probe failure falls back to cache cold", PolicyReportStatus{Status: KyvernoStatusDeferred, ReasonCode: ReasonProbeFailed}, "cache_cold", true},
 	}
@@ -224,8 +238,8 @@ func TestPolicyReportStatusOmittedReason(t *testing.T) {
 	}
 }
 
-// Bugbot #2 (HIGH): a denial on one sibling must not discard the other.
-// Namespace-scoped RBAC routinely grants `list policyreports` in the user's
+// A denial on one sibling must not discard the other. Namespace-scoped RBAC
+// routinely grants `list policyreports` in the user's
 // namespaces while denying cluster-scoped `clusterpolicyreports`; the old
 // per-family probeFailed flag dropped the whole family and lost every finding
 // the user could legitimately see.
@@ -277,11 +291,9 @@ func TestSelectReportGVRs_ProbeErrorOnSiblingKeepsReadableOne(t *testing.T) {
 	}
 }
 
-// Codex #1 (HIGH): when every served family is legitimately empty — an
-// openreports-enabled cluster that hasn't produced a violation yet — locking
-// onto the first served family leaves the group Kyverno is about to write to
-// unwatched. Reports would then appear in the cluster and never in Radar,
-// with the status still claiming `ready`.
+// When every served family is legitimately empty, locking onto the first
+// family leaves the group Kyverno may write to unwatched. Reports could then
+// appear in the cluster but not in Radar while the status still claims ready.
 func TestSelectReportGVRs_AllEmptyWatchesEveryReadableFamily(t *testing.T) {
 	sel := selectReportGVRs(
 		servedSet(wgReports, wgClusterReports, orReports, orClusterReports),
@@ -301,8 +313,8 @@ func TestSelectReportGVRs_AllEmptyWatchesEveryReadableFamily(t *testing.T) {
 	}
 }
 
-// Codex #3 (MEDIUM): watching what we can read is right, but publishing it as
-// unqualified coverage is not — the denied family has to be nameable.
+// Partial coverage must name the denied family so consumers do not present it
+// as complete.
 func TestSelectReportGVRs_RecordsDeniedGroupsAlongsideAPartialWatch(t *testing.T) {
 	sel := selectReportGVRs(
 		servedSet(wgReports, orReports),

--- a/internal/k8s/policy_reports_status_test.go
+++ b/internal/k8s/policy_reports_status_test.go
@@ -44,8 +44,8 @@ func coreOnlyList() *metav1.APIResourceList {
 	}
 }
 
-// Bugbot #1 (HIGH). Warmup only runs when the dynamic cache initialized, and
-// that init failure is non-fatal — so "no decision recorded" is permanent on
+// Warmup only runs when the dynamic cache initialized, and that init failure
+// is non-fatal — so "no decision recorded" is permanent on
 // such a cluster, not transient. Reporting it as `warmup` made OmittedReason
 // emit `policySummary.kyverno: cache_cold` on every resource of every
 // non-Kyverno cluster, forever, which is the exact noise the silent
@@ -63,8 +63,8 @@ func TestGetPolicyReportStatus_UndecidedWithoutKyvernoStaysSilent(t *testing.T) 
 	}
 }
 
-// Codex #5: "we couldn't look" is not "there's nothing to see". With no
-// discovery we never established whether Kyverno exists, so concluding
+// "We couldn't look" is not "there's nothing to see". With no discovery we
+// never established whether Kyverno exists, so concluding
 // absence would be inferring a negative from a failed lookup — the silent
 // emptiness this codebase treats as a bug. The reason code separates it from
 // genuine absence, and only genuine absence is silent.

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/pkg/policyreports"
 )
@@ -270,5 +274,147 @@ func TestWarmupKyvernoPolicyReports_SnapshotsOnceAndGenAtomically(t *testing.T) 
 
 	if got := mismatch.Load(); got != 0 {
 		t.Fatalf("snapshot pair was not atomic under policyReportMu: %d mismatches (Reset is mutating policyReportInit and/or kyvernoWarmupGen outside the mutex, OR the snapshot is being torn — either breaks the race protection)", got)
+	}
+}
+
+func TestRebuildPolicyReportIndex_DropsStaleGeneration(t *testing.T) {
+	ResetPolicyReportIndex()
+	t.Cleanup(ResetPolicyReportIndex)
+
+	oldIndex := policyreports.NewIndex()
+	policyReportMu.Lock()
+	policyReportIndex.Store(oldIndex)
+	policyReportWatched = []schema.GroupVersionResource{orReports}
+	policyReportMu.Unlock()
+
+	staleReport := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "openreports.io/v1alpha1",
+		"kind":       "Report",
+		"metadata": map[string]any{
+			"name":      "stale-report",
+			"namespace": "default",
+		},
+		"results": []any{map[string]any{
+			"policy": "stale-policy",
+			"result": "fail",
+			"resources": []any{map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"namespace":  "default",
+				"name":       "stale-pod",
+			}},
+		}},
+	}}
+	listStarted := make(chan struct{})
+	allowList := make(chan struct{})
+	rebuildDone := make(chan struct{})
+	go func() {
+		rebuildPolicyReportIndexUsing(func([]schema.GroupVersionResource) []*unstructured.Unstructured {
+			close(listStarted)
+			<-allowList
+			return []*unstructured.Unstructured{staleReport}
+		})
+		close(rebuildDone)
+	}()
+
+	<-listStarted
+	ResetPolicyReportIndex()
+	freshIndex := policyreports.NewIndex()
+	policyReportMu.Lock()
+	policyReportIndex.Store(freshIndex)
+	policyReportWatched = []schema.GroupVersionResource{orReports}
+	policyReportMu.Unlock()
+	close(allowList)
+	<-rebuildDone
+
+	if findings := oldIndex.FindingsFor("", "Pod", "default", "stale-pod"); len(findings) != 0 {
+		t.Fatalf("stale rebuild mutated the old index after a context switch: %+v", findings)
+	}
+	if findings := freshIndex.FindingsFor("", "Pod", "default", "stale-pod"); len(findings) != 0 {
+		t.Fatalf("stale rebuild published into the new index: %+v", findings)
+	}
+}
+
+func TestRebuildPolicyReportIndex_PublishesCurrentGeneration(t *testing.T) {
+	ResetPolicyReportIndex()
+	t.Cleanup(ResetPolicyReportIndex)
+
+	idx := policyreports.NewIndex()
+	policyReportMu.Lock()
+	policyReportIndex.Store(idx)
+	policyReportWatched = []schema.GroupVersionResource{orReports}
+	policyReportMu.Unlock()
+
+	report := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "openreports.io/v1alpha1",
+		"kind":       "Report",
+		"metadata": map[string]any{
+			"name":      "current-report",
+			"namespace": "default",
+		},
+		"results": []any{map[string]any{
+			"policy": "current-policy",
+			"result": "fail",
+			"resources": []any{map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"namespace":  "default",
+				"name":       "current-pod",
+			}},
+		}},
+	}}
+	rebuildPolicyReportIndexUsing(func([]schema.GroupVersionResource) []*unstructured.Unstructured {
+		return []*unstructured.Unstructured{report}
+	})
+
+	findings := idx.FindingsFor("", "Pod", "default", "current-pod")
+	if len(findings) != 1 || findings[0].Policy != "current-policy" {
+		t.Fatalf("current rebuild findings = %+v, want current-policy", findings)
+	}
+}
+
+func TestRebuildPolicyReportIndex_CollapsesConcurrentRequests(t *testing.T) {
+	ResetPolicyReportIndex()
+	t.Cleanup(ResetPolicyReportIndex)
+
+	policyReportMu.Lock()
+	policyReportIndex.Store(policyreports.NewIndex())
+	policyReportWatched = []schema.GroupVersionResource{orReports}
+	policyReportMu.Unlock()
+
+	var listCalls atomic.Int64
+	firstListStarted := make(chan struct{})
+	allowFirstList := make(chan struct{})
+	secondListStarted := make(chan struct{})
+	rebuildDone := make(chan struct{})
+	listReports := func([]schema.GroupVersionResource) []*unstructured.Unstructured {
+		switch listCalls.Add(1) {
+		case 1:
+			close(firstListStarted)
+			<-allowFirstList
+		case 2:
+			close(secondListStarted)
+		}
+		return nil
+	}
+	go func() {
+		rebuildPolicyReportIndexUsing(listReports)
+		close(rebuildDone)
+	}()
+
+	<-firstListStarted
+	for range 100 {
+		rebuildPolicyReportIndexUsing(listReports)
+	}
+	followupNotBefore := time.Now().Add(rebuildDebounce)
+	close(allowFirstList)
+	<-secondListStarted
+	if time.Now().Before(followupNotBefore) {
+		t.Fatal("collapsed follow-up started before the production debounce delay")
+	}
+	<-rebuildDone
+
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("list calls = %d, want one in-flight rebuild plus one collapsed follow-up", got)
 	}
 }

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -367,7 +367,14 @@ func TestRebuildPolicyReportIndex_PublishesCurrentGeneration(t *testing.T) {
 		return []*unstructured.Unstructured{report}
 	})
 
-	findings := idx.FindingsFor("", "Pod", "default", "current-pod")
+	if findings := idx.FindingsFor("", "Pod", "default", "current-pod"); len(findings) != 0 {
+		t.Fatalf("rebuild mutated the previously published snapshot: %+v", findings)
+	}
+	current := policyReportIndex.Load()
+	if current == idx {
+		t.Fatal("rebuild did not publish a new index snapshot")
+	}
+	findings := current.FindingsFor("", "Pod", "default", "current-pod")
 	if len(findings) != 1 || findings[0].Policy != "current-policy" {
 		t.Fatalf("current rebuild findings = %+v, want current-policy", findings)
 	}

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1541,6 +1541,36 @@ func TestDynamicResourceCache_ListWatchedUnionsNamespaceInformers(t *testing.T) 
 	if len(got) != 2 {
 		t.Errorf("ListWatched returned %d objects, want 2 (union of both namespace-scoped informers)", len(got))
 	}
+
+	readOnly, err := d.ListWatchedReadOnly(gvr)
+	if err != nil {
+		t.Fatalf("ListWatchedReadOnly failed: %v", err)
+	}
+	if len(readOnly) != 2 {
+		t.Fatalf("ListWatchedReadOnly returned %d objects, want 2", len(readOnly))
+	}
+	copiesByName := make(map[string]*unstructured.Unstructured, len(got))
+	for _, item := range got {
+		copiesByName[item.GetName()] = item
+	}
+	for _, item := range readOnly {
+		if item == copiesByName[item.GetName()] {
+			t.Fatalf("ListWatched returned cached pointer for %s instead of a defensive copy", item.GetName())
+		}
+	}
+	readOnlyAgain, err := d.ListWatchedReadOnly(gvr)
+	if err != nil {
+		t.Fatalf("second ListWatchedReadOnly failed: %v", err)
+	}
+	readOnlyByName := make(map[string]*unstructured.Unstructured, len(readOnly))
+	for _, item := range readOnly {
+		readOnlyByName[item.GetName()] = item
+	}
+	for _, item := range readOnlyAgain {
+		if item != readOnlyByName[item.GetName()] {
+			t.Fatalf("ListWatchedReadOnly copied cached object %s", item.GetName())
+		}
+	}
 }
 
 // ListNamespaces must short-circuit a cluster-scoped GVR to a cluster-wide

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -1174,6 +1174,21 @@ func (d *DynamicResourceCache) List(gvr schema.GroupVersionResource, namespace s
 // Request-facing reads must stay on List / ListNamespaces with explicit
 // namespaces.
 func (d *DynamicResourceCache) ListWatched(gvr schema.GroupVersionResource) ([]*unstructured.Unstructured, error) {
+	items, err := d.ListWatchedReadOnly(gvr)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*unstructured.Unstructured, 0, len(items))
+	for _, item := range items {
+		result = append(result, StripUnstructuredFields(item))
+	}
+	return result, nil
+}
+
+// ListWatchedReadOnly returns the cached objects covered by ListWatched
+// without copying them. Callers must not mutate the objects or retain them
+// beyond the synchronous computation that requested them.
+func (d *DynamicResourceCache) ListWatchedReadOnly(gvr schema.GroupVersionResource) ([]*unstructured.Unstructured, error) {
 	if d == nil {
 		return nil, fmt.Errorf("dynamic resource cache not initialized")
 	}
@@ -1185,7 +1200,7 @@ func (d *DynamicResourceCache) ListWatched(gvr schema.GroupVersionResource) ([]*
 	result := make([]*unstructured.Unstructured, 0, len(items))
 	for _, item := range items {
 		if u, ok := item.(*unstructured.Unstructured); ok {
-			result = append(result, StripUnstructuredFields(u))
+			result = append(result, u)
 		}
 	}
 	return result, nil

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -1186,8 +1186,10 @@ func (d *DynamicResourceCache) ListWatched(gvr schema.GroupVersionResource) ([]*
 }
 
 // ListWatchedReadOnly returns the cached objects covered by ListWatched
-// without copying them. Callers must not mutate the objects or retain them
-// beyond the synchronous computation that requested them.
+// without copying them. Informer transforms run before objects enter the store,
+// and updates replace stored objects rather than mutating them in place. Callers
+// must not mutate the returned objects or retain them beyond the synchronous
+// computation that requested them.
 func (d *DynamicResourceCache) ListWatchedReadOnly(gvr schema.GroupVersionResource) ([]*unstructured.Unstructured, error) {
 	if d == nil {
 		return nil, fmt.Errorf("dynamic resource cache not initialized")

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -1,6 +1,8 @@
 package policyreports
 
 import (
+	"cmp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -31,11 +33,11 @@ type SubjectFindings struct {
 	Findings []Finding
 }
 
-// MaxIndexedReports caps how many PolicyReport documents the index keeps,
-// chosen by newest `metadata.creationTimestamp` first. Reports beyond the
-// cap are silently dropped on rebuild. Tunable here for clusters where a
-// single namespace generates a runaway number of reports — the index is
-// purely diagnostic, so dropping the oldest is acceptable.
+// MaxIndexedReports is retained for source compatibility. It no longer limits
+// the index; every report supplied to BuildIndex or Replace is included.
+//
+// Deprecated: PolicyReport retention belongs to the cluster and report
+// producers, not the index.
 const MaxIndexedReports = 500
 
 // Index maps subject keys ("Group/Kind/namespace/name", group-prefixed
@@ -58,9 +60,8 @@ func NewIndex() *Index {
 
 // BuildIndex constructs an Index from a slice of PolicyReport documents
 // (both namespaced PolicyReport and cluster-scoped ClusterPolicyReport).
-// Reports are processed newest-first by `metadata.creationTimestamp`, and
-// only the first MaxIndexedReports are considered — older reports are
-// dropped to bound memory.
+// Every supplied report is included; retention is owned by the cluster and
+// the report producers rather than this projection.
 //
 // For each report, every entry in `results[]` becomes one Finding per
 // resource in `results[].resources[]`. When a result has no `resources[]`
@@ -81,18 +82,8 @@ func (i *Index) Replace(reports []*unstructured.Unstructured) {
 		return
 	}
 
-	// Sort newest-first so the cap drops the oldest reports.
-	sorted := make([]*unstructured.Unstructured, len(reports))
-	copy(sorted, reports)
-	sort.SliceStable(sorted, func(a, b int) bool {
-		return sorted[a].GetCreationTimestamp().Time.After(sorted[b].GetCreationTimestamp().Time)
-	})
-	if len(sorted) > MaxIndexedReports {
-		sorted = sorted[:MaxIndexedReports]
-	}
-
 	next := make(map[string][]Finding)
-	for _, r := range sorted {
+	for _, r := range reports {
 		extractFindings(r, next)
 	}
 	dedupeFindings(next)
@@ -110,9 +101,8 @@ func (i *Index) Replace(reports []*unstructured.Unstructured) {
 // from view entirely. The same (policy, rule, result, message, source) on the
 // same subject carries no extra information whichever report it arrived in,
 // and counting it twice would inflate every violation total.
-//
-// Order is preserved: the first occurrence wins, so the newest report's copy
-// is the one kept (Replace feeds reports newest-first).
+// Sorting by the complete finding value keeps downstream top-N summaries
+// stable even though informer stores do not promise report iteration order.
 func dedupeFindings(bySubject map[string][]Finding) {
 	for key, findings := range bySubject {
 		if len(findings) < 2 {
@@ -127,6 +117,17 @@ func dedupeFindings(bySubject map[string][]Finding) {
 			seen[f] = true
 			out = append(out, f)
 		}
+		slices.SortFunc(out, func(left, right Finding) int {
+			return cmp.Or(
+				cmp.Compare(left.Policy, right.Policy),
+				cmp.Compare(left.Rule, right.Rule),
+				cmp.Compare(left.Result, right.Result),
+				cmp.Compare(left.Severity, right.Severity),
+				cmp.Compare(left.Category, right.Category),
+				cmp.Compare(left.Message, right.Message),
+				cmp.Compare(left.Source, right.Source),
+			)
+		})
 		bySubject[key] = out
 	}
 }
@@ -138,10 +139,7 @@ func dedupeFindings(bySubject map[string][]Finding) {
 // part of the index key so distinct CRDs sharing a Kind don't collide.
 //
 // The returned slice is a defensive copy: callers may freely sort, truncate,
-// or filter it without racing the index's own rebuild path. The cost is
-// modest — findings per subject are bounded (Kyverno emits at most one
-// PolicyReport entry per (policy, rule, resource) tuple, and pathological
-// reports are capped during BuildIndex anyway).
+// or filter it without racing the index's own rebuild path.
 func (i *Index) FindingsFor(group, kind, namespace, name string) []Finding {
 	if i == nil {
 		return nil
@@ -315,8 +313,12 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 
 	scopeGroup, scopeKind, scopeNS, scopeName := reportScope(report)
 
-	results, found, err := unstructured.NestedSlice(report.Object, "results")
+	rawResults, found, err := unstructured.NestedFieldNoCopy(report.Object, "results")
 	if err != nil || !found {
+		return
+	}
+	results, ok := rawResults.([]any)
+	if !ok {
 		return
 	}
 
@@ -389,8 +391,12 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 // Group is derived from `scope.apiVersion` (the part before "/"; "" for
 // core kinds like Pod whose apiVersion is just "v1").
 func reportScope(report *unstructured.Unstructured) (group, kind, namespace, name string) {
-	scope, found, err := unstructured.NestedMap(report.Object, "scope")
+	rawScope, found, err := unstructured.NestedFieldNoCopy(report.Object, "scope")
 	if err != nil || !found {
+		return "", "", "", ""
+	}
+	scope, ok := rawScope.(map[string]any)
+	if !ok {
 		return "", "", "", ""
 	}
 	return groupFromAPIVersion(stringField(scope, "apiVersion")),

--- a/pkg/policyreports/index_test.go
+++ b/pkg/policyreports/index_test.go
@@ -2,6 +2,7 @@ package policyreports
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -318,16 +319,11 @@ func TestBuildIndex_FindingsForUnknownSubject(t *testing.T) {
 	}
 }
 
-func TestBuildIndex_Cap_OldestDropped(t *testing.T) {
-	// Build with MaxIndexedReports + 5 reports, each targeting a unique
-	// pod. The 5 oldest should be dropped — only the newest
-	// MaxIndexedReports survive.
-	base := time.Now()
-	reports := make([]*unstructured.Unstructured, 0, MaxIndexedReports+5)
-	for i := 0; i < MaxIndexedReports+5; i++ {
-		// Older reports first; index sorts newest-first internally.
-		created := base.Add(time.Duration(i) * time.Second)
-		reports = append(reports, makeReport(t, "PolicyReport", "ns", fmt.Sprintf("rep-%d", i), nil, created, []map[string]any{
+func TestBuildIndex_IndexesEveryReport(t *testing.T) {
+	const reportCount = 1000
+	reports := make([]*unstructured.Unstructured, 0, reportCount)
+	for i := 0; i < reportCount; i++ {
+		reports = append(reports, makeReport(t, "PolicyReport", "ns", fmt.Sprintf("rep-%d", i), nil, time.Now(), []map[string]any{
 			{
 				"policy": "p",
 				"result": "fail",
@@ -339,17 +335,38 @@ func TestBuildIndex_Cap_OldestDropped(t *testing.T) {
 	}
 
 	idx := BuildIndex(reports)
-	if idx.Size() != MaxIndexedReports {
-		t.Fatalf("expected exactly MaxIndexedReports=%d subjects after cap, got %d", MaxIndexedReports, idx.Size())
+	if idx.Size() != reportCount {
+		t.Fatalf("expected all %d report subjects, got %d", reportCount, idx.Size())
 	}
-	// The 5 oldest (indexes 0..4) should be absent. The newest (index
-	// MaxIndexedReports+4) should be present.
-	if got := idx.FindingsFor("", "Pod", "ns", "pod-0"); got != nil {
-		t.Errorf("pod-0 should have been dropped by cap, got %v", got)
+	if got := idx.FindingsFor("", "Pod", "ns", "pod-0"); len(got) != 1 {
+		t.Errorf("first report subject should be present, got %v", got)
 	}
-	newestName := fmt.Sprintf("pod-%d", MaxIndexedReports+4)
-	if got := idx.FindingsFor("", "Pod", "ns", newestName); len(got) != 1 {
-		t.Errorf("newest pod %s should be present, got %v", newestName, got)
+	lastName := fmt.Sprintf("pod-%d", reportCount-1)
+	if got := idx.FindingsFor("", "Pod", "ns", lastName); len(got) != 1 {
+		t.Errorf("last report subject %s should be present, got %v", lastName, got)
+	}
+}
+
+func TestBuildIndex_FindingOrderIsStableAcrossReportOrder(t *testing.T) {
+	result := func(policy string) map[string]any {
+		return map[string]any{
+			"policy": policy,
+			"result": "fail",
+			"resources": []any{
+				resourceRef("Pod", "ns", "pod"),
+			},
+		}
+	}
+	alpha := makeReport(t, "PolicyReport", "ns", "alpha", nil, time.Now(), []map[string]any{result("alpha")})
+	zeta := makeReport(t, "PolicyReport", "ns", "zeta", nil, time.Now(), []map[string]any{result("zeta"), result("alpha")})
+
+	forward := BuildIndex([]*unstructured.Unstructured{zeta, alpha}).FindingsFor("", "Pod", "ns", "pod")
+	reverse := BuildIndex([]*unstructured.Unstructured{alpha, zeta}).FindingsFor("", "Pod", "ns", "pod")
+	if !reflect.DeepEqual(forward, reverse) {
+		t.Fatalf("finding order changed with report order: forward=%v reverse=%v", forward, reverse)
+	}
+	if len(forward) != 2 || forward[0].Policy != "alpha" || forward[1].Policy != "zeta" {
+		t.Fatalf("findings = %v, want deduplicated deterministic order [alpha zeta]", forward)
 	}
 }
 
@@ -640,9 +657,9 @@ func TestBuildIndex_GroupCollisionAcrossCRDs(t *testing.T) {
 
 func TestParseSubjectKey(t *testing.T) {
 	cases := []struct {
-		key                    string
-		group, kind, ns, name  string
-		ok                     bool
+		key                   string
+		group, kind, ns, name string
+		ok                    bool
 	}{
 		// Core-group + namespaced
 		{"/Pod/prod/web", "", "Pod", "prod", "web", true},


### PR DESCRIPTION
## Why

Radar treated 500 PolicyReport objects as a hard local budget in two places: startup declined to warm the report informer above that count, and the subject index retained only the newest 500 reports on later rebuilds. That made resource detail and MCP policy context silently incomplete based on an arbitrary object count.

PolicyReports are current cluster state whose retention is already controlled by their producers and cluster owners. Multiple reports can legitimately target the same resource across policies, rules, producers, and report API families, so selecting one "latest report per object" would also discard valid findings.

The startup protection was leaky as well: browsing PolicyReports later could start the same dynamic informer, paying the cache cost while the subject index remained unavailable.

## Design

- Index every current report from each readable, selected PolicyReport API family. Radar no longer imposes a report-count cap or newest-report retention policy.
- Keep the informer-backed path. Resource detail and MCP `get_resource` need synchronous per-subject findings; treating PolicyReports like EndpointSlices and bypassing the informer would preserve raw report browsing but silently empty those policy summaries.
- Read immutable informer objects directly and traverse `results[]` without deep copies. The existing `ListWatched` API remains defensive for every other caller.
- Deduplicate identical findings across simultaneously served report families and sort the result deterministically so downstream top-N summaries do not change with informer iteration order.
- Rebuild outside the context-switch mutex, reject stale cluster generations, collapse concurrent demand to one active rebuild plus one follow-up, and delay a follow-up by at least the prior rebuild duration under sustained churn.
- Remove the obsolete `over_cap`, `cap`, and truncation status behavior. The exported `MaxIndexedReports` constant remains deprecated solely for source compatibility with the separately versioned `pkg` Go module; it has no runtime effect.

## Tradeoffs

Radar's cache and index now scale with the reports and findings the cluster actually retains. That is intentional: silently omitting current policy results is worse than respecting cluster state, and report-object count was not a sound proxy for memory because `results[]` cardinality dominates.

This does not yet move PolicyReports to an on-demand cache or suppress their dynamic-cache timeline/SSE churn. Those require a freshness/error contract and measurement from real high-cardinality clusters. The rebuild path now avoids redundant copies and adaptively throttles sustained update storms.

## Verification

- `make tsc`
- `make test`
- `make build`
- focused `-race -count=3` coverage for PolicyReport indexing, cache pointer ownership, context-switch publication, positive rebuild publication, and rebuild collapse/throttling in both Go modules
- independent concurrency and architecture review converged with no remaining actionable findings

Visual testing was skipped because this is a Go-only cache/index change with no rendered UI change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related issues

Fixes [RAD-331](https://linear.app/skyhook-io/issue/RAD-331/policyreport-index-silently-truncates-past-the-500-cap-after-boot-status-still-reports-ready)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core policy-summary data paths and memory/CPU scaling with full report cardinality; concurrency and context-switch behavior were heavily tested but production clusters with very high report volume carry operational risk.
> 
> **Overview**
> Fixes **silent policy gaps** where Radar skipped or truncated Kyverno PolicyReports past a 500-object budget while still reporting a live index.
> 
> **Warmup and status:** Kyverno warmup no longer defers when probe counts exceed a cap; large clusters (e.g. 20k reports) are watched like smaller ones. `PolicyReportStatus` drops `cap` and `ReasonOverCap` / `budget_exceeded` omitted reasons; deferred now means RBAC or probe failure only.
> 
> **Indexing:** `pkg/policyreports` stops sorting by creation time and capping at `MaxIndexedReports` (constant kept deprecated, no runtime limit). Rebuilds **publish a new snapshot** via `BuildIndex` instead of mutating the live index in place. Findings are deduplicated and **sorted deterministically**; extraction uses `NestedFieldNoCopy` on `results`/`scope`.
> 
> **Rebuild path:** Listing uses `ListWatchedReadOnly` for zero-copy reads; `ListWatched` still returns defensive copies for other callers. Rebuilds run outside the long-held context mutex, ignore stale cluster generations after reset, collapse concurrent work to one active plus one follow-up, and throttle follow-ups under churn.
> 
> **Tests** cover large selection counts, snapshot publication, generation guards, and read-only vs copied list behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edba78e24a403222fa58e7cfbabb0a333d26b661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->