### PR TITLE
Add Helm distribution badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Topology, resources, Helm, GitOps, traffic, audit, upgrade impact, and MCP conte
 [![CodeQL](https://github.com/skyhook-io/radar/actions/workflows/codeql.yml/badge.svg)](https://github.com/skyhook-io/radar/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/release/skyhook-io/radar?logo=github)](https://github.com/skyhook-io/radar/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/skyhook-io/radar/total?logo=github)](https://github.com/skyhook-io/radar/releases)
+[![Helm repo downloads](https://img.shields.io/github/downloads/skyhook-io/helm-charts/total?logo=helm&label=Helm%20repo%20downloads)](https://artifacthub.io/packages/helm/skyhook/radar)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://radarhq.io/community/chat)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/)


### PR DESCRIPTION
## Summary

Surface Radar's in-cluster distribution alongside binary releases so readers can see Helm repository reach and open the Artifact Hub listing directly.

## What changed

- Add a Helm repository download badge to the main README badge row, linked to Radar's Artifact Hub page.

## Testing

- git diff --check
- Badge and destination URL smoke checks returned HTTP 200.
- Visual test skipped because this is a README-only change.