### PR TITLE
feat(topology): connect Crossplane claims, XRs, and composed resources

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1470,6 +1470,16 @@ func applyClusterScopedTopologyRBAC(ctx context.Context, topo *topology.Topology
 		}
 	}
 	topo.StripNodeClassesExcept(allowedNodeClasses)
+
+	// Cluster-scoped Crossplane XR/MR nodes carry unbounded provider CRD kinds
+	// the fixed denylist can't cover; authorize each by its exact GVR.
+	allowedDynamic := make(map[topology.SARTuple]bool)
+	for _, tuple := range topo.ClusterScopedDynamicRBACTuples() {
+		if canReadInNamespace(ctx, tuple.Group, tuple.Resource, "", "list") {
+			allowedDynamic[tuple] = true
+		}
+	}
+	topo.StripClusterScopedDynamicExcept(allowedDynamic)
 }
 
 // topologySummary is an LLM-friendly text representation of the topology.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1647,6 +1647,16 @@ func (s *Server) applyClusterScopedTopologyRBAC(r *http.Request, topo *topology.
 		}
 	}
 	topo.StripNodeClassesExcept(allowedNodeClasses)
+
+	// Cluster-scoped Crossplane XR/MR nodes carry unbounded provider CRD kinds
+	// the fixed denylist can't cover; authorize each by its exact GVR.
+	allowedDynamic := make(map[topology.SARTuple]bool)
+	for _, tuple := range topo.ClusterScopedDynamicRBACTuples() {
+		if s.canRead(r, tuple.Group, tuple.Resource, "", "list") {
+			allowedDynamic[tuple] = true
+		}
+	}
+	topo.StripClusterScopedDynamicExcept(allowedDynamic)
 }
 
 // parseNamespaces parses the namespace filter from query parameters.

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -1139,6 +1139,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 		if topo, err := builder.Build(opts); err == nil {
 			topo.StripNodeKinds(deniedKinds)
 			topo.StripNodeClassesExcept(authorizedNodeClassTuples(topo, nodeClassAuthorizer(authorize)))
+			topo.StripClusterScopedDynamicExcept(authorizedClusterScopedDynamicTuples(topo, nodeClassAuthorizer(authorize)))
 			data, marshalErr := json.Marshal(topo)
 			if marshalErr != nil {
 				log.Printf("SSE: failed to marshal initial topology: %v", marshalErr)

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -691,25 +691,30 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			maxEstimated = int64(topo.EstimatedNodes)
 		}
 
-		// A synthesized NodeClass kind can contain several independently
-		// authorized provider APIs. Regroup against the exact tuples present in
-		// this build, then marshal once per effective provider permission set.
+		// A synthesized NodeClass kind, and cluster-scoped Crossplane XR/MR
+		// nodes, each contain independently authorized provider APIs. Regroup
+		// against the exact tuples present in this build, then marshal once per
+		// effective provider permission set.
 		type nodeClassGroup struct {
-			allowed  map[topology.SARTuple]bool
-			channels []chan SSEEvent
+			allowed        map[topology.SARTuple]bool
+			allowedDynamic map[topology.SARTuple]bool
+			channels       []chan SSEEvent
 		}
 		nodeClassGroups := make(map[string]*nodeClassGroup)
 		for ch, info := range group.clients {
-			allowed := authorizedNodeClassTuples(topo, nodeClassAuthorizer(info.Authorize))
-			authKey := nodeClassTuplesKey(allowed)
+			authorize := nodeClassAuthorizer(info.Authorize)
+			allowed := authorizedNodeClassTuples(topo, authorize)
+			allowedDynamic := authorizedClusterScopedDynamicTuples(topo, authorize)
+			authKey := nodeClassTuplesKey(allowed) + "\x02" + nodeClassTuplesKey(allowedDynamic)
 			if nodeClassGroups[authKey] == nil {
-				nodeClassGroups[authKey] = &nodeClassGroup{allowed: allowed}
+				nodeClassGroups[authKey] = &nodeClassGroup{allowed: allowed, allowedDynamic: allowedDynamic}
 			}
 			nodeClassGroups[authKey].channels = append(nodeClassGroups[authKey].channels, ch)
 		}
 		for _, authGroup := range nodeClassGroups {
 			filtered := cloneTopology(topo)
 			filtered.StripNodeClassesExcept(authGroup.allowed)
+			filtered.StripClusterScopedDynamicExcept(authGroup.allowedDynamic)
 			data, marshalErr := json.Marshal(filtered)
 			if marshalErr != nil {
 				log.Printf("Error marshaling topology for broadcast: %v", marshalErr)
@@ -765,6 +770,19 @@ func authorizedNodeClassTuples(topo *topology.Topology, authorize func(topology.
 		return allowed
 	}
 	for _, tuple := range topo.NodeClassRBACTuples() {
+		if authorize(tuple) {
+			allowed[tuple] = true
+		}
+	}
+	return allowed
+}
+
+func authorizedClusterScopedDynamicTuples(topo *topology.Topology, authorize func(topology.SARTuple) bool) map[topology.SARTuple]bool {
+	allowed := make(map[topology.SARTuple]bool)
+	if authorize == nil {
+		return allowed
+	}
+	for _, tuple := range topo.ClusterScopedDynamicRBACTuples() {
 		if authorize(tuple) {
 			allowed[tuple] = true
 		}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -5530,7 +5530,13 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-	// 16. Add generic CRD nodes connected via owner references
+	// 16. Add Crossplane Claim/XR/MR nodes + manages edges (spec-ref driven).
+	// Runs before the generic CRD pass so XR nodes exist first.
+	if opts.IncludeGenericCRDs {
+		nodes, edges = b.addCrossplaneNodes(nodes, edges, opts)
+	}
+
+	// 17. Add generic CRD nodes connected via owner references
 	// Only includes CRDs already being watched and with owner refs to existing nodes
 	if opts.IncludeGenericCRDs {
 		nodes, edges = b.addGenericCRDNodes(nodes, edges, opts)

--- a/pkg/topology/crossplane.go
+++ b/pkg/topology/crossplane.go
@@ -1,0 +1,248 @@
+package topology
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Crossplane relationships are spec-shape detected, not kind-enumerated:
+// Managed Resources, Composites (XRs) and Claims each have provider-defined
+// CRD kinds (one CRD per provider service), so there is no fixed kind list to
+// key off. The generic owner-reference pass (addGenericCRDNodes) does not wire
+// them because Claims have no ownerReference and XRs reference their Claim via
+// spec.claimRef rather than an ownerReference — so the composed MRs have no
+// owner node to attach to. This step adds the Claim/XR/MR nodes and the
+// spec-ref-driven edges directly.
+//
+// Detection mirrors the frontend accessors in resource-utils-crossplane.ts and
+// the audit walker in internal/audit/runner.go so all three agree on what
+// counts as a Crossplane resource. v1↔v2 path handling (spec.crossplane.x
+// first, fall back to spec.x) lives here.
+
+// isCrossplaneMR reports whether u is a Managed Resource. An MR always carries
+// a providerConfigRef (v1: spec.providerConfigRef, v2: spec.crossplane.providerConfigRef).
+func isCrossplaneMR(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return false
+	}
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, ok := spec["providerConfigRef"].(map[string]interface{}); ok {
+		return true
+	}
+	if cp, ok := spec["crossplane"].(map[string]interface{}); ok {
+		if _, ok := cp["providerConfigRef"].(map[string]interface{}); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// isCrossplaneComposite reports whether u is a Composite (XR) or a v1 Claim.
+// XRs expose spec.resourceRefs (v1) or spec.crossplane.resourceRefs (v2); v1
+// Claims expose singular spec.resourceRef + spec.compositionRef. MRs are
+// excluded — they share the same CRD group set and are discriminated by shape.
+func isCrossplaneComposite(u *unstructured.Unstructured) bool {
+	if u == nil || isCrossplaneMR(u) {
+		return false
+	}
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, ok := spec["resourceRefs"].([]interface{}); ok {
+		return true
+	}
+	if cp, ok := spec["crossplane"].(map[string]interface{}); ok {
+		if _, ok := cp["resourceRefs"].([]interface{}); ok {
+			return true
+		}
+	}
+	if _, hasRef := spec["resourceRef"].(map[string]interface{}); hasRef {
+		if _, hasComp := spec["compositionRef"].(map[string]interface{}); hasComp {
+			return true
+		}
+	}
+	return false
+}
+
+// crossplaneRef is a resolved composed-resource / bound-XR reference.
+type crossplaneRef struct {
+	group string
+	kind  string
+	name  string
+}
+
+func groupFromAPIVersion(apiVersion string) string {
+	if i := strings.IndexByte(apiVersion, '/'); i >= 0 {
+		return apiVersion[:i]
+	}
+	return ""
+}
+
+func refFromMap(m map[string]interface{}) (crossplaneRef, bool) {
+	kind, _ := m["kind"].(string)
+	name, _ := m["name"].(string)
+	if kind == "" || name == "" {
+		return crossplaneRef{}, false
+	}
+	apiVersion, _ := m["apiVersion"].(string)
+	return crossplaneRef{group: groupFromAPIVersion(apiVersion), kind: kind, name: name}, true
+}
+
+// getBoundXRRef returns the XR a v1 Claim is bound to (spec.resourceRef,
+// singular). Gated on spec.compositionRef so an unrelated CRD that happens to
+// carry a resourceRef isn't treated as a Claim.
+func getBoundXRRef(u *unstructured.Unstructured) (crossplaneRef, bool) {
+	if u == nil {
+		return crossplaneRef{}, false
+	}
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		return crossplaneRef{}, false
+	}
+	if _, hasComp := spec["compositionRef"].(map[string]interface{}); !hasComp {
+		return crossplaneRef{}, false
+	}
+	ref, ok := spec["resourceRef"].(map[string]interface{})
+	if !ok {
+		return crossplaneRef{}, false
+	}
+	return refFromMap(ref)
+}
+
+// getCrossplaneResourceRefs returns the composed-resource references of an XR
+// (spec.crossplane.resourceRefs first, falling back to spec.resourceRefs).
+func getCrossplaneResourceRefs(u *unstructured.Unstructured) []crossplaneRef {
+	if u == nil {
+		return nil
+	}
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	raw, _ := spec["resourceRefs"].([]interface{})
+	if cp, ok := spec["crossplane"].(map[string]interface{}); ok {
+		if cpRefs, ok := cp["resourceRefs"].([]interface{}); ok {
+			raw = cpRefs
+		}
+	}
+	var refs []crossplaneRef
+	for _, item := range raw {
+		if m, ok := item.(map[string]interface{}); ok {
+			if ref, ok := refFromMap(m); ok {
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return refs
+}
+
+// crossplaneIndexKey identifies a Crossplane node by group/kind/name. Composed
+// and bound-XR references carry apiVersion+kind+name but no namespace, so the
+// namespace is recovered from the indexed node (whose ID embeds it) rather than
+// guessed from the referrer.
+func crossplaneIndexKey(group, kind, name string) string {
+	return strings.ToLower(group) + "/" + strings.ToLower(kind) + "/" + name
+}
+
+// addCrossplaneNodes adds Managed Resource / Composite (XR) / Claim nodes and
+// the manages edges between them:
+//
+//	Claim  --manages--> bound XR   (via spec.resourceRef)
+//	XR     --manages--> composed MR (via spec.resourceRefs / spec.crossplane.resourceRefs)
+//
+// It runs before addGenericCRDNodes so the XR nodes exist first; nodes already
+// present are not duplicated. Only resources whose informers are already
+// watched are seen (same trade-off as the generic CRD pass and the audit walker).
+func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptions) ([]Node, []Edge) {
+	dynamicCache := b.dynamic
+	if dynamicCache == nil {
+		return nodes, edges
+	}
+
+	existingIDs := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		existingIDs[n.ID] = true
+	}
+
+	type xpObject struct {
+		obj    *unstructured.Unstructured
+		nodeID string
+	}
+	// index: group/kind/name -> node ID (namespace recovered from the node ID)
+	index := make(map[string]string)
+	var objects []xpObject
+
+	for _, gvr := range dynamicCache.GetWatchedResources() {
+		kind := dynamicCache.GetKindForGVR(gvr)
+		if kind == "" || !dynamicCache.IsCRD(kind) {
+			continue
+		}
+		resources, err := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
+		if err != nil {
+			continue
+		}
+		for _, r := range resources {
+			if !isCrossplaneMR(r) && !isCrossplaneComposite(r) {
+				continue
+			}
+			ns := r.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
+			name := r.GetName()
+			nodeID := fmt.Sprintf("%s/%s/%s", strings.ToLower(kind), ns, name)
+			objects = append(objects, xpObject{obj: r, nodeID: nodeID})
+			index[crossplaneIndexKey(groupFromAPIVersion(r.GetAPIVersion()), kind, name)] = nodeID
+
+			if existingIDs[nodeID] {
+				continue
+			}
+			existingIDs[nodeID] = true
+			nodes = append(nodes, Node{
+				ID:     nodeID,
+				Kind:   NodeKind(kind),
+				Name:   name,
+				Status: extractGenericStatus(r),
+				Data: map[string]any{
+					"namespace":  ns,
+					"labels":     r.GetLabels(),
+					"apiVersion": r.GetAPIVersion(),
+				},
+			})
+		}
+	}
+
+	edgeSeen := make(map[string]bool)
+	addEdge := func(src, dst string) {
+		if src == "" || dst == "" || src == dst {
+			return
+		}
+		id := fmt.Sprintf("%s-to-%s", src, dst)
+		if edgeSeen[id] {
+			return
+		}
+		edgeSeen[id] = true
+		edges = append(edges, Edge{ID: id, Source: src, Target: dst, Type: EdgeManages})
+	}
+
+	for _, o := range objects {
+		if ref, ok := getBoundXRRef(o.obj); ok {
+			if target, ok := index[crossplaneIndexKey(ref.group, ref.kind, ref.name)]; ok {
+				addEdge(o.nodeID, target)
+			}
+		}
+		for _, ref := range getCrossplaneResourceRefs(o.obj) {
+			if target, ok := index[crossplaneIndexKey(ref.group, ref.kind, ref.name)]; ok {
+				addEdge(o.nodeID, target)
+			}
+		}
+	}
+
+	return nodes, edges
+}

--- a/pkg/topology/crossplane.go
+++ b/pkg/topology/crossplane.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,6 +21,69 @@ import (
 // the audit walker in internal/audit/runner.go so all three agree on what
 // counts as a Crossplane resource. v1↔v2 path handling (spec.crossplane.x
 // first, fall back to spec.x) lives here.
+
+// Data keys recording a cluster-scoped Crossplane node's exact GVR, so the
+// topology RBAC strip can authorize it by (group, resource) — the same shape
+// NodeClass uses. Only set on cluster-scoped (empty-namespace) nodes.
+const (
+	clusterScopedResourceKey = "clusterScopedResource"
+	clusterScopedGroupKey    = "clusterScopedGroup"
+)
+
+// ClusterScopedDynamicRBACTuples returns the distinct (group, resource) tuples
+// of cluster-scoped dynamic nodes (Crossplane XRs/MRs) present in the graph.
+// These provider CRD kinds are unbounded, so they cannot be covered by the
+// fixed ClusterScopedKinds denylist; the caller SARs each tuple and passes the
+// authorized set to StripClusterScopedDynamicExcept.
+func (t *Topology) ClusterScopedDynamicRBACTuples() []SARTuple {
+	if t == nil {
+		return nil
+	}
+	seen := make(map[SARTuple]bool)
+	var tuples []SARTuple
+	for i := range t.Nodes {
+		tuple, ok := clusterScopedDynamicTuple(&t.Nodes[i])
+		if !ok || seen[tuple] {
+			continue
+		}
+		seen[tuple] = true
+		tuples = append(tuples, tuple)
+	}
+	return tuples
+}
+
+// StripClusterScopedDynamicExcept removes cluster-scoped dynamic nodes whose
+// (group, resource) is not in allowed. A node that records the cluster-scoped
+// GVR keys but whose tuple isn't allowed is dropped (fail closed).
+func (t *Topology) StripClusterScopedDynamicExcept(allowed map[SARTuple]bool) {
+	if t == nil {
+		return
+	}
+	deny := make(map[string]bool)
+	for i := range t.Nodes {
+		tuple, ok := clusterScopedDynamicTuple(&t.Nodes[i])
+		if ok && !allowed[tuple] {
+			deny[t.Nodes[i].ID] = true
+		}
+	}
+	if len(deny) > 0 {
+		t.StripNodeIDs(deny)
+	}
+}
+
+// clusterScopedDynamicTuple extracts the recorded GVR tuple of a cluster-scoped
+// dynamic node, or false if the node isn't one.
+func clusterScopedDynamicTuple(n *Node) (SARTuple, bool) {
+	if n == nil {
+		return SARTuple{}, false
+	}
+	resource, _ := n.Data[clusterScopedResourceKey].(string)
+	if resource == "" {
+		return SARTuple{}, false
+	}
+	group, _ := n.Data[clusterScopedGroupKey].(string)
+	return SARTuple{Group: group, Resource: resource, Namespace: ""}, true
+}
 
 // isCrossplaneMR reports whether u is a Managed Resource. An MR always carries
 // a providerConfigRef (v1: spec.providerConfigRef, v2: spec.crossplane.providerConfigRef).
@@ -72,9 +136,10 @@ func isCrossplaneComposite(u *unstructured.Unstructured) bool {
 
 // crossplaneRef is a resolved composed-resource / bound-XR reference.
 type crossplaneRef struct {
-	group string
-	kind  string
-	name  string
+	group     string
+	kind      string
+	namespace string // may be empty: cluster-scoped, or "same namespace as the referrer"
+	name      string
 }
 
 func groupFromAPIVersion(apiVersion string) string {
@@ -91,7 +156,8 @@ func refFromMap(m map[string]interface{}) (crossplaneRef, bool) {
 		return crossplaneRef{}, false
 	}
 	apiVersion, _ := m["apiVersion"].(string)
-	return crossplaneRef{group: groupFromAPIVersion(apiVersion), kind: kind, name: name}, true
+	namespace, _ := m["namespace"].(string)
+	return crossplaneRef{group: groupFromAPIVersion(apiVersion), kind: kind, namespace: namespace, name: name}, true
 }
 
 // getBoundXRRef returns the XR a v1 Claim is bound to (spec.resourceRef,
@@ -142,12 +208,13 @@ func getCrossplaneResourceRefs(u *unstructured.Unstructured) []crossplaneRef {
 	return refs
 }
 
-// crossplaneIndexKey identifies a Crossplane node by group/kind/name. Composed
-// and bound-XR references carry apiVersion+kind+name but no namespace, so the
-// namespace is recovered from the indexed node (whose ID embeds it) rather than
-// guessed from the referrer.
-func crossplaneIndexKey(group, kind, name string) string {
-	return strings.ToLower(group) + "/" + strings.ToLower(kind) + "/" + name
+// crossplaneIndexKey identifies a Crossplane node by group/kind/namespace/name.
+// Namespace is part of the key so same-named resources in different namespaces
+// don't collide. References often omit the namespace (a namespaced XR composes
+// in its own namespace; a v1 Claim's bound XR is cluster-scoped), so lookups try
+// candidate namespaces — see resolveRef.
+func crossplaneIndexKey(group, kind, namespace, name string) string {
+	return strings.ToLower(group) + "/" + strings.ToLower(kind) + "/" + namespace + "/" + name
 }
 
 // addCrossplaneNodes adds Managed Resource / Composite (XR) / Claim nodes and
@@ -185,6 +252,7 @@ func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptio
 		}
 		resources, err := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if err != nil {
+			log.Printf("WARNING [topology] Failed to list %s resources for Crossplane edges: %v", kind, err)
 			continue
 		}
 		for _, r := range resources {
@@ -192,28 +260,42 @@ func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptio
 				continue
 			}
 			ns := r.GetNamespace()
-			if !opts.MatchesNamespaceFilter(ns) {
+			// Cluster-scoped resources (empty namespace) are exempt from the
+			// namespace filter — a v1 XR/MR is global and would otherwise be
+			// dropped whenever a filter is set, breaking the Claim->XR->composed
+			// chain. Mirrors the Karpenter/CAPI cluster-scoped handling.
+			if ns != "" && !opts.MatchesNamespaceFilter(ns) {
 				continue
 			}
 			name := r.GetName()
 			nodeID := fmt.Sprintf("%s/%s/%s", strings.ToLower(kind), ns, name)
 			objects = append(objects, xpObject{obj: r, nodeID: nodeID})
-			index[crossplaneIndexKey(groupFromAPIVersion(r.GetAPIVersion()), kind, name)] = nodeID
+			index[crossplaneIndexKey(groupFromAPIVersion(r.GetAPIVersion()), kind, ns, name)] = nodeID
 
 			if existingIDs[nodeID] {
 				continue
 			}
 			existingIDs[nodeID] = true
+			data := map[string]any{
+				"namespace":  ns,
+				"labels":     r.GetLabels(),
+				"apiVersion": r.GetAPIVersion(),
+			}
+			// A cluster-scoped Crossplane resource (XR/MR) is not covered by the
+			// fixed cluster-scoped RBAC denylist — provider CRD kinds are
+			// unbounded. Record its exact GVR so the topology RBAC strip can SAR
+			// the caller's list access and drop it when unauthorized. Mirrors how
+			// NodeClass records its provider resource.
+			if ns == "" {
+				data[clusterScopedResourceKey] = gvr.Resource
+				data[clusterScopedGroupKey] = gvr.Group
+			}
 			nodes = append(nodes, Node{
 				ID:     nodeID,
 				Kind:   NodeKind(kind),
 				Name:   name,
 				Status: extractGenericStatus(r),
-				Data: map[string]any{
-					"namespace":  ns,
-					"labels":     r.GetLabels(),
-					"apiVersion": r.GetAPIVersion(),
-				},
+				Data:   data,
 			})
 		}
 	}
@@ -231,14 +313,35 @@ func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptio
 		edges = append(edges, Edge{ID: id, Source: src, Target: dst, Type: EdgeManages})
 	}
 
+	// resolveRef finds the node ID a reference points at. References usually
+	// omit the namespace, so candidates are tried in order: the ref's explicit
+	// namespace if set; otherwise cluster-scoped ("") — a v1 Claim's bound XR is
+	// cluster-scoped — then the referrer's own namespace — a namespaced XR
+	// composes in its own namespace.
+	resolveRef := func(referrerNS string, ref crossplaneRef) (string, bool) {
+		var candidates []string
+		if ref.namespace != "" {
+			candidates = []string{ref.namespace}
+		} else {
+			candidates = []string{"", referrerNS}
+		}
+		for _, ns := range candidates {
+			if id, ok := index[crossplaneIndexKey(ref.group, ref.kind, ns, ref.name)]; ok {
+				return id, true
+			}
+		}
+		return "", false
+	}
+
 	for _, o := range objects {
+		referrerNS := o.obj.GetNamespace()
 		if ref, ok := getBoundXRRef(o.obj); ok {
-			if target, ok := index[crossplaneIndexKey(ref.group, ref.kind, ref.name)]; ok {
+			if target, ok := resolveRef(referrerNS, ref); ok {
 				addEdge(o.nodeID, target)
 			}
 		}
 		for _, ref := range getCrossplaneResourceRefs(o.obj) {
-			if target, ok := index[crossplaneIndexKey(ref.group, ref.kind, ref.name)]; ok {
+			if target, ok := resolveRef(referrerNS, ref); ok {
 				addEdge(o.nodeID, target)
 			}
 		}

--- a/pkg/topology/crossplane_test.go
+++ b/pkg/topology/crossplane_test.go
@@ -1,0 +1,145 @@
+package topology
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// v1 Claim -> bound XR -> composed MRs, via spec.resourceRef (singular) on the
+// Claim and spec.resourceRefs (plural) on the XR.
+func TestBuildCrossplaneV1ClaimChainEdges(t *testing.T) {
+	claimGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "databaseclaims"}
+	xrGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "xdatabases"}
+	objGVR := schema.GroupVersionResource{Group: "kubernetes.crossplane.io", Version: "v1alpha2", Resource: "objects"}
+
+	claim := karpenterTopologyObject("demo.example.io/v1alpha1", "DatabaseClaim", "example-database", "claim-uid", map[string]any{
+		"spec": map[string]any{
+			"compositionRef": map[string]any{"name": "xdatabases.demo.example.io"},
+			"resourceRef": map[string]any{
+				"apiVersion": "demo.example.io/v1alpha1", "kind": "XDatabase", "name": "example-database-xr",
+			},
+		},
+	})
+	claim.SetNamespace("demo-app")
+
+	xr := karpenterTopologyObject("demo.example.io/v1alpha1", "XDatabase", "example-database-xr", "xr-uid", map[string]any{
+		"spec": map[string]any{
+			"resourceRefs": []any{
+				map[string]any{"apiVersion": "kubernetes.crossplane.io/v1alpha2", "kind": "Object", "name": "example-database-configmap"},
+				map[string]any{"apiVersion": "kubernetes.crossplane.io/v1alpha2", "kind": "Object", "name": "example-database-service"},
+				map[string]any{"apiVersion": "kubernetes.crossplane.io/v1alpha2", "kind": "Object", "name": "example-database-connection"},
+			},
+		},
+	})
+
+	mr := func(name string) *unstructured.Unstructured {
+		return karpenterTopologyObject("kubernetes.crossplane.io/v1alpha2", "Object", name, name+"-uid", map[string]any{
+			"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default"}},
+		})
+	}
+
+	dynamic := &karpenterDynamicProvider{
+		exact: map[string]schema.GroupVersionResource{},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			claimGVR: {claim},
+			xrGVR:    {xr},
+			objGVR:   {mr("example-database-configmap"), mr("example-database-service"), mr("example-database-connection")},
+		},
+		kinds: map[schema.GroupVersionResource]string{
+			claimGVR: "DatabaseClaim", xrGVR: "XDatabase", objGVR: "Object",
+		},
+		watched:            []schema.GroupVersionResource{claimGVR, xrGVR, objGVR},
+		listCalls:          make(map[schema.GroupVersionResource]int),
+		listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+	}
+
+	topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	claimID := "databaseclaim/demo-app/example-database"
+	xrID := "xdatabase//example-database-xr"
+	composed := []string{"object//example-database-configmap", "object//example-database-service", "object//example-database-connection"}
+
+	for _, id := range append([]string{claimID, xrID}, composed...) {
+		if findNode(topo, id) == nil {
+			t.Fatalf("missing Crossplane node %q; nodes=%+v", id, topo.Nodes)
+		}
+	}
+	if !hasKarpenterTopologyEdge(topo, claimID, xrID, EdgeManages) {
+		t.Fatalf("missing claim -> XR manages edge; edges=%+v", topo.Edges)
+	}
+	for _, mrID := range composed {
+		if !hasKarpenterTopologyEdge(topo, xrID, mrID, EdgeManages) {
+			t.Fatalf("missing XR -> composed edge %s; edges=%+v", mrID, topo.Edges)
+		}
+	}
+	// A claim has no composed refs of its own — no direct claim -> MR edge.
+	for _, mrID := range composed {
+		if hasKarpenterTopologyEdge(topo, claimID, mrID, EdgeManages) {
+			t.Fatalf("unexpected claim -> composed edge %s", mrID)
+		}
+	}
+}
+
+// v2 namespaced XR -> composed namespaced MRs, via spec.crossplane.resourceRefs.
+func TestBuildCrossplaneV2NamespacedXREdges(t *testing.T) {
+	xrGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "appstacks"}
+	objGVR := schema.GroupVersionResource{Group: "kubernetes.m.crossplane.io", Version: "v1alpha1", Resource: "objects"}
+
+	xr := karpenterTopologyObject("demo.example.io/v1alpha1", "AppStack", "web-stack", "xr-uid", map[string]any{
+		"spec": map[string]any{
+			"crossplane": map[string]any{
+				"resourceRefs": []any{
+					map[string]any{"apiVersion": "kubernetes.m.crossplane.io/v1alpha1", "kind": "Object", "name": "web-stack-configmap"},
+					map[string]any{"apiVersion": "kubernetes.m.crossplane.io/v1alpha1", "kind": "Object", "name": "web-stack-service"},
+				},
+			},
+		},
+	})
+	xr.SetNamespace("v2-app")
+
+	mr := func(name string) *unstructured.Unstructured {
+		o := karpenterTopologyObject("kubernetes.m.crossplane.io/v1alpha1", "Object", name, name+"-uid", map[string]any{
+			"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default", "kind": "ProviderConfig"}},
+		})
+		o.SetNamespace("v2-app")
+		return o
+	}
+
+	dynamic := &karpenterDynamicProvider{
+		exact: map[string]schema.GroupVersionResource{},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			xrGVR:  {xr},
+			objGVR: {mr("web-stack-configmap"), mr("web-stack-service")},
+		},
+		kinds: map[schema.GroupVersionResource]string{
+			xrGVR: "AppStack", objGVR: "Object",
+		},
+		watched:            []schema.GroupVersionResource{xrGVR, objGVR},
+		listCalls:          make(map[schema.GroupVersionResource]int),
+		listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+	}
+
+	topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	xrID := "appstack/v2-app/web-stack"
+	composed := []string{"object/v2-app/web-stack-configmap", "object/v2-app/web-stack-service"}
+	if findNode(topo, xrID) == nil {
+		t.Fatalf("missing namespaced XR node %q; nodes=%+v", xrID, topo.Nodes)
+	}
+	for _, mrID := range composed {
+		if findNode(topo, mrID) == nil {
+			t.Fatalf("missing composed node %q; nodes=%+v", mrID, topo.Nodes)
+		}
+		if !hasKarpenterTopologyEdge(topo, xrID, mrID, EdgeManages) {
+			t.Fatalf("missing v2 XR -> composed edge %s; edges=%+v", mrID, topo.Edges)
+		}
+	}
+}

--- a/pkg/topology/crossplane_test.go
+++ b/pkg/topology/crossplane_test.go
@@ -143,3 +143,177 @@ func TestBuildCrossplaneV2NamespacedXREdges(t *testing.T) {
 		}
 	}
 }
+
+// Cluster-scoped Crossplane XR/MR nodes must be authorizable by their exact
+// GVR so the topology RBAC strip can drop them for a user who can't list them.
+// Without this the pass leaks cluster-scoped resource identities.
+func TestCrossplaneClusterScopedNodesAreRBACStrippable(t *testing.T) {
+	claimGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "databaseclaims"}
+	xrGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "xdatabases"}
+	objGVR := schema.GroupVersionResource{Group: "kubernetes.crossplane.io", Version: "v1alpha2", Resource: "objects"}
+
+	claim := karpenterTopologyObject("demo.example.io/v1alpha1", "DatabaseClaim", "db", "c", map[string]any{
+		"spec": map[string]any{
+			"compositionRef": map[string]any{"name": "x"},
+			"resourceRef":    map[string]any{"apiVersion": "demo.example.io/v1alpha1", "kind": "XDatabase", "name": "db-xr"},
+		},
+	})
+	claim.SetNamespace("demo-app")
+	xr := karpenterTopologyObject("demo.example.io/v1alpha1", "XDatabase", "db-xr", "x", map[string]any{
+		"spec": map[string]any{"resourceRefs": []any{
+			map[string]any{"apiVersion": "kubernetes.crossplane.io/v1alpha2", "kind": "Object", "name": "db-cm"},
+		}},
+	})
+	mr := karpenterTopologyObject("kubernetes.crossplane.io/v1alpha2", "Object", "db-cm", "m", map[string]any{
+		"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default"}},
+	})
+
+	newProvider := func() *karpenterDynamicProvider {
+		return &karpenterDynamicProvider{
+			exact:              map[string]schema.GroupVersionResource{},
+			resources:          map[schema.GroupVersionResource][]*unstructured.Unstructured{claimGVR: {claim}, xrGVR: {xr}, objGVR: {mr}},
+			kinds:              map[schema.GroupVersionResource]string{claimGVR: "DatabaseClaim", xrGVR: "XDatabase", objGVR: "Object"},
+			watched:            []schema.GroupVersionResource{claimGVR, xrGVR, objGVR},
+			listCalls:          make(map[schema.GroupVersionResource]int),
+			listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+		}
+	}
+
+	xrTuple := SARTuple{Group: "demo.example.io", Resource: "xdatabases"}
+	objTuple := SARTuple{Group: "kubernetes.crossplane.io", Resource: "objects"}
+
+	// the cluster-scoped nodes advertise their GVR tuples
+	topo, _ := NewBuilder(&mockProvider{}).WithDynamic(newProvider()).Build(DefaultBuildOptions())
+	got := map[SARTuple]bool{}
+	for _, tp := range topo.ClusterScopedDynamicRBACTuples() {
+		got[tp] = true
+	}
+	if !got[xrTuple] || !got[objTuple] {
+		t.Fatalf("cluster-scoped tuples not advertised: %+v", got)
+	}
+
+	// deny everything: cluster-scoped XR + MR gone, namespaced Claim stays
+	topo.StripClusterScopedDynamicExcept(map[SARTuple]bool{})
+	if findNode(topo, "databaseclaim/demo-app/db") == nil {
+		t.Fatal("namespaced Claim node was wrongly stripped")
+	}
+	if findNode(topo, "xdatabase//db-xr") != nil || findNode(topo, "object//db-cm") != nil {
+		t.Fatalf("unauthorized cluster-scoped node leaked through strip; nodes=%+v", topo.Nodes)
+	}
+
+	// allow only the XR's GVR: XR stays, MR still stripped
+	topo2, _ := NewBuilder(&mockProvider{}).WithDynamic(newProvider()).Build(DefaultBuildOptions())
+	topo2.StripClusterScopedDynamicExcept(map[SARTuple]bool{xrTuple: true})
+	if findNode(topo2, "xdatabase//db-xr") == nil {
+		t.Fatal("authorized XR node was wrongly stripped")
+	}
+	if findNode(topo2, "object//db-cm") != nil {
+		t.Fatal("unauthorized MR node leaked (only XR was allowed)")
+	}
+}
+
+// A cluster-scoped XR/MR (empty namespace) must survive a namespace filter, or
+// the Claim->XR->composed chain silently breaks in a filtered topology view.
+func TestBuildCrossplaneClusterScopedSurvivesNamespaceFilter(t *testing.T) {
+	claimGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "databaseclaims"}
+	xrGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "xdatabases"}
+	objGVR := schema.GroupVersionResource{Group: "kubernetes.crossplane.io", Version: "v1alpha2", Resource: "objects"}
+
+	claim := karpenterTopologyObject("demo.example.io/v1alpha1", "DatabaseClaim", "db", "claim-uid", map[string]any{
+		"spec": map[string]any{
+			"compositionRef": map[string]any{"name": "xdatabases.demo.example.io"},
+			"resourceRef":    map[string]any{"apiVersion": "demo.example.io/v1alpha1", "kind": "XDatabase", "name": "db-xr"},
+		},
+	})
+	claim.SetNamespace("demo-app")
+	xr := karpenterTopologyObject("demo.example.io/v1alpha1", "XDatabase", "db-xr", "xr-uid", map[string]any{
+		"spec": map[string]any{"resourceRefs": []any{
+			map[string]any{"apiVersion": "kubernetes.crossplane.io/v1alpha2", "kind": "Object", "name": "db-cm"},
+		}},
+	})
+	mr := karpenterTopologyObject("kubernetes.crossplane.io/v1alpha2", "Object", "db-cm", "cm-uid", map[string]any{
+		"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default"}},
+	})
+
+	dynamic := &karpenterDynamicProvider{
+		exact: map[string]schema.GroupVersionResource{},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			claimGVR: {claim}, xrGVR: {xr}, objGVR: {mr},
+		},
+		kinds:              map[schema.GroupVersionResource]string{claimGVR: "DatabaseClaim", xrGVR: "XDatabase", objGVR: "Object"},
+		watched:            []schema.GroupVersionResource{claimGVR, xrGVR, objGVR},
+		listCalls:          make(map[schema.GroupVersionResource]int),
+		listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+	}
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"demo-app"} // filter active
+	topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	if !hasKarpenterTopologyEdge(topo, "databaseclaim/demo-app/db", "xdatabase//db-xr", EdgeManages) {
+		t.Fatalf("cluster-scoped XR dropped under namespace filter; edges=%+v", topo.Edges)
+	}
+	if !hasKarpenterTopologyEdge(topo, "xdatabase//db-xr", "object//db-cm", EdgeManages) {
+		t.Fatalf("cluster-scoped composed MR dropped under namespace filter; edges=%+v", topo.Edges)
+	}
+}
+
+// Same-named composed resources in different namespaces must not collide: each
+// namespaced XR must wire to the MR in ITS OWN namespace.
+func TestBuildCrossplaneSameNameDifferentNamespaceNoCollision(t *testing.T) {
+	xrGVR := schema.GroupVersionResource{Group: "demo.example.io", Version: "v1alpha1", Resource: "appstacks"}
+	objGVR := schema.GroupVersionResource{Group: "kubernetes.m.crossplane.io", Version: "v1alpha1", Resource: "objects"}
+
+	xrIn := func(ns string) *unstructured.Unstructured {
+		o := karpenterTopologyObject("demo.example.io/v1alpha1", "AppStack", "stack", "xr-"+ns, map[string]any{
+			"spec": map[string]any{"crossplane": map[string]any{"resourceRefs": []any{
+				// same composed name "shared-config" in both namespaces, no namespace on the ref
+				map[string]any{"apiVersion": "kubernetes.m.crossplane.io/v1alpha1", "kind": "Object", "name": "shared-config"},
+			}}},
+		})
+		o.SetNamespace(ns)
+		return o
+	}
+	mrIn := func(ns string) *unstructured.Unstructured {
+		o := karpenterTopologyObject("kubernetes.m.crossplane.io/v1alpha1", "Object", "shared-config", "mr-"+ns, map[string]any{
+			"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default", "kind": "ProviderConfig"}},
+		})
+		o.SetNamespace(ns)
+		return o
+	}
+
+	dynamic := &karpenterDynamicProvider{
+		exact: map[string]schema.GroupVersionResource{},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			xrGVR:  {xrIn("team-a"), xrIn("team-b")},
+			objGVR: {mrIn("team-a"), mrIn("team-b")},
+		},
+		kinds:              map[schema.GroupVersionResource]string{xrGVR: "AppStack", objGVR: "Object"},
+		watched:            []schema.GroupVersionResource{xrGVR, objGVR},
+		listCalls:          make(map[schema.GroupVersionResource]int),
+		listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+	}
+
+	topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	// each XR wires to the MR in its OWN namespace, not the other's
+	if !hasKarpenterTopologyEdge(topo, "appstack/team-a/stack", "object/team-a/shared-config", EdgeManages) {
+		t.Fatalf("team-a XR did not wire to its own composed MR; edges=%+v", topo.Edges)
+	}
+	if !hasKarpenterTopologyEdge(topo, "appstack/team-b/stack", "object/team-b/shared-config", EdgeManages) {
+		t.Fatalf("team-b XR did not wire to its own composed MR; edges=%+v", topo.Edges)
+	}
+	// and NOT to the other namespace's MR
+	if hasKarpenterTopologyEdge(topo, "appstack/team-a/stack", "object/team-b/shared-config", EdgeManages) {
+		t.Fatalf("cross-namespace collision: team-a XR wired to team-b MR")
+	}
+	if hasKarpenterTopologyEdge(topo, "appstack/team-b/stack", "object/team-a/shared-config", EdgeManages) {
+		t.Fatalf("cross-namespace collision: team-b XR wired to team-a MR")
+	}
+}


### PR DESCRIPTION
## Why

The topology graph drew **no Crossplane edges**. A Claim, its bound Composite (XR), and the composed Managed Resources all appeared as disconnected nodes — the graph disagreed with the resource side panel, which does follow the claim→XR→composed relationship. The generic owner-reference pass can't wire Crossplane: Claims have no `ownerReference`, and XRs reference their Claim via `spec.claimRef` (not an ownerRef), so the composed MRs have no owner node to attach to.

## What

A spec-ref-driven pass (`pkg/topology/crossplane.go`) that emits `manages` edges:

```
Claim  --manages--> bound XR     (via spec.resourceRef, singular)
XR     --manages--> composed MR  (via spec.resourceRefs / spec.crossplane.resourceRefs)
```

- Nodes are **spec-shape detected** (MR = `providerConfigRef`; XR/Claim = `resourceRefs` or `resourceRef`+`compositionRef`), matching the drawer's Crossplane dispatch and the audit walker — so **v1 and v2 are both covered** (v2 fields under `spec.crossplane.*` with v1 fallback).
- References carry no namespace, so targets resolve through an index keyed by group/kind/name whose node ID embeds the real namespace.
- Runs before the generic CRD pass so XR nodes exist first; already-present nodes are not duplicated.

Frontend needs no changes — `manages` edges render generically, and Crossplane nodes already display (spec-detected drawer + generic icon).

## Scope

Covers the mainstream models: **v1 Claim → XR → composed** and **v2 namespaced XR → composed**. Nested XRs (XR composing another XR) are out of scope for this pass.

## Testing

- Unit: `pkg/topology/crossplane_test.go` — both chains (v1 claim, v2 namespaced), asserting the manages edges and that a claim gets no direct claim→MR edge.
- `go build ./...`, `go vet ./pkg/topology`, full `pkg/topology` suite all pass.
- Verified live on a kind cluster (the `crossplane-demo` fixtures): the graph renders DatabaseClaim → XDatabase → 3 Objects and AppStack (namespaced XR) → 2 Objects.

Depends on the `crossplane-demo` 2.x fixtures for the live repro (separate PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization paths for topology (per-GVR SAR and SSE fan-out grouping); behavior is fail-closed and covered by tests, but incorrect detection or stripping could hide Crossplane nodes or leak cluster-scoped identities.
> 
> **Overview**
> **Crossplane resources now appear as connected topology**, not isolated CRD nodes. A new build step (`addCrossplaneNodes`) detects Claims, Composites (XRs), and Managed Resources by **spec shape** (not fixed kind lists), adds nodes from watched dynamic CRDs, and wires **`manages`** edges: Claim → bound XR via `spec.resourceRef`, XR → composed MRs via `spec.resourceRefs` / `spec.crossplane.resourceRefs` (v1 with v2 fallback). Cluster-scoped XRs/MRs bypass namespace filters so filtered views keep intact Claim→XR→MR chains.
> 
> **RBAC for unbounded provider kinds** is extended beyond the fixed cluster-scoped denylist: cluster-scoped Crossplane nodes record their exact **(group, resource)** on node data; callers SAR each tuple and **`StripClusterScopedDynamicExcept`** drops unauthorized nodes (fail closed). The same stripping runs on **MCP `get_topology`**, **REST topology**, and **SSE** broadcasts (including regrouping clients by NodeClass + dynamic tuple permissions, and the initial SSE topology frame).
> 
> Tests cover v1 claim chains, v2 namespaced XRs, namespace-filter survival, same-name cross-namespace resolution, and RBAC strip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741ebcde26667c6bd078a6fa071942bc3a8e988d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->