### PR TITLE
fix(desktop): drop Cut/Copy accelerator on Linux so Ctrl+C reaches the terminal

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -37,6 +37,22 @@ func pasteAccelerator(goos string) *keys.Accelerator {
 	return keys.CmdOrCtrl("v")
 }
 
+// clipboardAccelerator drops Ctrl+C/Ctrl+X on Linux only. GTK menubar
+// accelerators fire before the key reaches the focused webview, so binding
+// Cut/Copy there swallows Ctrl+C inside the pod terminal (xterm): it triggers a
+// menu Copy instead of sending SIGINT to the running process. Without the
+// accelerator the key reaches the webview — xterm gets its interrupt, and
+// Monaco copy/cut still works through the keydown handler in main.tsx. Cut/Copy
+// stay clickable via clipboardDelegate. macOS uses Cmd (terminals use Ctrl, no
+// collision) and Windows' winc forwards the key to the webview anyway, so both
+// keep the accelerator and its menu-item hint.
+func clipboardAccelerator(goos, key string) *keys.Accelerator {
+	if goos == "linux" {
+		return nil
+	}
+	return keys.CmdOrCtrl(key)
+}
+
 // clipboardDelegate returns nil on macOS, where Cut/Copy rely on the native
 // responder chain. Off macOS a nil callback binds no handler at all, so the menu
 // entries do nothing when clicked; routing through execCommand reaches the
@@ -72,7 +88,9 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	// Instead, the JS keydown handler in main.tsx intercepts Cmd+C/X before macOS
 	// consumes the event, reads the selection (including Monaco virtual selection),
 	// and writes to the clipboard via navigator.clipboard.writeText(). Elsewhere
-	// there is no responder chain to fall back on — see clipboardDelegate.
+	// there is no responder chain to fall back on — see clipboardDelegate. The
+	// keyboard accelerator is dropped on Linux so Ctrl+C reaches the terminal —
+	// see clipboardAccelerator.
 	//
 	// Paste: Must use explicit WindowExecJS because WKWebView's native paste:
 	// doesn't work for complex editors like Monaco. We read from the clipboard
@@ -88,8 +106,8 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('redo')")
 	})
 	editMenu.AddSeparator()
-	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), clipboardDelegate(goruntime.GOOS, desktopApp, "cut"))
-	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), clipboardDelegate(goruntime.GOOS, desktopApp, "copy"))
+	editMenu.AddText("Cut", clipboardAccelerator(goruntime.GOOS, "x"), clipboardDelegate(goruntime.GOOS, desktopApp, "cut"))
+	editMenu.AddText("Copy", clipboardAccelerator(goruntime.GOOS, "c"), clipboardDelegate(goruntime.GOOS, desktopApp, "copy"))
 	editMenu.AddText("Paste", pasteAccelerator(goruntime.GOOS), func(_ *menu.CallbackData) {
 		runtime.WindowExecJS(desktopApp.ctx, `
 			navigator.clipboard.readText().then(function(text) {

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -106,6 +106,48 @@ func TestPasteAcceleratorDroppedOnlyOnWindows(t *testing.T) {
 	}
 }
 
+func TestClipboardAcceleratorDroppedOnlyOnLinux(t *testing.T) {
+	for _, key := range []string{"c", "x"} {
+		cases := []struct {
+			goos string
+			want *keys.Accelerator
+		}{
+			{"linux", nil},
+			{"darwin", keys.CmdOrCtrl(key)},
+			{"windows", keys.CmdOrCtrl(key)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.goos+"/"+key, func(t *testing.T) {
+				got := clipboardAccelerator(tc.goos, key)
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("clipboardAccelerator(%q, %q) = %+v, want %+v", tc.goos, key, got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+// TestCreateMenuCutCopyAcceleratorMatchesPlatform guards the Linux terminal
+// contract: on Linux the Cut/Copy accelerators must be unbound so Ctrl+C reaches
+// xterm as SIGINT rather than firing a menu Copy, while the items keep their
+// click callbacks (covered by TestCreateMenuCutCopyAreClickableOffMac).
+func TestCreateMenuCutCopyAcceleratorMatchesPlatform(t *testing.T) {
+	editMenu := findSubmenu(t, createMenu(&DesktopApp{}, "test"), "Edit")
+
+	for _, tc := range []struct{ label, key string }{{"Cut", "x"}, {"Copy", "c"}} {
+		t.Run(tc.label, func(t *testing.T) {
+			item := findMenuItem(t, editMenu, tc.label)
+			want := clipboardAccelerator(goruntime.GOOS, tc.key)
+			if !reflect.DeepEqual(item.Accelerator, want) {
+				t.Fatalf("%s accelerator = %+v, want %+v", tc.label, item.Accelerator, want)
+			}
+			if goruntime.GOOS == "linux" && item.Accelerator != nil {
+				t.Fatalf("%s is bound to %+v on linux — GTK would swallow Ctrl+C before the terminal sees it", tc.label, item.Accelerator)
+			}
+		})
+	}
+}
+
 // TestCreateMenuPasteKeepsCallbackWithoutDoubleBinding pins both halves of the
 // paste contract: the callback must stay (a nil one leaves the item inert on
 // Windows), and on Windows no accelerator may be bound alongside it because


### PR DESCRIPTION
## Description

On the **Linux desktop build**, pressing **Ctrl+C** inside a pod terminal (the xterm-based Terminal tab) triggers the Edit → Copy menu action instead of sending **SIGINT** to the running process.

Cause: GTK menubar accelerators fire before the key reaches the focused webview. `gtk_window_activate_key` runs ahead of `gtk_window_propagate_key_event`, so the menu's `Ctrl+C` / `Ctrl+X` accelerator wins over the webview, and the terminal never sees the key.

This is **pre-existing**, not introduced by #1336. The Cut/Copy accelerators were already bound on `main` (with `nil` callbacks, so `Ctrl+C` did nothing before). Wiring the click callbacks in #1336 only turned that no-op into an active Copy — SIGINT was never delivered on Linux either way. This PR fixes the underlying collision.

## Fix

Add `clipboardAccelerator(goos, key)` and drop the Cut/Copy accelerator on **Linux only** — the same shape as the existing `pasteAccelerator` (Windows) and `reloadAccelerator` (off-mac) helpers.

With the accelerator gone on Linux, `Ctrl+C` / `Ctrl+X` reach the webview:
- **Pod terminal (xterm):** gets its interrupt — SIGINT works again.
- **Monaco editor:** copy/cut still work via the existing `keydown` handler in `web/src/main.tsx` (same `handleCopyOrCut` path).
- **Edit → Cut/Copy menu click:** still works — the `clipboardDelegate` callback is untouched.

Unchanged on the other platforms:
- **macOS** uses `Cmd+C` (terminals use `Ctrl`, no collision) — keeps the accelerator.
- **Windows** `winc` forwards the key to the webview anyway, so xterm already gets `Ctrl+C` — keeps the accelerator.

Only cost: the Linux Edit menu loses its `Ctrl+C` / `Ctrl+X` hint text — the same tradeoff already accepted for Reload.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- `go build ./cmd/desktop/` — clean.
- `go vet ./cmd/desktop/` / `gofmt` — clean.
- `go test ./cmd/desktop/` — pass. Added `TestClipboardAcceleratorDroppedOnlyOnLinux` and `TestCreateMenuCutCopyAcceleratorMatchesPlatform` (the latter fails if a Cut/Copy accelerator is ever bound on Linux).

**Not verified at runtime on Linux:** developed on macOS, so the actual GTK terminal-SIGINT path could not be exercised here. The change is scoped to `goos == "linux"` and unit-tested, and the reasoning follows the GTK source, but a Linux desktop build (`wails build -platform linux/amd64`) should confirm that Ctrl+C in a pod terminal sends SIGINT and that Cut/Copy still work in Monaco and via menu click.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Linux-only menu accelerator change with existing JS clipboard fallbacks and new regression tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **Linux desktop** pod terminals where **Ctrl+C** triggered Edit → Copy (GTK menubar accelerators) instead of **SIGINT** in xterm.
> 
> Adds **`clipboardAccelerator`**, mirroring **`pasteAccelerator`**, so **Cut/Copy** menu items have **no keyboard accelerator on Linux only**. Keys then reach the webview for the terminal; Monaco copy/cut still use the existing **`main.tsx`** keydown path, and menu clicks stay on **`clipboardDelegate`**. **macOS** and **Windows** behavior is unchanged.
> 
> Unit tests cover the helper and assert the built Edit menu never binds Cut/Copy accelerators on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47032bcf9aa3bec33f2cc50ed8faab4046fedc96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->