### PR TITLE
fix(reachability): a refused API-server relay is a skip, not a failure

### DIFF
--- a/internal/trace/probes_test.go
+++ b/internal/trace/probes_test.go
@@ -2175,3 +2175,45 @@ func TestPortKey_PairsEveryLabelShape(t *testing.T) {
 		}
 	}
 }
+
+// A refused proxy dial tested nothing, so it must not be scored as a route
+// outcome. Before this, an identity without the services/proxy subresource -
+// the default for Radar's own ServiceAccount - turned every laptop-vantage
+// trace into a confident "couldn't get through" about a healthy workload.
+func TestProbeService_ProxyDenialIsASkipNotAFailure(t *testing.T) {
+	origSvc := serviceProxyProbe
+	serviceProxyProbe = func(_ context.Context, _ kubernetes.Interface, ns, name string, port int32, _ string, vantage probe.Vantage) probe.Result {
+		return probe.Result{
+			Layer: probe.LayerHTTP, Target: fmt.Sprintf("port %d", port), Vantage: vantage, Path: probe.PathAPIServer,
+			Skipped: true, SkipClass: probe.SkipClassDenied,
+			Reason: "Permission denied. Your identity lacks get services/proxy or get pods/proxy in this namespace.",
+		}
+	}
+	t.Cleanup(func() { serviceProxyProbe = origSvc })
+
+	tr := &Trace{
+		Subject: ResourceRef{Kind: "Service", Namespace: "ns", Name: "svc"},
+		Downstream: []Hop{{
+			Resource: ResourceRef{Kind: "Service", Namespace: "ns", Name: "svc"},
+			Config:   &HopConfig{ServiceType: "ClusterIP", ClusterIP: "10.0.0.1", Ports: []PortMap{{Port: 80}}},
+		}},
+	}
+	runProbes(context.Background(), tr, Options{Probe: true, ProbeBudget: 500 * time.Millisecond}, fake.NewClientset())
+
+	for _, p := range tr.Downstream[0].Probes {
+		if p.Path != probe.PathAPIServer {
+			continue
+		}
+		if !p.Skipped {
+			t.Errorf("a denied proxy dial must be a skip, got a scored result: %+v", p)
+		}
+		if p.SkipClass != probe.SkipClassDenied {
+			t.Errorf("skip class = %q, want %q - the UI needs it to say 'not permitted' rather than 'couldn't test'", p.SkipClass, probe.SkipClassDenied)
+		}
+	}
+	for _, r := range tr.Routes {
+		if r.Outcome == OutcomeUnreachable {
+			t.Errorf("a permissions gap condemned the route: %+v", r)
+		}
+	}
+}

--- a/packages/k8s-ui/src/components/trace/reachInspector.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.test.ts
@@ -890,3 +890,51 @@ describe('the action sits with its explanation', () => {
     expect(ev.map((e) => e.text).join(' ')).toMatch(/no entry point|Ingress/i)
   })
 })
+
+// The two vantages that can be refused need DIFFERENT grants. Sending an
+// operator to their cluster admin asking for `create jobs` when what they lack
+// is the proxy subresource wastes the one request they get to make.
+describe('a refusal asks for the grant that would actually fix it', () => {
+  const sidebarFor = (t: Trace, originId: string, opts = {}) => {
+    const origins = buildOrigins(t, opts)
+    const origin = origins.find((o) => o.id === originId)!
+    const r = t.routes![0]
+    const g = buildGraph({ trace: t, route: r, origin, origins })
+    return buildSidebar(undefined, {
+      trace: t, route: r, origin, origins,
+      nodes: g.nodes, breakNodeId: g.breakNodeId, breakAtExitOf: g.breakAtExitOf,
+      nonNetworkNodeIds: g.nonNetworkNodeIds, contextNodeIds: g.contextNodeIds,
+      interleave: g.interleave, entryParallelCount: g.entryParallelCount,
+      journeyEntryNodeIds: g.journeyEntryNodeIds, pathNodeIds: g.pathNodeIds,
+    })
+  }
+
+  // The in-cluster dial already succeeded, so no stronger gap is left to
+  // propose - which is exactly when the panel falls through to the refusal.
+  it('names the proxy subresource when the relay was the refused vantage', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [
+      p({ vantage: 'in-cluster', path: 'data', ok: true, tone: 'healthy' }),
+      p({
+        vantage: 'local', path: 'apiserver', skipped: true, ok: false, skipClass: 'denied',
+        reason: 'Permission denied. Your identity lacks get services/proxy or get pods/proxy in this namespace.',
+      }),
+    ])
+    const next = sidebarFor(t, 'apiserver').path.next!
+    expect(next.header).toBe('ASK FOR THIS PERMISSION')
+    expect(next.body).toMatch(/services\/proxy/)
+    expect(next.body).not.toMatch(/jobs/)
+    expect(next.ctas[0].command).toBe('kubectl auth can-i get services/proxy -n store')
+  })
+
+  it('still names the Job grant when the in-cluster probe was the refused one', () => {
+    const t = mk([pod('a', true, '10.0.0.1')], [p({ vantage: 'local', path: 'data', ok: true, tone: 'healthy' })])
+    const next = sidebarFor(t, 'incluster', {
+      inClusterAllowed: false,
+      inClusterDeniedReason: 'RBAC denies create on jobs',
+    }).path.next!
+    expect(next.header).toBe('ASK FOR THIS PERMISSION')
+    expect(next.body).toMatch(/jobs/)
+    expect(next.body).not.toMatch(/services\/proxy/)
+    expect(next.ctas[0].command).toBe('kubectl auth can-i create jobs -n store')
+  })
+})

--- a/packages/k8s-ui/src/components/trace/reachInspector.ts
+++ b/packages/k8s-ui/src/components/trace/reachInspector.ts
@@ -201,11 +201,25 @@ function gapNext(
 
   if (!actionable && denied) {
     const ns = namespace || '<namespace>'
+    // Which grant to ask for depends on WHICH vantage was refused. The Job and
+    // the relay need different permissions, and naming the wrong one sends the
+    // operator to their cluster admin with a request that would not fix this.
+    // When both are refused the Job wins by strength order, which is also the
+    // more valuable ask - it is the stronger evidence.
+    const relay = denied.id === 'apiserver'
     return {
       header: 'ASK FOR THIS PERMISSION',
-      body: `Running an in-cluster test needs \`create\` on \`jobs\` in ${ns}. Grant it, or run the check from a workload you already control.`,
+      body: relay
+        ? `Relaying through the API server needs \`get\` on \`services/proxy\` and \`pods/proxy\` in ${ns}. Grant it, or test from inside the cluster instead.`
+        : `Running an in-cluster test needs \`create\` on \`jobs\` in ${ns}. Grant it, or run the check from a workload you already control.`,
       blocked: denied.unavailable,
-      ctas: [{ text: 'Copy the permission check', action: 'copy-command', command: `kubectl auth can-i create jobs -n ${ns}` }],
+      ctas: [
+        {
+          text: 'Copy the permission check',
+          action: 'copy-command',
+          command: relay ? `kubectl auth can-i get services/proxy -n ${ns}` : `kubectl auth can-i create jobs -n ${ns}`,
+        },
+      ],
     }
   }
   if (actionable && actionable.id === current.id) {

--- a/packages/k8s-ui/src/components/trace/reachOrigins.test.ts
+++ b/packages/k8s-ui/src/components/trace/reachOrigins.test.ts
@@ -59,6 +59,26 @@ describe('buildOrigins', () => {
     expect(local?.unavailable).toMatch(/not routable/)
   })
 
+  // A refused relay says nothing about the workload. Scoring it as a failure
+  // painted the vantage red for a permissions gap, and 'blocked' would have
+  // hidden that there is a grant to ask for.
+  it('reads a refused relay as not permitted, and says what to grant', () => {
+    const os = buildOrigins(
+      traceWith([
+        p({
+          vantage: 'local',
+          path: 'apiserver',
+          skipped: true,
+          skipClass: 'denied',
+          reason: 'Permission denied. Your identity lacks get services/proxy or get pods/proxy in this namespace.',
+        }),
+      ]),
+    )
+    const api = os.find((o) => o.id === 'apiserver')
+    expect(api?.mark).toBe('denied')
+    expect(api?.unavailable).toMatch(/services\/proxy/)
+  })
+
   it('reports denied rather than untested when the probe is not permitted', () => {
     const os = buildOrigins(traceWith([]), { inClusterAllowed: false, inClusterDeniedReason: 'RBAC denies create on jobs' })
     const ic = os.find((o) => o.id === 'incluster')

--- a/packages/k8s-ui/src/components/trace/reachOrigins.ts
+++ b/packages/k8s-ui/src/components/trace/reachOrigins.ts
@@ -141,6 +141,10 @@ function markFor(probes: ProbeResult[], id: OriginId, ctx: OriginContext): Mark 
   // its answer was deliberately kept informational. 'blocked' ("never tried -
   // something failed earlier") was false on both clauses.
   if (live.length === 0 && probes.some((p) => p.skipped && p.skipClass === 'informational')) return 'inconclusive'
+  // A refusal is not a dead end the operator has to accept: 'blocked' ("an
+  // earlier failure or a skip stopped it") hides that this one names a grant
+  // they can ask for.
+  if (live.length === 0 && probes.some((p) => p.skipped && p.skipClass === 'denied')) return 'denied'
   if (live.length === 0) return 'blocked'
   if (ctx.stale) return 'stale'
   if (live.some((p) => !p.ok || p.tone === 'unhealthy')) return 'failed'
@@ -153,6 +157,12 @@ function markFor(probes: ProbeResult[], id: OriginId, ctx: OriginContext): Mark 
 /** The reason an all-skipped origin never ran, taken from the probes themselves. */
 function skipReason(probes: ProbeResult[]): string | undefined {
   return probes.find((p) => p.skipped && p.reason)?.reason
+}
+
+/** The reason an origin was refused. Identity-scoped, so unlike `skipReason` it
+ *  speaks for every port and carries no misattribution risk. */
+function deniedReason(probes: ProbeResult[]): string | undefined {
+  return probes.find((p) => p.skipped && p.skipClass === 'denied' && p.reason)?.reason
 }
 
 /**
@@ -278,6 +288,7 @@ export function buildOrigins(trace: Trace | undefined, ctx: OriginContext = {}):
   }
 
   const apiProbes = byOrigin.get('apiserver') ?? []
+  const apiMark = markFor(apiProbes, 'apiserver', ctx)
   const apiserver: Origin = {
     id: 'apiserver',
     glyph: '⌸',
@@ -287,7 +298,16 @@ export function buildOrigins(trace: Trace | undefined, ctx: OriginContext = {}):
     kind: 'relayed',
     kindTag: ORIGIN_KIND_TAG.relayed,
     lane: 'control',
-    mark: markFor(apiProbes, 'apiserver', ctx),
+    mark: apiMark,
+    // The relay carries the identity Radar is running as, which is not always
+    // one that may proxy. Without the reason the capsule stated a refusal and
+    // left the reader no way to know what to grant.
+    //
+    // Only a DENIAL is read here, never any skip: a refusal is a property of the
+    // identity and so speaks for every port, while the other skips (an HTTPS
+    // port the relay can't verify, a non-HTTP port) are port-specific and would
+    // be misattributed the moment another port is selected.
+    unavailable: apiMark === 'denied' ? deniedReason(apiProbes) : undefined,
   }
 
   const localProbes = byOrigin.get('local') ?? []

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -131,6 +131,11 @@ const (
 	// condemn the path). A disposition, never a coverage gap: consumers must not
 	// describe it as "never tried".
 	SkipClassInformational = "informational"
+
+	// SkipClassDenied marks a probe the identity was not allowed to send. The
+	// request never reached the workload, so it says nothing about reachability -
+	// and unlike other skips it names something the operator can grant.
+	SkipClassDenied = "denied"
 )
 
 // Layer names which network layer this Result attests to. Higher layers
@@ -723,7 +728,14 @@ func proxyResult(ctx context.Context, req *rest.Request, r Result) Result {
 		// subresource, which a backend's own 403 body never does, so this
 		// distinguishes an apiserver refusal from an app that answered 403
 		// (the latter has a real status code and is "reached" below).
-		r.Error = "Permission denied. Your identity lacks get services/proxy or get pods/proxy in this namespace."
+		//
+		// This SKIPS rather than fails. A refused request tested nothing, so
+		// scoring it as a failure condemned a healthy workload for a
+		// permissions gap - red on every trace wherever the identity lacks the
+		// subresource, which is the default for Radar's own ServiceAccount.
+		r.Skipped = true
+		r.SkipClass = SkipClassDenied
+		r.Reason = "Permission denied. Your identity lacks get services/proxy or get pods/proxy in this namespace."
 		return r
 	case code == 502 || code == 503 || code == 504:
 		// A backend that genuinely answered 502/503/504 carries a real status code, and

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -14,6 +14,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // ── P0 probe trio: DNS classification, HTTP status semantics, TLS cert inspection ──
@@ -509,5 +511,43 @@ func TestTCP_SuccessCarriesDetail(t *testing.T) {
 	}
 	if r.Detail == "" {
 		t.Error("a successful TCP probe must carry a Detail - empty evidence reads as 'nothing ran'")
+	}
+}
+
+// A denied proxy dial never reached the workload, so it must SKIP rather than
+// score. Driven through a real client against a real 403 because the branch
+// depends on client-go's error typing, which a hand-built error does not
+// reproduce faithfully.
+func TestServiceProxy_PermissionDeniedSkipsRatherThanFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure",` +
+			`"message":"services \"echo\" is forbidden: User \"radar\" cannot get resource \"services/proxy\" in API group \"\" in the namespace \"shop\"",` +
+			`"reason":"Forbidden","code":403}`))
+	}))
+	defer srv.Close()
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+
+	r := ServiceProxy(context.Background(), client, "shop", "echo", 80, "/", VantageLocal)
+
+	if !r.Skipped {
+		t.Fatalf("a refused dial must skip, got a scored result: %+v", r)
+	}
+	if r.OK {
+		t.Errorf("OK = true on a refused dial: %+v", r)
+	}
+	if r.SkipClass != SkipClassDenied {
+		t.Errorf("SkipClass = %q, want %q", r.SkipClass, SkipClassDenied)
+	}
+	if !strings.Contains(r.Reason, "services/proxy") {
+		t.Errorf("the reason must name the grant to ask for, got %q", r.Reason)
+	}
+	if r.Error != "" {
+		t.Errorf("a permissions gap is not a probe error: %q", r.Error)
 	}
 }


### PR DESCRIPTION
## What

An RBAC refusal on the `services/proxy` / `pods/proxy` subresource was scored as a probe **failure**. The request never reached the workload, so it says nothing about reachability — and the identity Radar dials with often lacks that grant, which made a healthy workload read as red on every trace where it does.

The blast radius was wider than the vantage capsule:

- the refusal was folded into the route outcome as evidence, so a permissions gap could produce a confident "couldn't get through";
- the coverage line counted it among the failures.

It now skips with its own class (`SkipClassDenied`). The route is untested rather than condemned, the coverage line counts it as "couldn't be tried", and the vantage reads **not permitted** with the grant to ask for — rather than "couldn't test", which would have hidden that there is anything to grant. Same treatment the in-cluster probe Job's RBAC denial already gets.

## Note on scope

The reason is read only from a denial, never from any skip. A refusal is a property of the identity and so speaks for every port, while the relay's other skips — an HTTPS port it cannot verify, a non-HTTP port — are port-specific and would be misattributed the moment another port is selected. An existing test in `reachInspector` covers exactly that, and caught it.

## Who hits this

Any identity without the proxy subresource. Worth knowing that the Helm chart's ClusterRole grants `services` and `pods` but not their `proxy` subresources, so a chart-deployed Radar with auth disabled is refused on every relay dial and shows this state permanently. Whether to offer that grant as an opt-in chart value is a separate decision and deliberately not in this PR.

## Verification

`go test ./internal/...` and `./pkg/...`, the trace vitest suite and `make tsc` pass. Both new tests were confirmed to fail without the fix. The probe-level test drives a real 403 through a real client rather than a hand-built error, because the branch depends on client-go's error typing.

https://claude.ai/code/session_014ura9BCyEnYuSvfDJTwYLF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches probe scoring, route outcomes, and user-facing RBAC guidance on a core trace path; behavior change is intentional but affects how many deployments (e.g. chart SA without proxy subresource) appear in the UI.
> 
> **Overview**
> **RBAC refusal on `services/proxy` / `pods/proxy` no longer scores as a reachability failure.** In `ServiceProxy`, forbidden proxy errors set `Skipped` with new `SkipClassDenied` and a grant-oriented `Reason` instead of a scored error, so a permissions gap cannot mark a workload unreachable.
> 
> **Downstream behavior follows that semantics:** trace routing must not treat a denied relay as `OutcomeUnreachable` (covered by the new `TestProbeService_ProxyDenialIsASkipNotAFailure` integration test). Origins classify all-skipped proxy probes as **`denied`** (not blocked/failed) and surface the denial reason on the API-server capsule.
> 
> **The inspector’s “ASK FOR THIS PERMISSION” block is vantage-specific:** relay (`apiserver`) asks for `get services/proxy` / `pods/proxy` and copies `kubectl auth can-i get services/proxy`; in-cluster refusal still points at `create jobs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32139371bdb72b87f2a4bec8799ffacba5ceba12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->