### PR TITLE
fix: don't call SwitchContext during in-cluster reconnect

### DIFF
--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -420,18 +420,24 @@ func performContextSwitch(newContext string, observedOperationGen uint64, requir
 	ResetAllSubsystems()
 	logTiming("   [ops] ResetAllSubsystems: %v", time.Since(t))
 
-	// Step 2: Switch the K8s client to the new context
+	// Step 2: Switch the K8s client to the new context. In-cluster mode has a
+	// single fixed context (context switching is disabled there, per
+	// docs/configuration.md), so /connection/retry's reconnect-to-current-context
+	// would otherwise always fail here on SwitchContext's own in-cluster guard —
+	// skip straight to the connectivity test + reinit below.
 	reportProgress("Connecting to cluster...")
 	t = time.Now()
-	log.Printf("Switching K8s client to context %q...", newContext)
-	if err := SwitchContext(newContext); err != nil {
-		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
-		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v since switch start)", err, elapsed)
-		errorlog.Record("context-switch", "error",
-			"stage=SwitchContext target=%q elapsed=%v: %v", newContext, elapsed, err)
-		return fmt.Errorf("failed to switch context: %w", err)
+	if !IsInCluster() {
+		log.Printf("Switching K8s client to context %q...", newContext)
+		if err := SwitchContext(newContext); err != nil {
+			elapsed := time.Since(switchStart).Truncate(time.Millisecond)
+			log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v since switch start)", err, elapsed)
+			errorlog.Record("context-switch", "error",
+				"stage=SwitchContext target=%q elapsed=%v: %v", newContext, elapsed, err)
+			return fmt.Errorf("failed to switch context: %w", err)
+		}
+		logTiming("   [ops] SwitchContext: %v", time.Since(t))
 	}
-	logTiming("   [ops] SwitchContext: %v", time.Since(t))
 	ClearNamespaceScopeOverride()
 	RestoreNamespaceScopePreference(GetContextName())
 	if err := requireNamespaceScopeTarget(newContext); err != nil {


### PR DESCRIPTION
## Summary
- `PerformContextSwitch` always calls `SwitchContext`, which hard-rejects any call while running in-cluster (context switching is disabled there by design, per `docs/configuration.md`).
- `/connection/retry` calls `PerformContextSwitch(currentContext)` to reconnect after a transient disconnect — in-cluster, that path could never succeed: it always failed on "cannot switch context when running in-cluster" and surfaced the generic connection-failed screen with a misleading raw error, instead of actually retrying.
- In-cluster mode has one fixed context, so there's nothing to switch — skip `SwitchContext` and go straight to the connectivity test + subsystem reinit when `IsInCluster()`.

Found live on an in-cluster Radar deployment: backend logs showed a repeating retry loop of `Context switch FAILED at SwitchContext: cannot switch context when running in-cluster`, while direct API calls (`GET /api/contexts`) kept returning 200 — the underlying k8s connectivity was fine, only the reconnect path was structurally broken.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/k8s/...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared context-switch/reconnect path after subsystem teardown; wrong branching could skip a needed kubeconfig switch or leave reconnect behavior inconsistent between modes.
> 
> **Overview**
> **`PerformContextSwitch`** no longer calls **`SwitchContext`** when **`IsInCluster()`** is true. In-cluster Radar has a single fixed context, so reconnect (e.g. **`/connection/retry`** calling **`PerformContextSwitch`** with the current context) can proceed to the connectivity test and subsystem reinit instead of failing with *cannot switch context when running in-cluster*.
> 
> Out-of-cluster behavior is unchanged: **`SwitchContext`** still runs with the same error handling and timing logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743d13367738e9c193787b6bcbcfa21458216b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->