### PR TITLE
Validate that the Caretta traffic backend actually holds Caretta metrics

### DIFF
--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -25,6 +25,17 @@ import (
 const (
 	carettaNamespace = "caretta"
 	carettaAppLabel  = "app.kubernetes.io/name=caretta"
+
+	// Caretta's chart pins its bundled VictoriaMetrics to the service name
+	// caretta-vm and to the subchart's own name label, but the namespace follows
+	// the Helm release — so the store is located by (detected namespace, label),
+	// with the name as the fallback for a store that lost the label.
+	carettaStoreLabel   = "app.kubernetes.io/name=victoria-metrics-single"
+	carettaStoreService = "caretta-vm"
+
+	// maxMetricsCandidates bounds how many backends Connect will port-forward to
+	// and probe before giving up. Each rejected candidate costs a forward setup.
+	maxMetricsCandidates = 4
 )
 
 // Known Prometheus/VictoriaMetrics service locations to check.
@@ -63,18 +74,21 @@ var metricsServiceLocations = []struct {
 
 // CarettaSource implements TrafficSource for Caretta
 type CarettaSource struct {
-	k8sClient        kubernetes.Interface
-	httpClient       *http.Client
-	prometheusAddr   string
-	metricsBasePath  string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
-	metricsNamespace string // namespace where metrics service was found
-	metricsService   string // service name for port-forward
-	metricsPort      int    // port for port-forward
-	metricsURL       string // manual override URL from --prometheus-url flag
-	headers          map[string]string
-	isConnected      bool
-	currentContext   string // current K8s context name
-	mu               sync.RWMutex
+	k8sClient         kubernetes.Interface
+	httpClient        *http.Client
+	prometheusAddr    string
+	metricsBasePath   string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
+	metricsNamespace  string // namespace where metrics service was found
+	metricsService    string // service name for port-forward
+	metricsPort       int    // port for port-forward
+	metricsURL        string // manual override URL from --prometheus-url flag
+	headers           map[string]string
+	isConnected       bool
+	currentContext    string // current K8s context name
+	detectedNamespace string // namespace Caretta itself was detected in
+	backendVerified   bool   // bound backend proved it holds Caretta metrics
+	backendWarning    string // why no backend could be bound, surfaced to the UI
+	mu                sync.RWMutex
 }
 
 // applyHeaders attaches the configured custom headers to a Prometheus
@@ -136,11 +150,14 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 				}
 			}
 
+			c.mu.Lock()
+			c.detectedNamespace = ns
 			if runningPods > 0 {
-				c.mu.Lock()
 				c.isConnected = true
-				c.mu.Unlock()
+			}
+			c.mu.Unlock()
 
+			if runningPods > 0 {
 				result.Available = true
 				result.Message = fmt.Sprintf("Caretta detected with %d running pod(s) in namespace %s", runningPods, ns)
 
@@ -163,12 +180,15 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 	for _, ns := range namespacesToCheck {
 		ds, err := c.k8sClient.AppsV1().DaemonSets(ns).Get(ctx, "caretta", metav1.GetOptions{})
 		if err == nil {
+			c.mu.Lock()
+			c.detectedNamespace = ns
+			if ds.Status.NumberReady > 0 {
+				c.isConnected = true
+			}
+			c.mu.Unlock()
+
 			// DaemonSet exists, check its status
 			if ds.Status.NumberReady > 0 {
-				c.mu.Lock()
-				c.isConnected = true
-				c.mu.Unlock()
-
 				result.Available = true
 				result.Message = fmt.Sprintf("Caretta DaemonSet detected with %d ready pods in namespace %s", ds.Status.NumberReady, ns)
 				return result, nil
@@ -214,11 +234,17 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 
 	if promAddr == "" {
 		log.Printf("[caretta] Prometheus not found, returning empty flows")
+		c.mu.RLock()
+		warning := c.backendWarning
+		c.mu.RUnlock()
+		if warning == "" {
+			warning = noBackendWarning(nil, nil)
+		}
 		return &FlowsResponse{
 			Source:    "caretta",
 			Timestamp: time.Now(),
 			Flows:     []Flow{},
-			Warning:   "Prometheus/VictoriaMetrics service not found. Ensure Caretta's metrics backend is deployed.",
+			Warning:   warning,
 		}, nil
 	}
 
@@ -234,11 +260,31 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 		}, nil
 	}
 
-	return &FlowsResponse{
+	response := &FlowsResponse{
 		Source:    "caretta",
 		Timestamp: time.Now(),
 		Flows:     flows,
-	}, nil
+	}
+
+	// An unverified backend that returns nothing is indistinguishable from a quiet
+	// cluster in the UI. Say which backend answered so the user can tell "no
+	// traffic" apart from "reading the wrong database".
+	if len(flows) == 0 {
+		c.mu.RLock()
+		verified, ns, svc := c.backendVerified, c.metricsNamespace, c.metricsService
+		c.mu.RUnlock()
+		if !verified {
+			target := "the configured metrics URL"
+			if ns != "" && svc != "" {
+				target = fmt.Sprintf("%s/%s", ns, svc)
+			}
+			response.Warning = fmt.Sprintf("Connected to %s, which holds no Caretta metrics. "+
+				"Point Radar at Caretta's own metrics store (caretta-vm) with --prometheus-url, "+
+				"or reinstall Caretta with its bundled VictoriaMetrics.", target)
+		}
+	}
+
+	return response, nil
 }
 
 // discoverPrometheus finds and connects to the metrics service.
@@ -268,6 +314,8 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 			log.Printf("[caretta] Using manual metrics URL: %s", addr)
 			c.prometheusAddr = addr
 			c.metricsBasePath = ""
+			c.backendVerified = c.carettaMetricsPresentLocked(ctx, addr)
+			c.backendWarning = ""
 			return addr
 		}
 		log.Printf("[caretta] Manual metrics URL %s not reachable", addr)
@@ -275,64 +323,232 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 	}
 
 	// Layer 2+3: Well-known locations, then dynamic discovery
-	info := c.discoverServiceLocked(ctx)
-	if info == nil {
+	candidates := c.discoverServiceLocked(ctx)
+	if len(candidates) == 0 {
 		log.Printf("[caretta] No Prometheus/VictoriaMetrics service found via any discovery method")
+		c.backendWarning = noBackendWarning(nil, nil)
 		return ""
 	}
 
-	// Reuse an existing managed port-forward only if it targets the SAME service
-	// we just discovered. A generic reachability probe can't tell caretta-vm apart
-	// from the cluster's general Prometheus (both answer /api/v1/query), so match
-	// on (namespace, service) — otherwise we'd adopt the general-metrics forward
-	// and query it for caretta_links_observed, which returns 0 flows silently.
-	if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, info.namespace, info.name); pfAddr != "" {
-		testAddr := pfAddr + info.basePath
-		if c.tryMetricsEndpointLocked(ctx, testAddr) {
-			log.Printf("[caretta] Using managed port-forward at %s for %s/%s", pfAddr, info.namespace, info.name)
-			c.prometheusAddr = pfAddr
-			c.metricsBasePath = info.basePath
-			return pfAddr
+	var noData []string
+	for _, info := range candidates {
+		wrongData := false
+
+		// Reuse an existing managed port-forward only if it targets the SAME service
+		// we just discovered. A generic reachability probe can't tell caretta-vm apart
+		// from the cluster's general Prometheus (both answer /api/v1/query), so match
+		// on (namespace, service) — otherwise we'd adopt the general-metrics forward
+		// and query it for caretta_links_observed, which returns 0 flows silently.
+		if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, info.namespace, info.name); pfAddr != "" {
+			switch c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) {
+			case backendAccepted:
+				log.Printf("[caretta] Using managed port-forward at %s for %s/%s", pfAddr, info.namespace, info.name)
+				c.bindLocked(pfAddr, info)
+				return pfAddr
+			case backendNoCarettaData:
+				wrongData = true
+			}
+		}
+
+		// Try cluster address (works when running in-cluster)
+		switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
+		case backendAccepted:
+			log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
+			c.bindLocked(info.clusterAddr, info)
+			return info.clusterAddr
+		case backendNoCarettaData:
+			wrongData = true
+		}
+
+		if wrongData {
+			noData = append(noData, fmt.Sprintf("%s/%s", info.namespace, info.name))
 		}
 	}
 
-	// Try cluster address (works when running in-cluster)
-	if c.tryClusterAddrLocked(ctx, info) {
-		log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
-		return info.clusterAddr
-	}
-
-	// Service exists but not reachable in-cluster - will need port-forward
-	log.Printf("[caretta] Metrics service %s/%s found but not reachable in-cluster. Call Connect() for port-forward.",
-		info.namespace, info.name)
+	// Nothing bound. Either the candidates aren't reachable in-cluster (the local
+	// case — Connect() port-forwards to them) or none of them holds Caretta data.
+	// Only the latter is a diagnosis; unreachable here is the normal local case.
+	log.Printf("[caretta] No Caretta-backed metrics service reachable in-cluster. Call Connect() for port-forward.")
+	c.backendWarning = noBackendWarning(noData, nil)
 	return ""
 }
 
-// discoverServiceLocked finds a metrics service via Layer 2 (well-known) then Layer 3 (dynamic).
-// Sets metricsNamespace, metricsService, metricsPort on success. Caller must hold lock.
-func (c *CarettaSource) discoverServiceLocked(ctx context.Context) *metricsServiceInfo {
-	info := c.findMetricsServiceLocked(ctx)
-	if info == nil {
-		info = c.discoverMetricsServiceDynamic(ctx)
+// discoverServiceLocked returns candidate metrics backends in Caretta priority
+// order: Caretta's own store (Layer 1), then a well-known Prometheus (Layer 2),
+// then dynamic discovery (Layer 3) when the earlier layers found nothing.
+//
+// It returns a list rather than a single service because existence is not proof:
+// a cluster's general Prometheus answers PromQL just as well as Caretta's store
+// but holds no caretta_links_observed, so the caller probes down the list.
+// Caller must hold lock.
+func (c *CarettaSource) discoverServiceLocked(ctx context.Context) []*metricsServiceInfo {
+	var candidates []*metricsServiceInfo
+	seen := map[string]bool{}
+	add := func(info *metricsServiceInfo) {
+		if info == nil || seen[info.namespace+"/"+info.name] {
+			return
+		}
+		seen[info.namespace+"/"+info.name] = true
+		candidates = append(candidates, info)
 	}
+
+	add(c.findCarettaStoreLocked(ctx))
+	add(c.findMetricsServiceLocked(ctx))
+	if len(candidates) == 0 {
+		add(c.discoverMetricsServiceDynamic(ctx))
+	}
+
+	if len(candidates) > maxMetricsCandidates {
+		candidates = candidates[:maxMetricsCandidates]
+	}
+	return candidates
+}
+
+// findCarettaStoreLocked looks for Caretta's own metrics store in the namespace
+// Caretta was detected in. The chart pins the service name but its namespace
+// follows the Helm release, so a hardcoded namespace/name pair misses every
+// install that didn't land in "caretta" — and discovery then walks on to the
+// cluster's general Prometheus, which holds no Caretta metrics.
+// Caller must hold lock.
+func (c *CarettaSource) findCarettaStoreLocked(ctx context.Context) *metricsServiceInfo {
+	ns := c.detectedNamespace
+	if ns == "" {
+		ns = carettaNamespace
+	}
+
+	svcs, err := c.k8sClient.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: carettaStoreLabel})
+	if err == nil && len(svcs.Items) > 0 {
+		sort.Slice(svcs.Items, func(i, j int) bool { return svcs.Items[i].Name < svcs.Items[j].Name })
+		return carettaStoreInfo(svcs.Items[0])
+	}
+
+	// The List can fail on get-but-not-list RBAC, and a store whose labels were
+	// overridden won't match the selector — fall back to the pinned name.
+	svc, err := c.k8sClient.CoreV1().Services(ns).Get(ctx, carettaStoreService, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	return carettaStoreInfo(*svc)
+}
+
+func carettaStoreInfo(svc corev1.Service) *metricsServiceInfo {
+	port := resolveServicePort(svc, 0)
+	log.Printf("[caretta] Found Caretta metrics store: %s/%s:%d", svc.Namespace, svc.Name, port)
+	return &metricsServiceInfo{
+		namespace:      svc.Namespace,
+		name:           svc.Name,
+		port:           port,
+		targetPort:     resolveTargetPort(svc, port),
+		clusterAddr:    buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+		isCarettaStore: true,
+	}
+}
+
+// backendVerdict is why a candidate backend was accepted or turned down. The two
+// rejections are different problems for the user — one is a broken connection,
+// the other is a healthy connection to the wrong database — so they are reported
+// separately rather than collapsed into "not available".
+type backendVerdict int
+
+const (
+	backendAccepted backendVerdict = iota
+	backendUnreachable
+	backendNoCarettaData
+)
+
+// acceptBackendLocked decides whether an endpoint is the right backend for
+// Caretta. Caretta's own store is accepted on identity — a freshly installed
+// Caretta legitimately holds no series yet. Anything else has to prove it carries
+// Caretta data, because the generic reachability probe cannot tell the cluster's
+// general Prometheus apart from Caretta's store and binding to the former yields
+// successful, permanently empty queries.
+// Caller must hold lock.
+func (c *CarettaSource) acceptBackendLocked(ctx context.Context, info *metricsServiceInfo, addr string) backendVerdict {
+	if !c.tryMetricsEndpointLocked(ctx, addr) {
+		return backendUnreachable
+	}
+	if info != nil && info.isCarettaStore {
+		return backendAccepted
+	}
+	if c.carettaMetricsPresentLocked(ctx, addr) {
+		return backendAccepted
+	}
+	log.Printf("[caretta] Backend %s answers PromQL but holds no Caretta metrics, skipping", addr)
+	return backendNoCarettaData
+}
+
+// carettaMetricsPresentLocked reports whether the backend at addr holds Caretta
+// data. Observed links are the direct signal; the scrape target being up covers
+// both a fresh install that hasn't seen a connection yet and the deployment where
+// the cluster's Prometheus scrapes Caretta itself and is the correct backend.
+// Caller must hold lock.
+func (c *CarettaSource) carettaMetricsPresentLocked(ctx context.Context, addr string) bool {
+	for _, query := range []string{`count(caretta_links_observed)`, `count(up{job=~".*caretta.*"})`} {
+		if c.hasSeriesLocked(ctx, addr, query) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSeriesLocked runs query against addr and reports whether it returned any
+// sample. Caller must hold lock.
+func (c *CarettaSource) hasSeriesLocked(ctx context.Context, addr, query string) bool {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(queryCtx, "GET", fmt.Sprintf("%s/api/v1/query?query=%s", addr, url.QueryEscape(query)), nil)
+	if err != nil {
+		return false
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var promResp prometheusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&promResp); err != nil {
+		return false
+	}
+	return promResp.Status == "success" && len(promResp.Data.Result) > 0
+}
+
+// bindLocked records the backend the source will query from now on.
+// Caller must hold lock.
+func (c *CarettaSource) bindLocked(addr string, info *metricsServiceInfo) {
+	c.prometheusAddr = addr
+	c.backendWarning = ""
 	if info != nil {
+		c.metricsBasePath = info.basePath
 		c.metricsNamespace = info.namespace
 		c.metricsService = info.name
 		c.metricsPort = info.port
+		c.backendVerified = true
 	}
-	return info
 }
 
-// tryClusterAddrLocked tries the cluster address with basePath and stores the result on success.
-// Caller must hold lock.
-func (c *CarettaSource) tryClusterAddrLocked(ctx context.Context, info *metricsServiceInfo) bool {
-	testAddr := info.clusterAddr + info.basePath
-	if c.tryMetricsEndpointLocked(ctx, testAddr) {
-		c.prometheusAddr = info.clusterAddr
-		c.metricsBasePath = info.basePath
-		return true
+// noBackendWarning explains why no backend was bound, so the UI can say why Live
+// Traffic is empty instead of showing an indistinguishable "no traffic yet".
+// Reached-but-wrong and never-reached are separate problems and read as such.
+func noBackendWarning(noData, unreachable []string) string {
+	switch {
+	case len(noData) > 0:
+		return fmt.Sprintf("Connected to %s, which holds no Caretta metrics. Caretta's own metrics store (caretta-vm) was not found — "+
+			"reinstall Caretta with its bundled VictoriaMetrics, or point Radar at the backend holding Caretta data with --prometheus-url.",
+			strings.Join(noData, ", "))
+	case len(unreachable) > 0:
+		return fmt.Sprintf("Found %s but could not reach it. Check that the service is running and its pods are ready.",
+			strings.Join(unreachable, ", "))
+	default:
+		return "Prometheus/VictoriaMetrics service not found. Ensure Caretta's metrics backend is deployed."
 	}
-	return false
 }
 
 // queryPrometheusForFlows queries Prometheus for caretta_links_observed metrics
@@ -495,6 +711,9 @@ func (c *CarettaSource) Close() error {
 	c.prometheusAddr = ""
 	c.metricsBasePath = ""
 	c.currentContext = ""
+	c.detectedNamespace = ""
+	c.backendVerified = false
+	c.backendWarning = ""
 	return nil
 }
 
@@ -535,6 +754,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 			log.Printf("[caretta] Connected using manual metrics URL: %s", addr)
 			c.prometheusAddr = addr
 			c.metricsBasePath = ""
+			c.backendVerified = c.carettaMetricsPresentLocked(ctx, addr)
+			c.backendWarning = ""
 			return &portforward.ConnectionInfo{
 				Connected:   true,
 				Address:     addr,
@@ -548,75 +769,101 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	}
 
 	// Layer 2+3: Well-known locations, then dynamic discovery
-	metricsInfo := c.discoverServiceLocked(ctx)
-	if metricsInfo == nil {
+	candidates := c.discoverServiceLocked(ctx)
+	if len(candidates) == 0 {
 		return &portforward.ConnectionInfo{
 			Connected: false,
 			Error:     "No Prometheus/VictoriaMetrics service found. Use --prometheus-url to specify manually.",
 		}, nil
 	}
 
-	// Try cluster-internal address first (works when running in-cluster)
-	if c.tryClusterAddrLocked(ctx, metricsInfo) {
-		log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", metricsInfo.clusterAddr, metricsInfo.basePath)
-		return &portforward.ConnectionInfo{
-			Connected:   true,
-			Address:     metricsInfo.clusterAddr,
-			Namespace:   metricsInfo.namespace,
-			ServiceName: metricsInfo.name,
-			ContextName: contextName,
-		}, nil
-	}
-
-	// Check if there's already a valid managed port-forward for this context that
-	// targets the SAME service we discovered. Matching on (namespace, service)
-	// stops the traffic source from adopting the general-metrics forward (owner=
-	// prometheus, e.g. prometheus-operated:9090): it answers the generic probe but
-	// holds no caretta_links_observed, so flows would come back empty. On no match
-	// we fall through and start the dedicated forward to caretta-vm below.
-	if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, contextName, metricsInfo.namespace, metricsInfo.name); pfAddr != "" {
-		pfTestAddr := pfAddr + metricsInfo.basePath
-		if c.tryMetricsEndpointLocked(ctx, pfTestAddr) {
-			log.Printf("[caretta] Using existing port-forward at %s", pfAddr)
-			c.prometheusAddr = pfAddr
-			c.metricsBasePath = metricsInfo.basePath
+	// Walk the candidates in Caretta priority order. Existence is not proof: the
+	// cluster's general Prometheus answers PromQL but holds no Caretta series, so
+	// each candidate has to be accepted by acceptBackendLocked before it is bound.
+	var noData, unreachable []string
+	var lastErr string
+	for _, info := range candidates {
+		// Try cluster-internal address first (works when running in-cluster)
+		if c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) == backendAccepted {
+			log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
+			c.bindLocked(info.clusterAddr, info)
 			return &portforward.ConnectionInfo{
 				Connected:   true,
-				Address:     pfAddr,
-				Namespace:   metricsInfo.namespace,
-				ServiceName: metricsInfo.name,
+				Address:     info.clusterAddr,
+				Namespace:   info.namespace,
+				ServiceName: info.name,
 				ContextName: contextName,
 			}, nil
 		}
+
+		// Check if there's already a valid managed port-forward for this context that
+		// targets the SAME service we discovered. Matching on (namespace, service)
+		// stops the traffic source from adopting the general-metrics forward (owner=
+		// prometheus, e.g. prometheus-operated:9090): it answers the generic probe but
+		// holds no caretta_links_observed, so flows would come back empty. On no match
+		// we fall through and start the dedicated forward below.
+		if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, contextName, info.namespace, info.name); pfAddr != "" {
+			if c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) == backendAccepted {
+				log.Printf("[caretta] Using existing port-forward at %s", pfAddr)
+				c.bindLocked(pfAddr, info)
+				return &portforward.ConnectionInfo{
+					Connected:   true,
+					Address:     pfAddr,
+					Namespace:   info.namespace,
+					ServiceName: info.name,
+					ContextName: contextName,
+				}, nil
+			}
+		}
+
+		// Start a new managed port-forward
+		log.Printf("[caretta] Starting port-forward to %s/%s:%d (targetPort=%d)", info.namespace, info.name, info.port, info.targetPort)
+		connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, info.namespace, info.name, info.targetPort, contextName)
+		if err != nil {
+			lastErr = fmt.Sprintf("Failed to start port-forward to %s/%s: %v", info.namespace, info.name, err)
+			log.Printf("[caretta] %s", lastErr)
+			continue
+		}
+
+		target := fmt.Sprintf("%s/%s", info.namespace, info.name)
+		switch c.acceptBackendLocked(ctx, info, connInfo.Address+info.basePath) {
+		case backendAccepted:
+			c.bindLocked(connInfo.Address, info)
+			log.Printf("[caretta] Connected via port-forward at %s (basePath=%q)", connInfo.Address, info.basePath)
+			return connInfo, nil
+		case backendNoCarettaData:
+			noData = append(noData, target)
+		case backendUnreachable:
+			unreachable = append(unreachable, target)
+		}
 	}
 
-	// Start a new managed port-forward
-	log.Printf("[caretta] Starting port-forward to %s/%s:%d (targetPort=%d)", metricsInfo.namespace, metricsInfo.name, metricsInfo.port, metricsInfo.targetPort)
-	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, metricsInfo.namespace, metricsInfo.name, metricsInfo.targetPort, contextName)
-	if err != nil {
-		return &portforward.ConnectionInfo{
-			Connected:   false,
-			Namespace:   metricsInfo.namespace,
-			ServiceName: metricsInfo.name,
-			Error:       fmt.Sprintf("Failed to start port-forward: %v", err),
-		}, nil
+	// Every candidate was rejected. Leaving the last forward up would point the
+	// traffic module at a backend it just refused, so drop it and fail closed with
+	// a message naming what was tried — silently returning zero flows is what made
+	// this class of bug invisible.
+	portforward.Stop(portforward.OwnerTraffic)
+	errMsg := noBackendWarning(noData, unreachable)
+	if len(noData) == 0 && len(unreachable) == 0 && lastErr != "" {
+		errMsg = lastErr
 	}
-
-	c.prometheusAddr = connInfo.Address
-	c.metricsBasePath = metricsInfo.basePath
-	log.Printf("[caretta] Connected via port-forward at %s (basePath=%q)", connInfo.Address, metricsInfo.basePath)
-
-	return connInfo, nil
+	c.backendWarning = errMsg
+	c.backendVerified = false
+	return &portforward.ConnectionInfo{
+		Connected: false,
+		Error:     errMsg,
+	}, nil
 }
 
 // metricsServiceInfo holds info about a discovered metrics service
 type metricsServiceInfo struct {
-	namespace   string
-	name        string
-	port        int // service port (for cluster-internal address)
-	targetPort  int // container port (for port-forwarding to pod)
-	clusterAddr string
-	basePath    string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
+	namespace      string
+	name           string
+	port           int // service port (for cluster-internal address)
+	targetPort     int // container port (for port-forwarding to pod)
+	clusterAddr    string
+	basePath       string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
+	isCarettaStore bool   // Caretta's own metrics store, accepted without a content probe
 }
 
 // resolveServicePort determines the port to use for a service
@@ -665,6 +912,11 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 			targetPort:  tp,
 			clusterAddr: clusterAddr,
 			basePath:    loc.basePath,
+			// The well-known list still carries caretta-vm, for the split install
+			// whose store sits outside the namespace Caretta itself runs in. Mark it
+			// so it is accepted on identity here too, or a store with no links yet
+			// would be admitted by one discovery path and rejected by the other.
+			isCarettaStore: svc.Name == carettaStoreService,
 		}
 	}
 

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -552,7 +552,7 @@ func carettaStoreInfo(svc corev1.Service, owned bool) *metricsServiceInfo {
 		name:           svc.Name,
 		port:           port,
 		targetPort:     resolveTargetPort(svc, port),
-		clusterAddr:    buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+		clusterAddr:    buildClusterAddr(svc.Name, svc.Namespace, port),
 		isCarettaStore: owned,
 	}
 }
@@ -1071,7 +1071,7 @@ func (c *CarettaSource) findMetricsServicesLocked(ctx context.Context) []*metric
 		}
 
 		port := resolveServicePort(*svc, loc.port)
-		clusterAddr := buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port)
+		clusterAddr := buildClusterAddr(svc.Name, svc.Namespace, port)
 		tp := resolveTargetPort(*svc, port)
 
 		log.Printf("[caretta] Found metrics service: %s/%s:%d (targetPort=%d)", svc.Namespace, svc.Name, port, tp)
@@ -1231,7 +1231,7 @@ func (c *CarettaSource) discoverMetricsServiceDynamic(ctx context.Context) *metr
 				name:        svc.Name,
 				port:        port,
 				targetPort:  resolveTargetPort(svc, port),
-				clusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+				clusterAddr: buildClusterAddr(svc.Name, svc.Namespace, port),
 				basePath:    bp,
 			},
 			score: score,
@@ -1288,10 +1288,13 @@ func (c *CarettaSource) discoverMetricsServiceDynamic(ctx context.Context) *metr
 }
 
 // buildClusterAddr builds a cluster-internal address for a service
-func buildClusterAddr(name, namespace, clusterIP string, port int) string {
-	if clusterIP == "None" {
-		return fmt.Sprintf("http://%s-0.%s.%s.svc.cluster.local:%d", name, name, namespace, port)
-	}
+// A headless Service publishes A records for its ready pods under its own name,
+// so the plain service address works for both kinds. Addressing a headless one as
+// {service}-0.{service} assumes the StatefulSet is named after the Service: true
+// for caretta-vm, false for kube-prometheus-stack's prometheus-operated, whose
+// pod is prometheus-{release}-kube-prometheus-stack-prometheus-0. That guess made
+// a reachable backend look unreachable in-cluster.
+func buildClusterAddr(name, namespace string, port int) string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", name, namespace, port)
 }
 

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -474,11 +474,38 @@ func (c *CarettaSource) discoverServiceLocked(ctx context.Context) []*metricsSer
 // cluster's general Prometheus, which holds no Caretta metrics.
 // Caller must hold lock.
 func (c *CarettaSource) findCarettaStoreLocked(ctx context.Context) *metricsServiceInfo {
-	ns := c.detectedNamespace
-	if ns == "" {
-		ns = carettaNamespace
+	// Connect can run before anything has called Detect, leaving the namespace
+	// unknown. Look where Detect would have looked rather than assuming the
+	// default namespace name, or Caretta's own store is invisible on exactly the
+	// installs this lookup exists to handle.
+	if c.detectedNamespace != "" {
+		return c.carettaStoreInLocked(ctx, c.detectedNamespace)
 	}
 
+	for _, ns := range []string{carettaNamespace, "default", "kube-system"} {
+		if info := c.carettaStoreInLocked(ctx, ns); info != nil {
+			return info
+		}
+	}
+
+	// Still nothing: the install may be in a namespace nobody has named yet. One
+	// cluster-wide list finds a store carrying the name the chart pins.
+	svcs, err := c.k8sClient.CoreV1().Services("").List(ctx, metav1.ListOptions{LabelSelector: carettaStoreLabel})
+	if err != nil {
+		return nil
+	}
+	sort.Slice(svcs.Items, func(i, j int) bool { return svcs.Items[i].Name < svcs.Items[j].Name })
+	for _, svc := range svcs.Items {
+		if svc.Name == carettaStoreService {
+			return carettaStoreInfo(svc, true)
+		}
+	}
+	return nil
+}
+
+// carettaStoreInLocked looks for Caretta's metrics store in one namespace.
+// Caller must hold lock.
+func (c *CarettaSource) carettaStoreInLocked(ctx context.Context, ns string) *metricsServiceInfo {
 	svcs, err := c.k8sClient.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: carettaStoreLabel})
 	if err == nil && len(svcs.Items) > 0 {
 		sort.Slice(svcs.Items, func(i, j int) bool { return svcs.Items[i].Name < svcs.Items[j].Name })
@@ -979,7 +1006,10 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	portforward.Stop(portforward.OwnerTraffic)
 	errMsg := noBackendWarning(noData, unreachable)
 	if len(noData) == 0 && len(unreachable) == 0 && lastErr != "" {
-		errMsg = lastErr
+		// Keep the underlying error, but say what was being attempted. On its own
+		// something like a port-forward RBAC denial reads as an unrelated
+		// permissions problem rather than "Caretta's metrics store wasn't found".
+		errMsg = fmt.Sprintf("No metrics backend holding Caretta data could be reached. %s", lastErr)
 	}
 	c.backendWarning = errMsg
 	c.backendVerified = false

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -30,8 +30,9 @@ const (
 	// caretta-vm and to the subchart's own name label, but the namespace follows
 	// the Helm release — so the store is located by (detected namespace, label),
 	// with the name as the fallback for a store that lost the label.
-	carettaStoreLabel   = "app.kubernetes.io/name=victoria-metrics-single"
-	carettaStoreService = "caretta-vm"
+	carettaStoreLabel    = "app.kubernetes.io/name=victoria-metrics-single"
+	carettaStoreService  = "caretta-vm"
+	carettaInstanceLabel = "app.kubernetes.io/instance"
 
 	// maxMetricsCandidates bounds how many backends Connect will port-forward to
 	// and probe before giving up. Each rejected candidate costs a forward setup.
@@ -74,21 +75,23 @@ var metricsServiceLocations = []struct {
 
 // CarettaSource implements TrafficSource for Caretta
 type CarettaSource struct {
-	k8sClient         kubernetes.Interface
-	httpClient        *http.Client
-	prometheusAddr    string
-	metricsBasePath   string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
-	metricsNamespace  string // namespace where metrics service was found
-	metricsService    string // service name for port-forward
-	metricsPort       int    // port for port-forward
-	metricsURL        string // manual override URL from --prometheus-url flag
-	headers           map[string]string
-	isConnected       bool
-	currentContext    string // current K8s context name
-	detectedNamespace string // namespace Caretta itself was detected in
-	backendVerified   bool   // bound backend proved it holds Caretta metrics
-	backendWarning    string // why no backend could be bound, surfaced to the UI
-	mu                sync.RWMutex
+	k8sClient           kubernetes.Interface
+	httpClient          *http.Client
+	prometheusAddr      string
+	metricsBasePath     string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
+	metricsNamespace    string // namespace where metrics service was found
+	metricsService      string // service name for port-forward
+	metricsPort         int    // port for port-forward
+	metricsURL          string // manual override URL from --prometheus-url flag
+	headers             map[string]string
+	isConnected         bool
+	currentContext      string // current K8s context name
+	detectedNamespace   string // namespace Caretta itself was detected in
+	detectedInstance    string // Helm release Caretta was installed as, for store ownership
+	backendVerified     bool   // bound backend proved it holds Caretta metrics
+	boundIsCarettaStore bool   // bound backend is Caretta's own store, trusted on identity
+	backendWarning      string // why no backend could be bound, surfaced to the UI
+	mu                  sync.RWMutex
 }
 
 // applyHeaders attaches the configured custom headers to a Prometheus
@@ -143,37 +146,16 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 		}
 
 		if len(pods.Items) > 0 {
-			runningPods := 0
-			for _, pod := range pods.Items {
-				if pod.Status.Phase == "Running" {
-					runningPods++
-				}
-			}
-
-			c.mu.Lock()
-			c.detectedNamespace = ns
-			if runningPods > 0 {
-				c.isConnected = true
-			}
-			c.mu.Unlock()
-
-			if runningPods > 0 {
-				result.Available = true
-				result.Message = fmt.Sprintf("Caretta detected with %d running pod(s) in namespace %s", runningPods, ns)
-
-				// Try to get version from pod labels
-				if len(pods.Items) > 0 {
-					if ver, ok := pods.Items[0].Labels["app.kubernetes.io/version"]; ok {
-						result.Version = ver
-					}
-				}
-
-				return result, nil
-			}
-
-			result.Message = fmt.Sprintf("Caretta pods found in %s but none are running (%d total)", ns, len(pods.Items))
-			return result, nil
+			return c.resultFromPods(pods.Items, result), nil
 		}
+	}
+
+	// The chart's namespace follows the Helm release, so an install that landed
+	// outside the three names above is still a real Caretta. One labelled
+	// cluster-wide list finds it; where that list is denied we fall through to
+	// "not detected", which is the behavior without this lookup.
+	if pods, err := c.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: carettaAppLabel}); err == nil && len(pods.Items) > 0 {
+		return c.resultFromPods(pods.Items, result), nil
 	}
 
 	// Also check for DaemonSet
@@ -182,6 +164,7 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 		if err == nil {
 			c.mu.Lock()
 			c.detectedNamespace = ns
+			c.detectedInstance = ds.Labels[carettaInstanceLabel]
 			if ds.Status.NumberReady > 0 {
 				c.isConnected = true
 			}
@@ -201,6 +184,52 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 
 	result.Message = "Caretta not detected. Install Caretta for eBPF-based traffic visibility."
 	return result, nil
+}
+
+// resultFromPods records where Caretta was found and fills in the detection
+// result. Pods are sorted so a multi-namespace match resolves the same way every
+// call — the recorded namespace decides where the metrics store is looked up.
+func (c *CarettaSource) resultFromPods(pods []corev1.Pod, result *DetectionResult) *DetectionResult {
+	sort.Slice(pods, func(i, j int) bool {
+		if pods[i].Namespace != pods[j].Namespace {
+			return pods[i].Namespace < pods[j].Namespace
+		}
+		return pods[i].Name < pods[j].Name
+	})
+
+	// A running pod represents the install better than a crashlooping one, and
+	// namespace and release must come from the same pod — they together decide
+	// where the metrics store is looked up and which store is trusted as its own.
+	running := 0
+	chosen := &pods[0]
+	for i := range pods {
+		if pods[i].Status.Phase == "Running" {
+			if running == 0 {
+				chosen = &pods[i]
+			}
+			running++
+		}
+	}
+
+	c.mu.Lock()
+	c.detectedNamespace = chosen.Namespace
+	c.detectedInstance = chosen.Labels[carettaInstanceLabel]
+	if running > 0 {
+		c.isConnected = true
+	}
+	c.mu.Unlock()
+
+	if running == 0 {
+		result.Message = fmt.Sprintf("Caretta pods found in %s but none are running (%d total)", chosen.Namespace, len(pods))
+		return result
+	}
+
+	result.Available = true
+	result.Message = fmt.Sprintf("Caretta detected with %d running pod(s) in namespace %s", running, chosen.Namespace)
+	if ver, ok := chosen.Labels["app.kubernetes.io/version"]; ok {
+		result.Version = ver
+	}
+	return result
 }
 
 // GetFlows retrieves flows from Caretta via Prometheus metrics
@@ -299,7 +328,7 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 	// If we have a cached address, verify it's still valid
 	if c.prometheusAddr != "" {
 		testAddr := c.prometheusAddr + c.metricsBasePath
-		if c.tryMetricsEndpointLocked(ctx, testAddr) {
+		if c.revalidateBoundLocked(ctx, testAddr) {
 			return c.prometheusAddr
 		}
 		// Clear stale address
@@ -314,6 +343,7 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 			log.Printf("[caretta] Using manual metrics URL: %s", addr)
 			c.prometheusAddr = addr
 			c.metricsBasePath = ""
+			c.boundIsCarettaStore = false
 			c.backendVerified = c.carettaMetricsPresentLocked(ctx, addr)
 			c.backendWarning = ""
 			return addr
@@ -403,7 +433,13 @@ func (c *CarettaSource) discoverServiceLocked(ctx context.Context) []*metricsSer
 		add(c.discoverMetricsServiceDynamic(ctx))
 	}
 
+	// The cap bounds how long a Connect can take — every candidate past the first
+	// costs a probe and possibly a port-forward. Log what it drops: a silent
+	// truncation reads as "nothing else was available".
 	if len(candidates) > maxMetricsCandidates {
+		for _, dropped := range candidates[maxMetricsCandidates:] {
+			log.Printf("[caretta] Not trying %s/%s: candidate limit of %d reached", dropped.namespace, dropped.name, maxMetricsCandidates)
+		}
 		candidates = candidates[:maxMetricsCandidates]
 	}
 	return candidates
@@ -424,7 +460,15 @@ func (c *CarettaSource) findCarettaStoreLocked(ctx context.Context) *metricsServ
 	svcs, err := c.k8sClient.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: carettaStoreLabel})
 	if err == nil && len(svcs.Items) > 0 {
 		sort.Slice(svcs.Items, func(i, j int) bool { return svcs.Items[i].Name < svcs.Items[j].Name })
-		return carettaStoreInfo(svcs.Items[0])
+		for _, svc := range svcs.Items {
+			if c.ownsStore(svc) {
+				return carettaStoreInfo(svc, true)
+			}
+		}
+		// A VictoriaMetrics that merely shares Caretta's namespace proves nothing —
+		// `default` and `monitoring` host plenty of unrelated ones. Offer it, but make
+		// it earn admission on content like any other third-party backend.
+		return carettaStoreInfo(svcs.Items[0], false)
 	}
 
 	// The List can fail on get-but-not-list RBAC, and a store whose labels were
@@ -433,19 +477,34 @@ func (c *CarettaSource) findCarettaStoreLocked(ctx context.Context) *metricsServ
 	if err != nil {
 		return nil
 	}
-	return carettaStoreInfo(*svc)
+	return carettaStoreInfo(*svc, true)
 }
 
-func carettaStoreInfo(svc corev1.Service) *metricsServiceInfo {
+// ownsStore reports whether a metrics service demonstrably belongs to the Caretta
+// install that was detected: either the name the chart pins, or the same Helm
+// release as Caretta's own pods. Only then is the store trusted without a content
+// probe.
+func (c *CarettaSource) ownsStore(svc corev1.Service) bool {
+	if svc.Name == carettaStoreService {
+		return true
+	}
+	return c.detectedInstance != "" && svc.Labels[carettaInstanceLabel] == c.detectedInstance
+}
+
+func carettaStoreInfo(svc corev1.Service, owned bool) *metricsServiceInfo {
 	port := resolveServicePort(svc, 0)
-	log.Printf("[caretta] Found Caretta metrics store: %s/%s:%d", svc.Namespace, svc.Name, port)
+	if owned {
+		log.Printf("[caretta] Found Caretta metrics store: %s/%s:%d", svc.Namespace, svc.Name, port)
+	} else {
+		log.Printf("[caretta] Found unattributed metrics service %s/%s:%d in Caretta's namespace, will verify contents", svc.Namespace, svc.Name, port)
+	}
 	return &metricsServiceInfo{
 		namespace:      svc.Namespace,
 		name:           svc.Name,
 		port:           port,
 		targetPort:     resolveTargetPort(svc, port),
 		clusterAddr:    buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
-		isCarettaStore: true,
+		isCarettaStore: owned,
 	}
 }
 
@@ -535,7 +594,35 @@ func (c *CarettaSource) bindLocked(addr string, info *metricsServiceInfo) {
 		c.metricsNamespace = info.namespace
 		c.metricsService = info.name
 		c.metricsPort = info.port
+		c.boundIsCarettaStore = info.isCarettaStore
 		c.backendVerified = true
+	}
+}
+
+// revalidateBoundLocked re-checks a cached address. Reachability alone is enough
+// for Caretta's own store, but a third-party backend was admitted because it held
+// Caretta data at bind time and can stop scraping Caretta later — leaving
+// backendVerified stale would suppress the zero-flow warning and put the silence
+// back. Caller must hold lock.
+func (c *CarettaSource) revalidateBoundLocked(ctx context.Context, addr string) bool {
+	if !c.tryMetricsEndpointLocked(ctx, addr) {
+		return false
+	}
+	if !c.boundIsCarettaStore {
+		c.backendVerified = c.carettaMetricsPresentLocked(ctx, addr)
+	}
+	return true
+}
+
+// stopStaleTrafficForward drops the traffic-owned forward when it points at a
+// service other than the one being bound. A candidate refused mid-walk can leave
+// its forward running, which would make the reported connection name a different
+// service than the one being queried.
+func stopStaleTrafficForward(namespace, name string) {
+	pf := portforward.GetConnectionInfo(portforward.OwnerTraffic)
+	if pf.Connected && (pf.Namespace != namespace || pf.ServiceName != name) {
+		log.Printf("[caretta] Dropping refused port-forward to %s/%s", pf.Namespace, pf.ServiceName)
+		portforward.Stop(portforward.OwnerTraffic)
 	}
 }
 
@@ -717,6 +804,8 @@ func (c *CarettaSource) Close() error {
 	c.metricsBasePath = ""
 	c.currentContext = ""
 	c.detectedNamespace = ""
+	c.detectedInstance = ""
+	c.boundIsCarettaStore = false
 	c.backendVerified = false
 	c.backendWarning = ""
 	return nil
@@ -731,7 +820,7 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	// If already connected to the same context, check if still valid
 	if c.prometheusAddr != "" && c.currentContext == contextName {
 		testAddr := c.prometheusAddr + c.metricsBasePath
-		if c.tryMetricsEndpointLocked(ctx, testAddr) {
+		if c.revalidateBoundLocked(ctx, testAddr) {
 			return &portforward.ConnectionInfo{
 				Connected:   true,
 				Address:     c.prometheusAddr,
@@ -759,6 +848,7 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 			log.Printf("[caretta] Connected using manual metrics URL: %s", addr)
 			c.prometheusAddr = addr
 			c.metricsBasePath = ""
+			c.boundIsCarettaStore = false
 			c.backendVerified = c.carettaMetricsPresentLocked(ctx, addr)
 			c.backendWarning = ""
 			return &portforward.ConnectionInfo{
@@ -824,6 +914,7 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 			switch c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) {
 			case backendAccepted:
 				log.Printf("[caretta] Using existing port-forward at %s", pfAddr)
+				stopStaleTrafficForward(info.namespace, info.name)
 				c.bindLocked(pfAddr, info)
 				return &portforward.ConnectionInfo{
 					Connected:   true,

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -137,25 +137,38 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 	// Check for Caretta pods in caretta namespace or kube-system
 	namespacesToCheck := []string{carettaNamespace, "default", "kube-system"}
 
+	// Pods left behind by a dead install, kept only as a last resort: returning on
+	// them would hide a healthy Caretta running in another namespace and pin store
+	// discovery to the wrong release.
+	var stopped []corev1.Pod
+
 	for _, ns := range namespacesToCheck {
 		pods, err := c.k8sClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 			LabelSelector: carettaAppLabel,
 		})
-		if err != nil {
+		if err != nil || len(pods.Items) == 0 {
 			continue
 		}
 
-		if len(pods.Items) > 0 {
+		if anyRunning(pods.Items) {
 			return c.resultFromPods(pods.Items, result), nil
+		}
+		if stopped == nil {
+			stopped = pods.Items
 		}
 	}
 
 	// The chart's namespace follows the Helm release, so an install that landed
 	// outside the three names above is still a real Caretta. One labelled
-	// cluster-wide list finds it; where that list is denied we fall through to
-	// "not detected", which is the behavior without this lookup.
+	// cluster-wide list finds it, and covers the namespaces above too, so its
+	// result supersedes anything held back. Where that list is denied we fall back
+	// to what the fixed names turned up, which is the behavior without this lookup.
 	if pods, err := c.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: carettaAppLabel}); err == nil && len(pods.Items) > 0 {
 		return c.resultFromPods(pods.Items, result), nil
+	}
+
+	if stopped != nil {
+		return c.resultFromPods(stopped, result), nil
 	}
 
 	// Also check for DaemonSet
@@ -184,6 +197,15 @@ func (c *CarettaSource) Detect(ctx context.Context) (*DetectionResult, error) {
 
 	result.Message = "Caretta not detected. Install Caretta for eBPF-based traffic visibility."
 	return result, nil
+}
+
+func anyRunning(pods []corev1.Pod) bool {
+	for i := range pods {
+		if pods[i].Status.Phase == corev1.PodRunning {
+			return true
+		}
+	}
+	return false
 }
 
 // resultFromPods records where Caretta was found and fills in the detection

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -393,7 +393,12 @@ func (c *CarettaSource) discoverServiceLocked(ctx context.Context) []*metricsSer
 	}
 
 	add(c.findCarettaStoreLocked(ctx))
-	add(c.findMetricsServiceLocked(ctx))
+	for _, info := range c.findMetricsServicesLocked(ctx) {
+		add(info)
+	}
+	// Dynamic discovery is the last resort: it costs a cluster-wide Service list
+	// plus a scoring pass, and the well-known list already covers the mainstream
+	// installs. Run it only when nothing else turned anything up.
 	if len(candidates) == 0 {
 		add(c.discoverMetricsServiceDynamic(ctx))
 	}
@@ -783,8 +788,11 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	var noData, unreachable []string
 	var lastErr string
 	for _, info := range candidates {
+		target := fmt.Sprintf("%s/%s", info.namespace, info.name)
+
 		// Try cluster-internal address first (works when running in-cluster)
-		if c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) == backendAccepted {
+		switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
+		case backendAccepted:
 			log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
 			c.bindLocked(info.clusterAddr, info)
 			return &portforward.ConnectionInfo{
@@ -794,6 +802,11 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 				ServiceName: info.name,
 				ContextName: contextName,
 			}, nil
+		case backendNoCarettaData:
+			// Already reached it and it holds no Caretta data — a port-forward to the
+			// same service would only reach the same database.
+			noData = append(noData, target)
+			continue
 		}
 
 		// Check if there's already a valid managed port-forward for this context that
@@ -803,7 +816,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 		// holds no caretta_links_observed, so flows would come back empty. On no match
 		// we fall through and start the dedicated forward below.
 		if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, contextName, info.namespace, info.name); pfAddr != "" {
-			if c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) == backendAccepted {
+			switch c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) {
+			case backendAccepted:
 				log.Printf("[caretta] Using existing port-forward at %s", pfAddr)
 				c.bindLocked(pfAddr, info)
 				return &portforward.ConnectionInfo{
@@ -813,6 +827,9 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 					ServiceName: info.name,
 					ContextName: contextName,
 				}, nil
+			case backendNoCarettaData:
+				noData = append(noData, target)
+				continue
 			}
 		}
 
@@ -825,7 +842,6 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 			continue
 		}
 
-		target := fmt.Sprintf("%s/%s", info.namespace, info.name)
 		switch c.acceptBackendLocked(ctx, info, connInfo.Address+info.basePath) {
 		case backendAccepted:
 			c.bindLocked(connInfo.Address, info)
@@ -892,8 +908,14 @@ func resolveTargetPort(svc corev1.Service, servicePort int) int {
 	return servicePort
 }
 
-// findMetricsServiceLocked finds a metrics service from well-known locations (caller must hold lock)
-func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsServiceInfo {
+// findMetricsServicesLocked returns every well-known location that exists, in
+// declared order. All of them, not just the first: on a cluster running both
+// VictoriaMetrics and kube-prometheus-stack, the earlier match may hold no
+// Caretta data while a later one scrapes Caretta and is the right backend.
+// Stopping at the first hit would fail closed there.
+// Caller must hold lock.
+func (c *CarettaSource) findMetricsServicesLocked(ctx context.Context) []*metricsServiceInfo {
+	var found []*metricsServiceInfo
 	for _, loc := range metricsServiceLocations {
 		svc, err := c.k8sClient.CoreV1().Services(loc.namespace).Get(ctx, loc.name, metav1.GetOptions{})
 		if err != nil {
@@ -905,7 +927,7 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 		tp := resolveTargetPort(*svc, port)
 
 		log.Printf("[caretta] Found metrics service: %s/%s:%d (targetPort=%d)", svc.Namespace, svc.Name, port, tp)
-		return &metricsServiceInfo{
+		found = append(found, &metricsServiceInfo{
 			namespace:   svc.Namespace,
 			name:        svc.Name,
 			port:        port,
@@ -917,10 +939,10 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 			// so it is accepted on identity here too, or a store with no links yet
 			// would be admitted by one discovery path and rejected by the other.
 			isCarettaStore: svc.Name == carettaStoreService,
-		}
+		})
 	}
 
-	return nil
+	return found
 }
 
 // Namespaces to skip during dynamic discovery - never contain metrics services

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -794,6 +794,11 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 		switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
 		case backendAccepted:
 			log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
+			// Queries go to the cluster address from here, so the traffic module needs
+			// no forward of its own. An earlier candidate in this same walk may have
+			// left one up after being refused — keeping it would make the reported
+			// connection name a different service than the one being queried.
+			portforward.Stop(portforward.OwnerTraffic)
 			c.bindLocked(info.clusterAddr, info)
 			return &portforward.ConnectionInfo{
 				Connected:   true,

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -588,3 +588,44 @@ func TestCachedOwnStoreStaysVerifiedWhenIdle(t *testing.T) {
 		t.Errorf("idle own store downgraded: reachable=%v verified=%v", ok, verified)
 	}
 }
+
+// A dead install leaves pods behind. Returning on them hides a healthy Caretta in
+// another namespace and pins store discovery to the wrong release.
+func TestDetectSkipsPastStoppedPodsToRunningInstall(t *testing.T) {
+	c := sourceWithObjects(t, []*corev1.Pod{
+		carettaPod("default", "caretta-dead", "old-release", false),
+		carettaPod("observability", "caretta-live", "new-release", true),
+	})
+
+	result, err := c.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !result.Available {
+		t.Fatalf("healthy Caretta not detected: %s", result.Message)
+	}
+
+	c.mu.RLock()
+	ns, instance := c.detectedNamespace, c.detectedInstance
+	c.mu.RUnlock()
+	if ns != "observability" || instance != "new-release" {
+		t.Errorf("identity = %s/%s, want observability/new-release", ns, instance)
+	}
+}
+
+// With nothing running anywhere, the stopped pods are still reported — that is
+// the diagnosis the user needs, and it must not become "not detected".
+func TestDetectStillReportsStoppedPodsWhenNothingRuns(t *testing.T) {
+	c := sourceWithObjects(t, []*corev1.Pod{carettaPod("default", "caretta-dead", "old-release", false)})
+
+	result, err := c.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if result.Available {
+		t.Error("no pod is running, Caretta reported available")
+	}
+	if !strings.Contains(result.Message, "none are running") {
+		t.Errorf("message = %q, want it to say no pods are running", result.Message)
+	}
+}

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -1,0 +1,366 @@
+package traffic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func metricsSvc(ns, name string, port int32, clusterIP string, labels map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIP,
+			Ports:     []corev1.ServicePort{{Name: "http", Port: port, TargetPort: intstr.FromString("http")}},
+		},
+	}
+}
+
+// carettaStoreSvc mirrors what the groundcover/caretta chart renders: the
+// VictoriaMetrics subchart's name label, a headless service, port 8428.
+func carettaStoreSvc(ns, name string) *corev1.Service {
+	return metricsSvc(ns, name, 8428, "None", map[string]string{
+		"app":                    "server",
+		"app.kubernetes.io/name": "victoria-metrics-single",
+	})
+}
+
+// kubePrometheusStackSvcs are the services a kube-prometheus-stack install puts
+// in the well-known candidate list.
+func kubePrometheusStackSvcs() []*corev1.Service {
+	return []*corev1.Service{
+		metricsSvc("monitoring", "prometheus-operated", 9090, "None", map[string]string{
+			"operated-prometheus": "true",
+		}),
+		metricsSvc("monitoring", "kube-prometheus-stack-prometheus", 9090, "10.0.0.5", map[string]string{
+			"app":                       "kube-prometheus-stack-prometheus",
+			"app.kubernetes.io/part-of": "kube-prometheus-stack",
+		}),
+	}
+}
+
+func sourceWithServices(t *testing.T, detectedNS string, svcs ...*corev1.Service) *CarettaSource {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	for _, s := range svcs {
+		if _, err := cs.CoreV1().Services(s.Namespace).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seeding service %s/%s: %v", s.Namespace, s.Name, err)
+		}
+	}
+	return &CarettaSource{
+		k8sClient:         cs,
+		httpClient:        &http.Client{Timeout: 500 * time.Millisecond},
+		detectedNamespace: detectedNS,
+	}
+}
+
+func discover(t *testing.T, c *CarettaSource) []*metricsServiceInfo {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.discoverServiceLocked(context.Background())
+}
+
+// The store Caretta ships must outrank the cluster's general Prometheus. This is
+// the shape the wizard installs and the one reported in #1264.
+func TestCarettaPrefersOwnStoreOverGeneralPrometheus(t *testing.T) {
+	c := sourceWithServices(t, "caretta", append(kubePrometheusStackSvcs(), carettaStoreSvc("caretta", "caretta-vm"))...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].namespace != "caretta" || got[0].name != "caretta-vm" {
+		t.Errorf("top candidate = %s/%s, want caretta/caretta-vm", got[0].namespace, got[0].name)
+	}
+	if !got[0].isCarettaStore {
+		t.Error("top candidate not marked as Caretta's own store")
+	}
+}
+
+// The chart pins the service name but not the namespace: `helm install caretta
+// groundcover/caretta` with no -n puts everything in `default`. A namespace-blind
+// lookup walks past it and lands on kube-prometheus-stack, which holds no Caretta
+// series and answers every query successfully.
+func TestCarettaFindsStoreOutsideCarettaNamespace(t *testing.T) {
+	for _, ns := range []string{"default", "kube-system", "monitoring", "observability"} {
+		t.Run(ns, func(t *testing.T) {
+			c := sourceWithServices(t, ns, append(kubePrometheusStackSvcs(), carettaStoreSvc(ns, "caretta-vm"))...)
+
+			got := discover(t, c)
+			if len(got) == 0 {
+				t.Fatal("no candidates discovered")
+			}
+			if got[0].namespace != ns || got[0].name != "caretta-vm" {
+				t.Errorf("top candidate = %s/%s, want %s/caretta-vm", got[0].namespace, got[0].name, ns)
+			}
+		})
+	}
+}
+
+// A store whose name isn't the pinned caretta-vm is still found, because the
+// lookup keys on the VictoriaMetrics subchart label rather than the name.
+func TestCarettaFindsRenamedStoreByLabel(t *testing.T) {
+	c := sourceWithServices(t, "caretta",
+		append(kubePrometheusStackSvcs(), carettaStoreSvc("caretta", "caretta-victoria-metrics-single-server"))...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].name != "caretta-victoria-metrics-single-server" {
+		t.Errorf("top candidate = %s/%s, want the labelled VM store", got[0].namespace, got[0].name)
+	}
+}
+
+// Without its own store, the general Prometheus is still offered — it may be
+// scraping Caretta — but it comes second and has to prove it holds the data.
+func TestCarettaOffersGeneralPrometheusWhenNoStoreExists(t *testing.T) {
+	c := sourceWithServices(t, "caretta", kubePrometheusStackSvcs()...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	for _, info := range got {
+		if info.isCarettaStore {
+			t.Errorf("%s/%s wrongly marked as Caretta's own store", info.namespace, info.name)
+		}
+	}
+}
+
+// promBackend describes what a stub Prometheus holds. A real backend returns an
+// empty vector for a metric it never scraped while still answering `up`, which is
+// exactly why the generic reachability probe can't tell backends apart.
+type promBackend struct {
+	links      bool // has caretta_links_observed series
+	carettaJob bool // scrapes a target whose job name contains "caretta"
+}
+
+func promStub(t *testing.T, backend promBackend) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, err := url.QueryUnescape(r.URL.Query().Get("query"))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var hasSeries bool
+		switch {
+		case strings.Contains(q, "caretta_links_observed"):
+			hasSeries = backend.links
+		case strings.Contains(q, "caretta"):
+			hasSeries = backend.carettaJob
+		default:
+			hasSeries = true // plain `up` — every Prometheus answers this
+		}
+
+		result := []any{}
+		if hasSeries {
+			result = append(result, map[string]any{
+				"metric": map[string]string{"client_name": "frontend", "server_name": "backend", "server_port": "80"},
+				"value":  []any{1.0, "3"},
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data":   map[string]any{"resultType": "vector", "result": result},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func accept(t *testing.T, c *CarettaSource, info *metricsServiceInfo, addr string) bool {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.acceptBackendLocked(context.Background(), info, addr) == backendAccepted
+}
+
+// The generic reachability probe cannot tell the two apart — that is what made
+// the wrong-backend failure silent. Acceptance has to look at the content.
+func TestAcceptBackendRejectsPrometheusWithoutCarettaData(t *testing.T) {
+	general := promStub(t, promBackend{})
+	c := &CarettaSource{httpClient: &http.Client{Timeout: 2 * time.Second}}
+
+	c.mu.Lock()
+	reachable := c.tryMetricsEndpointLocked(context.Background(), general.URL)
+	c.mu.Unlock()
+	if !reachable {
+		t.Fatal("stub should pass the generic reachability probe")
+	}
+
+	if accept(t, c, &metricsServiceInfo{namespace: "monitoring", name: "prometheus-operated"}, general.URL) {
+		t.Error("accepted a Prometheus that holds no Caretta metrics")
+	}
+}
+
+// A general Prometheus that does scrape Caretta (ServiceMonitor deployments) is
+// the correct backend and must not be rejected by an identity-based gate.
+func TestAcceptBackendAcceptsPrometheusScrapingCaretta(t *testing.T) {
+	scraping := promStub(t, promBackend{links: true})
+	c := &CarettaSource{httpClient: &http.Client{Timeout: 2 * time.Second}}
+
+	if !accept(t, c, &metricsServiceInfo{namespace: "monitoring", name: "kube-prometheus-stack-prometheus"}, scraping.URL) {
+		t.Error("rejected a Prometheus that does hold Caretta metrics")
+	}
+}
+
+// A Caretta install that hasn't observed a connection yet holds no
+// caretta_links_observed. Its own store is accepted on identity so an idle
+// cluster doesn't read as a misconfiguration.
+func TestAcceptBackendAcceptsOwnStoreWithoutSeriesYet(t *testing.T) {
+	fresh := promStub(t, promBackend{})
+	c := &CarettaSource{httpClient: &http.Client{Timeout: 2 * time.Second}}
+
+	if !accept(t, c, &metricsServiceInfo{namespace: "caretta", name: "caretta-vm", isCarettaStore: true}, fresh.URL) {
+		t.Error("rejected Caretta's own store because it has no links yet")
+	}
+}
+
+// The scrape-target signal covers a store that has targets but no links.
+func TestCarettaMetricsPresentAcceptsScrapeTargetSignal(t *testing.T) {
+	srv := promStub(t, promBackend{carettaJob: true})
+	c := &CarettaSource{httpClient: &http.Client{Timeout: 2 * time.Second}}
+
+	c.mu.Lock()
+	got := c.carettaMetricsPresentLocked(context.Background(), srv.URL)
+	c.mu.Unlock()
+	if !got {
+		t.Error("scrape-target signal not recognised")
+	}
+}
+
+// The acceptance probe must carry the configured auth headers, or an
+// auth-protected store reads as "holds no Caretta metrics".
+func TestCarettaProbeCarriesHeaders(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := &CarettaSource{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		headers:    map[string]string{"Authorization": "Bearer caretta-token"},
+	}
+	c.mu.Lock()
+	c.carettaMetricsPresentLocked(context.Background(), srv.URL)
+	c.mu.Unlock()
+
+	if gotAuth != "Bearer caretta-token" {
+		t.Errorf("probe Authorization = %q, want %q", gotAuth, "Bearer caretta-token")
+	}
+}
+
+// Zero flows from a backend that never proved it holds Caretta data is
+// indistinguishable from a quiet cluster unless the response says so.
+func TestGetFlowsWarnsWhenBackendHasNoCarettaMetrics(t *testing.T) {
+	general := promStub(t, promBackend{})
+
+	c := &CarettaSource{
+		httpClient:       &http.Client{Timeout: 2 * time.Second},
+		prometheusAddr:   general.URL,
+		metricsNamespace: "monitoring",
+		metricsService:   "prometheus-operated",
+		isConnected:      true,
+	}
+
+	resp, err := c.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("GetFlows: %v", err)
+	}
+	if len(resp.Flows) != 0 {
+		t.Fatalf("expected 0 flows, got %d", len(resp.Flows))
+	}
+	if resp.Warning == "" {
+		t.Fatal("zero flows from an unverified backend reported without a warning")
+	}
+	if !strings.Contains(resp.Warning, "monitoring/prometheus-operated") {
+		t.Errorf("warning does not name the backend: %q", resp.Warning)
+	}
+}
+
+// A verified backend that is simply quiet must not raise a false alarm.
+func TestGetFlowsStaysSilentOnVerifiedBackend(t *testing.T) {
+	store := promStub(t, promBackend{})
+
+	c := &CarettaSource{
+		httpClient:       &http.Client{Timeout: 2 * time.Second},
+		prometheusAddr:   store.URL,
+		metricsNamespace: "caretta",
+		metricsService:   "caretta-vm",
+		isConnected:      true,
+		backendVerified:  true,
+	}
+
+	resp, err := c.GetFlows(context.Background(), FlowOptions{})
+	if err != nil {
+		t.Fatalf("GetFlows: %v", err)
+	}
+	if resp.Warning != "" {
+		t.Errorf("verified quiet backend warned anyway: %q", resp.Warning)
+	}
+}
+
+// Reached-but-wrong and never-reached are different problems: one means Radar is
+// reading the wrong database, the other means it read nothing at all. Collapsing
+// them sends the user to fix the wrong thing.
+func TestNoBackendWarningDistinguishesRejectionReasons(t *testing.T) {
+	tests := []struct {
+		name        string
+		noData      []string
+		unreachable []string
+		want        string
+	}{
+		{"holds no caretta data", []string{"monitoring/prometheus-operated"}, nil, "holds no Caretta metrics"},
+		{"never reached", nil, []string{"caretta/caretta-vm"}, "could not reach it"},
+		{"data problem wins", []string{"monitoring/prometheus-operated"}, []string{"caretta/caretta-vm"}, "holds no Caretta metrics"},
+		{"nothing found", nil, nil, "service not found"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := noBackendWarning(tc.noData, tc.unreachable)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("noBackendWarning(%v, %v) = %q, want it to contain %q", tc.noData, tc.unreachable, got, tc.want)
+			}
+		})
+	}
+}
+
+// The well-known list still carries caretta-vm for split installs. A store found
+// that way must be treated the same as one found by label, or a Caretta with no
+// links yet is admitted or rejected depending on which path happened to find it.
+func TestWellKnownCarettaStoreIsMarkedAsOwnStore(t *testing.T) {
+	// Detected in `default`, but the store lives in `caretta` — only the well-known
+	// list can find it.
+	c := sourceWithServices(t, "default", append(kubePrometheusStackSvcs(), carettaStoreSvc("caretta", "caretta-vm"))...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].namespace != "caretta" || got[0].name != "caretta-vm" {
+		t.Fatalf("top candidate = %s/%s, want caretta/caretta-vm", got[0].namespace, got[0].name)
+	}
+	if !got[0].isCarettaStore {
+		t.Error("well-known caretta-vm not marked as Caretta's own store")
+	}
+}

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -413,3 +413,178 @@ func TestCandidateListIsCapped(t *testing.T) {
 		t.Errorf("got %d candidates, want at most %d", len(got), maxMetricsCandidates)
 	}
 }
+
+func carettaPod(ns, name, instance string, running bool) *corev1.Pod {
+	phase := corev1.PodPending
+	if running {
+		phase = corev1.PodRunning
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "caretta",
+				"app.kubernetes.io/instance": instance,
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func sourceWithObjects(t *testing.T, pods []*corev1.Pod, svcs ...*corev1.Service) *CarettaSource {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	for _, p := range pods {
+		if _, err := cs.CoreV1().Pods(p.Namespace).Create(context.Background(), p, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seeding pod %s/%s: %v", p.Namespace, p.Name, err)
+		}
+	}
+	for _, s := range svcs {
+		if _, err := cs.CoreV1().Services(s.Namespace).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seeding service %s/%s: %v", s.Namespace, s.Name, err)
+		}
+	}
+	return &CarettaSource{k8sClient: cs, httpClient: &http.Client{Timeout: 500 * time.Millisecond}}
+}
+
+// Caretta's namespace follows its Helm release, so an install outside the three
+// hardcoded names is still real. Without this it isn't detected at all, and the
+// namespace-aware store lookup never runs.
+func TestDetectFindsCarettaInAnyNamespace(t *testing.T) {
+	c := sourceWithObjects(t, []*corev1.Pod{carettaPod("observability", "caretta-abc", "caretta", true)})
+
+	result, err := c.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !result.Available {
+		t.Fatalf("Caretta not detected: %s", result.Message)
+	}
+
+	c.mu.RLock()
+	ns, instance := c.detectedNamespace, c.detectedInstance
+	c.mu.RUnlock()
+	if ns != "observability" {
+		t.Errorf("detectedNamespace = %q, want observability", ns)
+	}
+	if instance != "caretta" {
+		t.Errorf("detectedInstance = %q, want caretta", instance)
+	}
+}
+
+// Namespace and release must be read off the same pod: they jointly decide where
+// the store is looked up and which store is trusted without a content probe.
+func TestDetectPrefersRunningPodForIdentity(t *testing.T) {
+	c := sourceWithObjects(t, []*corev1.Pod{
+		carettaPod("aaa-dead", "caretta-old", "stale-release", false),
+		carettaPod("zzz-live", "caretta-new", "live-release", true),
+	})
+
+	if _, err := c.Detect(context.Background()); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	c.mu.RLock()
+	ns, instance := c.detectedNamespace, c.detectedInstance
+	c.mu.RUnlock()
+	if ns != "zzz-live" || instance != "live-release" {
+		t.Errorf("identity = %s/%s, want zzz-live/live-release", ns, instance)
+	}
+}
+
+// Sharing a namespace with Caretta is not proof of belonging to it. `default` and
+// `monitoring` host unrelated VictoriaMetrics; trusting one on identity would skip
+// the content check and put the silent zero-flow failure right back.
+func TestUnrelatedVictoriaMetricsMustEarnAdmission(t *testing.T) {
+	unrelated := metricsSvc("default", "billing-metrics", 8428, "10.0.0.7", map[string]string{
+		"app.kubernetes.io/name":     "victoria-metrics-single",
+		"app.kubernetes.io/instance": "billing",
+	})
+	c := sourceWithServices(t, "default", unrelated)
+	c.detectedInstance = "caretta"
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].isCarettaStore {
+		t.Error("an unrelated VictoriaMetrics was trusted as Caretta's own store")
+	}
+}
+
+// A store belonging to the same Helm release as Caretta is its own, whatever the
+// release was named.
+func TestStoreOfSameReleaseIsTrusted(t *testing.T) {
+	store := metricsSvc("default", "traffic-vm", 8428, "None", map[string]string{
+		"app.kubernetes.io/name":     "victoria-metrics-single",
+		"app.kubernetes.io/instance": "traffic",
+	})
+	c := sourceWithServices(t, "default", store)
+	c.detectedInstance = "traffic"
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if !got[0].isCarettaStore {
+		t.Error("store from Caretta's own release not trusted")
+	}
+}
+
+// A third-party backend was admitted because it held Caretta data at bind time.
+// It can stop scraping Caretta later; if the cached-address check only asks `up`,
+// backendVerified stays true and the zero-flow warning is suppressed again.
+func TestCachedGenericBackendIsRevalidated(t *testing.T) {
+	scraping := promStub(t, promBackend{links: true})
+
+	c := &CarettaSource{
+		httpClient:          &http.Client{Timeout: 2 * time.Second},
+		prometheusAddr:      scraping.URL,
+		backendVerified:     true,
+		boundIsCarettaStore: false,
+	}
+
+	c.mu.Lock()
+	stillUp := c.revalidateBoundLocked(context.Background(), scraping.URL)
+	verified := c.backendVerified
+	c.mu.Unlock()
+	if !stillUp || !verified {
+		t.Fatalf("backend still holds Caretta data: reachable=%v verified=%v", stillUp, verified)
+	}
+
+	// Same backend, no longer scraping Caretta.
+	stopped := promStub(t, promBackend{})
+	c.mu.Lock()
+	c.prometheusAddr = stopped.URL
+	stillUp = c.revalidateBoundLocked(context.Background(), stopped.URL)
+	verified = c.backendVerified
+	c.mu.Unlock()
+	if !stillUp {
+		t.Fatal("backend is reachable, revalidation said otherwise")
+	}
+	if verified {
+		t.Error("backend that stopped holding Caretta data is still marked verified")
+	}
+}
+
+// Caretta's own store is trusted on identity, so an idle one must not be
+// downgraded on revalidation and start warning about a healthy install.
+func TestCachedOwnStoreStaysVerifiedWhenIdle(t *testing.T) {
+	idle := promStub(t, promBackend{})
+
+	c := &CarettaSource{
+		httpClient:          &http.Client{Timeout: 2 * time.Second},
+		prometheusAddr:      idle.URL,
+		backendVerified:     true,
+		boundIsCarettaStore: true,
+	}
+
+	c.mu.Lock()
+	ok := c.revalidateBoundLocked(context.Background(), idle.URL)
+	verified := c.backendVerified
+	c.mu.Unlock()
+	if !ok || !verified {
+		t.Errorf("idle own store downgraded: reachable=%v verified=%v", ok, verified)
+	}
+}

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -362,5 +363,53 @@ func TestWellKnownCarettaStoreIsMarkedAsOwnStore(t *testing.T) {
 	}
 	if !got[0].isCarettaStore {
 		t.Error("well-known caretta-vm not marked as Caretta's own store")
+	}
+}
+
+// A cluster can run more than one Prometheus-family backend. If the well-known
+// walk stops at the first hit, a cluster whose earlier backend holds no Caretta
+// data never reaches the later one that scrapes Caretta, and Live Traffic fails
+// closed on a cluster that has the data.
+func TestWellKnownLayerOffersEveryMatch(t *testing.T) {
+	vm := metricsSvc("monitoring", "victoria-metrics-single-server", 8428, "10.0.0.9", map[string]string{
+		"app.kubernetes.io/name": "victoria-metrics-single",
+	})
+	c := sourceWithServices(t, "caretta", append(kubePrometheusStackSvcs(), vm)...)
+
+	got := discover(t, c)
+	if len(got) < 2 {
+		t.Fatalf("got %d candidate(s), want every well-known match", len(got))
+	}
+
+	names := make([]string, 0, len(got))
+	for _, info := range got {
+		names = append(names, info.namespace+"/"+info.name)
+	}
+	want := []string{"monitoring/victoria-metrics-single-server", "monitoring/prometheus-operated"}
+	for _, w := range want {
+		if !slices.Contains(names, w) {
+			t.Errorf("candidate %s missing from %v", w, names)
+		}
+	}
+
+	// Declared order decides: the VictoriaMetrics entry precedes prometheus-operated.
+	if slices.Index(names, want[0]) > slices.Index(names, want[1]) {
+		t.Errorf("candidates out of declared order: %v", names)
+	}
+}
+
+// The candidate list is walked with a port-forward per attempt, so it stays bounded.
+func TestCandidateListIsCapped(t *testing.T) {
+	svcs := kubePrometheusStackSvcs()
+	svcs = append(svcs,
+		metricsSvc("monitoring", "victoria-metrics-single-server", 8428, "10.0.0.9", nil),
+		metricsSvc("monitoring", "vmsingle", 8428, "10.0.0.10", nil),
+		metricsSvc("monitoring", "prometheus-server", 9090, "10.0.0.11", nil),
+		metricsSvc("prometheus", "prometheus-server", 9090, "10.0.0.12", nil),
+	)
+	c := sourceWithServices(t, "caretta", svcs...)
+
+	if got := discover(t, c); len(got) > maxMetricsCandidates {
+		t.Errorf("got %d candidates, want at most %d", len(got), maxMetricsCandidates)
 	}
 }

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -629,3 +629,34 @@ func TestDetectStillReportsStoppedPodsWhenNothingRuns(t *testing.T) {
 		t.Errorf("message = %q, want it to say no pods are running", result.Message)
 	}
 }
+
+// Connect does not run detection, so the store lookup cannot assume Detect has
+// already recorded a namespace. When it hasn't, Caretta's own store must still be
+// found — otherwise connecting before listing sources binds the wrong backend.
+func TestStoreFoundWithoutPriorDetection(t *testing.T) {
+	c := sourceWithServices(t, "", append(kubePrometheusStackSvcs(), carettaStoreSvc("default", "caretta-vm"))...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].namespace != "default" || got[0].name != "caretta-vm" {
+		t.Errorf("top candidate = %s/%s, want default/caretta-vm", got[0].namespace, got[0].name)
+	}
+	if !got[0].isCarettaStore {
+		t.Error("store found without prior detection not trusted as Caretta's own")
+	}
+}
+
+// Same, for an install in a namespace none of the fixed names cover.
+func TestStoreFoundWithoutPriorDetectionInAnyNamespace(t *testing.T) {
+	c := sourceWithServices(t, "", append(kubePrometheusStackSvcs(), carettaStoreSvc("observability", "caretta-vm"))...)
+
+	got := discover(t, c)
+	if len(got) == 0 {
+		t.Fatal("no candidates discovered")
+	}
+	if got[0].namespace != "observability" || got[0].name != "caretta-vm" {
+		t.Errorf("top candidate = %s/%s, want observability/caretta-vm", got[0].namespace, got[0].name)
+	}
+}

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -660,3 +660,23 @@ func TestStoreFoundWithoutPriorDetectionInAnyNamespace(t *testing.T) {
 		t.Errorf("top candidate = %s/%s, want observability/caretta-vm", got[0].namespace, got[0].name)
 	}
 }
+
+// A headless Service publishes A records for its ready pods under its own name.
+// Addressing it as {service}-0.{service} assumes the StatefulSet is named after
+// the Service — true for caretta-vm, false for kube-prometheus-stack's
+// prometheus-operated — and made a reachable backend look unreachable in-cluster.
+func TestClusterAddrUsesPlainServiceDNS(t *testing.T) {
+	tests := []struct {
+		name, namespace string
+		port            int
+		want            string
+	}{
+		{"caretta-vm", "default", 8428, "http://caretta-vm.default.svc.cluster.local:8428"},
+		{"prometheus-operated", "monitoring", 9090, "http://prometheus-operated.monitoring.svc.cluster.local:9090"},
+	}
+	for _, tc := range tests {
+		if got := buildClusterAddr(tc.name, tc.namespace, tc.port); got != tc.want {
+			t.Errorf("buildClusterAddr(%s/%s) = %q, want %q", tc.namespace, tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Live Traffic (Caretta) reports zero flows, with no error anywhere in the UI, on any cluster where Caretta's metrics store is not at exactly `caretta/caretta-vm`.

Backend selection never checks that the chosen backend holds Caretta data. `findMetricsServiceLocked` returns the first well-known service that *exists* — no probe at all — and `tryMetricsEndpointLocked` only asks `query=up`, which the cluster's general Prometheus answers just as readily as Caretta's own store. Binding to it produces successful, permanently empty queries: `[caretta] Retrieved 0 flows from Prometheus`, an empty `FlowsResponse.Warning`, and the ordinary "no traffic yet" empty state.

This is the second half of the fix suggested in #1264. #1347 fixed the port-forward adoption path and declared the Caretta-specific probe out of scope ("because reuse is now target-verified, the generic reachability probe stays sufficient"). It isn't: when discovery itself picks the wrong service, target-aware reuse faithfully forwards to the wrong service.

The common trigger is an install that didn't land in the `caretta` namespace. The chart pins the service name to `caretta-vm` but its namespace follows the Helm release, so `helm install caretta groundcover/caretta` with no `-n` puts the store in `default`. `Detect()` scans `{caretta, default, kube-system}` and still reports Caretta **available** — then every query goes to kube-prometheus-stack.

## Fix

**Find the store where Caretta actually runs.** `Detect()` records the namespace it found Caretta in; the store is looked up there by the VictoriaMetrics subchart label (`app.kubernetes.io/name=victoria-metrics-single`), falling back to the pinned `caretta-vm` name for a relabelled store or a get-but-not-list identity.

**Validate before binding.** Discovery returns a ranked candidate list instead of a single service, and each candidate must be accepted before it is used. Caretta's own store is accepted on identity — a fresh install legitimately holds no series yet. Any other backend has to answer `count(caretta_links_observed)` or `count(up{job=~".*caretta.*"})` with at least one sample. The second signal deliberately keeps working for deployments where the cluster's Prometheus scrapes Caretta itself and *is* the correct backend; an identity-only gate would have broken those.

**Fail loudly.** When every candidate is rejected, `Connect` drops the forward it opened and returns not-connected with a message naming what was tried; zero flows from an unproven backend set `FlowsResponse.Warning`. Reached-but-wrong and never-reached are reported as different problems — one means Radar is reading the wrong database, the other means it read nothing. `TrafficView` already renders the warning, so there is no frontend change.

`pkg/prom`'s ordering is deliberately untouched: it ranks `caretta-vm` last so the resource-metrics module doesn't bind to it, and that ranking is correct for that module. Caretta ranks its own candidates.

## Verification

Real kind cluster: kube-prometheus-stack in `monitoring`, Caretta installed with no `-n` so it lands in `default`, traffic generator in `demo`. Ground truth at the time of the run — `default/caretta-vm` held 122 `caretta_links_observed` series, `monitoring/prometheus-operated` held none.

| cluster shape | connects to | flows | warning |
|---|---|---|---|
| before this change | `monitoring/prometheus-operated` | 0 | `""` (silent) |
| after | `default/caretta-vm` | 125 | `""` |
| after, no Caretta store anywhere | nothing — fails closed | 0 | names the rejected backend |
| after, kube-prometheus-stack scrapes Caretta itself | `monitoring/prometheus-operated` | 134 | `""` |

The last row is the guard against over-tightening.

11 unit tests in `internal/traffic/caretta_discovery_test.go` cover candidate ordering, the namespace-independent and relabelled store lookups, all three probe verdicts, header propagation, and the warning wording. `go test ./internal/...`, `go vet`, and `gofmt` are clean.

## Not included

`queryPrometheusRaw` and `GetMetricsServiceInfo` in this file have no production callers left — Istio moved to `internal/prometheus.Client`. Removing them is unrelated to this fix and `queryPrometheusRaw` still backs the existing header test, so they stay for now.

Closes #1264 for the remaining case.

https://claude.ai/code/session_011turT1Hgzf33v9x6AW2dsM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Caretta metrics discovery and Connect binding logic for Live Traffic. Risk is moderated by fail-closed behavior and broad unit coverage of acceptance and warning paths.
> 
> **Overview**
> Fixes Live Traffic silently returning zero flows when discovery bound to a Prometheus that answered PromQL but held no Caretta data — common when Caretta's store is not at `caretta/caretta-vm`.
> 
> **Detect** now records the install's namespace and Helm release, finds Caretta cluster-wide (not just three hardcoded namespaces), and prefers a running pod over leftover stopped ones so store lookup targets the live release.
> 
> **Discovery** returns a ranked candidate list (Caretta's own store first) instead of the first well-known hit. Each candidate must be accepted before bind: Caretta's store is trusted on identity; anything else must prove it has `caretta_links_observed` or a caretta scrape target. Rejected candidates produce distinct UI warnings for "wrong database" vs "unreachable".
> 
> Also uses plain service DNS for headless Services (fixes false unreachability for `prometheus-operated`) and adds extensive discovery/acceptance unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f783b5030a75a6126f30256dc9ab4f39393499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->