### PR TITLE
feat(scripts): kyverno-demo cluster for policy UI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,21 @@ gitops-demo-status:
 gitops-demo-drift:
 	./scripts/gitops-demo.sh drift
 
+# Bootstrap a kind cluster pre-loaded with Kyverno 1.18.2 and curated policy
+# fixtures (both API families, the four enforcement-posture cases, dual-API
+# PolicyExceptions, and ~40 real PolicyReports across several sources).
+# Useful for visual-testing policy UI changes against realistic state.
+# See scripts/kyverno-demo/README.md for the coverage matrix — and read the
+# 1.20-simulation warning before running `kyverno-demo.sh modern-only`.
+kyverno-demo:
+	./scripts/kyverno-demo.sh up
+
+kyverno-demo-down:
+	./scripts/kyverno-demo.sh down
+
+kyverno-demo-status:
+	./scripts/kyverno-demo.sh status
+
 # Bootstrap a kind cluster pre-loaded with curated Crossplane fixtures
 # (core + provider-kubernetes + function-patch-and-transform + XRD/Composition/XRs).
 # Useful for visual-testing Crossplane UI changes against realistic state.

--- a/scripts/kyverno-demo.sh
+++ b/scripts/kyverno-demo.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# Bootstrap a kind cluster pre-populated with a curated set of Kyverno
+# scenarios for visual-testing the policy UI. Idempotent — can be re-run to
+# refresh state or apply fixture updates without recreating the cluster.
+#
+# Subcommands:
+#   up            Create cluster (if missing), install Kyverno, apply fixtures.
+#   down          Delete the kind cluster.
+#   reset         down + up.
+#   status        Inventory the policies, reports and report API groups.
+#   openreports   Switch report output to openreports.io, leaving the
+#                 wgpolicyk8s.io CRDs served but EMPTY. This is the
+#                 report-family selection case: a naive "first served wins"
+#                 picks the empty API and shows zero findings on a cluster
+#                 full of them.
+#   modern-only   Remove the legacy kyverno.io policy CRDs to reproduce the
+#                 Kyverno 1.20 API surface. READ THE WARNING IT PRINTS.
+#   help          Show this message.
+#
+# Prerequisites:
+#   - kind         https://kind.sigs.k8s.io/
+#   - kubectl
+#   - helm
+#
+# Set CLUSTER_NAME=foo to use a different cluster (default: radar-kyverno-demo).
+#
+# See scripts/kyverno-demo/README.md for the coverage matrix and the
+# 1.20-simulation gotcha.
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-radar-kyverno-demo}"
+KUBECTL_CTX="kind-${CLUSTER_NAME}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/kyverno-demo"
+
+# Pinned so the demo behaves consistently. Chart 3.8.2 ships Kyverno 1.18.2,
+# which is the first release where the modern policies.kyverno.io CEL family
+# is stable AND the legacy family still exists — i.e. the migration state the
+# integration is built for. Bump deliberately; several fixtures depend on
+# 1.18-era spec shapes.
+KYVERNO_CHART_VERSION="${KYVERNO_CHART_VERSION:-3.8.2}"
+
+# Pretty colors for status output. Quietly turn off in non-interactive env.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_BLUE='\033[34m'; C_GREEN='\033[32m'; C_YELLOW='\033[33m'; C_RED='\033[31m'; C_DIM='\033[2m'; C_RESET='\033[0m'
+else
+  C_BLUE=''; C_GREEN=''; C_YELLOW=''; C_RED=''; C_DIM=''; C_RESET=''
+fi
+
+step()    { printf "${C_BLUE}==> %s${C_RESET}\n" "$1"; }
+ok()      { printf "${C_GREEN}    ✓ %s${C_RESET}\n" "$1"; }
+warn()    { printf "${C_YELLOW}    ! %s${C_RESET}\n" "$1"; }
+fail()    { printf "${C_RED}    ✗ %s${C_RESET}\n" "$1"; exit 1; }
+note()    { printf "${C_DIM}    %s${C_RESET}\n" "$1"; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required but not installed"
+}
+
+k() { kubectl --context "${KUBECTL_CTX}" "$@"; }
+
+cluster_exists() {
+  kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"
+}
+
+# --- Cluster lifecycle -----------------------------------------------------
+
+cmd_up() {
+  require_cmd kind
+  require_cmd kubectl
+  require_cmd helm
+
+  if cluster_exists; then
+    step "Cluster ${CLUSTER_NAME} already exists — reusing"
+  else
+    step "Creating kind cluster ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}" >/dev/null
+    ok "Cluster created"
+  fi
+  k cluster-info >/dev/null || fail "kind context not reachable"
+
+  install_kyverno
+  apply_fixtures
+  wait_for_reports
+  cmd_status
+
+  printf "\n"
+  step "Run Radar against it"
+  note "kubectl config use-context ${KUBECTL_CTX}"
+  note "./scripts/visual-test-start.sh"
+}
+
+install_kyverno() {
+  step "Installing Kyverno ${KYVERNO_CHART_VERSION}"
+  helm repo add kyverno https://kyverno.github.io/kyverno/ >/dev/null 2>&1 || true
+  helm repo update kyverno >/dev/null 2>&1 || true
+
+  # policyExceptions is off by default; the exception fixtures need it on.
+  # Single replicas keep a laptop-sized kind cluster responsive.
+  helm upgrade --install kyverno kyverno/kyverno \
+    --version "${KYVERNO_CHART_VERSION}" \
+    -n kyverno --create-namespace \
+    --set admissionController.replicas=1 \
+    --set backgroundController.replicas=1 \
+    --set reportsController.replicas=1 \
+    --set cleanupController.replicas=1 \
+    --set features.policyExceptions.enabled=true \
+    --set features.policyExceptions.namespace="" \
+    --wait --timeout 10m >/dev/null
+  ok "Kyverno installed (all four controllers)"
+
+  wait_for_webhook
+}
+
+# `helm --wait` returns once the Deployments report ready, which is NOT the
+# same as the admission webhook accepting connections — the Service endpoints
+# and the webhook's TLS cert land a little later. Applying a policy in that
+# window fails with:
+#   failed calling webhook "validate-policy.kyverno.svc": connection refused
+# Wait for endpoints, then confirm with a real policy round-trip, because
+# endpoint readiness alone still races the cert.
+wait_for_webhook() {
+  step "Waiting for the policy-validating webhook to accept connections"
+
+  local i
+  for i in $(seq 1 60); do
+    if [ -n "$(k get endpoints kyverno-svc -n kyverno -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]; then
+      break
+    fi
+    sleep 2
+  done
+
+  # Round-trip a throwaway policy until it sticks. Server-side dry-run still
+  # goes through the webhook, so this proves the real path without leaving
+  # anything behind.
+  for i in $(seq 1 60); do
+    if k apply --dry-run=server -f - >/dev/null 2>&1 <<'EOF'
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: kyverno-demo-webhook-probe
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["configmaps"]
+  validations:
+    - expression: "true"
+      message: "probe"
+EOF
+    then
+      ok "Webhook ready (after ${i} attempt(s))"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "Kyverno webhook never became ready — check 'kubectl -n kyverno get pods'"
+}
+
+apply_fixtures() {
+  step "Applying Kyverno demo fixtures"
+  [ -d "${FIXTURES_DIR}" ] || fail "Fixtures dir not found: ${FIXTURES_DIR}"
+
+  # Apply in number order: the namespace and its label must exist before the
+  # policies that select on it, and the aggregated ClusterRole must exist
+  # before the ClusterCleanupPolicy whose admission check depends on it.
+  for f in $(ls "${FIXTURES_DIR}"/*.yaml 2>/dev/null | sort); do
+    if ! grep -q '^[[:space:]]*[^#[:space:]-]' "$f"; then
+      note "skipping $(basename "$f") (placeholder / comments only)"
+      continue
+    fi
+    note "applying $(basename "$f")"
+    # Retry: the webhook can still blip under load even after the readiness
+    # gate above, and a half-applied fixture set is worse than a slow one.
+    # audit-require-labels warns on demo-web by design, so stderr noise here
+    # is expected and not a failure.
+    local attempt
+    for attempt in 1 2 3 4 5; do
+      if k apply -f "$f" >/dev/null 2>&1; then
+        break
+      fi
+      if [ "$attempt" = 5 ]; then
+        # Surface the real error on the final try rather than swallowing it.
+        k apply -f "$f" >/dev/null || fail "could not apply $(basename "$f")"
+      fi
+      sleep 3
+    done
+  done
+  ok "Fixtures applied"
+}
+
+wait_for_reports() {
+  step "Waiting for the background scanner to produce PolicyReports"
+  local n=0
+  for _ in $(seq 1 30); do
+    n=$(k get policyreports -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    [ "${n:-0}" -gt 5 ] && break
+    sleep 10
+  done
+  if [ "${n:-0}" -gt 5 ]; then
+    ok "${n} PolicyReports produced"
+  else
+    warn "only ${n:-0} PolicyReports so far — the scanner may still be working"
+    note "re-run '$(basename "$0") status' in a minute"
+  fi
+}
+
+cmd_down() {
+  require_cmd kind
+  if cluster_exists; then
+    step "Deleting cluster ${CLUSTER_NAME}"
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null
+    ok "Cluster deleted"
+  else
+    note "Cluster ${CLUSTER_NAME} does not exist"
+  fi
+}
+
+cmd_reset() { cmd_down; cmd_up; }
+
+# --- Scenario toggles ------------------------------------------------------
+
+cmd_openreports() {
+  require_cmd helm
+  cluster_exists || fail "Cluster ${CLUSTER_NAME} does not exist — run 'up' first"
+
+  step "Switching report output to openreports.io"
+  helm upgrade kyverno kyverno/kyverno \
+    --version "${KYVERNO_CHART_VERSION}" -n kyverno --reuse-values \
+    --set openreports.enabled=true \
+    --set openreports.installCrds=true \
+    --no-hooks --wait --timeout 8m >/dev/null
+  ok "openreports enabled"
+
+  note "waiting for reports to migrate..."
+  sleep 60
+
+  local wg or
+  wg=$(k get policyreports.wgpolicyk8s.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  or=$(k get reports.openreports.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  printf "\n"
+  ok "wgpolicyk8s.io: ${wg} reports (CRDs still SERVED)"
+  ok "openreports.io: ${or} reports"
+  printf "\n"
+  note "Both families are now served; only one holds data. Selection that"
+  note "takes the first SERVED group picks the empty one and reports zero"
+  note "findings. Radar probes each group for actual objects instead —"
+  note "check the log for 'warming up N report CRDs from [openreports.io]'."
+}
+
+cmd_modern_only() {
+  require_cmd helm
+  cluster_exists || fail "Cluster ${CLUSTER_NAME} does not exist — run 'up' first"
+
+  printf "\n"
+  warn "READ THIS BEFORE THE CLUSTER LOOKS BROKEN:"
+  note "Removing the legacy CRDs reproduces the Kyverno 1.20 API surface"
+  note "faithfully, but Kyverno 1.18.2's ADMISSION CONTROLLER CRASHLOOPS in"
+  note "that state — it sanity-checks for clusterpolicies.kyverno.io and"
+  note "policies.kyverno.io at startup and exits when they are absent."
+  note ""
+  note "That is upstream behaviour, not a Radar bug and not a broken cluster."
+  note "The reports controller stays healthy and the existing PolicyReports"
+  note "survive, which is what the detection gate is tested against."
+  note ""
+  note "Run 'reset' to get a working cluster back."
+  printf "\n"
+
+  step "Removing legacy kyverno.io policy CRDs"
+  # --no-hooks: the chart's post-upgrade migration job fails once the CRDs it
+  # migrates are gone. The CRD removal itself still applies.
+  helm upgrade kyverno kyverno/kyverno \
+    --version "${KYVERNO_CHART_VERSION}" -n kyverno --reuse-values \
+    --set crds.groups.kyverno.clusterpolicies=false \
+    --set crds.groups.kyverno.policies=false \
+    --no-hooks --wait --timeout 8m >/dev/null 2>&1 || true
+
+  printf "\n"
+  local legacy modern reports
+  legacy=$(k get crd -o json 2>/dev/null | grep -c '"clusterpolicies.kyverno.io"' || true)
+  modern=$(k get crd -o json 2>/dev/null | jq -r '[.items[]|select(.spec.group=="policies.kyverno.io")]|length' 2>/dev/null || echo "?")
+  reports=$(k get policyreports -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  ok "legacy ClusterPolicy CRD present: ${legacy} (expect 0)"
+  ok "policies.kyverno.io CRDs: ${modern}"
+  ok "PolicyReports surviving: ${reports}"
+  printf "\n"
+  note "Detection keyed only on the legacy family would now report"
+  note "'not_installed' and drop the entire report index. Check Radar's log"
+  note "for 'Kyverno detected' plus 'Index initialized with N subjects'."
+}
+
+# --- Status ----------------------------------------------------------------
+
+cmd_status() {
+  cluster_exists || fail "Cluster ${CLUSTER_NAME} does not exist — run 'up' first"
+
+  printf "\n"
+  step "Kyverno controllers"
+  k get pods -n kyverno --no-headers 2>/dev/null \
+    | grep -v migrate \
+    | awk '{printf "    %-52s %s %s\n", $1, $2, $3}' || note "none"
+
+  printf "\n"
+  step "Modern policies (policies.kyverno.io)"
+  for kind in validatingpolicies namespacedvalidatingpolicies imagevalidatingpolicies \
+              mutatingpolicies generatingpolicies deletingpolicies namespaceddeletingpolicies; do
+    printf "    %-34s %s\n" "$kind" \
+      "$(k get "${kind}.policies.kyverno.io" -A --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  done
+
+  printf "\n"
+  step "Legacy policies (kyverno.io)"
+  for kind in clusterpolicies clustercleanuppolicies; do
+    printf "    %-34s %s\n" "$kind" \
+      "$(k get "${kind}.kyverno.io" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  done
+  printf "    %-34s %s (modern) / %s (legacy)\n" "policyexceptions" \
+    "$(k get policyexceptions.policies.kyverno.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')" \
+    "$(k get policyexceptions.kyverno.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+
+  printf "\n"
+  step "Reports"
+  printf "    %-34s %s\n" "wgpolicyk8s.io policyreports" \
+    "$(k get policyreports.wgpolicyk8s.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  printf "    %-34s %s\n" "wgpolicyk8s.io clusterpolicyreports" \
+    "$(k get clusterpolicyreports.wgpolicyk8s.io --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  printf "    %-34s %s\n" "openreports.io reports" \
+    "$(k get reports.openreports.io -A --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+
+  printf "\n"
+  step "Distinct results[].source values (the engine-taxonomy case)"
+  k get policyreports,clusterpolicyreports -A -o json 2>/dev/null \
+    | jq -r '[.items[].results[]?.source] | group_by(.) | map({s:.[0],n:length}) | sort_by(-.n) | .[] | "    \(.n)\t\(.s)"' 2>/dev/null \
+    || note "jq not installed — skipping"
+  note "One engine, several producer strings. Filtering on the raw value"
+  note "fragments Kyverno across as many buckets as it has policy types."
+}
+
+cmd_help() {
+  sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-help}" in
+  up)          cmd_up          ;;
+  down)        cmd_down        ;;
+  reset)       cmd_reset       ;;
+  status)      cmd_status      ;;
+  openreports) cmd_openreports ;;
+  modern-only) cmd_modern_only ;;
+  help|-h|--help) cmd_help     ;;
+  *)
+    printf "${C_RED}Unknown subcommand: %s${C_RESET}\n\n" "$1"
+    cmd_help
+    exit 1
+    ;;
+esac

--- a/scripts/kyverno-demo/01-namespace.yaml
+++ b/scripts/kyverno-demo/01-namespace.yaml
@@ -1,0 +1,9 @@
+# The label is load-bearing: require-run-as-nonroot scopes itself to it via
+# matchConstraints.namespaceSelector, so the Deny path only fires here and
+# doesn't block unrelated workloads elsewhere in the cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: policy-demo
+  labels:
+    policy-demo: "true"

--- a/scripts/kyverno-demo/02-validating-policies.yaml
+++ b/scripts/kyverno-demo/02-validating-policies.yaml
@@ -1,0 +1,145 @@
+# ValidatingPolicy (policies.kyverno.io) — the four enforcement-posture cases.
+#
+# Radar computes an EFFECTIVE posture rather than echoing spec.validationActions,
+# because three fields interact: validationActions, evaluation.admission.enabled
+# and evaluation.mode. These four policies are the reason that computation
+# exists — each renders a different badge, and two of them contradict what a
+# quick read of the spec would suggest.
+---
+# CASE 1 — Deny, admission on. The straightforward one: actually blocks.
+# Renders "Deny" (red). Scoped by namespaceSelector so it only guards
+# policy-demo and can't interfere with the rest of the cluster.
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-run-as-nonroot
+spec:
+  validationActions: [Deny]
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: true
+    background:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+    namespaceSelector:
+      matchLabels:
+        policy-demo: "true"
+  variables:
+    - name: allContainers
+      expression: "object.spec.containers"
+  validations:
+    - expression: "object.spec.containers.all(c, has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == true)"
+      message: "All containers must set securityContext.runAsNonRoot=true"
+    - expression: "!object.spec.?hostNetwork.orValue(false)"
+      message: "hostNetwork is not permitted"
+      reason: Forbidden
+---
+# CASE 2 — deliberate audit. Renders "Audit + Warn" (amber). Declared and
+# effective agree, so it stays in the deliberate tier, visually distinct from
+# the discrepancy tier below. Applying a Deployment without a `team` label
+# produces a live admission warning.
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: audit-require-labels
+spec:
+  validationActions: [Audit, Warn]
+  failurePolicy: Ignore
+  evaluation:
+    admission:
+      enabled: true
+    background:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments"]
+  validations:
+    - expression: "has(object.metadata.labels) && has(object.metadata.labels.team)"
+      message: "Deployments should carry a 'team' label"
+---
+# CASE 3 — THE HEADLINE. Declares Deny, but admission evaluation is disabled,
+# so it blocks nothing and only produces background-scan findings.
+#
+# Renders "Background only" in the ORANGE discrepancy tier, with the reason
+# spelled out — never a red Deny badge, which would tell an operator the
+# cluster is protected when it isn't.
+#
+# Verify by hand: `kubectl run probe --image=nginx:latest -n default`
+# succeeds despite the policy saying Deny.
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: background-only-no-latest-tag
+spec:
+  validationActions: [Deny]
+  evaluation:
+    admission:
+      enabled: false
+    background:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  validations:
+    - expression: "object.spec.containers.all(c, !c.image.endsWith(':latest'))"
+      message: "Images must not use the :latest tag"
+---
+# CASE 4 — no validationActions AT ALL, which Kyverno treats as Deny.
+#
+# This is undocumented upstream: the ValidatingPolicy docs show the field in
+# examples but never state its allowed values or what omission means. The
+# legacy family defaults the analogous field to *Audit*, so inheriting that
+# assumption would display "Audit" for a policy that blocks.
+#
+# Verify by hand — this really is rejected at admission:
+#   kubectl create configmap probe --from-literal=a=b -n policy-demo
+#   → admission webhook "vpol.validate.kyverno.svc-fail" denied the request
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: implicit-deny-configmap-labels
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["configmaps"]
+    namespaceSelector:
+      matchLabels:
+        policy-demo: "true"
+  validations:
+    - expression: "has(object.metadata.labels)"
+      message: "ConfigMaps in this namespace must carry labels"
+---
+# Namespaced twin — same spec shape, narrower scope. Shares its renderer and
+# cell logic with the cluster-scoped kind; present so the twin-collapsing is
+# exercised against a real object rather than only in unit tests.
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedValidatingPolicy
+metadata:
+  name: ns-require-resources
+  namespace: policy-demo
+spec:
+  validationActions: [Audit]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  validations:
+    - expression: "object.spec.containers.all(c, has(c.resources) && has(c.resources.limits))"
+      message: "Containers must declare resource limits"

--- a/scripts/kyverno-demo/03-image-mutating-generating.yaml
+++ b/scripts/kyverno-demo/03-image-mutating-generating.yaml
@@ -1,0 +1,143 @@
+# ImageValidatingPolicy, MutatingPolicy and GeneratingPolicy — the families
+# whose specs diverge enough to need their own renderers.
+---
+# Supply-chain posture. Reads nothing like a validation rule, which is why it
+# gets its own renderer: attestors (who must have signed), attestations (what
+# metadata must exist), and image references (what it applies to).
+#
+# Note the cosign shape — `keyless.identities[]` with issuer/subject, NOT
+# `keyless.issuer`. The flatter form is rejected by strict decoding.
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-signed-images
+spec:
+  validationActions: [Deny]
+  failurePolicy: Fail
+  evaluation:
+    admission:
+      enabled: true
+    background:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  matchImageReferences:
+    - glob: "ghcr.io/skyhook-io/*"
+  images:
+    - name: containers
+      expression: "object.spec.containers.map(c, c.image)"
+  attestors:
+    - name: skyhook-keyless
+      cosign:
+        keyless:
+          identities:
+            - issuer: "https://token.actions.githubusercontent.com"
+              subjectRegExp: "https://github.com/skyhook-io/.*"
+    - name: notary-authority
+      notary:
+        certs:
+          value: |
+            -----BEGIN CERTIFICATE-----
+            PLACEHOLDER
+            -----END CERTIFICATE-----
+  attestations:
+    - name: sbom
+      referrer:
+        type: "sbom/cyclone-dx"
+    - name: provenance
+      intoto:
+        type: "https://slsa.dev/provenance/v1"
+  validations:
+    - expression: "images.containers.map(image, verifyImageSignatures(image, [attestors.skyhook_keyless])).all(e, e > 0)"
+      message: "Images must carry a valid keyless cosign signature"
+---
+# Ordinary mutating policy — admission on. Renders "Mutates on admission".
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: add-default-labels
+spec:
+  failurePolicy: Ignore
+  reinvocationPolicy: IfNeeded
+  evaluation:
+    admission:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: >
+          Object{ metadata: Object.metadata{ labels: {"managed-by": "kyverno"} } }
+---
+# Admission DISABLED but mutateExisting ON — a policy that rewrites resources
+# that already exist, independently of the admission path.
+#
+# This used to render "Inactive — modifies nothing" while actively rewriting
+# the cluster. Now renders "Mutates existing". Note the default: unlike
+# admission/background, `mutateExisting.enabled` defaults to FALSE, so it has
+# to be set explicitly for this case to exist at all.
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: backfill-cost-center-existing
+spec:
+  failurePolicy: Ignore
+  evaluation:
+    admission:
+      enabled: false
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["configmaps"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: >
+          Object{ metadata: Object.metadata{ labels: {"cost-center": "platform"} } }
+---
+# GeneratingPolicy. Its evaluation block is a different shape again — the
+# keys are generation-lifecycle concerns (generateExisting, synchronize,
+# orphanDownstreamOnPolicyDelete), each an object with .enabled rather than a
+# bare boolean, which is why it doesn't share the validating renderer.
+#
+# The generate expression needs dyn() wrapping: CEL infers a homogeneous map
+# type otherwise and rejects the mixed-value object literal.
+apiVersion: policies.kyverno.io/v1
+kind: GeneratingPolicy
+metadata:
+  name: generate-default-netpol
+spec:
+  evaluation:
+    generateExisting:
+      enabled: false
+    synchronize:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["namespaces"]
+  generate:
+    - expression: >
+        generator.Apply("default-deny", [
+          {
+            "apiVersion": dyn("networking.k8s.io/v1"),
+            "kind": dyn("NetworkPolicy"),
+            "metadata": dyn({"name": dyn("default-deny"), "namespace": dyn(string(object.metadata.name))}),
+            "spec": dyn({"podSelector": dyn({}), "policyTypes": dyn(["Ingress"])})
+          }
+        ])

--- a/scripts/kyverno-demo/04-deleting-policies.yaml
+++ b/scripts/kyverno-demo/04-deleting-policies.yaml
@@ -1,0 +1,67 @@
+# DeletingPolicy — the only modern family that is scheduled rather than
+# admission-driven. No failurePolicy, no evaluation block, no
+# webhookConfiguration; instead a cron schedule and deletion conditions.
+#
+# Its table carries a "Last Run" column rather than a readiness one, because
+# Kyverno never populates status.conditionStatus.ready on this kind (the CRD
+# declares a READY printer column that stays blank even after the cron fires),
+# and an uncompilable policy is rejected at admission so a broken one never
+# exists to flag. What does go wrong is a policy that never runs.
+---
+# Six-hourly, so it renders "Never run" for a while after bootstrap — which is
+# the state the Last Run column exists to surface.
+apiVersion: policies.kyverno.io/v1
+kind: DeletingPolicy
+metadata:
+  name: cleanup-completed-jobs
+spec:
+  schedule: "0 */6 * * *"
+  deletionPropagationPolicy: Foreground
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+  conditions:
+    - name: completed
+      expression: "has(object.status.succeeded) && object.status.succeeded > 0"
+---
+# Every-minute schedule, so within ~2 minutes of bootstrap this one flips to
+# "43s ago" while the six-hourly one above still says "Never run". That
+# contrast is the point — one table, both states, no hand-patching.
+#
+# The condition deliberately never matches, so it runs without deleting
+# anything.
+apiVersion: policies.kyverno.io/v1
+kind: DeletingPolicy
+metadata:
+  name: probe-every-minute
+spec:
+  schedule: "* * * * *"
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["configmaps"]
+  conditions:
+    - name: never-matches
+      expression: "has(object.metadata.labels) && object.metadata.labels['delete-me'] == 'yes'"
+---
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedDeletingPolicy
+metadata:
+  name: ns-cleanup-old-pods
+  namespace: policy-demo
+spec:
+  schedule: "*/30 * * * *"
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  conditions:
+    - name: succeeded
+      expression: "object.status.phase == 'Succeeded'"

--- a/scripts/kyverno-demo/05-legacy-family.yaml
+++ b/scripts/kyverno-demo/05-legacy-family.yaml
@@ -1,0 +1,63 @@
+# Legacy kyverno.io family — deprecated in Kyverno 1.18, removal planned for
+# 1.20. Present because the whole point of the integration is that BOTH
+# families coexist during migration: family selection, the Kyverno sidebar
+# group collapsing two API groups, and the legacy-vs-modern renderer split all
+# only have meaning with both installed.
+#
+# Note the vocabulary difference, which is deliberate and not an inconsistency:
+# legacy uses Enforce/Audit (validationFailureAction), modern uses
+# Deny/Audit/Warn (validationActions). Each family renders in its own upstream
+# terms.
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: legacy-disallow-latest-tag
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      validate:
+        message: "Using a mutable image tag e.g. 'latest' is not allowed."
+        pattern:
+          spec:
+            containers:
+              - image: "!*:latest"
+---
+# The cleanup controller runs under its own aggregated ClusterRole and can't
+# delete anything it hasn't been granted. Without this, creating the
+# ClusterCleanupPolicy below is rejected:
+#   "cleanup controller has no permission to delete kind Pod"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-cleanup-demo
+  labels:
+    rbac.kyverno.io/aggregate-to-cleanup-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "configmaps"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+# CleanupPolicy's replacement is DeletingPolicy, but the installed base still
+# runs this, and "what deleted my resource?" is expensive to answer without it.
+apiVersion: kyverno.io/v2
+kind: ClusterCleanupPolicy
+metadata:
+  name: legacy-cleanup-completed-pods
+spec:
+  schedule: "0 2 * * *"
+  match:
+    any:
+      - resources:
+          kinds: [Pod]
+  conditions:
+    all:
+      - key: "{{ target.status.phase }}"
+        operator: Equals
+        value: "Succeeded"

--- a/scripts/kyverno-demo/06-exceptions.yaml
+++ b/scripts/kyverno-demo/06-exceptions.yaml
@@ -1,0 +1,45 @@
+# PolicyException in BOTH API families.
+#
+# This is the sharpest collision in the integration: same Kind, same plural
+# (`policyexceptions`), served by kyverno.io/v2 AND policies.kyverno.io/v1,
+# with genuinely different spec shapes. One renderer handles both via
+# group-qualified accessors — reading spec.exceptions off a modern object
+# yields nothing, which on this surface would read as "no policies are
+# excepted" for an object whose entire purpose is to except them.
+#
+# Requires features.policyExceptions.enabled=true, which the bootstrap script
+# sets. Kyverno disables exceptions by default.
+---
+# Modern shape: policyRefs (with a Kind, since a ref can point at
+# ValidatingPolicy or ImageValidatingPolicy) + CEL matchConditions.
+apiVersion: policies.kyverno.io/v1
+kind: PolicyException
+metadata:
+  name: modern-exempt-monitoring
+  namespace: policy-demo
+spec:
+  policyRefs:
+    - name: require-run-as-nonroot
+      kind: ValidatingPolicy
+  matchConditions:
+    - name: only-monitoring-pods
+      expression: "object.metadata.name.startsWith('prometheus-')"
+---
+# Legacy shape: exceptions[].policyName + ruleNames (CEL policies have no
+# named rules, which is why the modern shape drops them) + an any/all match
+# block instead of CEL conditions.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: legacy-exempt-latest-tag
+  namespace: policy-demo
+spec:
+  exceptions:
+    - policyName: legacy-disallow-latest-tag
+      ruleNames:
+        - validate-image-tag
+  match:
+    any:
+      - resources:
+          kinds: [Pod]
+          namespaces: [policy-demo]

--- a/scripts/kyverno-demo/07-workloads.yaml
+++ b/scripts/kyverno-demo/07-workloads.yaml
@@ -1,0 +1,54 @@
+# Workloads for the background scanner to evaluate.
+#
+# Without subjects there are no PolicyReports, and without reports the
+# PolicyReport index, the per-resource policySummary rollup and the whole
+# engine-taxonomy story have nothing to show. The scanner also evaluates
+# kube-system's existing workloads, so a bootstrapped cluster lands around
+# 40 reports across several `source` values.
+#
+# One passes and one fails on purpose, so reports contain a mix rather than
+# all-green.
+---
+# Fails: no `team` label (audit-require-labels warns at admission), containers
+# lack runAsNonRoot and resource limits.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-web
+  namespace: policy-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels: { app: demo-web }
+  template:
+    metadata:
+      labels: { app: demo-web }
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27
+---
+# Passes the pod-level policies: runAsNonRoot set, limits declared.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-api
+  namespace: policy-demo
+  labels:
+    team: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: demo-api }
+  template:
+    metadata:
+      labels: { app: demo-api }
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.27
+          resources:
+            limits: { cpu: 100m, memory: 128Mi }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000

--- a/scripts/kyverno-demo/README.md
+++ b/scripts/kyverno-demo/README.md
@@ -1,0 +1,170 @@
+# Kyverno Demo Cluster
+
+Bootstraps a `kind` cluster with Kyverno 1.18.2 and a curated set of policy
+fixtures covering the scenarios Radar's policy UI needs to render correctly.
+Use it for visual-testing changes to the Kyverno renderers, the PolicyReport
+pipeline, or the enforcement-posture computation — and for future work on
+attributing an admission denial to the policy and rule that caused it, which
+needs live admission and real policies rather than hand-patched states.
+
+## Quick start
+
+```bash
+# Prerequisites: kind, kubectl, helm
+./scripts/kyverno-demo.sh up        # ~4 minutes on first run
+./scripts/kyverno-demo.sh status    # inventory policies, reports and sources
+
+# Run Radar against it
+kubectl config use-context kind-radar-kyverno-demo
+./scripts/visual-test-start.sh
+
+# When done
+./scripts/kyverno-demo.sh down
+```
+
+## ⚠️ Read this before running `modern-only`
+
+`./scripts/kyverno-demo.sh modern-only` removes the legacy `kyverno.io` policy
+CRDs to reproduce the **Kyverno 1.20 API surface**, which is what the detection
+gate exists for.
+
+**Kyverno 1.18.2's admission controller crashloops in that state.** It
+sanity-checks for `clusterpolicies.kyverno.io` and `policies.kyverno.io` at
+startup and exits when they're absent:
+
+```
+sanity checks failed  error="failed to check CRD clusterpolicies.kyverno.io is
+installed: customresourcedefinitions.apiextensions.k8s.io
+\"clusterpolicies.kyverno.io\" not found"
+```
+
+This is **upstream behaviour, not a Radar bug and not a broken cluster.** The
+reports controller stays healthy and the existing PolicyReports survive, which
+is exactly what the detection gate needs to be tested against. Kyverno 1.20
+presumably drops the check along with the CRDs; until it ships, this is the
+closest faithful simulation available.
+
+Run `./scripts/kyverno-demo.sh reset` to get a working cluster back.
+
+## What's in the cluster
+
+### Enforcement posture — the cases that motivated computing it
+
+Radar computes an **effective** posture rather than echoing
+`spec.validationActions`, because three fields interact. These four policies
+are why:
+
+| Resource | Renders | Why it matters |
+|---|---|---|
+| `require-run-as-nonroot` | `Deny` (red) | Deny + admission on. Genuinely blocks — the control case. |
+| `audit-require-labels` | `Audit + Warn` (amber) | Deliberate posture; declared and effective agree. Warns live on `demo-web`. |
+| `background-only-no-latest-tag` | `Background only` (**orange**) | **Declares `Deny`, blocks nothing** — `admission.enabled: false`. The discrepancy tier. |
+| `implicit-deny-configmap-labels` | `Deny` (red) | **No `validationActions` at all**, which Kyverno treats as Deny. Undocumented upstream. |
+
+Tone marks the *discrepancy*, not the label: `Background only` is orange on a
+Deny-declaring policy and neutral on an Audit-declaring one, because skipping
+admission loses nothing an audit policy promised.
+
+Verify the two surprising ones by hand:
+
+```bash
+# Declares Deny, admission disabled → NOT blocked
+kubectl run probe --image=nginx:latest -n default
+
+# No validationActions at all → IS blocked
+kubectl create configmap probe --from-literal=a=b -n policy-demo
+# admission webhook "vpol.validate.kyverno.svc-fail" denied the request
+```
+
+### The rest of the modern family
+
+| Resource | Kind | What it exercises |
+|---|---|---|
+| `ns-require-resources` | NamespacedValidatingPolicy | Namespaced twin sharing its cluster-scoped renderer |
+| `verify-signed-images` | ImageValidatingPolicy | Supply chain: cosign keyless attestors, notary certs, SBOM/SLSA attestations |
+| `add-default-labels` | MutatingPolicy | `Mutates on admission` |
+| `backfill-cost-center-existing` | MutatingPolicy | **`mutateExisting` with admission off** — used to read "Inactive" while rewriting the cluster |
+| `generate-default-netpol` | GeneratingPolicy | Generation lifecycle: `generateExisting` / `synchronize` / `orphanDownstreamOnPolicyDelete` |
+| `cleanup-completed-jobs` | DeletingPolicy | Six-hourly cron → renders `Never run` for a while |
+| `probe-every-minute` | DeletingPolicy | Every-minute cron → flips to `43s ago` within ~2 min |
+| `ns-cleanup-old-pods` | NamespacedDeletingPolicy | Namespaced twin |
+
+The two DeletingPolicies exist as a pair on purpose: within two minutes of
+bootstrap the table shows both `Never run` and a recent timestamp, which is
+what the Last Run column exists to surface. No hand-patching required.
+
+### Legacy family and the dual-API collision
+
+| Resource | Kind | What it exercises |
+|---|---|---|
+| `legacy-disallow-latest-tag` | `kyverno.io` ClusterPolicy | Deprecated family still rendering; `Enforce`/`Audit` vocabulary |
+| `legacy-cleanup-completed-pods` | `kyverno.io` ClusterCleanupPolicy | Deprecated-but-deployed; needs the aggregated cleanup ClusterRole |
+| `modern-exempt-monitoring` | `policies.kyverno.io` PolicyException | `policyRefs` + CEL `matchConditions` |
+| `legacy-exempt-latest-tag` | `kyverno.io/v2` PolicyException | `exceptions[].policyName` + `ruleNames` + any/all match |
+
+**Both API families are installed deliberately.** Family selection, the Kyverno
+sidebar group collapsing two API groups, and the legacy-vs-modern renderer
+split only have meaning with both present. `PolicyException` is the sharpest
+case: same Kind, same plural, two groups, different spec shapes.
+
+### Reports and the engine taxonomy
+
+The background scanner produces ~40 PolicyReports across the fixtures plus
+kube-system's own workloads. `status` prints the distinct `results[].source`
+values, which on a bootstrapped cluster looks like:
+
+```
+47  KyvernoValidatingPolicy
+32  KyvernoMutatingPolicy
+32  kyverno
+ 7  KyvernoGeneratingPolicy
+```
+
+**One engine, four producer strings.** `source` is a producer type, not an
+engine — filtering on the raw value fragments Kyverno across as many buckets as
+it has policy types, which is why the taxonomy normalizes it.
+
+### The report-family selection case
+
+```bash
+./scripts/kyverno-demo.sh openreports
+```
+
+Enables `openreports.enabled`, which leaves the `wgpolicyk8s.io` CRDs **served
+but empty** while every report lands in `openreports.io`. Selection that takes
+the first *served* group picks the empty one and reports zero findings on a
+cluster full of them — indistinguishable from a clean cluster. Radar probes
+each group for actual objects instead; check the log for:
+
+```
+[policy-reports] warming up 2 report CRDs from [openreports.io] (probed 36 reports)
+```
+
+## Coverage this deliberately does not include
+
+- **Enforce-blocked resources.** Kyverno writes reports for audit policies and
+  background scans only, so a resource rejected at admission was never created
+  and no report describes it. No fixture can produce one — it's a property of
+  the PolicyReport data model.
+- **A `Not Ready` policy.** Kyverno rejects uncompilable policies at admission,
+  so a broken one can't be created. It also never populates
+  `status.conditionStatus.ready` on DeletingPolicy.
+- **A real Kyverno 1.20.** Unreleased; `modern-only` simulates the API surface.
+
+## Subcommands
+
+| Command | What it does |
+|---|---|
+| `up` | Create cluster if missing, install Kyverno, apply fixtures, wait for reports |
+| `down` | Delete the cluster |
+| `reset` | `down` + `up` |
+| `status` | Inventory policies, reports, and distinct `source` values |
+| `openreports` | Switch to `openreports.io`, leaving `wgpolicyk8s.io` served-but-empty |
+| `modern-only` | Remove legacy CRDs to simulate 1.20 — **read the warning above** |
+
+`make kyverno-demo`, `make kyverno-demo-down` and `make kyverno-demo-status`
+wrap the common three.
+
+Set `CLUSTER_NAME=foo` to use a different cluster name, or
+`KYVERNO_CHART_VERSION=x.y.z` to pin a different chart. Several fixtures depend
+on 1.18-era spec shapes, so bump the version deliberately.


### PR DESCRIPTION
Scripts the Kyverno fixture set from #1371 so it survives the cluster it was built on. Follows `scripts/gitops-demo.sh` — same subcommand shape, same fixture-numbering convention, same status output.

`make kyverno-demo` · `make kyverno-demo-down` · `make kyverno-demo-status`

## Why script this one

Several of #1371's most load-bearing verifications came from cluster states that aren't reproducible by guesswork — a policy that declares `Deny` and blocks nothing, one with no `validationActions` at all, a report family that's served but empty. Without a script, testing policy UI means testing against whatever cluster you happen to be pointed at.

It's also the shape RAD-322 needs: admission-denial attribution requires live admission and real policies, which is what this bootstraps.

## What's in the fixtures

The set encodes the states that are hard to get right, not a minimal smoke test.

**The four enforcement-posture cases**, which are why Radar computes an effective posture instead of echoing `spec.validationActions`:

| Policy | Renders | Why |
|---|---|---|
| `require-run-as-nonroot` | `Deny` | Deny + admission on — genuinely blocks |
| `audit-require-labels` | `Audit + Warn` | Deliberate; declared and effective agree |
| `background-only-no-latest-tag` | `Background only` | **Declares Deny, blocks nothing** |
| `implicit-deny-configmap-labels` | `Deny` | **No `validationActions` at all** — Kyverno treats this as Deny, undocumented upstream |

Both surprising ones are verifiable by hand, and the README shows the commands. Confirmed on a fresh cluster from this script:

```
$ kubectl run probe --image=nginx:latest -n default
pod/probe created                                    # declares Deny, doesn't block

$ kubectl create configmap probe --from-literal=a=b -n policy-demo
admission webhook "vpol.validate.kyverno.svc-fail" denied the request:
  Policy implicit-deny-configmap-labels failed                # no validationActions, blocks
```

**Everything else worth a fixture:** a `MutatingPolicy` with `mutateExisting` and admission off (the case that used to render "Inactive" while rewriting the cluster — note its default is `false`, unlike admission/background); an `ImageValidatingPolicy` with cosign keyless attestors and SBOM/SLSA attestations; a `GeneratingPolicy` whose evaluation block is a different shape again; and namespaced twins.

**Both API families**, because family selection, the sidebar grouping and the legacy-vs-modern renderer split only have meaning during migration. `PolicyException` is the sharp case — same Kind, same plural, two groups, different specs — so there's one of each.

**Two DeletingPolicies on six-hourly and every-minute crons**, so within two minutes of bootstrap the table shows `Never run` beside a recent timestamp. That pairing is what the Last Run column exists to surface, and it happens on its own rather than needing a hand-patched status:

```
NAME                     LASTRUN
cleanup-completed-jobs   <none>
probe-every-minute       2026-08-09T08:16:09Z
```

**Real workloads, one passing and one failing**, so the background scanner produces ~40 reports across four distinct `results[].source` values — the engine-taxonomy case made visible:

```
37  KyvernoValidatingPolicy
29  KyvernoMutatingPolicy
25  kyverno
 7  KyvernoGeneratingPolicy
```

One engine, four producer strings.

## Two scenario subcommands

`openreports` reconfigures the chart so reports land in `openreports.io` while the `wgpolicyk8s.io` CRDs stay **served but empty** — the selection case where taking the first *served* group shows zero findings on a cluster full of them. Verified on this script's cluster: `wgpolicyk8s.io: 0`, `openreports.io: 37`.

`modern-only` removes the legacy CRDs to reproduce the Kyverno 1.20 API surface.

## The gotcha, stated up front

`modern-only` prints a warning before it runs and the README leads with it:

> **Kyverno 1.18.2's admission controller crashloops without the legacy CRDs.** It sanity-checks for `clusterpolicies.kyverno.io` and `policies.kyverno.io` at startup and exits when they're absent.

That's upstream behaviour, not a broken cluster. The reports controller stays healthy and the reports survive, which is what the detection gate needs. Anyone who hits this without warning will think they broke something.

## Testing

Ran `up` on a clean machine and it **failed** — which is why it's worth saying. `helm --wait` returns once the Deployments report ready, but the admission webhook isn't accepting connections yet, so the first policy apply died with `failed calling webhook "validate-policy.kyverno.svc": connection refused`.

Fixed with a readiness gate that waits for the Service endpoints and then round-trips a real policy through a server-side dry-run, because endpoint readiness alone still races the TLS cert. Fixture applies also retry, since the webhook can blip under load and a half-applied fixture set is worse than a slow one.

After the fix, verified end-to-end on a fresh cluster:

- `up` from nothing → all four controllers healthy, all fixtures applied, 40 reports
- `up` again on the existing cluster → idempotent, webhook ready first attempt
- `status` → full inventory including the source breakdown above
- `openreports` → 0 vs 37 as described
- Both hand-verification commands in the README behave as documented
- `bash -n` clean; `help` renders; unknown subcommand exits 1

**Not tested end-to-end: `modern-only`.** It intentionally breaks the cluster and costs a full reset to recover, and its behaviour was already established empirically during #1371 — that's where the crashloop and the surviving-reports observations come from. Flagging rather than implying full coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local dev scripts, fixtures, and documentation; no application runtime or auth paths are modified.
> 
> **Overview**
> Adds a **Kyverno demo bootstrap** (same shape as `gitops-demo`) so policy UI work can run against a predictable **kind** cluster instead of whatever kube context is active.
> 
> **`scripts/kyverno-demo.sh`** provisions Kyverno 1.18.2 (pinned chart), applies numbered fixtures under `scripts/kyverno-demo/`, waits for PolicyReports, and prints inventory via `status`. It includes a **webhook readiness gate** (endpoints + server-side dry-run policy) and **retried fixture applies** so `up` does not fail when Helm reports ready before admission is actually accepting traffic.
> 
> **Makefile** exposes `kyverno-demo`, `kyverno-demo-down`, and `kyverno-demo-status`. The fixture set targets Radar policy rendering: the four **effective enforcement-posture** cases, modern policy kinds (image/mutate/generate/delete + namespaced twins), **legacy + modern** APIs including dual-shape **PolicyException**, workloads that seed ~40 reports, plus scenario toggles **`openreports`** (served-but-empty `wgpolicyk8s.io` vs populated `openreports.io`) and **`modern-only`** (legacy CRD removal / 1.20 surface simulation, with documented admission-controller crashloop caveat). **`scripts/kyverno-demo/README.md`** documents the coverage matrix and hand-verification commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0835d7292901843770809cbb54e07bbe171188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->