### PR TITLE
fix(health): a container that succeeded must not name the pod's problem

### DIFF
--- a/internal/k8s/detect_oom_test.go
+++ b/internal/k8s/detect_oom_test.go
@@ -287,8 +287,13 @@ func TestDetectProblems_OOMLimitDiscrepancy(t *testing.T) {
 			},
 		},
 		{
-			name: "benchmark-completed-reason", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
-			wantDetection: true, wantCause: true, wantReason: "Completed",
+			// A successful init container must not name the pod's problem. This
+			// pod is OOM-crashlooping; it previously reported "Completed" from
+			// the init container that finished cleanly, so the row carried an
+			// OOM cause and remediation under a reason that said nothing had
+			// gone wrong.
+			name: "succeeded-init-does-not-mask-crashloop", specLimit: "16Mi", statusLimit: "16Mi", templateLimit: "256Mi",
+			wantDetection: true, wantCause: true, wantReason: "CrashLoopBackOff",
 			mutate: func(pod *corev1.Pod, _ *appsv1.ReplicaSet) []runtime.Object {
 				pod.Spec.InitContainers = []corev1.Container{{Name: "setup"}}
 				pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}}}

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -288,8 +288,15 @@ func PodProblemMessage(pod *corev1.Pod) string {
 	if cs := problemContainer(pod, true); cs != nil {
 		return containerStateMessage(cs)
 	}
-	if cs := problemContainer(pod, false); cs != nil {
-		return containerStateMessage(cs)
+	// Gated exactly as podProblemReasonRaw gates its own fallback. Without the
+	// phase check a still-running pod took its reason from readiness or from the
+	// phase — later normalized to CrashLoopBackOff / OOMKilled — while the
+	// message came from a container that had merely finished, which is the
+	// cross-container pairing this walk exists to prevent.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		if cs := problemContainer(pod, false); cs != nil {
+			return containerStateMessage(cs)
+		}
 	}
 	return ""
 }

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -218,17 +218,29 @@ func podProblemReasonRaw(pod *corev1.Pod, now time.Time) string {
 	if podHasReadinessProbeFailure(pod, now) {
 		return reasonReadinessProbeFail
 	}
-	// Only a pod that has itself finished is described by a container that
-	// completed. While it is still running, the phase is the honest answer —
-	// and it is a phase-like reason, so the crashloop / OOM / thrash
-	// normalizations in PodProblemReason can still replace it. "Completed" is
-	// in neither of their predicate sets, so returning it here would silence
-	// every one of them.
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+	// A failed pod is never described by a container that succeeded. The kubelet
+	// puts the cause on the pod itself for the failures that have no failing
+	// container at all — Evicted, DeadlineExceeded, Shutdown, NodeAffinity — and
+	// without this an evicted pod reported "Completed" from the container the
+	// kubelet stopped cleanly on its way out.
+	if pod.Status.Phase == corev1.PodFailed {
+		if pod.Status.Reason != "" {
+			return pod.Status.Reason
+		}
+		return string(corev1.PodFailed)
+	}
+
+	// A succeeded pod, though, IS described by its completed containers.
+	if pod.Status.Phase == corev1.PodSucceeded {
 		if cs := problemContainer(pod, false); cs != nil {
 			return containerStateReason(cs)
 		}
 	}
+
+	// Still running: the phase is the honest answer, and it is a phase-like
+	// reason, so the crashloop / OOM / thrash normalizations in
+	// PodProblemReason can still replace it. "Completed" is in neither of their
+	// predicate sets, so returning it here would silence every one of them.
 	return string(pod.Status.Phase)
 }
 
@@ -293,7 +305,13 @@ func PodProblemMessage(pod *corev1.Pod) string {
 	// phase — later normalized to CrashLoopBackOff / OOMKilled — while the
 	// message came from a container that had merely finished, which is the
 	// cross-container pairing this walk exists to prevent.
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+	// Mirrors podProblemReasonRaw: the pod-level message is what explains an
+	// eviction or a deadline, and it belongs to the same object rather than to
+	// some other container.
+	if pod.Status.Phase == corev1.PodFailed {
+		return pod.Status.Message
+	}
+	if pod.Status.Phase == corev1.PodSucceeded {
 		if cs := problemContainer(pod, false); cs != nil {
 			return containerStateMessage(cs)
 		}

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -202,27 +202,77 @@ func PodProblemReason(pod *corev1.Pod, now time.Time) string {
 // podProblemReasonRaw is the phase/state walk: init containers first (they block
 // the pod Pending before main ContainerStatuses populate), then main containers,
 // falling back to the bare phase string.
+//
+// Containers that exited 0 are skipped on the first pass. A completed init
+// container did its job, and naming its "Completed" as the pod's problem reason
+// reports a success as the fault, hides the container that actually failed
+// below it, and classifies to the catch-all category — leaving a critical row
+// with nothing to act on. The second pass restores the plain walk so a pod whose
+// containers all succeeded still reports what it did.
 func podProblemReasonRaw(pod *corev1.Pod, now time.Time) string {
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
-			return cs.State.Waiting.Reason
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
+	if cs := problemContainer(pod, true); cs != nil {
+		return containerStateReason(cs)
 	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
-			return cs.State.Waiting.Reason
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
-	}
+	// Derived pod-level signals outrank a container that merely finished, so a
+	// completed init container cannot shadow a readiness failure below it.
 	if podHasReadinessProbeFailure(pod, now) {
 		return reasonReadinessProbeFail
 	}
+	// Only a pod that has itself finished is described by a container that
+	// completed. While it is still running, the phase is the honest answer —
+	// and it is a phase-like reason, so the crashloop / OOM / thrash
+	// normalizations in PodProblemReason can still replace it. "Completed" is
+	// in neither of their predicate sets, so returning it here would silence
+	// every one of them.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		if cs := problemContainer(pod, false); cs != nil {
+			return containerStateReason(cs)
+		}
+	}
 	return string(pod.Status.Phase)
+}
+
+// problemContainer picks the one container status that explains the pod, so the
+// reason and the message always describe the same container rather than being
+// gathered from two. Init containers first (they block the pod Pending before
+// main ContainerStatuses populate). When skipSucceeded is set, a container
+// terminated with exit code 0 is passed over.
+func problemContainer(pod *corev1.Pod, skipSucceeded bool) *corev1.ContainerStatus {
+	for _, statuses := range [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses} {
+		for i := range statuses {
+			cs := &statuses[i]
+			if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+				return cs
+			}
+			if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+				if skipSucceeded && cs.State.Terminated.ExitCode == 0 {
+					continue
+				}
+				return cs
+			}
+		}
+	}
+	return nil
+}
+
+func containerStateReason(cs *corev1.ContainerStatus) string {
+	if cs.State.Waiting != nil {
+		return cs.State.Waiting.Reason
+	}
+	if cs.State.Terminated != nil {
+		return cs.State.Terminated.Reason
+	}
+	return ""
+}
+
+func containerStateMessage(cs *corev1.ContainerStatus) string {
+	if cs.State.Waiting != nil {
+		return cs.State.Waiting.Message
+	}
+	if cs.State.Terminated != nil {
+		return cs.State.Terminated.Message
+	}
+	return ""
 }
 
 // PodProblemMessage returns the kubelet's waiting/terminated message for the
@@ -230,22 +280,16 @@ func podProblemReasonRaw(pod *corev1.Pod, now time.Time) string {
 // podProblemReasonRaw's walk). This is the actionable detail behind an otherwise
 // bare reason — ImagePullBackOff's "Failed to pull image X: …not found",
 // CreateContainerConfigError's "couldn't find key Y in Secret Z".
+// It selects the same container the reason came from, so a chatty container
+// that merely finished cannot supply the explanation for a different
+// container's failure. A failing container with no message stays empty rather
+// than borrowing one.
 func PodProblemMessage(pod *corev1.Pod) string {
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
-			return cs.State.Waiting.Message
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
+	if cs := problemContainer(pod, true); cs != nil {
+		return containerStateMessage(cs)
 	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
-			return cs.State.Waiting.Message
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
+	if cs := problemContainer(pod, false); cs != nil {
+		return containerStateMessage(cs)
 	}
 	return ""
 }

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -454,22 +454,65 @@ func TestPodProblemReasonStillReportsAnAllSucceededPod(t *testing.T) {
 // failed readiness.
 func TestPodProblemReasonSucceededInitDoesNotShadowReadinessFailure(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	// Every clause podHasReadinessProbeFailure requires must hold, or this
+	// passes through the phase fallback and proves nothing about precedence:
+	// a declared readiness probe, Running phase, and Ready=False for over 5min.
 	pod := &corev1.Pod{
-		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:           "app",
+			ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz"}}},
+		}}},
 		Status: corev1.PodStatus{
-			Phase:      corev1.PodRunning,
-			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodReady, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-20 * time.Minute)),
+			}},
 			InitContainerStatuses: []corev1.ContainerStatus{
 				{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
 			},
 			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", Ready: false, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-10 * time.Minute))}}},
+				{Name: "app", Ready: false, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-20 * time.Minute))}}},
 			},
 		},
 	}
 
-	if got := PodProblemReason(pod, now); got == "Completed" {
-		t.Errorf("PodProblemReason = %q — a completed init container shadowed the readiness failure", got)
+	if got := PodProblemReason(pod, now); got != reasonReadinessProbeFail {
+		t.Errorf("PodProblemReason = %q, want %q — a completed init container shadowed the readiness failure", got, reasonReadinessProbeFail)
+	}
+}
+
+// The message must be gated the same way the reason is. A still-running pod
+// takes its reason from readiness or from the phase, and used to take its
+// message from a container that had merely finished.
+func TestPodProblemMessageDoesNotBorrowOnAStillRunningPod(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:           "app",
+			ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz"}}},
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodReady, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-20 * time.Minute)),
+			}},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason: "Completed", ExitCode: 0, Message: "setup wrote 4 files"}}},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: false, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-20 * time.Minute))}}},
+			},
+		},
+	}
+
+	if got := PodProblemReason(pod, now); got != reasonReadinessProbeFail {
+		t.Fatalf("PodProblemReason = %q, want %q", got, reasonReadinessProbeFail)
+	}
+	if got := PodProblemMessage(pod); got != "" {
+		t.Errorf("PodProblemMessage = %q — borrowed from a container that merely finished", got)
 	}
 }
 

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -562,3 +562,68 @@ func TestPodProblemMessageDoesNotBorrowFromAnotherContainer(t *testing.T) {
 		t.Errorf("PodProblemMessage = %q — the failing container has no message, so this was borrowed from another container", got)
 	}
 }
+
+// An evicted pod has no failing container: the kubelet stops its containers
+// cleanly on the way out, so every one of them terminates with exit 0. Reading
+// the reason off a container reported the pod as "Completed" while its verdict
+// said unhealthy, and dropped the pod-level message that says WHY it was
+// evicted — the only actionable text there is.
+func TestPodProblemReasonUsesPodLevelReasonOnAFailedPod(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase:   corev1.PodFailed,
+		Reason:  "Evicted",
+		Message: "The node was low on resource: ephemeral-storage.",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Evicted" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Evicted")
+	}
+	if got := PodProblemMessage(pod); got != "The node was low on resource: ephemeral-storage." {
+		t.Errorf("PodProblemMessage = %q, want the pod-level eviction message", got)
+	}
+
+	// The verdict and the reason must agree: unhealthy must never read as a success.
+	v := Pod(pod, now)
+	if v.Level != LevelUnhealthy || v.Reason == "Completed" {
+		t.Errorf("Pod() = %v/%q — an unhealthy pod reported a successful reason", v.Level, v.Reason)
+	}
+}
+
+// A failed pod with no pod-level reason falls back to the phase, not to a
+// container that exited cleanly.
+func TestPodProblemReasonFailedPodWithoutPodLevelReason(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+		},
+	}}
+	if got := PodProblemReason(pod, now); got != "Failed" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Failed")
+	}
+}
+
+// A genuinely failed container still wins over the pod-level reason: it is the
+// more specific explanation.
+func TestPodProblemReasonPrefersAFailedContainerOverThePodReason(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase:  corev1.PodFailed,
+		Reason: "Evicted",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "OOMKilled", ExitCode: 137, Message: "container was OOM killed"}}},
+		},
+	}}
+	if got := PodProblemReason(pod, now); got != "OOMKilled" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "OOMKilled")
+	}
+	if got := PodProblemMessage(pod); got != "container was OOM killed" {
+		t.Errorf("PodProblemMessage = %q, want the container's message", got)
+	}
+}

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -361,3 +361,161 @@ func TestPodCrashLoopDiagnosis(t *testing.T) {
 		t.Fatalf("action = %q, want command/args guidance", action)
 	}
 }
+
+// An init container that exited 0 did its job. Reporting its "Completed" as the
+// pod's problem reason names a success as the fault, buries the real failure in
+// the container below it, and classifies to the catch-all category — so the row
+// reads "critical" with nothing to act on. CNPG's bootstrap pods hit this
+// (successful init, failed join), but any pod with init containers can.
+func TestPodProblemReasonSkipsSuccessfulInitContainers(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "bootstrap", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1, Message: "join failed"}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Error" {
+		t.Errorf("PodProblemReason = %q, want %q — the failed container is the problem, not the init container that succeeded", got, "Error")
+	}
+	if got := PodProblemMessage(pod); got != "join failed" {
+		t.Errorf("PodProblemMessage = %q, want %q", got, "join failed")
+	}
+}
+
+// A failed init container is still the pod's problem — it blocks everything
+// after it, and the main containers never start.
+func TestPodProblemReasonKeepsFailedInitContainers(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "ok", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+			{Name: "broken", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 2, Message: "migration failed"}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Error" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Error")
+	}
+	if got := PodProblemMessage(pod); got != "migration failed" {
+		t.Errorf("PodProblemMessage = %q, want %q", got, "migration failed")
+	}
+}
+
+// The reason and the message must describe the same container. A chatty init
+// container that succeeded used to supply the message while the failed one
+// supplied the reason, pairing a failure with an unrelated explanation.
+func TestPodProblemMessageMatchesTheReasonsContainer(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "bootstrap", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed", ExitCode: 0, Message: "bootstrap finished cleanly"}}},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Error", ExitCode: 1, Message: "could not reach primary"}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Error" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Error")
+	}
+	if got := PodProblemMessage(pod); got != "could not reach primary" {
+		t.Errorf("PodProblemMessage = %q, want the failed container's message", got)
+	}
+}
+
+// A pod whose containers all succeeded still reports what it did, rather than
+// falling through to a bare phase.
+func TestPodProblemReasonStillReportsAnAllSucceededPod(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodSucceeded,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "job", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Completed" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Completed")
+	}
+}
+
+// A completed init container must not shadow a derived pod-level failure. The
+// readiness check used to sit behind the plain container walk, so a pod whose
+// init container finished cleanly reported "Completed" while its main container
+// failed readiness.
+func TestPodProblemReasonSucceededInitDoesNotShadowReadinessFailure(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: false, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-10 * time.Minute))}}},
+			},
+		},
+	}
+
+	if got := PodProblemReason(pod, now); got == "Completed" {
+		t.Errorf("PodProblemReason = %q — a completed init container shadowed the readiness failure", got)
+	}
+}
+
+// "Completed" is in neither override predicate set, so returning it from a
+// still-running pod silences the crashloop, OOM and thrash normalizations that
+// exist to name exactly this state. A running pod is described by its phase.
+func TestPodProblemReasonDoesNotReportCompletedOnARunningPod(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-time.Minute))}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Running" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Running")
+	}
+}
+
+// The message must come from the container the reason came from, even when that
+// container has no message of its own. Borrowing a later container's message
+// pairs a failure with an unrelated explanation.
+func TestPodProblemMessageDoesNotBorrowFromAnotherContainer(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed", ExitCode: 0, Message: "setup wrote 4 files"}}},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Error", ExitCode: 1}}},
+			{Name: "sidecar", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed", ExitCode: 0, Message: "sidecar shut down cleanly"}}},
+		},
+	}}
+
+	if got := PodProblemReason(pod, now); got != "Error" {
+		t.Errorf("PodProblemReason = %q, want %q", got, "Error")
+	}
+	if got := PodProblemMessage(pod); got != "" {
+		t.Errorf("PodProblemMessage = %q — the failing container has no message, so this was borrowed from another container", got)
+	}
+}


### PR DESCRIPTION
`podProblemReasonRaw` walked init containers then main containers and returned the first non-empty terminated reason — **including `Completed` from a container that exited 0**.

So a pod whose init container finished cleanly and whose main container failed reported its problem as "Completed": a success named as the fault, the real failure hidden below it, and a category of `unknown`, leaving a `critical` row with nothing on it to act on.

Found by running Radar against a CloudNativePG cluster whose bootstrap `join` pod had failed and been retried. CNPG is only where it surfaced — **any pod with init containers can hit this**, and it is worse than the first example suggests:

| pod | before | after |
|---|---|---|
| init succeeded, main failed | `Completed` | `Error` |
| **first init succeeded, second init failed** | `Completed` | `Error` |
| completed init + main failing readiness | `Completed` | `ReadinessProbeFail` |
| completed init + main crashlooping (on the Running tick) | `Completed` | `CrashLoopBackOff` |

The last two are the sharpest, and they are why this is not just a cosmetic label. **`"Completed"` is in neither `isPhaseOrCrashReason` nor `isPhaseOnlyReason`**, so the crashloop, OOM and thrash normalizations in `PodProblemReason` — the machinery that exists to name exactly these states — all declined to replace it. One completed init container silenced every one of them.

## What changed

**One container is selected, and it explains both fields.** `problemContainer` picks the status that explains the pod; the reason and the message are both read from it. Previously they walked independently, so a failing container with no message let the message walk continue and return a *later* container's message — pairing a failure with an unrelated explanation. A failing container with no message now stays empty rather than borrowing one.

**Exit-0 containers are skipped on a first pass, with the plain walk as fallback**, so a pod whose containers all succeeded still reports what it did.

**The fallback only applies to a pod that has itself finished.** A still-running pod reports its phase, which *is* in the predicate sets, so the normalizations work again. This is the fix for the readiness and crashloop rows above.

## An existing test had pinned the bug

`detect_oom_test.go`'s `benchmark-completed-reason` asserted `wantReason: "Completed"` on a fixture whose base pod is an actively OOM-crashlooping container — `Waiting{CrashLoopBackOff}`, restart count 3, last termination `OOMKilled`/137. The detection therefore carried an OOM cause and a remediation action under a reason stating that nothing had gone wrong.

Nothing in the case explained why "Completed" was wanted, and its name reads as a record of current behaviour rather than a decision. Renamed to `succeeded-init-does-not-mask-crashloop` and now expects `CrashLoopBackOff`, which is both what the pod is doing and what its own cause and action describe. **Flagging it explicitly, because changing an existing expectation to make new code pass deserves a second opinion regardless of the argument behind it.**

## Testing

`go test ./...` clean in both modules. Six new tests, each checked against the pre-fix code — all six fail there.

Verified live with a purpose-built pod (init exits 0, main exits 1):

```
before:  reason "Completed", category "unknown"
after:   reason "Error",     category "crashloop"
```

Also driven through MCP against a Kyverno fixture cluster: a crashlooping workload reports `CrashLoopBackOff` with cause and action intact, and ordinary running pods are unaffected.

## Reviewed against a second model

A cross-model review of this diff raised three findings. Two were real and are fixed above — the fallback running ahead of the derived signals, and the reason/message pair being drawn from different containers. Both were pre-existing rather than introduced here, but they are the same defect on another branch, so they belong in this change.

The third — restrict exit-0 skipping to non-restartable init containers, on the grounds that a sidecar exiting 0 can itself be a signal — was **not** taken. When no container has a failing reason the fallback returns exactly what the old code returned, so nothing is hidden that was not already uninformative; and when another container has failed, its reason is strictly more useful than "Completed". The underlying point about restartable-init semantics is real but changes no output today.

## Blast radius

`PodProblemReason` and `PodProblemMessage` feed the Issues engine, topology node colour, timeline, MCP and the dashboard, so this is worth reviewing on its own rather than as part of a larger change. Behaviour is unchanged for every pod where the first container with a reason is the one that failed, which is the common case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pod problem classification used by Issues, dashboard, MCP, and topology. Behavior changes for multi-container and eviction cases, including an updated existing test expectation.
> 
> **Overview**
> **Successful (exit-0) containers no longer name a pod's problem.** `podProblemReasonRaw` used to return the first terminated reason — including `Completed` from a finished init — which hid real failures, silenced crashloop/OOM/thrash normalizations, and left critical rows in the catch-all category.
> 
> Reason and message now come from the **same** selected container via `problemContainer`. Exit-0 statuses are skipped first; a plain walk remains as fallback for all-succeeded pods. Still-running pods fall back to phase (so normalizations work again). Failed pods without a failing container use the pod-level reason/message (e.g. `Evicted`).
> 
> Updates the OOM fixture that had pinned the bug (`wantReason: "Completed"` → `CrashLoopBackOff`) and adds coverage for init masking, reason/message pairing, readiness precedence, and eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1c7b591ebf6d9f14ba56283f28796137c544a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->