### PR TITLE
feat(kyverno): name the workload each policy report is about

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -707,6 +707,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   policyreports: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'scope', label: 'Subject', width: 'w-56' },
     { key: 'status', label: 'Status', width: 'w-32' },
     { key: 'pass', label: 'Pass', width: 'w-16' },
     { key: 'fail', label: 'Fail', width: 'w-16' },
@@ -717,6 +718,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   ],
   clusterpolicyreports: [
     { key: 'name', label: 'Name' },
+    { key: 'scope', label: 'Subject', width: 'w-56' },
     { key: 'status', label: 'Status', width: 'w-32' },
     { key: 'pass', label: 'Pass', width: 'w-16' },
     { key: 'fail', label: 'Fail', width: 'w-16' },

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx'
 import {
+  getPolicyReportScope,
   getPolicyReportStatus,
   getPolicyReportSummary,
   getKyvernoPolicyStatus,
@@ -18,6 +19,14 @@ export function PolicyReportCell({ resource, column }: { resource: any; column: 
           {status.text}
         </span>
       )
+    }
+    // Kyverno names a per-resource report after the subject's UID, so the Name
+    // column reads as a bare UUID. Without the subject the whole table is
+    // unidentifiable rows with counts beside them — you cannot tell which of
+    // your workloads a failing report belongs to without opening every one.
+    case 'scope': {
+      const scope = getPolicyReportScope(resource)
+      return <span className="truncate text-theme-text-primary" title={scope}>{scope}</span>
     }
     case 'pass': {
       const summary = getPolicyReportSummary(resource)

--- a/packages/k8s-ui/src/components/resources/renderers/policyreport-subject.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/policyreport-subject.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { PolicyReportCell } from './kyverno-cells'
+import { getPolicyReportScope } from '../resource-utils-kyverno'
+
+// Kyverno names each per-resource report after the subject's UID, so the Name
+// column is a bare UUID. Without the subject, the table is a list of
+// unidentifiable rows with counts beside them.
+describe('PolicyReport subject column', () => {
+  const report = {
+    metadata: { name: '4c1d2f8a-91e3-4b7c-9f11-2a6e0c5d7b83', namespace: 'payments' },
+    scope: { kind: 'Deployment', namespace: 'payments', name: 'checkout-api' },
+  }
+
+  it('names the workload the report is about', () => {
+    const html = renderToString(<PolicyReportCell resource={report} column="scope" />)
+    expect(html).toContain('checkout-api')
+    expect(html).toContain('Deployment')
+  })
+
+  it('degrades to a dash rather than an empty cell when there is no subject', () => {
+    // Cluster-scoped reports and some producers omit scope entirely.
+    expect(getPolicyReportScope({ metadata: { name: 'x' } })).toBe('-')
+    const html = renderToString(<PolicyReportCell resource={{ metadata: { name: 'x' } }} column="scope" />)
+    expect(html).toContain('-')
+  })
+})


### PR DESCRIPTION
Kyverno names each per-resource report after the subject's UID, so the PolicyReports table rendered a list of bare UUIDs with counts beside them. You could see that something in the cluster was failing three checks, and not which of your workloads it was, without opening every row.

Measured on a fixture cluster with 33 reports — this is the actual table:

| Name | Namespace | Status |
|---|---|---|
| `0597304e-3715-4a24-a7d5-63bccf5d73ba` | kyverno | 1 Error |
| `0c88d9a6-764f-4ce9-bf59-bf62f5d300ee` | kube-system | 1 Fail |
| `1f2c29bb-e311-4118-9969-7a4b8ea3e491` | kube-system | 1 Error |

With the column:

| Name | Namespace | **Subject** | Status |
|---|---|---|---|
| `0597304e-…` | kyverno | **Deployment/kyverno/kyverno-reports-controller** | 1 Error |
| `0c88d9a6-…` | kube-system | **Pod/kube-system/kindnet-d4hdk** | 1 Fail |
| `1f2c29bb-…` | kube-system | **DaemonSet/kube-system/kindnet** | 1 Error |

## Why this is a column and not a project

The subject was already being extracted — `getPolicyReportScope` exists and the detail drawer renders it. Nothing needed parsing, indexing or fetching; the value was one accessor away from the table the whole time. Added to both `policyreports` and `clusterpolicyreports`.

## Scope, deliberately

This makes the report-browsing view usable. It does **not** answer "what is *this* workload violating" from the workload's own page, which is the bigger gap — the per-subject findings currently reach `/api/ai/*` and MCP and no human-facing surface. That needs an endpoint and a UI section and is scoped separately. Half a day here is worth spending anyway, because the report list is where anyone lands today.

## Testing

`go test ./...` clean · `make tsc` clean · k8s-ui 2154 passing.

Two unit tests: the column names the workload, and it degrades to `-` rather than an empty cell when a report carries no subject (cluster-scoped reports and some producers omit `scope` entirely).

Verified on screen against a live Kyverno 1.18.2 cluster with 33 real reports produced by the background scanner — the before/after table above is that cluster, not a fixture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only table column using an existing accessor; no API, auth, or data-handling changes.
> 
> **Overview**
> Makes **PolicyReports** and **ClusterPolicyReports** tables usable by adding a **Subject** column that names the workload each report is about (e.g. `Deployment/payments/checkout-api`).
> 
> Kyverno names per-resource reports after the subject's UID, so the Name column alone was a list of bare UUIDs. The column reuses existing `getPolicyReportScope` and falls back to `-` when a report has no scope. Includes unit coverage for both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4021c4aa50023856e59faf3ffbe2c55f4cb205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->