### PR TITLE
feat(cnpg): show what the volumes are actually doing, not what was requested

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -7,6 +7,7 @@ import {
   getCNPGClusterImage,
   getCNPGClusterStorage,
   getCNPGClusterStorageClass,
+  getCNPGVolumeHealth,
   getCNPGClusterWALStorage,
   getCNPGClusterBootstrapMethod,
   getCNPGClusterUpdateStrategy,
@@ -43,6 +44,7 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   const monitoring = getCNPGClusterMonitoring(data)
   const isReplica = getCNPGClusterIsReplica(data)
   const walStorage = getCNPGClusterWALStorage(data)
+  const volumeHealth = getCNPGVolumeHealth(data)
   const postgresParams = getCNPGClusterPostgresParams(data)
   const instanceNames = getCNPGClusterInstanceNames(data)
   const bootstrapMethod = getCNPGClusterBootstrapMethod(data)
@@ -210,6 +212,14 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
         />
       )}
 
+      {volumeHealth && volumeHealth.unusable.length > 0 && (
+        <AlertBanner
+          variant="error"
+          title="Unusable storage volume"
+          message={`${volumeHealth.unusable.join(', ')} cannot be used because a paired volume is missing. An instance backed by it will not start, and the cluster cannot return to full size until the volume is restored or removed.`}
+        />
+      )}
+
       {/* Cluster Overview */}
       <Section title="Cluster Overview" icon={Database} defaultExpanded>
         <PropertyList>
@@ -290,6 +300,20 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
         <PropertyList>
           <Property label="Data Size" value={getCNPGClusterStorage(data)} />
           <Property label="Storage Class" value={getCNPGClusterStorageClass(data)} />
+          {/* Requested size and class are spec-side intentions. These are what the
+              operator reports about the volumes that actually exist. */}
+          {volumeHealth?.total !== undefined && (
+            <Property label="Volumes" value={`${volumeHealth.healthy.length}/${volumeHealth.total} healthy`} />
+          )}
+          {volumeHealth && volumeHealth.unusable.length > 0 && (
+            <Property label="Unusable" value={volumeHealth.unusable.join(', ')} />
+          )}
+          {volumeHealth && volumeHealth.resizing.length > 0 && (
+            <Property label="Resizing" value={volumeHealth.resizing.join(', ')} />
+          )}
+          {volumeHealth && volumeHealth.dangling.length > 0 && (
+            <Property label="Detached" value={volumeHealth.dangling.join(', ')} />
+          )}
         </PropertyList>
         {walStorage && (
           <div className="mt-2 pt-2 border-t border-theme-border">

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -5,6 +5,7 @@ import {
   getCNPGBackupStatus,
   getCNPGPoolerStatus,
   isCNPGPoolerPaused,
+  getCNPGVolumeHealth,
   getCNPGClusterInstancesReportedState,
   getCNPGClusterBackupConfig,
   getCNPGClusterBarmanPlugin,
@@ -628,5 +629,36 @@ describe('paused Pooler', () => {
       .toMatchObject({ text: 'Scheduled', level: 'healthy' })
     expect(isCNPGPoolerPaused({ spec: { pgbouncer: { paused: true } } })).toBe(true)
     expect(isCNPGPoolerPaused({ spec: {} })).toBe(false)
+  })
+})
+
+describe('volume health', () => {
+  // Field names and shape verified against a live CloudNativePG 1.27 CRD and a
+  // running cluster: pvcCount is a number, the rest are arrays of PVC names.
+  const healthy = {
+    status: { pvcCount: 2, healthyPVC: ['pg-healthy-1', 'pg-healthy-2'] },
+  }
+
+  it('reads what the operator reports about volumes that exist', () => {
+    const h = getCNPGVolumeHealth(healthy)
+    expect(h).toMatchObject({ total: 2, healthy: ['pg-healthy-1', 'pg-healthy-2'], unusable: [] })
+  })
+
+  it('surfaces an unusable volume, which is why an instance cannot start', () => {
+    // Upstream: unusable means a paired volume is missing.
+    const h = getCNPGVolumeHealth({ status: { pvcCount: 3, healthyPVC: ['a'], unusablePVC: ['pg-main-3'] } })
+    expect(h?.unusable).toEqual(['pg-main-3'])
+  })
+
+  it('stays silent when the operator has reported nothing', () => {
+    // Absence must not render as "0 problems" — the section is hidden instead,
+    // so it never claims a check it did not perform.
+    expect(getCNPGVolumeHealth({ status: {} })).toBeNull()
+    expect(getCNPGVolumeHealth({})).toBeNull()
+  })
+
+  it('ignores malformed entries rather than rendering them', () => {
+    const h = getCNPGVolumeHealth({ status: { pvcCount: 1, healthyPVC: ['ok', 42, null] } })
+    expect(h?.healthy).toEqual(['ok'])
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -723,3 +723,47 @@ export function getCNPGPoolerAuthQuerySecret(resource: any): { name: string } | 
   if (!secret?.name) return undefined
   return { name: secret.name }
 }
+
+/**
+ * Volume health for a CNPG cluster, read from the arrays the operator publishes
+ * on status. Radar previously showed only the REQUESTED size and storage class,
+ * which are spec-side intentions — a cluster whose volumes had failed rendered
+ * a cheerful "20Gi" with nothing to suggest otherwise.
+ *
+ * `unusablePVC` is the sharp one. Upstream defines it as a volume that cannot be
+ * used because a paired volume is missing, which is why a database instance can
+ * be permanently unable to start while every other field looks ordinary.
+ *
+ * Returns null when the operator has published nothing, so the section can stay
+ * silent rather than claim zero problems it never checked for.
+ */
+export interface CNPGVolumeHealth {
+  total?: number
+  healthy: string[]
+  unusable: string[]
+  dangling: string[]
+  resizing: string[]
+  initializing: string[]
+}
+
+export function getCNPGVolumeHealth(resource: any): CNPGVolumeHealth | null {
+  const s = resource?.status
+  if (!s) return null
+  const list = (v: any): string[] => (Array.isArray(v) ? v.filter((x: any) => typeof x === 'string') : [])
+  const health: CNPGVolumeHealth = {
+    total: typeof s.pvcCount === 'number' ? s.pvcCount : undefined,
+    healthy: list(s.healthyPVC),
+    unusable: list(s.unusablePVC),
+    dangling: list(s.danglingPVC),
+    resizing: list(s.resizingPVC),
+    initializing: list(s.initializingPVC),
+  }
+  const reportedAnything =
+    health.total !== undefined ||
+    health.healthy.length > 0 ||
+    health.unusable.length > 0 ||
+    health.dangling.length > 0 ||
+    health.resizing.length > 0 ||
+    health.initializing.length > 0
+  return reportedAnything ? health : null
+}


### PR DESCRIPTION
The Storage section on a CloudNativePG cluster reported **Data Size** and **Storage Class** — both read from `spec`. They are what was *requested*, not what exists. A cluster whose volumes had failed rendered a cheerful `256Mi` with nothing anywhere to suggest otherwise, and storage is the most common reason a Postgres cluster cannot come back.

The operator publishes volume state on `status`, and Radar read **none** of it. `grep` for any of these across the repo returned nothing:

`pvcCount` · `healthyPVC` · `unusablePVC` · `danglingPVC` · `resizingPVC` · `initializingPVC`

## What changed

The section now reports how many volumes are healthy out of the total, and names any that are unusable, resizing, or detached.

`unusablePVC` also raises a banner, because upstream defines it precisely:

> List of all the PVCs that are unusable **because another PVC is missing**

That is not a soft warning. An instance backed by such a volume will not start, which is how a database cluster can be permanently unable to return to full size while every other field on the page looks ordinary.

**Absence stays silent.** When the operator has published nothing, the rows are hidden rather than rendering zeros — the section never claims a check it did not perform. Malformed array entries are dropped rather than rendered.

## Division of labour with the existing checks

This does **not** add an Issue, on purpose. In a real unusable-volume scenario the desired instance count exceeds the ready count, and the existing detector already raises `Only N of M instances are ready`. That row says *what*; this section says *why*. Adding a second Issue would double-report the same fault, which the CNPG detector work went to some trouble to avoid.

## Verification

Field names and shapes were confirmed against a **live CloudNativePG 1.27 CRD** before any code was written, then against a running cluster: `pvcCount` is an integer, the rest are arrays of PVC names (`pg-healthy-1`, `pg-healthy-2`).

Rendering was verified by inducing the broken state on a frozen-operator fixture:

```
Storage
  Data Size    256Mi
  Storage Class -
  Volumes      2/3 healthy
  Unusable     pg-healthy-3
```

plus the banner: *"pg-healthy-3 cannot be used because a paired volume is missing. An instance backed by it will not start…"*

Before this change that same cluster showed only the first two rows.

## Testing

`go test ./...` clean in both modules · `make tsc` clean · k8s-ui 2156 passing.

Four unit tests covering the reported shape, the unusable case, the silent-on-absence contract, and malformed entries.

## Not in scope

Escalating the cluster's status badge when a volume is unusable. The cluster in that state is often still serving — it simply cannot grow back — and the instance-count check already covers the case where it is genuinely short. Changing the badge is a status-derivation decision that wants its own argument rather than riding along here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only UI reading existing status fields; no status-badge or issue-detector changes, with silent absence and unit coverage.
> 
> **Overview**
> The CNPG cluster **Storage** section previously showed only requested `spec` size and storage class. It now also reports **operator-published volume state** from status (`pvcCount`, healthy/unusable/dangling/resizing PVCs).
> 
> Adds `getCNPGVolumeHealth` and wires it into the drawer: healthy volume counts, named problem volumes, and an **error banner** when `unusablePVC` is set (paired volume missing — instances cannot start). When the operator reports nothing, the new rows stay hidden rather than showing zeros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1786a6e2c674892de6d20c611046eabbe272e29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->