### PR TITLE
fix(issues): detect missing Gateway API references

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -60,7 +60,9 @@ func Classify(in classifyInput) issuesapi.Category {
 			return issuesapi.CategoryIngressBackendMissing
 		case "Missing IngressClass":
 			return issuesapi.CategoryIngressClassMissing
-		case "Missing Gateway backend Service", "Missing Gateway backend Service port", "Missing Gateway ReferenceGrant":
+		case "Missing GatewayClass":
+			return issuesapi.CategoryGatewayNotReady
+		case "Missing Gateway parent", "Missing Gateway backend Service", "Missing Gateway backend Service port", "Missing Gateway ReferenceGrant":
 			return issuesapi.CategoryGatewayRouteInvalid
 		case k8s.MissingWebhookBackendReason:
 			return issuesapi.CategoryWebhookBackendDown

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -124,6 +124,8 @@ func TestClassify(t *testing.T) {
 		{"missing sa", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ServiceAccount"}, issuesapi.CategoryMissingConfigRef},
 		{"ingress backend missing", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing backend Service"}, issuesapi.CategoryIngressBackendMissing},
 		{"ingress class missing", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing IngressClass"}, issuesapi.CategoryIngressClassMissing},
+		{"gateway class missing", classifyInput{Source: SourceMissingRef, Kind: "Gateway", APIGroup: "gateway.networking.k8s.io", Reason: "Missing GatewayClass"}, issuesapi.CategoryGatewayNotReady},
+		{"gateway parent missing", classifyInput{Source: SourceMissingRef, Kind: "HTTPRoute", APIGroup: "gateway.networking.k8s.io", Reason: "Missing Gateway parent"}, issuesapi.CategoryGatewayRouteInvalid},
 		{"gateway backend missing", classifyInput{Source: SourceMissingRef, Kind: "HTTPRoute", APIGroup: "gateway.networking.k8s.io", Reason: "Missing Gateway backend Service"}, issuesapi.CategoryGatewayRouteInvalid},
 		{"gateway reference grant missing", classifyInput{Source: SourceMissingRef, Kind: "HTTPRoute", APIGroup: "gateway.networking.k8s.io", Reason: "Missing Gateway ReferenceGrant"}, issuesapi.CategoryGatewayRouteInvalid},
 		{"ingress tls secret is config", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing TLS Secret"}, issuesapi.CategoryMissingConfigRef},

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -226,24 +226,50 @@ var restartCycleCategories = map[issuesapi.Category]bool{
 // Service/port and works before controller reconciliation, so it is the richer
 // row.
 func dedupeConditionOverMissingRef(in []Issue) []Issue {
-	structural := map[string]bool{}
+	structuralEchoes := map[string]map[string]bool{}
 	for _, i := range in {
 		if i.Source != SourceMissingRef {
 			continue
 		}
-		structural[issueResourceCategoryKey(i)] = true
+		prefixes := missingRefConditionEchoPrefixes(i)
+		if len(prefixes) == 0 {
+			continue
+		}
+		key := issueResourceCategoryKey(i)
+		if structuralEchoes[key] == nil {
+			structuralEchoes[key] = map[string]bool{}
+		}
+		for _, prefix := range prefixes {
+			structuralEchoes[key][prefix] = true
+		}
 	}
-	if len(structural) == 0 {
+	if len(structuralEchoes) == 0 {
 		return in
 	}
 	out := in[:0]
 	for _, i := range in {
-		if i.Source == SourceCondition && structural[issueResourceCategoryKey(i)] && isMissingRefEchoCondition(i) {
+		if i.Source == SourceCondition && isMissingRefEchoCondition(i, structuralEchoes[issueResourceCategoryKey(i)]) {
 			continue
 		}
 		out = append(out, i)
 	}
 	return out
+}
+
+func missingRefConditionEchoPrefixes(i Issue) []string {
+	if i.Group != "gateway.networking.k8s.io" {
+		return nil
+	}
+	switch i.Reason {
+	case "Missing Gateway backend Service":
+		return []string{"ResolvedRefs: BackendNotFound"}
+	case "Missing Gateway backend Service port":
+		return []string{"ResolvedRefs: BackendNotFound", "ResolvedRefs: PortNotFound"}
+	case "Missing Gateway ReferenceGrant":
+		return []string{"ResolvedRefs: RefNotPermitted"}
+	default:
+		return nil
+	}
 }
 
 // dedupePVCPendingOverMissingRef drops the generic phase-Pending PVC row when
@@ -375,13 +401,18 @@ func dedupeHPAOverMissingTarget(in []Issue) []Issue {
 		})
 }
 
-func isMissingRefEchoCondition(i Issue) bool {
-	if i.Group != "gateway.networking.k8s.io" {
+func isMissingRefEchoCondition(i Issue, prefixes map[string]bool) bool {
+	if len(prefixes) == 0 || i.Group != "gateway.networking.k8s.io" {
 		return false
 	}
 	switch i.Kind {
 	case "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
-		return strings.HasPrefix(i.Reason, "ResolvedRefs:")
+		for prefix := range prefixes {
+			if strings.HasPrefix(i.Reason, prefix) {
+				return true
+			}
+		}
+		return false
 	default:
 		return false
 	}

--- a/internal/issues/dedupe_test.go
+++ b/internal/issues/dedupe_test.go
@@ -292,6 +292,7 @@ func TestDedupeConditionOverMissingRef(t *testing.T) {
 		Kind:      "HTTPRoute",
 		Namespace: "prod",
 		Name:      "broken",
+		Reason:    "Missing Gateway backend Service",
 		Category:  issuesapi.CategoryGatewayRouteInvalid,
 	}
 	conditionEcho := Issue{
@@ -305,25 +306,73 @@ func TestDedupeConditionOverMissingRef(t *testing.T) {
 	}
 	conditionAccepted := conditionEcho
 	conditionAccepted.Reason = "Accepted: NoMatchingParent"
+	conditionFilterNotFound := conditionEcho
+	conditionFilterNotFound.Reason = "ResolvedRefs: FilterNotFound"
+	conditionInvalidKind := conditionEcho
+	conditionInvalidKind.Reason = "ResolvedRefs: InvalidKind"
+	conditionPortNotFound := conditionEcho
+	conditionPortNotFound.Reason = "ResolvedRefs: PortNotFound"
 	conditionOtherCategory := conditionEcho
 	conditionOtherCategory.Category = issuesapi.CategoryGatewayNotReady
 	conditionOtherObject := conditionEcho
 	conditionOtherObject.Name = "other"
 
-	out := dedupeConditionOverMissingRef([]Issue{missing, conditionEcho, conditionAccepted, conditionOtherCategory, conditionOtherObject})
-	if len(out) != 4 {
+	out := dedupeConditionOverMissingRef([]Issue{missing, conditionEcho, conditionAccepted, conditionFilterNotFound, conditionInvalidKind, conditionPortNotFound, conditionOtherCategory, conditionOtherObject})
+	if len(out) != 7 {
 		t.Fatalf("expected only the ResolvedRefs echo to be dropped, got %+v", out)
 	}
-	var keptAccepted bool
+	kept := map[string]bool{}
 	for _, i := range out {
 		if i.Source == SourceCondition && i.Name == "broken" && i.Category == issuesapi.CategoryGatewayRouteInvalid && i.Reason == "ResolvedRefs: BackendNotFound" {
 			t.Fatalf("same-object ResolvedRefs echo survived: %+v", out)
 		}
-		if i.Source == SourceCondition && i.Name == "broken" && i.Reason == "Accepted: NoMatchingParent" {
-			keptAccepted = true
+		if i.Source == SourceCondition && i.Name == "broken" {
+			kept[i.Reason] = true
 		}
 	}
-	if !keptAccepted {
-		t.Fatalf("non-ResolvedRefs route condition was incorrectly dropped: %+v", out)
+	for _, reason := range []string{"Accepted: NoMatchingParent", "ResolvedRefs: FilterNotFound", "ResolvedRefs: InvalidKind", "ResolvedRefs: PortNotFound"} {
+		if !kept[reason] {
+			t.Fatalf("unrelated route condition %q was incorrectly dropped: %+v", reason, out)
+		}
 	}
+
+	missingParent := missing
+	missingParent.Reason = "Missing Gateway parent"
+	out = dedupeConditionOverMissingRef([]Issue{missingParent, conditionEcho, conditionAccepted})
+	if len(out) != 3 {
+		t.Fatalf("missing parent must preserve controller conditions that may describe another parent: %+v", out)
+	}
+	if !hasReason(out, conditionAccepted.Reason) || !hasReason(out, conditionEcho.Reason) {
+		t.Fatalf("missing parent incorrectly hid a controller condition: %+v", out)
+	}
+
+	out = dedupeConditionOverMissingRef([]Issue{missing, missingParent, conditionEcho, conditionAccepted})
+	if len(out) != 3 || hasReason(out, conditionEcho.Reason) || !hasReason(out, conditionAccepted.Reason) {
+		t.Fatalf("each structural root must hide only its matching condition family: %+v", out)
+	}
+
+	missingPort := missing
+	missingPort.Reason = "Missing Gateway backend Service port"
+	out = dedupeConditionOverMissingRef([]Issue{missingPort, conditionEcho, conditionPortNotFound, conditionFilterNotFound})
+	if len(out) != 2 || hasReason(out, conditionEcho.Reason) || hasReason(out, conditionPortNotFound.Reason) || !hasReason(out, conditionFilterNotFound.Reason) {
+		t.Fatalf("missing Service port must hide only backend/port-not-found echoes: %+v", out)
+	}
+
+	missingGrant := missing
+	missingGrant.Reason = "Missing Gateway ReferenceGrant"
+	conditionRefNotPermitted := conditionEcho
+	conditionRefNotPermitted.Reason = "ResolvedRefs: RefNotPermitted"
+	out = dedupeConditionOverMissingRef([]Issue{missingGrant, conditionRefNotPermitted, conditionEcho})
+	if len(out) != 2 || hasReason(out, conditionRefNotPermitted.Reason) || !hasReason(out, conditionEcho.Reason) {
+		t.Fatalf("ReferenceGrant root must hide only RefNotPermitted: %+v", out)
+	}
+}
+
+func hasReason(in []Issue, reason string) bool {
+	for _, issue := range in {
+		if issue.Reason == reason {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/k8s/detect_crd_refs.go
+++ b/internal/k8s/detect_crd_refs.go
@@ -190,7 +190,7 @@ func scaleTargetExists(cache *ResourceCache, dynamicCache *DynamicResourceCache,
 		if !ok {
 			return false, false
 		}
-		return dynamicScaleTargetExists(dynamicCache, gvr, namespace, "Rollout", ref.name)
+		return dynamicScaleTargetExists(dynamicCache, gvr, namespace, ref.name)
 	default:
 		return false, false
 	}
@@ -210,18 +210,9 @@ func scaleTargetLookupResult(cache *ResourceCache, resource, kind, namespace, na
 	return refLookupResult(cache, resource, namespace, err)
 }
 
-func dynamicScaleTargetExists(dynamicCache *DynamicResourceCache, gvr schema.GroupVersionResource, namespace, kind, name string) (checked bool, exists bool) {
-	items, err := dynamicCache.ListWatched(gvr)
-	if err != nil {
-		log.Printf("[missing-refs] failed to verify %s %s/%s scaleTargetRef: %s", logsafe.Sanitize(kind), logsafe.Sanitize(namespace), logsafe.Sanitize(name), logsafe.Sanitize(err.Error()))
-		return false, false
-	}
-	for _, item := range items {
-		if item.GetNamespace() == namespace && item.GetName() == name {
-			return true, true
-		}
-	}
-	return true, false
+func dynamicScaleTargetExists(dynamicCache *DynamicResourceCache, gvr schema.GroupVersionResource, namespace, name string) (checked bool, exists bool) {
+	found, authoritative := dynamicCache.HasWatchedInSyncedNamespace(gvr, namespace, name)
+	return authoritative, found
 }
 
 func listDynamicForMissingRefs(dynamicCache *DynamicResourceCache, gvr schema.GroupVersionResource, namespace, kind string) []*unstructured.Unstructured {

--- a/internal/k8s/detect_missing_refs.go
+++ b/internal/k8s/detect_missing_refs.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
@@ -11,6 +12,7 @@ import (
 	"github.com/skyhook-io/radar/internal/ingressstatus"
 	"github.com/skyhook-io/radar/internal/logsafe"
 	"github.com/skyhook-io/radar/pkg/envresolve"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -988,48 +991,159 @@ func sortedWebhookMissingBackendKeys(in map[string]*webhookMissingBackend) []str
 	return keys
 }
 
-// DetectMissingGatewayRefs scans Gateway API Routes for backend Service refs
-// that point at missing Services or missing Service ports. Controller status
-// usually reports these via ResolvedRefs=False, but this structural check still
-// works before a controller reconciles and on clusters where route status is
-// sparse.
+const missingGatewayRefGrace = 2 * time.Minute
+
+// DetectMissingGatewayRefs scans Gateway API resources for dangling
+// GatewayClass, parent Gateway, backend Service, Service port, and
+// ReferenceGrant references.
 func DetectMissingGatewayRefs(cache *ResourceCache, dynamicCache *DynamicResourceCache, discovery *ResourceDiscovery, namespace string) []Detection {
 	if cache == nil || dynamicCache == nil || discovery == nil {
 		return nil
 	}
 	svcLister := cache.Services()
-	if svcLister == nil {
-		return nil
-	}
 	now := time.Now()
-	getReferenceGrants := gatewayReferenceGrantGetter(dynamicCache, discovery)
 	var out []Detection
+
+	gatewayGVR, hasGateways := discovery.GetGVRWithGroup("Gateway", "gateway.networking.k8s.io")
+	if hasGateways {
+		gateways, ok := listGatewaySourceObjects(dynamicCache, gatewayGVR, "Gateway", namespace)
+		if ok {
+			out = append(out, detectGatewayMissingClasses(dynamicCache, discovery, gateways, now)...)
+		}
+	}
+
+	getReferenceGrants := gatewayReferenceGrantGetter(dynamicCache, discovery)
 	for _, kind := range []string{"HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute"} {
 		gvr, ok := discovery.GetGVRWithGroup(kind, "gateway.networking.k8s.io")
 		if !ok {
 			continue
 		}
-		var routes []*unstructured.Unstructured
-		if namespace != "" {
-			items, err := dynamicCache.List(gvr, namespace)
-			if err != nil {
-				log.Printf("[missing-refs] failed to list %s.gateway.networking.k8s.io in %s: %s", logsafe.Sanitize(kind), logsafe.Sanitize(namespace), logsafe.Sanitize(err.Error()))
-				continue
-			}
-			routes = items
-		} else {
-			items, err := dynamicCache.ListWatched(gvr)
-			if err != nil {
-				log.Printf("[missing-refs] failed to list %s.gateway.networking.k8s.io: %s", logsafe.Sanitize(kind), logsafe.Sanitize(err.Error()))
-				continue
-			}
-			routes = items
+		routes, ok := listGatewaySourceObjects(dynamicCache, gvr, kind, namespace)
+		if !ok {
+			continue
 		}
 		for _, route := range routes {
-			out = append(out, detectGatewayRouteMissingBackends(cache, svcLister, getReferenceGrants, kind, route, now)...)
+			if hasGateways {
+				out = append(out, detectGatewayRouteMissingParents(dynamicCache, gatewayGVR, kind, route, now)...)
+			}
+			if svcLister != nil {
+				out = append(out, detectGatewayRouteMissingBackends(cache, svcLister, getReferenceGrants, kind, route, now)...)
+			}
 		}
 	}
 	return out
+}
+
+func listGatewaySourceObjects(dynamicCache *DynamicResourceCache, gvr schema.GroupVersionResource, kind, namespace string) ([]*unstructured.Unstructured, bool) {
+	var (
+		items []*unstructured.Unstructured
+		err   error
+	)
+	if namespace == "" {
+		items, err = dynamicCache.ListWatched(gvr)
+	} else {
+		items, err = dynamicCache.List(gvr, namespace)
+	}
+	if err != nil {
+		if namespace == "" {
+			log.Printf("[missing-refs] failed to list %s.gateway.networking.k8s.io: %s", logsafe.Sanitize(kind), logsafe.Sanitize(err.Error()))
+		} else {
+			log.Printf("[missing-refs] failed to list %s.gateway.networking.k8s.io in %s: %s", logsafe.Sanitize(kind), logsafe.Sanitize(namespace), logsafe.Sanitize(err.Error()))
+		}
+		return nil, false
+	}
+	return items, true
+}
+
+func detectGatewayMissingClasses(dynamicCache *DynamicResourceCache, discovery *ResourceDiscovery, gateways []*unstructured.Unstructured, now time.Time) []Detection {
+	classGVR, ok := discovery.GetGVRWithGroup("GatewayClass", "gateway.networking.k8s.io")
+	if !ok || !dynamicCache.IsClusterWideSynced(classGVR) {
+		return nil
+	}
+	var out []Detection
+	for _, gateway := range gateways {
+		if !gatewayRefGraceElapsed(gateway, now) {
+			continue
+		}
+		className, _, _ := unstructured.NestedString(gateway.Object, "spec", "gatewayClassName")
+		className = strings.TrimSpace(className)
+		if className == "" {
+			continue
+		}
+		_, err := dynamicCache.GetWatched(classGVR, "", className)
+		if err == nil || !errors.Is(err, k8score.ErrResourceNotFound) {
+			continue
+		}
+		detection := withFix(missingRefProblemSev(now, "Gateway", "gateway.networking.k8s.io", gateway.GetNamespace(), gateway.GetName(), "warning",
+			"Missing GatewayClass",
+			fmt.Sprintf("spec.gatewayClassName references GatewayClass %q which does not exist", className),
+			gateway.GetCreationTimestamp().Time),
+			fmt.Sprintf("GatewayClass %q is not installed, so no Gateway controller can accept this Gateway.", className),
+			"Set spec.gatewayClassName to an installed class, or install the intended Gateway controller and GatewayClass.")
+		detection.Fingerprint = missingRefFingerprint(detection.Reason, "spec.gatewayClassName:"+className)
+		out = append(out, detection)
+	}
+	return out
+}
+
+func detectGatewayRouteMissingParents(dynamicCache *DynamicResourceCache, gatewayGVR schema.GroupVersionResource, kind string, route *unstructured.Unstructured, now time.Time) []Detection {
+	if !gatewayRefGraceElapsed(route, now) {
+		return nil
+	}
+	parentRefs, found, err := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+	if err != nil || !found {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []Detection
+	for index, parentRef := range parentRefs {
+		ref, ok := parentRef.(map[string]any)
+		if !ok {
+			continue
+		}
+		group, _ := ref["group"].(string)
+		if group == "" {
+			group = "gateway.networking.k8s.io"
+		}
+		parentKind, _ := ref["kind"].(string)
+		if parentKind == "" {
+			parentKind = "Gateway"
+		}
+		if group != "gateway.networking.k8s.io" || parentKind != "Gateway" {
+			continue
+		}
+		name, _ := ref["name"].(string)
+		if name == "" {
+			continue
+		}
+		parentNamespace, _ := ref["namespace"].(string)
+		if parentNamespace == "" {
+			parentNamespace = route.GetNamespace()
+		}
+		key := group + "/" + parentKind + "/" + parentNamespace + "/" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		found, authoritative := dynamicCache.HasWatchedInSyncedNamespace(gatewayGVR, parentNamespace, name)
+		if !authoritative || found {
+			continue
+		}
+		detection := withFix(missingRefProblemSev(now, kind, "gateway.networking.k8s.io", route.GetNamespace(), route.GetName(), "warning",
+			"Missing Gateway parent",
+			fmt.Sprintf("spec.parentRefs[%d] references Gateway %q in namespace %q which does not exist", index, name, parentNamespace),
+			route.GetCreationTimestamp().Time),
+			fmt.Sprintf("Gateway %q in namespace %q doesn't exist, so this route cannot attach to that parent.", name, parentNamespace),
+			fmt.Sprintf("Point the parentRef at an existing Gateway in namespace %q, remove the stale parentRef, or create Gateway %q if it should still receive this route.", parentNamespace, name))
+		detection.Fingerprint = missingRefFingerprint(detection.Reason, "spec.parentRefs:"+key)
+		out = append(out, detection)
+	}
+	return out
+}
+
+func gatewayRefGraceElapsed(resource *unstructured.Unstructured, now time.Time) bool {
+	createdAt := resource.GetCreationTimestamp().Time
+	return !createdAt.IsZero() && !createdAt.After(now) && now.Sub(createdAt) >= missingGatewayRefGrace
 }
 
 type referenceGrantGetter func(namespace string) ([]*unstructured.Unstructured, bool)

--- a/internal/k8s/detect_missing_refs_test.go
+++ b/internal/k8s/detect_missing_refs_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestMissingRefProblemUsesInjectedClockForResourceAge(t *testing.T) {
@@ -1008,6 +1010,10 @@ func TestDetectMissingGatewayRefs(t *testing.T) {
 	if len(problems) != 4 {
 		t.Fatalf("expected exactly 4 Gateway missing-ref problems, got %+v", problems)
 	}
+	withoutServices := DetectMissingGatewayRefs(&ResourceCache{ResourceCache: &k8score.ResourceCache{}}, dynCache, GetResourceDiscovery(), "")
+	if len(withoutServices) != 0 {
+		t.Fatalf("Gateway backend checks must stay disabled when the Service lister is unavailable: %+v", withoutServices)
+	}
 	assertProblemActionOrder(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway backend Service", "missing", "existing Service", "create Service")
 	assertProblemActionOrder(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway backend Service port", "9090", "already exposes", "add port")
 	assertProblemActionStarts(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway ReferenceGrant", "Create a ReferenceGrant")
@@ -1026,6 +1032,299 @@ func TestDetectMissingGatewayRefs(t *testing.T) {
 	scoped := DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "prod")
 	if len(scoped) != 4 {
 		t.Fatalf("namespace-scoped Gateway refs should include prod route problems, got %+v", scoped)
+	}
+}
+
+func TestDetectMissingGatewayTopologyRefs(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	old := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	young := metav1.NewTime(time.Now().Add(-time.Minute))
+	if err := InitTestResourceCache(fake.NewClientset()); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	classGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
+	gatewayGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	routeGVRs := map[string]schema.GroupVersionResource{
+		"HTTPRoute": {Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+		"GRPCRoute": {Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes"},
+		"TCPRoute":  {Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tcproutes"},
+		"TLSRoute":  {Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tlsroutes"},
+	}
+	listKinds := map[schema.GroupVersionResource]string{
+		classGVR:   "GatewayClassList",
+		gatewayGVR: "GatewayList",
+	}
+	for kind, gvr := range routeGVRs {
+		listKinds[gvr] = kind + "List"
+	}
+
+	objects := []runtime.Object{
+		gatewayRouteWithParents("HTTPRoute", "missing-default", "prod", old, []any{
+			map[string]any{"name": "absent-http"},
+			map[string]any{"name": "absent-http"},
+		}),
+		gatewayRouteWithParents("HTTPRoute", "existing", "prod", old, []any{
+			map[string]any{"name": "existing-parent"},
+		}),
+		gatewayRouteWithParents("HTTPRoute", "missing-cross-namespace", "prod", old, []any{
+			map[string]any{"group": "gateway.networking.k8s.io", "kind": "Gateway", "namespace": "platform", "name": "absent-cross"},
+		}),
+		gatewayRouteWithParents("HTTPRoute", "unsupported-parent-kind", "prod", old, []any{
+			map[string]any{"group": "example.io", "kind": "Mesh", "name": "ignored"},
+		}),
+		gatewayRouteWithParents("HTTPRoute", "young-missing-parent", "prod", young, []any{
+			map[string]any{"name": "young-absent"},
+		}),
+		gatewayRouteWithParents("GRPCRoute", "missing-grpc", "prod", old, []any{map[string]any{"name": "absent-grpc"}}),
+		gatewayRouteWithParents("TCPRoute", "missing-tcp", "prod", old, []any{map[string]any{"name": "absent-tcp"}}),
+		gatewayRouteWithParents("TLSRoute", "missing-tls", "prod", old, []any{map[string]any{"name": "absent-tls"}}),
+	}
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds, objects...)
+	if _, err := dynClient.Resource(classGVR).Create(t.Context(), gatewayClass("installed", old), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed GatewayClass: %v", err)
+	}
+	for _, gateway := range []*unstructured.Unstructured{
+		gatewayObject("missing-class", "prod", "absent-class", old),
+		gatewayObject("existing-parent", "prod", "installed", old),
+		gatewayObject("young-missing-class", "prod", "young-absent", young),
+	} {
+		if _, err := dynClient.Resource(gatewayGVR).Namespace(gateway.GetNamespace()).Create(t.Context(), gateway, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed Gateway %s: %v", gateway.GetName(), err)
+		}
+	}
+	resources := []APIResource{
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass", Name: "gatewayclasses", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway", Name: "gateways", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute", Name: "httproutes", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GRPCRoute", Name: "grpcroutes", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute", Name: "tcproutes", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute", Name: "tlsroutes", Verbs: []string{"list", "watch"}},
+	}
+	if err := InitTestDynamicResourceCache(dynClient, resources); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	dynCache := GetDynamicResourceCache()
+	for _, gvr := range append([]schema.GroupVersionResource{classGVR, gatewayGVR}, routeGVRs["HTTPRoute"], routeGVRs["GRPCRoute"], routeGVRs["TCPRoute"], routeGVRs["TLSRoute"]) {
+		if err := dynCache.EnsureWatching(gvr); err != nil {
+			t.Fatalf("EnsureWatching %s: %v", gvr.Resource, err)
+		}
+		if !dynCache.WaitForSync(gvr, 2*time.Second) {
+			t.Fatalf("%s cache did not sync", gvr.Resource)
+		}
+	}
+
+	problems := DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	if !findProblem(problems, "Gateway", "prod", "missing-class", "Missing GatewayClass") {
+		t.Fatalf("missing GatewayClass not detected: %+v", problems)
+	}
+	for _, route := range []struct{ kind, name string }{
+		{"HTTPRoute", "missing-default"},
+		{"HTTPRoute", "missing-cross-namespace"},
+		{"GRPCRoute", "missing-grpc"},
+		{"TCPRoute", "missing-tcp"},
+		{"TLSRoute", "missing-tls"},
+	} {
+		if !findProblem(problems, route.kind, "prod", route.name, "Missing Gateway parent") {
+			t.Errorf("missing parent not detected for %s/%s: %+v", route.kind, route.name, problems)
+		}
+	}
+	for _, silent := range []string{"existing", "unsupported-parent-kind", "young-missing-parent", "young-missing-class"} {
+		for _, problem := range problems {
+			if problem.Name == silent && (problem.Reason == "Missing GatewayClass" || problem.Reason == "Missing Gateway parent") {
+				t.Errorf("%s must not produce a topology missing-ref issue: %+v", silent, problem)
+			}
+		}
+	}
+	missingDefaultCount := 0
+	for _, problem := range problems {
+		if problem.Name == "missing-default" && problem.Reason == "Missing Gateway parent" {
+			missingDefaultCount++
+		}
+		if problem.Reason == "Missing GatewayClass" || problem.Reason == "Missing Gateway parent" {
+			if problem.Severity != "warning" || !problem.OnsetUnknown || problem.Fingerprint == "" {
+				t.Errorf("Gateway topology issue must be warning with unknown onset and stable fingerprint: %+v", problem)
+			}
+		}
+	}
+	if missingDefaultCount != 1 {
+		t.Fatalf("repeated identical parentRefs produced %d issues, want 1", missingDefaultCount)
+	}
+
+	withoutServices := DetectMissingGatewayRefs(&ResourceCache{ResourceCache: &k8score.ResourceCache{}}, dynCache, GetResourceDiscovery(), "")
+	if !findProblem(withoutServices, "Gateway", "prod", "missing-class", "Missing GatewayClass") ||
+		!findProblem(withoutServices, "HTTPRoute", "prod", "missing-default", "Missing Gateway parent") {
+		t.Fatalf("Gateway topology checks must run when the Service lister is unavailable: %+v", withoutServices)
+	}
+	for _, problem := range withoutServices {
+		if problem.Reason == "Missing Gateway backend Service" || problem.Reason == "Missing Gateway backend Service port" || problem.Reason == "Missing Gateway ReferenceGrant" {
+			t.Fatalf("backend checks must stay disabled when the Service lister is unavailable: %+v", problem)
+		}
+	}
+
+	for _, target := range []*unstructured.Unstructured{
+		gatewayObject("absent-http", "prod", "installed", old),
+		gatewayObject("absent-cross", "platform", "installed", old),
+		gatewayObject("absent-grpc", "prod", "installed", old),
+		gatewayObject("absent-tcp", "prod", "installed", old),
+		gatewayObject("absent-tls", "prod", "installed", old),
+	} {
+		if _, err := dynClient.Resource(gatewayGVR).Namespace(target.GetNamespace()).Create(t.Context(), target, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create Gateway %s/%s: %v", target.GetNamespace(), target.GetName(), err)
+		}
+	}
+	if _, err := dynClient.Resource(classGVR).Create(t.Context(), gatewayClass("absent-class", old), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create GatewayClass: %v", err)
+	}
+	waitForGatewayTopologyIssueCount(t, func() []Detection {
+		return DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	}, 0)
+
+	if err := dynClient.Resource(gatewayGVR).Namespace("prod").Delete(t.Context(), "absent-http", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete Gateway: %v", err)
+	}
+	waitForGatewayTopologyIssueCount(t, func() []Detection {
+		return DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	}, 1)
+}
+
+func TestDetectMissingGatewayTopologyRefsRequiresSyncedTargetCoverage(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	old := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	if err := InitTestResourceCache(fake.NewClientset()); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	classGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
+	gatewayGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{classGVR: "GatewayClassList", gatewayGVR: "GatewayList", routeGVR: "HTTPRouteList"},
+		gatewayRouteWithParents("HTTPRoute", "missing-parent", "prod", old, []any{map[string]any{"name": "absent"}}),
+		gatewayRouteWithParents("HTTPRoute", "uncovered-parent-namespace", "prod", old, []any{map[string]any{"namespace": "platform", "name": "absent-cross"}}),
+	)
+	if _, err := dynClient.Resource(gatewayGVR).Namespace("prod").Create(t.Context(), gatewayObject("missing-class", "prod", "absent-class", old), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed Gateway: %v", err)
+	}
+	if err := InitTestDynamicResourceCache(dynClient, []APIResource{
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass", Name: "gatewayclasses", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway", Name: "gateways", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute", Name: "httproutes", Verbs: []string{"list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	dynCache := GetDynamicResourceCache()
+	if err := dynCache.EnsureWatching(routeGVR); err != nil {
+		t.Fatalf("EnsureWatching route: %v", err)
+	}
+	if !dynCache.WaitForSync(routeGVR, 2*time.Second) {
+		t.Fatal("route cache did not sync")
+	}
+
+	problems := DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	for _, problem := range problems {
+		if problem.Reason == "Missing GatewayClass" || problem.Reason == "Missing Gateway parent" {
+			t.Fatalf("unwatched target inventories must not assert absence: %+v", problems)
+		}
+	}
+}
+
+func TestDetectMissingGatewayTopologyRefsConcreteNamespaceWaitsForTargetSync(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	old := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	if err := InitTestResourceCache(fake.NewClientset()); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	classGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
+	gatewayGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	routeGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{classGVR: "GatewayClassList", gatewayGVR: "GatewayList", routeGVR: "HTTPRouteList"},
+		gatewayRouteWithParents("HTTPRoute", "missing-parent", "prod", old, []any{map[string]any{"name": "absent"}}),
+		gatewayRouteWithParents("HTTPRoute", "uncovered-parent-namespace", "prod", old,
+			[]any{map[string]any{"namespace": "platform", "name": "absent-cross"}}),
+	)
+	if _, err := dynClient.Resource(gatewayGVR).Namespace("prod").Create(t.Context(), gatewayObject("missing-class", "prod", "absent-class", old), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed Gateway: %v", err)
+	}
+	listStarted := make(chan struct{})
+	releaseList := make(chan struct{})
+	var gatewayListMu sync.Mutex
+	gatewayProdLists := 0
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListAction)
+		if !ok {
+			return false, nil, nil
+		}
+		gvr := listAction.GetResource()
+		if gvr != gatewayGVR && gvr != routeGVR {
+			return false, nil, nil
+		}
+		if listAction.GetNamespace() == "" {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+		}
+		if gvr == gatewayGVR && listAction.GetNamespace() == "prod" {
+			gatewayListMu.Lock()
+			gatewayProdLists++
+			call := gatewayProdLists
+			gatewayListMu.Unlock()
+			if call == 2 {
+				close(listStarted)
+				<-releaseList
+			}
+		}
+		return false, nil, nil
+	})
+	if err := InitTestDynamicResourceCache(dynClient, []APIResource{
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass", Name: "gatewayclasses", Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway", Name: "gateways", Namespaced: true, Verbs: []string{"list", "watch"}},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute", Name: "httproutes", Namespaced: true, Verbs: []string{"list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	dynCache := GetDynamicResourceCache()
+	if err := dynCache.EnsureWatching(classGVR); err != nil {
+		t.Fatalf("EnsureWatching GatewayClass: %v", err)
+	}
+	if !dynCache.WaitForSync(classGVR, 2*time.Second) {
+		t.Fatal("GatewayClass cache did not sync")
+	}
+	if _, err := dynCache.ListBlocking(routeGVR, "prod", 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking HTTPRoute/prod: %v", err)
+	}
+
+	problems := DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "prod")
+	select {
+	case <-listStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Gateway informer did not begin its initial namespace list")
+	}
+	for _, problem := range problems {
+		if problem.Reason == "Missing GatewayClass" || problem.Reason == "Missing Gateway parent" {
+			t.Fatalf("unsynced namespace target inventory must not assert absence: %+v", problems)
+		}
+	}
+
+	close(releaseList)
+	if !dynCache.WaitForSync(gatewayGVR, 2*time.Second) {
+		t.Fatal("Gateway namespace cache did not sync")
+	}
+	problems = DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "prod")
+	if !findProblem(problems, "Gateway", "prod", "missing-class", "Missing GatewayClass") {
+		t.Fatalf("concrete-namespace scan did not detect missing GatewayClass after sync: %+v", problems)
+	}
+	if !findProblem(problems, "HTTPRoute", "prod", "missing-parent", "Missing Gateway parent") {
+		t.Fatalf("concrete-namespace scan did not detect missing parent after sync: %+v", problems)
+	}
+	if findProblem(problems, "HTTPRoute", "prod", "uncovered-parent-namespace", "Missing Gateway parent") {
+		t.Fatalf("synced prod informer must not assert absence in uncovered platform namespace: %+v", problems)
 	}
 }
 
@@ -1069,6 +1368,8 @@ func TestDetectMissingCRDRefs(t *testing.T) {
 		kedaScaledObject("ok", "prod", now, "apps/v1", "Deployment", "web"),
 		kedaScaledObject("missing-target", "prod", now, "apps/v1", "Deployment", "ghost"),
 		kedaScaledObject("missing-default-deployment-target", "prod", now, "apps/v1", "", "also-ghost"),
+		kedaScaledObject("existing-rollout-target", "prod", now, "argoproj.io/v1alpha1", "Rollout", "checkout"),
+		kedaScaledObject("missing-rollout-target", "prod", now, "argoproj.io/v1alpha1", "Rollout", "ghost-rollout"),
 		kedaScaledObject("wrong-group-target", "prod", now, "example.com/v1", "Deployment", "ghost"),
 		kedaScaledObject("unsupported-target", "prod", now, "example.com/v1", "Widget", "ghost"),
 	)
@@ -1079,13 +1380,21 @@ func TestDetectMissingCRDRefs(t *testing.T) {
 		t.Fatalf("InitTestDynamicResourceCache: %v", err)
 	}
 	dynCache := GetDynamicResourceCache()
-	for _, gvr := range []schema.GroupVersionResource{rolloutGVR, scaledObjectGVR} {
-		if err := dynCache.EnsureWatching(gvr); err != nil {
-			t.Fatalf("EnsureWatching %s: %v", gvr.String(), err)
-		}
-		if !dynCache.WaitForSync(gvr, 2*time.Second) {
-			t.Fatalf("%s dynamic cache did not sync", gvr.String())
-		}
+	if err := dynCache.EnsureWatching(scaledObjectGVR); err != nil {
+		t.Fatalf("EnsureWatching %s: %v", scaledObjectGVR.String(), err)
+	}
+	if !dynCache.WaitForSync(scaledObjectGVR, 2*time.Second) {
+		t.Fatalf("%s dynamic cache did not sync", scaledObjectGVR.String())
+	}
+	beforeRolloutSync := DetectMissingCRDRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	if findProblem(beforeRolloutSync, "ScaledObject", "prod", "missing-rollout-target", "Missing scaleTargetRef") {
+		t.Fatalf("unwatched Rollout inventory must not assert a missing scaleTargetRef: %+v", beforeRolloutSync)
+	}
+	if err := dynCache.EnsureWatching(rolloutGVR); err != nil {
+		t.Fatalf("EnsureWatching %s: %v", rolloutGVR.String(), err)
+	}
+	if !dynCache.WaitForSync(rolloutGVR, 2*time.Second) {
+		t.Fatalf("%s dynamic cache did not sync", rolloutGVR.String())
 	}
 
 	problems := DetectMissingCRDRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
@@ -1101,8 +1410,14 @@ func TestDetectMissingCRDRefs(t *testing.T) {
 	if !findProblem(problems, "ScaledObject", "prod", "missing-default-deployment-target", "Missing scaleTargetRef") {
 		t.Fatalf("KEDA scaleTargetRef with omitted kind should default to Deployment: %+v", problems)
 	}
-	if len(problems) != 4 {
-		t.Fatalf("expected exactly 4 curated CRD missing refs, got %+v", problems)
+	if !findProblem(problems, "ScaledObject", "prod", "missing-rollout-target", "Missing scaleTargetRef") {
+		t.Fatalf("missing KEDA Rollout scaleTargetRef not detected after target cache sync: %+v", problems)
+	}
+	if findProblem(problems, "ScaledObject", "prod", "existing-rollout-target", "Missing scaleTargetRef") {
+		t.Fatalf("existing KEDA Rollout scaleTargetRef incorrectly reported missing: %+v", problems)
+	}
+	if len(problems) != 5 {
+		t.Fatalf("expected exactly 5 curated CRD missing refs, got %+v", problems)
 	}
 	assertProblemActionOrder(t, problems, "Rollout", "prod", "checkout", "Missing Rollout Service", "missing-canary", "existing Service", "create Service")
 	assertProblemActionContains(t, problems, "Rollout", "prod", "checkout", "Missing Rollout Service", "spec.strategy.canary.canaryService")
@@ -1118,7 +1433,7 @@ func TestDetectMissingCRDRefs(t *testing.T) {
 	}
 
 	scoped := DetectMissingCRDRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "prod")
-	if len(scoped) != 4 {
+	if len(scoped) != 5 {
 		t.Fatalf("namespace-scoped CRD refs should include prod problems, got %+v", scoped)
 	}
 }
@@ -1150,6 +1465,70 @@ func gatewayRoute(name, namespace string, ts metav1.Time, backendRefs []any) *un
 			},
 		},
 	}}
+}
+
+func gatewayClass(name string, ts metav1.Time) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "GatewayClass",
+		"metadata": map[string]any{
+			"name":              name,
+			"creationTimestamp": ts.Format(time.RFC3339),
+		},
+		"spec": map[string]any{"controllerName": "example.io/controller"},
+	}}
+}
+
+func gatewayObject(name, namespace, className string, ts metav1.Time) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": ts.Format(time.RFC3339),
+		},
+		"spec": map[string]any{"gatewayClassName": className},
+	}}
+}
+
+func gatewayRouteWithParents(kind, name, namespace string, ts metav1.Time, parentRefs []any) *unstructured.Unstructured {
+	version := "v1"
+	if kind == "TCPRoute" || kind == "TLSRoute" {
+		version = "v1alpha2"
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/" + version,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": ts.Format(time.RFC3339),
+		},
+		"spec": map[string]any{"parentRefs": parentRefs},
+	}}
+}
+
+func waitForGatewayTopologyIssueCount(t *testing.T, detect func() []Detection, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		count := 0
+		var problems []Detection
+		for _, problem := range detect() {
+			if problem.Reason == "Missing GatewayClass" || problem.Reason == "Missing Gateway parent" {
+				count++
+				problems = append(problems, problem)
+			}
+		}
+		if count == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Gateway topology issue count = %d, want %d: %+v", count, want, problems)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func argoRollout(name, namespace string, ts metav1.Time, strategy map[string]any) *unstructured.Unstructured {

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -118,8 +118,8 @@ var categoryDescription = map[Category]string{
 	CategoryIngressBackendMissing: "An Ingress points at a Service that doesn't exist — incoming requests get 503s.",
 	CategoryIngressClassMissing:   "An Ingress names an IngressClass that doesn't exist, so no matching controller can serve it.",
 	CategoryLoadBalancerPending:   "A LoadBalancer Service is stuck Pending — the cloud controller hasn't provisioned an external IP.",
-	CategoryGatewayNotReady:       "A Gateway (Gateway API) isn't accepted or programmed — its listeners aren't serving.",
-	CategoryGatewayRouteInvalid:   "An HTTPRoute (or other route) was rejected or not accepted by its parent Gateway.",
+	CategoryGatewayNotReady:       "A Gateway (Gateway API) isn't accepted or programmed, or names a GatewayClass that doesn't exist — its listeners aren't serving.",
+	CategoryGatewayRouteInvalid:   "An HTTPRoute (or other route) names a parent Gateway that doesn't exist, or was rejected or not accepted by its parent.",
 	CategoryDNSFailure:            "CoreDNS's Corefile has a rule (an NXDOMAIN template or a rewrite) that can override Kubernetes service DNS — a misconfiguration that risks breaking in-cluster name resolution.",
 	// Storage
 	CategoryPVCPending:               "A PersistentVolumeClaim is stuck Pending — no matching volume and provisioning hasn't completed.",

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1650,6 +1650,91 @@ func TestDynamicResourceCache_ClusterWideSupersedesNamespaceInformers(t *testing
 	}
 }
 
+func TestDynamicResourceCache_HasWatchedInSyncedNamespace(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	listKinds := map[schema.GroupVersionResource]string{gvr: "WidgetList"}
+
+	t.Run("unsynced informer is not authoritative", func(t *testing.T) {
+		dyn := fakeDynamicForListAccess(t, listKinds, func(schema.GroupVersionResource, string) bool { return true })
+		listStarted := make(chan struct{})
+		releaseList := make(chan struct{})
+		var startOnce sync.Once
+		dyn.PrependReactor("list", "widgets", func(k8stesting.Action) (bool, runtime.Object, error) {
+			startOnce.Do(func() { close(listStarted) })
+			<-releaseList
+			return false, nil, nil
+		})
+		d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+		if err != nil {
+			t.Fatalf("NewDynamicResourceCache failed: %v", err)
+		}
+		defer d.Stop()
+
+		if err := d.startWatching(gvr, "team-a"); err != nil {
+			t.Fatalf("startWatching failed: %v", err)
+		}
+		select {
+		case <-listStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("informer did not begin its initial list")
+		}
+		if found, authoritative := d.HasWatchedInSyncedNamespace(gvr, "team-a", "absent"); found || authoritative {
+			t.Fatalf("unsynced lookup = (%t, %t), want (false, false)", found, authoritative)
+		}
+		close(releaseList)
+		if !d.WaitForSync(gvr, 2*time.Second) {
+			t.Fatal("informer did not sync")
+		}
+		if found, authoritative := d.HasWatchedInSyncedNamespace(gvr, "team-a", "absent"); found || !authoritative {
+			t.Fatalf("synced lookup = (%t, %t), want (false, true)", found, authoritative)
+		}
+	})
+
+	t.Run("scope replacement is not authoritative before replacement sync", func(t *testing.T) {
+		dyn := fakeDynamicForListAccess(t, listKinds, func(schema.GroupVersionResource, string) bool { return true })
+		d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+		if err != nil {
+			t.Fatalf("NewDynamicResourceCache failed: %v", err)
+		}
+		defer d.Stop()
+
+		if err := d.startWatching(gvr, "team-a"); err != nil {
+			t.Fatalf("startWatching team-a failed: %v", err)
+		}
+		if !d.WaitForSync(gvr, 2*time.Second) {
+			t.Fatal("team-a informer did not sync")
+		}
+		if found, authoritative := d.HasWatchedInSyncedNamespace(gvr, "team-a", "absent"); found || !authoritative {
+			t.Fatalf("synced team-a absence = (%t, %t), want (false, true)", found, authoritative)
+		}
+
+		listStarted := make(chan struct{})
+		releaseList := make(chan struct{})
+		defer close(releaseList)
+		var startOnce sync.Once
+		dyn.PrependReactor("list", "widgets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			listAction, ok := action.(k8stesting.ListAction)
+			if !ok || listAction.GetNamespace() != "" {
+				return false, nil, nil
+			}
+			startOnce.Do(func() { close(listStarted) })
+			<-releaseList
+			return false, nil, nil
+		})
+		if err := d.startWatching(gvr, ""); err != nil {
+			t.Fatalf("startWatching cluster-wide failed: %v", err)
+		}
+		select {
+		case <-listStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("replacement informer did not begin its initial list")
+		}
+		if found, authoritative := d.HasWatchedInSyncedNamespace(gvr, "team-a", "absent"); found || authoritative {
+			t.Fatalf("unsynced replacement lookup = (%t, %t), want (false, false)", found, authoritative)
+		}
+	})
+}
+
 // A handler registered via AddGVRChangeHandler must reach informers created
 // AFTER registration (lazy per-namespace watches, reap re-creations) — not
 // only those present at call time — or derived caches miss those events.

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -659,7 +659,7 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 	isSyncAdd := false
 	if op == OpAdd {
 		d.mu.RLock()
-		synced := d.gvrSyncedLocked(gvr, namespace)
+		synced := d.gvrInitialAddSuppressionDoneLocked(gvr, namespace)
 		d.mu.RUnlock()
 
 		if !synced {
@@ -826,10 +826,11 @@ func indexerItems(entries []*informerEntry, namespace string) ([]any, error) {
 	return items, nil
 }
 
-// gvrSyncedLocked reports whether the informer holding objects of gvr in
-// namespace has finished its initial sync (cluster-wide informer first, else
-// the namespace-scoped one). Caller must hold d.mu.
-func (d *DynamicResourceCache) gvrSyncedLocked(gvr schema.GroupVersionResource, namespace string) bool {
+// gvrInitialAddSuppressionDoneLocked reports whether initial add-event
+// suppression has ended, either after sync or its bounded timeout. It is not
+// an authority check; absence assertions must use the informer's HasSynced.
+// Caller must hold d.mu.
+func (d *DynamicResourceCache) gvrInitialAddSuppressionDoneLocked(gvr schema.GroupVersionResource, namespace string) bool {
 	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
 		return e.synced
 	}
@@ -1774,6 +1775,37 @@ func (d *DynamicResourceCache) IsClusterWideSynced(gvr schema.GroupVersionResour
 	_, clusterWide := d.informers[informerKey{gvr: gvr}]
 	d.mu.RUnlock()
 	return clusterWide && d.IsSynced(gvr)
+}
+
+// HasWatchedInSyncedNamespace checks existence in the same synced informer
+// generation whose namespace coverage it validates.
+// It is only valid for namespaced GVRs; cluster-scoped kinds use IsClusterWideSynced and GetWatched.
+func (d *DynamicResourceCache) HasWatchedInSyncedNamespace(gvr schema.GroupVersionResource, namespace, name string) (found, authoritative bool) {
+	if d == nil || namespace == "" || name == "" {
+		return false, false
+	}
+	d.mu.RLock()
+	key := informerKey{gvr: gvr}
+	e := d.informers[key]
+	if e == nil {
+		key = informerKey{gvr: gvr, ns: namespace}
+		e = d.informers[key]
+	}
+	stopped := d.stopped
+	d.mu.RUnlock()
+	if e == nil || stopped || !e.informer.HasSynced() {
+		return false, false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.stopped || d.informers[key] != e {
+		return false, false
+	}
+	_, found, err := e.informer.GetIndexer().GetByKey(namespace + "/" + name)
+	if err != nil {
+		return false, false
+	}
+	return found, true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- detect Gateways that reference a missing GatewayClass after a two-minute reconciliation grace
- detect HTTPRoute, GRPCRoute, TCPRoute, and TLSRoute parentRefs that target a missing Gateway
- require authoritative cluster or exact-namespace informer coverage before asserting absence
- preserve unrelated Gateway controller conditions while deduplicating exact structural echoes, including Envoy Gateway PortNotFound
- apply the same authority check to KEDA Rollout scaleTargetRefs so partial caches cannot produce false missing-target issues

## Validation
- `make build`
- `make test`
- `make tsc`
- `go test ./internal/issues ./internal/k8s`
- `go test ./...` from `pkg/k8score/`
- live EKS smoke on `radar-test-nonprod`: grace suppression, both findings present, target creation recovery, and fixture cleanup
- Playwright Issues-page smoke with both findings rendered and zero console errors
- visual-test skipped: no UI delta

## Stack
- stacked on #1391
- #1391 is stacked on #1390

Linear: RAD-346

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live issue detection for Gateway networking and dynamic-cache “absence” semantics; incorrect authority or dedupe could hide real problems or briefly miss issues during informer sync, but behavior is heavily tested and biased toward silence when coverage is incomplete.
> 
> **Overview**
> Extends **Gateway API missing-reference detection** beyond route backend Services: after a **2-minute grace**, it flags **Gateways** with a non-existent `spec.gatewayClassName` and **routes** (`HTTPRoute`, `GRPCRoute`, `TCPRoute`, `TLSRoute`) whose `parentRefs` point at a **missing Gateway** (same- or cross-namespace). **Backend Service / port / ReferenceGrant** checks still require the Service lister; **topology** checks (class + parent) run even when Services aren’t available.
> 
> **Issue taxonomy** maps `Missing GatewayClass` to **gateway_not_ready** and `Missing Gateway parent` to **gateway_route_invalid**; user-facing catalog copy is updated accordingly.
> 
> **Dedupe** no longer drops every `ResolvedRefs:*` condition when any structural missing-ref exists on the route. It only hides **matching** controller echoes (e.g. backend missing → `BackendNotFound` / `PortNotFound`; ReferenceGrant → `RefNotPermitted`). A **missing parent** structural row does **not** suppress unrelated `ResolvedRefs` conditions.
> 
> **Dynamic cache authority**: new `HasWatchedInSyncedNamespace` returns “missing” only when the relevant informer has **synced** for that namespace (including during informer scope replacement). **KEDA `Rollout` scaleTargetRefs** use the same rule so partial watches don’t emit false **missing scaleTargetRef** issues. Initial add-event suppression is renamed/clarified so it isn’t confused with sync authority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ee4796ae936a89b953408885ab7951c0aea642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->