### PR TITLE
Fix cascade delete previews for collided CRD kinds

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3883,13 +3883,19 @@ func (s *Server) handleCascadeDeletePreview(w http.ResponseWriter, r *http.Reque
 	kind := chi.URLParam(r, "kind")
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+	group := r.URL.Query().Get("group")
 	if namespace == "_" {
 		namespace = ""
 	}
 
 	cachedTopo := s.broadcaster.GetCachedTopology()
 	dp := k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery())
-	preview := topology.GetCascadeDeletePreview(kind, namespace, name, cachedTopo, dp)
+	preview := topology.GetCascadeDeletePreview(topology.ResourceRef{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+		Group:     group,
+	}, cachedTopo, dp)
 
 	s.writeJSON(w, preview)
 }

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -70,6 +70,7 @@ interface ResourceActionsBarProps {
   isDeleting?: boolean
   cascadeDependents?: CascadeDependent[]
   cascadeLoading?: boolean
+  cascadeRootResolved?: boolean
 
   // Workload restart
   onRestart?: (params: { kind: string; namespace: string; name: string }, callbacks?: { onSuccess?: () => void; onError?: (err: unknown) => void }) => void
@@ -130,7 +131,7 @@ export function ResourceActionsBar({
   canExec, canViewLogs, canPortForward,
   onOpenTerminal, onOpenLogs: openLogs, onOpenWorkloadLogs: openWorkloadLogs, onCopyCommand,
   renderPortForward,
-  onDelete, isDeleting, cascadeDependents, cascadeLoading,
+  onDelete, isDeleting, cascadeDependents, cascadeLoading, cascadeRootResolved,
   onRestart, isRestarting,
   revisions: revisionsList, revisionsLoading, revisionsError, onRollback, isRollingBack,
   onTriggerCronJob, isTriggeringCronJob,
@@ -608,6 +609,7 @@ export function ResourceActionsBar({
         isLoading={isDeleting ?? false}
         cascadeDependents={cascadeDependents}
         cascadeLoading={cascadeLoading}
+        cascadeRootResolved={cascadeRootResolved}
       />
 
       {/* Node cordon confirmation */}

--- a/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import { ConfirmDialog } from './ConfirmDialog'
 import { pluralize } from '../../utils/pluralize'
 
@@ -20,6 +20,7 @@ interface ForceDeleteConfirmDialogProps {
   isLoading: boolean
   cascadeDependents?: CascadeDependent[]
   cascadeLoading?: boolean
+  cascadeRootResolved?: boolean
 }
 
 export function ForceDeleteConfirmDialog({
@@ -32,6 +33,7 @@ export function ForceDeleteConfirmDialog({
   isLoading,
   cascadeDependents,
   cascadeLoading,
+  cascadeRootResolved,
 }: ForceDeleteConfirmDialogProps) {
   const [forceDelete, setForceDelete] = useState(false)
 
@@ -66,6 +68,15 @@ export function ForceDeleteConfirmDialog({
 
         {!cascadeLoading && cascadeDependents && cascadeDependents.length > 0 && (
           <CascadeDependentsList dependents={cascadeDependents} />
+        )}
+
+        {!cascadeLoading && cascadeRootResolved === false && (
+          <div className="flex items-start gap-2 rounded border border-theme-border bg-theme-elevated px-3 py-2 text-xs text-warning-text">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              Radar couldn&apos;t verify which dependent resources Kubernetes will also delete. Additional resources may be deleted but aren&apos;t shown here.
+            </span>
+          </div>
         )}
 
         <label className="flex items-center gap-2 text-sm text-theme-text-secondary">

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,12 +13,12 @@ import (
 	k8score "github.com/skyhook-io/radar/pkg/k8score"
 )
 
-// stubDP is a minimal DynamicProvider for CRD-fallback regression tests in
-// the topology package. Only GetGVR and Get are exercised by the metadata
-// lookup path; the rest are stubs sufficient to satisfy the interface.
+// stubDP is the shared minimal DynamicProvider for topology package tests.
 type stubDP struct {
-	gvr map[string]schema.GroupVersionResource
-	obj map[string]*unstructured.Unstructured // key = "ns/name"
+	gvr        map[string]schema.GroupVersionResource
+	gvrByGroup map[string]schema.GroupVersionResource
+	kindByGVR  map[schema.GroupVersionResource]string
+	obj        map[string]*unstructured.Unstructured // key = "ns/name"
 }
 
 func (s *stubDP) List(_ schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
@@ -38,11 +39,16 @@ func (s *stubDP) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) {
 	g, ok := s.gvr[kindOrName]
 	return g, ok
 }
-func (s *stubDP) GetGVRWithGroup(kindOrName, _ string) (schema.GroupVersionResource, bool) {
+func (s *stubDP) GetGVRWithGroup(kindOrName, group string) (schema.GroupVersionResource, bool) {
+	if gvr, ok := s.gvrByGroup[group+"/"+strings.ToLower(kindOrName)]; ok {
+		return gvr, true
+	}
 	return s.GetGVR(kindOrName)
 }
-func (s *stubDP) GetKindForGVR(_ schema.GroupVersionResource) string { return "" }
-func (s *stubDP) IsCRD(_ string) bool                                { return true }
+func (s *stubDP) GetKindForGVR(gvr schema.GroupVersionResource) string {
+	return s.kindByGVR[gvr]
+}
+func (s *stubDP) IsCRD(_ string) bool { return true }
 
 func meta(labels, annos map[string]string) metav1.Object {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annos}}

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -86,19 +86,66 @@ func edgesForNode(topo *Topology, idx *RelationshipsIndex, nodeID string) (incom
 	return incoming, outgoing
 }
 
-// GetCascadeDeletePreview returns a preview of all resources that will be garbage-collected
-// when the specified resource is deleted. It walks EdgeManages edges recursively
-// to find all transitive dependents — mirroring Kubernetes owner-reference cascade behavior.
-func GetCascadeDeletePreview(kind, namespace, name string, topo *Topology, dp DynamicProvider) *CascadeDeletePreview {
+// GetCascadeDeletePreview walks topology management edges to approximate the
+// resources Kubernetes may garbage-collect with root.
+func GetCascadeDeletePreview(root ResourceRef, topo *Topology, dp DynamicProvider) *CascadeDeletePreview {
+	preview := &CascadeDeletePreview{
+		Root:       root,
+		Dependents: []ResourceRef{},
+	}
 	if topo == nil {
-		return &CascadeDeletePreview{
-			Root:       ResourceRef{Kind: kind, Namespace: namespace, Name: name},
-			Dependents: []ResourceRef{},
-		}
+		return preview
 	}
 
-	root := ResourceRef{Kind: kind, Namespace: namespace, Name: name}
-	enrichRef(&root, dp)
+	rootID := buildNodeID(root.Kind, root.Namespace, root.Name, dp)
+	if root.Group != "" {
+		if dp == nil {
+			return preview
+		}
+		gvr, ok := dp.GetGVRWithGroup(root.Kind, root.Group)
+		if !ok {
+			return preview
+		}
+		resolvedKind := dp.GetKindForGVR(gvr)
+		if resolvedKind == "" {
+			return preview
+		}
+		rootID = strings.ToLower(KindForGVK(resolvedKind, root.Group)) + "/" + root.Namespace + "/" + root.Name
+	}
+
+	nodeByID := make(map[string]*Node, len(topo.Nodes))
+	for i := range topo.Nodes {
+		nodeByID[topo.Nodes[i].ID] = &topo.Nodes[i]
+	}
+	rootNode, ok := nodeByID[rootID]
+	if !ok {
+		return preview
+	}
+	if root.Group != "" {
+		if nodeGroup := nodeAPIGroupFromData(rootNode); nodeGroup != "" && nodeGroup != root.Group {
+			return preview
+		}
+	} else {
+		rootKind := string(rootNode.Kind)
+		if externalKind, found := collisionKindToK8sKind[rootNode.Kind]; found {
+			rootKind = externalKind
+		}
+		matches := 0
+		for i := range topo.Nodes {
+			node := &topo.Nodes[i]
+			nodeKind := string(node.Kind)
+			if externalKind, found := collisionKindToK8sKind[node.Kind]; found {
+				nodeKind = externalKind
+			}
+			if strings.EqualFold(nodeKind, rootKind) && node.Name == root.Name && nodeNamespaceFromData(node) == root.Namespace {
+				matches++
+			}
+		}
+		if matches > 1 {
+			return preview
+		}
+	}
+	preview.RootResolved = true
 
 	// Build adjacency list for EdgeManages edges (source → targets)
 	manages := make(map[string][]string)
@@ -109,7 +156,6 @@ func GetCascadeDeletePreview(kind, namespace, name string, topo *Topology, dp Dy
 	}
 
 	// BFS from root node
-	rootID := buildNodeID(kind, namespace, name, dp)
 	visited := map[string]bool{rootID: true}
 	queue := []string{rootID}
 	var dependents []ResourceRef
@@ -128,20 +174,20 @@ func GetCascadeDeletePreview(kind, namespace, name string, topo *Topology, dp Dy
 			if ref == nil {
 				continue
 			}
+			if node := nodeByID[targetID]; node != nil {
+				ref.Group = nodeAPIGroupFromData(node)
+			}
 			enrichRef(ref, dp)
 			dependents = append(dependents, *ref)
 			queue = append(queue, targetID)
 		}
 	}
 
-	if dependents == nil {
-		dependents = []ResourceRef{}
+	if dependents != nil {
+		preview.Dependents = dependents
 	}
 
-	return &CascadeDeletePreview{
-		Root:       root,
-		Dependents: dependents,
-	}
+	return preview
 }
 
 // resolveAPIGroup returns the API group for a resource kind using resource discovery.

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -10,6 +10,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // stubProvider supplies a typed K8s resource for the kinds GetRelationships
@@ -48,6 +49,117 @@ func (s *stubProvider) NetworkPolicies() ([]*networkingv1.NetworkPolicy, error) 
 func (s *stubProvider) Nodes() ([]*corev1.Node, error)                          { return nil, nil }
 func (s *stubProvider) GetResourceStatus(kind, namespace, name string) *ResourceStatus {
 	return nil
+}
+
+func TestGetCascadeDeletePreview_GroupQualifiedCollisions(t *testing.T) {
+	capiGVR := schema.GroupVersionResource{Group: "cluster.x-k8s.io", Version: "v1beta1", Resource: "clusters"}
+	cnpgGVR := schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "clusters"}
+	dp := &stubDP{
+		gvrByGroup: map[string]schema.GroupVersionResource{
+			"cluster.x-k8s.io/clusters":   capiGVR,
+			"postgresql.cnpg.io/clusters": cnpgGVR,
+		},
+		kindByGVR: map[schema.GroupVersionResource]string{
+			capiGVR: "Cluster",
+			cnpgGVR: "Cluster",
+		},
+	}
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "capicluster/fleet/prod", Kind: KindCAPICluster, Name: "prod", Data: map[string]any{"namespace": "fleet", "apiVersion": "cluster.x-k8s.io/v1beta1"}},
+			{ID: "machinedeployment/fleet/capi-workers", Kind: KindMachineDeployment, Name: "capi-workers", Data: map[string]any{"namespace": "fleet", "apiVersion": "cluster.x-k8s.io/v1beta1"}},
+			{ID: "machine/fleet/capi-worker-1", Kind: KindMachine, Name: "capi-worker-1", Data: map[string]any{"namespace": "fleet", "apiVersion": "cluster.x-k8s.io/v1beta1"}},
+			{ID: "cluster/fleet/prod", Kind: NodeKind("Cluster"), Name: "prod", Data: map[string]any{"namespace": "fleet", "apiVersion": "postgresql.cnpg.io/v1"}},
+			{ID: "backup/fleet/cnpg-backup", Kind: NodeKind("Backup"), Name: "cnpg-backup", Data: map[string]any{"namespace": "fleet", "apiVersion": "postgresql.cnpg.io/v1"}},
+		},
+		Edges: []Edge{
+			{Source: "capicluster/fleet/prod", Target: "machinedeployment/fleet/capi-workers", Type: EdgeManages},
+			{Source: "machinedeployment/fleet/capi-workers", Target: "machine/fleet/capi-worker-1", Type: EdgeManages},
+			{Source: "cluster/fleet/prod", Target: "backup/fleet/cnpg-backup", Type: EdgeManages},
+		},
+	}
+
+	capi := GetCascadeDeletePreview(ResourceRef{Kind: "clusters", Namespace: "fleet", Name: "prod", Group: "cluster.x-k8s.io"}, topo, dp)
+	if !capi.RootResolved {
+		t.Fatal("expected CAPI root to resolve")
+	}
+	if len(capi.Dependents) != 2 || capi.Dependents[0].Name != "capi-workers" || capi.Dependents[1].Name != "capi-worker-1" {
+		t.Fatalf("CAPI dependents = %+v, want its MachineDeployment and transitive Machine", capi.Dependents)
+	}
+	for _, dep := range capi.Dependents {
+		if dep.Group != "cluster.x-k8s.io" {
+			t.Errorf("CAPI dependent %s group = %q, want cluster.x-k8s.io", dep.Name, dep.Group)
+		}
+	}
+
+	cnpg := GetCascadeDeletePreview(ResourceRef{Kind: "clusters", Namespace: "fleet", Name: "prod", Group: "postgresql.cnpg.io"}, topo, dp)
+	if !cnpg.RootResolved {
+		t.Fatal("expected CNPG root to resolve")
+	}
+	if len(cnpg.Dependents) != 1 || cnpg.Dependents[0].Name != "cnpg-backup" {
+		t.Fatalf("CNPG dependents = %+v, want only cnpg-backup", cnpg.Dependents)
+	}
+	if cnpg.Dependents[0].Group != "postgresql.cnpg.io" {
+		t.Errorf("CNPG dependent group = %q, want postgresql.cnpg.io", cnpg.Dependents[0].Group)
+	}
+
+	dp.gvr = map[string]schema.GroupVersionResource{"clusters": cnpgGVR}
+	unqualified := GetCascadeDeletePreview(ResourceRef{Kind: "clusters", Namespace: "fleet", Name: "prod"}, topo, dp)
+	if unqualified.RootResolved {
+		t.Fatalf("unqualified collided root = %+v, want unresolved rather than an arbitrary group", unqualified)
+	}
+}
+
+func TestGetCascadeDeletePreview_ResolutionState(t *testing.T) {
+	topo := &Topology{Nodes: []Node{{ID: "pod/demo/leaf", Kind: KindPod, Name: "leaf", Data: map[string]any{"namespace": "demo"}}}}
+
+	leaf := GetCascadeDeletePreview(ResourceRef{Kind: "pods", Namespace: "demo", Name: "leaf"}, topo, nil)
+	if !leaf.RootResolved || len(leaf.Dependents) != 0 {
+		t.Fatalf("resolved leaf preview = %+v, want resolved with zero dependents", leaf)
+	}
+
+	absent := GetCascadeDeletePreview(ResourceRef{Kind: "pods", Namespace: "demo", Name: "missing"}, topo, nil)
+	if absent.RootResolved || len(absent.Dependents) != 0 {
+		t.Fatalf("absent preview = %+v, want unresolved with zero dependents", absent)
+	}
+
+	discoveryMiss := GetCascadeDeletePreview(ResourceRef{Kind: "clusters", Namespace: "fleet", Name: "prod", Group: "cluster.x-k8s.io"}, topo, &stubDP{})
+	if discoveryMiss.RootResolved {
+		t.Fatalf("discovery miss preview = %+v, want unresolved without group-blind fallback", discoveryMiss)
+	}
+}
+
+func TestGetCascadeDeletePreview_RouteCollisionUsesGroup(t *testing.T) {
+	knativeGVR := schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "routes"}
+	openshiftGVR := schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
+	dp := &stubDP{
+		gvrByGroup: map[string]schema.GroupVersionResource{
+			"serving.knative.dev/routes": knativeGVR,
+			"route.openshift.io/routes":  openshiftGVR,
+		},
+		kindByGVR: map[schema.GroupVersionResource]string{knativeGVR: "Route", openshiftGVR: "Route"},
+	}
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "knativeroute/demo/shop", Kind: KindKnativeRoute, Name: "shop", Data: map[string]any{"namespace": "demo", "apiVersion": "serving.knative.dev/v1"}},
+			{ID: "revision/demo/shop-v1", Kind: KindKnativeRevision, Name: "shop-v1", Data: map[string]any{"namespace": "demo", "apiVersion": "serving.knative.dev/v1"}},
+			{ID: "route/demo/shop", Kind: NodeKind("Route"), Name: "shop", Data: map[string]any{"namespace": "demo", "apiVersion": "route.openshift.io/v1"}},
+			{ID: "service/demo/shop", Kind: KindService, Name: "shop", Data: map[string]any{"namespace": "demo"}},
+		},
+		Edges: []Edge{
+			{Source: "knativeroute/demo/shop", Target: "revision/demo/shop-v1", Type: EdgeManages},
+			{Source: "route/demo/shop", Target: "service/demo/shop", Type: EdgeManages},
+		},
+	}
+
+	knative := GetCascadeDeletePreview(ResourceRef{Kind: "routes", Namespace: "demo", Name: "shop", Group: "serving.knative.dev"}, topo, dp)
+	if !knative.RootResolved || len(knative.Dependents) != 1 || knative.Dependents[0].Name != "shop-v1" {
+		t.Fatalf("Knative preview = %+v, want only shop-v1", knative)
+	}
+	openshift := GetCascadeDeletePreview(ResourceRef{Kind: "routes", Namespace: "demo", Name: "shop", Group: "route.openshift.io"}, topo, dp)
+	if !openshift.RootResolved || len(openshift.Dependents) != 1 || openshift.Dependents[0].Kind != "Service" {
+		t.Fatalf("OpenShift preview = %+v, want only Service/shop", openshift)
+	}
 }
 
 // TestGetRelationships_PodHygieneFields covers T2: pods carry

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -464,8 +464,9 @@ type SecretCertificateInfo struct {
 // CascadeDeletePreview represents all resources that will be garbage-collected
 // when a parent resource is deleted via Kubernetes owner reference cascade.
 type CascadeDeletePreview struct {
-	Root       ResourceRef   `json:"root"`
-	Dependents []ResourceRef `json:"dependents"`
+	Root         ResourceRef   `json:"root"`
+	RootResolved bool          `json:"rootResolved"`
+	Dependents   []ResourceRef `json:"dependents"`
 }
 
 // ResourceWithRelationships wraps a K8s resource with computed relationships

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3622,6 +3622,7 @@ export function useUpdateResource() {
 // Cascade delete preview — shows resources that will be garbage-collected
 export interface CascadeDeletePreview {
   root: { kind: string; namespace: string; name: string; group?: string };
+  rootResolved: boolean;
   dependents: {
     kind: string;
     namespace: string;
@@ -3634,13 +3635,14 @@ export function useCascadeDeletePreview(
   kind: string,
   namespace: string,
   name: string,
+  group: string | undefined,
   enabled: boolean,
 ) {
   return useQuery<CascadeDeletePreview>({
-    queryKey: ["cascade-preview", kind, namespace, name],
+    queryKey: ["cascade-preview", kind, group, namespace, name],
     queryFn: () =>
       fetchJSON<CascadeDeletePreview>(
-        `/resources/${kind}/${namespace}/${name}/cascade-preview`,
+        `/resources/${kind}/${namespace}/${name}/cascade-preview${group ? `?group=${encodeURIComponent(group)}` : ""}`,
       ),
     enabled,
     staleTime: 30_000,

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -248,7 +248,13 @@ interface WorkloadViewProps {
   pushTabHistory?: boolean
 }
 
-function useActionsBarProps(kind: string, namespace: string, name: string) {
+function useActionsBarProps(
+  kind: string,
+  namespace: string,
+  name: string,
+  group: string | undefined,
+  cascadeEnabled: boolean,
+) {
   const { showCopied } = useToast()
   const openTerminal = useOpenTerminal()
   const openLogs = useOpenLogs()
@@ -284,11 +290,16 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
   const argoSuspendMutation = useArgoSuspend()
   const argoResumeMutation = useArgoResume()
 
-  const { data: cascadePreview, isLoading: cascadeLoading } = useCascadeDeletePreview(
+  const {
+    data: cascadePreview,
+    isLoading: cascadeLoading,
+    isError: cascadeError,
+  } = useCascadeDeletePreview(
     kind,
     namespace,
     name,
-    true,
+    group,
+    cascadeEnabled,
   )
 
   const canNodeWrite = useCanNodeWrite()
@@ -327,6 +338,7 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
     isDeleting: deleteMutation.isPending,
     cascadeDependents: cascadePreview?.dependents,
     cascadeLoading,
+    cascadeRootResolved: cascadeError ? false : cascadePreview?.rootResolved,
     onRestart: (params: Parameters<typeof restartWorkloadMutation.mutate>[0]) =>
       restartWorkloadMutation.mutate(params),
     isRestarting: restartWorkloadMutation.isPending,
@@ -675,7 +687,13 @@ export function WorkloadView({
   )
   const updateResource = useUpdateResource()
   const previewResources = usePreviewResources()
-  const baseActionsBarProps = useActionsBarProps(apiKind, namespace, name)
+  const baseActionsBarProps = useActionsBarProps(
+    apiKind,
+    namespace,
+    name,
+    effectiveGroup,
+    !resourceLoading && Boolean(resource),
+  )
   const desktopDownload = useDesktopDownload()
 
   // Live Operational Issues for this resource. Fetched here (not inside the lead


### PR DESCRIPTION
## Summary

Kubernetes API groups can define resources with the same kind, namespace, and name. Cascade delete preview now preserves the selected resource's API-group identity through the frontend, API, discovery, and topology lookup, preventing a collided CRD from displaying another group's dependents before deletion.

When Radar cannot resolve the exact topology root, the confirmation dialog reports that the cascade scope could not be verified instead of presenting an empty dependent list as authoritative.

## What changed

- The frontend waits for the loaded resource identity, sends its API group with the preview request, and includes the group in the React Query cache key.
- The server resolves group-qualified roots through API discovery and the topology's canonical kind mapping. Explicit discovery misses and ambiguous unqualified roots remain unresolved rather than falling back to an arbitrary resource group.
- Preview responses expose `rootResolved`, distinguishing a confirmed leaf with zero dependents from an unavailable preview. Preview fetch failures use the same visible warning state.
- Dependent references preserve their API groups from topology node data, including transitive management relationships.
- Regression coverage includes CAPI/CNPG `Cluster` collisions, Knative/OpenShift `Route` collisions, transitive dependents, confirmed leaves, missing roots, discovery misses, and ambiguous unqualified roots.

## Testing

- `make tsc`
- `make test`
- `go -C pkg test ./topology -count=1`
- `go test ./internal/server -run ^$ -count=1`
- `make build`
- Live read-only smoke test against a GKE cluster: the embedded UI at 1920x1080 requested a Deployment preview with `group=apps` and displayed its ReplicaSet and two Pods. Wrong-group and absent CNPG roots returned `rootResolved=false` with no dependents. The browser reported zero console errors or warnings, and no cluster state was changed.
- The exact CAPI/CNPG collision was not available in the live cluster because it has no CAPI Cluster CRD or CNPG Cluster instances; deterministic topology regression tests cover that case.

## Notes

Cascade preview remains an advisory approximation based on topology `EdgeManages` relationships. Separating Kubernetes garbage-collection ownership from broader topology management and source relationships is a distinct topology-contract change.
