### PR TITLE
fix(radar-app): raise the k8s-ui peer floor to the version it actually needs

### DIFF
--- a/.github/workflows/publish-radar-app.yml
+++ b/.github/workflows/publish-radar-app.yml
@@ -1,11 +1,13 @@
 name: Publish @skyhook-io/radar-app
 
-# Radar's source imports deep paths from @skyhook-io/k8s-ui
-# (./types/*, ./utils/*, ./components/gitops/*, ./components/timeline/*,
-# ./components/resources/renderers/*, ./components/checks/*, and the shared
-# Input primitive and YAML editor APIs shipped through k8s-ui v1.8.15). Publish
-# k8s-ui FIRST before tagging a radar-app release — peer dep resolves to '>=1.8.15',
-# so the imported k8s-ui source exports must already be on the registry.
+# This package ships source, not a build, so every @skyhook-io/k8s-ui export that
+# web/src imports must already be on the registry when a consumer installs it.
+# Publish k8s-ui FIRST, then tag radar-app.
+#
+# The floor is the k8s-ui peer range in web/package.json. Any PR that imports a
+# newly added k8s-ui export must raise it in the same change — otherwise this
+# package advertises compatibility with a k8s-ui that cannot compile it, and
+# consumers fail at build time with "has no exported member".
 
 on:
   push:

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
-    "@skyhook-io/k8s-ui": ">=1.11.0",
+    "@skyhook-io/k8s-ui": ">=1.12.0",
     "@tanstack/react-query": ">=5",
     "@xyflow/react": ">=12.0.0",
     "clsx": ">=2",


### PR DESCRIPTION
## What

Raise the `@skyhook-io/k8s-ui` peer floor in `web/package.json` from `>=1.11.0` to `>=1.12.0`, and rewrite the ordering note at the top of the radar-app publish workflow.

## Why

`web/src/api/policy.ts` imports `PolicyResourceResponse` from `@skyhook-io/k8s-ui`. That type is new — it lives in `packages/k8s-ui/src/types/policy.ts` and reaches the package root via `src/index.ts` -> `./types` -> `./policy`. It does not exist at tag `k8s-ui-v1.11.0`, which is the currently published version:

```
$ git grep PolicyResourceResponse k8s-ui-v1.11.0 -- packages/k8s-ui
(no output)
```

The peer range still says `>=1.11.0`. `@skyhook-io/radar-app` ships source rather than a build, so a consumer that resolves k8s-ui to the low end of that range gets a package that cannot compile — it fails at build time with `TS2305: has no exported member 'PolicyResourceResponse'`. In `radar-hub-web`, where k8s-ui is a direct dependency pinned by a lockfile, that is exactly the failure mode.

This is normally handled in the PR that introduces the import. Every earlier k8s-ui dependency bump did it (`>=1.5.0` -> `1.7.3` -> `1.8.11` -> `1.8.15` -> `1.10.0` -> `1.11.0`); this one was missed.

## The workflow comment

The ordering note in `publish-radar-app.yml` hard-coded `1.8.15` in two places and had drifted five releases behind, so it no longer said anything true about the current floor — plausibly why the bump got missed. It now points at the peer range in `web/package.json` as the single source of truth and states the rule that keeps it accurate, rather than restating a version that has to be maintained in a second place.

## Verification

- `npm run tsc` in `web/` — clean
- `npm test` in `packages/k8s-ui/` — 121 files, 2187 passed, 1 skipped

## Release context

This unblocks publishing `k8s-ui-v1.12.0` followed by `radar-app-v1.10.0`. The k8s-ui diff since `k8s-ui-v1.11.0` is additive only — new `PolicyResourceResponse` type, new `PolicySection` export, and new optional props on `WorkloadRenderer` (`policyData`, `policyLoading`, `policyError`) and `CompositeRenderer` (`composedRefs`, `boundXRStatus`). Nothing removed or renamed, so minor is the right bump for both.

Worth flagging separately: the policy feature calls `GET /api/policy/resource/{kind}/{ns}/{name}`, a route that exists only on `main`. The newest radar binary release is v1.9.2 and does not serve it, so the policy section will 404 against currently deployed agents until a binary release ships with it. The renderer props are optional and the query sets `retry: false`, so this does not block the npm release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor and comment-only change; no runtime or auth/security logic is modified.
> 
> **Overview**
> Raises the `@skyhook-io/k8s-ui` peer floor from `>=1.11.0` to `>=1.12.0` so published `radar-app` no longer claims compatibility with a k8s-ui that lacks exports it imports (notably `PolicyResourceResponse`).
> 
> Also rewrites the publish-workflow ordering note to point at the peer range in `web/package.json` as the source of truth, instead of hard-coding a stale `1.8.15` version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032b0b9441d5c5780d2d78764c022196b7e28a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->