### PR TITLE
fix(traffic): make the 3xx status filter readable when active

### DIFF
--- a/web/src/components/traffic/TrafficFilterSidebar.tsx
+++ b/web/src/components/traffic/TrafficFilterSidebar.tsx
@@ -373,7 +373,7 @@ export const TrafficFilterSidebar = memo(function TrafficFilterSidebar({
                   <div className="flex flex-wrap gap-1">
                     {([
                       { label: '2xx', active: SEVERITY_BADGE.success },
-                      { label: '3xx', active: SEVERITY_BADGE.neutral },
+                      { label: '3xx', active: SEVERITY_BADGE.info },
                       { label: '4xx', active: SEVERITY_BADGE.warning },
                       { label: '5xx', active: SEVERITY_BADGE.error },
                     ] as const).map(({ label, active }) => (

--- a/web/src/components/traffic/TrafficGraph.tsx
+++ b/web/src/components/traffic/TrafficGraph.tsx
@@ -20,7 +20,7 @@ import type { AggregatedFlow } from '../../types'
 import { clsx } from 'clsx'
 import { X, ArrowRight, Globe, Server, Activity, Puzzle } from 'lucide-react'
 import { isClusterAddon, type AddonMode } from './TrafficView'
-import { SEVERITY_BADGE, SEVERITY_TEXT } from '@skyhook-io/k8s-ui/utils/badge-colors'
+import { SEVERITY_BADGE, SEVERITY_DOT, SEVERITY_TEXT } from '@skyhook-io/k8s-ui/utils/badge-colors'
 import { getNamespaceColor } from '../../utils/traffic-colors'
 import { Tooltip } from '../ui/Tooltip'
 
@@ -87,10 +87,10 @@ function latencyColor(ms: number): string {
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-  '2xx': { bg: 'bg-emerald-500', text: SEVERITY_TEXT.success },
-  '3xx': { bg: 'bg-amber-500', text: SEVERITY_TEXT.neutral },
-  '4xx': { bg: 'bg-amber-500', text: SEVERITY_TEXT.warning },
-  '5xx': { bg: 'bg-red-500', text: SEVERITY_TEXT.error },
+  '2xx': { bg: SEVERITY_DOT.success, text: SEVERITY_TEXT.success },
+  '3xx': { bg: SEVERITY_DOT.info, text: SEVERITY_TEXT.info },
+  '4xx': { bg: SEVERITY_DOT.warning, text: SEVERITY_TEXT.warning },
+  '5xx': { bg: SEVERITY_DOT.error, text: SEVERITY_TEXT.error },
 }
 
 const VERDICT_BADGE: Record<string, string> = {


### PR DESCRIPTION
Fixes #1218

## The bug

Toggling the 3xx status-code filter in the Live Traffic sidebar produced no visible change — the active pill looked the same as the inactive one.

3xx was the only status range mapped to `SEVERITY_BADGE.neutral`. That token is `bg-theme-hover/50 text-theme-text-secondary border-theme-border`, and two things conspire to make it invisible here:

- The filter pills carry no `border` width class, so `border-theme-border` never paints. The other three severities don't need it — they have a coloured background tint. `neutral` does.
- That leaves only the background. Composited over the sidebar's `bg-theme-surface/90`:

| Theme | Inactive | Active (before) | RGB distance |
|---|---|---|---|
| Light | `#E6ECF5` | `#EAF0F8` | 6.4 |
| Dark | `#1E2338` | `#1E2339` | **1.0** |

In dark mode the on and off states differ by one unit of blue. The only real signal was the text stepping from `text-theme-text-tertiary` to `text-theme-text-secondary` — a small lightness change within the same grey hue, which reads as antialiasing rather than as "on".

## The fix

3xx now uses `SEVERITY_BADGE.info`. It follows the same pale-tint-plus-saturated-text grammar the 2xx/4xx/5xx pills already use, and it reads as a redirect rather than an error — which the success/warning/error traffic-light scale has no slot for.

| Check | Light | Dark |
|---|---|---|
| Text contrast on its own background | 5.17:1 (AA) | 7.37:1 (AAA) |
| RGB distance vs inactive pill | 12.4 (was 6.4) | 16.1 (was 1.0) |
| Distance vs 2xx / 4xx / 5xx | 30 / 63 / 44 | 19 / 47 / 47 |

No new design tokens. `info` is the only existing severity that works — `alert` is orange and would sit between 4xx amber and 5xx red.

One knock-on worth naming: the HTTP Method pills directly above already use `info`, so an active `GET` and an active `3xx` are now the same blue. They live under separate headings and the colour scale is per-group rather than global, so this seems acceptable. The alternative was adding a severity to the shared `Badge.tsx` `SEVERITY` record, which changes a type union consumed across all of `k8s-ui` for the sake of one pill.

## Also fixed

The status distribution bar in `TrafficGraph.tsx` had a related defect found while investigating: 3xx and 4xx both rendered `bg-amber-500`. They're adjacent segments in a fixed 2xx→5xx order, so they merged into one amber block with no way to see where redirects ended and client errors began — and the legend underneath did distinguish them, which made the bar actively misleading. 3xx now matches the filter.

The other three entries move to the `SEVERITY_DOT` tokens they were already duplicating by hand. Byte-identical classes, no visual change, but it keeps the map from being half tokens and half literals.

## Verification

The L7 filter block only mounts for Hubble sources, so this was checked by rendering `TrafficFilterSidebar` through Vite with the real Tailwind build and theme CSS, in both themes, with all four ranges on and with only 3xx on. Before the change the 3xx-only panel is indistinguishable from having nothing selected; after, it's unambiguous.

`make tsc` clean. `npm run test` in `web`: 45 files, 410 tests, all pass. ESLint on both changed files: no errors.

## Follow-up not included here

`TrafficFlowList.tsx` renders 3xx status codes in flow rows as plain grey body text while 2xx/4xx/5xx are colour-coded. Cosmetic, and it leaves the filter and the rows disagreeing about what colour a redirect is. Happy to fold it in if wanted.

There is also no regression test. Catching this class of bug properly means lifting the inline status-range array to an exported module-scope const so it can be asserted on — a small refactor that seemed worth raising separately rather than bundling into a colour fix.

https://claude.ai/code/session_014k43XsLDdXUYeqrTB51NqR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Traffic UI styling only; no API, auth, or data-path changes.
> 
> **Overview**
> Fixes **#1218**: the active **3xx** L7 status filter pill in `TrafficFilterSidebar` was nearly invisible because it used `SEVERITY_BADGE.neutral` (subtle hover tint on the sidebar). **3xx** now uses **`SEVERITY_BADGE.info`**, matching the tinted active style of 2xx/4xx/5xx so selected redirects read clearly in light and dark themes (same blue as active HTTP method pills in that section).
> 
> In **`TrafficGraph`**, the HTTP status distribution bar no longer paints **3xx** and **4xx** both as amber; **3xx** uses info styling and legend text aligns with the filter. **`STATUS_COLORS`** segment backgrounds switch from hard-coded `bg-*-500` classes to shared **`SEVERITY_DOT`** tokens (equivalent classes for 2xx/4xx/5xx; visible change for 3xx).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89dbd575ddefe8ecd75da1017277336f9c80267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->