### PR TITLE
fix(crossplane): show composed resources for v1 claims via bound XR

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { CompositeRenderer } from './CompositeRenderer'
+import type { CrossplaneResourceRef } from '../resource-utils-crossplane'
+
+const claim = {
+  apiVersion: 'platform.example.org/v1alpha1',
+  kind: 'DatabaseClaim',
+  metadata: { name: 'example-database', namespace: 'demo-app' },
+  spec: {
+    compositionRef: { name: 'database' },
+    resourceRef: {
+      apiVersion: 'platform.example.org/v1alpha1',
+      kind: 'Database',
+      name: 'example-database-x7k2m',
+    },
+  },
+}
+
+const composed: CrossplaneResourceRef[] = [
+  { apiVersion: 'database.example.org/v1beta1', kind: 'Instance', name: 'example-database-instance' },
+  { apiVersion: 'identity.example.org/v1beta1', kind: 'Role', name: 'example-database-access' },
+  { apiVersion: 'kubernetes.crossplane.io/v1alpha2', kind: 'Object', name: 'example-database-connection' },
+]
+
+const html = (props: any) => renderToString(<CompositeRenderer {...props} />)
+
+describe('CompositeRenderer — claim composed-resources panel (issue coverage)', () => {
+  it('lists composed resources resolved from the bound XR (the fix)', () => {
+    const out = html({ data: claim, composedRefs: composed })
+    expect(out).toContain('Composed Resources (3)')
+    for (const ref of composed) {
+      expect(out).toContain(ref.name)
+    }
+    expect(out).not.toContain('No composed resources yet')
+    // claim identity section + the bound-XR link
+    expect(out).toContain('Claim')
+    expect(out).toContain('Bound Composite')
+    expect(out).toContain('example-database-x7k2m')
+  })
+
+  it('shows a loading state while the bound XR is being fetched — not "none"', () => {
+    const out = html({ data: claim, composedRefs: [], boundXRStatus: { loading: true } })
+    expect(out).toContain('Loading composed resources')
+    expect(out).not.toContain('No composed resources yet')
+  })
+
+  it('distinguishes a not-found / unreadable bound XR from genuinely-none', () => {
+    const out = html({ data: claim, composedRefs: [], boundXRStatus: { missing: true } })
+    expect(out).toContain('was not found')
+    expect(out).not.toContain('No composed resources yet')
+  })
+
+  it('surfaces a bound-XR read error (RBAC/500) distinctly, with the message', () => {
+    const out = html({
+      data: claim,
+      composedRefs: [],
+      boundXRStatus: { error: true, errorMessage: 'forbidden: cannot get databases' },
+    })
+    expect(out).toContain('read the bound composite') // apostrophe is HTML-escaped in SSR output
+    expect(out).toContain('forbidden: cannot get databases')
+    expect(out).not.toContain('No composed resources yet')
+  })
+
+  it('falls back to the genuine empty state for a claim whose XR simply has none yet', () => {
+    const out = html({ data: claim, composedRefs: [] })
+    expect(out).toContain('No composed resources yet')
+  })
+
+  it('for an XR viewed directly (no bound-XR status), reads its own resourceRefs', () => {
+    const xr = {
+      apiVersion: 'platform.example.org/v1alpha1',
+      kind: 'Database',
+      metadata: { name: 'example-database-x7k2m' },
+      spec: { resourceRefs: composed },
+    }
+    const out = html({ data: xr })
+    expect(out).toContain('Composed Resources (3)')
+    expect(out).toContain('Composite Resource') // not "Claim"
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
@@ -247,7 +247,9 @@ function ComposedRefRow({
   return (
     <div className="flex items-center gap-2 py-1 px-2 rounded hover:bg-theme-hover text-sm">
       <Box className="w-3.5 h-3.5 text-theme-text-tertiary shrink-0" />
-      <span className="text-theme-text-tertiary font-mono shrink-0 w-32 truncate">{ref_.kind}</span>
+      {/* Kind is content-sized (capped) so the resource name — the field that
+          distinguishes rows — keeps the width instead of truncating. */}
+      <span className="text-theme-text-tertiary font-mono shrink-0 max-w-[8rem] truncate">{ref_.kind}</span>
       <span className="flex-1 min-w-0 truncate">
         <ResourceLink
           name={ref_.name}
@@ -258,7 +260,7 @@ function ComposedRefRow({
         />
       </span>
       {ref_.namespace && (
-        <span className="text-xs text-theme-text-tertiary truncate w-32 text-right">{ref_.namespace}</span>
+        <span className="text-xs text-theme-text-tertiary truncate max-w-[8rem] shrink-0 text-right">{ref_.namespace}</span>
       )}
       <StatusCellInline statusEntry={statusEntry} />
       <ChevronRight className="w-3.5 h-3.5 text-theme-text-tertiary shrink-0" />

--- a/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CompositeRenderer.tsx
@@ -52,6 +52,28 @@ interface CompositeRendererProps {
    * of an unrelated Bucket from another provider. Populated by the host
    * wrapper. When absent, the renderer shows refs without status badges. */
   composedRefStatuses?: Map<string, ComposedRefStatus>
+  /** Composed-resource refs resolved by the host. A v1 Claim carries only a
+   * singular spec.resourceRef to its bound XR — the composed refs live on that
+   * XR, not the claim — so the host follows the ref, fetches the XR, and passes
+   * its refs here. When omitted, refs are read off `data` directly (correct for
+   * an XR/Composite viewed on its own). */
+  composedRefs?: CrossplaneResourceRef[]
+  /** State of the host's fetch of the claim's bound XR. Set only for a v1 Claim.
+   * Without it, a claim whose XR is still loading or unreadable (404/RBAC) would
+   * fall into the empty branch and read "No composed resources yet" — which is
+   * indistinguishable from a claim that genuinely has none. */
+  boundXRStatus?: BoundXRStatus
+}
+
+/** Fetch state of a claim's bound XR, reported by the host wrapper. */
+export interface BoundXRStatus {
+  /** true while the XR fetch is in flight */
+  loading?: boolean
+  /** 404 — the referenced XR does not exist (dangling resourceRef) */
+  missing?: boolean
+  /** any non-404 failure (auth, network, server error); message in errorMessage */
+  error?: boolean
+  errorMessage?: string
 }
 
 function makeRefKey(ref: CrossplaneResourceRef): string {
@@ -67,13 +89,13 @@ function groupFromApiVersion(apiVersion: string | undefined): string {
   return slash < 0 ? '' : apiVersion.slice(0, slash)
 }
 
-export function CompositeRenderer({ data, onNavigate, composedRefStatuses }: CompositeRendererProps) {
+export function CompositeRenderer({ data, onNavigate, composedRefStatuses, composedRefs, boundXRStatus }: CompositeRendererProps) {
   const status = getCrossplaneStatus(data)
   const reason = getCrossplaneStatusReason(data)
   const compositionRef = getCompositionRef(data)
   const compositionRevisionRef = getCompositionRevisionRef(data)
   const compositionUpdatePolicy = getCompositionUpdatePolicy(data)
-  const resourceRefs = getCrossplaneResourceRefs(data)
+  const resourceRefs = composedRefs ?? getCrossplaneResourceRefs(data)
   const claim = isClaim(data)
   const boundXR = claim ? getBoundXRRef(data) : null
   const paused = isCrossplanePaused(data)
@@ -153,9 +175,7 @@ export function CompositeRenderer({ data, onNavigate, composedRefStatuses }: Com
         defaultExpanded
       >
         {resourceRefs.length === 0 ? (
-          <div className="text-sm text-theme-text-tertiary py-2">
-            No composed resources yet — the composition has not produced any managed resources.
-          </div>
+          <ComposedResourcesEmpty boundXRStatus={boundXRStatus} boundXRName={boundXR?.name} />
         ) : (
           <div className="space-y-1">
             {resourceRefs.map((ref) => (
@@ -172,6 +192,44 @@ export function CompositeRenderer({ data, onNavigate, composedRefStatuses }: Com
 
       <ConditionsSection conditions={data?.status?.conditions} />
     </>
+  )
+}
+
+function ComposedResourcesEmpty({
+  boundXRStatus,
+  boundXRName,
+}: {
+  boundXRStatus?: BoundXRStatus
+  boundXRName?: string
+}) {
+  if (boundXRStatus?.loading) {
+    return (
+      <div className="text-sm text-theme-text-tertiary py-2">
+        Loading composed resources from the bound composite…
+      </div>
+    )
+  }
+  if (boundXRStatus?.missing) {
+    const named = boundXRName ? ` (${boundXRName})` : ''
+    return (
+      <div className="text-sm text-theme-text-tertiary py-2">
+        The bound composite{named} referenced by this claim was not found — it may not have been
+        created yet, or you may not have permission to read it.
+      </div>
+    )
+  }
+  if (boundXRStatus?.error) {
+    const named = boundXRName ? ` (${boundXRName})` : ''
+    return (
+      <div className="text-sm status-unhealthy rounded px-2 py-2">
+        Couldn't read the bound composite{named}: {boundXRStatus.errorMessage || 'fetch failed'}
+      </div>
+    )
+  }
+  return (
+    <div className="text-sm text-theme-text-tertiary py-2">
+      No composed resources yet — the composition has not produced any managed resources.
+    </div>
   )
 }
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-crossplane.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-crossplane.test.ts
@@ -9,6 +9,7 @@ import {
   getProviderConfigStatus,
   getProviderConfigRef,
   getCrossplaneResourceRefs,
+  getBoundXRRef,
   getExternalName,
   getComposingXRRef,
   isCrossplanePaused,
@@ -509,6 +510,73 @@ describe('getCrossplaneResourceRefs', () => {
     expect(getCrossplaneResourceRefs({} as const)).toEqual([])
     expect(getCrossplaneResourceRefs({ spec: {} } as const)).toEqual([])
     expect(getCrossplaneResourceRefs({ spec: { resourceRefs: 'oops' } } as const)).toEqual([])
+  })
+})
+
+describe('getBoundXRRef', () => {
+  it('returns the singular spec.resourceRef of a v1 claim', () => {
+    const claim = {
+      spec: {
+        compositionRef: { name: 'database' },
+        resourceRef: {
+          apiVersion: 'platform.example.org/v1alpha1',
+          kind: 'Database',
+          name: 'example-database-x7k2m',
+        },
+      },
+    } as const
+    const ref = getBoundXRRef(claim)
+    expect(ref?.kind).toBe('Database')
+    expect(ref?.name).toBe('example-database-x7k2m')
+    expect(ref?.apiVersion).toBe('platform.example.org/v1alpha1')
+  })
+
+  it('returns null when resourceRef is absent or malformed', () => {
+    expect(getBoundXRRef({ spec: {} } as const)).toBeNull()
+    expect(getBoundXRRef({ spec: { resourceRef: { name: 'no-kind' } } } as const)).toBeNull()
+    expect(getBoundXRRef({ spec: { resourceRef: { kind: 'X' } } } as const)).toBeNull()
+    expect(getBoundXRRef({} as const)).toBeNull()
+  })
+})
+
+describe('claim vs XR composed-refs split', () => {
+  // A v1 claim carries NO resourceRefs of its own — only a singular resourceRef
+  // to its bound XR. The composed refs live on that XR. The claim panel must
+  // follow the ref rather than read the claim, or it shows "No composed
+  // resources" for a claim that has composed plenty.
+  const claim = {
+    spec: {
+      compositionRef: { name: 'database' },
+      resourceRef: {
+        apiVersion: 'platform.example.org/v1alpha1',
+        kind: 'Database',
+        name: 'example-database-x7k2m',
+      },
+    },
+  } as const
+  const boundXR = {
+    spec: {
+      resourceRefs: [
+        { apiVersion: 'database.example.org/v1beta1', kind: 'Instance', name: 'example-database-x7k2m' },
+        { apiVersion: 'identity.example.org/v1beta1', kind: 'Role', name: 'example-database-access' },
+        { apiVersion: 'kubernetes.crossplane.io/v1alpha2', kind: 'Object', name: 'example-database-connection' },
+      ],
+    },
+  } as const
+
+  it('reads nothing off the claim itself', () => {
+    expect(getCrossplaneResourceRefs(claim)).toEqual([])
+  })
+
+  it('is detected as a claim with a bound XR', () => {
+    expect(isClaim(claim)).toBe(true)
+    expect(getBoundXRRef(claim)?.name).toBe('example-database-x7k2m')
+  })
+
+  it('reads the composed refs off the bound XR', () => {
+    const refs = getCrossplaneResourceRefs(boundXR)
+    expect(refs).toHaveLength(3)
+    expect(refs.map(r => r.kind)).toEqual(['Instance', 'Role', 'Object'])
   })
 })
 

--- a/web/src/components/resources/CompositeRenderer.tsx
+++ b/web/src/components/resources/CompositeRenderer.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react'
-import { useQueries } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import {
   CompositeRenderer as BaseCompositeRenderer,
   type ComposedRefStatus,
+  type BoundXRStatus,
 } from '@skyhook-io/k8s-ui/components/resources/renderers/CompositeRenderer'
 import {
   getCrossplaneResourceRefs,
+  getBoundXRRef,
+  isClaim,
   type CrossplaneResourceRef,
 } from '@skyhook-io/k8s-ui/components/resources/resource-utils-crossplane'
 import { getResourceStatus } from '@skyhook-io/k8s-ui'
@@ -41,7 +44,53 @@ function groupFromApiVersion(apiVersion: string | undefined): string {
  * it yet) is a normal state for a freshly-applied Composite, not a failure.
  */
 export function CompositeRenderer({ data, onNavigate }: CompositeRendererProps) {
-  const refs = useMemo<CrossplaneResourceRef[]>(() => getCrossplaneResourceRefs(data), [data])
+  // A v1 Claim carries only a singular spec.resourceRef to its bound XR; the
+  // composed-resource refs live on that XR. Follow the ref, fetch the XR, and
+  // read its refs — otherwise the claim panel reads its own (absent) resourceRefs
+  // and shows "No composed resources" for a claim that has composed plenty.
+  const boundXRRef = useMemo(() => (isClaim(data) ? getBoundXRRef(data) : null), [data])
+  const boundXRQuery = useQuery({
+    queryKey: [
+      'bound-xr',
+      groupFromApiVersion(boundXRRef?.apiVersion),
+      boundXRRef?.kind ?? '',
+      boundXRRef?.namespace ?? '',
+      boundXRRef?.name ?? '',
+    ],
+    queryFn: async () => {
+      const ns = boundXRRef!.namespace || '_'
+      const plural = kindToPlural(boundXRRef!.kind)
+      const group = groupFromApiVersion(boundXRRef!.apiVersion)
+      const query = group ? `?group=${encodeURIComponent(group)}` : ''
+      return fetchJSON<{ resource: any }>(`/resources/${plural}/${ns}/${boundXRRef!.name}${query}`)
+    },
+    staleTime: 30000,
+    retry: false,
+    enabled: Boolean(boundXRRef?.kind && boundXRRef?.name),
+  })
+
+  const refs = useMemo<CrossplaneResourceRef[]>(() => {
+    // For a claim, refs come from the bound XR once it's fetched; for an XR/MR
+    // viewed directly, they're on `data` itself.
+    if (boundXRRef) return getCrossplaneResourceRefs(boundXRQuery.data?.resource)
+    return getCrossplaneResourceRefs(data)
+  }, [boundXRRef, boundXRQuery.data, data])
+
+  // Surface the bound-XR fetch state so the empty composed-resources branch can
+  // tell "XR still loading / unreadable" apart from "claim genuinely has none".
+  const boundXRStatus = useMemo<BoundXRStatus | undefined>(() => {
+    if (!boundXRRef) return undefined
+    if (boundXRQuery.isLoading) return { loading: true }
+    if (boundXRQuery.isError) {
+      if (boundXRQuery.error instanceof ApiError && boundXRQuery.error.status === 404) {
+        return { missing: true }
+      }
+      const message =
+        boundXRQuery.error instanceof Error ? boundXRQuery.error.message : 'Failed to fetch bound composite'
+      return { error: true, errorMessage: message }
+    }
+    return undefined
+  }, [boundXRRef, boundXRQuery.isLoading, boundXRQuery.isError, boundXRQuery.error])
 
   const queries = useQueries({
     queries: refs.map(ref => {
@@ -97,5 +146,13 @@ export function CompositeRenderer({ data, onNavigate }: CompositeRendererProps) 
     return map
   }, [refs, queries])
 
-  return <BaseCompositeRenderer data={data} onNavigate={onNavigate} composedRefStatuses={composedRefStatuses} />
+  return (
+    <BaseCompositeRenderer
+      data={data}
+      onNavigate={onNavigate}
+      composedRefStatuses={composedRefStatuses}
+      composedRefs={refs}
+      boundXRStatus={boundXRStatus}
+    />
+  )
 }


### PR DESCRIPTION
## Problem

Fixes #1219. In the GitOps / resource view, opening the side panel for a Crossplane **v1 Claim** always showed:

> No composed resources yet — the composition has not produced any managed resources.

even when the composition had produced resources.

A v1 Claim carries only a singular `spec.resourceRef` pointing at its bound composite (XR). The composed-resource references (`spec.resourceRefs`) live on that **XR**, not on the claim. The panel read `resourceRefs` off the claim itself, so the list was always empty for claims.

## Fix

The host `CompositeRenderer` now, when the resource is a claim, follows `spec.resourceRef`, fetches the bound XR via the existing `/resources/...` endpoint, and derives the composed-resource list (and per-row status) from the XR.

The pure package renderer gains:
- `composedRefs` — resolved refs from the host (falls back to reading `data` directly for an XR viewed on its own, so non-claim behavior is unchanged).
- `boundXRStatus` — so the empty state distinguishes **XR still loading** and **XR not found / unreadable (RBAC/404)** from a claim that genuinely has no composed resources, instead of collapsing all three into the same misleading message.

Non-claim XR/Composite rendering is unchanged.

## Testing

- Unit: added coverage for `getBoundXRRef` and the claim-vs-XR ref split in `resource-utils-crossplane.test.ts`.
- `tsc` clean; full k8s-ui + web unit suites pass.
- Verified live on a kind cluster with a healthy Crossplane v1 claim → bound XR → 3 composed resources: the panel now lists the composed resources with live status badges. Before: "No composed resources yet"; after: "Composed Resources (3)".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only GitOps/Crossplane detail panel behavior with an extra read per claim view; no auth or data-model changes beyond existing `/resources` fetches.
> 
> **Overview**
> Fixes Crossplane **v1 Claim** side panels that always showed “No composed resources yet” even when the bound composite had managed resources. Claims only expose `spec.resourceRef` to the XR; composed refs live on the XR’s `spec.resourceRefs`.
> 
> The **web** `CompositeRenderer` wrapper now fetches the bound XR for claims, passes resolved `composedRefs` into the package renderer, and maps fetch state to `boundXRStatus` (loading, 404 missing, or RBAC/other errors). The **k8s-ui** renderer accepts those props, uses `composedRefs ?? getCrossplaneResourceRefs(data)` so direct XR views are unchanged, and replaces the single empty message with **`ComposedResourcesEmpty`** states that distinguish loading, missing/unreadable XR, and genuinely empty compositions.
> 
> Adds tests for `getBoundXRRef`, claim-vs-XR ref behavior, and SSR coverage for the composed-resources panel. Minor layout tweak: composed-resource row kind/namespace columns use `max-w-[8rem]` so names truncate less aggressively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa45c77a6a386733eba2f884fbdcef5f6a6aa39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->