### PR TITLE
fix(gitops): stop Reconciling outvoting Ready on Flux resources

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
@@ -191,8 +191,21 @@ export function HealthStatusBadge({ health }: { health: GitOpsHealthStatus }) {
  * a real pass completes in milliseconds. In practice this only becomes visible
  * when a controller is wedged, which is exactly when it should be.
  */
-export function ReconcilingIndicator({ reconciling, since }: { reconciling?: boolean; since?: string }) {
-  if (!reconciling) return null
+export function ReconcilingIndicator({
+  reconciling,
+  since,
+  sync,
+}: {
+  reconciling?: boolean
+  since?: string
+  /** The sync word shown beside this. Omitted when there is no badge alongside. */
+  sync?: SyncStatus
+}) {
+  // Suppressed when the sync badge already says Reconciling — it carries the
+  // same fact and spins for it. Showing both puts two spinners on one row for
+  // one thing. The secondary exists for the case the primary CANNOT express:
+  // an applied object whose reconcile pass never finished.
+  if (!reconciling || sync === 'Reconciling') return null
   const age = formatCompactAge(since)
   const tip = age
     ? `A reconcile pass has been in flight for ${age}. On a healthy resource a pass finishes in milliseconds, so a long-running one usually means the controller is stuck.`

--- a/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
@@ -2,6 +2,8 @@ import { clsx } from 'clsx'
 import { CheckCircle2, AlertCircle, Loader2, Pause, HelpCircle, XCircle } from 'lucide-react'
 import type { GitOpsStatus, SyncStatus, GitOpsHealthStatus } from '../../types/gitops'
 import { SEVERITY_BADGE_BORDERED, SEVERITY_BADGE } from '../../utils/badge-colors'
+import { formatCompactAge } from '../../utils/format'
+import { Tooltip } from '../ui/Tooltip'
 
 interface GitOpsStatusBadgeProps {
   status: GitOpsStatus
@@ -174,5 +176,30 @@ export function HealthStatusBadge({ health }: { health: GitOpsHealthStatus }) {
       <Icon className={clsx('w-3 h-3', health === 'Progressing' && 'animate-spin')} />
       {label}
     </span>
+  )
+}
+
+
+/**
+ * ReconcilingIndicator rides alongside the sync badge rather than replacing it,
+ * the same primary-plus-secondary shape the Velero schedule cell uses for a
+ * paused-and-rejected schedule.
+ *
+ * A pass being in flight says nothing about whether the declared state is
+ * applied, so it must not touch the sync word — but a pass that never finishes
+ * is the one fault nothing else in the product notices, and on a healthy object
+ * a real pass completes in milliseconds. In practice this only becomes visible
+ * when a controller is wedged, which is exactly when it should be.
+ */
+export function ReconcilingIndicator({ reconciling, since }: { reconciling?: boolean; since?: string }) {
+  if (!reconciling) return null
+  const age = formatCompactAge(since)
+  const tip = age
+    ? `A reconcile pass has been in flight for ${age}. On a healthy resource a pass finishes in milliseconds, so a long-running one usually means the controller is stuck.`
+    : 'A reconcile pass is in flight.'
+  return (
+    <Tooltip content={tip}>
+      <Loader2 className="w-3 h-3 shrink-0 animate-spin text-theme-text-tertiary" aria-label="Reconcile pass in flight" />
+    </Tooltip>
   )
 }

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -1311,7 +1311,7 @@ function GitOpsTable({
                   : (
                     <span className="inline-flex items-center gap-1 min-w-0">
                       <SyncStatusBadge sync={row.sync as any} suspended={row.suspended} />
-                      <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} />
+                      <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} sync={row.sync as any} />
                     </span>
                   )}
               </TableCell>
@@ -1542,7 +1542,7 @@ function GitOpsTile({
           ) : (
             <>
               <SyncStatusBadge sync={row.sync as any} suspended={row.suspended} />
-              <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} />
+              <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} sync={row.sync as any} />
               <HealthStatusBadge health={row.health as any} />
             </>
           )}

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -24,7 +24,7 @@ import {
   Zap,
 } from 'lucide-react'
 
-import { HealthStatusBadge, SyncStatusBadge } from './GitOpsStatusBadge'
+import { HealthStatusBadge, ReconcilingIndicator, SyncStatusBadge } from './GitOpsStatusBadge'
 import { Tooltip } from '../ui/Tooltip'
 import { Input } from '../ui/Input'
 import { PageHeader } from '../ui/PageHeader'
@@ -150,6 +150,14 @@ export interface GitOpsRow {
   sync: string
   health: string
   suspended: boolean
+  /**
+   * A reconcile pass is executing. Deliberately separate from sync: a pass
+   * being in flight says nothing about whether the declared state is applied,
+   * but a pass that never finishes is the one fault nothing else in the
+   * product notices.
+   */
+  reconciling?: boolean
+  reconcilingSince?: string
   repository: string
   targetRevision: string
   path: string
@@ -1300,7 +1308,12 @@ function GitOpsTable({
               <TableCell>
                 {row.terminating
                   ? <span className="text-[11px] text-theme-text-tertiary">—</span>
-                  : <SyncStatusBadge sync={row.sync as any} suspended={row.suspended} />}
+                  : (
+                    <span className="inline-flex items-center gap-1 min-w-0">
+                      <SyncStatusBadge sync={row.sync as any} suspended={row.suspended} />
+                      <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} />
+                    </span>
+                  )}
               </TableCell>
               <TableCell>
                 {row.terminating
@@ -1529,6 +1542,7 @@ function GitOpsTile({
           ) : (
             <>
               <SyncStatusBadge sync={row.sync as any} suspended={row.suspended} />
+              <ReconcilingIndicator reconciling={row.reconciling} since={row.reconcilingSince} />
               <HealthStatusBadge health={row.health as any} />
             </>
           )}
@@ -1896,6 +1910,8 @@ export function normalizeArgoApplication(resource: any): GitOpsRow {
     labels: (resource.metadata?.labels ?? {}) as Record<string, string>,
     sync: status?.sync ?? 'Unknown',
     health: status?.health ?? 'Unknown',
+    reconciling: status?.reconciling,
+    reconcilingSince: status?.reconcilingSince,
     suspended: (status?.suspended ?? false) || isArgoSuspendedByRadar(resource),
     repository: resource.spec?.source?.repoURL ?? '',
     targetRevision: resource.spec?.source?.targetRevision ?? '',
@@ -1932,6 +1948,8 @@ export function normalizeFluxKustomization(resource: any, fluxSourceUrls?: Map<s
     labels: (resource.metadata?.labels ?? {}) as Record<string, string>,
     sync: status?.sync ?? 'Unknown',
     health: status?.health ?? 'Unknown',
+    reconciling: status?.reconciling,
+    reconcilingSince: status?.reconcilingSince,
     suspended: status?.suspended ?? resource.spec?.suspend === true,
     repository,
     targetRevision: resource.status?.lastAppliedRevision ?? resource.status?.lastAttemptedRevision ?? '',
@@ -1969,6 +1987,8 @@ export function normalizeFluxHelmRelease(resource: any, fluxSourceUrls?: Map<str
     labels: (resource.metadata?.labels ?? {}) as Record<string, string>,
     sync: status?.sync ?? 'Unknown',
     health: status?.health ?? 'Unknown',
+    reconciling: status?.reconciling,
+    reconcilingSince: status?.reconcilingSince,
     suspended: status?.suspended ?? resource.spec?.suspend === true,
     repository,
     targetRevision: chartSpec.version ?? resource.status?.lastAttemptedRevision ?? '',

--- a/packages/k8s-ui/src/components/gitops/ReconcilingIndicator.test.tsx
+++ b/packages/k8s-ui/src/components/gitops/ReconcilingIndicator.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { ReconcilingIndicator } from './GitOpsStatusBadge'
+
+const LABEL = 'Reconcile pass in flight'
+
+// A reconcile pass in flight is worth showing only where the sync word cannot
+// already say it. Radar's own precedent for a secondary indicator (the Velero
+// schedule cell's paused-and-rejected case) suppresses the icon when the badge
+// carries the same fact, and without that rule one row shows two spinners.
+describe('ReconcilingIndicator', () => {
+  it('shows on an applied object whose pass never finished', () => {
+    // The case the sync word cannot express, and the reason this exists: a
+    // wedged controller behind a correct "Synced".
+    const html = renderToString(
+      <ReconcilingIndicator reconciling since="2026-08-11T06:05:00Z" sync="Synced" />,
+    )
+    expect(html).toContain(LABEL)
+  })
+
+  it('is suppressed when the sync badge already reports Reconciling', () => {
+    const html = renderToString(
+      <ReconcilingIndicator reconciling since="2026-08-11T06:05:00Z" sync="Reconciling" />,
+    )
+    expect(html).toBe('')
+  })
+
+  it('is absent when nothing is in flight', () => {
+    expect(renderToString(<ReconcilingIndicator reconciling={false} sync="Synced" />)).toBe('')
+  })
+})

--- a/packages/k8s-ui/src/components/gitops/detail-helpers.ts
+++ b/packages/k8s-ui/src/components/gitops/detail-helpers.ts
@@ -100,7 +100,10 @@ export function getGitOpsResourceStatus(kind: string, resource: any): GitOpsStat
     return argoStatusToGitOpsStatus(resource?.status ?? {})
   }
   const conditions = (resource?.status?.conditions ?? []) as FluxCondition[]
-  return fluxConditionsToGitOpsStatus(conditions, resource?.spec?.suspend === true)
+  return fluxConditionsToGitOpsStatus(conditions, resource?.spec?.suspend === true, {
+    generation: resource?.metadata?.generation,
+    observedGeneration: resource?.status?.observedGeneration,
+  })
 }
 
 // getGitOpsTool routes a kind+group to 'argo' or 'flux'. Same shape used

--- a/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
@@ -14,7 +14,10 @@ export function AlertRenderer({ data }: AlertRendererProps) {
   const conditions = (status.conditions || []) as FluxCondition[]
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []

--- a/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
@@ -17,7 +17,10 @@ export function FluxHelmReleaseRenderer({ data, onNavigate }: FluxHelmReleaseRen
   const history = status.history || []
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []

--- a/packages/k8s-ui/src/components/resources/renderers/GitRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GitRepositoryRenderer.tsx
@@ -16,7 +16,10 @@ export function GitRepositoryRenderer({ data }: GitRepositoryRendererProps) {
   const artifact = status.artifact || {}
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []

--- a/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
@@ -17,7 +17,10 @@ export function HelmRepositoryRenderer({ data }: HelmRepositoryRendererProps) {
   const artifact = status.artifact || {}
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Determine repository type
   const isOCI = spec.type === 'oci'

--- a/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
@@ -16,7 +16,10 @@ export function KustomizationRenderer({ data, onNavigate }: KustomizationRendere
   const inventoryEntries = status.inventory?.entries || []
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Parse inventory to managed resources
   const managedResources = parseFluxInventory(inventoryEntries)

--- a/packages/k8s-ui/src/components/resources/renderers/OCIRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/OCIRepositoryRenderer.tsx
@@ -16,7 +16,10 @@ export function OCIRepositoryRenderer({ data }: OCIRepositoryRendererProps) {
   const artifact = status.artifact || {}
 
   // Convert to unified GitOps status
-  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true)
+  const gitOpsStatus = fluxConditionsToGitOpsStatus(conditions, spec.suspend === true, {
+    generation: data.metadata?.generation,
+    observedGeneration: status.observedGeneration,
+  })
 
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []

--- a/packages/k8s-ui/src/types/gitops-flux-status.test.ts
+++ b/packages/k8s-ui/src/types/gitops-flux-status.test.ts
@@ -76,7 +76,29 @@ describe('fluxConditionsToGitOpsStatus truth table', () => {
       fluxConditionsToGitOpsStatus([c('Ready', 'True')], true, { generation: 2, observedGeneration: 1 }).sync,
     ).toBe('Unknown')
   })
+
+  it('treats a retrying Ready=False as progressing, not degraded', () => {
+    // Mirrors pkg/gitops/fluxstatus_test.go. Flux composes reasons like
+    // ProgressingWithRetry; a retry in flight is out of sync but not settled.
+    const got = fluxConditionsToGitOpsStatus(
+      [c('Ready', 'False', { reason: 'ProgressingWithRetry' })],
+      false,
+      { generation: 1, observedGeneration: 1 },
+    )
+    expect(got.sync).toBe('OutOfSync')
+    expect(got.health).toBe('Progressing')
+  })
+
+  it('treats a settled Ready=False as degraded', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'False', { reason: 'BuildFailed' })], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('OutOfSync')
+    expect(got.health).toBe('Degraded')
+  })
 })
+
 
 describe('reconciling activity', () => {
   it('survives even when it no longer drives the status', () => {

--- a/packages/k8s-ui/src/types/gitops-flux-status.test.ts
+++ b/packages/k8s-ui/src/types/gitops-flux-status.test.ts
@@ -136,3 +136,28 @@ describe('non-Kustomization Flux kinds', () => {
     expect(got.health).toBe('Healthy')
   })
 })
+
+// The wedged-controller case end to end: a fully-applied object whose reconcile
+// pass never finished must read Synced (it IS applied) AND still carry the
+// in-flight fact, or a stuck controller becomes invisible. Before the sync fix
+// this state showed a permanent "Syncing", which was the wrong word but the
+// only thing in the product that noticed.
+describe('a wedged controller stays visible', () => {
+  it('reports Synced and keeps the in-flight fact with its start time', () => {
+    const got = fluxConditionsToGitOpsStatus(
+      [
+        c('Ready', 'True', { lastTransitionTime: '2026-08-11T06:00:00Z' }),
+        c('Healthy', 'True'),
+        c('Reconciling', 'True', { lastTransitionTime: '2026-08-11T06:05:00Z' }),
+      ],
+      false,
+      { generation: 1, observedGeneration: 1 },
+    )
+    expect(got.sync).toBe('Synced')
+    expect(got.health).toBe('Healthy')
+    // Both are required: without these the indicator has nothing to render and
+    // the operator gets a confident all-clear over a stuck controller.
+    expect(got.reconciling).toBe(true)
+    expect(got.reconcilingSince).toBe('2026-08-11T06:05:00Z')
+  })
+})

--- a/packages/k8s-ui/src/types/gitops-flux-status.test.ts
+++ b/packages/k8s-ui/src/types/gitops-flux-status.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { fluxConditionsToGitOpsStatus, type FluxCondition } from './gitops'
+
+const c = (type: string, status: string, extra: Partial<FluxCondition> = {}): FluxCondition =>
+  ({ type, status, ...extra } as FluxCondition)
+
+// Mirrors pkg/gitops/fluxstatus_test.go. The two implementations must not drift:
+// they feed the same columns from different sides of the wire.
+describe('fluxConditionsToGitOpsStatus truth table', () => {
+  it('a stale Reconciling does not outvote an applied Ready', () => {
+    // The reported bug: kubectl and k9s read the printer columns and show
+    // READY=True while Radar showed the row as syncing.
+    const got = fluxConditionsToGitOpsStatus(
+      [c('Ready', 'True'), c('Healthy', 'True'), c('Reconciling', 'True')],
+      false,
+      { generation: 1, observedGeneration: 1 },
+    )
+    expect(got.sync).toBe('Synced')
+    expect(got.health).toBe('Healthy')
+  })
+
+  it('generation drift outranks a stale Ready', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'True')], false, {
+      generation: 2,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('Reconciling')
+    expect(got.health).toBe('Progressing')
+  })
+
+  it('treats the -1 sentinel as drift', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'False'), c('Reconciling', 'True')], false, {
+      generation: 1,
+      observedGeneration: -1,
+    })
+    expect(got.sync).toBe('Reconciling')
+  })
+
+  it('does not treat an absent observedGeneration as drift', () => {
+    // Kinds and controller versions that never set it must not all read stale.
+    expect(fluxConditionsToGitOpsStatus([c('Ready', 'True')], false, { generation: 3 }).sync).toBe('Synced')
+    expect(fluxConditionsToGitOpsStatus([c('Ready', 'True')], false, {}).sync).toBe('Synced')
+    expect(fluxConditionsToGitOpsStatus([c('Ready', 'True')], false).sync).toBe('Synced')
+  })
+
+  it('lets Stalled outrank Ready', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'True'), c('Stalled', 'True')], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('OutOfSync')
+    expect(got.health).toBe('Degraded')
+  })
+
+  it('separates applied from healthy', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'True'), c('Healthy', 'False')], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('Synced')
+    expect(got.health).toBe('Degraded')
+  })
+
+  it('reports Reconciling when the pass has not reached Ready', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'Unknown'), c('Reconciling', 'True')], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('Reconciling')
+  })
+
+  it('keeps a suspended-but-applied object Synced, and drops it on drift', () => {
+    const gen = { generation: 1, observedGeneration: 1 }
+    expect(fluxConditionsToGitOpsStatus([c('Ready', 'True')], true, gen).sync).toBe('Synced')
+    expect(
+      fluxConditionsToGitOpsStatus([c('Ready', 'True')], true, { generation: 2, observedGeneration: 1 }).sync,
+    ).toBe('Unknown')
+  })
+})
+
+describe('reconciling activity', () => {
+  it('survives even when it no longer drives the status', () => {
+    const got = fluxConditionsToGitOpsStatus(
+      [c('Ready', 'True'), c('Reconciling', 'True', { lastTransitionTime: '2026-08-11T06:05:00Z' })],
+      false,
+      { generation: 1, observedGeneration: 1 },
+    )
+    expect(got.sync).toBe('Synced')
+    expect(got.reconciling).toBe(true)
+    expect(got.reconcilingSince).toBe('2026-08-11T06:05:00Z')
+  })
+
+  it('is absent on a quiet object', () => {
+    const got = fluxConditionsToGitOpsStatus([c('Ready', 'True')], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.reconciling).toBeUndefined()
+  })
+})
+
+// Source kinds carry no Healthy condition; HelmRelease uses Released.
+describe('non-Kustomization Flux kinds', () => {
+  it.each([
+    ['GitRepository', [c('Ready', 'True'), c('ArtifactInStorage', 'True')]],
+    ['HelmRepository', [c('Ready', 'True'), c('ArtifactInStorage', 'True')]],
+    ['HelmRelease', [c('Ready', 'True'), c('Released', 'True')]],
+  ])('%s reads as Synced/Healthy', (_kind, conds) => {
+    const got = fluxConditionsToGitOpsStatus(conds as FluxCondition[], false, {
+      generation: 1,
+      observedGeneration: 1,
+    })
+    expect(got.sync).toBe('Synced')
+    expect(got.health).toBe('Healthy')
+  })
+})

--- a/packages/k8s-ui/src/types/gitops.ts
+++ b/packages/k8s-ui/src/types/gitops.ts
@@ -63,6 +63,15 @@ export interface GitOpsStatus {
   message?: string
   lastSyncTime?: string
   suspended: boolean
+  /**
+   * A reconcile pass is executing right now. Activity, not sync and not health —
+   * it never influences either, because a controller being mid-pass says nothing
+   * about whether the declared state is applied. Renderers may show a subtle
+   * indicator; nothing that drives a status word.
+   */
+  reconciling?: boolean
+  /** When the in-flight pass started, so a wedged controller can be told from a routine one. */
+  reconcilingSince?: string
 }
 
 /**
@@ -97,61 +106,78 @@ export interface FluxCondition {
 // ============================================================================
 
 /**
- * Maps FluxCD conditions to unified GitOpsStatus
+ * Generation tracking for a Flux object. `observedGeneration` has three states,
+ * and the difference matters: absent means the controller never reports it and
+ * we have no signal, which must not be read as drift.
+ */
+export interface FluxGeneration {
+  generation?: number
+  observedGeneration?: number
+}
+
+/**
+ * True when the controller has demonstrably not yet acted on the current spec.
+ * Absent observedGeneration is no signal, not drift — some Flux kinds and older
+ * controllers never set it, and treating absence as drift would mark every
+ * healthy object on them as out of date. A present-but-different value counts,
+ * including the -1 sentinel Flux writes on an object it has never reconciled.
+ */
+function hasGenerationDrift(gen?: FluxGeneration): boolean {
+  if (!gen) return false
+  const { generation, observedGeneration } = gen
+  if (typeof generation !== 'number' || typeof observedGeneration !== 'number') return false
+  return generation !== observedGeneration
+}
+
+/**
+ * Maps FluxCD conditions to unified GitOpsStatus.
  *
- * FluxCD status patterns:
- * - Ready=True: Synced and healthy
- * - Ready=False + Stalled=True: Degraded
- * - Ready=False + Reconciling=True: Reconciling
- * - Ready=False (other): OutOfSync
- * - Healthy=False: Deployed but unhealthy resources
- * - spec.suspend=true: Suspended
+ * Sync answers "is the declared state applied", which is `Ready` plus
+ * `observedGeneration`. `Reconciling` answers "is the controller mid-pass",
+ * which is neither — the two are independent conditions upstream, and letting
+ * activity outvote readiness reported a healthy object as not synced.
+ *
+ * Order matters:
+ * - suspend                                   → Suspended (sync from Ready, unless drifted)
+ * - Stalled=True                              → OutOfSync / Degraded
+ * - Ready=True and no generation drift        → Synced, health from Healthy
+ * - drift, or Reconciling with Ready not True → Reconciling / Progressing
+ * - Ready=False                               → OutOfSync
  */
 export function fluxConditionsToGitOpsStatus(
   conditions: FluxCondition[],
-  suspended: boolean
+  suspended: boolean,
+  generation?: FluxGeneration
 ): GitOpsStatus {
   const readyCondition = conditions.find(c => c.type === 'Ready')
   const reconcilingCondition = conditions.find(c => c.type === 'Reconciling')
   const stalledCondition = conditions.find(c => c.type === 'Stalled')
   const healthyCondition = conditions.find(c => c.type === 'Healthy')
 
-  // Handle suspended state
+  const drifted = hasGenerationDrift(generation)
+  const isReconciling = reconcilingCondition?.status === 'True'
+  // Carried on every result so a wedged controller is visible next to an
+  // otherwise-correct Synced, without any status word claiming a fault.
+  const activity = isReconciling
+    ? { reconciling: true, reconcilingSince: reconcilingCondition?.lastTransitionTime }
+    : {}
+
+  // Handle suspended state. Suspending does not un-apply what was applied, so a
+  // suspended object that was Ready stays Synced — but a spec change made while
+  // suspended will never be picked up, so drift downgrades it to Unknown.
   if (suspended) {
     return {
-      sync: readyCondition?.status === 'True' ? 'Synced' : 'Unknown',
+      sync: readyCondition?.status === 'True' && !drifted ? 'Synced' : 'Unknown',
       health: 'Suspended',
       message: 'Reconciliation is suspended',
       lastSyncTime: readyCondition?.lastTransitionTime,
       suspended: true,
+      ...activity,
     }
   }
 
-  // Handle reconciling state
-  if (reconcilingCondition?.status === 'True') {
-    return {
-      sync: 'Reconciling',
-      health: 'Progressing',
-      message: reconcilingCondition.message || 'Reconciliation in progress',
-      lastSyncTime: readyCondition?.lastTransitionTime,
-      suspended: false,
-    }
-  }
-
-  // Handle ready state
-  if (readyCondition?.status === 'True') {
-    // Check if deployed resources are healthy
-    const isHealthy = healthyCondition?.status !== 'False'
-    return {
-      sync: 'Synced',
-      health: isHealthy ? 'Healthy' : 'Degraded',
-      message: isHealthy ? undefined : healthyCondition?.message,
-      lastSyncTime: readyCondition.lastTransitionTime,
-      suspended: false,
-    }
-  }
-
-  // Handle stalled state (permanent failure)
+  // Stalled is a terminal failure and outranks readiness: it means the
+  // controller has given up, whatever the last successful apply left behind.
   if (stalledCondition?.status === 'True') {
     return {
       sync: 'OutOfSync',
@@ -159,6 +185,34 @@ export function fluxConditionsToGitOpsStatus(
       message: stalledCondition.message || 'Reconciliation stalled',
       lastSyncTime: readyCondition?.lastTransitionTime,
       suspended: false,
+      ...activity,
+    }
+  }
+
+  // The applied state. Ahead of the reconciling branch on purpose — this is the
+  // whole point of the ordering.
+  if (readyCondition?.status === 'True' && !drifted) {
+    const isHealthy = healthyCondition?.status !== 'False'
+    return {
+      sync: 'Synced',
+      health: isHealthy ? 'Healthy' : 'Degraded',
+      message: isHealthy ? undefined : healthyCondition?.message,
+      lastSyncTime: readyCondition.lastTransitionTime,
+      suspended: false,
+      ...activity,
+    }
+  }
+
+  // Genuinely not applied: the controller has not observed the current spec, or
+  // it is working and has not reached Ready.
+  if (drifted || isReconciling) {
+    return {
+      sync: 'Reconciling',
+      health: 'Progressing',
+      message: reconcilingCondition?.message || 'Reconciliation in progress',
+      lastSyncTime: readyCondition?.lastTransitionTime,
+      suspended: false,
+      ...activity,
     }
   }
 
@@ -173,6 +227,7 @@ export function fluxConditionsToGitOpsStatus(
       message: readyCondition.message,
       lastSyncTime: readyCondition.lastTransitionTime,
       suspended: false,
+      ...activity,
     }
   }
 
@@ -182,6 +237,7 @@ export function fluxConditionsToGitOpsStatus(
     health: 'Unknown',
     message: 'Status cannot be determined',
     suspended: false,
+    ...activity,
   }
 }
 

--- a/pkg/gitops/fluxstatus.go
+++ b/pkg/gitops/fluxstatus.go
@@ -1,6 +1,10 @@
 package gitops
 
-import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
 // FluxState is the sync/health pair derived from a Flux object's conditions.
 type FluxState struct {
@@ -31,13 +35,14 @@ type FluxState struct {
 // Shared by the insights and tree packages, which previously carried
 // near-duplicate copies that had already drifted apart on suspend handling.
 func FluxStatus(root *unstructured.Unstructured) FluxState {
-	var ready, healthy string
+	var ready, readyReason, healthy string
 	var reconciling, stalled bool
 
 	for _, c := range fluxConditions(root) {
 		switch c.typ {
 		case "Ready":
 			ready = c.status
+			readyReason = c.reason
 		case "Healthy":
 			healthy = c.status
 		case "Reconciling":
@@ -85,7 +90,14 @@ func FluxStatus(root *unstructured.Unstructured) FluxState {
 	}
 
 	if ready == "False" {
-		return FluxState{Sync: "OutOfSync", Health: "Degraded", Reconciling: reconciling}
+		// Flux distinguishes a retry or remediation in flight (ProgressingWithRetry,
+		// and the Wait/Retry reasons) from a settled failure. Both are out of sync,
+		// but calling a retry Degraded overstates it.
+		health := "Degraded"
+		if isTransientFluxReason(readyReason) {
+			health = "Progressing"
+		}
+		return FluxState{Sync: "OutOfSync", Health: health, Reconciling: reconciling}
 	}
 
 	return FluxState{Sync: "Unknown", Health: "Unknown", Reconciling: reconciling}
@@ -107,9 +119,23 @@ func fluxGenerationDrift(root *unstructured.Unstructured) bool {
 	return gen != obs
 }
 
+// isTransientFluxReason mirrors the frontend mapper's substring test so the two
+// implementations agree on this row. Substring rather than an enumeration
+// because Flux composes reasons (ProgressingWithRetry, HealthCheckFailed after
+// a wait) and the set is not stable across controller versions.
+func isTransientFluxReason(reason string) bool {
+	for _, marker := range []string{"Progress", "Retry", "Wait"} {
+		if strings.Contains(reason, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 type fluxCondition struct {
 	typ    string
 	status string
+	reason string
 }
 
 func fluxConditions(root *unstructured.Unstructured) []fluxCondition {
@@ -123,7 +149,11 @@ func fluxConditions(root *unstructured.Unstructured) []fluxCondition {
 		if !ok {
 			continue
 		}
-		out = append(out, fluxCondition{typ: StringValue(m["type"]), status: StringValue(m["status"])})
+		out = append(out, fluxCondition{
+			typ:    StringValue(m["type"]),
+			status: StringValue(m["status"]),
+			reason: StringValue(m["reason"]),
+		})
 	}
 	return out
 }

--- a/pkg/gitops/fluxstatus.go
+++ b/pkg/gitops/fluxstatus.go
@@ -1,0 +1,129 @@
+package gitops
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// FluxState is the sync/health pair derived from a Flux object's conditions.
+type FluxState struct {
+	Sync   string
+	Health string
+	// Reconciling reports that a pass is executing right now. Activity, not
+	// sync and not health — it never influences either. Carried so a wedged
+	// controller can be surfaced next to an otherwise-correct Synced.
+	Reconciling bool
+}
+
+// FluxStatus derives sync and health for any Flux object.
+//
+// Sync answers "is the declared state applied", which is Ready plus
+// observedGeneration. Reconciling answers "is the controller mid-pass", which
+// is neither: upstream the two are independent conditions (MarkReconciling
+// deletes only Stalled, never Ready), so letting activity outvote readiness
+// reported a healthy, fully-applied object as not synced — while kubectl and
+// k9s, which read the CRD's printer columns, showed it Ready.
+//
+// Order:
+//   - suspend                                   → Suspended (sync from Ready, unless drifted)
+//   - Stalled=True                              → OutOfSync / Degraded
+//   - Ready=True and no generation drift        → Synced / Healthy
+//   - drift, or Reconciling with Ready not True → Reconciling / Progressing
+//   - Ready=False                               → OutOfSync / Degraded
+//
+// Shared by the insights and tree packages, which previously carried
+// near-duplicate copies that had already drifted apart on suspend handling.
+func FluxStatus(root *unstructured.Unstructured) FluxState {
+	var ready, healthy string
+	var reconciling, stalled bool
+
+	for _, c := range fluxConditions(root) {
+		switch c.typ {
+		case "Ready":
+			ready = c.status
+		case "Healthy":
+			healthy = c.status
+		case "Reconciling":
+			reconciling = reconciling || c.status == "True"
+		case "Stalled":
+			stalled = stalled || c.status == "True"
+		}
+	}
+
+	drifted := fluxGenerationDrift(root)
+
+	// Suspending does not un-apply what was applied, so a suspended object that
+	// was Ready stays Synced. A spec change made while suspended will never be
+	// picked up, though, so drift downgrades it.
+	if suspended, _, _ := unstructured.NestedBool(root.Object, "spec", "suspend"); suspended {
+		sync := "Unknown"
+		if ready == "True" && !drifted {
+			sync = "Synced"
+		}
+		return FluxState{Sync: sync, Health: "Suspended", Reconciling: reconciling}
+	}
+
+	// Terminal failure outranks readiness: the controller has given up,
+	// whatever the last successful apply left behind.
+	if stalled {
+		return FluxState{Sync: "OutOfSync", Health: "Degraded", Reconciling: reconciling}
+	}
+
+	// Applied. Health comes from the Healthy condition where the kind has one —
+	// the workloads can be unhealthy while the manifests are correctly applied,
+	// and those are different facts. Source kinds carry no Healthy condition, so
+	// absence means healthy rather than unknown.
+	if ready == "True" && !drifted {
+		health := "Healthy"
+		if healthy == "False" {
+			health = "Degraded"
+		}
+		return FluxState{Sync: "Synced", Health: health, Reconciling: reconciling}
+	}
+
+	// Genuinely not applied: the controller has not observed the current spec,
+	// or it is working and has not reached Ready.
+	if drifted || reconciling {
+		return FluxState{Sync: "Reconciling", Health: "Progressing", Reconciling: reconciling}
+	}
+
+	if ready == "False" {
+		return FluxState{Sync: "OutOfSync", Health: "Degraded", Reconciling: reconciling}
+	}
+
+	return FluxState{Sync: "Unknown", Health: "Unknown", Reconciling: reconciling}
+}
+
+// fluxGenerationDrift reports that the controller has demonstrably not acted on
+// the current spec.
+//
+// An absent observedGeneration is no signal, not drift: some Flux kinds and
+// older controllers never set it, and reading absence as drift would mark every
+// healthy object on them as out of date. A present-but-different value counts,
+// including the -1 sentinel Flux writes on an object it has never reconciled.
+func fluxGenerationDrift(root *unstructured.Unstructured) bool {
+	gen, genOK, _ := unstructured.NestedInt64(root.Object, "metadata", "generation")
+	obs, obsOK, _ := unstructured.NestedInt64(root.Object, "status", "observedGeneration")
+	if !genOK || !obsOK {
+		return false
+	}
+	return gen != obs
+}
+
+type fluxCondition struct {
+	typ    string
+	status string
+}
+
+func fluxConditions(root *unstructured.Unstructured) []fluxCondition {
+	raw, ok, _ := unstructured.NestedSlice(root.Object, "status", "conditions")
+	if !ok {
+		return nil
+	}
+	out := make([]fluxCondition, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, fluxCondition{typ: StringValue(m["type"]), status: StringValue(m["status"])})
+	}
+	return out
+}

--- a/pkg/gitops/fluxstatus_test.go
+++ b/pkg/gitops/fluxstatus_test.go
@@ -1,0 +1,175 @@
+package gitops
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func fluxObj(suspend bool, gen, obs any, conds ...map[string]any) *unstructured.Unstructured {
+	raw := make([]any, 0, len(conds))
+	for _, c := range conds {
+		raw = append(raw, c)
+	}
+	meta := map[string]any{"name": "k1", "namespace": "flux-system"}
+	if gen != nil {
+		meta["generation"] = gen
+	}
+	status := map[string]any{"conditions": raw}
+	if obs != nil {
+		status["observedGeneration"] = obs
+	}
+	obj := map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   meta,
+		"status":     status,
+	}
+	if suspend {
+		obj["spec"] = map[string]any{"suspend": true}
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func cond(typ, status string) map[string]any {
+	return map[string]any{"type": typ, "status": status}
+}
+
+func TestFluxStatusTruthTable(t *testing.T) {
+	cases := []struct {
+		name       string
+		obj        *unstructured.Unstructured
+		wantSync   string
+		wantHealth string
+	}{
+		{
+			// The reported bug. Ready and Reconciling are independent upstream, so a
+			// stale Reconciling sat on a fully-applied object and outvoted it, while
+			// kubectl and k9s read the printer columns and showed it Ready.
+			name:     "stale Reconciling does not outvote an applied Ready",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "True"), cond("Healthy", "True"), cond("Reconciling", "True")),
+			wantSync: "Synced", wantHealth: "Healthy",
+		},
+		{
+			name:     "ready and applied",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "True")),
+			wantSync: "Synced", wantHealth: "Healthy",
+		},
+		{
+			// Generation drift is the only state that genuinely means "not applied",
+			// and it holds even with Ready=True from the previous spec.
+			name:     "generation drift outranks a stale Ready",
+			obj:      fluxObj(false, int64(2), int64(1), cond("Ready", "True")),
+			wantSync: "Reconciling", wantHealth: "Progressing",
+		},
+		{
+			// Flux writes -1 on an object it has never reconciled. Present and
+			// different, so it counts.
+			name:     "the -1 sentinel counts as drift",
+			obj:      fluxObj(false, int64(1), int64(-1), cond("Ready", "False"), cond("Reconciling", "True")),
+			wantSync: "Reconciling", wantHealth: "Progressing",
+		},
+		{
+			// Absence is no signal. Reading it as drift would mark every healthy
+			// object on kinds that never set it as out of date.
+			name:     "absent observedGeneration is not drift",
+			obj:      fluxObj(false, int64(3), nil, cond("Ready", "True")),
+			wantSync: "Synced", wantHealth: "Healthy",
+		},
+		{
+			name:     "absent generation is not drift",
+			obj:      fluxObj(false, nil, int64(3), cond("Ready", "True")),
+			wantSync: "Synced", wantHealth: "Healthy",
+		},
+		{
+			// A behaviour change from the previous ordering, asserted rather than
+			// assumed: the controller has given up, whatever the last apply left.
+			name:     "Stalled outranks Ready",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "True"), cond("Stalled", "True")),
+			wantSync: "OutOfSync", wantHealth: "Degraded",
+		},
+		{
+			name:     "reconciling while not yet ready",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "Unknown"), cond("Reconciling", "True")),
+			wantSync: "Reconciling", wantHealth: "Progressing",
+		},
+		{
+			name:     "not ready",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "False")),
+			wantSync: "OutOfSync", wantHealth: "Degraded",
+		},
+		{
+			// Applied but the workloads are unhealthy — two different facts, and
+			// the sync axis must not absorb the health one.
+			name:     "unhealthy deployed resources are applied but degraded",
+			obj:      fluxObj(false, int64(1), int64(1), cond("Ready", "True"), cond("Healthy", "False")),
+			wantSync: "Synced", wantHealth: "Degraded",
+		},
+		{
+			// Suspending does not un-apply what was applied.
+			name:     "suspended and applied stays Synced",
+			obj:      fluxObj(true, int64(1), int64(1), cond("Ready", "True")),
+			wantSync: "Synced", wantHealth: "Suspended",
+		},
+		{
+			// A spec change made while suspended will never be picked up.
+			name:     "suspended with drift is not Synced",
+			obj:      fluxObj(true, int64(2), int64(1), cond("Ready", "True")),
+			wantSync: "Unknown", wantHealth: "Suspended",
+		},
+		{
+			name:     "no conditions at all",
+			obj:      fluxObj(false, int64(1), int64(1)),
+			wantSync: "Unknown", wantHealth: "Unknown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FluxStatus(tc.obj)
+			if got.Sync != tc.wantSync || got.Health != tc.wantHealth {
+				t.Errorf("FluxStatus = %s/%s, want %s/%s", got.Sync, got.Health, tc.wantSync, tc.wantHealth)
+			}
+		})
+	}
+}
+
+// The in-flight fact survives even when it no longer drives the status, so a
+// wedged controller can be surfaced next to an otherwise-correct Synced.
+func TestFluxStatusCarriesReconcilingActivity(t *testing.T) {
+	stuck := fluxObj(false, int64(1), int64(1), cond("Ready", "True"), cond("Reconciling", "True"))
+	got := FluxStatus(stuck)
+	if got.Sync != "Synced" {
+		t.Fatalf("Sync = %q, want Synced", got.Sync)
+	}
+	if !got.Reconciling {
+		t.Error("Reconciling activity was dropped; a wedged controller would be invisible")
+	}
+
+	quiet := FluxStatus(fluxObj(false, int64(1), int64(1), cond("Ready", "True")))
+	if quiet.Reconciling {
+		t.Error("Reconciling reported on an object with no Reconciling condition")
+	}
+}
+
+// Source kinds carry neither Healthy nor, in some versions, observedGeneration.
+// Measured shapes: GitRepository/HelmRepository expose Ready + ArtifactInStorage,
+// HelmRelease exposes Ready + Released.
+func TestFluxStatusHandlesNonKustomizationKinds(t *testing.T) {
+	cases := []struct {
+		name  string
+		conds []map[string]any
+	}{
+		{"GitRepository", []map[string]any{cond("Ready", "True"), cond("ArtifactInStorage", "True")}},
+		{"HelmRepository", []map[string]any{cond("Ready", "True"), cond("ArtifactInStorage", "True")}},
+		{"HelmRelease", []map[string]any{cond("Ready", "True"), cond("Released", "True")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FluxStatus(fluxObj(false, int64(1), int64(1), tc.conds...))
+			if got.Sync != "Synced" || got.Health != "Healthy" {
+				t.Errorf("FluxStatus = %s/%s, want Synced/Healthy", got.Sync, got.Health)
+			}
+		})
+	}
+}

--- a/pkg/gitops/fluxstatus_test.go
+++ b/pkg/gitops/fluxstatus_test.go
@@ -35,6 +35,10 @@ func cond(typ, status string) map[string]any {
 	return map[string]any{"type": typ, "status": status}
 }
 
+func condReason(typ, status, reason string) map[string]any {
+	return map[string]any{"type": typ, "status": status, "reason": reason}
+}
+
 func TestFluxStatusTruthTable(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -116,6 +120,19 @@ func TestFluxStatusTruthTable(t *testing.T) {
 			name:     "suspended with drift is not Synced",
 			obj:      fluxObj(true, int64(2), int64(1), cond("Ready", "True")),
 			wantSync: "Unknown", wantHealth: "Suspended",
+		},
+		{
+			// A retry or remediation in flight is out of sync but not settled
+			// failure. Mirrors the frontend mapper, which has always drawn this
+			// distinction — the two must agree.
+			name:     "a retrying Ready=False is progressing, not degraded",
+			obj:      fluxObj(false, int64(1), int64(1), condReason("Ready", "False", "ProgressingWithRetry")),
+			wantSync: "OutOfSync", wantHealth: "Progressing",
+		},
+		{
+			name:     "a settled Ready=False is degraded",
+			obj:      fluxObj(false, int64(1), int64(1), condReason("Ready", "False", "BuildFailed")),
+			wantSync: "OutOfSync", wantHealth: "Degraded",
 		},
 		{
 			name:     "no conditions at all",

--- a/pkg/gitops/insights/insights.go
+++ b/pkg/gitops/insights/insights.go
@@ -1227,36 +1227,8 @@ type fluxState struct {
 }
 
 func fluxStatus(root *unstructured.Unstructured) fluxState {
-	if suspended, _, _ := unstructured.NestedBool(root.Object, "spec", "suspend"); suspended {
-		return fluxState{sync: "Unknown", health: "Suspended"}
-	}
-	ready := ""
-	reconciling := false
-	stalled := false
-	for _, c := range conditions(root) {
-		if c.typ == "Ready" {
-			ready = c.status
-		}
-		if c.typ == "Reconciling" && c.status == "True" {
-			reconciling = true
-		}
-		if c.typ == "Stalled" && c.status == "True" {
-			stalled = true
-		}
-	}
-	if reconciling {
-		return fluxState{sync: "Reconciling", health: "Progressing"}
-	}
-	if stalled {
-		return fluxState{sync: "OutOfSync", health: "Degraded"}
-	}
-	if ready == "True" {
-		return fluxState{sync: "Synced", health: "Healthy"}
-	}
-	if ready == "False" {
-		return fluxState{sync: "OutOfSync", health: "Degraded"}
-	}
-	return fluxState{sync: "Unknown", health: "Unknown"}
+	st := gitops.FluxStatus(root)
+	return fluxState{sync: st.Sync, health: st.Health}
 }
 
 func nestedRef(root *unstructured.Unstructured, fields ...string) (Ref, bool) {

--- a/pkg/gitops/tree/inventory.go
+++ b/pkg/gitops/tree/inventory.go
@@ -96,45 +96,8 @@ func rootStatus(root *unstructured.Unstructured, tool Tool) gitOpsStatus {
 		health, _, _ := unstructured.NestedString(root.Object, "status", "health", "status")
 		return gitOpsStatus{Sync: normalizeSync(sync), Health: normalizeHealth(health)}
 	}
-	conditions, _, _ := unstructured.NestedSlice(root.Object, "status", "conditions")
-	ready := ""
-	reconciling := false
-	stalled := false
-	for _, item := range conditions {
-		m, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		t := gitops.StringValue(m["type"])
-		s := gitops.StringValue(m["status"])
-		if t == "Ready" {
-			ready = s
-		}
-		if t == "Reconciling" && s == "True" {
-			reconciling = true
-		}
-		if t == "Stalled" && s == "True" {
-			stalled = true
-		}
-	}
-	if root.Object["spec"] != nil {
-		if suspended, _, _ := unstructured.NestedBool(root.Object, "spec", "suspend"); suspended {
-			return gitOpsStatus{Sync: "Unknown", Health: "Suspended"}
-		}
-	}
-	if reconciling {
-		return gitOpsStatus{Sync: "Reconciling", Health: "Progressing"}
-	}
-	if stalled {
-		return gitOpsStatus{Sync: "OutOfSync", Health: "Degraded"}
-	}
-	if ready == "True" {
-		return gitOpsStatus{Sync: "Synced", Health: "Healthy"}
-	}
-	if ready == "False" {
-		return gitOpsStatus{Sync: "OutOfSync", Health: "Degraded"}
-	}
-	return gitOpsStatus{Sync: "Unknown", Health: "Unknown"}
+	st := gitops.FluxStatus(root)
+	return gitOpsStatus{Sync: st.Sync, Health: st.Health}
 }
 
 func normalizeSync(status string) string {


### PR DESCRIPTION
Closes [RAD-368](https://linear.app/skyhook-io/issue/RAD-368). Reported by a user: Radar shows Flux resources as reconciling while k9s shows the same objects fully synced.

Both tools read the object correctly. They read **different fields**. In Flux, `Ready` and `Reconciling` are independent conditions — upstream's own setter makes `Reconciling` mutually exclusive only with `Stalled`, never with `Ready` — and all three of Radar's copies of the derivation returned on `Reconciling` before ever looking at `Ready`.

The frontend copy was self-incriminating: its doc comment stated the rule as `Ready=False + Reconciling=True: Reconciling`, and the code 26 lines below never checked `Ready`.

## Measured before designing the fix

Flux v2.4.0 on the repo's own `gitops-demo` fixture, ~2,800 samples across four Kustomizations with forced reconciles. Two findings changed the approach:

**The obvious theory was wrong.** Zero samples had `Ready=True` and `Reconciling=True` together. Whenever `Reconciling=True` was observable, `Ready` was `Unknown` or `False`; healthy objects carry no `Reconciling` condition at all.

**The routine pass is imperceptible.** A forced reconcile provably ran on `podinfo-base` — `status.lastHandledReconcileAt` matched the trigger — yet never appeared as `Reconciling` across 711 samples. With nothing to apply the pass completes in under ~65ms.

So the reported symptom is not the routine-pass flicker it looks like. It is the **stale** `Reconciling` — a pass that started and never finished, described in [flux2#5119](https://github.com/fluxcd/flux2/discussions/5119) as persisting 24h+ while `Ready=True`. Reproduced by freezing `kustomize-controller` and writing that condition set:

```
kubectl / k9s printer columns:   READY=True   STATUS="Applied revision: master@sha1:eec06d1"
Radar GitOps row (before):       Syncing | Progressing
Radar GitOps row (after):        Synced  | Healthy
```

That measurement also settles the open product question in the ticket — whether showing plain `Synced` loses an in-flight signal. In normal operation there is no signal to lose. Where it *is* visible is the stale case, and there a permanent "Syncing" is not an in-flight indicator, it is a wrong answer that never resolves.

## The rule

Sync answers "is the declared state applied" — `Ready` plus `observedGeneration`. `Reconciling` answers "is the controller mid-pass", which is neither.

| order | condition | sync | health |
|---|---|---|---|
| 1 | `suspend`, no drift | `Synced` if `Ready=True` else `Unknown` | `Suspended` |
| 2 | `Stalled=True` | `OutOfSync` | `Degraded` |
| 3 | `Ready=True`, no drift | `Synced` | from `Healthy` |
| 4 | drift, or `Reconciling` with `Ready != True` | `Reconciling` | `Progressing` |
| 5 | `Ready=False` | `OutOfSync` | `Degraded` |

Row 3 ahead of row 4 is the fix. This matches kstatus — which Flux's Kustomization API declares compatibility with, and which computes status from `observedGeneration` plus readiness while treating `Reconciling` as abnormal-true metadata.

It also matches **this file's own Argo mapper**, which already takes sync from Argo's sync field and uses `Reconciling` only as a fallback when sync is otherwise undecided. Argo applications keep Synced-while-Progressing today; the Flux mapper was the odd one out.

**`observedGeneration` has three states, not two.** Absent is *no signal* and must not block `Synced` — some kinds and controller versions never set it. Present-and-different is drift, including the `-1` sentinel Flux writes on an object it has never reconciled (measured on the fixture's failing HelmRelease).

**Activity is preserved, not discarded.** `GitOpsStatus` gains `reconciling` and `reconcilingSince`, set whenever `Reconciling=True` and never consulted for sync or health, so a wedged controller can be surfaced next to an otherwise-correct `Synced`.

## Two Go copies became one

`pkg/gitops/insights/insights.go` and `pkg/gitops/tree/inventory.go` carried near-duplicates that **had already drifted** — they disagreed on suspend handling. Both now delegate to `gitops.FluxStatus`.

## Signature change

`fluxConditionsToGitOpsStatus` had no access to generation. It takes an optional third parameter, so the change is additive — `packages/k8s-ui` is a published package and altering the existing two would be breaking. All 8 call sites updated; each already had the resource in scope.

## Testing

`go test ./...` clean in both modules · `make tsc` clean · k8s-ui 2161 passing.

Truth-table tests in **both** languages over every row, deliberately mirrored so the two implementations cannot drift again. Beyond the happy path: the exact reported state, generation drift outranking a stale `Ready`, the `-1` sentinel, absent `observedGeneration` **not** counting as drift, suspend with and without drift, and one pass per Flux kind — `GitRepository` and `HelmRepository` carry `ArtifactInStorage` and no `Healthy`, `HelmRelease` carries `Released`.

There were **zero** tests on any of the three copies before this, which is why the precedence survived from the original GitOps view.

Verified live against the reproduced fixture. After the fix `podinfo-base` reads `Synced | Healthy` while `kubectl` still reads `READY=True`, and nothing broken was masked — `podinfo-broken` (both Kustomization and HelmRelease) still reads `Syncing | Progressing`, suspended still reads `Suspended`.

## One behaviour worth knowing

`Ready=True` + `Stalled=True` now reads `OutOfSync` where it previously read `Synced`. Stalled means the controller has given up, whatever the last successful apply left behind. It is asserted in both languages rather than left implicit.

And a genuine in-flight pass still reads `Reconciling` — because at that moment `Ready` is genuinely `Unknown`, which is what `kubectl` shows too. Sampling Radar's own API 25 times during back-to-back forced reconciles caught it twice; at the fixture's 5m interval the real exposure is ~0.02% of the time. That is the honest answer, and it is not the reported bug.

## Not done here

A staleness threshold that escalates health once a pass has been in flight for many intervals. `reconcilingSince` carries the data for it, but flipping health to `Degraded` asserts a controller fault the object cannot prove — that wants controller liveness, and field evidence on how common wedging is.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Flux sync/health derivation across UI and backend paths that drive GitOps status display. Incorrect precedence here can mislead operators about whether resources are applied.
> 
> **Overview**
> **Fixes Flux status so a stale `Reconciling` condition no longer outvotes `Ready`.** Applied objects now read **Synced** (matching kubectl/k9s), with sync driven by `Ready` plus `observedGeneration` rather than mid-pass activity.
> 
> `fluxConditionsToGitOpsStatus` and a new shared Go `FluxStatus` helper use the same precedence: suspend → Stalled → Ready (no drift) → reconciling/drift → Ready=False. Duplicate insights/tree mappers now delegate to that shared helper. Absent `observedGeneration` is treated as no signal, not drift.
> 
> Activity is kept separate via new `reconciling` / `reconcilingSince` fields and a secondary `ReconcilingIndicator` beside the sync badge—visible when a controller is wedged behind an otherwise-correct Synced, suppressed when sync already says Reconciling. Mirrored truth-table tests cover both languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058a4f23c928ce07c9e4d8df6d3d365305b56edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->