### PR TITLE
perf(topology): index active Jobs by namespace for Service pairing

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -2955,6 +2955,14 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	for _, ds := range daemonsets {
 		daemonsetsByNS[ds.Namespace] = append(daemonsetsByNS[ds.Namespace], ds)
 	}
+	// Completed Jobs have no pods left to back a Service.
+	activeJobsByNS := make(map[string][]*batchv1.Job)
+	for _, job := range jobs {
+		if job.Status.Active == 0 {
+			continue
+		}
+		activeJobsByNS[job.Namespace] = append(activeJobsByNS[job.Namespace], job)
+	}
 
 	for _, svc := range services {
 		if !opts.MatchesNamespaceFilter(svc.Namespace) {
@@ -3050,13 +3058,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		// Check Jobs
-		for _, job := range jobs {
-			if job.Namespace != svc.Namespace {
-				continue
-			}
-			if job.Status.Active == 0 {
-				continue
-			}
+		for _, job := range activeJobsByNS[svc.Namespace] {
 			if matchesSelector(job.Spec.Template.ObjectMeta.Labels, svc.Spec.Selector) {
 				jobID := jobIDs[job.Namespace+"/"+job.Name]
 				if jobID != "" {

--- a/pkg/topology/service_job_pairing_test.go
+++ b/pkg/topology/service_job_pairing_test.go
@@ -1,0 +1,239 @@
+package topology
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Pairing Services with Jobs is the one workload branch that used to rescan
+// the whole Job list per Service. On a cluster that runs CronJobs the Job list
+// is dominated by completed runs which can never back a Service, so the scan
+// cost grew as services x completed-jobs while the useful work stayed flat.
+//
+// The tests below pin both halves of the fix: the edges it must still produce,
+// and the cost it must no longer pay.
+
+func pairingService(ns, name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": name}},
+	}
+}
+
+func pairingJob(ns, name string, labels map[string]string, active int32) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}},
+		},
+		Status: batchv1.JobStatus{Active: active},
+	}
+}
+
+func serviceJobEdges(t *testing.T, provider *mockProvider) map[string]bool {
+	t.Helper()
+	opts := DefaultBuildOptions()
+	opts.ForRelationshipCache = true
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	edges := map[string]bool{}
+	for _, e := range topo.Edges {
+		if e.Type == EdgeExposes {
+			edges[e.Source+" -> "+e.Target] = true
+		}
+	}
+	return edges
+}
+
+func TestServiceExposesActiveJobInSameNamespace(t *testing.T) {
+	provider := &mockProvider{
+		services: []*corev1.Service{pairingService("team-a", "web")},
+		jobs:     []*batchv1.Job{pairingJob("team-a", "web-run", map[string]string{"app": "web"}, 1)},
+	}
+	if edges := serviceJobEdges(t, provider); !edges["service/team-a/web -> job/team-a/web-run"] {
+		t.Fatalf("expected the Service to expose its active Job; got edges %v", edges)
+	}
+}
+
+func TestServiceIgnoresJobsItCannotBack(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *batchv1.Job
+	}{
+		{
+			// A finished run has no pods left to receive traffic.
+			name: "completed job in the same namespace",
+			job:  pairingJob("team-a", "web-run", map[string]string{"app": "web"}, 0),
+		},
+		{
+			// Services never select across a namespace boundary, however well
+			// the labels line up.
+			name: "active job with matching labels in another namespace",
+			job:  pairingJob("team-b", "web-run", map[string]string{"app": "web"}, 1),
+		},
+		{
+			name: "active job in the same namespace with unrelated labels",
+			job:  pairingJob("team-a", "batch-run", map[string]string{"app": "batch"}, 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &mockProvider{
+				services: []*corev1.Service{pairingService("team-a", "web")},
+				jobs:     []*batchv1.Job{tt.job},
+			}
+			for edge := range serviceJobEdges(t, provider) {
+				if edge == "service/team-a/web -> job/"+tt.job.Namespace+"/"+tt.job.Name {
+					t.Fatalf("Service must not expose %s", edge)
+				}
+			}
+		})
+	}
+}
+
+// pairingProvider builds a cluster of the given shape. The Jobs that can
+// actually back a Service are held at one per namespace, so everything beyond
+// that is a completed run that pairing must never look at twice.
+func pairingProvider(services, namespaces, completedJobs int) *mockProvider {
+	ns := func(i int) string { return fmt.Sprintf("ns-%03d", i%namespaces) }
+
+	p := &mockProvider{}
+	for i := 0; i < services; i++ {
+		p.services = append(p.services, pairingService(ns(i), fmt.Sprintf("svc-%05d", i)))
+	}
+	// One live Job per namespace: the useful pairing work, constant across sizes.
+	for i := 0; i < namespaces; i++ {
+		p.jobs = append(p.jobs, pairingJob(ns(i), fmt.Sprintf("live-%05d", i), map[string]string{"app": fmt.Sprintf("svc-%05d", i)}, 1))
+	}
+	for i := 0; i < completedJobs; i++ {
+		p.jobs = append(p.jobs, pairingJob(ns(i), fmt.Sprintf("done-%05d", i), map[string]string{"app": "cron"}, 0))
+	}
+	return p
+}
+
+func buildDuration(tb testing.TB, provider *mockProvider, runs int) time.Duration {
+	tb.Helper()
+	opts := DefaultBuildOptions()
+	opts.ForRelationshipCache = true
+
+	// Min of several runs: a single sample on a shared CI box is mostly noise,
+	// and the minimum is the run least disturbed by it.
+	best := time.Duration(1<<63 - 1)
+	for i := 0; i < runs; i++ {
+		start := time.Now()
+		if _, err := NewBuilder(provider).Build(opts); err != nil {
+			tb.Fatalf("Build: %v", err)
+		}
+		if d := time.Since(start); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// Adding Services must not re-walk the Job list. Job count is held fixed so
+// the Job nodes — a legitimate linear cost — are identical in both builds and
+// cancel out of the ratio; only the pairing differs.
+//
+// The bound is a complexity guard, not a latency budget: a per-Service rescan
+// grows with the Service multiplier, so there is several-fold headroom before
+// this can fire on timing noise alone.
+func TestServiceJobPairingDoesNotRescanJobsPerService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skipped under -short")
+	}
+
+	const (
+		namespaces    = 200
+		completedJobs = 20000
+		baseServices  = 500
+		factor        = 8
+		maxGrowth     = 2.5
+	)
+
+	base := buildDuration(t, pairingProvider(baseServices, namespaces, completedJobs), 3)
+	scaled := buildDuration(t, pairingProvider(baseServices*factor, namespaces, completedJobs), 3)
+
+	growth := float64(scaled) / float64(base)
+	t.Logf("%5d services x %d completed jobs: %v", baseServices, completedJobs, base)
+	t.Logf("%5d services x %d completed jobs: %v", baseServices*factor, completedJobs, scaled)
+	t.Logf("services x%d -> build time x%.2f (a per-Service rescan would approach x%d)", factor, growth, factor)
+
+	if growth > maxGrowth {
+		t.Errorf("build time grew %.2fx for %dx the Services against an unchanged Job list (limit %.1fx) — Service/Job pairing is rescanning every Job per Service",
+			growth, factor, maxGrowth)
+	}
+}
+
+// The large-cluster census this pairing has to survive: 432 namespaces
+// carrying Services and Jobs in the tens of thousands, most Jobs completed.
+const (
+	largeClusterServices      = 23547
+	largeClusterNamespaces    = 432
+	largeClusterCompletedJobs = 19861
+)
+
+// Doubling the whole cluster must roughly double the build, not square it.
+// Ratios rather than a wall-clock budget keep this meaningful on any machine:
+// per-namespace density is identical at both sizes, so linear growth tracks
+// the object count while a per-Service rescan of the Job list grows with the
+// product and lands near 4x.
+func TestServiceJobPairingScalesAtTwiceTheLargeCluster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive and allocation-heavy; skipped under -short")
+	}
+
+	const maxGrowth = 2.6
+
+	large := buildDuration(t, pairingProvider(largeClusterServices, largeClusterNamespaces, largeClusterCompletedJobs), 2)
+	doubled := buildDuration(t, pairingProvider(2*largeClusterServices, 2*largeClusterNamespaces, 2*largeClusterCompletedJobs), 2)
+
+	growth := float64(doubled) / float64(large)
+	t.Logf("large cluster    (%d svc / %d jobs / %d ns): %v",
+		largeClusterServices, largeClusterCompletedJobs, largeClusterNamespaces, large)
+	t.Logf("2x that cluster  (%d svc / %d jobs / %d ns): %v",
+		2*largeClusterServices, 2*largeClusterCompletedJobs, 2*largeClusterNamespaces, doubled)
+	t.Logf("cluster x2 -> build time x%.2f (linear ~x2, per-Service rescan ~x4)", growth)
+
+	if growth > maxGrowth {
+		t.Errorf("doubling the cluster grew build time %.2fx (limit %.1fx) — Service/Job pairing is superlinear at large-cluster scale",
+			growth, maxGrowth)
+	}
+}
+
+// Reports CPU and allocation cost for the pairing at the large-cluster shape.
+func BenchmarkBuildTopologyServiceJobPairing(b *testing.B) {
+	provider := pairingProvider(largeClusterServices, largeClusterNamespaces, largeClusterCompletedJobs)
+	opts := DefaultBuildOptions()
+	opts.ForRelationshipCache = true
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := NewBuilder(provider).Build(opts); err != nil {
+			b.Fatalf("Build: %v", err)
+		}
+	}
+}
+
+func BenchmarkBuildTopologyServiceJobPairingTwiceLargeCluster(b *testing.B) {
+	provider := pairingProvider(2*largeClusterServices, 2*largeClusterNamespaces, 2*largeClusterCompletedJobs)
+	opts := DefaultBuildOptions()
+	opts.ForRelationshipCache = true
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := NewBuilder(provider).Build(opts); err != nil {
+			b.Fatalf("Build: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Deployments, StatefulSets and DaemonSets are pre-indexed by namespace before the Service loop, under a comment stating the intent: avoid O(services x all_workloads). The Jobs branch was never converted and rescanned the entire Job list for every Service, comparing namespaces as strings and discarding completed runs inside the loop.

Completed Jobs can never back a Service, and a Service never reaches another namespace, so both filters are now applied once while building activeJobsByNS. The Service loop walks only the candidates.

Unit tests (pkg/topology/service_job_pairing_test.go), measured by reverting this change and re-running:

  TestServiceJobPairingDoesNotRescanJobsPerService
  8x the Services against an unchanged 20k-Job list:
    before   458.7ms ->  3.181s   growth x6.93   FAIL
    after     50.4ms -> 60.9ms    growth x1.21   PASS

  TestServiceJobPairingScalesAtTwiceTheLargeCluster
  23,547 svc / 19,861 jobs / 432 ns, then double each:
    before   16.83s  -> 1m17.11s  growth x4.58   FAIL
    after   111.7ms  -> 249.3ms   growth x2.23   PASS

  BenchmarkBuildTopologyServiceJobPairing (same census, -benchtime=1x)
    before  18,662,842,873 ns/op  55,844,472 B/op  650,073 allocs/op
    after      118,858,675 ns/op  55,843,832 B/op  650,063 allocs/op

Allocations are unchanged; the cost was CPU burned on 467M namespace string comparisons, which is why it never surfaced as a memory problem.

Three correctness cases pin the edges the pairing must still produce - an active same-namespace Job is exposed, while completed Jobs, cross-namespace Jobs and non-matching selectors are not. They pass against both the old and new code: this changes cost, not edges.

Impact on large clusters:

SSEBroadcaster.Start() calls initCachedTopology(), a ForRelationshipCache build that bypasses the large-cluster guard, and the SSE watcher does not start until it returns - so no live resource updates reach the browser while it runs. Against a synthetic cluster reproducing a reported 250-node EKS install (628,824 objects, 134,013 cached resources, 23,547 Services, 19,861 Jobs, 432 namespaces):

  startup relationship build   36s -> 2s
  time to first live update   ~38s -> ~6s

First paint is unaffected (1.2s either way); it is gated on the critical informers and completes before this build starts.

This is not the 1.7.x -> 1.8.x regression reported in #1303. The same unindexed scan is present in v1.7.9, so it is a constant tax in both versions rather than the source of that delta. It does explain the 12.9s p95 topology builds in that report, on a cluster carrying both tens of thousands of Services and tens of thousands of mostly-completed Jobs.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor of topology edge building with explicit correctness and scaling tests; graph semantics for Service–Job exposure are unchanged.
> 
> **Overview**
> **Service–Job `EdgeExposes` pairing** no longer rescans the full Job list for every Service. Active Jobs (`Status.Active > 0`) are indexed once into `activeJobsByNS`, matching how Deployments, StatefulSets, and DaemonSets are already grouped by namespace.
> 
> The per-Service loop now only considers active Jobs in that Service’s namespace, which cuts redundant work from completed CronJob runs on large clusters without changing which edges are emitted.
> 
> **Tests** in `service_job_pairing_test.go` lock in the three negative cases (completed, cross-namespace, label mismatch), the positive active same-namespace case, timing guards against per-Service rescans, and benchmarks at large-cluster scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af7d92e046f109c29c3021e062faa2964814629a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->