### PR TITLE
test(crossplane-demo): cover v1 claim + v2 namespaced XR on Crossplane 2.x

### DIFF
--- a/scripts/crossplane-demo.sh
+++ b/scripts/crossplane-demo.sh
@@ -18,11 +18,13 @@
 #
 # Set CLUSTER_NAME=foo to use a different cluster (default: radar-crossplane-demo).
 #
-# NOTE: Crossplane v2 cluster-scoped XR composition is broken in 2.2.1 — XR
-# instances created from cluster-scoped XRDs that compose provider-kubernetes
-# Objects do not reconcile and stay Synced=False. We keep them in the fixture
-# set on purpose: they exercise the unhealthy/stuck XR rendering path and the
-# crossplaneStuck audit check. See README for details.
+# Fixtures cover both Crossplane API models on a single cluster:
+#   - v1 Claim -> bound XR -> composed resources (the v1 claim/XR/MR flow), via
+#     an apiextensions.crossplane.io/v1 XRD with claimNames.
+#   - v2 namespaced XR -> composed resources, via an apiextensions.crossplane.io/v2
+#     XRD with scope: Namespaced composing namespaced provider-kubernetes Objects.
+# Both reconcile healthy. See README for the coverage matrix and the version
+# constraints that make this work.
 
 set -euo pipefail
 
@@ -31,8 +33,11 @@ KUBECTL_CTX="kind-${CLUSTER_NAME}"
 
 # Versions pinned so the demo behaves consistently across runs. Bump when
 # you want a newer release; otherwise leave alone.
-CROSSPLANE_CHART_VERSION="${CROSSPLANE_CHART_VERSION:-1.17.3}"
-PROVIDER_KUBERNETES_VERSION="${PROVIDER_KUBERNETES_VERSION:-v0.18.0}"
+# provider-kubernetes must be v1.0.0+ — it is the first release to ship the
+# namespaced Object (kubernetes.m.crossplane.io), which a v2 Namespaced XR
+# needs to compose (a namespaced XR cannot compose cluster-scoped resources).
+CROSSPLANE_CHART_VERSION="${CROSSPLANE_CHART_VERSION:-2.3.4}"
+PROVIDER_KUBERNETES_VERSION="${PROVIDER_KUBERNETES_VERSION:-v1.0.0}"
 FUNCTION_PATCH_VERSION="${FUNCTION_PATCH_VERSION:-v0.9.0}"
 
 # Pretty colors for status output. Quietly turn off in non-interactive env.
@@ -85,9 +90,9 @@ cmd_up() {
   install_function_patch_and_transform
   apply_provider_config
   apply_standalone_managed_resources
-  apply_xrd_and_composition
-  apply_xr_instances
-  wait_briefly_for_reconcile
+  apply_v1_claim_fixture
+  apply_v2_namespaced_fixture
+  wait_for_chains_healthy
   print_summary
 }
 
@@ -302,27 +307,29 @@ EOF
   ok "Standalone MRs applied (Object/standalone-configmap, Object/standalone-namespace)"
 }
 
-# --- XRD + Composition ----------------------------------------------------
+# --- v1 Claim fixture (v1 Claim -> bound XR -> composed resources) ---------
 
-# XRD: AppBundle (cluster-scoped) — apiextensions.crossplane.io/v2
-# Composition wiring AppBundle → function-patch-and-transform with two
-# composed resources (a ConfigMap and a Service via provider-kubernetes
-# Objects). The patches use FromCompositeFieldPath with string.type: Format
-# transforms so the composed names + labels derive from the XR's spec.
-apply_xrd_and_composition() {
-  step "Applying XRD (AppBundle) + Composition"
+# An apiextensions.crossplane.io/v1 XRD with claimNames gives the classic v1
+# flow: a namespaced Claim (DatabaseClaim) bound to a cluster-scoped XR
+# (XDatabase) that composes three cluster-scoped provider-kubernetes Objects.
+# The v1 XRD API is deprecated on Crossplane 2.x but still served — it is the
+# only way to get Claims, which v2 XRDs (scope: Namespaced|Cluster) do not offer.
+apply_v1_claim_fixture() {
+  step "Applying v1 Claim fixture (XRD + Composition)"
 
   cat <<'EOF' | kctl apply -f - >/dev/null
-apiVersion: apiextensions.crossplane.io/v2
+apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: appbundles.demo.example.io
+  name: xdatabases.demo.example.io
 spec:
-  scope: Cluster
   group: demo.example.io
   names:
-    kind: AppBundle
-    plural: appbundles
+    kind: XDatabase
+    plural: xdatabases
+  claimNames:
+    kind: DatabaseClaim
+    plural: databaseclaims
   versions:
     - name: v1alpha1
       served: true
@@ -336,31 +343,24 @@ spec:
               properties:
                 appName:
                   type: string
-                  description: Name used for the composed ConfigMap and Service.
+                  description: Name used for the composed resources.
                 namespace:
                   type: string
                   default: default
-                  description: Namespace into which the composed resources are written.
+                  description: Namespace the composed resources are written into.
               required:
                 - appName
-            status:
-              type: object
-              properties:
-                composedConfigMap:
-                  type: string
-                composedService:
-                  type: string
 EOF
 
   cat <<'EOF' | kctl apply -f - >/dev/null
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: appbundles.demo.example.io
+  name: xdatabases.demo.example.io
 spec:
   compositeTypeRef:
     apiVersion: demo.example.io/v1alpha1
-    kind: AppBundle
+    kind: XDatabase
   mode: Pipeline
   pipeline:
     - step: patch-and-transform
@@ -372,7 +372,7 @@ spec:
         resources:
           - name: configmap
             base:
-              apiVersion: kubernetes.crossplane.io/v1alpha1
+              apiVersion: kubernetes.crossplane.io/v1alpha2
               kind: Object
               spec:
                 providerConfigRef:
@@ -387,28 +387,12 @@ spec:
                     data:
                       managed-by: crossplane-composition
             patches:
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.appName
-                toFieldPath: spec.forProvider.manifest.metadata.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-config"
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.namespace
-                toFieldPath: spec.forProvider.manifest.metadata.namespace
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.appName
-                toFieldPath: metadata.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-configmap"
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-config" } }] }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-configmap" } }] }
           - name: service
             base:
-              apiVersion: kubernetes.crossplane.io/v1alpha1
+              apiVersion: kubernetes.crossplane.io/v1alpha2
               kind: Object
               spec:
                 providerConfigRef:
@@ -427,82 +411,236 @@ spec:
                         - port: 80
                           targetPort: 8080
             patches:
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.appName
-                toFieldPath: spec.forProvider.manifest.metadata.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-svc"
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.namespace
-                toFieldPath: spec.forProvider.manifest.metadata.namespace
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.appName
-                toFieldPath: spec.forProvider.manifest.spec.selector.app
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.appName
-                toFieldPath: metadata.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-service"
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-svc" } }] }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.spec.selector.app }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-service" } }] }
+          - name: secret
+            base:
+              apiVersion: kubernetes.crossplane.io/v1alpha2
+              kind: Object
+              spec:
+                providerConfigRef:
+                  name: default
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: Secret
+                    metadata:
+                      name: placeholder
+                      namespace: placeholder
+                    stringData:
+                      managed-by: crossplane-composition
+            patches:
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-conn" } }] }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-connection" } }] }
 EOF
 
-  ok "XRD + Composition applied"
+  wait_for_established xrd xdatabases.demo.example.io
+  wait_for_crd databaseclaims.demo.example.io
+
+  kctl apply -f - >/dev/null <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-app
+---
+apiVersion: demo.example.io/v1alpha1
+kind: DatabaseClaim
+metadata:
+  name: example-database
+  namespace: demo-app
+spec:
+  appName: example-database
+  namespace: demo-app
+EOF
+
+  ok "v1 Claim applied (DatabaseClaim/example-database in demo-app)"
 }
 
-# --- XR Instances ----------------------------------------------------------
+# --- v2 namespaced XR fixture (namespaced XR -> composed resources) --------
 
-apply_xr_instances() {
-  step "Applying AppBundle XR instances (hello-world, greeter)"
+# An apiextensions.crossplane.io/v2 XRD with scope: Namespaced gives the v2
+# flow: a namespaced XR (AppStack) composing namespaced provider-kubernetes
+# Objects (kubernetes.m.crossplane.io). A namespaced XR cannot compose
+# cluster-scoped resources, so this uses the namespaced Object variant and a
+# namespaced ProviderConfig in the XR's namespace.
+apply_v2_namespaced_fixture() {
+  step "Applying v2 namespaced XR fixture (XRD + Composition + ProviderConfig)"
 
-  # Wait for the XRD to be Established before creating XR instances so the
-  # apiserver has registered the CRD endpoint. Without this, the first
-  # `kubectl apply` of the XR can race the XRD reconciler and fail with
-  # "no matches for kind AppBundle".
-  local deadline=$((SECONDS + 60))
+  cat <<'EOF' | kctl apply -f - >/dev/null
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: appstacks.demo.example.io
+spec:
+  scope: Namespaced
+  group: demo.example.io
+  names:
+    kind: AppStack
+    plural: appstacks
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                appName:
+                  type: string
+                  description: Name used for the composed resources.
+              required:
+                - appName
+EOF
+
+  cat <<'EOF' | kctl apply -f - >/dev/null
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: appstacks.demo.example.io
+spec:
+  compositeTypeRef:
+    apiVersion: demo.example.io/v1alpha1
+    kind: AppStack
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: configmap
+            base:
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              spec:
+                providerConfigRef:
+                  name: default
+                  kind: ProviderConfig
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: ConfigMap
+                    metadata:
+                      name: placeholder
+                    data:
+                      managed-by: crossplane-composition
+            patches:
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-config" } }] }
+              - { type: FromCompositeFieldPath, fromFieldPath: metadata.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-configmap" } }] }
+          - name: service
+            base:
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              spec:
+                providerConfigRef:
+                  name: default
+                  kind: ProviderConfig
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: Service
+                    metadata:
+                      name: placeholder
+                    spec:
+                      selector:
+                        app: placeholder
+                      ports:
+                        - port: 80
+                          targetPort: 8080
+            patches:
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-svc" } }] }
+              - { type: FromCompositeFieldPath, fromFieldPath: metadata.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.spec.selector.app }
+              - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-service" } }] }
+EOF
+
+  wait_for_established xrd appstacks.demo.example.io
+  wait_for_crd appstacks.demo.example.io
+
+  # Namespaced ProviderConfig lives in the XR's namespace; the namespaced
+  # Object references it by name within that namespace.
+  kctl apply -f - >/dev/null <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: v2-app
+---
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+  namespace: v2-app
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+apiVersion: demo.example.io/v1alpha1
+kind: AppStack
+metadata:
+  name: web-stack
+  namespace: v2-app
+spec:
+  appName: web-stack
+EOF
+
+  ok "v2 namespaced XR applied (AppStack/web-stack in v2-app)"
+}
+
+# wait_for_established blocks until an XRD reports Established=True so the
+# apiserver has registered the generated CRD endpoints before we create an
+# instance — otherwise the first apply races the XRD reconciler and fails
+# with "no matches for kind".
+wait_for_established() {
+  local kind="$1" name="$2" deadline=$((SECONDS + 90))
   while [ $SECONDS -lt $deadline ]; do
-    if kctl get xrd appbundles.demo.example.io \
+    if kctl get "$kind" "$name" \
          -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' 2>/dev/null \
          | grep -q "True"; then
-      break
+      return 0
     fi
     sleep 2
   done
-
-  cat <<'EOF' | kctl apply -f - >/dev/null
-apiVersion: demo.example.io/v1alpha1
-kind: AppBundle
-metadata:
-  name: hello-world
-spec:
-  appName: hello-world
-  namespace: default
----
-apiVersion: demo.example.io/v1alpha1
-kind: AppBundle
-metadata:
-  name: greeter
-spec:
-  appName: greeter
-  namespace: default
-EOF
-
-  ok "XR instances applied (will stay Synced=False — see README, this is intentional)"
+  warn "$kind/$name did not report Established=True within 90s"
 }
 
-# wait_briefly_for_reconcile gives the controllers a few seconds to roll
-# through status updates so the summary table has populated fields rather
-# than empty cells. Not gated on Synced=True because the XRs are expected
-# to stay Synced=False (Crossplane v2 cluster-scoped XR limitation).
-wait_briefly_for_reconcile() {
-  step "Waiting briefly for reconcile loops to populate status (~10s)"
-  sleep 10
-  ok "done"
+wait_for_crd() {
+  local name="$1" deadline=$((SECONDS + 90))
+  while [ $SECONDS -lt $deadline ]; do
+    kctl get crd "$name" >/dev/null 2>&1 && return 0
+    sleep 2
+  done
+  warn "CRD $name did not register within 90s"
 }
+
+# wait_for_chains_healthy gates on the claim and the namespaced XR reaching
+# Ready=True so the summary reflects real reconciled state. Warns rather than
+# fails on timeout — a slow first image pull shouldn't abort the whole demo.
+wait_for_chains_healthy() {
+  step "Waiting for composed resources to reconcile (up to 4m)"
+  local deadline=$((SECONDS + 240)) claim_ready="" xr_ready=""
+  while [ $SECONDS -lt $deadline ]; do
+    claim_ready=$(kctl -n demo-app get databaseclaim example-database \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+    xr_ready=$(kctl -n v2-app get appstack web-stack \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+    if [ "$claim_ready" = "True" ] && [ "$xr_ready" = "True" ]; then
+      ok "v1 claim and v2 XR both Ready"
+      return 0
+    fi
+    sleep 5
+  done
+  warn "chains not fully Ready within 3m (claim Ready=${claim_ready:-?}, XR Ready=${xr_ready:-?}); check '$0 status'"
+}
+
 
 # --- Status ----------------------------------------------------------------
 
@@ -544,13 +682,23 @@ cmd_status() {
   kctl get compositionrevisions --no-headers 2>/dev/null \
     | awk '{ printf "    %s revision=%s\n", $1, $2 }' || note "(none)"
 
-  printf "\n${C_BLUE}AppBundle XRs${C_RESET}\n"
-  kctl get appbundles.demo.example.io --no-headers 2>/dev/null \
+  printf "\n${C_BLUE}v1 Claim (demo-app)${C_RESET}\n"
+  kctl -n demo-app get databaseclaims.demo.example.io --no-headers 2>/dev/null \
     | awk '{ printf "    %s synced=%s ready=%s\n", $1, $2, $3 }' || note "(none)"
 
-  printf "\n${C_BLUE}Managed Resources (Object/kubernetes.crossplane.io)${C_RESET}\n"
+  printf "\n${C_BLUE}Composites (XRs)${C_RESET}\n"
+  kctl get xdatabases.demo.example.io --no-headers 2>/dev/null \
+    | awk '{ printf "    XDatabase/%s synced=%s ready=%s\n", $1, $2, $3 }' || note "(none)"
+  kctl get appstacks.demo.example.io -A --no-headers 2>/dev/null \
+    | awk '{ printf "    AppStack/%s (ns %s) synced=%s ready=%s\n", $2, $1, $3, $4 }' || note "(none)"
+
+  printf "\n${C_BLUE}Managed Resources — cluster-scoped (kubernetes.crossplane.io)${C_RESET}\n"
   kctl get objects.kubernetes.crossplane.io --no-headers 2>/dev/null \
     | awk '{ printf "    %s synced=%s ready=%s\n", $1, $2, $3 }' || note "(none)"
+
+  printf "\n${C_BLUE}Managed Resources — namespaced (kubernetes.m.crossplane.io)${C_RESET}\n"
+  kctl get objects.kubernetes.m.crossplane.io -A --no-headers 2>/dev/null \
+    | awk '{ printf "    %s/%s synced=%s ready=%s\n", $1, $2, $3, $4 }' || note "(none)"
 
   printf "\n"
 }
@@ -570,12 +718,10 @@ print_summary() {
     Functions          — function-patch-and-transform (${FUNCTION_PATCH_VERSION}), Healthy
     ProviderConfig     — kubernetes.crossplane.io/default (InjectedIdentity)
     Standalone MRs     — Object/standalone-configmap, Object/standalone-namespace
-    XRD                — appbundles.demo.example.io (cluster-scoped, v2)
-    Composition        — appbundles.demo.example.io (Pipeline mode)
-    XR instances       — AppBundle/hello-world, AppBundle/greeter
-                         (intentionally Synced=False — Crossplane v2 cluster-scoped
-                          XR + provider-kubernetes Object composition is broken in
-                          2.2.x; useful for testing the unhealthy XR + audit paths)
+    v1 Claim chain     — DatabaseClaim/example-database (demo-app) -> bound XR
+                         XDatabase -> 3 composed cluster-scoped Objects (Ready)
+    v2 namespaced XR   — AppStack/web-stack (v2-app) -> 2 composed namespaced
+                         Objects (kubernetes.m.crossplane.io) (Ready)
 
   Run Radar against this cluster:
     kubectl config use-context ${KUBECTL_CTX}

--- a/scripts/crossplane-demo.sh
+++ b/scripts/crossplane-demo.sh
@@ -89,6 +89,7 @@ cmd_up() {
   grant_provider_cluster_admin
   install_function_patch_and_transform
   apply_provider_config
+  cleanup_legacy_fixtures
   apply_standalone_managed_resources
   apply_v1_claim_fixture
   apply_v2_namespaced_fixture
@@ -307,6 +308,19 @@ EOF
   ok "Standalone MRs applied (Object/standalone-configmap, Object/standalone-namespace)"
 }
 
+# cleanup_legacy_fixtures removes the previous demo's AppBundle XRD/Composition
+# when `up` reuses an existing cluster. Deleting the XRD cascades its XR
+# instances, so stale broken AppBundle XRs don't contaminate the new fixture
+# set or the status/topology output. Best-effort and idempotent.
+cleanup_legacy_fixtures() {
+  if kctl get xrd appbundles.demo.example.io >/dev/null 2>&1; then
+    step "Removing legacy AppBundle fixtures from a previous demo"
+    kctl delete composition appbundles.demo.example.io --ignore-not-found >/dev/null 2>&1 || true
+    kctl delete xrd appbundles.demo.example.io --ignore-not-found >/dev/null 2>&1 || true
+    ok "Legacy AppBundle XRD/Composition removed"
+  fi
+}
+
 # --- v1 Claim fixture (v1 Claim -> bound XR -> composed resources) ---------
 
 # An apiextensions.crossplane.io/v1 XRD with claimNames gives the classic v1
@@ -429,8 +443,13 @@ spec:
                     metadata:
                       name: placeholder
                       namespace: placeholder
-                    stringData:
-                      managed-by: crossplane-composition
+                    type: Opaque
+                    # base64("crossplane-composition"). Using `data` (not
+                    # stringData) avoids provider-kubernetes SSA drift — the
+                    # apiserver never returns stringData, so an observe would
+                    # perpetually diff and re-apply.
+                    data:
+                      managed-by: Y3Jvc3NwbGFuZS1jb21wb3NpdGlvbg==
             patches:
               - { type: FromCompositeFieldPath, fromFieldPath: spec.appName, toFieldPath: spec.forProvider.manifest.metadata.name, transforms: [{ type: string, string: { type: Format, fmt: "%s-conn" } }] }
               - { type: FromCompositeFieldPath, fromFieldPath: spec.namespace, toFieldPath: spec.forProvider.manifest.metadata.namespace }
@@ -621,6 +640,10 @@ wait_for_crd() {
   warn "CRD $name did not register within 90s"
 }
 
+# CHAINS_READY_HINT reflects the real reconcile state in the final summary, so
+# the summary never claims "Ready" when the wait timed out.
+CHAINS_READY_HINT="not checked"
+
 # wait_for_chains_healthy gates on the claim and the namespaced XR reaching
 # Ready=True so the summary reflects real reconciled state. Warns rather than
 # fails on timeout — a slow first image pull shouldn't abort the whole demo.
@@ -634,11 +657,13 @@ wait_for_chains_healthy() {
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
     if [ "$claim_ready" = "True" ] && [ "$xr_ready" = "True" ]; then
       ok "v1 claim and v2 XR both Ready"
+      CHAINS_READY_HINT="all Ready"
       return 0
     fi
     sleep 5
   done
-  warn "chains not fully Ready within 3m (claim Ready=${claim_ready:-?}, XR Ready=${xr_ready:-?}); check '$0 status'"
+  CHAINS_READY_HINT="NOT all Ready yet (claim Ready=${claim_ready:-?}, XR Ready=${xr_ready:-?}) — run '$0 status'"
+  warn "chains not fully Ready within 4m (claim Ready=${claim_ready:-?}, XR Ready=${xr_ready:-?}); check '$0 status'"
 }
 
 
@@ -719,9 +744,11 @@ print_summary() {
     ProviderConfig     — kubernetes.crossplane.io/default (InjectedIdentity)
     Standalone MRs     — Object/standalone-configmap, Object/standalone-namespace
     v1 Claim chain     — DatabaseClaim/example-database (demo-app) -> bound XR
-                         XDatabase -> 3 composed cluster-scoped Objects (Ready)
+                         XDatabase -> 3 composed cluster-scoped Objects
     v2 namespaced XR   — AppStack/web-stack (v2-app) -> 2 composed namespaced
-                         Objects (kubernetes.m.crossplane.io) (Ready)
+                         Objects (kubernetes.m.crossplane.io)
+
+  Live reconcile state (Ready/Synced): ${CHAINS_READY_HINT}
 
   Run Radar against this cluster:
     kubectl config use-context ${KUBECTL_CTX}

--- a/scripts/crossplane-demo/README.md
+++ b/scripts/crossplane-demo/README.md
@@ -4,8 +4,8 @@ Bootstraps a `kind` cluster with Crossplane installed (core + provider-kubernete
 function-patch-and-transform) and a curated set of Crossplane fixtures covering the
 resource kinds Radar's Crossplane UI needs to render. Use it for visual-testing
 changes to the Crossplane surfaces (resource list, MR/XR/Claim/Composition/XRD/Function
-renderers, composed-resources panel, audit `crossplaneStuck` check) without needing a
-real cluster running a cloud provider.
+renderers, composed-resources panel) without needing a real cluster running a cloud
+provider.
 
 Both Crossplane API models are exercised on the one cluster:
 

--- a/scripts/crossplane-demo/README.md
+++ b/scripts/crossplane-demo/README.md
@@ -3,15 +3,22 @@
 Bootstraps a `kind` cluster with Crossplane installed (core + provider-kubernetes +
 function-patch-and-transform) and a curated set of Crossplane fixtures covering the
 resource kinds Radar's Crossplane UI needs to render. Use it for visual-testing
-changes to the Crossplane surfaces (resource list, MR/XR/Composition/XRD/Function
-renderers, audit `crossplaneStuck` check) without needing a real cluster running a
-cloud provider.
+changes to the Crossplane surfaces (resource list, MR/XR/Claim/Composition/XRD/Function
+renderers, composed-resources panel, audit `crossplaneStuck` check) without needing a
+real cluster running a cloud provider.
+
+Both Crossplane API models are exercised on the one cluster:
+
+- **v1 Claim → bound XR → composed resources** (the v1 claim/XR/MR flow).
+- **v2 namespaced XR → composed resources** (the v2 `scope: Namespaced` flow).
+
+Both reconcile **healthy**.
 
 ## Quick start
 
 ```bash
 # Prerequisites: kind, kubectl, helm
-./scripts/crossplane-demo.sh up        # ~3-5 minutes on first run
+./scripts/crossplane-demo.sh up        # ~4-6 minutes on first run
 ./scripts/crossplane-demo.sh status    # inventory what's installed
 
 # Run Radar against it
@@ -38,93 +45,65 @@ make crossplane-demo-down       # = ./scripts/crossplane-demo.sh down
 | `provider-kubernetes` | `Provider` (pkg.crossplane.io/v1) | Provider list view + provider detail renderer + Healthy=True condition + revision tracking |
 | `function-patch-and-transform` | `Function` (pkg.crossplane.io/v1) | Function list view + function detail renderer (used inside Composition Pipeline) |
 | `default` | `ProviderConfig` (kubernetes.crossplane.io/v1alpha1) | ProviderConfig renderer + InjectedIdentity credential source path |
-| `appbundles.demo.example.io` | `CompositeResourceDefinition` (apiextensions.crossplane.io/v2) | XRD renderer + cluster-scoped XRD path + Established condition + offered/served version display |
-| `appbundles.demo.example.io` | `Composition` (apiextensions.crossplane.io/v1) | Composition renderer + Pipeline mode + function reference + composed resources list |
-| `appbundles.demo.example.io-<hash>` | `CompositionRevision` | CompositionRevision renderer + revision number + spec hash + auto-generated history |
-| `standalone-configmap`, `standalone-namespace` | `Object` (kubernetes.crossplane.io/v1alpha1) | **Standalone MR renderer** — Managed Resources created directly (no XR), wrapping a ConfigMap and a Namespace. Drives the Synced=True/Ready=True healthy MR path. |
-| `hello-world`, `greeter` | `AppBundle` (demo.example.io/v1alpha1, XR) | **Composite (XR) renderer** — XR instances referencing the Composition. Drive the Synced=False unhealthy path + `crossplaneStuck` audit check (see limitation below). |
+| `v2-app/default` | `ProviderConfig` (kubernetes.m.crossplane.io/v1alpha1) | Namespaced ProviderConfig — used by the v2 namespaced XR's composed Objects |
+| `xdatabases.demo.example.io` | `CompositeResourceDefinition` (apiextensions.crossplane.io/v1) | XRD renderer + v1 XRD-with-`claimNames` path + Established/Offered conditions |
+| `appstacks.demo.example.io` | `CompositeResourceDefinition` (apiextensions.crossplane.io/v2) | XRD renderer + v2 `scope: Namespaced` path |
+| `xdatabases.demo.example.io`, `appstacks.demo.example.io` | `Composition` (apiextensions.crossplane.io/v1) | Composition renderer + Pipeline mode + function reference + composed resources list |
+| `standalone-configmap`, `standalone-namespace` | `Object` (kubernetes.crossplane.io) | **Standalone MR renderer** — Managed Resources created directly (no XR), wrapping a ConfigMap and a Namespace. Synced=True/Ready=True healthy MR path. |
+| `demo-app/example-database` | `DatabaseClaim` (demo.example.io/v1alpha1, **v1 Claim**) | **Claim renderer + composed-resources-via-bound-XR path.** Claim's singular `spec.resourceRef` -> bound `XDatabase` XR -> the XR's `spec.resourceRefs` (3 composed Objects). |
+| `example-database-*` | `XDatabase` (demo.example.io/v1alpha1, **v1 XR**) | **Composite (XR) renderer** — cluster-scoped XR bound to the claim, healthy, 3 composed cluster-scoped Objects. |
+| `v2-app/web-stack` | `AppStack` (demo.example.io/v1alpha1, **v2 namespaced XR**) | **Composite (XR) renderer** — namespaced XR, healthy, 2 composed namespaced Objects (`kubernetes.m.crossplane.io`). Composed refs live at `spec.crossplane.resourceRefs` (v2 path). |
 
 ### Resource kind coverage
-
-The fixtures collectively cover the Crossplane resource kinds Radar renders:
 
 - ✅ Core Crossplane controller (Deployment in `crossplane-system`)
 - ✅ Provider (Healthy=True, with a Revision)
 - ✅ Function (Healthy=True, referenced from a Composition Pipeline)
-- ✅ ProviderConfig (kubernetes.crossplane.io, InjectedIdentity)
-- ✅ CompositeResourceDefinition (XRD, v2, cluster-scoped)
+- ✅ ProviderConfig — cluster-scoped (`kubernetes.crossplane.io`) + namespaced (`kubernetes.m.crossplane.io`)
+- ✅ CompositeResourceDefinition — v1 (with `claimNames`) + v2 (`scope: Namespaced`)
 - ✅ Composition (Pipeline mode + function-patch-and-transform input)
-- ✅ CompositionRevision (auto-generated from Composition)
 - ✅ Standalone Managed Resource — Synced=True, Ready=True (healthy MR path)
-- ✅ Composite (XR) — Synced=False (intentionally unhealthy, see below)
-- ✅ Audit `crossplaneStuck` finding (the two broken XRs trip the check)
+- ✅ **v1 Claim → bound XR → composed resources** (healthy; the composed-resources-via-bound-XR panel path)
+- ✅ **v2 namespaced XR → composed resources** (healthy)
+- ✅ Managed Resources — cluster-scoped and namespaced variants
 
-## Known limitation: Crossplane v2 cluster-scoped XR composition is broken
+## Version constraints (important)
 
-The two `AppBundle` XR instances (`hello-world`, `greeter`) are **expected to stay
-`Synced=False`**. They will not produce composed `Object` resources, and you'll see
-`Synced=False` on `kubectl get appbundles`.
+- **Crossplane chart `2.3.4`.** v2 introduced the `scope` field on XRDs (`Namespaced` / `Cluster`).
+- **provider-kubernetes `v1.0.0`.** This is the first release to ship the **namespaced** `Object`
+  (`kubernetes.m.crossplane.io`). A v2 `scope: Namespaced` XR **cannot compose cluster-scoped
+  resources**, so the namespaced XR fixture composes the namespaced `Object`. Older provider
+  versions (v0.18–v0.20) only ship the cluster-scoped `Object` and will not reconcile the v2 fixture.
+- **function-patch-and-transform `v0.9.0`.**
 
-Why: in Crossplane 2.2.x, a cluster-scoped XR (`scope: Cluster` on a v2 XRD)
-cannot compose `provider-kubernetes` `Object` resources via
-`function-patch-and-transform`. The composite reconciler refuses to create the
-composed objects because of a scope mismatch in v2's namespacing rules — XR is
-cluster-scoped but the composed MRs are also cluster-scoped, and the v2 reconciler
-doesn't currently handle that combination cleanly. The fix is upstream; tracking
-it isn't this fixture's job.
+Pinned at the top of `scripts/crossplane-demo.sh`; override via the matching env vars.
 
-**We keep these broken XRs in the fixture set on purpose** — they are *useful* test
-material:
+### How Claims work on Crossplane 2.x
 
-- They exercise Radar's **unhealthy XR rendering path** (Synced=False badge,
-  condition message surfacing, last-reconcile timestamp).
-- They feed the **`crossplaneStuck` audit check** — the check looks for Managed
-  Resources, Composites, and Composite Resource Claims that have been
-  `Synced=False` or `Ready=False` for an extended period, and the broken XRs are
-  exactly that shape.
-- They exercise the **Composite renderer** with realistic spec/status, not just
-  an "all green" happy-path render that hides edge cases.
-
-If you specifically need a healthy XR-with-composed-resources fixture, the
-workaround is to use a namespace-scoped XR (`scope: Namespaced` on the XRD) — but
-that's a different rendering path and a separate fixture concern.
-
-The standalone MRs (`standalone-configmap`, `standalone-namespace`) are healthy
-and reconcile normally, so the MR renderer's healthy path is covered.
+v2 XRDs (`apiextensions.crossplane.io/v2`) do **not** offer Claims. To keep the v1 Claim flow,
+the claim fixture uses the **`apiextensions.crossplane.io/v1` XRD API with `claimNames`** — deprecated
+on 2.x but still served, and the only way to get a Claim. `scope: LegacyCluster` does **not** exist in
+2.3.4 (only `Namespaced` / `Cluster`).
 
 ## Scenarios NOT covered (intentional gaps)
 
-- **Healthy cluster-scoped XR with composed resources** — blocked on the
-  upstream Crossplane v2 bug above. A namespace-scoped XRD variant would
-  unblock this but adds complexity; skipped for now.
-- **Cloud providers (AWS / GCP / Azure)** — using a cloud provider in the demo
-  cluster would require real credentials and create real cloud infrastructure.
-  `provider-kubernetes` is the right choice for an offline-friendly demo.
-- **Composite Resource Claims** — v2 XRDs no longer offer claims; the v2-native
-  flow is XR-direct. If we need to render Claims (v1 XRD path), add a v1 XRD
-  fixture later.
-- **Provider revision conflicts / pinned revisions** — provider rev-history UI
-  isn't a planned surface; add a fixture if/when it is.
+- **Cloud providers (AWS / GCP / Azure)** — would require real credentials and create real cloud
+  infrastructure. `provider-kubernetes` is the right choice for an offline-friendly demo.
+- **Nested XRs (an XR composing another XR)** — the fixtures are one level deep.
+- **`Usage` / `ClusterUsage`, provider revision conflicts** — add a fixture if/when those become
+  rendered surfaces.
 
 ## Implementation notes
 
-- **Crossplane Helm chart pinned to `1.17.3`**, **provider-kubernetes pinned to
-  `v0.18.0`**, **function-patch-and-transform pinned to `v0.9.0`**. Bump in
-  `scripts/crossplane-demo.sh` (top of file) when the demo should track a newer
-  release.
-- The script grants the provider's auto-generated ServiceAccount `cluster-admin`
-  via a `ClusterRoleBinding`. provider-kubernetes generates the SA name with a
-  revision-hash suffix (`provider-kubernetes-d7f6a...`), so the script discovers
-  the SA name dynamically rather than hard-coding it. This binding is what lets
-  the provider's `Object` MRs manage arbitrary in-cluster resources.
-- The `ProviderConfig` uses `source: InjectedIdentity` so the provider uses its
-  own SA token to talk to the apiserver — no external kubeconfig needed, no
-  secrets to manage.
-- The Composition uses **Pipeline mode** with `function-patch-and-transform`
-  (the v2-native composition shape). Patches use `type: FromCompositeFieldPath`
-  with `string.type: Format` transforms — that exact shape is what the function
-  expects; using shorthand patches (no `type:` field) or string transforms
-  without `string.type: Format` will silently no-op.
-- The XR composites are intentionally broken (see limitation above) and that's
-  *desired* — re-running the script does not "fix" them; reset the cluster if
-  you need clean state.
+- The script grants the provider's auto-generated ServiceAccount `cluster-admin` via a
+  `ClusterRoleBinding`. provider-kubernetes generates the SA name with a revision-hash suffix, so
+  the script discovers the SA name dynamically rather than hard-coding it.
+- ProviderConfigs use `source: InjectedIdentity` so the provider uses its own SA token — no external
+  kubeconfig, no secrets to manage.
+- Compositions use **Pipeline mode** with `function-patch-and-transform`. Patches use
+  `type: FromCompositeFieldPath` with `string.type: Format` transforms — that exact shape is what the
+  function expects; shorthand patches (no `type:`) or string transforms without `string.type: Format`
+  silently no-op.
+- The namespaced `Object` (`kubernetes.m.crossplane.io`) requires `spec.providerConfigRef.kind`
+  (to disambiguate namespaced `ProviderConfig` from `ClusterProviderConfig`), and the wrapped
+  manifest must carry a namespace — otherwise the provider fails to observe it.


### PR DESCRIPTION
## Why

`make crossplane-demo` was broken on `main`: it installed Crossplane **1.17.3** but the XRD fixture used the `apiextensions.crossplane.io/v2` API (only exists on Crossplane 2.x), so the run failed at the XRD step. Its XR instances were also documented as intentionally broken (Synced=False, no composed resources), which left the composed-resources panel and the whole v1 Claim flow untested — the exact surfaces touched by #1219.

## What

Rebuild the fixtures on **Crossplane 2.3.4** with two chains that both reconcile **healthy**:

- **v1 Claim → bound XR → composed resources** — an `apiextensions.crossplane.io/v1` XRD with `claimNames` (the only way to get Claims on 2.x; v2 XRDs drop them). Namespaced `DatabaseClaim` → cluster-scoped `XDatabase` XR → 3 composed cluster-scoped Objects.
- **v2 namespaced XR → composed resources** — an `apiextensions.crossplane.io/v2` XRD with `scope: Namespaced`. Namespaced `AppStack` XR → 2 composed namespaced Objects (`kubernetes.m.crossplane.io`).

Provider bumped to **provider-kubernetes v1.0.0** — the first release shipping the namespaced `Object`, which a namespaced XR must compose (a namespaced XR cannot compose cluster-scoped resources).

The run now gates on both chains reaching `Ready`; `status` and the summary reflect the new fixtures. README updated with the coverage matrix and the version constraints (including why Claims need the v1 XRD API and why `scope: LegacyCluster` isn't used — it doesn't exist in 2.3.4).

## Testing

- `./scripts/crossplane-demo.sh reset` from a clean slate: both chains reach `Ready=True` ("✓ v1 claim and v2 XR both Ready").
- `bash -n` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to demo/bootstrap scripts and documentation; no production app or auth paths are modified.
> 
> **Overview**
> Realigns the Crossplane **kind** demo with **Crossplane 2.3.4** and **provider-kubernetes v1.0.0**, replacing the broken **AppBundle** v2 cluster-scoped XR fixtures with two **healthy** composition chains used for Radar visual testing.
> 
> **v1 Claim path:** `apiextensions.crossplane.io/v1` XRD with `claimNames` (`DatabaseClaim` → `XDatabase` → three cluster-scoped `kubernetes.crossplane.io` Objects, including a Secret composed with `data` to avoid SSA drift).
> 
> **v2 namespaced XR path:** `apiextensions.crossplane.io/v2` XRD with `scope: Namespaced` (`AppStack` in `v2-app` → two `kubernetes.m.crossplane.io` Objects plus a namespaced `ProviderConfig`).
> 
> The `up` flow adds **legacy AppBundle cleanup** on cluster reuse, **XRD/CRD establishment waits**, and **`wait_for_chains_healthy`** (up to 4m) so the summary and **`status`** report real Ready/Synced state instead of assuming stuck XRs. README documents the coverage matrix, version pins, and drops the intentional unhealthy-XR / `crossplaneStuck` narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07f75ca7f1933d0a993ab0e2534e455808f5b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->