### PR TITLE
fix(cnpg): file backup failures as backups, and stop a paused Pooler reading healthy

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -122,6 +122,27 @@ func Classify(in classifyInput) issuesapi.Category {
 				return issuesapi.CategoryBackupTargetUnavailable
 			}
 			return issuesapi.CategoryBackupFailed
+		case g == "postgresql.cnpg.io":
+			// Only the durability signals are backups. A cluster that is
+			// unrecoverable, failing over or degraded is a control-plane
+			// problem, and filing it under backups would make the backup
+			// filter answer a different question than it claims to.
+			//
+			// Archiving failure stays here rather than under
+			// backup_target_unavailable: ContinuousArchiving proves the last
+			// archive attempt failed, not that the destination is unreachable,
+			// and the two have different fixes.
+			switch in.Kind {
+			case "Backup", "ScheduledBackup":
+				// Anything wrong with a backup object is backup-shaped
+				// whatever reason a future CNPG minor gives it.
+				return issuesapi.CategoryBackupFailed
+			}
+			switch in.Reason {
+			case "CNPGWALArchivingFailing", "CNPGLastBackupFailed", "CNPGBackupFailed":
+				return issuesapi.CategoryBackupFailed
+			}
+			return issuesapi.CategoryOperatorConditionFail
 		case g == "external-secrets.io":
 			return issuesapi.CategorySecretSyncFailed
 		case g == "keda.sh":

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -484,5 +485,61 @@ func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 				t.Errorf("phase %q: partial shortfall should stay suppressed", phase)
 			}
 		}
+	}
+}
+
+// A lost recovery point is a backup problem, and the Problems surface says so
+// by category. Filing it under the generic controller category rendered it as
+// "Controller reports a problem" and left it out of any backup-shaped filter,
+// while Velero's identical failures were categorised correctly.
+func TestCNPGBackupSignalsUseTheBackupCategory(t *testing.T) {
+	walFailing := cnpgCluster(
+		map[string]any{"instances": int64(2)},
+		map[string]any{
+			"phase":          "Cluster in healthy state",
+			"readyInstances": int64(2),
+			"conditions": []any{
+				cnpgCondition("ContinuousArchiving", "False", "ContinuousArchivingFailing", "unreachable"),
+				cnpgCondition("LastBackupSucceeded", "False", "BackupFailed", "upload rejected"),
+			},
+		})
+
+	got := detectCNPGIssues(cnpgClusterGVR, "Cluster", walFailing)
+	for _, reason := range []string{"CNPGWALArchivingFailing", "CNPGLastBackupFailed"} {
+		if c := findIssue(t, got, reason).Category; c != issuesapi.CategoryBackupFailed {
+			t.Errorf("%s category = %q, want %q", reason, c, issuesapi.CategoryBackupFailed)
+		}
+	}
+
+	backup := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Backup",
+		"metadata":   map[string]any{"name": "b1", "namespace": "pg"},
+		"status":     map[string]any{"phase": "failed", "error": "boom"},
+	}}
+	if c := findIssue(t, detectCNPGIssues(cnpgBackupGVR, "Backup", backup), "CNPGBackupFailed").Category; c != issuesapi.CategoryBackupFailed {
+		t.Errorf("CNPGBackupFailed category = %q, want %q", c, issuesapi.CategoryBackupFailed)
+	}
+}
+
+// The cluster's own health is not a backup problem. Without this the backup
+// filter would collect every unrelated CNPG fault and stop meaning anything.
+func TestCNPGClusterHealthKeepsTheControllerCategory(t *testing.T) {
+	unrecoverable := cnpgCluster(
+		map[string]any{"instances": int64(2)},
+		map[string]any{"phase": cnpgPhaseUnrecoverable, "readyInstances": int64(2)})
+
+	got := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", unrecoverable), "CNPGClusterUnrecoverable")
+	if got.Category != issuesapi.CategoryOperatorConditionFail {
+		t.Errorf("category = %q, want %q", got.Category, issuesapi.CategoryOperatorConditionFail)
+	}
+}
+
+// A future CNPG minor can name a Backup failure anything it likes; the object
+// it happened to is what makes it backup-shaped.
+func TestCNPGBackupKindIsBackupShapedWhateverTheReason(t *testing.T) {
+	in := classifyInput{Source: SourceCondition, APIGroup: "postgresql.cnpg.io", Kind: "Backup", Reason: "SomethingCNPGInventsLater"}
+	if got := Classify(in); got != issuesapi.CategoryBackupFailed {
+		t.Errorf("category = %q, want %q", got, issuesapi.CategoryBackupFailed)
 	}
 }

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
@@ -8,6 +8,7 @@ import {
   getCNPGPoolerParameters,
   getCNPGPoolerAuthQuery,
   getCNPGPoolerAuthQuerySecret,
+  isCNPGPoolerPaused,
 } from '../resource-utils-cnpg'
 
 interface CNPGPoolerRendererProps {
@@ -23,6 +24,7 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
   // CR never establishes.
   const scheduled = data.status?.instances ?? 0
   const isDegraded = desired > 0 && scheduled < desired
+  const isPaused = isCNPGPoolerPaused(data)
   const clusterName = getCNPGPoolerCluster(data)
   const parameters = getCNPGPoolerParameters(data)
   const authQuery = getCNPGPoolerAuthQuery(data)
@@ -39,12 +41,21 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
         />
       )}
 
+      {isPaused && (
+        <AlertBanner
+          variant="warning"
+          title="Pooler Paused"
+          message="PgBouncer is paused, so client connections are held rather than served. The pods stay scheduled and Ready throughout, so nothing else about this Pooler will look wrong."
+        />
+      )}
+
       {/* Pooler Configuration */}
       <Section title="Pooler Configuration" icon={Users} defaultExpanded>
         <PropertyList>
           <Property label="Type" value={getCNPGPoolerType(data)} />
           <Property label="Pool Mode" value={getCNPGPoolerMode(data)} />
           <Property label="Instances Scheduled" value={getCNPGPoolerInstances(data)} />
+          {isPaused && <Property label="PgBouncer" value="Paused" />}
         </PropertyList>
       </Section>
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -4,6 +4,7 @@ import {
   getCNPGClusterStatus,
   getCNPGBackupStatus,
   getCNPGPoolerStatus,
+  isCNPGPoolerPaused,
   getCNPGClusterInstancesReportedState,
   getCNPGClusterBackupConfig,
   getCNPGClusterBarmanPlugin,
@@ -597,5 +598,35 @@ describe('an absent count is unknown, never zero', () => {
       .toMatchObject({ text: 'Not Scheduled', level: 'unhealthy' })
     expect(getCNPGPoolerStatus({ spec: { instances: 2 }, status: { instances: 2 } }))
       .toMatchObject({ text: 'Scheduled', level: 'healthy' })
+  })
+})
+
+describe('paused Pooler', () => {
+  // PgBouncer PAUSE holds client connections instead of serving them, while
+  // every pod stays scheduled and Ready. Reading only the pod counts rendered
+  // a pooler that serves nothing in healthy green.
+  const paused = { spec: { instances: 2, pgbouncer: { paused: true } }, status: { instances: 2 } }
+
+  it('does not read as healthy', () => {
+    expect(getCNPGPoolerStatus(paused)).toMatchObject({ text: 'Paused', level: 'degraded' })
+  })
+
+  it('treats pausing as intent, not a fault', () => {
+    // Same tier as a paused Velero Schedule: amber, not red.
+    expect(getCNPGPoolerStatus(paused).level).not.toBe('unhealthy')
+  })
+
+  it('lets a real fault outrank the pause', () => {
+    const pausedAndDown = { spec: { instances: 2, pgbouncer: { paused: true } }, status: { instances: 0 } }
+    expect(getCNPGPoolerStatus(pausedAndDown)).toMatchObject({ text: 'Not Scheduled', level: 'unhealthy' })
+  })
+
+  it('only an explicit true pauses', () => {
+    expect(getCNPGPoolerStatus({ spec: { instances: 2, pgbouncer: {} }, status: { instances: 2 } }))
+      .toMatchObject({ text: 'Scheduled', level: 'healthy' })
+    expect(getCNPGPoolerStatus({ spec: { instances: 2, pgbouncer: { paused: false } }, status: { instances: 2 } }))
+      .toMatchObject({ text: 'Scheduled', level: 'healthy' })
+    expect(isCNPGPoolerPaused({ spec: { pgbouncer: { paused: true } } })).toBe(true)
+    expect(isCNPGPoolerPaused({ spec: {} })).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -666,11 +666,27 @@ export function getCNPGPoolerStatus(resource: any): StatusBadge {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
 
+  // Faults outrank intent: a Pooler that is both paused and unscheduled has a
+  // problem worth fixing before the pause is worth mentioning.
+  if (isCNPGPoolerPaused(resource)) {
+    return { text: 'Paused', color: healthColors.degraded, level: 'degraded' }
+  }
+
   if (desired > 0 && scheduled >= desired) {
     return { text: 'Scheduled', color: healthColors.healthy, level: 'healthy' }
   }
 
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+/**
+ * PgBouncer holds client connections instead of serving them while paused, and
+ * every pod stays scheduled and Ready throughout - the one Pooler state that
+ * pod counts cannot express. CRD-defaulted to false, so only an explicit true
+ * pauses.
+ */
+export function isCNPGPoolerPaused(resource: any): boolean {
+  return resource.spec?.pgbouncer?.paused === true
 }
 
 /** Name of the Deployment CNPG generates for this Pooler — where real readiness lives. */

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -128,7 +128,7 @@ var categoryDescription = map[Category]string{
 	CategoryPVCResizeFailed:          "A volume expansion didn't complete — the requested resize failed or is stuck.",
 	CategoryVolumeMountFailed:        "A pod can't mount a volume — attach/mount failed (wrong node, missing CSI driver, or permissions).",
 	CategoryVolumeAccessModeConflict: "A volume's access mode conflicts with how it's mounted (e.g. an RWO volume claimed by pods on different nodes).",
-	CategoryBackupFailed:             "A backup or restore run failed, partially failed, or was rejected in validation — the recovery point you'd expect to have may not exist.",
+	CategoryBackupFailed:             "A backup or restore run failed, partially failed, or was rejected in validation, or a database's continuous archiving has stopped — the recovery point you'd expect to have may not exist.",
 	CategoryBackupTargetUnavailable:  "The backup destination itself is unhealthy — an object-store location or backup repository the backup tool can't reach or validate.",
 	// Scaling
 	CategoryRolloutStalled:     "A workload rollout is stuck — the new revision isn't progressing (progressDeadlineExceeded).",


### PR DESCRIPTION
Two CNPG surfaces reported something other than what the cluster was doing. Both were found by running Radar against the CNPG demo fixture from #1402 rather than by a failing test, and neither is caught by the existing suites.

## 1. A lost recovery point was not filed as a backup problem

`internal/issues/category.go` classifies by API group. There is a `velero.io` case mapping runs to `backup_failed` and locations/repositories to `backup_target_unavailable`, and there was no `postgresql.cnpg.io` case at all — so every CNPG issue fell through to `operator_condition_failed`.

The effect on a cluster whose WAL archiving has stopped:

| | before | after |
|---|---|---|
| `/api/issues` category | `operator_condition_failed` | `backup_failed` |
| drawer issue card | "Controller reports a problem" · Control plane | "Backup failed" · Storage |
| a backup-shaped filter | misses it | finds it |

The argument for those categories was made in the Velero work: without them every backup issue read "Controller reports a problem", which is wrong for a lost recovery point. That reasoning applies unchanged to CNPG, which landed a day later and did not get it. Two integrations were describing the same class of failure in two different vocabularies.

**Only the durability signals move.** `CNPGWALArchivingFailing`, `CNPGLastBackupFailed` and `CNPGBackupFailed` become `backup_failed`; a cluster that is unrecoverable, failing over or degraded keeps `operator_condition_failed`. Filing cluster health under backups would make the backup filter collect every unrelated CNPG fault and stop meaning anything.

**Backup and ScheduledBackup objects are matched by kind, not reason**, so a reason a future CNPG minor invents still lands in the right place.

**Archiving failure is `backup_failed`, not `backup_target_unavailable`.** `ContinuousArchiving=False` proves the last archive attempt failed; it does not prove the destination is unreachable, and the two have different fixes.

The category's catalog description previously described Velero runs only, so it now also covers continuous archiving.

## 2. A paused Pooler rendered healthy

`getCNPGPoolerStatus` compared scheduled pods against desired and never read `spec.pgbouncer.paused`. PgBouncer PAUSE holds client connections instead of serving them, while every pod stays scheduled and Ready — so a pooler serving nothing rendered in healthy green, and the word "paused" appeared nowhere in the row or the drawer.

Reproduced on the fixture: patching `spec.pgbouncer.paused: true` left the row reading **Scheduled**, 2/2, green.

Now an amber **Paused** badge, plus a drawer banner and a PgBouncer property. Two deliberate choices:

- **Amber, not an Issue.** Pausing is an operator action, so it follows the paused Velero Schedule precedent exactly — same text, same tier. It must not read healthy, because nothing is being served, but it is not a fault.
- **Faults outrank intent.** The paused check sits after the scheduling checks, so a pooler that is both paused and unscheduled still reads "Not Scheduled" — the problem worth fixing before the pause is worth mentioning. Same ordering the Velero Schedule uses for rejected-and-paused.

`Instances Scheduled` still reads 2/2 throughout, because the pods really are scheduled.

## Testing

`go test ./...` clean in both modules · `make tsc` clean · k8s-ui 2152 passing.

New tests fail without the corresponding fix — checked by reverting each source file and re-running:

- all three CNPG backup reasons come back `operator_condition_failed`
- the paused pooler comes back `Scheduled` / healthy

Verified live against the demo fixture (four clusters at 2/2 Ready, real archiver failure induced against an unroutable object store):

- `/api/issues` shows `backup_failed` on both the failing Cluster and its Backup, while the two unrecoverable clusters stay `operator_condition_failed`
- the drawer reads "Backup failed · Storage"; the unrecoverable cluster still reads "Controller reports a problem · Control plane", which is the correct half of the split
- MCP passes `category` through verbatim, so this reaches AI consumers too
- the pooler flips green → amber → green as it is paused and unpaused

No regression across the fixture's full checklist: four badges, status-filter counts, `cnpgNoDeclarativeBackup` at evaluated 4 / passed 1, CNPG and Velero column sets on the shared `backups` plural, KubeBlocks falling through to the generic drawer.

## Limits

- The demo fixture has one un-paused Pooler, so nothing in it exercises the paused path automatically — it has to be induced by hand.
- `Paused` is a badge, not an Issue, so a pooler paused indefinitely raises nothing on the Problems surface. That follows the established treatment of operator intent; if indefinite pausing turns out to be a real failure mode in the field it wants a staleness check rather than a status change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes issue categorization for CNPG durability failures, which affects Problems filtering and labels. Scoped classification fix with tests; no auth or data-path changes.
> 
> **Overview**
> Fixes two CNPG reporting bugs so durability and pause state match what the cluster is actually doing.
> 
> **Backup categorization.** CNPG issues previously fell through to `operator_condition_failed`, so WAL archiving and backup failures showed as generic controller problems and missed backup filters. Durability signals (`CNPGWALArchivingFailing`, `CNPGLastBackupFailed`, `CNPGBackupFailed`) and `Backup`/`ScheduledBackup` kinds now map to **`backup_failed`**; cluster health (unrecoverable, degraded, failover) stays under the controller category. The catalog description now also covers continuous archiving.
> 
> **Paused Pooler.** `getCNPGPoolerStatus` now reads `spec.pgbouncer.paused` and shows an amber **Paused** badge instead of healthy green (pods stay Ready while connections are held). The drawer adds a warning banner and PgBouncer property. Scheduling faults still outrank the pause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4346536571737b7d5e452ce1e06d86324b8b0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->