### PR TITLE
fix(issues): stop issue_timing changing its answer as a resource ages

### DIFF
--- a/internal/k8s/issue_timing.go
+++ b/internal/k8s/issue_timing.go
@@ -62,7 +62,7 @@ func IssueTimingFromConditionLTT(failingSince, resourceCreated time.Time, basis 
 		return IssueTimingResult{IssueTiming: "started_at_resource_creation", Basis: basis}
 	}
 	// Rule 3: confirmed healthy — at least 10 minutes of healthy operation.
-	if healthyFor > 10*time.Minute {
+	if healthyFor >= 10*time.Minute {
 		return IssueTimingResult{IssueTiming: "started_after_resource_was_healthy", Basis: basis}
 	}
 	return IssueTimingResult{} // gray zone: omit

--- a/internal/k8s/issue_timing.go
+++ b/internal/k8s/issue_timing.go
@@ -19,13 +19,22 @@ type IssueTimingResult struct {
 //   - zero value the gap is in the gray zone, or timestamps are missing.
 //     Caller must omit issue_timing; do not infer timing from age alone.
 //
-// Two started-at-resource-creation rules:
+// Two started-at-resource-creation rules, both keyed only on how long the
+// resource was healthy. That quantity is fixed once the condition transitions,
+// so the same pair of timestamps yields the same answer at every point in the
+// resource's life:
 //  1. Absolute slop (30s): conditions take a moment to be written after creation.
-//  2. Ratio rule: healthyFor < 5min AND resource was failing for ≥75% of its
-//     lifetime. Catches misconfigured workloads that crash within ~1-2 min of
-//     deploy — the Kubernetes controller reconciliation loop means Available=False
-//     is set 60-120s after the first crash, which exceeds the 30s slop but is
-//     still clearly a deploy-time misconfiguration.
+//  2. Deploy window (3min): catches misconfigured workloads that crash within
+//     ~1-2 min of deploy — the Kubernetes controller reconciliation loop means
+//     Available=False is set 60-120s after the first crash, which exceeds the
+//     30s slop but is still clearly a deploy-time misconfiguration. Bounded just
+//     above that lag, because past it a healthy window is a real one.
+//
+// Anything that compares the healthy window against the resource's current age
+// decays as the resource gets older, so an unchanged pair of timestamps starts
+// out unclassified and silently becomes "started at resource creation" later.
+// Callers surface this in MCP output and in the UI as "since creation", so the
+// answer has to be stable.
 func IssueTimingFromConditionLTT(failingSince, resourceCreated time.Time, basis string) IssueTimingResult {
 	if failingSince.IsZero() || resourceCreated.IsZero() {
 		return IssueTimingResult{}
@@ -46,16 +55,11 @@ func IssueTimingFromConditionLTT(failingSince, resourceCreated time.Time, basis 
 	if healthyFor < 30*time.Second {
 		return IssueTimingResult{IssueTiming: "started_at_resource_creation", Basis: basis}
 	}
-	// Rule 2: ratio — if the resource was healthy for < 25% of its lifetime and
-	// that window is under 5 minutes, the healthy period is noise not a clean bill
-	// of health. Handles the common case of a misconfigured workload that crashes
-	// within 1-2 minutes of first deploy (controller reconciliation lag keeps
-	// healthyFor above the 30s slop even though the failure is deploy-time).
-	if healthyFor < 5*time.Minute && resourceAge > 0 {
-		ratio := float64(healthyFor) / float64(resourceAge)
-		if ratio < 0.25 {
-			return IssueTimingResult{IssueTiming: "started_at_resource_creation", Basis: basis}
-		}
+	// Rule 2: deploy window — a healthy period this short is reconciliation lag,
+	// not a clean bill of health. Handles the common case of a misconfigured
+	// workload that crashes within 1-2 minutes of first deploy.
+	if healthyFor <= 3*time.Minute {
+		return IssueTimingResult{IssueTiming: "started_at_resource_creation", Basis: basis}
 	}
 	// Rule 3: confirmed healthy — at least 10 minutes of healthy operation.
 	if healthyFor > 10*time.Minute {

--- a/internal/k8s/issue_timing_test.go
+++ b/internal/k8s/issue_timing_test.go
@@ -62,9 +62,9 @@ func TestIssueTimingFromConditionLTT(t *testing.T) {
 			wantBasis:       "condition",
 		},
 		{
-			// ratio rule: product-catalog case — crashes 1min after 7min-old deploy
-			// healthyFor=1min (14% of 7min) < 25% AND < 5min → started_at_resource_creation
-			name:            "started_at_resource_creation: ratio rule — crash within 1min of 7min-old deploy",
+			// healthyFor=1min — inside the deploy window, so the healthy period is
+			// reconciliation lag rather than a clean bill of health.
+			name:            "started_at_resource_creation: crash within 1min of deploy",
 			failingSince:    now.Add(-6 * time.Minute),
 			resourceCreated: now.Add(-7 * time.Minute),
 			basis:           "owner_condition",
@@ -81,9 +81,8 @@ func TestIssueTimingFromConditionLTT(t *testing.T) {
 			wantBasis:       "condition",
 		},
 		{
-			// ratio rule doesn't fire: healthyFor=7min (35% of 20min), above 25% ratio
-			// AND above 5min cap → falls to gray zone (between 5min and 10min healthy)
-			name:            "gray zone: 7min healthy out of 20min — ratio 35% above threshold",
+			// healthyFor=7min — past the deploy window, short of confirmed-healthy.
+			name:            "gray zone: 7min healthy is neither deploy-time nor confirmed",
 			failingSince:    now.Add(-13 * time.Minute),
 			resourceCreated: now.Add(-20 * time.Minute),
 			basis:           "condition",
@@ -91,9 +90,9 @@ func TestIssueTimingFromConditionLTT(t *testing.T) {
 			wantBasis:       "",
 		},
 		{
-			// ratio rule cap: healthyFor=4min, resourceAge=15min (27%) but healthyFor
-			// < 5min check only — wait, 4/15=26.7%>25% so no ratio rule → gray zone
-			name:            "gray zone: ratio rule doesn't apply when ratio >= 25%",
+			// healthyFor=4min. The verdict must not depend on the resource's age,
+			// which is what the removed ratio term made it do.
+			name:            "gray zone: 4min healthy, whatever the resource's age",
 			failingSince:    now.Add(-11 * time.Minute),
 			resourceCreated: now.Add(-15 * time.Minute),
 			basis:           "condition",
@@ -101,8 +100,8 @@ func TestIssueTimingFromConditionLTT(t *testing.T) {
 			wantBasis:       "",
 		},
 		{
-			// ratio rule doesn't fire when healthyFor >= 5min even with low ratio
-			name:            "gray zone: ratio rule capped at 5min healthyFor",
+			// healthyFor=5min on an hour-old resource: past the deploy window.
+			name:            "gray zone: 5min healthy on an old resource",
 			failingSince:    now.Add(-55 * time.Minute),
 			resourceCreated: now.Add(-1 * time.Hour),
 			basis:           "condition",
@@ -253,5 +252,18 @@ func TestIssueTimingClassifiesTheDeployWindowImmediately(t *testing.T) {
 		if got.IssueTiming != "started_at_resource_creation" {
 			t.Errorf("age %v: IssueTiming = %q, want started_at_resource_creation", age, got.IssueTiming)
 		}
+	}
+}
+
+// The rule-3 boundary is inclusive, matching what its comment claims. A
+// comment that misdescribes its own code is how the wrong behaviour survives
+// review, which is the same shape of defect this function was fixed for.
+func TestIssueTimingConfirmedHealthyBoundaryIsInclusive(t *testing.T) {
+	now := time.Now()
+	created := now.Add(-3 * time.Hour)
+	// Exactly 10 minutes of healthy operation before the failure.
+	got := IssueTimingFromConditionLTT(created.Add(10*time.Minute), created, "condition")
+	if got.IssueTiming != "started_after_resource_was_healthy" {
+		t.Errorf("IssueTiming = %q, want started_after_resource_was_healthy at exactly 10m healthy", got.IssueTiming)
 	}
 }

--- a/internal/k8s/issue_timing_test.go
+++ b/internal/k8s/issue_timing_test.go
@@ -220,3 +220,38 @@ func TestTerminatingProblemIssueTiming(t *testing.T) {
 			createdThenDeleted.IssueTiming, createdThenDeleted.IssueTimingBasis, ok)
 	}
 }
+
+// The classification must depend only on how long the resource was healthy, not
+// on how long ago that was. Comparing the healthy window against the resource's
+// current age decays as the resource ages, so one unchanged pair of timestamps
+// answered "no verdict" early in a resource's life and "started at resource
+// creation" later, with nothing about the evidence having changed.
+func TestIssueTimingIsStableAsTheResourceAges(t *testing.T) {
+	const healthyFor = 4 * time.Minute
+
+	// A cluster that came up, served for four minutes, then broke — asked at
+	// five minutes old, at an hour old, and at a week old.
+	for _, age := range []time.Duration{5 * time.Minute, time.Hour, 24 * time.Hour, 7 * 24 * time.Hour} {
+		now := time.Now()
+		created := now.Add(-age)
+		got := IssueTimingFromConditionLTT(created.Add(healthyFor), created, "condition")
+		if got.IssueTiming == "started_at_resource_creation" {
+			t.Errorf("age %v: claimed the issue started at creation, but the resource was healthy for %v first", age, healthyFor)
+		}
+	}
+}
+
+// The same property for a window short enough to classify: it must classify at
+// every age, not only once the resource is old enough.
+func TestIssueTimingClassifiesTheDeployWindowImmediately(t *testing.T) {
+	const healthyFor = 90 * time.Second
+
+	for _, age := range []time.Duration{2 * time.Minute, 10 * time.Minute, 48 * time.Hour} {
+		now := time.Now()
+		created := now.Add(-age)
+		got := IssueTimingFromConditionLTT(created.Add(healthyFor), created, "condition")
+		if got.IssueTiming != "started_at_resource_creation" {
+			t.Errorf("age %v: IssueTiming = %q, want started_at_resource_creation", age, got.IssueTiming)
+		}
+	}
+}


### PR DESCRIPTION
`IssueTimingFromConditionLTT` classifies when a failure began by comparing a condition's `lastTransitionTime` against the resource's creation. Its second at-creation rule was a **ratio**: healthy for under 5 minutes *and* under 25% of the resource's lifetime.

`healthyFor` is fixed once the condition transitions. `resourceAge` keeps growing. So the ratio decays with nothing else changing, and one unchanged pair of timestamps produces different answers depending on when it is asked:

| resource age | healthy window | verdict |
|---|---|---|
| 5 min | 4 min | *(unclassified — gray zone)* |
| 1 hour | 4 min | `started_at_resource_creation` |
| 1 day | 4 min | `started_at_resource_creation` |
| 1 week | 4 min | `started_at_resource_creation` |

The claim appears later and never goes away. Rule 3 ("confirmed healthy", over 10 minutes) can never fire for these, so nothing corrects it.

Callers surface this in MCP output and in the UI as "since creation", so it is an assertion about history that the timestamps do not support.

Found on a CloudNativePG cluster that came up clean and had its WAL archiving broken 75 seconds later: Radar reported the failure as having started at creation.

## The fix

Rule 2 keeps its 5-minute intent boundary and drops the ratio term, so it depends only on how long the resource was healthy — a quantity that does not move. The same evidence now yields the same answer at every point in a resource's life.

The rule's stated purpose is unchanged: catching a workload that is misconfigured at deploy, where controller reconciliation lag puts `Available=False` 60-120s after the first crash and past the 30s slop.

The direction of the change is conservative. A case that previously earned the claim only after the resource had aged now earns it immediately and permanently; a case that never aged enough is now left unclassified rather than acquiring a claim later. Where the two differ, this omits rather than asserts, which is what the file's own contract asks for: *"Caller must omit issue_timing; do not infer timing from age alone."*

## Testing

`go test ./...` clean. Every existing timing case still passes, including the gen-1 rollout case that depends on the gray zone falling through to the stronger `spec` provenance — that one is load-bearing, since `observedGeneration == 1` is proof rather than inference and must not be displaced.

Two new tests pin the property itself rather than a threshold: identical evidence must classify identically at 5 minutes, an hour, a day and a week; and a window short enough to classify must classify at every age rather than only once the resource is old enough. Both fail on the current code, at every age past five minutes.

## What this does not fix

It makes the answer stable; it does not make it *right* in every case. A cluster that came up healthy and broke 75 seconds later is still reported as having started at creation, because from two timestamps alone that is indistinguishable from a resource that was misconfigured at deploy and took 75 seconds to show it.

Telling those apart needs a "the resource reached a healthy state at T" signal — for a CNPG cluster, the `Ready` condition's own transition time. That is a design change to the helper's inputs and to every caller, not a threshold tweak, so it is deliberately not attempted here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes issue-timing classification used across detectors and surfaced in MCP/UI as “since creation.” Threshold shift is conservative and well-tested, but it alters how failures are labeled for many resources.
> 
> **Overview**
> Makes `IssueTimingFromConditionLTT` **stable over time** by dropping the age-dependent ratio rule that could flip an unchanged timestamp pair from gray-zone to `started_at_resource_creation` as the resource aged.
> 
> **Rule 2** is now a fixed **3-minute deploy window** on `healthyFor` only (was: healthy &lt; 5min *and* &lt; 25% of lifetime). Rule 3’s confirmed-healthy check becomes inclusive at exactly 10 minutes. Same evidence now yields the same verdict at every age; where the old and new rules disagree, the change prefers omit over assert.
> 
> Adds tests that pin stability across ages (5m → 1w) and the inclusive 10m boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28d23a1182700c0d406aec0d67dfae7128a68c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->