### PR TITLE
Accept the Kubernetes names for a subject and a pod

### DIFF
--- a/internal/k8s/detect_missing_refs.go
+++ b/internal/k8s/detect_missing_refs.go
@@ -145,6 +145,24 @@ func refKnownMissing(cache *ResourceCache, resource, ns string, err error) bool 
 	return verifiable && !exists
 }
 
+// ServiceAccountPresence reports whether a ServiceAccount could be observed.
+//
+// Callers outside this package need the same three-way answer the detectors
+// use — present, absent, or unobservable — because "absent" and "we could not
+// look" mean opposite things to a reader. A namespace-restricted install or a
+// cold informer must never be reported as a missing account.
+func ServiceAccountPresence(cache *ResourceCache, namespace, name string) (verifiable, exists bool) {
+	if cache == nil || namespace == "" || name == "" {
+		return false, false
+	}
+	lister := cache.ServiceAccounts()
+	if lister == nil {
+		return false, false
+	}
+	_, err := lister.ServiceAccounts(namespace).Get(name)
+	return refLookupResult(cache, "serviceaccounts", namespace, err)
+}
+
 // withFix attaches the plain-English consequence (cause) and the concrete fix
 // (action) to a dangling-ref Detection. message stays the precise locator (which
 // field/path references what); cause is the lead the operator reads; action is

--- a/internal/mcp/toolparams.go
+++ b/internal/mcp/toolparams.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -89,15 +90,24 @@ func isRegisteredTool(tool string) bool {
 // is the same false-negative class this file exists to remove.
 //
 // Only aliases whose value means the same thing under the target parameter
-// qualify, as decided by aliasValueKeepsMeaning below. `pod` and `workload`
-// were considered and rejected: an agent may reasonably send
-// `pod: "prod/api-0"` or `workload: "deployment/api"`, which are not names.
+// qualify, as decided by aliasValueKeepsMeaning below. `workload` stays
+// rejected: `workload: "deployment/api"` names a kind *and* an object, and no
+// single canonical parameter carries both.
+//
+// `pod` was rejected here originally on the same reasoning — a caller may send
+// `pod: "prod/api-0"`. That risk is real but already covered: the alias target
+// is `name`, so aliasValueKeepsMeaning runs and refuses anything that is not a
+// DNS-1123 subdomain, leaving the qualified form on the rejection-with-help
+// path exactly as before. Plain pod names, which is what callers actually
+// send, now repair instead of failing the call.
 //
 // Cross-tool spelling differences do NOT belong here — those are pure
 // orthography and are handled generically below.
 var perToolAliases = map[string]map[string]string{
 	// RBAC subjects are naturally called "subjects", so an agent reaching for
 	// this tool tends to send subject/subjectKind rather than name/kind.
+	// (`serviceAccount` is not here: it carries the kind as well as the name,
+	// so it needs the expansion in perToolKindShorthand below, not a rename.)
 	"get_subject_permissions": {
 		"subject":      "name",
 		"subjectkind":  "kind",
@@ -105,6 +115,84 @@ var perToolAliases = map[string]map[string]string{
 		"subjectname":  "name",
 		"subject_name": "name",
 	},
+	// The tool takes pods and nothing else, and every caller-facing description
+	// of it — kubectl's `logs POD`, radar's own "pod name" — calls the argument
+	// a pod. Observed in the wild: get_pod_logs(pod=…, container=…) rejected
+	// mid-investigation.
+	"get_pod_logs": {
+		"pod": "name",
+	},
+}
+
+// perToolKindShorthand handles the one shape a rename cannot: a key that
+// carries BOTH the kind and the name. `serviceAccount: "cleanup-controller"`
+// is not a renamed `name` — it also says the subject is a ServiceAccount.
+//
+// Deliberately a hand-written table for one tool, NOT inference over the
+// cluster's kind set. Sourcing kinds from API discovery would make the accepted
+// arguments depend on which CRDs happen to be installed, so a key rejected
+// today would be accepted tomorrow, and on a write tool an unknown property
+// matching an installed Kind could be reinterpreted into a real mutation
+// target. The value of this repair does not justify a schema that varies by
+// cluster.
+//
+// Why this key: radar's own get_resource returns `serviceAccountName` on a pod
+// spec. A caller that reads that value and asks about it is using radar's own
+// vocabulary; rejecting it sent one investigation to a wrong conclusion after
+// it had already identified the right subject.
+var perToolKindShorthand = map[string]map[string]string{
+	"get_subject_permissions": {
+		"serviceaccount":     "ServiceAccount",
+		"service_account":    "ServiceAccount",
+		"serviceaccountname": "ServiceAccount",
+	},
+}
+
+// expandKindShorthand rewrites a shorthand key into kind+name in place.
+//
+// Every guard here is load-bearing:
+//   - an explicit kind or name always wins; a caller who supplied both meant
+//     something we cannot infer, and guessing risks answering about a different
+//     subject than the one asked about
+//   - two shorthand keys at once is ambiguous, so neither expands — map
+//     iteration order must never decide which subject gets answered
+//   - the value must be a real ServiceAccount name (DNS-1123). A qualified
+//     "prod/cleanup" would otherwise validate and have the handler report an
+//     empty permission set for an account that cannot exist: a confident wrong
+//     answer, where a rejection carrying the accepted names lets the caller
+//     retry.
+func expandKindShorthand(tool string, args map[string]json.RawMessage, isAccepted func(string) bool, repairs *[]string) {
+	table := perToolKindShorthand[tool]
+	if len(table) == 0 || !isAccepted("kind") || !isAccepted("name") {
+		return
+	}
+	if _, ok := args["kind"]; ok {
+		return
+	}
+	if _, ok := args["name"]; ok {
+		return
+	}
+
+	var foundKey, foundKind string
+	var foundVal json.RawMessage
+	for key, val := range args {
+		kind, ok := table[strings.ToLower(key)]
+		if !ok {
+			continue
+		}
+		if foundKey != "" {
+			return // ambiguous: more than one shorthand supplied
+		}
+		foundKey, foundKind, foundVal = key, kind, val
+	}
+	if foundKey == "" || !aliasValueKeepsMeaning(foundKind, foundVal) {
+		return
+	}
+
+	delete(args, foundKey)
+	args["name"] = foundVal
+	args["kind"] = json.RawMessage(strconv.Quote(foundKind))
+	*repairs = append(*repairs, fmt.Sprintf("%s->kind+name", foundKey))
 }
 
 // aliasValueKeepsMeaning reports whether moving val into the canonical
@@ -311,6 +399,8 @@ func repairToolArgs(tool string, raw json.RawMessage) (fixed json.RawMessage, re
 		}
 		return ""
 	}
+
+	expandKindShorthand(tool, args, isAccepted, &repairs)
 
 	for key, val := range args {
 		if isAccepted(key) {

--- a/internal/mcp/toolparams_test.go
+++ b/internal/mcp/toolparams_test.go
@@ -617,3 +617,115 @@ func TestAliasTargetsExist(t *testing.T) {
 		}
 	}
 }
+
+// TestServiceAccountShorthandExpands covers the shape a rename cannot express:
+// a key carrying both the subject kind and its name.
+//
+// The first case is the exact call that lost a benchmark investigation. The
+// agent had already identified cleanup-controller as the finalizer's owner and
+// asked the right question; the rejection sent it to an unrelated crashloop and
+// a wrong conclusion. It had read "cleanup-controller" out of radar's own
+// get_resource output, under the field name serviceAccountName.
+func TestServiceAccountShorthandExpands(t *testing.T) {
+	registerToolsOnce(t)
+	tests := []struct {
+		name      string
+		args      map[string]any
+		wantKind  string
+		wantName  string
+		wantFixed bool
+	}{
+		{
+			name:      "the observed call",
+			args:      map[string]any{"namespace": "hotel-reservation", "serviceAccount": "cleanup-controller"},
+			wantKind:  "ServiceAccount",
+			wantName:  "cleanup-controller",
+			wantFixed: true,
+		},
+		{
+			name:      "snake spelling",
+			args:      map[string]any{"namespace": "ns", "service_account": "builder"},
+			wantKind:  "ServiceAccount",
+			wantName:  "builder",
+			wantFixed: true,
+		},
+		{
+			name:      "the spelling k8s itself uses on a pod spec",
+			args:      map[string]any{"namespace": "ns", "serviceAccountName": "builder"},
+			wantKind:  "ServiceAccount",
+			wantName:  "builder",
+			wantFixed: true,
+		},
+		{
+			// A qualified value is not a ServiceAccount name. Expanding it would
+			// validate and then report an empty permission set for an account
+			// that cannot exist — a confident wrong answer.
+			name:      "qualified value is refused, not reinterpreted",
+			args:      map[string]any{"namespace": "ns", "serviceAccount": "prod/cleanup"},
+			wantFixed: false,
+		},
+		{
+			// An explicit subject always wins; the caller who sent both meant
+			// something we cannot infer.
+			name:      "explicit kind and name are never overwritten",
+			args:      map[string]any{"kind": "User", "name": "alice", "serviceAccount": "builder"},
+			wantKind:  "User",
+			wantName:  "alice",
+			wantFixed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(tt.args)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			fixed, repairs, _ := repairToolArgs("get_subject_permissions", raw)
+			var got map[string]any
+			if err := json.Unmarshal(fixed, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			expanded := false
+			for _, r := range repairs {
+				if strings.Contains(r, "->kind+name") {
+					expanded = true
+				}
+			}
+			if expanded != tt.wantFixed {
+				t.Errorf("expanded = %v, want %v (repairs %v)", expanded, tt.wantFixed, repairs)
+			}
+			if tt.wantKind != "" {
+				if got["kind"] != tt.wantKind {
+					t.Errorf("kind = %v, want %q", got["kind"], tt.wantKind)
+				}
+				if got["name"] != tt.wantName {
+					t.Errorf("name = %v, want %q", got["name"], tt.wantName)
+				}
+			}
+		})
+	}
+}
+
+// TestPodAliasRepairsPlainNamesOnly restores an alias this file originally
+// rejected. The reasoning for rejecting it — a caller may send "prod/api-0" —
+// is handled by the value guard, since the alias target is `name`: plain names
+// repair, qualified ones still fall through to the rejection carrying help.
+func TestPodAliasRepairsPlainNamesOnly(t *testing.T) {
+	registerToolsOnce(t)
+	for _, tt := range []struct {
+		val       string
+		wantFixed bool
+	}{
+		{"wrk2-job-frr7c", true},
+		{"prod/api-0", false},
+	} {
+		raw, _ := json.Marshal(map[string]any{"namespace": "ns", "pod": tt.val, "container": "app"})
+		fixed, repairs, _ := repairToolArgs("get_pod_logs", raw)
+		var got map[string]any
+		_ = json.Unmarshal(fixed, &got)
+		if fixedOK := got["name"] == tt.val; fixedOK != tt.wantFixed {
+			t.Errorf("pod=%q: name set = %v, want %v (repairs %v)", tt.val, fixedOK, tt.wantFixed, repairs)
+		}
+	}
+}

--- a/internal/mcp/tools_prometheus.go
+++ b/internal/mcp/tools_prometheus.go
@@ -82,7 +82,7 @@ type promRulesResponse struct {
 }
 
 type discoverMetricsInput struct {
-	Match string `json:"match,omitempty" jsonschema:"PromQL series selector to filter, e.g. {__name__=~\"node_cpu.*|node_memory.*\"} or {namespace=\"payments\"}. Combine patterns with regex | to reduce calls. REQUIRED when label is empty (unfiltered metric-name listing is rarely useful)"`
+	Match string `json:"match,omitempty" jsonschema:"PromQL series selector to filter, e.g. {__name__=~\"node_cpu.*|node_memory.*\"} or {namespace=\"payments\"}. Combine patterns with regex | to reduce calls. REQUIRED when label is empty (unfiltered metric-name listing is rarely useful). This tool takes no namespace argument — scope to a namespace inside the selector, as {namespace=\"payments\"}"`
 	Label string `json:"label,omitempty" jsonschema:"discover values of this label instead of metric names, e.g. namespace, pod, job, instance"`
 	Limit int    `json:"limit,omitempty" jsonschema:"max values returned (default 100, max 500)"`
 }

--- a/internal/mcp/tools_rbac.go
+++ b/internal/mcp/tools_rbac.go
@@ -32,9 +32,9 @@ import (
 //     specific Role/ClusterRole to inspect)
 
 type subjectPermissionsInput struct {
-	Kind              string  `json:"kind" jsonschema:"subject kind: ServiceAccount, User, or Group; access checks support ServiceAccount only"`
-	Namespace         string  `json:"namespace,omitempty" jsonschema:"subject namespace (required for ServiceAccount, omit for User/Group)"`
-	Name              string  `json:"name" jsonschema:"subject name"`
+	Kind      string `json:"kind" jsonschema:"subject kind: ServiceAccount, User, or Group; access checks support ServiceAccount only. A serviceAccountName read off a pod spec can be passed directly as service_account instead of kind+name"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"subject namespace (required for ServiceAccount, omit for User/Group)"`
+	Name      string `json:"name" jsonschema:"subject name"`
 	Verb              string  `json:"verb,omitempty" jsonschema:"access check only: Kubernetes API verb; must be supplied together with resource"`
 	Resource          string  `json:"resource,omitempty" jsonschema:"access check only: plural Kubernetes API resource, e.g. configmaps; must be supplied together with verb"`
 	Group             string  `json:"group,omitempty" jsonschema:"access check only: resource API group; omit for core/v1"`
@@ -51,6 +51,13 @@ type subjectPermissionsResult struct {
 	UsedByPods []string            `json:"usedByPods,omitempty"` // "ns/name" pairs
 	PodsTotal  int                 `json:"podsTotal,omitempty"`  // >0 when usedByPods was truncated
 	NarrowHint string              `json:"narrowHint,omitempty"`
+	// SubjectWarning fires when the answer is empty for a reason other than
+	// "this subject has no permissions". The rules are computed from the RBAC
+	// index alone — no lookup of the subject itself — so a mistyped or
+	// wrong-namespace ServiceAccount produces exactly the same empty result as
+	// a real account with nothing bound to it. Without this the caller cannot
+	// tell those apart, and an empty set reads as a confident negative.
+	SubjectWarning string `json:"subjectWarning,omitempty"`
 }
 
 type mcpSubject struct {
@@ -219,6 +226,21 @@ func handleGetSubjectPermissions(ctx context.Context, _ *mcp.CallToolRequest, in
 		Bindings:  make([]mcpBindingLite, 0, len(er.ViaBindings)),
 		FlatRules: er.Flat,
 		Truncated: er.Truncated,
+	}
+
+	// Only worth saying when the answer is empty — a subject with bindings is
+	// self-evidently real, and the note would be noise on every other call.
+	if subj.Kind == "ServiceAccount" && len(er.ViaBindings) == 0 && len(er.Flat) == 0 {
+		switch verifiable, exists := k8s.ServiceAccountPresence(cache, subj.Namespace, subj.Name); {
+		case verifiable && !exists:
+			result.SubjectWarning = fmt.Sprintf(
+				"no ServiceAccount %q exists in namespace %q — this empty result reflects a subject that was never found, not an account without permissions. Check the name and namespace.",
+				subj.Name, subj.Namespace)
+		case !verifiable:
+			result.SubjectWarning = fmt.Sprintf(
+				"could not confirm ServiceAccount %q exists in namespace %q (not observable by Radar), so an empty result may mean either no permissions or a subject that does not exist.",
+				subj.Name, subj.Namespace)
+		}
 	}
 	if er.Truncated {
 		result.NarrowHint = "rule list truncated — the subject has more rules than shown; do not treat this list as the subject's complete permissions"


### PR DESCRIPTION
## Summary

`get_subject_permissions` takes `kind` + `name`. A caller that reads `serviceAccountName` off a pod spec — the field name Kubernetes uses, and the one radar's own `get_resource` returns — and asks about that value gets the call rejected, because `serviceAccount` is not a property in the schema.

That is not a hypothetical. In a benchmark run the agent had already found the stuck ConfigMap, the finalizer, and identified `cleanup-controller` as its owner. It reached for the decisive last hop, was rejected, did not retry, and reported an unrelated crashloop instead. The run that completed that hop scored 0.89; this one scored 0.00.

Two more rejections in the same investigation: `get_pod_logs(pod=…)` and `discover_metrics(namespace=…)`.

## What changed

**A subject can be named the way Kubernetes names it.** `serviceAccount`, `service_account` and `serviceAccountName` expand to `kind=ServiceAccount` plus `name`. This is the one shape the existing alias table cannot express — those aliases are 1:1 renames, and this key carries the kind as well as the name.

The expansion is a hand-written table for one tool, not inference over the cluster's kind set. Sourcing kinds from API discovery would make the accepted arguments depend on which CRDs happen to be installed — a key rejected today accepted tomorrow — and on a write tool an unknown property matching an installed Kind could be reinterpreted into a real mutation target.

Guards, each load-bearing: an explicit `kind` or `name` always wins; two shorthand keys at once expand neither, so map iteration order can never decide which subject gets answered; and the value must be a DNS-1123 name, so `prod/cleanup` is refused rather than turned into a lookup that cannot match.

**`get_pod_logs` accepts `pod`.** The tool takes pods and nothing else, and both kubectl (`logs POD`) and radar's own description call the argument a pod. This alias was previously declined on the grounds that a caller might send `pod: "prod/api-0"` — a real risk, but one the value guard already covers, since the alias target is `name` and anything that is not a bare name falls through to the rejection carrying the accepted names.

**An empty permission set no longer reads as a confident negative.** Effective rules are computed from the RBAC index alone, with no lookup of the subject itself, so a mistyped or wrong-namespace ServiceAccount produced exactly the same empty result as a real account with nothing bound to it. The answer now distinguishes the two, and says explicitly when it could not tell — a namespace-restricted install or a cold informer must never be reported as a missing account.

**`discover_metrics` says it has no namespace argument** and points at the selector, which is where namespace scoping belongs.

## Reviewer notes

The `service_account` spelling stays out of the schema deliberately. Making it a real field means `kind` and `name` can no longer be structurally required, which strips `(required)` from the generated parameter help and removes the annotation from missing-argument errors — the exact affordance that lets a caller recover from a wrong guess. Keeping the schema strict and expanding in middleware preserves it; the alternate spelling is documented in the `kind` description instead.

Worth focusing on: the guard ordering in `expandKindShorthand`, and `ServiceAccountPresence`, which returns present/absent/unobservable rather than a bool so the caller cannot collapse "we could not look" into "it is not there".

## Testing

`go build ./...`, `go test ./internal/...`, `pkg` module suite, and `make tsc` all green.

New coverage: the exact rejected call from the benchmark, both alternate spellings, a qualified value refused rather than reinterpreted, explicit `kind`/`name` never overwritten, and the `pod` alias repairing plain names while still refusing qualified ones.

Not covered by a test: the subject-existence warning. `internal/k8s` has no cache fixture, so building one is its own piece of work — the logic is guarded such that the unverifiable branch is the default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP argument rewriting and RBAC empty-result semantics; incorrect shorthand expansion could route values to the wrong subject, though guards and existing aliasValueKeepsMeaning limit that risk.
> 
> **Overview**
> MCP tool argument repair now accepts **Kubernetes-shaped names** that agents were already sending, instead of hard schema rejections mid-investigation.
> 
> **`get_subject_permissions`** gains **`expandKindShorthand`**: keys like `serviceAccount`, `service_account`, and `serviceAccountName` expand to `kind=ServiceAccount` plus `name`, with guards so explicit `kind`/`name` win, two shorthands at once do not expand, and qualified values (e.g. `prod/cleanup`) are refused. **`get_pod_logs`** adds a **`pod` → `name`** alias, with DNS-1123 validation so qualified pod names still fail with help.
> 
> When a ServiceAccount lookup returns **no bindings and no rules**, **`get_subject_permissions`** sets **`subjectWarning`** using new **`k8s.ServiceAccountPresence`** (present / absent / unobservable via the same tri-state as missing-ref detection), so an empty set is not read as “no permissions” when the account may be missing or unobservable.
> 
> **`discover_metrics`** schema text now states there is **no `namespace` argument** and namespace must be scoped in the PromQL selector. **`get_subject_permissions`** `kind` jsonschema documents the shorthand spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cace5b92f8222aa443e75f377252f78489faf1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->