### PR TITLE
fix(reachability): only offer vantages the deployment can actually test from

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -322,12 +322,15 @@ type Trace struct {
 	// Truncated is set when fan-out (e.g. Gateway attached routes) exceeded
 	// the cap, so the UI can surface "showing N of M".
 	Truncated bool `json:"truncated,omitempty"`
-	// RunVantage names WHERE Radar itself ran the inline probes from: "in-cluster"
-	// (Radar is a pod - its direct probes are real pod-to-pod, the in-cluster data
-	// path is already covered, and it CANNOT test an external ingress front door) or
-	// "local" (a laptop - the direct probes are the external client's view, and the
-	// in-cluster data path needs the manual in-cluster Job). The UI labels columns,
-	// gates the in-cluster button, and words the verdict honestly per architecture.
+	// RunVantage names WHERE Radar itself runs, and so where its inline probes are
+	// sent from: "in-cluster" (Radar is a pod - its direct probes are real
+	// pod-to-pod, the in-cluster data path is already covered, and it CANNOT test
+	// an external ingress front door) or "local" (a laptop - the direct probes are
+	// the external client's view, and the in-cluster data path needs the manual
+	// in-cluster Job). Set on every trace, probed or not: it is a deployment fact,
+	// and the UI needs it to decide which vantages are offerable at all. The UI
+	// labels columns, gates the in-cluster button, and words the verdict honestly
+	// per architecture.
 	RunVantage string `json:"runVantage,omitempty"`
 
 	// Coverage-honest projection of the trace, computed server-side alongside
@@ -425,6 +428,7 @@ func BuildTraceWithOptions(ctx context.Context, deps Deps, kind, namespace, name
 	if !cacheReady(deps) {
 		return &Trace{
 			Subject:      subject,
+			RunVantage:   string(detectVantage()),
 			Downstream:   []Hop{},
 			Upstreams:    []Hop{},
 			Verdict:      VerdictUnknown,
@@ -444,7 +448,11 @@ func BuildTraceWithOptions(ctx context.Context, deps Deps, kind, namespace, name
 	ctx, cancel := context.WithTimeout(ctx, totalBudget)
 	defer cancel()
 
-	t := &Trace{Subject: subject, BrokenAt: -1}
+	// Stamped before any probe runs. Where Radar sits is a deployment fact, not a
+	// result, and the UI needs it on the static trace too: it decides which
+	// vantages are even offerable, and a trace with no probes would otherwise
+	// advertise a workstation vantage that a Radar running as a Pod can never use.
+	t := &Trace{Subject: subject, BrokenAt: -1, RunVantage: string(detectVantage())}
 
 	switch normalizeKind(kind) {
 	case "Service":

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -270,6 +270,7 @@ function ReachabilityBoard(props: BoardProps) {
         actions={
           <ReachActions
             {...props}
+            runVantage={trace.runVantage}
             inClusterRunnable={traceInClusterRunnable(trace)}
             inClusterTested={origins.some((o) => o.id === 'incluster' && o.mark !== 'untested')}
             supportsHTTPPath={(trace.routes ?? []).some((r) => {

--- a/packages/k8s-ui/src/components/trace/TracePanel.tsx
+++ b/packages/k8s-ui/src/components/trace/TracePanel.tsx
@@ -384,7 +384,7 @@ function ProbeOptionsMenu({ probePath, onApplyProbePath }: { probePath?: string;
 // test" (proxy/laptop vantage) plus, once allowed, the secondary "Test inside the
 // cluster" (real pod-to-pod) - one grouped control instead of two split corners.
 // Uses the design-system button classes (.btn-brand / .btn-brand-muted).
-export function ReachActions({ onRunProbes, probeRequested, probed, onRunInCluster, inClusterRunning, inClusterAllowed, inClusterRunnable, inClusterTested, probePath, onApplyProbePath, supportsHTTPPath = true }: {
+export function ReachActions({ onRunProbes, probeRequested, probed, onRunInCluster, inClusterRunning, inClusterAllowed, inClusterRunnable, inClusterTested, probePath, onApplyProbePath, supportsHTTPPath = true, runVantage }: {
   onRunProbes?: () => void
   probeRequested?: boolean
   // probed/inClusterTested: each test has already produced a result, so its
@@ -403,6 +403,10 @@ export function ReachActions({ onRunProbes, probeRequested, probed, onRunInClust
   probePath?: string
   onApplyProbePath?: (p: string) => void
   supportsHTTPPath?: boolean
+  /** Where Radar itself runs. The primary test is sent by the Radar PROCESS, so
+   *  "from your machine" is only true when Radar is on one - a hosted or
+   *  in-cluster Radar dials from its own Pod. */
+  runVantage?: 'in-cluster' | 'local'
 }) {
   // The in-cluster test stays available whenever the cluster allows it - NEVER
   // gated on the verdict. Hiding it after it succeeds (when the verdict turns
@@ -437,7 +441,13 @@ export function ReachActions({ onRunProbes, probeRequested, probed, onRunInClust
       {/* Primary: the reachability test. The refresh icon signals it's
           re-runnable (it auto-ran on load), so re-running reads as a refresh. */}
       {onRunProbes && (
-        <Tooltip content="Tests reachability from your machine and through the API server. Covers EVERY path on this resource, not only the one selected above.">
+        <Tooltip
+          content={
+            runVantage === 'in-cluster'
+              ? 'Tests reachability from Radar’s own Pod and through the API server. Covers EVERY path on this resource, not only the one selected above.'
+              : 'Tests reachability from your machine and through the API server. Covers EVERY path on this resource, not only the one selected above.'
+          }
+        >
           <button
             type="button"
             onClick={onRunProbes}

--- a/packages/k8s-ui/src/components/trace/reachFixtures.ts
+++ b/packages/k8s-ui/src/components/trace/reachFixtures.ts
@@ -12,7 +12,7 @@ import type { Trace, PodStatus, ProbeResult } from './types'
  * so two disagreeing origins cannot both be retained. Faking it here would
  * imply a capability the model does not have.
  */
-export type DevState = 'mixed' | 'break' | 'front' | 'synth' | 'scale' | 'fanout' | 'none' | 'running' | 'stale' | 'rbac'
+export type DevState = 'mixed' | 'break' | 'front' | 'synth' | 'scale' | 'fanout' | 'none' | 'running' | 'stale' | 'rbac' | 'hosted'
 
 export const DEV_STATES: { id: DevState; label: string }[] = [
   { id: 'mixed', label: '1 · Mixed vantages' },
@@ -25,6 +25,7 @@ export const DEV_STATES: { id: DevState; label: string }[] = [
   { id: 'running', label: 'Probe running' },
   { id: 'stale', label: 'Stale + changed' },
   { id: 'rbac', label: 'Probe not permitted' },
+  { id: 'hosted', label: 'Radar runs in-cluster' },
 ]
 
 const NS = 'payments'
@@ -230,6 +231,30 @@ export function devTrace(state: DevState): Trace {
       ],
       routes: [{ route: 'GET / · :80 → 8080', target: ':80 → 8080', outcome: 'verified', confidence: 'indirect', evidence: 'HTTP 200 through the apiserver proxy' }],
       notTested: [{ route: 'gRPC :9090 → 9090', reason: 'probe creation denied by RBAC', reasonClass: 'vantage' }],
+    }
+  }
+
+  // Radar deployed as a Pod - the hosted and self-hosted-in-cluster shape. The
+  // only way to see the vantage rail as those users see it without running a
+  // cluster-side Radar: no workstation vantage exists there, and Radar's own
+  // process is a first-class origin rather than the throwaway Job.
+  if (state === 'hosted') {
+    return {
+      ...t,
+      runVantage: 'in-cluster',
+      headline: 'Reachable in-cluster on :80 — the front door is still unproven',
+      coverage: { tested: 3, passed: 3, failed: 0, skipped: 1 },
+      downstream: [
+        serviceHop(),
+        podsHop(PODS, [
+          ...okProbes.map((p) => ({ ...p, source: 'radar' as const })),
+          probe({ path: 'apiserver', target: 'checkout-api port 80', detail: 'HTTP 200 via proxy', latencyNs: 12_000_000 }),
+        ]),
+      ],
+      routes: [
+        { route: 'GET / · :80 → 8080', target: ':80 → 8080', outcome: 'verified', confidence: 'real', evidence: 'DNS 2 ms · TCP 1 ms · HTTP 200 · 11 ms' },
+      ],
+      notTested: [{ route: 'front door · primary-gateway', reason: 'no request has entered through the Gateway', reasonClass: 'coverage' }],
     }
   }
 

--- a/packages/k8s-ui/src/components/trace/reachGraphModel.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachGraphModel.test.ts
@@ -65,6 +65,26 @@ describe('buildGraph lanes', () => {
     }
   })
 
+  // The board must not offer a vantage the deployment cannot use: a Radar
+  // running as a Pod dials from that Pod, never from the operator's machine.
+  it('draws no workstation capsule when Radar runs in the cluster', () => {
+    const t = trace([pod('a', true, '10.0.0.1')], [p({ source: 'radar' })])
+    t.runVantage = 'in-cluster'
+    const os = originsFor(t)
+    const g = buildGraph({ trace: t, route: route(), origin: os.find((o) => o.id === 'radar-incluster')!, origins: os })
+    expect(g.nodes.find((n) => n.id === 'origin:local')).toBeUndefined()
+    expect(g.nodes.filter((n) => n.isOrigin).map((n) => n.id).sort()).toEqual(['origin:apiserver', 'origin:incluster', 'origin:radar-incluster'])
+  })
+
+  it('drops the two-mechanism control-lane note with it', () => {
+    const t = trace([pod('a', true, '10.0.0.1')], [p({ path: 'apiserver' })])
+    t.runVantage = 'in-cluster'
+    const os = originsFor(t)
+    const g = buildGraph({ trace: t, route: route(), origin: os.find((o) => o.id === 'apiserver')!, origins: os })
+    expect(g.laneControl!.help).not.toMatch(/your machine/)
+    expect(g.laneControl!.help).toMatch(/control plane/)
+  })
+
   it('the origin is drawn as a vantage capsule, never as a Kubernetes resource', () => {
     const t = trace([pod('a', true, '10.0.0.1')], [p({})])
     const g = buildGraph({ trace: t, route: route(), origin: pick(t, 'incluster') })

--- a/packages/k8s-ui/src/components/trace/reachGraphModel.ts
+++ b/packages/k8s-ui/src/components/trace/reachGraphModel.ts
@@ -1425,10 +1425,17 @@ export function buildGraph({ trace, route, origin, origins, stale, running }: Bu
     const y1 = Math.max(...list.map((n) => n.y + n.h)) + LANE_PAD.bottom
     return { x: x0, y: y0, w: x1 - x0, h: y1 - y0, label, help, color, dashed }
   }
+  // The two-mechanism wording only holds while the workstation vantage is drawn.
+  // With Radar running as a Pod there is no dial from a machine outside, and
+  // contrasting it with the relay described a lane with one member as if it had
+  // two.
+  const laptopDrawn = nodes.some((n) => n.id === 'origin:local')
   const laneControl = boxFor(
     nodes.filter((n) => n.lane === 'control'),
     'NOT FROM INSIDE THE CLUSTER',
-    'Neither request originates inside the cluster’s dataplane, but they differ: a dial from your machine sends real traffic from outside - through a real entry it exercises the path from the entry inward (routing, NetworkPolicy, mesh included). A relayed request is carried by the Kubernetes control plane and bypasses the traffic path entirely.',
+    laptopDrawn
+      ? 'Neither request originates inside the cluster’s dataplane, but they differ: a dial from your machine sends real traffic from outside - through a real entry it exercises the path from the entry inward (routing, NetworkPolicy, mesh included). A relayed request is carried by the Kubernetes control plane and bypasses the traffic path entirely.'
+      : 'This request is carried by the Kubernetes control plane rather than sent along the traffic path: the API server relays it to the target, so routing, NetworkPolicy and the mesh are all bypassed.',
     'var(--color-info)',
     true,
   )

--- a/packages/k8s-ui/src/components/trace/reachOrigins.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachOrigins.test.ts
@@ -218,6 +218,37 @@ describe('Radar-as-a-Pod is not the throwaway probe Job', () => {
     expect(radar?.unsupported).toBeFalsy()
   })
 
+  // The mirror rule. A Radar that runs as a Pod has no process on the operator's
+  // machine, so a workstation vantage there is not a test anyone can run - it is
+  // a control that would never do anything, standing where a real gap should be.
+  it('omits the workstation vantage entirely when Radar runs in the cluster', () => {
+    const t = traceWith([p({ vantage: 'in-cluster', path: 'data', source: 'radar', ok: true })])
+    t.runVantage = 'in-cluster'
+    const os = buildOrigins(t)
+    expect(os.find((o) => o.id === 'local')).toBeUndefined()
+    expect(os.map((o) => o.id)).toEqual(['caller', 'external', 'incluster', 'radar-incluster', 'apiserver'])
+  })
+
+  it('keeps the external gap declared there — it is what nothing can prove', () => {
+    const t = traceWith([p({ vantage: 'in-cluster', path: 'data', source: 'radar', ok: true })])
+    t.runVantage = 'in-cluster'
+    expect(buildOrigins(t).find((o) => o.id === 'external')?.unsupported).toBe(true)
+  })
+
+  // Hiding a vantage must never hide evidence. If a laptop-side result somehow
+  // arrives on an in-cluster trace, the row it belongs to has to stay.
+  it('keeps the workstation vantage when it actually produced a result', () => {
+    const t = traceWith([p({ vantage: 'local', path: 'data', ok: true })])
+    t.runVantage = 'in-cluster'
+    expect(buildOrigins(t).find((o) => o.id === 'local')).toBeDefined()
+  })
+
+  it('keeps it on a laptop trace that has not been probed yet', () => {
+    const t = traceWith([])
+    t.runVantage = 'local'
+    expect(buildOrigins(t).find((o) => o.id === 'local')).toBeDefined()
+  })
+
   it('describes Radar-in-cluster with Radar\'s own identity, not the Job\'s', () => {
     const t = traceWith([p({ vantage: 'in-cluster', path: 'data', source: 'radar', ok: true })])
     t.runVantage = 'in-cluster'

--- a/packages/k8s-ui/src/components/trace/reachOrigins.ts
+++ b/packages/k8s-ui/src/components/trace/reachOrigins.ts
@@ -357,7 +357,17 @@ export function buildOrigins(trace: Trace | undefined, ctx: OriginContext = {}):
   // same ground. Listing it as "never tested" would pad the coverage caveat with
   // a deployment detail, next to genuine holes like "as your application".
   const radarIsAbsent = radarProbes.length === 0 && trace?.runVantage !== 'in-cluster'
-  return ORIGIN_STRENGTH.filter((id) => !(id === 'radar-incluster' && radarIsAbsent)).map((id) => all[id])
+  // The mirror image, and the same reasoning. When Radar runs as a Pod - hosted,
+  // or self-hosted in-cluster - there is no Radar on the operator's machine to
+  // dial from, so this vantage is not one that can be run and then isn't. The
+  // browser being on a laptop is irrelevant: the request is sent by the Radar
+  // process. What a machine outside the cluster would see is still declared, by
+  // the external origin, which is a real gap and stays. Guarded on having no
+  // probes so a mislabelled result can never hide evidence that exists.
+  const laptopIsAbsent = localProbes.length === 0 && trace?.runVantage === 'in-cluster'
+  return ORIGIN_STRENGTH.filter(
+    (id) => !(id === 'radar-incluster' && radarIsAbsent) && !(id === 'local' && laptopIsAbsent),
+  ).map((id) => all[id])
 }
 
 /**


### PR DESCRIPTION
## What

The vantage rail drew **Radar on your machine** unconditionally. When Radar runs as a Pod — hosted, or self-hosted in-cluster — there is no Radar on the operator's machine, so that capsule advertised a test nobody can run: a permanent "not tested" standing where a real evidence gap should be, beside genuine ones like "as your application".

The mirror rule already existed in the other direction (**Radar, inside the cluster** is dropped when Radar runs on a laptop), so this applies the same reasoning symmetrically. One rule now governs the rail:

> A vantage appears when the mechanism exists in this deployment. What happened to it is its state, never its presence.

What a machine outside the cluster would see stays declared by the **Direct external client** origin, which is a real gap and remains in the ceiling note.

## Vantages drawn, by deployment

| Radar runs | Vantages drawn |
|---|---|
| On a laptop | In-cluster probe · Radar on your machine · API-server proxy |
| As a Pod | In-cluster probe · Radar, inside the cluster · API-server proxy |

Both hide-rules are guarded on the vantage having produced no probes, so a result can never be hidden by a mislabelled or future producer. An unknown `runVantage` falls back to the laptop shape.

## Supporting changes

`Trace.RunVantage` is now stamped when the trace is **built**, not only when probes run. Where Radar sits is a deployment fact rather than a result, and the UI needs it on the static trace too — otherwise an unprobed trace cannot tell which vantages are offerable.

Two pieces of copy were only true on a laptop and are now worded from the actual vantage: the control-lane note contrasted "a dial from your machine" with the relay in a lane that now has one member, and the reachability-test tooltip described the test as coming from your machine when a Pod deployment sends it from its own Pod.

A dev fixture for the Radar-as-a-Pod shape is included, so the vantage rail those users see is reachable without a cluster-side Radar.

## Verification

`go test ./internal/...`, the trace vitest suite and `make tsc` pass. Checked visually against a kind cluster in both deployment shapes via the dev fixture.

https://claude.ai/code/session_014ura9BCyEnYuSvfDJTwYLF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and trace metadata changes with guarded hide rules so existing probe evidence is not dropped; no auth or data-path changes.
> 
> **Overview**
> Reachability no longer shows **Radar on your machine** when Radar runs as a Pod. The vantage rail now mirrors the existing rule for in-cluster Radar on a laptop: a capsule appears only when that mechanism exists in this deployment (still kept if it already produced probes).
> 
> **Backend:** `Trace.RunVantage` is set when a trace is **built** (including cache-not-ready and static-only traces), not only after probes run, so unprobed traces can tell which vantages are offerable.
> 
> **UI:** `buildOrigins` drops the `local` origin when `runVantage === 'in-cluster'` and there are no laptop probes; the reachability test tooltip and control-lane help no longer mention “your machine” in that shape. `ReachActions` receives `runVantage` from the trace.
> 
> **Dev/tests:** A `hosted` dev fixture and vitest coverage for origin filtering and graph layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16a91b60150424aac9d90cecffe4ba453186a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->