### PR TITLE
feat(traffic): dial Hubble Relay directly, port-forward only as fallback

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -132,6 +132,7 @@ func main() {
 	aiHistory := flag.Bool("ai-history", fileCfg.AIHistoryOr(true), "Persist AI investigations (transcripts + verdicts) to ~/.radar/ai-runs.db so they survive restarts")
 	// Traffic/metrics options
 	prometheusURL := flag.String("prometheus-url", fileCfg.PrometheusURL, "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
+	hubbleAddress := flag.String("hubble-address", fileCfg.HubbleAddress, "Manual Hubble Relay gRPC address (host:port, e.g. hubble-relay.kube-system.svc:80; skips discovery and port-forwarding)")
 	// --prometheus-header Key=Value, repeatable. Defaults populated from
 	// config file; any --prometheus-header flag replaces the file value rather
 	// than merging — matches kubectl semantics (file is the default, CLI wins).
@@ -350,6 +351,7 @@ func main() {
 		PrometheusURL:            *prometheusURL,
 		PrometheusHeaders:        resolvedPrometheusHeaders,
 		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),
+		HubbleAddress:            *hubbleAddress,
 		MCPEnabled:               mcpEnabled,
 		AIHistory:                *aiHistory,
 		AIHistoryDBPath:          fileCfg.AIHistoryDBPath,

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -97,6 +97,9 @@ spec:
             {{- range $k, $v := .Values.traffic.prometheusHeadersFromEnv }}
             - {{ printf "--prometheus-header-from-env=%s=%s" $k $v | quote }}
             {{- end }}
+            {{- if .Values.traffic.hubbleAddress }}
+            - --hubble-address={{ .Values.traffic.hubbleAddress }}
+            {{- end }}
             {{- if not .Values.mcp.enabled }}
             - --no-mcp
             {{- end }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -305,6 +305,7 @@
       "additionalProperties": true,
       "properties": {
         "prometheusUrl": { "type": "string" },
+        "hubbleAddress": { "type": "string", "description": "Manual Hubble Relay gRPC address (host:port); skips discovery and port-forwarding." },
         "prometheusHeaders": {
           "type": "object",
           "additionalProperties": { "type": "string" }

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -477,6 +477,14 @@ traffic:
   #           name: prometheus-auth
   #           key: token
   prometheusHeadersFromEnv: {}
+  # Manual Hubble Relay gRPC address (host:port), e.g.
+  # hubble-relay.kube-system.svc:80. When set, Radar dials it directly and
+  # never falls back to port-forwarding. Usually unnecessary: with it unset,
+  # Radar discovers the relay and dials its Service address directly (always
+  # reachable in-cluster), falling back to a port-forward through the API
+  # server only when the Service address is unreachable (which requires
+  # rbac.portForward).
+  hubbleAddress: ""
 
 # Argo CD integration (GitOps deep diff)
 # Provisions the Argo CD API connection declaratively so it survives pod

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -369,6 +369,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
 | `timeline.maxSize` | SQLite max DB + WAL size before oldest events are pruned (`0` disables) | `800Mi` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL | `""` (auto-discover) |
+| `traffic.hubbleAddress` | Manual Hubble Relay gRPC address (host:port) | `""` (discover; direct-dial the Service, port-forward fallback) |
 | `traffic.prometheusHeadersFromEnv` | Prometheus headers sourced from environment variables, for secret-backed auth headers | `{}` |
 | `persistence.enabled` | Enable PVC for SQLite storage | `false` |
 | `persistence.size` | PVC size | `1Gi` |

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -61,6 +62,7 @@ type AppConfig struct {
 	PrometheusURL            string
 	PrometheusHeaders        map[string]string
 	PrometheusHeadersFromEnv map[string]string
+	HubbleAddress            string // manual Hubble Relay gRPC address (host:port); "" = discover + direct-dial/port-forward
 	Version                  string
 	MCPEnabled               bool
 	AIHistory                bool   // persist AI investigations across restarts
@@ -241,6 +243,12 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 	if len(cfg.PrometheusHeaders) > 0 {
 		traffic.SetMetricsHeaders(cfg.PrometheusHeaders)
 		prometheuspkg.SetHeaders(cfg.PrometheusHeaders)
+	}
+	if cfg.HubbleAddress != "" {
+		if _, _, err := net.SplitHostPort(cfg.HubbleAddress); err != nil {
+			log.Fatalf("Invalid --hubble-address %q: must be host:port (e.g., hubble-relay.kube-system.svc:80): %v", cfg.HubbleAddress, err)
+		}
+		traffic.SetHubbleAddress(cfg.HubbleAddress)
 	}
 
 	k8s.RegisterTrafficFuncs(traffic.Reset, func() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	// Stored in plain text in ~/.radar/config.json — protect the file accordingly.
 	PrometheusHeaders        map[string]string `json:"prometheusHeaders,omitempty"`
 	PrometheusHeadersFromEnv map[string]string `json:"prometheusHeadersFromEnv,omitempty"`
+	// HubbleAddress is a manual Hubble Relay gRPC address (host:port). When
+	// set, Radar dials it directly instead of discovering the relay Service and
+	// port-forwarding to it.
+	HubbleAddress string `json:"hubbleAddress,omitempty"`
 	MCP                      *bool             `json:"mcp,omitempty"` // nil = default (true), false = disabled
 	// DebugImage is the image used for ephemeral debug containers and node debug
 	// pods. Empty falls back to busybox:latest; set it to a reachable mirror for

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +30,13 @@ const (
 	hubbleRelayService    = "hubble-relay"
 	hubbleRelayLabel      = "k8s-app=hubble-relay"
 	hubbleRelayCertSecret = "hubble-relay-client-certs"
+
+	// directDialBudget caps the direct pass at the relay's Service address
+	// before falling back to port-forwarding. In-cluster (and on networks that
+	// route Service DNS) the dial succeeds well inside it; off-cluster without
+	// such routing DNS resolution fails fast, so the budget's real job is the
+	// pathological middle ground where the address resolves but blackholes.
+	directDialBudget = 4 * time.Second
 )
 
 // allowedHTTPHeaders is the curated set of safe, useful HTTP headers to extract.
@@ -45,6 +53,7 @@ type HubbleSource struct {
 	grpcConn       *grpc.ClientConn
 	observerClient observerpb.ObserverClient
 	localPort      int    // Port-forward local port
+	directAddr     string // Address of a live direct (non-port-forward) gRPC connection; empty when port-forwarded
 	currentContext string // K8s context for port-forward validation
 	relayNamespace string // Discovered namespace where hubble-relay lives
 	relayPort      int    // Hubble relay container port (for port-forward)
@@ -314,7 +323,13 @@ func (h *HubbleSource) resolveTargetPort(ctx context.Context, svc *corev1.Servic
 	return 80
 }
 
-// Connect establishes connection to Hubble Relay via port-forward and gRPC
+// Connect establishes a connection to Hubble Relay. A manually configured
+// address (--hubble-address) is dialed as-is; otherwise the relay's Service
+// address is dialed directly first — which succeeds when Radar runs in-cluster,
+// and also off-cluster on a network that routes Service DNS (VPN, routed dev
+// cluster) — and only when that fails does it fall back to a port-forward
+// through the API server (the primary off-cluster path). The direct path needs
+// no pods/portforward RBAC.
 func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portforward.ConnectionInfo, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -328,14 +343,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	if h.grpcConn != nil && h.currentContext == contextName {
 		// Test the connection
 		if h.testConnection(ctx) {
-			return &portforward.ConnectionInfo{
-				Connected:   true,
-				LocalPort:   h.localPort,
-				Address:     fmt.Sprintf("localhost:%d", h.localPort),
-				Namespace:   namespace,
-				ServiceName: hubbleRelayService,
-				ContextName: contextName,
-			}, nil
+			return h.connectionInfoLocked(namespace, contextName), nil
 		}
 		// Connection lost, clean up
 		h.closeConnectionLocked()
@@ -347,8 +355,25 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 		h.currentContext = contextName
 	}
 
-	// Get the relay port from detection if not already set
-	if h.relayPort == 0 {
+	// Manual address wins: dial it as-is — no service lookup, no discovery, no
+	// fallback (mirrors --prometheus-url semantics — an explicit endpoint
+	// should fail loudly rather than silently connect somewhere else).
+	if manual := hubbleAddress(); manual != "" {
+		log.Printf("[hubble] Dialing configured address %s (--hubble-address)", manual)
+		if connected, lastErr := h.establishGRPC(ctx, manual, addrPort(manual) == 443); !connected {
+			return &portforward.ConnectionInfo{
+				Connected:   false,
+				Namespace:   namespace,
+				ServiceName: hubbleRelayService,
+				Error:       fmt.Sprintf("Failed to connect to Hubble Relay at %s (--hubble-address): %v", manual, lastErr),
+			}, nil
+		}
+		h.directAddr = manual
+		return h.connectionInfoLocked(namespace, contextName), nil
+	}
+
+	// Get the relay ports from detection if not already set
+	if h.relayPort == 0 || h.servicePort == 0 {
 		relaySvc, err := h.k8sClient.CoreV1().Services(namespace).Get(ctx, hubbleRelayService, metav1.GetOptions{})
 		if err != nil {
 			return &portforward.ConnectionInfo{
@@ -357,9 +382,28 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 			}, nil
 		}
 		h.relayPort = h.resolveTargetPort(ctx, relaySvc)
+		h.servicePort = 80
+		if len(relaySvc.Spec.Ports) > 0 {
+			h.servicePort = int(relaySvc.Spec.Ports[0].Port)
+		}
 	}
 
-	// Start port-forward to Hubble Relay
+	// Direct pass: dial the relay's Service address. This connects immediately
+	// when Radar runs in-cluster, and also off-cluster on a network that routes
+	// Service DNS (VPN, routed dev cluster) — the reachability of the address
+	// decides, not how the kubeconfig was loaded. Off-cluster without such
+	// routing, DNS resolution fails fast and we fall through to port-forwarding.
+	serviceAddr := fmt.Sprintf("%s.%s.svc.cluster.local:%d", hubbleRelayService, namespace, h.servicePort)
+	directCtx, cancelDirect := context.WithTimeout(ctx, directDialBudget)
+	directConnected, directErr := h.establishGRPC(directCtx, serviceAddr, h.servicePort == 443)
+	cancelDirect()
+	if directConnected {
+		h.directAddr = serviceAddr
+		return h.connectionInfoLocked(namespace, contextName), nil
+	}
+	log.Printf("[hubble] Service address %s not reachable directly (%v); falling back to port-forward", serviceAddr, directErr)
+
+	// Fallback: port-forward through the API server (requires pods/portforward RBAC)
 	log.Printf("[hubble] Starting port-forward to %s/%s:%d", namespace, hubbleRelayService, h.relayPort)
 	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, namespace, hubbleRelayService, h.relayPort, contextName)
 	if err != nil {
@@ -375,12 +419,87 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 		return connInfo, nil
 	}
 
-	h.localPort = connInfo.LocalPort
-	grpcAddr := fmt.Sprintf("localhost:%d", h.localPort)
+	// A failed attempt inside establishGRPC resets localPort via
+	// closeConnectionLocked, so restore it once a later attempt succeeds.
+	localPort := connInfo.LocalPort
+	h.localPort = localPort
 
-	// Use service port as heuristic: port 443 suggests TLS, otherwise try plaintext first
-	// This avoids unnecessary latency from failed connection attempts
-	tryTLSFirst := h.servicePort == 443 && h.tlsConfig != nil
+	connected, lastErr := h.establishGRPC(ctx, fmt.Sprintf("localhost:%d", localPort), h.servicePort == 443)
+	if connected {
+		h.localPort = localPort
+		return h.connectionInfoLocked(namespace, contextName), nil
+	}
+
+	// Both attempts failed
+	portforward.Stop(portforward.OwnerTraffic)
+	h.localPort = 0
+	return &portforward.ConnectionInfo{
+		Connected: false,
+		Error:     fmt.Sprintf("Failed to connect to Hubble Relay: %v", lastErr),
+	}, nil
+}
+
+// connectionInfoLocked builds the ConnectionInfo for the current live
+// connection. Caller must hold the lock.
+func (h *HubbleSource) connectionInfoLocked(namespace, contextName string) *portforward.ConnectionInfo {
+	info := &portforward.ConnectionInfo{
+		Connected:   true,
+		Namespace:   namespace,
+		ServiceName: hubbleRelayService,
+		ContextName: contextName,
+	}
+	if h.directAddr != "" {
+		info.Address = h.directAddr
+	} else {
+		info.LocalPort = h.localPort
+		info.Address = fmt.Sprintf("localhost:%d", h.localPort)
+	}
+	return info
+}
+
+// DirectConnectionInfo returns live connection info when this source holds a
+// direct (non-port-forward) connection, nil otherwise. Direct connections
+// never appear in the port-forward registry, so the manager consults this
+// before falling back to the registry.
+func (h *HubbleSource) DirectConnectionInfo() *portforward.ConnectionInfo {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if !h.isConnected || h.directAddr == "" {
+		return nil
+	}
+	namespace := h.relayNamespace
+	if namespace == "" {
+		namespace = "kube-system"
+	}
+	return &portforward.ConnectionInfo{
+		Connected:   true,
+		Address:     h.directAddr,
+		Namespace:   namespace,
+		ServiceName: hubbleRelayService,
+		ContextName: h.currentContext,
+	}
+}
+
+// addrPort returns the numeric port of a host:port address, 0 if unparseable.
+func addrPort(addr string) int {
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0
+	}
+	return port
+}
+
+// establishGRPC dials grpcAddr, trying plaintext and TLS in the order the
+// tlsHint suggests (true = the endpoint looks TLS-terminated, e.g. Service
+// port 443 — avoids unnecessary latency from failed connection attempts), and
+// installs the connection on success. Caller must hold the lock. Returns
+// whether a connection passed the test, plus the last attempt's error.
+func (h *HubbleSource) establishGRPC(ctx context.Context, grpcAddr string, tlsHint bool) (bool, error) {
+	tryTLSFirst := tlsHint && h.tlsConfig != nil
 
 	var conn *grpc.ClientConn
 	var lastErr error
@@ -466,32 +585,14 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 		return false
 	}
 
-	// Try connections in order based on service port heuristic
+	// Try connections in order based on the TLS hint
 	var connected bool
 	if tryTLSFirst {
 		connected = tryTLS() || tryPlaintext()
 	} else {
 		connected = tryPlaintext() || tryTLS()
 	}
-
-	if connected {
-		return &portforward.ConnectionInfo{
-			Connected:   true,
-			LocalPort:   h.localPort,
-			Address:     grpcAddr,
-			Namespace:   namespace,
-			ServiceName: hubbleRelayService,
-			ContextName: contextName,
-		}, nil
-	}
-
-	// Both attempts failed
-	portforward.Stop(portforward.OwnerTraffic)
-	h.localPort = 0
-	return &portforward.ConnectionInfo{
-		Connected: false,
-		Error:     fmt.Sprintf("Failed to connect to Hubble Relay: %v", lastErr),
-	}, nil
+	return connected, lastErr
 }
 
 // testConnection tests the gRPC connection by calling ServerStatus
@@ -520,6 +621,7 @@ func (h *HubbleSource) closeConnectionLocked() {
 	h.observerClient = nil
 	h.isConnected = false
 	h.localPort = 0
+	h.directAddr = ""
 }
 
 // GetFlows retrieves flows from Hubble via gRPC

--- a/internal/traffic/hubble_direct_test.go
+++ b/internal/traffic/hubble_direct_test.go
@@ -1,0 +1,105 @@
+package traffic
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// stubObserver is a minimal Hubble Relay stand-in: just enough Observer
+// surface for Connect's ServerStatus connection test to pass.
+type stubObserver struct {
+	observerpb.UnimplementedObserverServer
+}
+
+func (s *stubObserver) ServerStatus(ctx context.Context, _ *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
+	return &observerpb.ServerStatusResponse{}, nil
+}
+
+func startStubRelay(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	observerpb.RegisterObserverServer(srv, &stubObserver{})
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// A manual --hubble-address is dialed as-is: no Service lookup (the fake
+// clientset holds no hubble-relay Service), no port-forward (no port-forward
+// clients are registered), and the source reports the direct connection
+// itself since it never appears in the port-forward registry.
+func TestConnectManualHubbleAddress(t *testing.T) {
+	addr := startStubRelay(t)
+
+	SetHubbleAddress(addr)
+	t.Cleanup(func() { SetHubbleAddress("") })
+
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	info, err := h.Connect(context.Background(), "test-context")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !info.Connected {
+		t.Fatalf("expected connected, got error: %s", info.Error)
+	}
+	if info.Address != addr {
+		t.Errorf("Address = %q, want %q", info.Address, addr)
+	}
+	if info.LocalPort != 0 {
+		t.Errorf("LocalPort = %d, want 0 for a direct connection", info.LocalPort)
+	}
+
+	di := h.DirectConnectionInfo()
+	if di == nil || !di.Connected || di.Address != addr {
+		t.Fatalf("DirectConnectionInfo = %+v, want connected at %q", di, addr)
+	}
+
+	// Reconnecting while healthy reuses the live connection.
+	info2, err := h.Connect(context.Background(), "test-context")
+	if err != nil || !info2.Connected || info2.Address != addr {
+		t.Fatalf("reconnect: info=%+v err=%v", info2, err)
+	}
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if h.DirectConnectionInfo() != nil {
+		t.Error("DirectConnectionInfo should be nil after Close")
+	}
+}
+
+// An unreachable manual address fails loudly instead of falling back to
+// discovery or port-forwarding.
+func TestConnectManualHubbleAddressUnreachable(t *testing.T) {
+	// Reserve a port and close the listener so the dial is refused fast.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := lis.Addr().String()
+	lis.Close()
+
+	SetHubbleAddress(addr)
+	t.Cleanup(func() { SetHubbleAddress("") })
+
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	info, err := h.Connect(context.Background(), "test-context")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if info.Connected {
+		t.Fatal("expected connection failure for unreachable manual address")
+	}
+	if info.Error == "" {
+		t.Error("expected a populated Error for the failed manual dial")
+	}
+}

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -74,6 +74,29 @@ func metricsConfig() (string, map[string]string) {
 	return configuredMetricsURL, configuredMetricsHeaders
 }
 
+var (
+	hubbleAddrMu sync.RWMutex
+	// configuredHubbleAddr is the user-provided --hubble-address flag value
+	// (host:port). Stored at package level so it persists across context-switch
+	// resets, like the metrics config above.
+	configuredHubbleAddr string
+)
+
+// SetHubbleAddress sets a manual Hubble Relay gRPC address (host:port),
+// bypassing discovery and port-forwarding.
+func SetHubbleAddress(addr string) {
+	hubbleAddrMu.Lock()
+	defer hubbleAddrMu.Unlock()
+	configuredHubbleAddr = addr
+}
+
+// hubbleAddress returns the configured Hubble Relay address under the read lock.
+func hubbleAddress() string {
+	hubbleAddrMu.RLock()
+	defer hubbleAddrMu.RUnlock()
+	return configuredHubbleAddr
+}
+
 // Initialize sets up the traffic manager with the given K8s client
 func Initialize(client kubernetes.Interface) error {
 	return InitializeWithConfig(client, nil, "")
@@ -548,13 +571,23 @@ func (m *Manager) Connect(ctx context.Context) (*portforward.ConnectionInfo, err
 	}
 }
 
-// GetConnectionInfo returns live traffic connection status — traffic's own
-// metrics forward, read from the live registry so a forward that has since been
-// stopped isn't reported as connected. It deliberately does NOT report another
-// owner's forward: traffic's data path always uses its own (Caretta/Hubble bring
-// one up), so a Prometheus forward for the same context means Prometheus is
-// connected, not traffic.
+// GetConnectionInfo returns live traffic connection status — a direct Hubble
+// connection when one is up, otherwise traffic's own metrics forward, read from
+// the live registry so a forward that has since been stopped isn't reported as
+// connected. It deliberately does NOT report another owner's forward: traffic's
+// data path always uses its own (Caretta/Hubble bring one up), so a Prometheus
+// forward for the same context means Prometheus is connected, not traffic.
 func (m *Manager) GetConnectionInfo() *portforward.ConnectionInfo {
+	// A direct (non-port-forward) Hubble connection never registers a forward —
+	// ask the source before reading the registry.
+	m.mu.RLock()
+	hubble, _ := m.sources["hubble"].(*HubbleSource)
+	m.mu.RUnlock()
+	if hubble != nil {
+		if info := hubble.DirectConnectionInfo(); info != nil {
+			return info
+		}
+	}
 	return portforward.GetConnectionInfo(portforward.OwnerTraffic)
 }
 


### PR DESCRIPTION
## Description

The Hubble traffic source always connects to hubble-relay through the K8s pods/portforward API, even when Radar runs in-cluster where the relay's Service address is directly reachable. That silently makes traffic visibility depend on the `rbac.portForward` chart flag (default `false`) — an in-cluster install with default RBAC detects Hubble but can never connect — and routes every flow through an extra apiserver round-trip.

This PR makes `HubbleSource.Connect` dial `hubble-relay.<ns>.svc.cluster.local:<servicePort>` directly first, falling back to the existing port-forward path only when the direct dial fails (the primary off-cluster case). It mirrors the Prometheus client's direct-probe-then-port-forward pattern: the reachability of the address decides, not how the kubeconfig was loaded. The direct path needs no `pods/portforward` RBAC, and it also removes the port-forward stream setup race that could fail the first connect with "TLS gRPC connection test failed" until a retry.

It also adds a manual override, mirroring `--prometheus-url` semantics: `--hubble-address` (chart: `traffic.hubbleAddress`, config file: `hubbleAddress`) takes a `host:port` that is dialed as-is — no discovery, no fallback — for relays behind nonstandard Service names or reachable only via a specific endpoint.

Since direct connections never appear in the port-forward registry, `Manager.GetConnectionInfo` now consults the Hubble source first; otherwise `GET /api/traffic/connection` would report disconnected while flows stream. The existing plaintext/TLS attempt ladder (including TLS ServerName discovery) is extracted into `establishGRPC` and reused unchanged by all three paths.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [x] Added/updated unit tests

Remote cluster: k3s v1.34.3, Cilium 1.20 with Hubble Relay (plaintext, Service port 80), Radar deployed in-cluster from this branch's image with `rbac.portForward: false` — ClusterRole contains zero `pods/portforward` rules. `POST /api/traffic/connect` returns `address: hubble-relay.kube-system.svc.cluster.local:80`, `GET /api/traffic/connection` reports the direct connection, and flows stream (`Retrieved 6000 flows`). Reverting to the released 1.10.0 image on the same cluster reproduces the old behavior (port-forward, `localhost:<port>`), confirming the delta.

Unit tests (`internal/traffic/hubble_direct_test.go`): manual-address connect against an in-process gRPC Observer stub — dialed as-is with no Service object and no port-forward clients registered, reported via `DirectConnectionInfo`, cleaned up on `Close`; and an unreachable manual address fails loudly with a populated error instead of falling back. `go test ./internal/traffic/ ./internal/config/ ./internal/app/ ./internal/server/ ./internal/portforward/` and `go vet ./...` pass; `helm lint` passes and `helm template --set traffic.hubbleAddress=...` renders the flag.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Hubble connect path and traffic connection reporting; behavior is well-tested but affects observability connectivity in production clusters with Cilium/Hubble.
> 
> **Overview**
> **Hubble traffic** no longer always uses `pods/portforward`. `HubbleSource.Connect` tries the relay Service DNS (`hubble-relay.<ns>.svc.cluster.local`) first (4s budget), then falls back to the existing API-server port-forward path. In-cluster installs with default `rbac.portForward: false` can connect without port-forward RBAC.
> 
> Adds **`--hubble-address`** / config `hubbleAddress` / Helm `traffic.hubbleAddress` (Prometheus-URL style): dial that `host:port` only, no discovery or fallback; startup validates with `net.SplitHostPort`. gRPC plaintext/TLS logic is refactored into **`establishGRPC`**; direct connections are tracked via **`directAddr`** and **`DirectConnectionInfo`**, and **`Manager.GetConnectionInfo`** consults the Hubble source so `/api/traffic/connection` stays accurate when flows are streaming.
> 
> Docs, Helm schema/values, and unit tests in `hubble_direct_test.go` cover manual address success and unreachable failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7abbd4ee5588ac48725ef7d3fc5eb9d11d25fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->