### PR TITLE
Increase Cloud button rollout to 30%

### DIFF
--- a/internal/server/cloud_funnel_rollout.go
+++ b/internal/server/cloud_funnel_rollout.go
@@ -22,7 +22,7 @@ import (
 // anyone already inside a lower percentage stays inside a higher one. Older
 // releases keep whatever value they were built with, so during a ramp the fleet
 // runs several percentages at once.
-const cloudFunnelRolloutPercent = 20
+const cloudFunnelRolloutPercent = 30
 
 // cloudFunnelInCohort decides whether this installation sees the Cloud
 // funnel during the staged rollout. RADAR_CLOUD_FUNNEL=on|off overrides in


### PR DESCRIPTION
## Summary

Expand the staged Cloud button rollout from 20% to 30% of eligible Radar installations, increasing exposure while preserving the existing cohort.

## What changed

- Raised the compiled Cloud funnel rollout percentage to 30%.
- Existing bucket assignments remain stable, so all previously eligible installations continue to see the button.

## Testing

- `go test ./internal/server -run "TestCloudFunnel|TestBucket" -count=1`
- Visual testing skipped: this changes cohort eligibility only, with no UI or styling changes.