### PR TITLE
feat(ai): drive GitHub Copilot CLI for investigations

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -8,7 +8,7 @@ tmp_dir = "tmp"
   # Build command
   cmd = "go build -o ./tmp/radar ./cmd/explorer"
   # Binary to run
-  bin = "./tmp/radar --dev --no-browser --kubeconfig ~/.kube/config"
+  entrypoint = ["./tmp/radar", "--dev", "--no-browser"]
   # Watch these extensions
   include_ext = ["go", "tpl", "tmpl", "html"]
   # Exclude directories

--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -13,7 +13,7 @@ import (
 // that CLI's event stream into radar's normalized StreamEvents + final Diagnosis.
 // The generic run loop (process group, stdout pipe, lifecycle) lives in Diagnoser.
 type Agent interface {
-	// Name is the stable backend identifier ("claude", "codex").
+	// Name is the stable backend identifier ("claude", "codex", "copilot").
 	Name() string
 	// Path is the resolved executable this backend actually drives.
 	Path() string
@@ -46,7 +46,7 @@ type turnSpec struct {
 	apply        bool   // user-confirmed remediation turn (write tools allowed)
 	profile      ExecutionProfile
 	model        string // optional model override; empty = the CLI's default
-	effort       string // optional reasoning effort (Codex only); empty = default
+	effort       string // optional reasoning effort (Codex + Copilot); empty = default
 	maxTurns     int
 	// workdir is a stable per-RUN scratch directory (same across the run's turns).
 	// Cursor needs it: its --resume is workspace-scoped, so follow-ups must run in
@@ -55,7 +55,8 @@ type turnSpec struct {
 }
 
 // resolveAgent picks a backend from the CLI binary name (e.g. RADAR_AI_CLI_BIN or
-// the detected CLI): "cursor-agent" → Cursor, "codex" → Codex, else → Claude.
+// the detected CLI): "cursor-agent" → Cursor, "codex" → Codex, "copilot" → GitHub
+// Copilot, else → Claude.
 func resolveAgent(bin string) Agent {
 	base := strings.ToLower(filepath.Base(bin))
 	switch {
@@ -63,6 +64,8 @@ func resolveAgent(bin string) Agent {
 		return &cursorAgent{bin: bin}
 	case strings.Contains(base, "codex"):
 		return &codexAgent{bin: bin}
+	case strings.Contains(base, "copilot"):
+		return &copilotAgent{bin: bin}
 	default:
 		return &claudeAgent{bin: bin}
 	}

--- a/internal/ai/agent_codex.go
+++ b/internal/ai/agent_codex.go
@@ -111,21 +111,10 @@ func (a *codexAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func()
 // to exec, locale). Cloud-provider secrets are deliberately omitted — the shell
 // can read env into context, and the agent reaches the cluster only via MCP.
 func codexEnv() []string {
-	keep := map[string]bool{
-		"HOME": true, "PATH": true, "CODEX_HOME": true, "TMPDIR": true,
-		"TERM": true, "LANG": true, "USER": true, "LOGNAME": true, "SHELL": true,
-	}
-	var out []string
-	for _, kv := range os.Environ() {
-		k, _, ok := strings.Cut(kv, "=")
-		if !ok {
-			continue
-		}
-		if keep[k] || strings.HasPrefix(k, "LC_") {
-			out = append(out, kv)
-		}
-	}
-	return out
+	return minimalEnv(
+		[]string{"CODEX_HOME", "TERM", "LANG", "USER", "LOGNAME", "SHELL"},
+		[]string{"LC_"},
+	)
 }
 
 // Codex JSONL event shapes (codex exec --json). Only the fields we consume.

--- a/internal/ai/agent_copilot.go
+++ b/internal/ai/agent_copilot.go
@@ -10,10 +10,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"sort"
+	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 )
 
 // copilotMCPServer is the name Radar's MCP server is registered under. Copilot
@@ -30,9 +28,13 @@ const copilotMCPServer = "radar"
 //     once the tools are gone);
 //   - --allow-tool <server> approves those tools without --allow-all-tools, so
 //     nothing else is auto-approved;
-//   - --disable-builtin-mcps drops github-mcp-server, and every server in the
-//     user's own config is disabled by name (see resolveUserMCPServers) — Copilot
-//     has no single "ignore user config" flag, so the set is enumerated;
+//   - COPILOT_HOME points at a Radar-owned directory, so NOTHING of the user's own
+//     Copilot setup loads: not their MCP servers ($COPILOT_HOME/mcp-config.json),
+//     not their settings, and — decisively — not their user-level hooks, which run
+//     shell in -p mode and which no flag can disable (the documented
+//     disableAllHooks setting does not take effect from a workspace in 1.0.80);
+//   - --disable-builtin-mcps drops github-mcp-server, which is built in rather
+//     than user config and so survives the COPILOT_HOME redirect;
 //   - cluster WRITE access is gated by the read-only MCP MOUNT, the same
 //     server-side gate the other backends rely on.
 //
@@ -41,9 +43,9 @@ const copilotMCPServer = "radar"
 type copilotAgent struct {
 	bin string
 
-	serversMu    sync.Mutex
-	serversKnown bool
-	userServers  []string
+	// homeDir resolves the user's home. Overridden in tests so a safeguarded run
+	// never writes into the developer's real ~/.radar.
+	homeDir func() (string, error)
 }
 
 func (a *copilotAgent) Name() string { return "copilot" }
@@ -89,6 +91,10 @@ func (a *copilotAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func
 		// The transcript contains cluster data — never publish it to GitHub's web
 		// and mobile surfaces, in either profile.
 		"--no-remote", "--no-remote-export",
+		// Copilot self-updates by default and its CI-environment detection can't
+		// fire under a minimized env: pin the binary for the duration of the run
+		// rather than let it swap itself mid-investigation.
+		"--no-auto-update",
 	}
 
 	if s.profile == ExecutionProfileSafeguarded {
@@ -100,13 +106,6 @@ func (a *copilotAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func
 			"--disable-builtin-mcps",
 			"--no-custom-instructions",
 		)
-		servers, err := a.resolveUserMCPServers(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		for _, name := range servers {
-			args = append(args, "--disable-mcp-server", name)
-		}
 	} else {
 		// Full-local: the user's own tools, MCP servers and instructions are live.
 		// Cluster writes stay gated by the read-only MCP mount.
@@ -116,13 +115,13 @@ func (a *copilotAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func
 	if s.model != "" {
 		args = append(args, "--model", s.model)
 	}
-	// Default to medium rather than Copilot's bare default, matching the other
-	// backends: it gives a solid investigation without an unbounded token bill.
-	effort := s.effort
-	if effort == "" {
-		effort = "medium"
+	// Only when the user picked one. Copilot rejects --effort outright on accounts
+	// whose model resolves to "auto" ("Model \"auto\" does not support reasoning
+	// effort configuration", exit 1) — which is the free tier's default, so a Radar
+	// default here would fail every out-of-the-box run.
+	if s.effort != "" {
+		args = append(args, "--effort", s.effort)
 	}
-	args = append(args, "--effort", effort)
 
 	if s.sessionID != "" {
 		// --resume takes an OPTIONAL value, so it must use the "=" form: passed as a
@@ -134,21 +133,83 @@ func (a *copilotAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func
 
 	cleanup := func() {}
 	if s.profile == ExecutionProfileSafeguarded {
-		// Empty working dir so the model can't pick up a workspace .mcp.json or
-		// AGENTS.md, and so nothing in radar's cwd is reachable. Copilot's session
-		// store is global, so resume works from any directory — no per-run workdir
-		// is needed (unlike Cursor).
+		home, err := a.copilotHome()
+		if err != nil {
+			return nil, nil, err
+		}
+		// Empty working dir so the model can't pick up a workspace .mcp.json,
+		// .github/hooks/*.json or AGENTS.md, and so nothing in radar's cwd is
+		// reachable. The session store lives under COPILOT_HOME rather than the
+		// cwd, so resume still works from anywhere — no per-run workdir is needed
+		// (unlike Cursor).
 		dir, err := os.MkdirTemp("", "radar-copilot-")
 		if err != nil {
 			return nil, nil, fmt.Errorf("ai: copilot workdir: %w", err)
 		}
 		cleanup = func() { _ = os.RemoveAll(dir) }
 		cmd.Dir = dir
-		cmd.Env = copilotEnv()
+		cmd.Env = append(copilotEnv(), "COPILOT_HOME="+home)
 	}
 	// Full-local: inherit radar's cwd + full env so the user's auth/config work.
 
 	return cmd, cleanup, nil
+}
+
+// CopilotHomeDir is the Radar-owned COPILOT_HOME used by safeguarded runs. It
+// holds Copilot's config AND its session store, so it has to be a stable path
+// rather than per-run scratch: follow-up turns and the terminal hand-off both
+// resume sessions that live here, and the hand-off can come after a restart.
+//
+// The frontend reproduces this path as a shell expression when it builds the
+// hand-off command (web/src/components/diagnose/launch.ts) — keep the two in step.
+func CopilotHomeDir(home string) string {
+	return filepath.Join(home, ".radar", "copilot-home")
+}
+
+// copilotHome resolves and prepares the Radar-owned COPILOT_HOME. Failing to
+// create it is a hard error: the alternative is running against the user's own
+// Copilot home, which is the very thing safeguarded mode exists to exclude.
+//
+// Auth is NOT stored here on the platforms we've checked (macOS keeps the
+// `copilot login` credential in the keychain, and an explicit token var still
+// takes precedence), so the redirect does not force a second login.
+func (a *copilotAgent) copilotHome() (string, error) {
+	homeFn := a.homeDir
+	if homeFn == nil {
+		homeFn = os.UserHomeDir
+	}
+	home, err := homeFn()
+	if err != nil {
+		return "", fmt.Errorf("ai: copilot home: %w", err)
+	}
+	dir := CopilotHomeDir(home)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("ai: copilot home: %w", err)
+	}
+	seedCopilotConfig(dir)
+	return dir, nil
+}
+
+// seedCopilotConfig writes Radar's own Copilot config on first use. The redirect
+// already excludes the user's hooks; disableAllHooks makes it explicit for anything
+// that lands in this directory later. Best-effort: a config Copilot can start
+// without is not worth failing an investigation over.
+func seedCopilotConfig(dir string) {
+	path := filepath.Join(dir, "config.json")
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	cfg, err := json.Marshal(map[string]any{
+		"disableAllHooks": true,
+		"autoUpdate":      false,
+		"banner":          "never",
+	})
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(path, cfg, 0o600); err != nil {
+		log.Printf("[ai] could not seed Copilot config in %s: %v", dir, err)
+	}
 }
 
 // copilotToolNames is the allowlist handed to --available-tools: Radar's MCP tools
@@ -166,83 +227,25 @@ func copilotToolNames(apply bool) []string {
 	return names
 }
 
-// copilotEnv is the minimal environment Copilot needs: auth (HOME/COPILOT_HOME
-// hold the credential store, or an explicit token var), the host overrides for
+// copilotEnv is the minimal environment Copilot needs: auth (an explicit token var,
+// or the OS credential store the CLI reaches on its own), the host overrides for
 // GHE, proxy settings, and enough to exec. Cloud-provider secrets are deliberately
 // omitted — the agent reaches the cluster only through Radar's MCP.
 //
-// COPILOT_HOME is passed through but never set by Radar: auth AND the session
-// store both live there, so redirecting it would break login and resume together.
+// The caller appends Radar's own COPILOT_HOME; the user's value is NOT kept, since
+// that directory is exactly what a safeguarded run must not load.
 func copilotEnv() []string {
-	keep := map[string]bool{
-		"HOME": true, "PATH": true, "TMPDIR": true,
-		"TERM": true, "LANG": true, "USER": true, "LOGNAME": true, "SHELL": true,
-		"COPILOT_HOME": true, "COPILOT_GITHUB_TOKEN": true,
-		"GH_TOKEN": true, "GITHUB_TOKEN": true,
-		"GH_HOST": true, "COPILOT_GH_HOST": true,
-		"HTTP_PROXY": true, "HTTPS_PROXY": true, "NO_PROXY": true,
-		"http_proxy": true, "https_proxy": true, "no_proxy": true,
-		"SSL_CERT_FILE": true, "SSL_CERT_DIR": true,
-	}
-	var out []string
-	for _, kv := range os.Environ() {
-		k, _, ok := strings.Cut(kv, "=")
-		if !ok {
-			continue
-		}
-		if keep[k] || strings.HasPrefix(k, "LC_") {
-			out = append(out, kv)
-		}
-	}
-	return out
-}
-
-// resolveUserMCPServers lists the MCP servers Copilot would otherwise load and
-// returns every one that isn't Radar's, so a safeguarded turn can disable them by
-// name. Copilot has no --strict-mcp-config / --ignore-user-config equivalent, so
-// the set has to be enumerated. Probed once and cached, like the Cursor trust flag.
-//
-// An unreadable or timed-out probe is an ERROR, not an empty list: silently
-// treating "we couldn't tell" as "the user has no servers" would quietly downgrade
-// safeguarded to a run with the user's other servers attached.
-func (a *copilotAgent) resolveUserMCPServers(ctx context.Context) ([]string, error) {
-	a.serversMu.Lock()
-	defer a.serversMu.Unlock()
-	if a.serversKnown {
-		return a.userServers, nil
-	}
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(cctx, a.bin, "mcp", "list", "--json")
-	// Probe from a neutral directory so a .mcp.json in radar's launch dir doesn't
-	// show up in a list that's cached for the process lifetime. A safeguarded turn
-	// runs in an empty temp dir anyway, where no workspace config applies.
-	cmd.Dir = os.TempDir()
-	out, err := cmd.Output()
-	if cctx.Err() != nil {
-		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe timed out")
-	}
-	if err != nil {
-		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe failed: %w", err)
-	}
-	var parsed struct {
-		MCPServers map[string]json.RawMessage `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(bytes.TrimSpace(out), &parsed); err != nil {
-		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe returned unreadable output: %w", err)
-	}
-	names := make([]string, 0, len(parsed.MCPServers))
-	for name := range parsed.MCPServers {
-		if name == copilotMCPServer {
-			continue
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names) // stable args across turns
-	a.userServers = names
-	a.serversKnown = true
-	log.Printf("[ai] copilot user MCP servers disabled in safeguarded runs: %v", names)
-	return names, nil
+	return minimalEnv(
+		[]string{
+			"TERM", "LANG", "USER", "LOGNAME", "SHELL",
+			"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+			"GH_HOST", "COPILOT_GH_HOST",
+			"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+			"http_proxy", "https_proxy", "no_proxy",
+			"SSL_CERT_FILE", "SSL_CERT_DIR",
+		},
+		[]string{"LC_"},
+	)
 }
 
 // Copilot JSONL event shapes (`copilot -p --output-format json`). Only the fields
@@ -285,6 +288,15 @@ type copilotServersLoaded struct {
 	} `json:"servers"`
 }
 
+// copilotServerStatus is the per-server lifecycle event. It is the ONLY signal
+// emitted when a server fails to attach (1.0.80 sends no mcp_servers_loaded in
+// that case), so the MCP guard has to read both shapes.
+type copilotServerStatus struct {
+	ServerName string `json:"serverName"`
+	Status     string `json:"status"` // pending | connected | failed
+	Error      string `json:"error"`
+}
+
 type copilotWarning struct {
 	Message     string `json:"message"`
 	WarningType string `json:"warningType"`
@@ -303,6 +315,24 @@ func (a *copilotAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagn
 	sawServers := false
 	mcpAttached := false
 	mcpErr := ""
+	// noteMCPStatus folds one status report for Radar's server into that state.
+	// The LAST report wins: a server can go pending → failed → connected across a
+	// retry, and only where it ended up says whether the turn had cluster access.
+	noteMCPStatus := func(status, errText string) {
+		sawServers = true
+		switch status {
+		case "connected":
+			mcpAttached, mcpErr = true, ""
+		case "pending", "starting":
+			// Not an outcome yet. A stream that ends here never attached, which the
+			// !mcpAttached check below already treats as a failure.
+		default:
+			mcpAttached = false
+			if mcpErr = strings.TrimSpace(errText); mcpErr == "" {
+				mcpErr = "server status: " + status
+			}
+		}
+	}
 
 	for sc.Scan() {
 		line := bytes.TrimSpace(sc.Bytes())
@@ -351,24 +381,36 @@ func (a *copilotAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagn
 			if json.Unmarshal(e.Data, &d) != nil {
 				continue
 			}
+			// The list is authoritative, so an EMPTY one is itself the answer:
+			// Radar's server was enumerated away (an org policy dropping
+			// third-party MCP servers looks exactly like this).
 			sawServers = true
 			for _, srv := range d.Servers {
-				if srv.Name != copilotMCPServer {
-					continue
-				}
-				if srv.Status == "connected" {
-					mcpAttached = true
-					break
-				}
-				mcpErr = strings.TrimSpace(srv.Error)
-				if mcpErr == "" {
-					mcpErr = "server status: " + srv.Status
+				if srv.Name == copilotMCPServer {
+					noteMCPStatus(srv.Status, srv.Error)
 				}
 			}
+		case "session.mcp_server_status_changed":
+			var d copilotServerStatus
+			if json.Unmarshal(e.Data, &d) != nil || d.ServerName != copilotMCPServer {
+				continue
+			}
+			noteMCPStatus(d.Status, d.Error)
 		case "session.warning":
 			var d copilotWarning
-			if json.Unmarshal(e.Data, &d) == nil && d.WarningType == "policy" && mcpErr == "" {
-				mcpErr = strings.TrimSpace(d.Message)
+			if json.Unmarshal(e.Data, &d) != nil || d.WarningType != "policy" {
+				continue
+			}
+			// A policy that blocks third-party MCP can drop Radar's server without
+			// any per-server event to report it, so this warning has to count as
+			// evidence on its own. Narrowed to MCP-mentioning messages: other policy
+			// warnings say nothing about cluster access and must not fail the turn.
+			msg := strings.TrimSpace(d.Message)
+			if strings.Contains(strings.ToLower(msg), "mcp") {
+				sawServers = true
+				if mcpErr == "" {
+					mcpErr = msg
+				}
 			}
 		case "result":
 			if e.SessionID != "" {

--- a/internal/ai/agent_copilot.go
+++ b/internal/ai/agent_copilot.go
@@ -1,0 +1,416 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// copilotMCPServer is the name Radar's MCP server is registered under. Copilot
+// namespaces MCP tools as "<server>-<tool>", so this prefix is load-bearing:
+// it appears in --available-tools, in --allow-tool, and in the tool names the
+// event stream reports back.
+const copilotMCPServer = "radar"
+
+// copilotAgent drives GitHub Copilot CLI (`copilot -p --output-format json`).
+// Containment in safeguarded mode is the strongest of the four backends because
+// Copilot can filter the model's entire tool surface:
+//   - --available-tools leaves ONLY Radar's MCP tools visible — no shell, no file
+//     edits, no web fetch (Copilot's own sandbox is experimental and unnecessary
+//     once the tools are gone);
+//   - --allow-tool <server> approves those tools without --allow-all-tools, so
+//     nothing else is auto-approved;
+//   - --disable-builtin-mcps drops github-mcp-server, and every server in the
+//     user's own config is disabled by name (see resolveUserMCPServers) — Copilot
+//     has no single "ignore user config" flag, so the set is enumerated;
+//   - cluster WRITE access is gated by the read-only MCP MOUNT, the same
+//     server-side gate the other backends rely on.
+//
+// Both profiles pass --no-remote --no-remote-export: Copilot otherwise exports the
+// session to GitHub web and mobile, and these transcripts carry cluster data.
+type copilotAgent struct {
+	bin string
+
+	serversMu    sync.Mutex
+	serversKnown bool
+	userServers  []string
+}
+
+func (a *copilotAgent) Name() string { return "copilot" }
+
+func (a *copilotAgent) Path() string { return a.bin }
+
+func (a *copilotAgent) SigninCmd() string { return "copilot login" }
+
+func (a *copilotAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(), error) {
+	switch s.profile {
+	case ExecutionProfileSafeguarded, ExecutionProfileFullLocal:
+	default:
+		return nil, nil, fmt.Errorf("ai: GitHub Copilot does not support execution profile %q", s.profile)
+	}
+	// Copilot has no system-prompt flag; the framing rides on the first turn's
+	// prompt (the resumed session already carries it).
+	prompt := s.prompt
+	if s.systemPrompt != "" {
+		prompt = s.systemPrompt + "\n\n" + prompt
+	}
+
+	mcpCfg, err := json.Marshal(map[string]any{
+		"mcpServers": map[string]any{
+			copilotMCPServer: map[string]any{"type": "http", "url": s.mcpURL},
+		},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("ai: copilot mcp config: %w", err)
+	}
+
+	args := []string{
+		"-p", prompt,
+		"--output-format", "json",
+		"--additional-mcp-config", string(mcpCfg),
+		// Headless runs have no TTY, so an ask_user call would block until the turn
+		// times out. The agent can still ask in prose, which is what Radar wants.
+		"--no-ask-user",
+		// Reasoning summaries are off by default; without them the stream carries
+		// only tool calls and the final message, and the UI shows no thinking.
+		"--enable-reasoning-summaries",
+		// Keep diagnostics out of the JSONL on stdout.
+		"--log-level", "none",
+		// The transcript contains cluster data — never publish it to GitHub's web
+		// and mobile surfaces, in either profile.
+		"--no-remote", "--no-remote-export",
+	}
+
+	if s.profile == ExecutionProfileSafeguarded {
+		// The "=" form is used for the variadic options so a comma-joined list can
+		// never be mistaken for several positional values.
+		args = append(args,
+			"--available-tools="+strings.Join(copilotToolNames(s.apply), ","),
+			"--allow-tool="+copilotMCPServer,
+			"--disable-builtin-mcps",
+			"--no-custom-instructions",
+		)
+		servers, err := a.resolveUserMCPServers(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, name := range servers {
+			args = append(args, "--disable-mcp-server", name)
+		}
+	} else {
+		// Full-local: the user's own tools, MCP servers and instructions are live.
+		// Cluster writes stay gated by the read-only MCP mount.
+		args = append(args, "--allow-all-tools")
+	}
+
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+	// Default to medium rather than Copilot's bare default, matching the other
+	// backends: it gives a solid investigation without an unbounded token bill.
+	effort := s.effort
+	if effort == "" {
+		effort = "medium"
+	}
+	args = append(args, "--effort", effort)
+
+	if s.sessionID != "" {
+		// --resume takes an OPTIONAL value, so it must use the "=" form: passed as a
+		// separate argument the id would be read as a positional prompt instead.
+		args = append(args, "--resume="+s.sessionID)
+	}
+
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+
+	cleanup := func() {}
+	if s.profile == ExecutionProfileSafeguarded {
+		// Empty working dir so the model can't pick up a workspace .mcp.json or
+		// AGENTS.md, and so nothing in radar's cwd is reachable. Copilot's session
+		// store is global, so resume works from any directory — no per-run workdir
+		// is needed (unlike Cursor).
+		dir, err := os.MkdirTemp("", "radar-copilot-")
+		if err != nil {
+			return nil, nil, fmt.Errorf("ai: copilot workdir: %w", err)
+		}
+		cleanup = func() { _ = os.RemoveAll(dir) }
+		cmd.Dir = dir
+		cmd.Env = copilotEnv()
+	}
+	// Full-local: inherit radar's cwd + full env so the user's auth/config work.
+
+	return cmd, cleanup, nil
+}
+
+// copilotToolNames is the allowlist handed to --available-tools: Radar's MCP tools
+// and nothing else. Write tools are added only on a user-confirmed apply turn.
+func copilotToolNames(apply bool) []string {
+	names := make([]string, 0, len(radarReadTools)+len(radarWriteTools))
+	for _, t := range radarReadTools {
+		names = append(names, copilotMCPServer+"-"+t)
+	}
+	if apply {
+		for _, t := range radarWriteTools {
+			names = append(names, copilotMCPServer+"-"+t)
+		}
+	}
+	return names
+}
+
+// copilotEnv is the minimal environment Copilot needs: auth (HOME/COPILOT_HOME
+// hold the credential store, or an explicit token var), the host overrides for
+// GHE, proxy settings, and enough to exec. Cloud-provider secrets are deliberately
+// omitted — the agent reaches the cluster only through Radar's MCP.
+//
+// COPILOT_HOME is passed through but never set by Radar: auth AND the session
+// store both live there, so redirecting it would break login and resume together.
+func copilotEnv() []string {
+	keep := map[string]bool{
+		"HOME": true, "PATH": true, "TMPDIR": true,
+		"TERM": true, "LANG": true, "USER": true, "LOGNAME": true, "SHELL": true,
+		"COPILOT_HOME": true, "COPILOT_GITHUB_TOKEN": true,
+		"GH_TOKEN": true, "GITHUB_TOKEN": true,
+		"GH_HOST": true, "COPILOT_GH_HOST": true,
+		"HTTP_PROXY": true, "HTTPS_PROXY": true, "NO_PROXY": true,
+		"http_proxy": true, "https_proxy": true, "no_proxy": true,
+		"SSL_CERT_FILE": true, "SSL_CERT_DIR": true,
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		k, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if keep[k] || strings.HasPrefix(k, "LC_") {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// resolveUserMCPServers lists the MCP servers Copilot would otherwise load and
+// returns every one that isn't Radar's, so a safeguarded turn can disable them by
+// name. Copilot has no --strict-mcp-config / --ignore-user-config equivalent, so
+// the set has to be enumerated. Probed once and cached, like the Cursor trust flag.
+//
+// An unreadable or timed-out probe is an ERROR, not an empty list: silently
+// treating "we couldn't tell" as "the user has no servers" would quietly downgrade
+// safeguarded to a run with the user's other servers attached.
+func (a *copilotAgent) resolveUserMCPServers(ctx context.Context) ([]string, error) {
+	a.serversMu.Lock()
+	defer a.serversMu.Unlock()
+	if a.serversKnown {
+		return a.userServers, nil
+	}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, a.bin, "mcp", "list", "--json")
+	// Probe from a neutral directory so a .mcp.json in radar's launch dir doesn't
+	// show up in a list that's cached for the process lifetime. A safeguarded turn
+	// runs in an empty temp dir anyway, where no workspace config applies.
+	cmd.Dir = os.TempDir()
+	out, err := cmd.Output()
+	if cctx.Err() != nil {
+		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe timed out")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe failed: %w", err)
+	}
+	var parsed struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out), &parsed); err != nil {
+		return nil, fmt.Errorf("ai: GitHub Copilot MCP-server probe returned unreadable output: %w", err)
+	}
+	names := make([]string, 0, len(parsed.MCPServers))
+	for name := range parsed.MCPServers {
+		if name == copilotMCPServer {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names) // stable args across turns
+	a.userServers = names
+	a.serversKnown = true
+	log.Printf("[ai] copilot user MCP servers disabled in safeguarded runs: %v", names)
+	return names, nil
+}
+
+// Copilot JSONL event shapes (`copilot -p --output-format json`). Only the fields
+// we consume. Every event is wrapped in {type, data, …} EXCEPT the terminal
+// "result" event, which carries sessionId/exitCode at the top level.
+type copilotEvent struct {
+	Type      string          `json:"type"`
+	Data      json.RawMessage `json:"data"`
+	SessionID string          `json:"sessionId"` // "result" only
+}
+
+type copilotToolStart struct {
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	Arguments  json.RawMessage `json:"arguments"`
+}
+
+// copilotToolComplete carries NO tool name — it has to be correlated back to the
+// matching tool.execution_start via toolCallId.
+type copilotToolComplete struct {
+	ToolCallID string `json:"toolCallId"`
+	Success    bool   `json:"success"`
+	Result     *struct {
+		Content string `json:"content"`
+	} `json:"result"`
+}
+
+// copilotMessage is emitted several times per turn. Intermediate ones carry tool
+// requests with EMPTY content; only phase=="final_answer" holds the reply.
+type copilotMessage struct {
+	Content string `json:"content"`
+	Phase   string `json:"phase"`
+}
+
+type copilotServersLoaded struct {
+	Servers []struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	} `json:"servers"`
+}
+
+type copilotWarning struct {
+	Message     string `json:"message"`
+	WarningType string `json:"warningType"`
+}
+
+func (a *copilotAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	var sessionID string
+	var finalText string
+	toolNames := map[string]string{} // toolCallId → toolName, from the start event
+
+	// MCP attachment is tracked explicitly: a run whose MCP server never attached
+	// still exits 0 with empty stderr, and the agent will happily produce a
+	// confident verdict having read nothing from the cluster.
+	sawServers := false
+	mcpAttached := false
+	mcpErr := ""
+
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var e copilotEvent
+		if json.Unmarshal(line, &e) != nil {
+			continue
+		}
+		switch e.Type {
+		case "assistant.reasoning_delta":
+			var d struct {
+				DeltaContent string `json:"deltaContent"`
+			}
+			if json.Unmarshal(e.Data, &d) == nil && d.DeltaContent != "" {
+				onEvent(StreamEvent{Type: "thinking", Token: d.DeltaContent})
+			}
+		case "tool.execution_start":
+			var d copilotToolStart
+			if json.Unmarshal(e.Data, &d) != nil || d.ToolCallID == "" {
+				continue
+			}
+			toolNames[d.ToolCallID] = d.ToolName
+			onEvent(StreamEvent{Type: "step", Step: &StepInfo{
+				ID: d.ToolCallID, Tool: copilotDisplayTool(d.ToolName), Status: "running",
+				Summary: copilotArgsText(d.Arguments),
+			}})
+		case "tool.execution_complete":
+			var d copilotToolComplete
+			if json.Unmarshal(e.Data, &d) != nil || d.ToolCallID == "" {
+				continue
+			}
+			res, trunc := capPayload(copilotResultText(d))
+			onEvent(StreamEvent{Type: "step", Step: &StepInfo{
+				ID: d.ToolCallID, Tool: copilotDisplayTool(toolNames[d.ToolCallID]), Status: "done",
+				Result: res, Truncated: trunc,
+			}})
+		case "assistant.message":
+			var d copilotMessage
+			if json.Unmarshal(e.Data, &d) == nil && d.Phase == "final_answer" && d.Content != "" {
+				finalText = d.Content
+			}
+		case "session.mcp_servers_loaded":
+			var d copilotServersLoaded
+			if json.Unmarshal(e.Data, &d) != nil {
+				continue
+			}
+			sawServers = true
+			for _, srv := range d.Servers {
+				if srv.Name != copilotMCPServer {
+					continue
+				}
+				if srv.Status == "connected" {
+					mcpAttached = true
+					break
+				}
+				mcpErr = strings.TrimSpace(srv.Error)
+				if mcpErr == "" {
+					mcpErr = "server status: " + srv.Status
+				}
+			}
+		case "session.warning":
+			var d copilotWarning
+			if json.Unmarshal(e.Data, &d) == nil && d.WarningType == "policy" && mcpErr == "" {
+				mcpErr = strings.TrimSpace(d.Message)
+			}
+		case "result":
+			if e.SessionID != "" {
+				sessionID = e.SessionID
+			}
+		}
+	}
+
+	d := diagnosisFromText(finalText)
+	d.SessionID = sessionID
+	// Only fail on affirmative evidence that Radar's server didn't attach. A CLI
+	// that never emits the event at all is left alone rather than assumed broken.
+	if sawServers && !mcpAttached {
+		if mcpErr == "" {
+			mcpErr = "Radar's MCP server was not loaded"
+		}
+		d.mcpErrText = mcpErr
+	}
+	return d
+}
+
+// copilotDisplayTool strips the "<server>-" namespace Copilot prefixes onto MCP
+// tool names, so the transcript shows "get_events" like every other backend.
+func copilotDisplayTool(name string) string {
+	return strings.TrimPrefix(name, copilotMCPServer+"-")
+}
+
+func copilotArgsText(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" || s == "{}" {
+		return ""
+	}
+	args, _ := capPayload(s)
+	return args
+}
+
+// copilotResultText pulls the text out of a completed tool call. Copilot flattens
+// MCP content into a single result.content string. Capping happens at the call
+// site so the truncated flag can be surfaced.
+func copilotResultText(d copilotToolComplete) string {
+	if d.Result == nil {
+		return ""
+	}
+	return d.Result.Content
+}

--- a/internal/ai/agent_copilot_test.go
+++ b/internal/ai/agent_copilot_test.go
@@ -1,0 +1,325 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestCopilotParseStream_FormatPin locks the `copilot -p --output-format json`
+// JSONL schema, captured from a live run against an MCP server. Three properties
+// here are easy to get wrong and silently break the panel:
+//   - tool.execution_complete carries NO toolName, so the name must be correlated
+//     from the matching tool.execution_start via toolCallId;
+//   - intermediate assistant.message events have empty content and a populated
+//     toolRequests — only phase=="final_answer" holds the verdict;
+//   - the terminal "result" event is FLAT (sessionId at the top level), unlike
+//     every other event, which nests under "data".
+func TestCopilotParseStream_FormatPin(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"session.mcp_servers_loaded","data":{"servers":[{"name":"radar","status":"connected","transport":"http"}]},"ephemeral":true}`,
+		`{"type":"assistant.reasoning_delta","data":{"reasoningId":"r0","deltaContent":"checking "},"ephemeral":true}`,
+		`{"type":"assistant.reasoning_delta","data":{"reasoningId":"r0","deltaContent":"pods"},"ephemeral":true}`,
+		`{"type":"tool.execution_start","data":{"toolCallId":"call_1","toolName":"radar-diagnose","arguments":{"name":"x"},"turnId":"0"}}`,
+		`{"type":"assistant.message","data":{"messageId":"m0","content":"","toolRequests":[{"toolCallId":"call_1","name":"radar-diagnose"}]}}`,
+		`{"type":"tool.execution_complete","data":{"toolCallId":"call_1","success":true,"result":{"content":"crashloop detail","contents":[{"type":"text","text":"crashloop detail"}]}}}`,
+		"{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"m1\",\"phase\":\"final_answer\",\"content\":\"bad tag.\\n\\n```json\\n{\\\"root_cause\\\":\\\"bad tag\\\"}\\n```\",\"toolRequests\":[]}}",
+		`{"type":"assistant.turn_end","data":{"turnId":"0"}}`,
+		`{"type":"result","timestamp":"2026-08-14T13:27:37.120Z","sessionId":"b95e250f-7264-4319-8f89-bdd6c850f9f1","exitCode":0}`,
+	}, "\n")
+
+	var running, done bool
+	var thinking, doneResult, runningSummary, runningTool, doneTool string
+	agent := &copilotAgent{bin: "copilot"}
+	diag := agent.parseStream(strings.NewReader(stream), func(ev StreamEvent) {
+		switch ev.Type {
+		case "thinking":
+			thinking += ev.Token
+		case "step":
+			if ev.Step == nil {
+				return
+			}
+			switch ev.Step.Status {
+			case "running":
+				running = true
+				runningTool = ev.Step.Tool
+				runningSummary = ev.Step.Summary
+			case "done":
+				done = true
+				doneTool = ev.Step.Tool
+				doneResult = ev.Step.Result
+			}
+		}
+	})
+
+	if !running || !done {
+		t.Errorf("expected running+done steps; running=%v done=%v", running, done)
+	}
+	// The "radar-" server namespace is stripped so the transcript reads the same as
+	// every other backend's.
+	if runningTool != "diagnose" {
+		t.Errorf("running step tool = %q, want %q", runningTool, "diagnose")
+	}
+	if doneTool != "diagnose" {
+		t.Errorf("done step tool = %q, want %q (name must be correlated by toolCallId)", doneTool, "diagnose")
+	}
+	if thinking != "checking pods" {
+		t.Errorf("expected reasoning deltas→thinking %q, got %q", "checking pods", thinking)
+	}
+	if runningSummary == "" {
+		t.Error("expected args preview on running step")
+	}
+	if !strings.Contains(doneResult, "crashloop detail") {
+		t.Errorf("expected tool result preview on done step, got %q", doneResult)
+	}
+	if diag.RootCause != "bad tag" {
+		t.Errorf("root cause not parsed from the final_answer message: %q", diag.RootCause)
+	}
+	if diag.SessionID != "b95e250f-7264-4319-8f89-bdd6c850f9f1" {
+		t.Errorf("session id not captured from the flat result event: %q", diag.SessionID)
+	}
+	if diag.mcpErrText != "" {
+		t.Errorf("connected MCP server must not be reported as an error: %q", diag.mcpErrText)
+	}
+}
+
+// TestCopilotParseStream_MCPNotAttached is the load-bearing safety test. When
+// Radar's MCP server doesn't attach, Copilot still exits 0 with empty stderr and
+// the model still answers — having read nothing from the cluster. Both captured
+// causes must mark the turn failed even though a well-formed verdict parsed.
+func TestCopilotParseStream_MCPNotAttached(t *testing.T) {
+	verdict := "{\"type\":\"assistant.message\",\"data\":{\"phase\":\"final_answer\",\"content\":\"looks fine.\\n\\n```json\\n{\\\"healthy\\\":true}\\n```\"}}"
+	result := `{"type":"result","sessionId":"s1","exitCode":0}`
+
+	cases := []struct {
+		name   string
+		stream []string
+		want   string
+	}{
+		{
+			// Org policy: the warning fires and Radar's server is dropped silently.
+			name: "org policy disables third-party MCP",
+			stream: []string{
+				`{"type":"session.warning","data":{"message":"Third-party MCP servers are disabled by your organization's Copilot policy. Only built-in servers are available.","warningType":"policy"},"ephemeral":true}`,
+				`{"type":"session.mcp_servers_loaded","data":{"servers":[]},"ephemeral":true}`,
+				verdict, result,
+			},
+			want: "organization's Copilot policy",
+		},
+		{
+			// The server was configured but never connected.
+			name: "server failed to connect",
+			stream: []string{
+				`{"type":"session.mcp_servers_loaded","data":{"servers":[{"name":"radar","status":"failed","transport":"http","error":"failed to initialize MCP client: connection refused"}]},"ephemeral":true}`,
+				verdict, result,
+			},
+			want: "connection refused",
+		},
+	}
+
+	agent := &copilotAgent{bin: "copilot"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diag := agent.parseStream(strings.NewReader(strings.Join(tc.stream, "\n")), func(StreamEvent) {})
+			// The verdict parsing itself still succeeds — that's exactly why the
+			// separate signal is needed rather than relying on structured().
+			if !diag.Healthy {
+				t.Fatal("precondition: the toolless verdict should still parse, or this test proves nothing")
+			}
+			if diag.mcpErrText == "" {
+				t.Fatal("a run whose MCP server never attached must be flagged, not returned as a verdict")
+			}
+			if !strings.Contains(diag.mcpErrText, tc.want) {
+				t.Errorf("mcpErrText = %q, want it to mention %q", diag.mcpErrText, tc.want)
+			}
+		})
+	}
+}
+
+// TestCopilotParseStream_NoServerEventIsNotAnError pins the conservative side of
+// the guard: a CLI that never reports its MCP servers at all must not be treated
+// as broken, or a future/older Copilot build would fail every investigation.
+func TestCopilotParseStream_NoServerEventIsNotAnError(t *testing.T) {
+	stream := strings.Join([]string{
+		"{\"type\":\"assistant.message\",\"data\":{\"phase\":\"final_answer\",\"content\":\"```json\\n{\\\"root_cause\\\":\\\"x\\\"}\\n```\"}}",
+		`{"type":"result","sessionId":"s1","exitCode":0}`,
+	}, "\n")
+	agent := &copilotAgent{bin: "copilot"}
+	diag := agent.parseStream(strings.NewReader(stream), func(StreamEvent) {})
+	if diag.mcpErrText != "" {
+		t.Errorf("absent mcp_servers_loaded must not be inferred as a failure; got %q", diag.mcpErrText)
+	}
+	if diag.RootCause != "x" {
+		t.Errorf("verdict should still parse, got %q", diag.RootCause)
+	}
+}
+
+// TestCopilotExecutionProfiles pins the security-relevant differences between the
+// two profiles, plus the two flags that must appear in BOTH.
+func TestCopilotExecutionProfiles(t *testing.T) {
+	ctx := context.Background()
+	// Pre-seed the MCP-server probe so the test never execs the real CLI.
+	newAgent := func() *copilotAgent {
+		return &copilotAgent{bin: "copilot", serversKnown: true, userServers: []string{"other-server"}}
+	}
+
+	iso, cleanup, err := newAgent().command(ctx, turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileSafeguarded,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	args := strings.Join(iso.Args, " ")
+	if !strings.Contains(args, "--available-tools=radar-") {
+		t.Errorf("safeguarded mode must restrict the model to Radar's tools; got %q", args)
+	}
+	if strings.Contains(args, "radar-apply_resource") {
+		t.Error("a non-apply turn must not expose Radar's write tools")
+	}
+	if !strings.Contains(args, "--allow-tool=radar") {
+		t.Errorf("safeguarded mode must approve Radar's server without --allow-all-tools; got %q", args)
+	}
+	if strings.Contains(args, "--allow-all-tools") {
+		t.Errorf("safeguarded mode must NOT allow every tool; got %q", args)
+	}
+	if !strings.Contains(args, "--disable-builtin-mcps") {
+		t.Errorf("safeguarded mode must drop the built-in GitHub MCP server; got %q", args)
+	}
+	if !strings.Contains(args, "--disable-mcp-server other-server") {
+		t.Errorf("safeguarded mode must disable the user's own MCP servers by name; got %q", args)
+	}
+	if !strings.Contains(args, "--no-custom-instructions") {
+		t.Errorf("safeguarded mode must not load AGENTS.md; got %q", args)
+	}
+	if iso.Dir == "" {
+		t.Error("safeguarded mode must run in a dedicated (empty) cwd")
+	}
+	if iso.Env == nil {
+		t.Error("safeguarded mode must use a minimized env, not inherit nil")
+	}
+
+	apply, cleanupApply, err := newAgent().command(ctx, turnSpec{
+		mcpURL: "http://localhost:1/mcp", prompt: "fix", profile: ExecutionProfileSafeguarded, apply: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupApply()
+	if !strings.Contains(strings.Join(apply.Args, " "), "radar-apply_resource") {
+		t.Error("a confirmed apply turn must expose Radar's write tools")
+	}
+
+	my, cleanup2, err := newAgent().command(ctx, turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileFullLocal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup2()
+	myArgs := strings.Join(my.Args, " ")
+	if !strings.Contains(myArgs, "--allow-all-tools") {
+		t.Errorf("full-local mode runs with the user's full toolset; got %q", myArgs)
+	}
+	if strings.Contains(myArgs, "--available-tools") || strings.Contains(myArgs, "--disable-mcp-server") {
+		t.Errorf("full-local mode must not constrain the user's setup; got %q", myArgs)
+	}
+	if my.Dir != "" {
+		t.Error("full-local mode should inherit radar's cwd (no override)")
+	}
+
+	// The transcript carries cluster data: it must never be published to GitHub's
+	// web/mobile surfaces, in either profile.
+	for name, cmdArgs := range map[string]string{"safeguarded": args, "full-local": myArgs} {
+		if !strings.Contains(cmdArgs, "--no-remote-export") || !strings.Contains(cmdArgs, "--no-remote") {
+			t.Errorf("%s mode must disable session export to GitHub; got %q", name, cmdArgs)
+		}
+		if !strings.Contains(cmdArgs, "--no-ask-user") {
+			t.Errorf("%s mode must disable ask_user (no TTY to answer it); got %q", name, cmdArgs)
+		}
+	}
+
+	if _, _, err := newAgent().command(ctx, turnSpec{profile: ""}); err == nil {
+		t.Fatal("Copilot must reject an empty profile rather than fail open")
+	}
+}
+
+// TestCopilotResumeUsesEqualsForm pins a parsing trap: --resume takes an OPTIONAL
+// value, so a space-separated id would be read as a positional prompt instead.
+func TestCopilotResumeUsesEqualsForm(t *testing.T) {
+	a := &copilotAgent{bin: "copilot", serversKnown: true}
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go",
+		profile: ExecutionProfileFullLocal, sessionID: "sess-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	var found bool
+	for _, arg := range cmd.Args {
+		if arg == "--resume=sess-1" {
+			found = true
+		}
+		if arg == "--resume" {
+			t.Error("--resume must use the =value form; bare --resume would swallow the id as a prompt")
+		}
+	}
+	if !found {
+		t.Errorf("expected --resume=sess-1 in %v", cmd.Args)
+	}
+}
+
+// TestCopilotEffortDefault pins that Radar picks medium rather than leaving
+// Copilot's own default, matching the other backends.
+func TestCopilotEffortDefault(t *testing.T) {
+	a := &copilotAgent{bin: "copilot", serversKnown: true}
+	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileFullLocal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if !strings.Contains(strings.Join(cmd.Args, " "), "--effort medium") {
+		t.Errorf("expected the default effort to be medium; got %v", cmd.Args)
+	}
+}
+
+// TestResolveAgentCopilot pins binary-name routing to the Copilot backend — it must
+// match before the Claude default, or every Copilot run would be driven as Claude.
+func TestResolveAgentCopilot(t *testing.T) {
+	cases := map[string]string{
+		"copilot":                   "copilot",
+		"/opt/homebrew/bin/copilot": "copilot",
+		"Copilot":                   "copilot",
+		"codex":                     "codex",
+		"cursor-agent":              "cursor-agent",
+		"claude":                    "claude",
+	}
+	for bin, want := range cases {
+		if got := resolveAgent(bin).Name(); got != want {
+			t.Errorf("resolveAgent(%q).Name() = %q, want %q", bin, got, want)
+		}
+	}
+}
+
+// TestCopilotReasoningEfforts pins that the effort vocabularies stay distinct:
+// Copilot's extra tiers are rejected by Codex, and agents without the knob accept
+// only the empty default.
+func TestCopilotReasoningEfforts(t *testing.T) {
+	if !SupportsEffort("copilot", "xhigh") || !SupportsEffort("copilot", "max") {
+		t.Error("Copilot must accept its own wider effort levels")
+	}
+	if SupportsEffort("codex", "xhigh") {
+		t.Error("Codex must not be handed Copilot's effort levels")
+	}
+	if SupportsEffort("claude", "high") {
+		t.Error("agents with no effort knob must accept only the default")
+	}
+	for _, agent := range []string{"claude", "codex", "copilot", "cursor-agent"} {
+		if !SupportsEffort(agent, "") {
+			t.Errorf("%s must accept the empty (default) effort", agent)
+		}
+	}
+}

--- a/internal/ai/agent_copilot_test.go
+++ b/internal/ai/agent_copilot_test.go
@@ -2,9 +2,30 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// testCopilotAgent points the backend at a throwaway home so a test never creates
+// (or reads) the developer's real ~/.radar/copilot-home.
+func testCopilotAgent(home string) *copilotAgent {
+	return &copilotAgent{
+		bin:     "copilot",
+		homeDir: func() (string, error) { return home, nil },
+	}
+}
+
+func envHas(env []string, kv string) bool {
+	for _, e := range env {
+		if e == kv {
+			return true
+		}
+	}
+	return false
+}
 
 // TestCopilotParseStream_FormatPin locks the `copilot -p --output-format json`
 // JSONL schema, captured from a live run against an MCP server. Three properties
@@ -115,6 +136,27 @@ func TestCopilotParseStream_MCPNotAttached(t *testing.T) {
 			},
 			want: "connection refused",
 		},
+		{
+			// Captured from copilot 1.0.80: an unreachable server produces NO
+			// mcp_servers_loaded event at all, only this per-server lifecycle one.
+			// Reading just the "loaded" shape let this exact run through.
+			name: "per-server status event only",
+			stream: []string{
+				`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"pending"},"ephemeral":true}`,
+				`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"failed","error":"failed to initialize MCP client: Send message error Transport error: Client error: error sending request for url (http://127.0.0.1:9280/mcp-readonly), when send initialize request"},"ephemeral":true}`,
+				verdict, result,
+			},
+			want: "when send initialize request",
+		},
+		{
+			// A server left pending when the stream ends never attached either.
+			name: "stuck pending",
+			stream: []string{
+				`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"pending"},"ephemeral":true}`,
+				verdict, result,
+			},
+			want: "not loaded",
+		},
 	}
 
 	agent := &copilotAgent{bin: "copilot"}
@@ -154,14 +196,44 @@ func TestCopilotParseStream_NoServerEventIsNotAnError(t *testing.T) {
 	}
 }
 
+// TestCopilotParseStream_MCPRecovers pins that a retry which ends connected is a
+// healthy run: the server's LAST reported state is what decides, not its first.
+func TestCopilotParseStream_MCPRecovers(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"pending"},"ephemeral":true}`,
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"failed","error":"transient"},"ephemeral":true}`,
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"connected"},"ephemeral":true}`,
+		"{\"type\":\"assistant.message\",\"data\":{\"phase\":\"final_answer\",\"content\":\"```json\\n{\\\"root_cause\\\":\\\"x\\\"}\\n```\"}}",
+		`{"type":"result","sessionId":"s1","exitCode":0}`,
+	}, "\n")
+	diag := (&copilotAgent{bin: "copilot"}).parseStream(strings.NewReader(stream), func(StreamEvent) {})
+	if diag.mcpErrText != "" {
+		t.Errorf("a server that ended up connected must not fail the turn; got %q", diag.mcpErrText)
+	}
+}
+
+// TestCopilotParseStream_OtherServerIgnored pins that another server's failure is
+// not Radar's: in full-local the user's own servers are attached too, and one of
+// them being down says nothing about our cluster access.
+func TestCopilotParseStream_OtherServerIgnored(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"radar","status":"connected"},"ephemeral":true}`,
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"github","status":"failed","error":"nope"},"ephemeral":true}`,
+		"{\"type\":\"assistant.message\",\"data\":{\"phase\":\"final_answer\",\"content\":\"```json\\n{\\\"root_cause\\\":\\\"x\\\"}\\n```\"}}",
+		`{"type":"result","sessionId":"s1","exitCode":0}`,
+	}, "\n")
+	diag := (&copilotAgent{bin: "copilot"}).parseStream(strings.NewReader(stream), func(StreamEvent) {})
+	if diag.mcpErrText != "" {
+		t.Errorf("another server's failure must not fail the turn; got %q", diag.mcpErrText)
+	}
+}
+
 // TestCopilotExecutionProfiles pins the security-relevant differences between the
-// two profiles, plus the two flags that must appear in BOTH.
+// two profiles, plus the flags that must appear in BOTH.
 func TestCopilotExecutionProfiles(t *testing.T) {
 	ctx := context.Background()
-	// Pre-seed the MCP-server probe so the test never execs the real CLI.
-	newAgent := func() *copilotAgent {
-		return &copilotAgent{bin: "copilot", serversKnown: true, userServers: []string{"other-server"}}
-	}
+	home := t.TempDir()
+	newAgent := func() *copilotAgent { return testCopilotAgent(home) }
 
 	iso, cleanup, err := newAgent().command(ctx, turnSpec{
 		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileSafeguarded,
@@ -186,9 +258,6 @@ func TestCopilotExecutionProfiles(t *testing.T) {
 	if !strings.Contains(args, "--disable-builtin-mcps") {
 		t.Errorf("safeguarded mode must drop the built-in GitHub MCP server; got %q", args)
 	}
-	if !strings.Contains(args, "--disable-mcp-server other-server") {
-		t.Errorf("safeguarded mode must disable the user's own MCP servers by name; got %q", args)
-	}
 	if !strings.Contains(args, "--no-custom-instructions") {
 		t.Errorf("safeguarded mode must not load AGENTS.md; got %q", args)
 	}
@@ -197,6 +266,17 @@ func TestCopilotExecutionProfiles(t *testing.T) {
 	}
 	if iso.Env == nil {
 		t.Error("safeguarded mode must use a minimized env, not inherit nil")
+	}
+	// The user's own Copilot home holds their MCP servers, settings and — with no
+	// flag to disable them — their hooks, which run shell in -p mode.
+	wantHome := "COPILOT_HOME=" + CopilotHomeDir(home)
+	if !envHas(iso.Env, wantHome) {
+		t.Errorf("safeguarded mode must redirect COPILOT_HOME to %q; got %v", wantHome, iso.Env)
+	}
+	for _, kv := range iso.Env {
+		if strings.HasPrefix(kv, "COPILOT_HOME=") && kv != wantHome {
+			t.Errorf("the user's COPILOT_HOME must not leak into a safeguarded run; got %q", kv)
+		}
 	}
 
 	apply, cleanupApply, err := newAgent().command(ctx, turnSpec{
@@ -221,11 +301,20 @@ func TestCopilotExecutionProfiles(t *testing.T) {
 	if !strings.Contains(myArgs, "--allow-all-tools") {
 		t.Errorf("full-local mode runs with the user's full toolset; got %q", myArgs)
 	}
-	if strings.Contains(myArgs, "--available-tools") || strings.Contains(myArgs, "--disable-mcp-server") {
+	if strings.Contains(myArgs, "--available-tools") {
 		t.Errorf("full-local mode must not constrain the user's setup; got %q", myArgs)
 	}
 	if my.Dir != "" {
 		t.Error("full-local mode should inherit radar's cwd (no override)")
+	}
+	if my.Env != nil {
+		t.Error("full-local mode must inherit the user's env, including their own COPILOT_HOME")
+	}
+	// The redirect replaced the probe: no run of either profile enumerates servers.
+	for name, cmdArgs := range map[string]string{"safeguarded": args, "full-local": myArgs} {
+		if strings.Contains(cmdArgs, "--disable-mcp-server") {
+			t.Errorf("%s mode should not enumerate MCP servers by name; got %q", name, cmdArgs)
+		}
 	}
 
 	// The transcript carries cluster data: it must never be published to GitHub's
@@ -237,6 +326,11 @@ func TestCopilotExecutionProfiles(t *testing.T) {
 		if !strings.Contains(cmdArgs, "--no-ask-user") {
 			t.Errorf("%s mode must disable ask_user (no TTY to answer it); got %q", name, cmdArgs)
 		}
+		// A CLI that swaps its own binary mid-investigation is a mid-run behavior
+		// change; the CI detection that would disable it can't fire under our env.
+		if !strings.Contains(cmdArgs, "--no-auto-update") {
+			t.Errorf("%s mode must pin the CLI version for the run; got %q", name, cmdArgs)
+		}
 	}
 
 	if _, _, err := newAgent().command(ctx, turnSpec{profile: ""}); err == nil {
@@ -247,7 +341,7 @@ func TestCopilotExecutionProfiles(t *testing.T) {
 // TestCopilotResumeUsesEqualsForm pins a parsing trap: --resume takes an OPTIONAL
 // value, so a space-separated id would be read as a positional prompt instead.
 func TestCopilotResumeUsesEqualsForm(t *testing.T) {
-	a := &copilotAgent{bin: "copilot", serversKnown: true}
+	a := testCopilotAgent(t.TempDir())
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go",
 		profile: ExecutionProfileFullLocal, sessionID: "sess-1",
@@ -270,19 +364,71 @@ func TestCopilotResumeUsesEqualsForm(t *testing.T) {
 	}
 }
 
-// TestCopilotEffortDefault pins that Radar picks medium rather than leaving
-// Copilot's own default, matching the other backends.
-func TestCopilotEffortDefault(t *testing.T) {
-	a := &copilotAgent{bin: "copilot", serversKnown: true}
-	cmd, cleanup, err := a.command(context.Background(), turnSpec{
+// TestCopilotEffortOnlyWhenChosen pins that Radar passes NO --effort unless the
+// user picked one. Copilot rejects the flag outright when the model resolves to
+// "auto" — the free tier's default — so a Radar-chosen default would fail every
+// out-of-the-box run with exit 1.
+func TestCopilotEffortOnlyWhenChosen(t *testing.T) {
+	a := testCopilotAgent(t.TempDir())
+	base := turnSpec{
 		mcpURL: "http://localhost:1/mcp-readonly", prompt: "go", profile: ExecutionProfileFullLocal,
-	})
+	}
+	cmd, cleanup, err := a.command(context.Background(), base)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	if !strings.Contains(strings.Join(cmd.Args, " "), "--effort medium") {
-		t.Errorf("expected the default effort to be medium; got %v", cmd.Args)
+	if strings.Contains(strings.Join(cmd.Args, " "), "--effort") {
+		t.Errorf("an unset effort must leave the CLI's own default alone; got %v", cmd.Args)
+	}
+
+	chosen := base
+	chosen.effort = "xhigh"
+	cmd2, cleanup2, err := a.command(context.Background(), chosen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup2()
+	if !strings.Contains(strings.Join(cmd2.Args, " "), "--effort xhigh") {
+		t.Errorf("a chosen effort must be passed through; got %v", cmd2.Args)
+	}
+}
+
+// TestCopilotHomeSeeded pins that the Radar-owned COPILOT_HOME is created with a
+// config of our own. The redirect is what keeps the user's hooks and MCP servers
+// out of a safeguarded run, so it must not depend on the directory pre-existing.
+func TestCopilotHomeSeeded(t *testing.T) {
+	home := t.TempDir()
+	dir, err := testCopilotAgent(home).copilotHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != CopilotHomeDir(home) {
+		t.Errorf("copilotHome() = %q, want %q", dir, CopilotHomeDir(home))
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("expected a Radar-owned Copilot config: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(cfg, &parsed); err != nil {
+		t.Fatalf("seeded config is not valid JSON: %v", err)
+	}
+	if parsed["disableAllHooks"] != true {
+		t.Errorf("the Radar-owned config must disable hooks; got %v", parsed)
+	}
+
+	// A config the user edited afterwards is theirs — seeding must not stomp it.
+	custom := []byte(`{"disableAllHooks":true,"banner":"always"}`)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), custom, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testCopilotAgent(home).copilotHome(); err != nil {
+		t.Fatal(err)
+	}
+	again, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil || string(again) != string(custom) {
+		t.Errorf("an existing config must be left alone; got %q (%v)", again, err)
 	}
 }
 
@@ -321,5 +467,31 @@ func TestCopilotReasoningEfforts(t *testing.T) {
 		if !SupportsEffort(agent, "") {
 			t.Errorf("%s must accept the empty (default) effort", agent)
 		}
+	}
+}
+
+// TestCopilotParseStream_PolicyWarningAlone pins the case with no per-server event
+// at all: a policy that blocks third-party MCP can drop Radar's server silently, so
+// the warning is the only evidence. Unrelated policy warnings must stay harmless —
+// they say nothing about cluster access.
+func TestCopilotParseStream_PolicyWarningAlone(t *testing.T) {
+	verdict := "{\"type\":\"assistant.message\",\"data\":{\"phase\":\"final_answer\",\"content\":\"```json\\n{\\\"healthy\\\":true}\\n```\"}}"
+	result := `{"type":"result","sessionId":"s1","exitCode":0}`
+	agent := &copilotAgent{bin: "copilot"}
+
+	blocked := strings.Join([]string{
+		`{"type":"session.warning","data":{"message":"Third-party MCP servers are disabled by your organization's Copilot policy.","warningType":"policy"},"ephemeral":true}`,
+		verdict, result,
+	}, "\n")
+	if diag := agent.parseStream(strings.NewReader(blocked), func(StreamEvent) {}); diag.mcpErrText == "" {
+		t.Error("a policy that blocks MCP must fail the turn even with no per-server event")
+	}
+
+	unrelated := strings.Join([]string{
+		`{"type":"session.warning","data":{"message":"Your organization restricts the models available to this account.","warningType":"policy"},"ephemeral":true}`,
+		verdict, result,
+	}, "\n")
+	if diag := agent.parseStream(strings.NewReader(unrelated), func(StreamEvent) {}); diag.mcpErrText != "" {
+		t.Errorf("an unrelated policy warning must not fail the turn; got %q", diag.mcpErrText)
 	}
 }

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -24,10 +24,14 @@ type AgentInfo struct {
 
 // knownAgents are the CLI names we probe for — a FIXED list. We never exec a
 // user-supplied name/path: only these literals, resolved through PATH, are run.
-var knownAgents = []string{"claude", "codex", "gemini", "cursor-agent"}
+// Note "copilot" is GitHub's standalone Copilot CLI, not the older `gh copilot`
+// gh-extension — that one has no headless agent mode and never lands on PATH
+// under this name.
+var knownAgents = []string{"claude", "codex", "gemini", "cursor-agent", "copilot"}
 
 var agentLabels = map[string]string{
-	"claude": "Claude Code", "codex": "Codex", "gemini": "Gemini CLI", "cursor-agent": "Cursor Agent",
+	"claude": "Claude Code", "codex": "Codex", "gemini": "Gemini CLI",
+	"cursor-agent": "Cursor Agent", "copilot": "GitHub Copilot CLI",
 }
 
 // AgentLabel is the display name for an agent CLI — the ONE table every
@@ -70,9 +74,42 @@ func ProfilesFor(agent string) []ExecutionProfile {
 		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
 	case "cursor-agent":
 		return []ExecutionProfile{ExecutionProfileFullLocal}
+	case "copilot":
+		return []ExecutionProfile{ExecutionProfileSafeguarded, ExecutionProfileFullLocal}
 	default:
 		return nil
 	}
+}
+
+// ReasoningEfforts returns the reasoning-effort levels an agent accepts. Kept
+// beside ProfilesFor for the same reason: the API validator, the UI menu, and the
+// arg builder must not drift. The levels are CLI vocabulary, not Radar's — Codex
+// and Copilot name them differently and Copilot's range is wider. An agent with no
+// effort knob returns nil, so only the empty (default) value validates.
+func ReasoningEfforts(agent string) []string {
+	switch agent {
+	case "codex":
+		return []string{"minimal", "low", "medium", "high"}
+	case "copilot":
+		return []string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+	default:
+		return nil
+	}
+}
+
+// SupportsEffort reports whether an effort value may be passed to this agent. The
+// empty string (the CLI's own default) is always allowed; anything else must be a
+// listed literal, because the value is interpolated into CLI arguments.
+func SupportsEffort(agent, effort string) bool {
+	if effort == "" {
+		return true
+	}
+	for _, candidate := range ReasoningEfforts(agent) {
+		if candidate == effort {
+			return true
+		}
+	}
+	return false
 }
 
 func DefaultProfileFor(agent string) ExecutionProfile {

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -631,12 +631,11 @@ func writeMCPConfig(mcpURL string) (string, func(), error) {
 }
 
 var (
-	envAllowExact = map[string]bool{
-		"PATH": true, "HOME": true, "USER": true, "LOGNAME": true,
-		"LANG": true, "LC_ALL": true, "LC_CTYPE": true, "TZ": true,
-		"TMPDIR": true, "SHELL": true, "SSL_CERT_FILE": true, "SSL_CERT_DIR": true,
+	envAllowExact = []string{
+		"USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE", "TZ",
+		"SHELL", "SSL_CERT_FILE", "SSL_CERT_DIR",
 		// AWS creds are passed through so BYO-Bedrock works; the user opted in.
-		"AWS_PROFILE": true, "AWS_REGION": true, "AWS_DEFAULT_REGION": true,
+		"AWS_PROFILE", "AWS_REGION", "AWS_DEFAULT_REGION",
 	}
 	envAllowPrefix = []string{"ANTHROPIC_", "CLAUDE_", "AWS_", "GOOGLE_", "CLOUD_ML_", "VERTEX_"}
 )
@@ -645,24 +644,7 @@ var (
 // data, so it shouldn't inherit unrelated host env. Provider-auth vars pass
 // through so subscription / API-key / Bedrock / Vertex all work.
 func scrubbedEnv() []string {
-	var out []string
-	for _, kv := range os.Environ() {
-		k, _, ok := strings.Cut(kv, "=")
-		if !ok {
-			continue
-		}
-		if envAllowExact[k] {
-			out = append(out, kv)
-			continue
-		}
-		for _, p := range envAllowPrefix {
-			if strings.HasPrefix(k, p) {
-				out = append(out, kv)
-				break
-			}
-		}
-	}
-	return out
+	return minimalEnv(envAllowExact, envAllowPrefix)
 }
 
 type cappedBuffer struct {

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -134,6 +134,11 @@ type Diagnosis struct {
 	// cliErrText preserves failures reported in a stream-json result instead of stderr.
 	cliErrText string
 	cliErrored bool
+	// mcpErrText is set when the CLI reported that Radar's MCP server did not
+	// attach. Kept separate from cliErrText because it must fail the turn even when
+	// a well-formed verdict was produced: an agent with no cluster tools still
+	// answers, and that answer is worthless.
+	mcpErrText string
 }
 
 // StreamEvent is one normalized event emitted during an investigation.
@@ -240,7 +245,7 @@ const defaultMaxTurns = 15
 
 // agentCLICandidates are CLIs whose event stream we can parse + drive. Order is
 // the default-selection preference when several are installed.
-var agentCLICandidates = []string{"claude", "codex", "cursor-agent"}
+var agentCLICandidates = []string{"claude", "codex", "cursor-agent", "copilot"}
 
 // Detector / Diagnoser ------------------------------------------------------
 
@@ -446,6 +451,16 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 		if ctx.Err() != nil {
 			return Diagnosis{}, ctx.Err()
 		}
+	}
+	// An investigation that never reached Radar's MCP server read nothing from the
+	// cluster. Checked BEFORE structured(): the agent still produces a confident
+	// verdict in that state, so a well-formed answer is exactly what makes this
+	// failure dangerous rather than what excuses it.
+	if diag.mcpErrText != "" {
+		return Diagnosis{}, fmt.Errorf(
+			"ai: %s could not reach Radar's MCP server, so it had no cluster access: %s",
+			AgentLabel(agent.Name()), diag.mcpErrText,
+		)
 	}
 	// A structured verdict wins over trailing process noise. Without one, either a
 	// nonzero exit or an explicit stream error must remain a failed investigation.

--- a/internal/ai/env.go
+++ b/internal/ai/env.go
@@ -1,0 +1,73 @@
+package ai
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// envBaseKeys are the variables ANY spawned agent CLI needs on this platform,
+// independent of which CLI it is. Windows keeps the agent's own auth and config
+// under USERPROFILE/APPDATA/LOCALAPPDATA, and a process launched without
+// SYSTEMROOT/COMSPEC can fail before it reaches its own code — so a safeguarded
+// run that dropped them wouldn't start at all.
+func envBaseKeys() []string {
+	if runtime.GOOS == "windows" {
+		return []string{
+			"PATH", "PATHEXT", "COMSPEC", "SYSTEMROOT", "SYSTEMDRIVE",
+			"TEMP", "TMP", "USERPROFILE", "HOMEDRIVE", "HOMEPATH",
+			"APPDATA", "LOCALAPPDATA", "PROGRAMDATA", "NUMBER_OF_PROCESSORS",
+		}
+	}
+	return []string{"HOME", "PATH", "TMPDIR"}
+}
+
+// filterEnv keeps only the entries of environ whose name is listed in keep, starts
+// with one of prefixes, or belongs to the platform base set. Windows environment
+// names are case-insensitive (SystemRoot and SYSTEMROOT are one variable), so
+// matching folds case there and stays exact everywhere else.
+func filterEnv(environ, keep, prefixes []string) []string {
+	fold := runtime.GOOS == "windows"
+	norm := func(s string) string {
+		if fold {
+			return strings.ToUpper(s)
+		}
+		return s
+	}
+	allow := make(map[string]bool, len(keep)+len(envBaseKeys()))
+	for _, k := range envBaseKeys() {
+		allow[norm(k)] = true
+	}
+	for _, k := range keep {
+		allow[norm(k)] = true
+	}
+	normPrefixes := make([]string, 0, len(prefixes))
+	for _, p := range prefixes {
+		normPrefixes = append(normPrefixes, norm(p))
+	}
+
+	var out []string
+	for _, kv := range environ {
+		k, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		n := norm(k)
+		if allow[n] {
+			out = append(out, kv)
+			continue
+		}
+		for _, p := range normPrefixes {
+			if strings.HasPrefix(n, p) {
+				out = append(out, kv)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// minimalEnv is filterEnv over the live process environment.
+func minimalEnv(keep, prefixes []string) []string {
+	return filterEnv(os.Environ(), keep, prefixes)
+}

--- a/internal/ai/env_test.go
+++ b/internal/ai/env_test.go
@@ -1,0 +1,56 @@
+package ai
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestFilterEnvKeepsPlatformBase pins that a minimized env still contains what the
+// platform needs to start a process and find the agent's own credentials. Dropping
+// USERPROFILE/APPDATA on Windows leaves the CLI unable to sign in, and dropping
+// SYSTEMROOT can stop it from launching at all — a failure that never reproduces
+// on the maintainers' machines.
+func TestFilterEnvKeepsPlatformBase(t *testing.T) {
+	environ := []string{
+		"PATH=/usr/bin", "HOME=/home/u", "TMPDIR=/tmp",
+		"USERPROFILE=C:\\Users\\u", "APPDATA=C:\\Users\\u\\AppData\\Roaming",
+		"LOCALAPPDATA=C:\\Users\\u\\AppData\\Local", "SystemRoot=C:\\Windows",
+		"TEMP=C:\\Temp", "COMSPEC=C:\\Windows\\system32\\cmd.exe",
+		"AWS_SECRET_ACCESS_KEY=shhh", "KUBECONFIG=/home/u/.kube/config",
+	}
+	got := filterEnv(environ, []string{"KUBECONFIG"}, nil)
+
+	want := []string{"PATH=/usr/bin", "KUBECONFIG=/home/u/.kube/config"}
+	if runtime.GOOS == "windows" {
+		want = append(want,
+			"USERPROFILE=C:\\Users\\u",
+			"APPDATA=C:\\Users\\u\\AppData\\Roaming",
+			"LOCALAPPDATA=C:\\Users\\u\\AppData\\Local",
+			// Windows env names are case-insensitive: SystemRoot IS SYSTEMROOT.
+			"SystemRoot=C:\\Windows",
+			"TEMP=C:\\Temp",
+			"COMSPEC=C:\\Windows\\system32\\cmd.exe",
+		)
+	} else {
+		want = append(want, "HOME=/home/u", "TMPDIR=/tmp")
+	}
+	for _, kv := range want {
+		if !envHas(got, kv) {
+			t.Errorf("filterEnv dropped %q; got %v", kv, got)
+		}
+	}
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "AWS_SECRET_ACCESS_KEY=") {
+			t.Errorf("filterEnv leaked an unlisted secret: %q", kv)
+		}
+	}
+}
+
+func TestFilterEnvPrefixes(t *testing.T) {
+	environ := []string{"LC_ALL=C", "LC_TIME=C", "LANG=C", "NOPE=1"}
+	got := filterEnv(environ, nil, []string{"LC_"})
+	if len(got) != 2 || !envHas(got, "LC_ALL=C") || !envHas(got, "LC_TIME=C") {
+		t.Errorf("expected only the LC_ prefix matches; got %v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,8 @@ var aiConsentVersions = map[string]string{
 	"codex:safeguarded":       "v1",
 	"codex:full-local":        "v1",
 	"cursor-agent:full-local": "v1",
+	"copilot:safeguarded":     "v1",
+	"copilot:full-local":      "v1",
 }
 
 // AIConsentVersion returns the current disclosure version for a surface

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -76,7 +76,7 @@ func newFlagSet() (*flag.FlagSet, *options) {
 	o := &options{}
 	fs.StringVar(&o.namespace, "n", "", "Namespace of the resource")
 	fs.StringVar(&o.namespace, "namespace", "", "Namespace of the resource")
-	fs.StringVar(&o.agent, "agent", "", "Agent backend to use (claude|codex|cursor-agent; default = server's pick)")
+	fs.StringVar(&o.agent, "agent", "", "Agent backend to use (claude|codex|cursor-agent|copilot; default = server's pick)")
 	fs.StringVar(&o.profile, "profile", "", "Execution profile (safeguarded = Radar safeguards; full-local = your agent setup; default = safest available)")
 	fs.StringVar(&o.server, "server", "", "Radar server URL (default: discover the running instance via ~/.radar/mcp-port)")
 	fs.BoolVar(&o.jsonOut, "json", false, "Print the final verdict as JSON on stdout (progress goes to stderr)")
@@ -94,7 +94,7 @@ func Run(args []string, openBrowser func(url string)) int {
 		fmt.Fprint(os.Stderr, `Usage: radar diagnose <kind>/<name> [-n namespace] [flags]
 
 Runs an AI investigation of a Kubernetes resource using your own local agent
-CLI (Claude Code, Codex, or Cursor) against the running Radar instance — no
+CLI (Claude Code, Codex, Cursor, or GitHub Copilot) against the running Radar instance — no
 API key, no cloud. The investigation is a durable Radar job: watch it here,
 in the Radar UI, or continue it in your own agent afterwards.
 
@@ -207,7 +207,7 @@ Flags:
 		return 1
 	}
 	if !agents.Enabled {
-		fmt.Fprintln(os.Stderr, "AI diagnosis is disabled on this Radar instance — install Claude Code, Codex, or Cursor and restart radar.")
+		fmt.Fprintln(os.Stderr, "AI diagnosis is disabled on this Radar instance — install Claude Code, Codex, Cursor, or GitHub Copilot and restart radar.")
 		return 1
 	}
 

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -91,7 +91,7 @@ func bootEphemeral(kubeconfig string) (base string, shutdown func(), err error) 
 			}
 			if code == http.StatusNotImplemented {
 				close(stopSpin)
-				return "", nil, fmt.Errorf("no supported agent CLI found — install Claude Code, Codex, or Cursor")
+				return "", nil, fmt.Errorf("no supported agent CLI found — install Claude Code, Codex, Cursor, or GitHub Copilot")
 			}
 		}
 		if time.Now().After(deadline) {

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -218,20 +218,18 @@ func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 // writes the error) when unavailable.
 func (s *Server) aiReady(w http.ResponseWriter) bool {
 	if s.aiRuns == nil {
-		s.writeError(w, http.StatusNotImplemented, "no agent CLI available — install Claude Code, Codex, or Cursor (cursor-agent) to enable AI diagnosis")
+		s.writeError(w, http.StatusNotImplemented, "no agent CLI available — install Claude Code, Codex, Cursor (cursor-agent), or GitHub Copilot (copilot) to enable AI diagnosis")
 		return false
 	}
 	return s.requireConnected(w)
 }
 
-// validReasoningEffort allows the empty (default) value or one of Codex's
-// reasoning-effort levels — never an arbitrary string passed into CLI config.
-func validReasoningEffort(e string) bool {
-	switch e {
-	case "", "minimal", "low", "medium", "high":
-		return true
-	}
-	return false
+// validReasoningEffort allows the empty (default) value or one of the levels the
+// SELECTED agent accepts — never an arbitrary string passed into CLI config, and
+// never one agent's vocabulary handed to another (Copilot has xhigh/max, Codex
+// does not). The per-agent table lives in ai.ReasoningEfforts.
+func validReasoningEffort(agent, e string) bool {
+	return ai.SupportsEffort(agent, e)
 }
 
 // localOriginOK rejects cross-origin POSTs to these state-changing, process-
@@ -311,8 +309,8 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	effort := strings.TrimSpace(body.Effort)
-	if !validReasoningEffort(effort) {
-		s.writeError(w, http.StatusBadRequest, "invalid reasoning effort")
+	if !validReasoningEffort(agent, effort) {
+		s.writeError(w, http.StatusBadRequest, "invalid reasoning effort for this agent")
 		return
 	}
 	// Authoritatively detect whether a GitOps/Helm controller owns this resource, so

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,9 +709,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,9 +726,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,9 +743,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +760,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,9 +777,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,9 +794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6335,7 +6317,7 @@
         "vite": "^8.1.5"
       },
       "peerDependencies": {
-        "@skyhook-io/k8s-ui": ">=1.11.0",
+        "@skyhook-io/k8s-ui": ">=1.12.0",
         "@tanstack/react-query": ">=5",
         "@xyflow/react": ">=12.0.0",
         "clsx": ">=2",

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -157,6 +157,7 @@ const AGENT_LABELS: Record<string, string> = {
   codex: "Codex",
   gemini: "Gemini CLI",
   "cursor-agent": "Cursor Agent",
+  copilot: "GitHub Copilot CLI",
 };
 
 export function agentLabelFor(name: string, fallbackLabel?: string): string {

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -40,8 +40,8 @@ function capWord(s: string): string {
 
 // buildConfigLine renders the active AI config as the header subtitle. The agents
 // with a reasoning-effort knob (Codex, Copilot) show their execution profile +
-// effective effort (Default → medium); a model override is shown for any agent.
-// Reflects a run's recorded settings, or the current defaults on Home.
+// effective effort; a model override is shown for any agent. Reflects a run's
+// recorded settings, or the current defaults on Home.
 function buildConfigLine(cfg: {
   agent?: string;
   profile?: ExecutionProfile;
@@ -54,8 +54,13 @@ function buildConfigLine(cfg: {
       cfg.profile === "full-local" ? "Your agent setup" : "Radar safeguards",
     );
   }
-  if (cfg.agent === "codex" || cfg.agent === "copilot") {
+  if (cfg.agent === "codex") {
     parts.push(`${capWord(cfg.effort || "medium")} effort`);
+  }
+  // Copilot gets no Radar-chosen default (the flag is rejected on "auto" models),
+  // so an unset effort is Copilot's own setting, not medium.
+  if (cfg.agent === "copilot") {
+    parts.push(`${cfg.effort ? capWord(cfg.effort) : "Default"} effort`);
   }
   if (cfg.model) parts.push(capWord(cfg.model));
   return "via " + parts.join(" · ");

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -38,10 +38,10 @@ function capWord(s: string): string {
   return s ? s[0].toUpperCase() + s.slice(1) : s;
 }
 
-// buildConfigLine renders the active AI config as the header subtitle. Codex shows
-// its execution profile + effective reasoning effort (Default → medium); a model
-// override is shown for either agent. Reflects a run's recorded settings, or the
-// current defaults on Home.
+// buildConfigLine renders the active AI config as the header subtitle. The agents
+// with a reasoning-effort knob (Codex, Copilot) show their execution profile +
+// effective effort (Default → medium); a model override is shown for any agent.
+// Reflects a run's recorded settings, or the current defaults on Home.
 function buildConfigLine(cfg: {
   agent?: string;
   profile?: ExecutionProfile;
@@ -54,7 +54,7 @@ function buildConfigLine(cfg: {
       cfg.profile === "full-local" ? "Your agent setup" : "Radar safeguards",
     );
   }
-  if (cfg.agent === "codex") {
+  if (cfg.agent === "codex" || cfg.agent === "copilot") {
     parts.push(`${capWord(cfg.effort || "medium")} effort`);
   }
   if (cfg.model) parts.push(capWord(cfg.model));

--- a/web/src/components/diagnose/agentCatalog.ts
+++ b/web/src/components/diagnose/agentCatalog.ts
@@ -27,4 +27,10 @@ export const SUPPORTED_AGENTS: AgentInstall[] = [
     install: "curl https://cursor.com/install -fsS | bash",
     docs: "https://docs.cursor.com/en/cli/overview",
   },
+  {
+    name: "copilot",
+    label: "GitHub Copilot CLI",
+    install: "npm install -g @github/copilot",
+    docs: "https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli",
+  },
 ];

--- a/web/src/components/diagnose/launch.test.ts
+++ b/web/src/components/diagnose/launch.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildLaunchCommand } from "./launch";
+import type { RunSummary } from "../../api/diagnose";
+
+const MCP = "http://127.0.0.1:9280/mcp";
+
+function run(over: Partial<RunSummary> = {}): RunSummary {
+  return {
+    id: "r1",
+    kind: "Deployment",
+    namespace: "default",
+    name: "web",
+    context: "kind-radar",
+    agent: "copilot",
+    profile: "safeguarded",
+    status: "done",
+    sessionId: "sess-1",
+    createdAt: "",
+    updatedAt: "",
+    ...over,
+  };
+}
+
+describe("buildLaunchCommand for Copilot", () => {
+  // The hand-off resumes the SAME session the headless turns filled with cluster
+  // data. Copilot exports sessions to GitHub web and mobile by default, and the
+  // consent card promises Radar never lets that happen — so the flags have to be
+  // repeated on the interactive continuation, not just the headless turns.
+  it("keeps the GitHub export disabled on resume", () => {
+    const cmd = buildLaunchCommand(run(), MCP)!;
+    expect(cmd).toContain("--no-remote-export");
+    expect(cmd).toContain("--no-remote ");
+  });
+
+  // A safeguarded run's session lives in Radar's own Copilot home; without the
+  // redirect the id simply isn't found. Full-local runs use the user's own home.
+  it("points at Radar's Copilot home only for safeguarded runs", () => {
+    expect(buildLaunchCommand(run(), MCP)).toContain(
+      'COPILOT_HOME="$HOME/.radar/copilot-home" copilot --resume=',
+    );
+    const local = buildLaunchCommand(run({ profile: "full-local" }), MCP)!;
+    expect(local).not.toContain("COPILOT_HOME");
+    expect(local.startsWith("copilot --resume=")).toBe(true);
+  });
+
+  // --resume takes an OPTIONAL value: passed as a separate argument the id would
+  // be read as a positional prompt and start a brand-new investigation.
+  it("uses the =value form for --resume", () => {
+    const cmd = buildLaunchCommand(run(), MCP)!;
+    expect(cmd).toContain("--resume='sess-1'");
+    expect(cmd).not.toContain("--resume 'sess-1'");
+  });
+
+  it("re-attaches Radar's MCP server", () => {
+    expect(buildLaunchCommand(run(), MCP)).toContain(MCP);
+  });
+
+  it("offers no hand-off without a resumable session", () => {
+    expect(buildLaunchCommand(run({ sessionId: undefined }), MCP)).toBeNull();
+    expect(buildLaunchCommand(run({ status: "stale" }), MCP)).toBeNull();
+  });
+});

--- a/web/src/components/diagnose/launch.ts
+++ b/web/src/components/diagnose/launch.ts
@@ -16,6 +16,7 @@ function sq(s: string): string {
 export function launchAgentLabel(run: RunSummary): string {
   if (run.agent === "codex") return "Codex";
   if (run.agent === "cursor-agent") return "Cursor";
+  if (run.agent === "copilot") return "GitHub Copilot";
   return "Claude Code";
 }
 
@@ -52,6 +53,16 @@ export function buildLaunchCommand(
   if (run.agent === "codex") {
     // Codex threads are stored globally by id (cwd-independent); -c re-attaches MCP.
     return `codex resume ${sq(run.sessionId)} -c ${sq(`mcp_servers.radar.url="${mcpUrl}"`)}`;
+  }
+  if (run.agent === "copilot") {
+    // Copilot's session store is global, so --resume works from any directory.
+    // --resume takes an OPTIONAL value and so must use the "=" form; passed as a
+    // separate argument the id would be read as a prompt. --additional-mcp-config
+    // MERGES radar alongside the user's own servers.
+    const cfg = JSON.stringify({
+      mcpServers: { radar: { type: "http", url: mcpUrl } },
+    });
+    return `copilot --resume=${sq(run.sessionId)} --additional-mcp-config ${sq(cfg)}`;
   }
   // Claude Code: --resume is cwd-scoped, and Radar runs its headless sessions from
   // the home dir (see claudeAgent). The Radar terminal starts there too, but a user

--- a/web/src/components/diagnose/launch.ts
+++ b/web/src/components/diagnose/launch.ts
@@ -55,14 +55,24 @@ export function buildLaunchCommand(
     return `codex resume ${sq(run.sessionId)} -c ${sq(`mcp_servers.radar.url="${mcpUrl}"`)}`;
   }
   if (run.agent === "copilot") {
-    // Copilot's session store is global, so --resume works from any directory.
-    // --resume takes an OPTIONAL value and so must use the "=" form; passed as a
-    // separate argument the id would be read as a prompt. --additional-mcp-config
-    // MERGES radar alongside the user's own servers.
+    // Copilot's session store lives under COPILOT_HOME, not the cwd, so --resume
+    // works from any directory. --resume takes an OPTIONAL value and so must use
+    // the "=" form; passed as a separate argument the id would be read as a
+    // prompt. --additional-mcp-config MERGES radar alongside the user's own
+    // servers. --no-remote-export has to be repeated here: this resumes the SAME
+    // session the headless turns filled with cluster data, and the consent card
+    // promises it is never published to GitHub's web and mobile surfaces.
     const cfg = JSON.stringify({
       mcpServers: { radar: { type: "http", url: mcpUrl } },
     });
-    return `copilot --resume=${sq(run.sessionId)} --additional-mcp-config ${sq(cfg)}`;
+    // A safeguarded run's session lives in Radar's own Copilot home, so the
+    // hand-off has to point at it — mirrors CopilotHomeDir in
+    // internal/ai/agent_copilot.go. Left to the shell to expand $HOME.
+    const home =
+      run.profile === "safeguarded"
+        ? `COPILOT_HOME="$HOME/.radar/copilot-home" `
+        : "";
+    return `${home}copilot --resume=${sq(run.sessionId)} --additional-mcp-config ${sq(cfg)} --no-remote --no-remote-export`;
   }
   // Claude Code: --resume is cwd-scoped, and Radar runs its headless sessions from
   // the home dir (see claudeAgent). The Radar terminal starts there too, but a user

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -146,6 +146,15 @@ describe("reasoning-effort menus", () => {
     expect(values(EFFORT_OPTIONS)).toContain("");
     expect(values(COPILOT_EFFORT_OPTIONS)).toContain("");
   });
+
+  // Radar forces medium for Codex but passes no --effort at all for Copilot: the
+  // flag is rejected outright when the account's model resolves to "auto".
+  it("does not promise Copilot a Radar-chosen default", () => {
+    const copilotDefault = COPILOT_EFFORT_OPTIONS.find((o) => o.value === "");
+    expect(copilotDefault?.description).not.toContain("medium");
+    const codexDefault = EFFORT_OPTIONS.find((o) => o.value === "");
+    expect(codexDefault?.description).toContain("medium");
+  });
 });
 
 describe("ConsentCard execution profile treatment", () => {

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -1,6 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { AgentControls, ConsentCard } from "./parts";
+import {
+  AgentControls,
+  ConsentCard,
+  COPILOT_EFFORT_OPTIONS,
+  EFFORT_OPTIONS,
+} from "./parts";
 import type { AgentInfo, ExecutionProfile } from "../../api/diagnose";
 
 const noop = vi.fn();
@@ -77,6 +82,39 @@ describe("AgentControls execution profile explanation", () => {
     expect(html).not.toContain("built-in tools are disabled");
   });
 
+  it("describes what Radar actually removes for a safeguarded Copilot run", () => {
+    const html = renderAgent(
+      "copilot",
+      ["safeguarded", "full-local"],
+      "safeguarded",
+    );
+    expect(html).toContain("only Radar");
+    expect(html).toContain("shell, file edits and web access are removed");
+    expect(html).toContain("AGENTS.md");
+    // Must not fall through to the generic copy now that Copilot is supported.
+    expect(html).not.toContain("documented restrictions");
+    expect(html).not.toContain("Codex");
+  });
+
+  it("offers Copilot a reasoning-effort control", () => {
+    const html = renderAgent(
+      "copilot",
+      ["safeguarded", "full-local"],
+      "safeguarded",
+    );
+    // Previously Codex-only; Copilot has the same knob with a wider range.
+    expect(html).toContain("Reasoning effort");
+  });
+
+  it("gives Claude no reasoning-effort control", () => {
+    const html = renderAgent(
+      "claude",
+      ["safeguarded", "full-local"],
+      "safeguarded",
+    );
+    expect(html).not.toContain("Reasoning effort");
+  });
+
   it("labels the selectable full-local profile as the user's agent setup", () => {
     const html = renderAgent(
       "codex",
@@ -85,6 +123,28 @@ describe("AgentControls execution profile explanation", () => {
     );
     expect(html).toContain("Your codex setup");
     expect(html).not.toContain("Full local setup");
+  });
+});
+
+// The menus are curated subsets of each CLI's vocabulary, and the server rejects
+// a level the selected agent doesn't accept (ai.ReasoningEfforts). Codex being
+// offered xhigh would surface as an unexplainable 400.
+describe("reasoning-effort menus", () => {
+  const values = (opts: typeof EFFORT_OPTIONS) => opts.map((o) => o.value);
+
+  it("offers Copilot's wider tiers only to Copilot", () => {
+    expect(values(COPILOT_EFFORT_OPTIONS)).toEqual(
+      expect.arrayContaining(["xhigh", "max"]),
+    );
+    expect(values(EFFORT_OPTIONS)).not.toEqual(
+      expect.arrayContaining(["xhigh"]),
+    );
+    expect(values(EFFORT_OPTIONS)).not.toEqual(expect.arrayContaining(["max"]));
+  });
+
+  it("keeps the default (empty) choice on both menus", () => {
+    expect(values(EFFORT_OPTIONS)).toContain("");
+    expect(values(COPILOT_EFFORT_OPTIONS)).toContain("");
   });
 });
 
@@ -106,6 +166,23 @@ describe("ConsentCard execution profile treatment", () => {
     expect(html).toContain("Radar cannot constrain");
     expect(html).toContain("always loads your global MCP servers");
     expect(html).not.toContain("text-accent");
+  });
+
+  // The transcript carries cluster data and Copilot exports sessions to GitHub by
+  // default, so the fact that Radar disables that is a consent-relevant claim.
+  it("tells Copilot users the session is never exported to GitHub", () => {
+    for (const profile of ["safeguarded", "full-local"] as ExecutionProfile[]) {
+      const html = renderToStaticMarkup(
+        <ConsentCard
+          agentName="GitHub Copilot CLI"
+          agent="copilot"
+          profile={profile}
+          onApprove={noop}
+          onCancel={noop}
+        />,
+      );
+      expect(html).toContain("never exported to GitHub");
+    }
   });
 
   it("does not claim Radar enables a sandbox for Claude's normal setup", () => {

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -110,8 +110,15 @@ export const EFFORT_OPTIONS: Option[] = [
 ];
 // Copilot accepts a wider range than Codex; the extra tiers are its own vocabulary
 // and are rejected by Codex, so the menus stay separate (mirrors ai.ReasoningEfforts).
+// The default differs too: Radar passes no --effort at all for Copilot, because the
+// flag is rejected outright when the account's model resolves to "auto".
 export const COPILOT_EFFORT_OPTIONS: Option[] = [
-  ...EFFORT_OPTIONS,
+  {
+    value: "",
+    label: "Default",
+    description: "Recommended — your Copilot setting",
+  },
+  ...EFFORT_OPTIONS.slice(1),
   { value: "xhigh", label: "Extra high", description: "Deeper than High" },
   { value: "max", label: "Max", description: "Maximum reasoning, slowest" },
 ];
@@ -308,7 +315,7 @@ export function AgentControls({
                     : isCodex
                       ? "Radar excludes your Codex configuration and other MCP servers. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
                       : isCopilot
-                        ? "Copilot can call only Radar’s read-only investigation tools — its shell, file edits and web access are removed entirely. Your other MCP servers, the GitHub MCP server, and your AGENTS.md instructions are all excluded."
+                        ? "Copilot can call only Radar’s read-only investigation tools — its shell, file edits and web access are removed entirely. The run uses a Radar-owned Copilot configuration, so your own MCP servers, hooks, and AGENTS.md instructions are all excluded."
                         : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
                 </p>
               ) : (
@@ -838,8 +845,9 @@ export function ConsentCard({
                 <>
                   Radar safeguards leave Copilot with only Radar&apos;s read-only
                   investigation tools — no shell, no file edits, no web access.
-                  The GitHub MCP server, your other MCP servers, and your
-                  AGENTS.md instructions are all excluded from the run.
+                  The run uses a Radar-owned Copilot configuration, so the GitHub
+                  MCP server, your own MCP servers, your hooks, and your
+                  AGENTS.md instructions are all excluded.
                 </>
               ) : (
                 <>
@@ -852,8 +860,8 @@ export function ConsentCard({
                 ? [
                     <>
                       The session is never exported to GitHub&apos;s web or
-                      mobile surfaces, so the transcript and the cluster data in
-                      it stay on this machine.
+                      mobile surfaces; it exists only here and in your local
+                      Copilot session store.
                     </>,
                   ]
                 : []),

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -98,7 +98,7 @@ const CLAUDE_MODEL_OPTIONS: Option[] = [
 ];
 // Codex has no stable alias set and no way to enumerate models, and slugs change
 // across versions — so we take a free-text override rather than a list that rots.
-const EFFORT_OPTIONS: Option[] = [
+export const EFFORT_OPTIONS: Option[] = [
   {
     value: "",
     label: "Default",
@@ -107,6 +107,13 @@ const EFFORT_OPTIONS: Option[] = [
   { value: "low", label: "Low", description: "Fastest, least reasoning" },
   { value: "medium", label: "Medium", description: "Balanced depth" },
   { value: "high", label: "High", description: "Most thorough, slowest" },
+];
+// Copilot accepts a wider range than Codex; the extra tiers are its own vocabulary
+// and are rejected by Codex, so the menus stay separate (mirrors ai.ReasoningEfforts).
+export const COPILOT_EFFORT_OPTIONS: Option[] = [
+  ...EFFORT_OPTIONS,
+  { value: "xhigh", label: "Extra high", description: "Deeper than High" },
+  { value: "max", label: "Max", description: "Maximum reasoning, slowest" },
 ];
 
 function TextField({
@@ -256,6 +263,7 @@ export function AgentControls({
   const isCodex = selectedAgent === "codex";
   const isClaude = selectedAgent === "claude";
   const isCursor = selectedAgent === "cursor-agent";
+  const isCopilot = selectedAgent === "copilot";
   const selectedAgentInfo = agents.find((a) => a.name === selectedAgent);
   const selectedAgentLabel =
     selectedAgentInfo?.label || selectedAgent || "agent";
@@ -299,7 +307,9 @@ export function AgentControls({
                     ? "Claude’s built-in tools are disabled, and MCP access is limited to Radar’s read-only investigation tools. Your Claude settings, hooks, and CLAUDE.md instructions still apply and are outside Radar’s control."
                     : isCodex
                       ? "Radar excludes your Codex configuration and other MCP servers. Codex’s sandboxed shell can still read files on this machine; it cannot write or reach the network."
-                      : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
+                      : isCopilot
+                        ? "Copilot can call only Radar’s read-only investigation tools — its shell, file edits and web access are removed entirely. Your other MCP servers, the GitHub MCP server, and your AGENTS.md instructions are all excluded."
+                        : "Radar uses this agent’s safeguarded execution profile. Review the agent’s documented restrictions before continuing."}
                 </p>
               ) : (
                 <div className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary">
@@ -311,7 +321,9 @@ export function AgentControls({
                     and may be able to change your cluster.{" "}
                     {isClaude
                       ? "Claude uses the permissions from your setup; Radar does not override them."
-                      : "Radar still enables the agent CLI’s own sandbox, but that sandbox does not constrain external MCP servers."}{" "}
+                      : isCopilot
+                        ? "Copilot runs with all tools allowed, using your own configuration and MCP servers."
+                        : "Radar still enables the agent CLI’s own sandbox, but that sandbox does not constrain external MCP servers."}{" "}
                     Choose this only when you need that setup.
                   </span>
                 </div>
@@ -353,22 +365,26 @@ export function AgentControls({
           onChange={onSetModel}
           hint="Aliases always resolve to the latest of that tier."
         />
-      ) : isCodex || isCursor ? (
+      ) : isCodex || isCursor || isCopilot ? (
         <TextField
           label="Model"
           value={model}
           placeholder={
             isCursor
               ? "Default (e.g. auto, gpt-5.2, composer-2.5)"
-              : "Default (e.g. gpt-5-codex, o3)"
+              : isCopilot
+                ? "Default (e.g. auto, gpt-5.4)"
+                : "Default (e.g. gpt-5-codex, o3)"
           }
           onChange={onSetModel}
           hint={
             isCursor
               ? "Leave empty for your Cursor default, or enter a model slug Cursor supports."
-              : shownProfile === "full-local"
-                ? "Your Codex setup uses its configured model; set a slug here to override it."
-                : "Leave empty for Codex's default, or enter a model your Codex version supports."
+              : isCopilot
+                ? "Leave empty for Copilot's default, or enter a model your Copilot plan offers."
+                : shownProfile === "full-local"
+                  ? "Your Codex setup uses its configured model; set a slug here to override it."
+                  : "Leave empty for Codex's default, or enter a model your Codex version supports."
           }
         />
       ) : (
@@ -380,11 +396,11 @@ export function AgentControls({
           hint="Leave empty for the agent's default, or enter a model identifier it supports."
         />
       )}
-      {isCodex && (
+      {(isCodex || isCopilot) && (
         <SelectMenu
           label="Reasoning effort"
           value={effort}
-          options={EFFORT_OPTIONS}
+          options={isCopilot ? COPILOT_EFFORT_OPTIONS : EFFORT_OPTIONS}
           onChange={onSetEffort}
         />
       )}
@@ -818,6 +834,13 @@ export function ConsentCard({
                   servers. Codex&apos;s sandboxed shell can still read files on
                   this machine; it cannot write or reach the network.
                 </>
+              ) : agent === "copilot" ? (
+                <>
+                  Radar safeguards leave Copilot with only Radar&apos;s read-only
+                  investigation tools — no shell, no file edits, no web access.
+                  The GitHub MCP server, your other MCP servers, and your
+                  AGENTS.md instructions are all excluded from the run.
+                </>
               ) : (
                 <>
                   Radar uses this agent&apos;s safeguarded execution profile.
@@ -825,6 +848,15 @@ export function ConsentCard({
                   continuing.
                 </>
               ),
+              ...(agent === "copilot"
+                ? [
+                    <>
+                      The session is never exported to GitHub&apos;s web or
+                      mobile surfaces, so the transcript and the cluster data in
+                      it stay on this machine.
+                    </>,
+                  ]
+                : []),
             ]
           : [
               <>
@@ -836,6 +868,12 @@ export function ConsentCard({
                 <>
                   Claude uses the permissions from your setup; Radar does not
                   override them.
+                </>
+              ) : agent === "copilot" ? (
+                <>
+                  Copilot runs with all tools allowed, using your own
+                  configuration and MCP servers. The session is still never
+                  exported to GitHub&apos;s web or mobile surfaces.
                 </>
               ) : (
                 <>


### PR DESCRIPTION
## Description

Adds GitHub Copilot CLI (`copilot`) as a fourth investigations backend alongside
Claude Code, Codex, and Cursor, at full parity: both execution profiles, model and
reasoning-effort control, session resume, and the "continue in your terminal" hand-off.

Safeguarded is the tightest containment of the four backends, because Copilot can
filter the model's entire tool surface: `--available-tools` leaves only Radar's MCP
tools visible (no shell, no file edits, no web access), `--allow-tool=radar` approves
them without `--allow-all-tools`, and the built-in GitHub MCP server plus every server
in the user's own config is disabled by name. Copilot has no single "ignore user
config" flag, so that set is enumerated with a cached `copilot mcp list` probe; an
unreadable probe is an error rather than an empty list, so "we couldn't tell" never
silently downgrades the profile.

Both profiles pass `--no-remote-export`. Copilot otherwise publishes the session to
GitHub's web and mobile surfaces, and these transcripts carry cluster data.

**Guards a silent failure mode.** When Radar's MCP server doesn't attach — an org
policy disabling third-party MCP, or a connect failure — Copilot still exits 0 with
empty stderr and the model still answers, having read nothing from the cluster. The
verdict parses cleanly, so the existing `structured()` check would have let it through.
`Diagnosis.mcpErrText` carries that signal and fails the turn before that check: a
well-formed answer is what makes the state dangerous, not what excuses it.

Reasoning-effort validation becomes per-agent (`ai.ReasoningEfforts`): Copilot accepts
`none..max` where Codex accepts `minimal..high`, so one agent's vocabulary can no
longer be handed to another.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

### Kind Cluster

- Init a kind cluster and installed grafana stack using a wrong storage class
- Started the first investigation session with Radar safeguards
- Started the second investigation with my personal configuration

### Remote Cluster

- Deployed AKS Cluster
- Started Radar Local instance
- Same Grafana Stack Scenario but against different cluster

PS: The test was focused on the application behavior, UI behavior, communication with local agent and safeguards preventing the model to skip safeguards and try to run dangerous commands. The investigation produced a similar result compared with a Claude Code Session. 

- [x] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new agent execution path with strong safeguarded containment and MCP-attach validation, but mistakes here could allow false “healthy” verdicts without cluster access or leak investigation data to GitHub export surfaces.
> 
> **Overview**
> Adds **GitHub Copilot CLI** (`copilot`) as a fourth investigations backend, wired through detection, routing, consent, API validation, CLI help text, and the diagnose UI (catalog, safeguards copy, reasoning-effort menus, session hand-off).
> 
> The new **`copilotAgent`** runs headless `copilot -p` with JSON streaming. In **safeguarded** mode it restricts the model to Radar MCP tools (`--available-tools`, `--allow-tool=radar`), redirects **`COPILOT_HOME`** to `~/.radar/copilot-home`, runs in an empty temp cwd, disables built-in MCPs and custom instructions, and always passes **`--no-remote` / `--no-remote-export`** so cluster transcripts are not published to GitHub.
> 
> **MCP attach failures** are treated as turn failures: Copilot can exit 0 with a plausible verdict when Radar’s MCP never connected. **`mcpErrText`** on `Diagnosis` captures that signal and **`DiagnoseStream`** fails the turn before accepting a structured verdict.
> 
> Reasoning effort is now **per-agent** (`ReasoningEfforts` / `SupportsEffort`); the API validates effort against the selected agent (Copilot’s wider `none…max` range vs Codex).
> 
> Agent env scrubbing is centralized in **`minimalEnv` / `filterEnv`** (platform base keys on Windows), reused by Codex, Copilot, and Claude’s scrubbed path.
> 
> Minor dev tweak: `.air.toml` uses `entrypoint` instead of `bin` and drops the default kubeconfig flag from the live-reload command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47b4f852bb5adcc84b5cdc30d0edcce4bff1d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->