### PR TITLE
chore(velero): script the demo cluster so the fixtures outlive the session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,24 @@ crossplane-demo-down:
 crossplane-demo-status:
 	./scripts/crossplane-demo.sh status
 
+# Bootstrap a kind cluster pre-loaded with curated Velero fixtures (all 13
+# Backup phases, the supersession series, a paused+invalid Schedule, an
+# unavailable BSL, a restic repository, and the rancher plural collision).
+# The Velero controller is deliberately scaled to 0 — the failure phases
+# cannot be produced without real object storage, so status is written
+# directly. See scripts/velero-demo/README.md for the coverage matrix.
+velero-demo:
+	./scripts/velero-demo.sh up
+
+velero-demo-down:
+	./scripts/velero-demo.sh down
+
+velero-demo-status:
+	./scripts/velero-demo.sh status
+
+velero-demo-verify:
+	./scripts/velero-demo.sh verify
+
 # Run linter
 lint:
 	go vet ./...

--- a/scripts/velero-demo.sh
+++ b/scripts/velero-demo.sh
@@ -157,7 +157,24 @@ install_velero() {
   # The load-bearing step. See the header comment.
   step "Scaling the Velero controller to 0 so hand-written status survives"
   k -n "${NS}" scale deployment/velero --replicas=0 >/dev/null
-  k -n "${NS}" wait --for=delete pod -l deploy=velero --timeout=90s >/dev/null 2>&1 || true
+
+  # Poll the Deployment's own replica count rather than waiting on a pod label
+  # selector. A label guess that matches nothing makes `kubectl wait` return
+  # instantly and succeed, so the fixtures then race a controller that is still
+  # running and reconciles every hand-written phase away — a failure that only
+  # shows up as mysteriously empty phases. (The first version of this waited on
+  # `deploy=velero`; the chart labels pods `name=velero`, so it never waited at
+  # all and passed on timing luck.) `.status.replicas` is omitted once it hits
+  # zero, so empty counts as stopped.
+  local running=""
+  for _ in $(seq 1 45); do
+    running="$(k -n "${NS}" get deployment velero -o jsonpath='{.status.replicas}' 2>/dev/null || true)"
+    if [ -z "${running}" ] || [ "${running}" = "0" ]; then break; fi
+    sleep 2
+  done
+  if [ -n "${running}" ] && [ "${running}" != "0" ]; then
+    fail "Velero controller still has ${running} replica(s) after 90s — fixtures would be reconciled away"
+  fi
   ok "Controller stopped — nothing will reconcile the fixtures away"
 }
 
@@ -227,6 +244,16 @@ apply_fixtures() {
 verify_fixtures() {
   step "Verifying fixture state"
   local errs=0
+
+  # 0. The controller is down. Everything below is meaningless if it isn't —
+  #    a running Velero rewrites every phase here within a reconcile loop.
+  local reps
+  reps="$(k -n "${NS}" get deployment velero -o jsonpath='{.status.replicas}' 2>/dev/null || true)"
+  if [ -n "${reps}" ] && [ "${reps}" != "0" ]; then
+    warn "velero controller is running (${reps} replica(s)) — fixtures will not survive"; errs=$((errs+1))
+  else
+    ok "velero controller is stopped"
+  fi
 
   # 1. Every Backup phase in the enum is present exactly once.
   local expected="Completed Deleting Failed FailedValidation Finalizing FinalizingPartiallyFailed InProgress New PartiallyFailed Queued ReadyToStart WaitingForPluginOperations WaitingForPluginOperationsPartiallyFailed"

--- a/scripts/velero-demo.sh
+++ b/scripts/velero-demo.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Bootstrap a kind cluster pre-populated with Velero backup/restore scenarios
+# for visual-testing the Velero views and the backup-failure Issues.
+# Idempotent — re-run to refresh state or apply fixture updates without
+# recreating the cluster.
+#
+# READ THIS FIRST — why the Velero controller is scaled to zero.
+#
+#   Velero's interesting phases (Failed, PartiallyFailed, FailedValidation,
+#   WaitingForPluginOperations...) cannot be produced on a kind cluster,
+#   because reaching them requires real object storage and a real backup that
+#   actually fails partway. A live controller with no bucket produces exactly
+#   one outcome — everything Failed with a credentials error — which is the
+#   least interesting row in the table.
+#
+#   So the controller is installed and then scaled to 0, and the fixtures carry
+#   their own status. Nothing reconciles it away, and every phase in the enum
+#   becomes reachable. This is the whole trick; without it you will spend an
+#   hour wondering why your hand-written status keeps reverting.
+#
+#   Worth knowing, because the usual advice sends you the wrong way: none of
+#   the Velero CRDs declare a status subresource, so a plain `kubectl apply`
+#   writes status. `kubectl patch --subresource=status` fails against them with
+#   a confusing NotFound.
+#
+#   The cost: nothing here exercises real controller behaviour. Anything that
+#   depends on a running Velero (data-mover DataUpload/DataDownload CRs,
+#   real progress counters ticking, backup logs in object storage) is out of
+#   reach. See the README's "What this cannot cover" section.
+#
+# Subcommands:
+#   up        Create cluster (if missing), install Velero CRDs, apply fixtures.
+#   down      Delete the kind cluster.
+#   reset     down + up.
+#   status    Inventory what's installed and what the fixtures look like.
+#   verify    Re-run the fixture assertions without reapplying.
+#   help      Show this message.
+#
+# Prerequisites:
+#   - kind     https://kind.sigs.k8s.io/
+#   - kubectl
+#   - helm     (installs the Velero chart; the controller is then scaled to 0)
+#   - python3  (expands the @now tokens; already required by gitops-demo.sh)
+#
+# Set CLUSTER_NAME=foo to use a different cluster (default: radar-velero-demo).
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-radar-velero-demo}"
+KUBECTL_CTX="kind-${CLUSTER_NAME}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/velero-demo"
+NS=velero
+
+# Pinned so the demo behaves consistently. Chart 12.1.0 ships Velero 1.18.1,
+# whose Backup phase enum is what the fixtures and the phase→level table in
+# resource-utils-velero.ts are written against. Bump both together.
+VELERO_CHART_VERSION="${VELERO_CHART_VERSION:-12.1.0}"
+VELERO_APP_VERSION="1.18.1"
+
+if [ -t 1 ]; then
+  C_RESET=$'\e[0m'; C_BLUE=$'\e[34m'; C_GREEN=$'\e[32m'
+  C_YELLOW=$'\e[33m'; C_RED=$'\e[31m'; C_DIM=$'\e[2m'
+else
+  C_RESET=""; C_BLUE=""; C_GREEN=""; C_YELLOW=""; C_RED=""; C_DIM=""
+fi
+step() { printf "${C_BLUE}==> %s${C_RESET}\n" "$1"; }
+ok()   { printf "${C_GREEN}    ✓ %s${C_RESET}\n" "$1"; }
+warn() { printf "${C_YELLOW}    ! %s${C_RESET}\n" "$1"; }
+fail() { printf "${C_RED}    ✗ %s${C_RESET}\n" "$1"; exit 1; }
+note() { printf "${C_DIM}    %s${C_RESET}\n" "$1"; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found — install it: $2"
+}
+
+k() { kubectl --context "${KUBECTL_CTX}" "$@"; }
+
+# Rendered fixtures (tokens expanded) live in temp dirs cleaned up on exit. A
+# RETURN trap looks tidier but fires on every later function return too, and
+# then trips `set -u` on a variable that has gone out of scope.
+RENDER_DIRS=()
+cleanup_render_dirs() {
+  for d in "${RENDER_DIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+}
+trap cleanup_render_dirs EXIT
+
+cluster_exists() { kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; }
+
+# --- Lifecycle -------------------------------------------------------------
+
+cmd_up() {
+  require_cmd kind "https://kind.sigs.k8s.io/docs/user/quick-start/#installation (or 'brew install kind')"
+  require_cmd kubectl "https://kubernetes.io/docs/tasks/tools/"
+  require_cmd helm "https://helm.sh/docs/intro/install/ (or 'brew install helm')"
+  require_cmd python3 "https://www.python.org/downloads/"
+
+  if cluster_exists; then
+    step "Cluster '${CLUSTER_NAME}' already exists — reusing"
+  else
+    step "Creating kind cluster '${CLUSTER_NAME}'"
+    kind create cluster --name "${CLUSTER_NAME}" --wait 60s
+    ok "Cluster created"
+  fi
+  k cluster-info >/dev/null || fail "kind context not reachable"
+
+  install_velero
+  apply_fixtures
+  verify_fixtures
+  print_summary
+}
+
+cmd_down() {
+  require_cmd kind "https://kind.sigs.k8s.io/"
+  if cluster_exists; then
+    step "Deleting cluster '${CLUSTER_NAME}'"
+    kind delete cluster --name "${CLUSTER_NAME}"
+    ok "Deleted"
+  else
+    warn "Cluster '${CLUSTER_NAME}' does not exist; nothing to do"
+  fi
+}
+
+cmd_reset() { cmd_down; cmd_up; }
+
+# --- Velero ----------------------------------------------------------------
+
+install_velero() {
+  step "Installing Velero chart ${VELERO_CHART_VERSION} (app ${VELERO_APP_VERSION})"
+
+  helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo update vmware-tanzu >/dev/null 2>&1 || true
+
+  # credentials.useSecret=false and snapshotsEnabled=false keep the install
+  # from demanding a cloud credential that would never be used — the
+  # controller is about to be scaled to zero. The BSL is declared anyway so
+  # the fixtures have a default location to reference.
+  helm upgrade --install velero vmware-tanzu/velero \
+    --kube-context "${KUBECTL_CTX}" \
+    --namespace "${NS}" --create-namespace \
+    --version "${VELERO_CHART_VERSION}" \
+    --set credentials.useSecret=false \
+    --set snapshotsEnabled=false \
+    --set deployNodeAgent=false \
+    --set "initContainers[0].name=velero-plugin-for-aws" \
+    --set "initContainers[0].image=velero/velero-plugin-for-aws:v1.12.0" \
+    --set "initContainers[0].volumeMounts[0].mountPath=/target" \
+    --set "initContainers[0].volumeMounts[0].name=plugins" \
+    --set "configuration.backupStorageLocation[0].name=default" \
+    --set "configuration.backupStorageLocation[0].provider=aws" \
+    --set "configuration.backupStorageLocation[0].bucket=radar-demo" \
+    --set "configuration.backupStorageLocation[0].default=true" \
+    --set "configuration.backupStorageLocation[0].config.region=us-east-1" \
+    --wait --timeout 5m >/dev/null
+  ok "Chart installed (13 CRDs)"
+
+  # The load-bearing step. See the header comment.
+  step "Scaling the Velero controller to 0 so hand-written status survives"
+  k -n "${NS}" scale deployment/velero --replicas=0 >/dev/null
+  k -n "${NS}" wait --for=delete pod -l deploy=velero --timeout=90s >/dev/null 2>&1 || true
+  ok "Controller stopped — nothing will reconcile the fixtures away"
+}
+
+# --- Fixtures --------------------------------------------------------------
+
+# None of the Velero CRDs declare a status subresource (checked across all six
+# in v1.18.1), so status is an ordinary field and a plain apply writes it. The
+# usual "kubectl apply drops status" rule only holds for kinds that DO register
+# the subresource — reaching for `kubectl patch --subresource=status` here
+# fails with a confusing NotFound, because there is no such subresource to
+# address. If a future Velero release adds one, this is the function to change.
+apply_one() {
+  k apply -f "$1" >/dev/null
+}
+
+# Fixtures carry @now±Nm tokens instead of absolute timestamps, so a demo
+# recorded today doesn't render as "expired 8 months ago" next year. Expand
+# them into RFC3339 at apply time.
+expand_tokens() {
+  local src="$1" dst="$2"
+  python3 - "$src" "$dst" <<'PY'
+import datetime, re, sys
+src, dst = sys.argv[1], sys.argv[2]
+now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+def sub(m):
+    t = now + datetime.timedelta(minutes=int(m.group(1)))
+    return t.strftime('%Y-%m-%dT%H:%M:%SZ')
+open(dst, 'w').write(re.sub(r'@now([+-]\d+)m', sub, open(src).read()))
+PY
+}
+
+apply_fixtures() {
+  step "Applying Velero demo fixtures"
+  [ -d "${FIXTURES_DIR}" ] || fail "Fixtures dir not found: ${FIXTURES_DIR}"
+
+  local tmp; tmp="$(mktemp -d)"
+  RENDER_DIRS+=("${tmp}")
+
+  for f in $(ls "${FIXTURES_DIR}"/*.yaml 2>/dev/null | sort); do
+    local base; base="$(basename "$f")"
+    grep -q '^[[:space:]]*[^#[:space:]]' "$f" || { note "skipping ${base} (comments only)"; continue; }
+
+    expand_tokens "$f" "${tmp}/${base}"
+    note "applying ${base}"
+    apply_one "${tmp}/${base}"
+
+    # The CRD needs to be established before its CR can be created, and the
+    # supersession backups need distinct creationTimestamps — see
+    # verify_fixtures. Both are handled by pausing after the relevant files.
+    case "${base}" in
+      05-collision-crd.yaml)
+        k wait --for=condition=Established crd/restores.resources.cattle.io --timeout=60s >/dev/null
+        ;;
+      6*-supersession-*.yaml)
+        sleep 2
+        ;;
+    esac
+  done
+  ok "Fixtures applied"
+}
+
+# --- Verification ----------------------------------------------------------
+
+# The fixture is only useful if it actually holds the states it claims to.
+# These assertions are cheap and they fail loudly, which beats discovering
+# mid-review that a phase silently didn't stick.
+verify_fixtures() {
+  step "Verifying fixture state"
+  local errs=0
+
+  # 1. Every Backup phase in the enum is present exactly once.
+  local expected="Completed Deleting Failed FailedValidation Finalizing FinalizingPartiallyFailed InProgress New PartiallyFailed Queued ReadyToStart WaitingForPluginOperations WaitingForPluginOperationsPartiallyFailed"
+  local missing=""
+  for p in ${expected}; do
+    k get backups.velero.io -n "${NS}" \
+      -o jsonpath='{.items[*].status.phase}' 2>/dev/null | tr ' ' '\n' | grep -qx "$p" || missing="${missing} $p"
+  done
+  if [ -n "${missing}" ]; then warn "missing Backup phases:${missing}"; errs=$((errs+1))
+  else ok "all 13 Backup phases present"; fi
+
+  # 2. Status actually stuck. If the controller were still running, or the
+  #    subresource patch silently no-opped, phases would be empty.
+  local empty
+  empty="$(k get backups.velero.io -n "${NS}" -o json \
+    | python3 -c 'import json,sys; print(sum(1 for i in json.load(sys.stdin)["items"] if not (i.get("status") or {}).get("phase")))')"
+  if [ "${empty}" != "0" ]; then warn "${empty} Backups have no phase — is the controller still running?"; errs=$((errs+1))
+  else ok "hand-written status survived (controller is down)"; fi
+
+  # 3. Supersession ordering. The rule under test is "a later successful backup
+  #    clears an earlier failure in the same schedule". If the two nightly
+  #    backups share a creationTimestamp, ordering falls back to the name
+  #    tie-break and the test passes for a reason that has nothing to do with
+  #    time — so assert the timestamps are actually distinct.
+  local t_old t_new
+  t_old="$(k get backup.velero.io -n "${NS}" nightly-20260806010000 -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || true)"
+  t_new="$(k get backup.velero.io -n "${NS}" nightly-20260807010000 -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || true)"
+  if [ -z "${t_old}" ] || [ -z "${t_new}" ]; then
+    warn "supersession backups missing"; errs=$((errs+1))
+  elif [ "${t_old}" = "${t_new}" ]; then
+    warn "supersession backups share creationTimestamp ${t_old} — ordering would be decided by name, not time"; errs=$((errs+1))
+  elif [[ "${t_old}" > "${t_new}" ]]; then
+    warn "supersession backups created out of order (${t_old} > ${t_new})"; errs=$((errs+1))
+  else
+    ok "supersession ordering distinct (${t_old} -> ${t_new})"
+  fi
+
+  # 4. The collision CR exists and is genuinely foreign.
+  if k get restores.resources.cattle.io rancher-restore >/dev/null 2>&1; then
+    ok "rancher restores.resources.cattle.io present (plural collision covered)"
+  else
+    warn "rancher collision CR missing"; errs=$((errs+1))
+  fi
+
+  # 5. A restic repository exists — the Type column exists to surface it.
+  if k get backuprepositories.velero.io -n "${NS}" -o jsonpath='{.items[*].spec.repositoryType}' 2>/dev/null | tr ' ' '\n' | grep -qx restic; then
+    ok "restic BackupRepository present"
+  else
+    warn "no restic BackupRepository — the Type column has nothing to flag"; errs=$((errs+1))
+  fi
+
+  [ "${errs}" -eq 0 ] || fail "${errs} fixture check(s) failed"
+}
+
+cmd_verify() { verify_fixtures; }
+
+# --- Status ----------------------------------------------------------------
+
+cmd_status() {
+  cluster_exists || fail "Cluster '${CLUSTER_NAME}' does not exist — run: $0 up"
+  step "Cluster '${CLUSTER_NAME}'"
+  note "$(k -n "${NS}" get deployment velero -o jsonpath='velero controller replicas={.spec.replicas} (0 is correct)' 2>/dev/null || echo 'velero deployment not found')"
+  for kind in backups restores schedules backupstoragelocations volumesnapshotlocations backuprepositories; do
+    printf "${C_DIM}    %-26s %s${C_RESET}\n" "${kind}" \
+      "$(k get "${kind}.velero.io" -n "${NS}" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  done
+  echo
+  step "Backup phases"
+  k get backups.velero.io -n "${NS}" \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,SCHEDULE:.metadata.labels.velero\.io/schedule-name' 2>/dev/null
+  echo
+  step "Schedules"
+  k get schedules.velero.io -n "${NS}" \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,PAUSED:.spec.paused,CRON:.spec.schedule' 2>/dev/null
+}
+
+print_summary() {
+  echo
+  step "Ready"
+  note "context:  ${KUBECTL_CTX}"
+  note "point Radar at it:  kubectl config use-context ${KUBECTL_CTX} && make restart"
+  note "coverage matrix:    scripts/velero-demo/README.md"
+  note "inventory:          $0 status"
+}
+
+case "${1:-help}" in
+  up)     cmd_up ;;
+  down)   cmd_down ;;
+  reset)  cmd_reset ;;
+  status) cmd_status ;;
+  verify) cmd_verify ;;
+  help|-h|--help) sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d' ;;
+  *) fail "Unknown subcommand: $1 (try: $0 help)" ;;
+esac

--- a/scripts/velero-demo.sh
+++ b/scripts/velero-demo.sh
@@ -158,23 +158,35 @@ install_velero() {
   step "Scaling the Velero controller to 0 so hand-written status survives"
   k -n "${NS}" scale deployment/velero --replicas=0 >/dev/null
 
-  # Poll the Deployment's own replica count rather than waiting on a pod label
-  # selector. A label guess that matches nothing makes `kubectl wait` return
-  # instantly and succeed, so the fixtures then race a controller that is still
-  # running and reconciles every hand-written phase away — a failure that only
-  # shows up as mysteriously empty phases. (The first version of this waited on
-  # `deploy=velero`; the chart labels pods `name=velero`, so it never waited at
-  # all and passed on timing luck.) `.status.replicas` is omitted once it hits
-  # zero, so empty counts as stopped.
-  local running=""
+  # Wait for the POD to be gone, not for a replica count, and take the selector
+  # from the Deployment instead of guessing labels. Two traps here, both real:
+  #
+  #   A hardcoded selector that matches nothing makes `kubectl wait` return
+  #   instantly and succeed. (This started life as `-l deploy=velero`; the
+  #   chart labels pods `name=velero`, so it never waited at all.)
+  #
+  #   `.status.replicas` stops counting a pod the moment it starts terminating,
+  #   while the container keeps running for its grace period — and Velero's is
+  #   terminationGracePeriodSeconds: 3600. A replica count of zero therefore
+  #   says nothing about whether a controller is still reconciling.
+  #
+  # Nothing is in flight worth draining, so the leftover pod is force-deleted
+  # rather than waited out for up to an hour.
+  local sel
+  sel="$(k -n "${NS}" get deployment velero \
+    -o go-template='{{range $k, $v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' 2>/dev/null | sed 's/,$//')"
+  [ -n "${sel}" ] || fail "could not read the velero Deployment's pod selector"
+
+  k -n "${NS}" delete pod -l "${sel}" --grace-period=0 --force --ignore-not-found >/dev/null 2>&1 || true
+
+  local pods=""
   for _ in $(seq 1 45); do
-    running="$(k -n "${NS}" get deployment velero -o jsonpath='{.status.replicas}' 2>/dev/null || true)"
-    if [ -z "${running}" ] || [ "${running}" = "0" ]; then break; fi
+    pods="$(k -n "${NS}" get pods -l "${sel}" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+    [ "${pods}" = "0" ] && break
     sleep 2
   done
-  if [ -n "${running}" ] && [ "${running}" != "0" ]; then
-    fail "Velero controller still has ${running} replica(s) after 90s — fixtures would be reconciled away"
-  fi
+  [ "${pods}" = "0" ] \
+    || fail "${pods} velero controller pod(s) still present after 90s — fixtures would be reconciled away"
   ok "Controller stopped — nothing will reconcile the fixtures away"
 }
 
@@ -245,14 +257,19 @@ verify_fixtures() {
   step "Verifying fixture state"
   local errs=0
 
-  # 0. The controller is down. Everything below is meaningless if it isn't —
+  # 0. No controller POD exists. Everything below is meaningless if one does —
   #    a running Velero rewrites every phase here within a reconcile loop.
-  local reps
-  reps="$(k -n "${NS}" get deployment velero -o jsonpath='{.status.replicas}' 2>/dev/null || true)"
-  if [ -n "${reps}" ] && [ "${reps}" != "0" ]; then
-    warn "velero controller is running (${reps} replica(s)) — fixtures will not survive"; errs=$((errs+1))
+  #    Checked as a pod count rather than a replica count: a terminating pod is
+  #    already excluded from .status.replicas but is still running its
+  #    container, and Velero's grace period is an hour.
+  local vsel vpods
+  vsel="$(k -n "${NS}" get deployment velero \
+    -o go-template='{{range $k, $v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' 2>/dev/null | sed 's/,$//')"
+  vpods="$(k -n "${NS}" get pods -l "${vsel:-app.kubernetes.io/name=velero}" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "${vpods}" != "0" ]; then
+    warn "${vpods} velero controller pod(s) present — fixtures will not survive"; errs=$((errs+1))
   else
-    ok "velero controller is stopped"
+    ok "no velero controller pod running"
   fi
 
   # 1. Every Backup phase in the enum is present exactly once.

--- a/scripts/velero-demo/05-collision-crd.yaml
+++ b/scripts/velero-demo/05-collision-crd.yaml
@@ -1,0 +1,42 @@
+# The collision fixture, and the reason it uses a REAL third-party CRD.
+#
+# rancher/backup-restore-operator ships restores.resources.cattle.io — the
+# same plural Velero uses. Radar's renderers, status readers and column sets
+# must select on the API group, not the plural, or a Rancher Restore renders
+# through Velero's UI. A mock CRD would not prove much; this is the actual
+# schema, trimmed to the fields the fixture sets.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.resources.cattle.io
+spec:
+  conversion:
+    strategy: None
+  group: resources.cattle.io
+  names:
+    kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              backupFilename:
+                type: string
+            type: object
+          status:
+            properties:
+              phase:
+                type: string
+              restoreCompletionTs:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/scripts/velero-demo/10-storage-locations.yaml
+++ b/scripts/velero-demo/10-storage-locations.yaml
@@ -1,0 +1,58 @@
+# Backup + VolumeSnapshot storage locations.
+#   dr-replica is Unavailable -> the backup-target-unavailable Issue category.
+#   The VSL has no status on purpose: the controller never populates one,
+#   which is why the VSL table has no status column at all.
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: 1.18.1
+    helm.sh/chart: velero-12.1.0
+  annotations:
+    meta.helm.sh/release-name: velero
+    meta.helm.sh/release-namespace: velero
+spec:
+  accessMode: ReadWrite
+  config:
+    region: us-east-1
+  default: true
+  objectStorage:
+    bucket: radar-demo
+  provider: aws
+status:
+  lastSyncedTime: "@now-1860m"
+  lastValidationTime: "@now-1860m"
+  phase: Available
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: dr-replica
+  namespace: velero
+spec:
+  accessMode: ReadOnly
+  config:
+    region: eu-west-1
+  objectStorage:
+    bucket: radar-dr
+  provider: aws
+status:
+  message: "BackupStorageLocation \"dr-replica\" is unavailable: rpc error: code = Unknown desc = NoCredentialProviders"
+  phase: Unavailable
+---
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: default
+  namespace: velero
+spec:
+  config:
+    profile: default
+    region: us-east-1
+  provider: aws

--- a/scripts/velero-demo/20-backup-repositories.yaml
+++ b/scripts/velero-demo/20-backup-repositories.yaml
@@ -1,0 +1,45 @@
+# BackupRepositories, one of them restic.
+#   restic is being retired (no new backups since v1.17, restore dropped in
+#   v1.19), which is what the Type column exists to make scannable.
+---
+apiVersion: velero.io/v1
+kind: BackupRepository
+metadata:
+  name: repo-legacy-restic
+  namespace: velero
+spec:
+  backupStorageLocation: default
+  maintenanceFrequency: 168h0m0s
+  repositoryType: restic
+  volumeNamespace: legacy-app
+status:
+  lastMaintenanceTime: "@now-11950m"
+  phase: Ready
+---
+apiVersion: velero.io/v1
+kind: BackupRepository
+metadata:
+  name: repo-notready
+  namespace: velero
+spec:
+  backupStorageLocation: default
+  maintenanceFrequency: 1h0m0s
+  repositoryType: kopia
+  volumeNamespace: default
+status:
+  message: "error running maintenance: unable to connect to repository"
+  phase: NotReady
+---
+apiVersion: velero.io/v1
+kind: BackupRepository
+metadata:
+  name: repo-ready
+  namespace: velero
+spec:
+  backupStorageLocation: default
+  maintenanceFrequency: 1h0m0s
+  repositoryType: kopia
+  volumeNamespace: default
+status:
+  lastMaintenanceTime: "@now-1870m"
+  phase: Ready

--- a/scripts/velero-demo/30-schedules.yaml
+++ b/scripts/velero-demo/30-schedules.yaml
@@ -1,0 +1,87 @@
+# Schedules. Covers healthy, invalid cron, a validation error with NO phase
+#   set (Velero leaves it empty on some failures), paused, and the important
+#   one: paused AND invalid, the row that used to read only "Paused" and gave
+#   no sign the schedule was broken.
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: sched-enabled
+  namespace: velero
+spec:
+  paused: false
+  schedule: "0 1 * * *"
+  template:
+    includedNamespaces:
+      - "*"
+    storageLocation: default
+    ttl: 720h0m0s
+status:
+  lastBackup: "@now-1870m"
+  phase: Enabled
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: sched-errors-no-phase
+  namespace: velero
+spec:
+  schedule: "0 4 * * *"
+  template:
+    includedNamespaces:
+      - default
+status:
+  validationErrors:
+    - "storage location \"gone\" not found"
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: sched-failedvalidation
+  namespace: velero
+spec:
+  paused: false
+  schedule: not-a-cron
+  template:
+    includedNamespaces:
+      - "*"
+    storageLocation: default
+    ttl: 720h0m0s
+status:
+  phase: FailedValidation
+  validationErrors:
+    - "invalid schedule: expected exactly 5 fields, found 1: [not-a-cron]"
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: sched-paused
+  namespace: velero
+spec:
+  paused: true
+  schedule: "0 3 * * 0"
+  template:
+    includedNamespaces:
+      - "*"
+    storageLocation: default
+    ttl: 720h0m0s
+status:
+  phase: Enabled
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: sched-paused-invalid
+  namespace: velero
+spec:
+  paused: true
+  schedule: bad-cron
+  template:
+    includedNamespaces:
+      - "*"
+    storageLocation: default
+    ttl: 720h0m0s
+status:
+  phase: FailedValidation
+  validationErrors:
+    - stale error retained while paused

--- a/scripts/velero-demo/40-backups-phases.yaml
+++ b/scripts/velero-demo/40-backups-phases.yaml
@@ -1,0 +1,207 @@
+# One Backup per phase in the v1.18 enum - all 13, including the six that
+#   must stay SILENT in Issues (Completed, New, Queued, ReadyToStart,
+#   InProgress, Deleting). A phase here starting to raise an issue is the
+#   regression this file exists to catch.
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-completed
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-1864m"
+  phase: Completed
+  progress:
+    itemsBackedUp: 841
+    totalItems: 841
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-deleting
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: Deleting
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-failed
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-1864m"
+  errors: 12
+  failureReason: "error uploading backup tarball: RequestError: send request failed"
+  phase: Failed
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-failedvalidation
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: FailedValidation
+  validationErrors:
+    - a BackupStorageLocation CRD for the location nonexistent was not found
+    - include-resources and exclude-resources overlap
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-finalizing
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: Finalizing
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-finalizing-partial
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  errors: 1
+  phase: FinalizingPartiallyFailed
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-inprogress
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: InProgress
+  progress:
+    itemsBackedUp: 412
+    totalItems: 841
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-new
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: New
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-partiallyfailed
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-1864m"
+  errors: 9
+  phase: PartiallyFailed
+  startTimestamp: "@now-1870m"
+  warnings: 3
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-queued
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: Queued
+  queuePosition: 3
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-readytostart
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: ReadyToStart
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-waitingforpluginoperations
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  phase: WaitingForPluginOperations
+  progress:
+    itemsBackedUp: 100
+    totalItems: 100
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: phase-waitingforpluginoperations-partial
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  errors: 2
+  phase: WaitingForPluginOperationsPartiallyFailed
+  progress:
+    itemsBackedUp: 118
+    totalItems: 120
+  startTimestamp: "@now-1870m"
+  warnings: 5

--- a/scripts/velero-demo/50-restores.yaml
+++ b/scripts/velero-demo/50-restores.yaml
@@ -1,0 +1,108 @@
+# Restores across the phase vocabulary, including both partial-failure
+#   variants that collapse onto a single label in the table.
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-completed
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  completionTimestamp: "@now-1864m"
+  phase: Completed
+  progress:
+    itemsRestored: 300
+    totalItems: 300
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-failed
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  completionTimestamp: "@now-1864m"
+  errors: 5
+  failureReason: "restore failed: could not connect to object store"
+  phase: Failed
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-failedvalidation
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  phase: FailedValidation
+  validationErrors:
+    - Backup nightly-20260807010000 not found
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-finalizing-partial
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  errors: 1
+  phase: FinalizingPartiallyFailed
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-inprogress
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  phase: InProgress
+  progress:
+    itemsRestored: 140
+    totalItems: 300
+  startTimestamp: "@now-1870m"
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-partiallyfailed
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  completionTimestamp: "@now-1864m"
+  errors: 7
+  phase: PartiallyFailed
+  startTimestamp: "@now-1870m"
+  warnings: 2
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: r-waitingplugins
+  namespace: velero
+spec:
+  backupName: nightly-20260807010000
+  includedNamespaces:
+    - default
+status:
+  phase: WaitingForPluginOperations
+  startTimestamp: "@now-1870m"

--- a/scripts/velero-demo/61-supersession-nightly-20260806010000.yaml
+++ b/scripts/velero-demo/61-supersession-nightly-20260806010000.yaml
@@ -1,0 +1,23 @@
+# Supersession fixture - applied in filename order with a pause between
+# each, so creationTimestamps are distinct. See the script's
+# assert_supersession_ordering: identical timestamps would make the
+# ordering test pass on the name tie-break instead of on time.
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: nightly-20260806010000
+  namespace: velero
+  labels:
+    velero.io/schedule-name: nightly
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-4746m"
+  errors: 12
+  failureReason: nightly run failed - object store unreachable
+  phase: Failed
+  startTimestamp: "@now-4750m"

--- a/scripts/velero-demo/62-supersession-adhoc-preupgrade.yaml
+++ b/scripts/velero-demo/62-supersession-adhoc-preupgrade.yaml
@@ -1,0 +1,21 @@
+# Supersession fixture - applied in filename order with a pause between
+# each, so creationTimestamps are distinct. See the script's
+# assert_supersession_ordering: identical timestamps would make the
+# ordering test pass on the name tie-break instead of on time.
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: adhoc-preupgrade
+  namespace: velero
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-1809m"
+  errors: 3
+  failureReason: timed out waiting for all PodVolumeBackups to complete
+  phase: Failed
+  startTimestamp: "@now-1810m"

--- a/scripts/velero-demo/63-supersession-nightly-20260807010000.yaml
+++ b/scripts/velero-demo/63-supersession-nightly-20260807010000.yaml
@@ -1,0 +1,21 @@
+# Supersession fixture - applied in filename order with a pause between
+# each, so creationTimestamps are distinct. See the script's
+# assert_supersession_ordering: identical timestamps would make the
+# ordering test pass on the name tie-break instead of on time.
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: nightly-20260807010000
+  namespace: velero
+  labels:
+    velero.io/schedule-name: nightly
+spec:
+  includedNamespaces:
+    - "*"
+  storageLocation: default
+  ttl: 720h0m0s
+status:
+  completionTimestamp: "@now-3304m"
+  phase: Completed
+  startTimestamp: "@now-3310m"

--- a/scripts/velero-demo/70-collision-restore.yaml
+++ b/scripts/velero-demo/70-collision-restore.yaml
@@ -1,0 +1,17 @@
+# The Rancher Restore itself — a foreign CR sharing Velero's plural.
+#
+# It must render through GenericRenderer with its own fields (Backup
+# Filename, Restore Completion Ts), leak no Velero strings, and NOT render
+# blank. Blank is the specific trap: the kind is in KNOWN_KINDS, so a
+# group-gated renderer that does not match suppresses GenericRenderer too
+# unless the fall-through is wired.
+---
+apiVersion: resources.cattle.io/v1
+kind: Restore
+metadata:
+  name: rancher-restore
+spec:
+  backupFilename: "rancher-backup-2026.tar.gz"
+status:
+  phase: "Completed"
+  restoreCompletionTs: "2026-08-08T01:00:00Z"

--- a/scripts/velero-demo/README.md
+++ b/scripts/velero-demo/README.md
@@ -1,0 +1,149 @@
+# Velero demo cluster
+
+```bash
+make velero-demo                                  # create + populate
+kubectl config use-context kind-radar-velero-demo
+make restart                                      # point Radar at it
+make velero-demo-status                           # inventory
+make velero-demo-down                             # tear down
+```
+
+## Read this first: the controller is scaled to zero, on purpose
+
+Velero's interesting phases — `Failed`, `PartiallyFailed`, `FailedValidation`,
+`WaitingForPluginOperations` — **cannot be produced on a kind cluster.**
+Reaching them needs real object storage and a real backup that fails partway
+through. A live controller with no bucket produces exactly one outcome:
+everything `Failed` with a credentials error, which is the least interesting
+row in the table.
+
+So the script installs Velero, **scales the controller to 0**, and the fixtures
+carry their own `status`. Nothing reconciles it away, and every phase in the
+enum becomes reachable.
+
+Two consequences worth knowing before you debug anything:
+
+- **A plain `kubectl apply` writes `status` here** — none of the six Velero
+  CRDs declare a status subresource. The familiar "apply drops status" rule
+  only applies to kinds that register one, and reaching for
+  `kubectl patch --subresource=status` against these fails with a confusing
+  `NotFound`. (This bit during development, which is why it's written down.)
+- **If you scale the controller back up, the fixtures dissolve.** Velero will
+  reconcile the hand-written phases into whatever the real world says, which
+  without a bucket is "everything failed".
+
+## Coverage
+
+### Backups — all 13 phases in the v1.18 enum (`40-backups-phases.yaml`)
+
+| Phase | Level | Raises an issue? |
+|---|---|---|
+| `Completed` | healthy | no |
+| `New` | unknown | **no** |
+| `Queued` | neutral | **no** |
+| `ReadyToStart` | neutral | **no** |
+| `InProgress` | neutral | **no** |
+| `Deleting` | degraded | **no** |
+| `Finalizing` | neutral | **no** |
+| `WaitingForPluginOperations` | neutral | **no** |
+| `Failed` | unhealthy | yes |
+| `FailedValidation` | unhealthy | yes |
+| `PartiallyFailed` | alert | yes |
+| `FinalizingPartiallyFailed` | alert | yes |
+| `WaitingForPluginOperationsPartiallyFailed` | alert | yes |
+
+The eight `no` rows are the point of the file. A phase that starts raising an
+issue is the regression this fixture exists to catch — silence is a
+requirement, not an absence of coverage.
+
+### Supersession (`61-`, `62-`, `63-`)
+
+The rule under test: **a later successful backup clears an earlier failure in
+the same schedule and namespace.**
+
+| Fixture | Phase | `velero.io/schedule-name` | Expected |
+|---|---|---|---|
+| `nightly-20260806010000` | Failed | `nightly` | **superseded** — no issue |
+| `nightly-20260807010000` | Completed | `nightly` | silent, and clears the above |
+| `adhoc-preupgrade` | Failed | *(none)* | raises — ad-hoc backups are never superseded |
+
+**Why these are three separate files applied with a pause.** Ordering is by
+`creationTimestamp`, which the API server assigns — the fixture cannot set it.
+If two backups land in the same second, ordering falls back to the name
+tie-break, and the supersession test then passes for a reason that has nothing
+to do with time. The script sleeps between them and `verify` asserts the
+timestamps are distinct and correctly ordered, so this fails loudly rather
+than silently passing.
+
+### Schedules (`30-schedules.yaml`)
+
+| Fixture | Covers |
+|---|---|
+| `sched-enabled` | healthy baseline, valid cron, `lastBackup` set |
+| `sched-failedvalidation` | `FailedValidation` + an invalid cron (`not-a-cron`) |
+| `sched-errors-no-phase` | validation errors with **no phase set** — Velero leaves it empty on some failures; the row must still be filterable |
+| `sched-paused` | paused and otherwise healthy |
+| `sched-paused-invalid` | **paused *and* rejected** — the row that used to read only "Paused" and gave no sign it was broken |
+
+`sched-errors-no-phase` is also the counter-example that stops "invalid cron"
+being derived from the status: it is rejected for a *missing storage location*
+while its cron is perfectly valid. Anything that reddens its cron cell is
+pointing at the wrong field.
+
+### Storage and repositories
+
+| Fixture | Covers |
+|---|---|
+| `default` BSL | `Available` |
+| `dr-replica` BSL | `Unavailable` → the backup-target-unavailable issue category |
+| `default` VSL | **no status at all** — the controller never populates one, which is why the VSL table has no status column |
+| `repo-ready`, `repo-notready` | `Ready` / `NotReady`, two distinct values so the status filter affordance renders |
+| `repo-legacy-restic` | a **restic** repository — what the Type column exists to make scannable |
+
+Two distinct repository statuses matter: a column with one distinct value
+renders no filter control at all, so a single-value fixture cannot exercise
+the filter.
+
+### Plural collision (`05-`, `70-`)
+
+`rancher/backup-restore-operator` ships `restores.resources.cattle.io` — the
+same plural as Velero. The real CRD is vendored here rather than mocked,
+because the guard being tested is "select on the API group, not the plural"
+and a mock proves much less.
+
+`rancher-restore` must render through `GenericRenderer` with its own fields
+(Backup Filename, Restore Completion Ts), show no Velero strings, and **not
+render blank**. Blank is the specific trap: the kind is in `KNOWN_KINDS`, so a
+group-gated renderer that doesn't match will also suppress `GenericRenderer`
+unless the fall-through is wired.
+
+## Timestamps don't rot
+
+Fixtures store `@now±Nm` tokens rather than absolute dates; the script expands
+them at apply time. Without this, a demo recorded today renders as "expired 8
+months ago" next year, and the Expires / Last Backup / Age columns stop
+demoing anything.
+
+## What this cannot cover
+
+**Anything requiring a live controller.** With Velero scaled to 0 there is no
+reconciliation, so:
+
+- **Data mover (`DataUpload` / `DataDownload`)** — needed for RAD-316. These
+  are emitted by a running controller during a real CSI-snapshot backup.
+  Reproducing them needs, at minimum, in-cluster object storage (MinIO) *and* a
+  snapshot-capable CSI driver (`csi-hostpath-driver`; kind's default
+  local-path provisioner cannot snapshot) *and* the node agent enabled *and* a
+  workload with a bound PVC. That is a different and much more fragile fixture,
+  not a flag on this one — which is why it isn't one. Faking `DataUpload` CRs
+  by hand would test our renderer against our own guess at the shape rather
+  than against Velero, and the shape is the thing in doubt.
+- **Real progress counters, backup logs, and per-item error detail.** Error and
+  warning *counts* are in the CR and are covered here; the messages behind them
+  live in a results artifact in object storage, reachable only through a
+  `DownloadRequest` served by a running controller.
+- **Restore-from-backup flows**, which need a real backup in a real bucket.
+
+If you need any of the above, you need a cluster with real object storage —
+say so rather than extending this fixture, because the value of this one is
+that it runs offline in about two minutes.

--- a/scripts/velero-demo/README.md
+++ b/scripts/velero-demo/README.md
@@ -129,15 +129,15 @@ demoing anything.
 **Anything requiring a live controller.** With Velero scaled to 0 there is no
 reconciliation, so:
 
-- **Data mover (`DataUpload` / `DataDownload`)** — needed for RAD-316. These
-  are emitted by a running controller during a real CSI-snapshot backup.
-  Reproducing them needs, at minimum, in-cluster object storage (MinIO) *and* a
-  snapshot-capable CSI driver (`csi-hostpath-driver`; kind's default
-  local-path provisioner cannot snapshot) *and* the node agent enabled *and* a
-  workload with a bound PVC. That is a different and much more fragile fixture,
-  not a flag on this one — which is why it isn't one. Faking `DataUpload` CRs
-  by hand would test our renderer against our own guess at the shape rather
-  than against Velero, and the shape is the thing in doubt.
+- **Data mover (`DataUpload` / `DataDownload`)**, which is what data-mover
+  support would need. These are emitted by a running controller during a real
+  CSI-snapshot backup. Reproducing them needs, at minimum, in-cluster object
+  storage (MinIO) *and* a snapshot-capable CSI driver (`csi-hostpath-driver`;
+  kind's default local-path provisioner cannot snapshot) *and* the node agent
+  enabled *and* a workload with a bound PVC. That is a different and much more
+  fragile fixture, not a flag on this one — which is why it isn't one. Faking
+  `DataUpload` CRs by hand would test our renderer against our own guess at the
+  shape rather than against Velero, and the shape is the thing in doubt.
 - **Real progress counters, backup logs, and per-item error detail.** Error and
   warning *counts* are in the CR and are covered here; the messages behind them
   live in a results artifact in object storage, reachable only through a


### PR DESCRIPTION
The Velero fixtures from RAD-314 existed only in one throwaway kind cluster. `gitops-demo` and `crossplane-demo` already solve this for their integrations, and CLAUDE.md gives the reason: without a demo cluster you test against whatever context happens to be current, which is usually a real cluster missing exactly the variety that matters. Velero had the same problem and no answer.

```bash
make velero-demo          # ~2 min, offline after the chart pull
make velero-demo-status   # inventory
make velero-demo-verify   # re-assert without reapplying
make velero-demo-down
```

## The payload is the states you can't get by installing Velero

Anyone can `helm install velero`. What took the time was everything below.

**All 13 Backup phases**, including the **eight that must stay silent** in Issues. A phase that starts raising is the regression this file exists to catch — silence here is coverage, not its absence.

**The supersession series** — a later success clearing an earlier failure within one schedule, plus an ad-hoc failure that must never be cleared. Three separate files applied with a pause, because ordering is by `creationTimestamp` and the API server assigns it: same-second creation decides ordering by the **name tie-break** instead of by time, and the test then passes for a reason unrelated to what it checks. `verify` asserts the timestamps are distinct and correctly ordered.

**The paused-AND-invalid Schedule**, and a schedule rejected for a *missing storage location while its cron is valid* — the counter-example that stops anyone deriving "invalid cron" from the status and reddening the wrong cell.

**A `restic` BackupRepository**, and two distinct repository statuses, since a column holding one distinct value renders no filter control at all and can't exercise the filter.

**The real `rancher/backup-restore-operator` CRD**, vendored rather than mocked, because the guard under test is "select on the API group, not the plural" and a mock proves much less.

## Two gotchas stated up front, both found the slow way

- **The controller is scaled to 0 on purpose.** The failure phases need real object storage; a live controller with no bucket produces exactly one outcome — everything `Failed` on credentials, the least interesting row in the table.
- **A plain `kubectl apply` writes `status` here.** None of the six Velero CRDs declare a status subresource, so the familiar "apply drops status" rule doesn't apply, and `kubectl patch --subresource=status` fails against them with a confusing `NotFound`. I built the patching layer first and deleted it.

Fixtures store `@now±Nm` tokens rather than absolute dates, so the demo doesn't age into "expired 8 months ago" and leave the Expires / Last Backup / Age columns demoing nothing.

## Deliberately not covered

Anything needing a live controller — data mover (`DataUpload`/`DataDownload`, wanted by RAD-316), real progress counters, and per-item error detail, which lives in an object-storage artifact behind a `DownloadRequest`. RAD-316 would need MinIO **and** a snapshot-capable CSI driver **and** the node agent **and** a workload with a bound PVC: a different and much more fragile fixture, not a flag on this one. Hand-faking `DataUpload` CRs would test our renderer against our own guess at the shape, and the shape is the thing in doubt. The README says so rather than pretending.

## Testing

`velero-demo.sh reset` from nothing, then Radar pointed at the result: **14 issues, matching the hand-built cluster exactly** — 12 `backup_failed`, 2 `backup_target_unavailable`. The superseded backup is absent, the ad-hoc failure present, and all eight silent phases silent. The five in-script assertions pass. Also `bash -n` clean, and the script is idempotent (re-run against an existing cluster reuses it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only scripts and fixtures; no production app, auth, or runtime behavior changes.
> 
> **Overview**
> Adds a **Velero demo bootstrap** parallel to `crossplane-demo` / `gitops-demo`: `make velero-demo` (plus `down`, `status`, `verify`) drives `scripts/velero-demo.sh`, which creates a kind cluster, installs pinned Velero **1.18.1** via Helm, **scales the controller to 0**, and applies YAML fixtures with `@now±Nm` timestamps expanded at apply time.
> 
> The fixtures encode states that are hard to get on kind without real object storage: **all 13 Backup phases** (including phases that must stay silent in Issues), **supersession** (failed then completed nightly backups plus a non-superseded ad-hoc failure), varied **Schedules** (paused+invalid, errors with no phase), **Unavailable** BSL, **restic** and multi-status **BackupRepositories**, restores across phases, and the **Rancher `restores.resources.cattle.io` plural collision** via a vendored CRD + sample CR.
> 
> **`verify`** re-asserts controller absence, phase coverage, supersession `creationTimestamp` ordering, collision CR, and restic repo without reapplying. Documentation in `scripts/velero-demo/README.md` explains the scaled-to-zero trick, status-on-apply behavior, coverage matrix, and explicit limits (no live controller / data mover / real buckets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f24eef932a8a61349c1fdd34d280632b6afa2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->