### PR TITLE
fix(issues): connect missing webhook Services to blocked workloads

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"strings"
 
+	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
@@ -61,7 +62,7 @@ func Classify(in classifyInput) issuesapi.Category {
 			return issuesapi.CategoryIngressClassMissing
 		case "Missing Gateway backend Service", "Missing Gateway backend Service port", "Missing Gateway ReferenceGrant":
 			return issuesapi.CategoryGatewayRouteInvalid
-		case "Missing webhook backend Service":
+		case k8s.MissingWebhookBackendReason:
 			return issuesapi.CategoryWebhookBackendDown
 		case "Missing StorageClass":
 			// the dangling ref is a StorageClass, but the user-facing effect is

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"testing"
 
+	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
@@ -126,7 +127,7 @@ func TestClassify(t *testing.T) {
 		{"gateway backend missing", classifyInput{Source: SourceMissingRef, Kind: "HTTPRoute", APIGroup: "gateway.networking.k8s.io", Reason: "Missing Gateway backend Service"}, issuesapi.CategoryGatewayRouteInvalid},
 		{"gateway reference grant missing", classifyInput{Source: SourceMissingRef, Kind: "HTTPRoute", APIGroup: "gateway.networking.k8s.io", Reason: "Missing Gateway ReferenceGrant"}, issuesapi.CategoryGatewayRouteInvalid},
 		{"ingress tls secret is config", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing TLS Secret"}, issuesapi.CategoryMissingConfigRef},
-		{"webhook backend down", classifyInput{Source: SourceMissingRef, Kind: "ValidatingWebhookConfiguration", APIGroup: "admissionregistration.k8s.io", Reason: "Missing webhook backend Service"}, issuesapi.CategoryWebhookBackendDown},
+		{"webhook backend down", classifyInput{Source: SourceMissingRef, Kind: "ValidatingWebhookConfiguration", APIGroup: "admissionregistration.k8s.io", Reason: k8s.MissingWebhookBackendReason}, issuesapi.CategoryWebhookBackendDown},
 		{"missing storageclass is pvc pending", classifyInput{Source: SourceMissingRef, Kind: "PersistentVolumeClaim", Reason: "Missing StorageClass"}, issuesapi.CategoryPVCPending},
 		{"missing roleref is config", classifyInput{Source: SourceMissingRef, Kind: "RoleBinding", APIGroup: "rbac.authorization.k8s.io", Reason: "Missing roleRef target"}, issuesapi.CategoryMissingConfigRef},
 

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -504,6 +504,9 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 	if len(configRefs) == 0 {
 		return
 	}
+	if missingServiceRoot && !failClosed {
+		return
+	}
 
 	message := "This Service is the backend for a fail-open admission webhook; admission continues while its validation or mutation is bypassed."
 	if failClosed {
@@ -511,10 +514,7 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 	}
 	if missingServiceRoot {
 		backend := refs[0]
-		message = fmt.Sprintf("A fail-open admission webhook declared by this configuration points to missing Service %q in namespace %q; admission continues while its validation or mutation is bypassed.", backend.ServiceName, backend.ServiceNamespace)
-		if failClosed {
-			message = fmt.Sprintf("A fail-closed admission webhook declared by this configuration points to missing Service %q in namespace %q; matching admission requests are blocked.", backend.ServiceName, backend.ServiceNamespace)
-		}
+		message = fmt.Sprintf("A fail-closed admission webhook declared by this configuration points to missing Service %q in namespace %q; matching admission requests are blocked.", backend.ServiceName, backend.ServiceNamespace)
 	}
 
 	type matchedGroup struct {
@@ -564,6 +564,9 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 		message += " The blocked workload also backs this Service, creating a startup deadlock; restore an independent ready backend or make bootstrap admission fail-open."
 	}
 	sortIssueRefs(related)
+	if missingServiceRoot && len(related) == 0 {
+		return
+	}
 	recordIncidentEdges(edges, root, factAdmissionWebhook, issuesapi.ConfidenceHigh, edgeIDs)
 	factRefs := configRefs
 	if missingServiceRoot {

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -33,13 +33,16 @@ type serviceBackendIssueProvider interface {
 }
 
 type AdmissionWebhookRef struct {
-	Configuration Ref
-	WebhookName   string
-	FailurePolicy string
+	Configuration    Ref
+	WebhookName      string
+	ServiceNamespace string
+	ServiceName      string
+	FailurePolicy    string
 }
 
 type admissionWebhookContextProvider interface {
 	AdmissionWebhookRefsForService(namespace, name string) []AdmissionWebhookRef
+	AdmissionWebhookRefsForConfiguration(group, kind, name string) []AdmissionWebhookRef
 	WorkloadBacksService(group, kind, namespace, name, serviceNamespace, serviceName string) bool
 }
 
@@ -51,6 +54,11 @@ func isAdmissionWebhookBackendService(issue Issue) bool {
 		return true
 	}
 	return issue.Reason == k8s.SelectorMatchesNoPodsReason || issue.Reason == k8s.SelectorMatchesOnlyCompletedPodsReason
+}
+
+func isMissingAdmissionWebhookBackend(issue Issue) bool {
+	return issue.Source == SourceMissingRef && issue.Category == issuesapi.CategoryWebhookBackendDown &&
+		issue.Reason == k8s.MissingWebhookBackendReason
 }
 
 func elevateAdmissionWebhookBackendSeverity(issues []Issue, p Provider) []Issue {
@@ -280,7 +288,7 @@ func enrichDiagnosticContextAuthorized(shaped, flat, grouped []Issue, p Provider
 			addServiceBackendContext(&b, *i, serviceProvider, flatByResource, groupedByID)
 		}
 
-		if webhookProvider != nil && isAdmissionWebhookBackendService(*i) {
+		if webhookProvider != nil && (isAdmissionWebhookBackendService(*i) || isMissingAdmissionWebhookBackend(*i)) {
 			addAdmissionWebhookContext(&b, *i, &incidentEdges, webhookProvider, canReadClusterScoped, flat, groupedByID, flatRowsByID)
 		}
 
@@ -471,7 +479,18 @@ func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceP
 }
 
 func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *[]incidentEdge, provider admissionWebhookContextProvider, canReadClusterScoped func(kind, group string) bool, flat []Issue, groupedByID map[string]Issue, flatRowsByID map[string]int) {
+	missingServiceRoot := isMissingAdmissionWebhookBackend(root)
 	refs := provider.AdmissionWebhookRefsForService(root.Namespace, root.Name)
+	if missingServiceRoot {
+		refs = provider.AdmissionWebhookRefsForConfiguration(root.Group, root.Kind, root.Name)
+		matching := make([]AdmissionWebhookRef, 0, len(refs))
+		for _, ref := range refs {
+			if root.Fingerprint == k8s.WebhookBackendFingerprint(ref.ServiceNamespace, ref.ServiceName) {
+				matching = append(matching, ref)
+			}
+		}
+		refs = matching
+	}
 	var configRefs []Ref
 	failClosed := false
 	for _, ref := range refs {
@@ -490,6 +509,13 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 	if failClosed {
 		message = "A fail-closed admission webhook depends on this Service; matching admission requests are blocked while it has no ready backend."
 	}
+	if missingServiceRoot {
+		backend := refs[0]
+		message = fmt.Sprintf("A fail-open admission webhook declared by this configuration points to missing Service %q in namespace %q; admission continues while its validation or mutation is bypassed.", backend.ServiceName, backend.ServiceNamespace)
+		if failClosed {
+			message = fmt.Sprintf("A fail-closed admission webhook declared by this configuration points to missing Service %q in namespace %q; matching admission requests are blocked.", backend.ServiceName, backend.ServiceNamespace)
+		}
+	}
 
 	type matchedGroup struct {
 		issue Issue
@@ -505,8 +531,9 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 			if candidate.Category != issuesapi.CategoryAdmissionWebhookBlocking {
 				continue
 			}
-			failure, ok := k8s.ParseAdmissionWebhookNoEndpoints(diagnosticMessage(candidate))
-			if !ok || failure.ServiceNamespace != root.Namespace || failure.ServiceName != root.Name {
+			failure, ok := k8s.ParseAdmissionWebhookBackendFailure(diagnosticMessage(candidate))
+			if !ok || (!missingServiceRoot && (failure.ServiceNamespace != root.Namespace || failure.ServiceName != root.Name)) ||
+				!admissionWebhookFailureMatchesRefs(failure, refs, missingServiceRoot) {
 				continue
 			}
 			shaped := candidate
@@ -524,7 +551,7 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 		for _, id := range matchedOrder {
 			matched := matchedByID[id]
 			related = append(related, issueRef(matched.issue))
-			if provider.WorkloadBacksService(matched.issue.Group, matched.issue.Kind, matched.issue.Namespace, matched.issue.Name, root.Namespace, root.Name) {
+			if !missingServiceRoot && provider.WorkloadBacksService(matched.issue.Group, matched.issue.Kind, matched.issue.Namespace, matched.issue.Name, root.Namespace, root.Name) {
 				selfDeadlock = true
 				continue
 			}
@@ -538,13 +565,30 @@ func addAdmissionWebhookContext(b *diagnosticContextBuilder, root Issue, edges *
 	}
 	sortIssueRefs(related)
 	recordIncidentEdges(edges, root, factAdmissionWebhook, issuesapi.ConfidenceHigh, edgeIDs)
+	factRefs := configRefs
+	if missingServiceRoot {
+		factRefs = nil
+	}
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
 		Type:          factAdmissionWebhook,
 		Message:       message,
 		Confidence:    issuesapi.ConfidenceHigh,
-		Refs:          limitRefs(configRefs, maxDiagnosticRefs),
+		Refs:          limitRefs(factRefs, maxDiagnosticRefs),
 		RelatedIssues: limitIssueRefs(related, maxDiagnosticIssueRefs),
 	})
+}
+
+func admissionWebhookFailureMatchesRefs(failure k8s.AdmissionWebhookBackendFailure, refs []AdmissionWebhookRef, missingServiceRoot bool) bool {
+	if missingServiceRoot != (failure.Kind == k8s.AdmissionWebhookServiceNotFound) {
+		return false
+	}
+	for _, ref := range refs {
+		if ref.FailurePolicy == "Fail" && ref.WebhookName == failure.WebhookName &&
+			ref.ServiceNamespace == failure.ServiceNamespace && ref.ServiceName == failure.ServiceName {
+			return true
+		}
+	}
+	return false
 }
 
 // linkBlastRadius adds a candidate-role fact linking a root issue to the

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -92,7 +92,33 @@ func (f *fakeProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
 }
 
 func (f *fakeProvider) AdmissionWebhookRefsForService(namespace, name string) []AdmissionWebhookRef {
-	return f.webhookRefs[namespace+"/"+name]
+	refs := f.webhookRefs[namespace+"/"+name]
+	out := make([]AdmissionWebhookRef, 0, len(refs))
+	for _, ref := range refs {
+		ref.ServiceNamespace = namespace
+		ref.ServiceName = name
+		out = append(out, ref)
+	}
+	return out
+}
+
+func (f *fakeProvider) AdmissionWebhookRefsForConfiguration(group, kind, name string) []AdmissionWebhookRef {
+	var out []AdmissionWebhookRef
+	for serviceKey, refs := range f.webhookRefs {
+		parts := strings.SplitN(serviceKey, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		for _, ref := range refs {
+			if ref.Configuration.Group != group || ref.Configuration.Kind != kind || ref.Configuration.Name != name {
+				continue
+			}
+			ref.ServiceNamespace = parts[0]
+			ref.ServiceName = parts[1]
+			out = append(out, ref)
+		}
+	}
+	return out
 }
 
 func (f *fakeProvider) WorkloadBacksService(group, kind, namespace, name, serviceNamespace, serviceName string) bool {
@@ -177,6 +203,227 @@ func TestComposeAdmissionWebhookBackendCorrelation(t *testing.T) {
 	}
 }
 
+func TestComposeMissingAdmissionWebhookServiceCorrelation(t *testing.T) {
+	message := `failed calling webhook "missing.example.com": Post "https://missing-webhook.hooks.svc:443/validate": service "missing-webhook" not found`
+	p := &fakeProvider{
+		missingRefs: []k8s.Detection{
+			{
+				Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io", Name: "policy", Severity: "critical",
+				Reason: k8s.MissingWebhookBackendReason, Fingerprint: k8s.WebhookBackendFingerprint("hooks", "missing-webhook"), OnsetUnknown: true,
+			},
+			{
+				Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io", Name: "policy", Severity: "critical",
+				Reason: k8s.MissingWebhookBackendReason, Fingerprint: k8s.WebhookBackendFingerprint("hooks", "other-missing-webhook"), OnsetUnknown: true,
+			},
+		},
+		scheduling: []k8s.Detection{{
+			Kind: "ReplicaSet", Group: "apps", Namespace: "apps", Name: "catalog-7d9f", Severity: "critical",
+			Reason: "WebhookUnavailable", Message: message,
+			OwnerGroup: "apps", OwnerKind: "Deployment", OwnerName: "catalog",
+		}},
+		webhookRefs: map[string][]AdmissionWebhookRef{
+			"hooks/missing-webhook": {{
+				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
+				WebhookName:   "missing.example.com", FailurePolicy: "Fail",
+			}},
+			"hooks/other-missing-webhook": {{
+				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
+				WebhookName:   "other.example.com", FailurePolicy: "Fail",
+			}},
+		},
+	}
+	out := Compose(p, Filters{Limit: NoLimit, Grouped: true, CanReadClusterScoped: func(string, string) bool { return true }})
+	if len(out) != 3 {
+		t.Fatalf("missing-Service correlation = %+v, want two configuration roots and blocked Deployment", out)
+	}
+	var root, unrelatedRoot, deployment Issue
+	for _, issue := range out {
+		switch issue.Kind {
+		case "ValidatingWebhookConfiguration":
+			if issue.Fingerprint == k8s.WebhookBackendFingerprint("hooks", "missing-webhook") {
+				root = issue
+			} else {
+				unrelatedRoot = issue
+			}
+		case "Deployment":
+			deployment = issue
+		case "Service":
+			t.Fatalf("missing backend must not create a synthetic Service issue: %+v", issue)
+		}
+	}
+	if root.ID == "" || root.DiagnosticContext == nil {
+		t.Fatalf("missing webhook root lacks diagnostic context: %+v", root)
+	}
+	if unrelatedRoot.ID == "" {
+		t.Fatalf("second missing backend root was collapsed: %+v", out)
+	}
+	if deployment.IncidentParent == nil || deployment.IncidentParent.ID != root.ID || deployment.IncidentParent.FactType != factAdmissionWebhook {
+		t.Fatalf("blocked Deployment incident parent = %+v, want configuration %q", deployment.IncidentParent, root.ID)
+	}
+	var webhookFact issuesapi.DiagnosticFact
+	for _, fact := range root.DiagnosticContext.Facts {
+		if fact.Type == factAdmissionWebhook {
+			webhookFact = fact
+		}
+	}
+	if len(webhookFact.RelatedIssues) != 1 || len(webhookFact.Refs) != 0 ||
+		!strings.Contains(webhookFact.Message, `Service "missing-webhook" in namespace "hooks"`) {
+		t.Fatalf("missing webhook root fact = %+v, want exact backend identity, one symptom, and no dead-link ref", webhookFact)
+	}
+	if unrelatedRoot.DiagnosticContext != nil {
+		for _, fact := range unrelatedRoot.DiagnosticContext.Facts {
+			if fact.Type == factAdmissionWebhook && len(fact.RelatedIssues) != 0 {
+				t.Fatalf("different missing backend fingerprint was correlated: %+v", fact)
+			}
+		}
+	}
+}
+
+func TestAdmissionWebhookFailureKindMustMatchRootShape(t *testing.T) {
+	refs := []AdmissionWebhookRef{{
+		WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", FailurePolicy: "Fail",
+	}}
+	noEndpoints := k8s.AdmissionWebhookBackendFailure{
+		WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", Kind: k8s.AdmissionWebhookNoReadyEndpoints,
+	}
+	serviceMissing := noEndpoints
+	serviceMissing.Kind = k8s.AdmissionWebhookServiceNotFound
+	if !admissionWebhookFailureMatchesRefs(noEndpoints, refs, false) || admissionWebhookFailureMatchesRefs(noEndpoints, refs, true) {
+		t.Fatal("no-endpoints failure must match only an existing-Service root")
+	}
+	if !admissionWebhookFailureMatchesRefs(serviceMissing, refs, true) || admissionWebhookFailureMatchesRefs(serviceMissing, refs, false) {
+		t.Fatal("service-not-found failure must match only a missing-Service configuration root")
+	}
+	refs[0].FailurePolicy = "Ignore"
+	if admissionWebhookFailureMatchesRefs(noEndpoints, refs, false) || admissionWebhookFailureMatchesRefs(serviceMissing, refs, true) {
+		t.Fatal("fail-open webhook reference must never create an incident edge")
+	}
+}
+
+func TestMissingAdmissionWebhookServiceFailOpenHasNoIncidentEdge(t *testing.T) {
+	message := `failed calling webhook "audit.example.com": Post "https://audit-webhook.hooks.svc:443/mutate": service "audit-webhook" not found`
+	p := &fakeProvider{
+		missingRefs: []k8s.Detection{{
+			Kind: "MutatingWebhookConfiguration", Group: "admissionregistration.k8s.io", Name: "audit", Severity: "warning",
+			Reason: k8s.MissingWebhookBackendReason, Fingerprint: k8s.WebhookBackendFingerprint("hooks", "audit-webhook"), OnsetUnknown: true,
+		}},
+		scheduling: []k8s.Detection{{
+			Kind: "Deployment", Group: "apps", Namespace: "apps", Name: "catalog", Severity: "critical",
+			Reason: "WebhookUnavailable", Message: message,
+		}},
+		webhookRefs: map[string][]AdmissionWebhookRef{
+			"hooks/audit-webhook": {{
+				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration", Name: "audit"},
+				WebhookName:   "audit.example.com", FailurePolicy: "Ignore",
+			}},
+		},
+	}
+	out := Compose(p, Filters{Limit: NoLimit, Grouped: true, CanReadClusterScoped: func(string, string) bool { return true }})
+	foundRoot := false
+	for _, issue := range out {
+		if issue.Kind == "Deployment" && issue.IncidentParent != nil {
+			t.Fatalf("fail-open webhook symptom received incident parent: %+v", issue.IncidentParent)
+		}
+		if issue.Kind != "MutatingWebhookConfiguration" {
+			continue
+		}
+		foundRoot = true
+		var fact issuesapi.DiagnosticFact
+		for _, candidate := range issue.DiagnosticContext.Facts {
+			if candidate.Type == factAdmissionWebhook {
+				fact = candidate
+			}
+		}
+		if !strings.Contains(fact.Message, "fail-open") || !strings.Contains(fact.Message, `Service "audit-webhook" in namespace "hooks"`) || len(fact.RelatedIssues) != 0 {
+			t.Fatalf("fail-open missing-Service fact = %+v", fact)
+		}
+	}
+	if !foundRoot {
+		t.Fatalf("fail-open missing-Service root not found: %+v", out)
+	}
+}
+
+func TestMissingAdmissionWebhookServiceRootAmbiguity(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		secondWebhookName string
+		wantParent        bool
+		wantRelatedRoots  int
+	}{
+		{name: "same webhook has two roots", secondWebhookName: "validate.example.com", wantRelatedRoots: 2},
+		{name: "webhook identity selects one root", secondWebhookName: "other.example.com", wantParent: true, wantRelatedRoots: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fingerprint := k8s.WebhookBackendFingerprint("hooks", "missing-webhook")
+			p := &fakeProvider{
+				missingRefs: []k8s.Detection{
+					{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io", Name: "policy-a", Severity: "critical", Reason: k8s.MissingWebhookBackendReason, Fingerprint: fingerprint},
+					{Kind: "ValidatingWebhookConfiguration", Group: "admissionregistration.k8s.io", Name: "policy-b", Severity: "critical", Reason: k8s.MissingWebhookBackendReason, Fingerprint: fingerprint},
+				},
+				scheduling: []k8s.Detection{{
+					Kind: "Deployment", Group: "apps", Namespace: "apps", Name: "catalog", Severity: "critical", Reason: "WebhookUnavailable",
+					Message: `failed calling webhook "validate.example.com": Post "https://missing-webhook.hooks.svc:443/validate": service "missing-webhook" not found`,
+				}},
+				webhookRefs: map[string][]AdmissionWebhookRef{
+					"hooks/missing-webhook": {
+						{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy-a"}, WebhookName: "validate.example.com", FailurePolicy: "Fail"},
+						{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy-b"}, WebhookName: tc.secondWebhookName, FailurePolicy: "Fail"},
+					},
+				},
+			}
+			out := Compose(p, Filters{Limit: NoLimit, Grouped: true, CanReadClusterScoped: func(string, string) bool { return true }})
+			relatedRoots := 0
+			for _, issue := range out {
+				if issue.Kind == "Deployment" {
+					if (issue.IncidentParent != nil) != tc.wantParent {
+						t.Fatalf("Deployment incident parent = %+v, want present=%v", issue.IncidentParent, tc.wantParent)
+					}
+					if issue.IncidentParent != nil && issue.IncidentParent.Ref.Name != "policy-a" {
+						t.Fatalf("selected incident root = %+v, want policy-a", issue.IncidentParent)
+					}
+				}
+				if issue.Kind == "ValidatingWebhookConfiguration" && issue.DiagnosticContext != nil {
+					for _, fact := range issue.DiagnosticContext.Facts {
+						if fact.Type == factAdmissionWebhook && len(fact.RelatedIssues) == 1 {
+							relatedRoots++
+						}
+					}
+				}
+			}
+			if relatedRoots != tc.wantRelatedRoots {
+				t.Fatalf("roots listing the symptom = %d, want %d: %+v", relatedRoots, tc.wantRelatedRoots, out)
+			}
+		})
+	}
+}
+
+func TestAdmissionWebhookCorrelationRequiresExactWebhookReference(t *testing.T) {
+	message := `failed calling webhook "unrelated.example.com": Post "https://policy-webhook.hooks.svc:443/validate": no endpoints available for service "policy-webhook"`
+	p := &fakeProvider{
+		problems:   []k8s.Detection{{Kind: "Service", Namespace: "hooks", Name: "policy-webhook", Severity: "warning", Reason: k8s.SelectorMatchesNoPodsReason}},
+		scheduling: []k8s.Detection{{Kind: "Deployment", Group: "apps", Namespace: "apps", Name: "catalog", Severity: "critical", Reason: "WebhookUnavailable", Message: message}},
+		webhookRefs: map[string][]AdmissionWebhookRef{
+			"hooks/policy-webhook": {{
+				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
+				WebhookName:   "validate.example.com", FailurePolicy: "Fail",
+			}},
+		},
+	}
+	out := Compose(p, Filters{Limit: NoLimit, Grouped: true, CanReadClusterScoped: func(string, string) bool { return true }})
+	for _, issue := range out {
+		if issue.Kind == "Deployment" && issue.IncidentParent != nil {
+			t.Fatalf("unreferenced webhook name received incident parent: %+v", issue.IncidentParent)
+		}
+		if issue.Kind == "Service" && issue.DiagnosticContext != nil {
+			for _, fact := range issue.DiagnosticContext.Facts {
+				if fact.Type == factAdmissionWebhook && len(fact.RelatedIssues) != 0 {
+					t.Fatalf("unreferenced webhook name was correlated: %+v", fact)
+				}
+			}
+		}
+	}
+}
+
 func TestAdmissionWebhookSelfDeadlockSuppressesCircularIncidentEdge(t *testing.T) {
 	p := &fakeProvider{
 		problems: []k8s.Detection{{Kind: "Service", Namespace: "hooks", Name: "policy-webhook", Severity: "warning", Reason: k8s.SelectorMatchesNoPodsReason}},
@@ -185,7 +432,7 @@ func TestAdmissionWebhookSelfDeadlockSuppressesCircularIncidentEdge(t *testing.T
 			Message: `failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": no endpoints available for service "policy-webhook"`,
 		}},
 		webhookRefs: map[string][]AdmissionWebhookRef{
-			"hooks/policy-webhook": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"}, FailurePolicy: "Fail"}},
+			"hooks/policy-webhook": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"}, WebhookName: "validate.example.com", FailurePolicy: "Fail"}},
 		},
 		workloadBacks: map[string]bool{"apps/Deployment/hooks/policy->hooks/policy-webhook": true},
 	}
@@ -223,7 +470,7 @@ func TestAdmissionWebhookCorrelationSurvivesReplicaSetWorkloadGrouping(t *testin
 		webhookRefs: map[string][]AdmissionWebhookRef{
 			"hooks/policy-webhook": {{
 				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
-				FailurePolicy: "Fail",
+				WebhookName:   "validate.example.com", FailurePolicy: "Fail",
 			}},
 		},
 	}
@@ -267,7 +514,7 @@ func TestAdmissionWebhookCorrelationRequiresWholeGroupedIssueCoverage(t *testing
 		webhookRefs: map[string][]AdmissionWebhookRef{
 			"hooks/policy-webhook": {{
 				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
-				FailurePolicy: "Fail",
+				WebhookName:   "validate.example.com", FailurePolicy: "Fail",
 			}},
 		},
 	}
@@ -307,7 +554,7 @@ func TestAdmissionWebhookCorrelationCountsGroupedSubjectRow(t *testing.T) {
 		webhookRefs: map[string][]AdmissionWebhookRef{
 			"hooks/policy-webhook": {{
 				Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "policy"},
-				FailurePolicy: "Fail",
+				WebhookName:   "validate.example.com", FailurePolicy: "Fail",
 			}},
 		},
 	}
@@ -393,8 +640,8 @@ func TestAdmissionWebhookPartialRBACKeepsObjectiveFailureMode(t *testing.T) {
 		}},
 		webhookRefs: map[string][]AdmissionWebhookRef{
 			"hooks/policy-webhook": {
-				{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration", Name: "visible-open"}, FailurePolicy: "Ignore"},
-				{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "hidden-closed"}, FailurePolicy: "Fail"},
+				{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration", Name: "visible-open"}, WebhookName: "other.example.com", FailurePolicy: "Ignore"},
+				{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "hidden-closed"}, WebhookName: "validate.example.com", FailurePolicy: "Fail"},
 			},
 		},
 	}
@@ -445,8 +692,8 @@ func TestAdmissionWebhookTwoServiceRootsLeaveIncidentParentAmbiguous(t *testing.
 			{Kind: "Deployment", Group: "apps", Namespace: "apps", Name: "catalog", Severity: "critical", Reason: "WebhookUnavailable", Message: message("webhook-b")},
 		},
 		webhookRefs: map[string][]AdmissionWebhookRef{
-			"hooks/webhook-a": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "a"}, FailurePolicy: "Fail"}},
-			"hooks/webhook-b": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "b"}, FailurePolicy: "Fail"}},
+			"hooks/webhook-a": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "a"}, WebhookName: "validate.example.com", FailurePolicy: "Fail"}},
+			"hooks/webhook-b": {{Configuration: Ref{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Name: "b"}, WebhookName: "validate.example.com", FailurePolicy: "Fail"}},
 		},
 	}
 	out := Compose(p, Filters{Limit: NoLimit, Grouped: true, CanReadClusterScoped: func(string, string) bool { return true }})

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -270,11 +270,12 @@ func TestComposeMissingAdmissionWebhookServiceCorrelation(t *testing.T) {
 		!strings.Contains(webhookFact.Message, `Service "missing-webhook" in namespace "hooks"`) {
 		t.Fatalf("missing webhook root fact = %+v, want exact backend identity, one symptom, and no dead-link ref", webhookFact)
 	}
-	if unrelatedRoot.DiagnosticContext != nil {
-		for _, fact := range unrelatedRoot.DiagnosticContext.Facts {
-			if fact.Type == factAdmissionWebhook && len(fact.RelatedIssues) != 0 {
-				t.Fatalf("different missing backend fingerprint was correlated: %+v", fact)
-			}
+	if unrelatedRoot.DiagnosticContext == nil {
+		t.Fatalf("unrelated missing backend lost its explicit-reference context: %+v", unrelatedRoot)
+	}
+	for _, fact := range unrelatedRoot.DiagnosticContext.Facts {
+		if fact.Type == factAdmissionWebhook {
+			t.Fatalf("missing backend without an observed blocked workload should not repeat its cause as an admission fact: %+v", fact)
 		}
 	}
 }
@@ -328,14 +329,15 @@ func TestMissingAdmissionWebhookServiceFailOpenHasNoIncidentEdge(t *testing.T) {
 			continue
 		}
 		foundRoot = true
-		var fact issuesapi.DiagnosticFact
+		foundExplicitReference := false
 		for _, candidate := range issue.DiagnosticContext.Facts {
 			if candidate.Type == factAdmissionWebhook {
-				fact = candidate
+				t.Fatalf("fail-open missing-Service root should not repeat its cause as an admission fact: %+v", candidate)
 			}
+			foundExplicitReference = foundExplicitReference || candidate.Type == factExplicitReference
 		}
-		if !strings.Contains(fact.Message, "fail-open") || !strings.Contains(fact.Message, `Service "audit-webhook" in namespace "hooks"`) || len(fact.RelatedIssues) != 0 {
-			t.Fatalf("fail-open missing-Service fact = %+v", fact)
+		if !foundExplicitReference {
+			t.Fatalf("fail-open missing-Service root lost its explicit-reference context: %+v", issue.DiagnosticContext)
 		}
 	}
 	if !foundRoot {

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -173,11 +173,8 @@ func (p *CacheProvider) AdmissionWebhookRefsForService(namespace, name string) [
 	if p == nil || namespace == "" || name == "" {
 		return nil
 	}
-	p.webhookRefsOnce.Do(func() {
-		p.webhookRefs = k8s.AdmissionWebhookServiceReferencesWatched(p.dynamic, p.discovery)
-	})
 	var refs []AdmissionWebhookRef
-	for _, ref := range p.webhookRefs {
+	for _, ref := range p.admissionWebhookRefs() {
 		if ref.ServiceNamespace != namespace || ref.ServiceName != name {
 			continue
 		}
@@ -187,11 +184,40 @@ func (p *CacheProvider) AdmissionWebhookRefsForService(namespace, name string) [
 				Kind:  ref.ConfigurationKind,
 				Name:  ref.ConfigurationName,
 			},
-			WebhookName:   ref.WebhookName,
-			FailurePolicy: ref.FailurePolicy,
+			WebhookName:      ref.WebhookName,
+			ServiceNamespace: ref.ServiceNamespace,
+			ServiceName:      ref.ServiceName,
+			FailurePolicy:    ref.FailurePolicy,
 		})
 	}
 	return refs
+}
+
+func (p *CacheProvider) AdmissionWebhookRefsForConfiguration(group, kind, name string) []AdmissionWebhookRef {
+	if p == nil || group == "" || kind == "" || name == "" {
+		return nil
+	}
+	var refs []AdmissionWebhookRef
+	for _, ref := range p.admissionWebhookRefs() {
+		if ref.ConfigurationGroup != group || ref.ConfigurationKind != kind || ref.ConfigurationName != name {
+			continue
+		}
+		refs = append(refs, AdmissionWebhookRef{
+			Configuration:    Ref{Group: ref.ConfigurationGroup, Kind: ref.ConfigurationKind, Name: ref.ConfigurationName},
+			WebhookName:      ref.WebhookName,
+			ServiceNamespace: ref.ServiceNamespace,
+			ServiceName:      ref.ServiceName,
+			FailurePolicy:    ref.FailurePolicy,
+		})
+	}
+	return refs
+}
+
+func (p *CacheProvider) admissionWebhookRefs() []k8s.AdmissionWebhookServiceReference {
+	p.webhookRefsOnce.Do(func() {
+		p.webhookRefs = k8s.AdmissionWebhookServiceReferencesWatched(p.dynamic, p.discovery)
+	})
+	return p.webhookRefs
 }
 
 func (p *CacheProvider) WorkloadBacksService(group, kind, namespace, name, serviceNamespace, serviceName string) bool {

--- a/internal/k8s/detect_missing_refs.go
+++ b/internal/k8s/detect_missing_refs.go
@@ -120,6 +120,12 @@ func missingRefFingerprint(reason, detail string) string {
 	return fmt.Sprintf("%s|%016x", reason, h.Sum64())
 }
 
+const MissingWebhookBackendReason = "Missing webhook backend Service"
+
+func WebhookBackendFingerprint(namespace, name string) string {
+	return missingRefFingerprint(MissingWebhookBackendReason, "clientConfig.service:"+namespace+"/"+name)
+}
+
 // refLookupResult classifies a lister Get result into the honest tri-state
 // "exists / known missing / couldn't verify". A lister miss is only
 // authoritative when the informer for the target's kind actually covers the
@@ -854,7 +860,7 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 	}
 	now := time.Now()
 	emit := func(kind, group, name, sourceRefPhrase, svcNS, svcName, severity, policySummary string, createdAt time.Time) Detection {
-		reason := "Missing webhook backend Service"
+		reason := MissingWebhookBackendReason
 		cause := fmt.Sprintf("Webhook backend Service %q in namespace %q doesn't exist.", svcName, svcNS)
 		if severity == "warning" {
 			cause += " One or more referencing webhooks use failurePolicy=Ignore, so admission proceeds but the webhook's validation or mutation is bypassed."
@@ -868,7 +874,7 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 			createdAt),
 			cause,
 			fmt.Sprintf("Restore Service %q and its endpoints in namespace %q, or fix clientConfig.service to point at the correct healthy Service.", svcName, svcNS))
-		det.Fingerprint = missingRefFingerprint(reason, "clientConfig.service:"+svcNS+"/"+svcName)
+		det.Fingerprint = WebhookBackendFingerprint(svcNS, svcName)
 		return det
 	}
 

--- a/internal/k8s/detect_missing_refs_test.go
+++ b/internal/k8s/detect_missing_refs_test.go
@@ -761,15 +761,16 @@ func TestDetectMissingWebhookRefs(t *testing.T) {
 	}
 
 	problems := DetectMissingWebhookRefs(GetResourceCache(), dynCache, discovery, "")
-	if !findProblem(problems, "ValidatingWebhookConfiguration", "", "validate-hooks", "Missing webhook backend Service") {
+	if !findProblem(problems, "ValidatingWebhookConfiguration", "", "validate-hooks", MissingWebhookBackendReason) {
 		t.Fatalf("missing validating webhook Service not detected: %+v", problems)
 	}
-	if !findProblem(problems, "MutatingWebhookConfiguration", "", "mutate-hooks", "Missing webhook backend Service") {
+	if !findProblem(problems, "MutatingWebhookConfiguration", "", "mutate-hooks", MissingWebhookBackendReason) {
 		t.Fatalf("missing mutating webhook Service not detected: %+v", problems)
 	}
 	if len(problems) != 2 {
 		t.Fatalf("expected exactly 2 missing webhook refs, got %+v", problems)
 	}
+	foundValidatingMissing := false
 	for _, p := range problems {
 		if p.Namespace != "" {
 			t.Errorf("webhook configs are cluster-scoped; got namespace on problem: %+v", p)
@@ -780,13 +781,36 @@ func TestDetectMissingWebhookRefs(t *testing.T) {
 		if !p.OnsetUnknown || p.Duration != "" || p.DurationSeconds != 0 {
 			t.Errorf("missing webhook Service must not use configuration age as outage onset: %+v", p)
 		}
+		if p.Kind == "ValidatingWebhookConfiguration" && p.Name == "validate-hooks" {
+			foundValidatingMissing = true
+			if p.Fingerprint != WebhookBackendFingerprint("hooks", "does-not-exist") {
+				t.Errorf("missing webhook Service fingerprint = %q, want exact backend identity", p.Fingerprint)
+			}
+		}
+	}
+	if !foundValidatingMissing {
+		t.Fatal("validating webhook missing-Service row not found for fingerprint assertion")
 	}
 	refs := AdmissionWebhookServiceReferences(dynCache, discovery)
 	if len(refs) != 3 {
 		t.Fatalf("service-backed webhook refs = %+v, want three and no URL-backed ref", refs)
 	}
-	if watched := AdmissionWebhookServiceReferencesWatched(dynCache, discovery); len(watched) != len(refs) {
+	watched := AdmissionWebhookServiceReferencesWatched(dynCache, discovery)
+	if len(watched) != len(refs) {
 		t.Fatalf("watched service-backed webhook refs = %+v, want %+v", watched, refs)
+	}
+	for _, problem := range problems {
+		matched := false
+		for _, ref := range watched {
+			if ref.ConfigurationKind == problem.Kind && ref.ConfigurationName == problem.Name &&
+				WebhookBackendFingerprint(ref.ServiceNamespace, ref.ServiceName) == problem.Fingerprint {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("missing webhook row fingerprint has no matching watched inventory ref: problem=%+v refs=%+v", problem, watched)
+		}
 	}
 	if refs[0].FailurePolicy != "Fail" {
 		t.Fatalf("omitted failurePolicy must normalize to Fail: %+v", refs[0])

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -1196,7 +1196,7 @@ func replicaSetDeploymentOwnerName(rs *appsv1.ReplicaSet) (string, bool) {
 // (e.g. transient "object is being deleted") so we don't over-report.
 func classifyAdmissionFailure(msg string) (string, bool) {
 	lower := strings.ToLower(msg)
-	if _, ok := ParseAdmissionWebhookNoEndpoints(msg); ok {
+	if _, ok := ParseAdmissionWebhookBackendFailure(msg); ok {
 		return "WebhookUnavailable", true
 	}
 	switch {
@@ -1218,35 +1218,65 @@ func classifyAdmissionFailure(msg string) (string, bool) {
 	}
 }
 
-type AdmissionWebhookNoEndpoints struct {
+type AdmissionWebhookBackendFailureKind string
+
+const (
+	AdmissionWebhookNoReadyEndpoints AdmissionWebhookBackendFailureKind = "no_ready_endpoints"
+	AdmissionWebhookServiceNotFound  AdmissionWebhookBackendFailureKind = "service_not_found"
+)
+
+type AdmissionWebhookBackendFailure struct {
+	WebhookName      string
 	ServiceNamespace string
 	ServiceName      string
+	Kind             AdmissionWebhookBackendFailureKind
 }
 
 var (
 	admissionWebhookURLPattern      = regexp.MustCompile(`https?://[^\s"]+`)
+	admissionWebhookNamePattern     = regexp.MustCompile(`(?i)failed calling webhook "([^"]+)"`)
 	admissionNoEndpointsNamePattern = regexp.MustCompile(`(?i)no endpoints available for service "([a-z0-9]([-a-z0-9]*[a-z0-9])?)"`)
+	admissionServiceNotFoundPattern = regexp.MustCompile(`(?i)services? "([a-z0-9]([-a-z0-9]*[a-z0-9])?)" not found`)
 )
 
-func ParseAdmissionWebhookNoEndpoints(message string) (AdmissionWebhookNoEndpoints, bool) {
+func ParseAdmissionWebhookBackendFailure(message string) (AdmissionWebhookBackendFailure, bool) {
 	lower := strings.ToLower(message)
-	if !strings.Contains(lower, "failed calling webhook") || !strings.Contains(lower, "no endpoints available for service") {
-		return AdmissionWebhookNoEndpoints{}, false
+	if !strings.Contains(lower, "failed calling webhook") {
+		return AdmissionWebhookBackendFailure{}, false
 	}
+	webhookMatch := admissionWebhookNamePattern.FindStringSubmatch(message)
+	if len(webhookMatch) < 2 || webhookMatch[1] == "" {
+		return AdmissionWebhookBackendFailure{}, false
+	}
+	var kind AdmissionWebhookBackendFailureKind
 	nameMatch := admissionNoEndpointsNamePattern.FindStringSubmatch(message)
+	if len(nameMatch) >= 2 {
+		kind = AdmissionWebhookNoReadyEndpoints
+	} else {
+		nameMatch = admissionServiceNotFoundPattern.FindStringSubmatch(message)
+		if len(nameMatch) < 2 {
+			return AdmissionWebhookBackendFailure{}, false
+		}
+		kind = AdmissionWebhookServiceNotFound
+	}
 	urlText := admissionWebhookURLPattern.FindString(message)
 	if len(nameMatch) < 2 || urlText == "" {
-		return AdmissionWebhookNoEndpoints{}, false
+		return AdmissionWebhookBackendFailure{}, false
 	}
 	parsed, err := url.Parse(urlText)
 	if err != nil {
-		return AdmissionWebhookNoEndpoints{}, false
+		return AdmissionWebhookBackendFailure{}, false
 	}
 	hostParts := strings.Split(strings.ToLower(parsed.Hostname()), ".")
 	if len(hostParts) < 3 || hostParts[0] == "" || hostParts[1] == "" || hostParts[2] != "svc" || hostParts[0] != strings.ToLower(nameMatch[1]) {
-		return AdmissionWebhookNoEndpoints{}, false
+		return AdmissionWebhookBackendFailure{}, false
 	}
-	return AdmissionWebhookNoEndpoints{ServiceNamespace: hostParts[1], ServiceName: hostParts[0]}, true
+	return AdmissionWebhookBackendFailure{
+		WebhookName:      webhookMatch[1],
+		ServiceNamespace: hostParts[1],
+		ServiceName:      hostParts[0],
+		Kind:             kind,
+	}, true
 }
 
 // ---- Post-bind detection ------------------------------------------------

--- a/internal/k8s/detect_scheduling_test.go
+++ b/internal/k8s/detect_scheduling_test.go
@@ -335,8 +335,12 @@ func TestClassifyAdmissionFailure(t *testing.T) {
 		{`Error creating: pods "x" is forbidden: violates PodSecurity "restricted:latest"`, "PodSecurityViolation", true},
 		{`Error creating: admission webhook "vpod.example.com" denied the request: nope`, "WebhookDenied", true},
 		{`Error creating: Internal error occurred: failed calling webhook "validate.example.com": failed to call webhook: Post "https://policy-webhook.hooks.svc:443/validate?timeout=10s": no endpoints available for service "policy-webhook"`, "WebhookUnavailable", true},
+		{`Error creating: Internal error occurred: failed calling webhook "missing.example.com": failed to call webhook: Post "https://missing-webhook.hooks.svc:443/validate?timeout=2s": service "missing-webhook" not found`, "WebhookUnavailable", true},
+		{`Error creating: Internal error occurred: failed calling webhook "missing.example.com": failed to call webhook: Post "https://missing-webhook.hooks.svc:443/validate?timeout=2s": services "missing-webhook" not found`, "WebhookUnavailable", true},
 		{`Error creating: failed calling webhook "validate.example.com": no endpoints available for service "policy-webhook"`, "", false},
 		{`Error creating: failed calling webhook "validate.example.com": Post "https://other.hooks.svc:443/validate": no endpoints available for service "policy-webhook"`, "", false},
+		{`Error creating: failed calling webhook "validate.example.com": Post "https://other.hooks.svc:443/validate": service "policy-webhook" not found`, "", false},
+		{`Error creating: failed calling webhook "validate.example.com": Post "https://policy-webhook.external.example/validate": service "policy-webhook" not found`, "", false},
 		{`Error creating: failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": dial tcp: connection refused`, "", false},
 		{`Error creating: pods "x" is forbidden: maximum cpu usage per Container is 1, but limit is 2`, "LimitRangeViolation", true},
 		{`Error creating: pods "web-abc" is forbidden: User "system:serviceaccount:prod:web" cannot create resource "pods" in API group "" in the namespace "prod"`, "RBACForbidden", true},
@@ -348,6 +352,56 @@ func TestClassifyAdmissionFailure(t *testing.T) {
 		if ok != c.ok || reason != c.reason {
 			t.Errorf("classifyAdmissionFailure(%.50q) = %q,%v want %q,%v", c.msg, reason, ok, c.reason, c.ok)
 		}
+	}
+}
+
+func TestParseAdmissionWebhookBackendFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want AdmissionWebhookBackendFailure
+		ok   bool
+	}{
+		{
+			name: "no ready endpoints",
+			msg:  `failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": no endpoints available for service "policy-webhook"`,
+			want: AdmissionWebhookBackendFailure{WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", Kind: AdmissionWebhookNoReadyEndpoints},
+			ok:   true,
+		},
+		{
+			name: "missing service",
+			msg:  `failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": service "policy-webhook" not found`,
+			want: AdmissionWebhookBackendFailure{WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", Kind: AdmissionWebhookServiceNotFound},
+			ok:   true,
+		},
+		{
+			name: "missing service plural",
+			msg:  `failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": services "policy-webhook" not found`,
+			want: AdmissionWebhookBackendFailure{WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", Kind: AdmissionWebhookServiceNotFound},
+			ok:   true,
+		},
+		{
+			name: "no endpoints takes precedence",
+			msg:  `failed calling webhook "validate.example.com": Post "https://policy-webhook.hooks.svc:443/validate": no endpoints available for service "policy-webhook"; service "policy-webhook" not found`,
+			want: AdmissionWebhookBackendFailure{WebhookName: "validate.example.com", ServiceNamespace: "hooks", ServiceName: "policy-webhook", Kind: AdmissionWebhookNoReadyEndpoints},
+			ok:   true,
+		},
+		{
+			name: "service name disagreement",
+			msg:  `failed calling webhook "validate.example.com": Post "https://other.hooks.svc:443/validate": service "policy-webhook" not found`,
+		},
+		{
+			name: "missing webhook identity",
+			msg:  `Post "https://policy-webhook.hooks.svc:443/validate": service "policy-webhook" not found`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseAdmissionWebhookBackendFailure(tc.msg)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("ParseAdmissionWebhookBackendFailure() = %+v,%v; want %+v,%v", got, ok, tc.want, tc.ok)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Radar connects a missing admission webhook backend Service with workload creation failures caused by the same fail-closed webhook. Operators see the webhook configuration as the incident root and the blocked workloads as symptoms, without inventing a synthetic Service resource.

## What changed

### Detection and identity

- Missing backend references from validating and mutating webhook configurations use one shared reason and a fingerprint derived from the exact Service namespace and name.
- Admission failure parsing recognizes both no-ready-endpoints and Service-not-found failures.
- Parsing requires the quoted webhook name, an in-cluster Service URL, and agreement between the URL host and API-server error before treating a message as attributable.

### Incident correlation

- Webhook inventory retains the configuration, webhook name, Service identity, and normalized failure policy needed for exact matching.
- A blocked workload is linked only when its observed admission failure matches the configuration webhook name, backend Service, failure kind, and failurePolicy=Fail.
- The webhook configuration remains the incident root. Related workload groups become symptoms only when a matching blocked workload was actually observed.
- Missing fail-open backends remain warnings that explain bypassed validation or mutation; they never become blocking incident parents.
- Missing backends without an observed blocked workload keep their direct missing-reference explanation without a redundant admission-dependency fact.

### Safety boundaries

- Ambiguous same-tier roots do not receive an incident parent.
- Existing-Service and missing-Service failures cannot cross-match.
- Cluster-scoped context remains bounded by readable cached inventory and RBAC.
- Unrecognized API-server wording under-correlates instead of assigning a speculative cause.

## Testing

- `go test ./internal/k8s ./internal/issues -count=1`
- `make tsc`
- `npm test --workspace @skyhook-io/k8s-ui -- --run src/components/issues/issues.test.ts`
- `make build`
- Live EKS reproduction covering the Service-not-found FailedCreate event, configuration-to-workload incident edge, backend recovery, and issue disappearance
- Visual behavior exercised in the live Issues view with no browser console errors; no new layout or styling was introduced

## Notes

Strict identity matching intentionally favors missing a correlation over presenting a false incident root.

RAD-346