### PR TITLE
docs: drop internal ticket IDs from test comments

### DIFF
--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -45,8 +45,8 @@ func findIssue(t *testing.T, issues []Issue, reason string) Issue {
 	return Issue{}
 }
 
-// The whole point of RAD-318: a cluster whose pods are all Ready but whose
-// phase says it is unrecoverable must not read as fine.
+// A cluster whose pods are all Ready but whose phase says it is unrecoverable
+// must not read as fine.
 func TestCNPGTerminalPhasesAreCriticalDespiteReadyInstances(t *testing.T) {
 	cases := []struct {
 		phase      string

--- a/internal/issues/source_velero_test.go
+++ b/internal/issues/source_velero_test.go
@@ -115,10 +115,10 @@ func namesOf(issues []Issue) []string {
 	return out
 }
 
-// The whole point of RAD-314: every terminal Backup phase Velero can report
-// must produce an Issue with the right severity, and no phase may fall through
-// to silence. FailedValidation is the one that used to render as a grey
-// "Unknown" pill and produced nothing at all.
+// Every terminal Backup phase Velero can report must produce an Issue with the
+// right severity, and no phase may fall through to silence. FailedValidation is
+// the one that used to render as a grey "Unknown" pill and produced nothing at
+// all.
 func TestVeleroBackupPhaseToIssue(t *testing.T) {
 	cases := []struct {
 		phase        string


### PR DESCRIPTION
Two code comments reference Linear IDs. The repo is public, an outside reader cannot resolve them, and CLAUDE.md already rules this out: *"Don't reference tickets, PRs, bug numbers, or diff history... Those belong in the PR description and rot as the codebase evolves."*

```
internal/issues/source_velero_test.go:118  // The whole point of RAD-314: …
internal/issues/source_cnpg_test.go:48     // The whole point of RAD-318: …
```

These are the **only** two occurrences in the tree, and both landed this week — same sentence pattern, written independently, both through review.

**Neither comment loses anything.** The clause after the colon was already doing the explaining; the ID was decoration:

> ~~The whole point of RAD-314:~~ every terminal Backup phase Velero can report must produce an Issue with the right severity…

## Testing

`git grep -E "\b(SKY|RAD|LIN)-[0-9]+"` over tracked files: **zero hits** after, two before. `go test ./internal/issues/...` passes, `gofmt` clean. Comment-only change — no code touched.

One note on how the count was verified, since it tripped someone already: `git grep` in a working tree reports on *that* tree, including anyone's uncommitted changes. Both greps above were run against the `origin/main` ref and against a worktree branched from it, not against a checkout carrying staged work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment edits with no runtime or test logic changes.
> 
> **Overview**
> **Comment-only cleanup** in `internal/issues` tests so public readers are not pointed at unresolvable internal ticket IDs.
> 
> In **`source_cnpg_test.go`** and **`source_velero_test.go`**, the leading *"The whole point of RAD-318/RAD-314:"* clauses are removed. The behavioral intent of each test is unchanged—the comments still explain why the cases matter (CNPG terminal phases vs ready instances; Velero backup phases including `FailedValidation`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe61ff4bd342adcf4be11b79c923251005295f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->