### PR TITLE
feat(cloud-funnel): rework the Cloud modal: short pitch, both lanes visible, honest trust row

### DIFF
--- a/internal/cloudinstall/recovery.go
+++ b/internal/cloudinstall/recovery.go
@@ -159,7 +159,7 @@ func TunnelConfirmationGuidance(err error, clusterID, cloudURL, clusterURL strin
 	case errors.Is(err, cloud.ErrConnectConsumptionTimeout):
 		reason = "the five-minute confirmation window elapsed"
 	case errors.Is(err, cloud.ErrConnectPickupExpired):
-		reason = "the Hub stopped reporting the approved request before the agent connected"
+		reason = "the Hub stopped reporting the approved request before the in-cluster Radar connected"
 	case errors.Is(err, context.Canceled):
 		reason = "confirmation was canceled"
 	}
@@ -167,7 +167,7 @@ func TunnelConfirmationGuidance(err error, clusterID, cloudURL, clusterURL strin
 	return RecoveryGuidance{
 		Summary: fmt.Sprintf("Radar was provisioned and Hub cluster %q already exists, but its tunnel could not be confirmed: %s.", clusterID, reason),
 		Lines: []string{
-			"Do not rerun the installer or delete the cluster by default; the existing agent can still connect after you resolve its startup or egress issue.",
+			"Do not rerun the installer or delete the cluster by default; the installed Radar can still connect after you resolve its startup or egress issue.",
 			fmt.Sprintf("Verify cluster DNS and outbound WSS/HTTPS access to %s.", cloudURL),
 			"Keep using this Hub cluster and token Secret for recovery. Only if you deliberately abandon the installation should you clean up Helm and the Secret, then delete the Hub cluster before starting a fresh flow.",
 		},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1795,6 +1795,11 @@ export const cloudInstallActive = (state: CloudInstallState | undefined): boolea
 export interface CloudConnectInfo {
   assurances?: string[]
   notice?: string
+  // Free-tier terms as a prose fragment completing "Radar Cloud is ___."
+  // (e.g. "free for 3 clusters"). Separate from assurances: chip copy and
+  // sentence copy have different grammar, and reusing one as the other breaks
+  // whenever either is reworded.
+  freeTier?: string
 }
 
 // Deliberately a bare cross-origin GET: no credentials, no identifiers, no

--- a/web/src/components/CloudConnectFlow.tsx
+++ b/web/src/components/CloudConnectFlow.tsx
@@ -469,8 +469,8 @@ function ConnectedCard({
         </h4>
       </div>
       <p className="text-[12.5px] leading-relaxed text-theme-text-secondary mb-4">
-        The in-cluster agent is live and tunneled. This local app keeps working exactly as before, and the
-        cluster is now also reachable for your team at one URL.
+        The in-cluster agent is live and tunneled. Radar keeps working here, and the cluster is now also
+        reachable for your team at one URL.
       </p>
       <div className="flex items-center gap-4 mb-4">
         <a

--- a/web/src/components/CloudConnectFlow.tsx
+++ b/web/src/components/CloudConnectFlow.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { AlertTriangle, ArrowUpRight, Check, ExternalLink, GitBranch, Info, Loader2, ShieldAlert, X } from 'lucide-react'
+import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
 import {
   ApiError,
   cancelCloudInstall,
@@ -143,6 +144,7 @@ function PlanCard({
   const [acceptAdoption, setAcceptAdoption] = useState(false)
   const [ackUncertainty, setAckUncertainty] = useState(false)
   const [ackShared, setAckShared] = useState(false)
+  const [notesOpen, setNotesOpen] = useState(false)
 
   // The approval tab is opened synchronously by the click below (popup
   // blockers reject window.open from an async callback) and navigated once the
@@ -236,19 +238,27 @@ function PlanCard({
           their presence visible so nobody approves blind, but don't let the
           wall of text bury the decision. */}
       {plan.advisories && plan.advisories.length > 0 && (
-        <details className="mt-2.5">
-          <summary className="flex items-center gap-1.5 cursor-pointer select-none text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors">
+        <div className="mt-2.5">
+          <button
+            type="button"
+            onClick={() => setNotesOpen((v) => !v)}
+            aria-expanded={notesOpen}
+            className="flex items-center gap-1.5 text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+          >
+            <CollapseChevron open={notesOpen} className="w-3.5 h-3.5" />
             <Info className="w-3.5 h-3.5 shrink-0" />
             {plan.advisories.length === 1 ? '1 preflight note' : `${plan.advisories.length} preflight notes`}
-          </summary>
-          <ul className="mt-1.5 space-y-1.5 pl-5">
-            {plan.advisories.map((note) => (
-              <li key={note} className="text-[11.5px] leading-snug text-theme-text-tertiary">
-                {note}
-              </li>
-            ))}
-          </ul>
-        </details>
+          </button>
+          <Collapse open={notesOpen}>
+            <ul className="mt-1.5 space-y-1.5 pl-5">
+              {plan.advisories.map((note) => (
+                <li key={note} className="text-[11.5px] leading-snug text-theme-text-tertiary">
+                  {note}
+                </li>
+              ))}
+            </ul>
+          </Collapse>
+        </div>
       )}
 
       <label className="mt-3.5 block">
@@ -313,7 +323,8 @@ function PlanCard({
        *  read correctly for a returning operator and a first-time one alike. */}
       <p className="mt-2.5 text-[11px] text-theme-text-tertiary">
         Nothing is installed yet. You'll approve this cluster in the browser, creating your account and
-        organization first if you don't have one. Then Radar installs the agent.
+        organization first if you don't have one.{' '}
+        {adopt ? 'Then your existing Radar is upgraded and connected.' : 'Then Radar is installed in your cluster.'}
       </p>
     </div>
   )
@@ -391,7 +402,7 @@ function ProgressCard({ status, onStatus }: { status: CloudInstallStatus; onStat
   const steps: Array<{ label: string; state: 'done' | 'active' | 'todo' }> = [
     { label: 'Approved in browser', state: 'done' },
     { label: `Installing Radar (namespace ${status.plan?.namespace ?? 'radar'})`, state: provisioning ? 'active' : 'done' },
-    { label: 'Waiting for the agent to connect', state: provisioning ? 'todo' : 'active' },
+    { label: 'Waiting for Radar to connect to Cloud', state: provisioning ? 'todo' : 'active' },
   ]
   return (
     <div className="px-8 pt-6 pb-5">
@@ -469,8 +480,8 @@ function ConnectedCard({
         </h4>
       </div>
       <p className="text-[12.5px] leading-relaxed text-theme-text-secondary mb-4">
-        The in-cluster agent is live and tunneled. Radar keeps working here, and the cluster is now also
-        reachable for your team at one URL.
+        Radar is live in the cluster and connected to Radar Cloud. The Radar you're running keeps working,
+        and the cluster is now also reachable for your team at one URL.
       </p>
       <div className="flex items-center gap-4 mb-4">
         <a
@@ -592,14 +603,23 @@ function GuidanceBlock({
 }
 
 function GuidanceDetails({ title, guidance }: { title: string; guidance: CloudInstallRecoveryGuidance }) {
+  const [open, setOpen] = useState(false)
   return (
-    <details className="group">
-      <summary className="cursor-pointer text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors select-none">
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+      >
+        <CollapseChevron open={open} className="w-3.5 h-3.5" />
         {title}
-      </summary>
-      <div className="mt-2">
-        <GuidanceBlock guidance={guidance} />
-      </div>
-    </details>
+      </button>
+      <Collapse open={open}>
+        <div className="mt-2">
+          <GuidanceBlock guidance={guidance} />
+        </div>
+      </Collapse>
+    </div>
   )
 }

--- a/web/src/components/CloudConnectFlow.tsx
+++ b/web/src/components/CloudConnectFlow.tsx
@@ -40,7 +40,7 @@ export function CloudConnectFlow({
         <div className="px-8 py-10 flex flex-col items-center gap-3 text-center">
           <Loader2 className="w-5 h-5 animate-spin text-emerald-600 dark:text-emerald-400" />
           <p className="text-[13px] text-theme-text-secondary">
-            Checking this cluster and preparing the install — this can take a moment on a slow link.
+            Checking this cluster and preparing the install. This can take a moment on a slow link.
           </p>
         </div>
       )
@@ -312,7 +312,7 @@ function PlanCard({
        *  so this cannot assert whether an account already exists. Phrased to
        *  read correctly for a returning operator and a first-time one alike. */}
       <p className="mt-2.5 text-[11px] text-theme-text-tertiary">
-        Nothing is installed yet — you'll approve this cluster in the browser, creating your account and
+        Nothing is installed yet. You'll approve this cluster in the browser, creating your account and
         organization first if you don't have one. Then Radar installs the agent.
       </p>
     </div>
@@ -365,7 +365,7 @@ function ApprovalCard({ status, onStatus }: { status: CloudInstallStatus; onStat
       </div>
       <p className="text-[12.5px] leading-relaxed text-theme-text-secondary mb-3.5">
         Approve connecting <b className="text-theme-text-primary">{status.clusterName}</b> in the browser tab.
-        Sign-in and org setup happen there too — this screen advances automatically.
+        Sign-in and org setup happen there too, and this screen advances automatically.
       </p>
       {status.connectUrl && (
         <div className="card-inner flex items-center gap-2">
@@ -419,7 +419,7 @@ function ProgressCard({ status, onStatus }: { status: CloudInstallStatus; onStat
       <div className="mt-4">
         {provisioning ? (
           <p className="text-[11px] text-theme-text-tertiary">
-            Installing — this step completes atomically and can’t be canceled midway.
+            Installing. This step completes atomically and can’t be canceled midway.
           </p>
         ) : (
           cancel
@@ -469,7 +469,7 @@ function ConnectedCard({
         </h4>
       </div>
       <p className="text-[12.5px] leading-relaxed text-theme-text-secondary mb-4">
-        The in-cluster agent is live and tunneled. This local app keeps working exactly as before — the
+        The in-cluster agent is live and tunneled. This local app keeps working exactly as before, and the
         cluster is now also reachable for your team at one URL.
       </p>
       <div className="flex items-center gap-4 mb-4">

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -17,6 +17,7 @@ import {
   useCloudConnectInfo,
   useCloudConnectSelf,
   useCloudInstallStatus,
+  useClusterInfo,
 } from '../api/client'
 
 // OSS → Cloud funnel: a quiet globe button in the top bar that opens a modal
@@ -34,12 +35,21 @@ const FALLBACK_APP_URL = 'https://app.radarhq.io'
 // copy as the fallback means an unreachable Hub, a self-hosted one, or an
 // offline laptop all render exactly what Radar rendered before this fetch
 // existed — the dialog never waits on the network and never shows a gap.
-const DEFAULT_ASSURANCES = ['Free for 3 clusters', 'No credit card', 'Your cluster data stays in your cluster']
-// A product fact, not funnel copy — appended even when the Hub supplies its
-// own assurances (deduped if the Hub starts sending it).
-const SOC2_ASSURANCE = 'SOC 2 compliant'
+// Ordered by what matters most when deciding to connect a cluster: network
+// posture, then reversibility, then attestation, then billing. Deliberately
+// no data-locality claim — retention and alerts work because cluster data
+// flows out through the relay, so the list describes the connection model
+// instead. The SOC 2 line comes from the Hub's live list, which owns its
+// wording; here it is only the offline fallback.
+const DEFAULT_ASSURANCES = [
+  'Secure outbound-only tunnel',
+  'Disconnect and delete your data anytime',
+  'SOC 2 Type II',
+  '3 clusters free, no card required',
+]
 const SIGNUP_QUERY = '?utm_source=radar-oss&utm_medium=app&utm_campaign=cloud-modal'
 const ABOUT_URL = 'https://radarhq.io/about'
+const PRICING_URL = 'https://radarhq.io/pricing'
 const SELF_HOSTED_DOCS_URL = 'https://radarhq.io/docs/cloud/self-hosted/'
 const SEEN_KEY = 'radar.cloudFunnel.seen'
 
@@ -69,9 +79,11 @@ export function CloudFunnelButton() {
   const [seen, setSeen] = useState(readSeen)
   const [inFlowView, setInFlowView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
-  // Set once an in-app attempt has actually failed, so the pitch offers the
-  // browser wizard alongside a retry. Deliberately survives closing the modal:
-  // whatever broke is a property of this cluster, not of the dialog session.
+  // Set once an in-app attempt has actually failed, so the CTA reads "Try
+  // again" instead of implying a first attempt. Survives closing the modal
+  // (the failure belongs to the cluster, not the dialog session) but not a
+  // reload, and is reset below when the kubeconfig context changes — it must
+  // never describe a cluster the user has switched away from.
   const [prepareFailed, setPrepareFailed] = useState(false)
 
   const capabilities = useCapabilities()
@@ -123,8 +135,7 @@ export function CloudFunnelButton() {
       // Anything else failed before a flow existed. Return to the pitch rather
       // than leaving the flow view armed, where a later status change would
       // pull the user into a screen they did not ask for.
-      setPrepareFailed(true)
-      exitFlow()
+      exitFlow(true)
       showApiError('Could not inspect this cluster for Cloud connect', err instanceof Error ? err.message : undefined)
     },
     // No meta.errorMessage: the global handler cannot tell a single-flight 409
@@ -147,9 +158,9 @@ export function CloudFunnelButton() {
     prepare.mutate()
   }
 
-  // A flow that ended in failure leaves the pitch as the only surface left, so
-  // the pitch has to carry the browser alternative. The caller passes the
-  // outcome because dismissing already overwrote the status by this point.
+  // A flow that ended in failure returns to a pitch whose CTA must not read
+  // like a first attempt. The caller passes the outcome because dismissing
+  // already overwrote the status by this point.
   const exitFlow = (failed = false) => {
     if (failed) setPrepareFailed(true)
     setInFlowView(false)
@@ -161,6 +172,15 @@ export function CloudFunnelButton() {
   useEffect(() => {
     if (open && lane === 'driver' && flowLive) setInFlowView(true)
   }, [open, lane, flowLive])
+
+  // prepareFailed outlives the dialog but must not outlive the cluster it
+  // describes: a context switch swaps every query cache, yet this component
+  // stays mounted, so without the reset cluster A's failure would relabel the
+  // CTA for cluster B.
+  const contextName = useClusterInfo().data?.context
+  useEffect(() => {
+    setPrepareFailed(false)
+  }, [contextName])
 
   // The server owns the "nothing to pitch" decision: an already-tunneled
   // deployment gets no cloudConnect capability at all. Waiting for
@@ -236,12 +256,14 @@ export function CloudFunnelButton() {
         ) : (
           <>
             <div className="min-h-0 overflow-y-auto">
-              <PitchBody lane={lane} />
+              <PitchBody lane={lane} freeTier={connectInfo.data?.freeTier} />
             </div>
             <ModalFooter
               lane={lane}
               signupUrl={signupUrl}
-              driverEscapeUrl={signupUrlFor('driver-escape')}
+              // driver-escape after a failed attempt, driver-alt before one, so
+              // the Hub can tell "prefers the browser" from "app path broke".
+              driverEscapeUrl={signupUrlFor(prepareFailed ? 'driver-escape' : 'driver-alt')}
               prepareFailed={prepareFailed}
               assurances={connectInfo.data?.assurances}
               notice={connectInfo.data?.notice}
@@ -260,12 +282,10 @@ export function CloudFunnelButton() {
   )
 }
 
+// The Hub's list renders verbatim — no client-side additions, so the Hub owns
+// the wording and can update it without a binary release.
 function assuranceItems(fromHub?: string[]): string[] {
-  const items = fromHub?.length ? fromHub : DEFAULT_ASSURANCES
-  if (items.some((item) => item.toLowerCase().includes('soc 2'))) return items
-  // Second to last: the closer ("data stays in your cluster") is the longest
-  // line, and trailing it keeps the short chips together on the first row.
-  return [...items.slice(0, -1), SOC2_ASSURANCE, items[items.length - 1]]
+  return fromHub?.length ? fromHub : DEFAULT_ASSURANCES
 }
 
 function RadarSweep() {
@@ -307,8 +327,8 @@ function ModalFooter({
 }: {
   lane: 'driver' | 'wizard'
   signupUrl: string
-  // Same destination as signupUrl, distinct utm_content so the Hub can tell an
-  // escape from a broken in-app attempt apart from a plain pitch CTA click.
+  // Same destination as signupUrl, distinct utm_content: the caller encodes
+  // whether this render follows a failed in-app attempt.
   driverEscapeUrl: string
   prepareFailed: boolean
   // Live copy from the Hub; undefined until (or unless) it arrives.
@@ -381,18 +401,21 @@ function ModalFooter({
               onClick={onConnect}
               className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
             >
-              {prepareFailed ? 'Try again' : 'Connect this cluster'}
+              {/* Trailing ellipsis: further input follows the click — the
+                  inspect step and a plan the user approves in the browser. */}
+              {prepareFailed ? 'Try again' : 'Connect this cluster…'}
             </button>
-            {prepareFailed && (
-              <a
-                href={driverEscapeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="whitespace-nowrap text-[13px] text-theme-text-secondary hover:text-theme-text-primary underline underline-offset-2 transition-colors"
-              >
-                or set up in the browser
-              </a>
-            )}
+            {/* Always visible: the browser wizard is a different workflow, not
+                a recovery path — install-averse operators need the door before
+                anything fails, or they close the modal instead. */}
+            <a
+              href={driverEscapeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="whitespace-nowrap text-[12.5px] text-theme-text-secondary hover:text-theme-text-primary hover:underline underline-offset-2 transition-colors"
+            >
+              or set up in the browser
+            </a>
           </>
         ) : cliOnly ? null : (
           <a
@@ -406,13 +429,25 @@ function ModalFooter({
             {self?.ownership === 'helm' || gitops ? 'Connect this cluster' : 'Try Cloud free'}
           </a>
         )}
-        <button onClick={onLater} className="whitespace-nowrap text-[13px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors">
+        <button onClick={onLater} className="ml-auto whitespace-nowrap text-[12px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors">
           Maybe later
         </button>
       </div>
-      <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1.5 text-[11.5px] text-theme-text-tertiary">
+      {/* Mechanics, not marketing: a falsifiable claim the plan card then
+          fulfills. Sits next to the button whose click it de-risks. */}
+      {lane === 'driver' && (
+        <p className="mt-2.5 text-[11px] leading-relaxed text-theme-text-tertiary">
+          Nothing installs on click. Radar inspects the cluster and shows you a plan; you approve it in
+          the browser before anything changes.
+        </p>
+      )}
+      {/* A 2-column grid, not flex-wrap: the long data-locality chip cannot
+          share a single row with the other three at this width, and flex
+          wrapping strands it as a 3+1 orphan. Two balanced columns read as a
+          designed layout at any chip length the Hub sends. */}
+      <div className="mt-4 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px] text-theme-text-tertiary">
         {assuranceItems(assurances).map((item) => (
-          <span key={item} className="flex items-center gap-1.5">
+          <span key={item} className="flex items-center gap-1">
             <Check className="w-3 h-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
             {item}
           </span>
@@ -423,15 +458,20 @@ function ModalFooter({
 }
 
 // The detail sits behind a disclosure so the first screen stays short.
-function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
+function PitchBody({ lane, freeTier }: { lane: 'driver' | 'wizard'; freeTier?: string }) {
   const [moreOpen, setMoreOpen] = useState(false)
   const moreId = useId()
+  // Hub-served prose fragment; the compiled fallback carries the same
+  // staleness trade as DEFAULT_ASSURANCES (rendered only when the Hub is
+  // unreachable or predates the field).
+  const freeLine = freeTier || 'free for 3 clusters'
+  // lead is the scannable anchor (medium, primary); rest stays secondary.
   const highlights = [
-    { icon: Globe, text: 'Your whole fleet in one URL: issues, checks and search across every cluster' },
-    { icon: Users, text: "Bring the team: SSO, invites and roles. Your cluster's RBAC has the final say" },
-    { icon: Bell, text: 'Alerts that reach you the moment something breaks' },
-    { icon: History, text: 'Long-term retention: history that survives restarts and keeps growing' },
-    { icon: Sparkles, text: 'An AI agent that digs into issues and pinpoints the root cause' },
+    { icon: Globe, lead: 'Your whole fleet in one URL', rest: ': issues, checks and search across every cluster' },
+    { icon: Users, lead: 'Bring the team', rest: ": SSO, invites and roles. Your cluster's RBAC has the final say" },
+    { icon: Bell, lead: 'Alerts', rest: ' that reach you the moment something breaks' },
+    { icon: History, lead: 'Long-term retention', rest: ': history that survives restarts and keeps growing' },
+    { icon: Sparkles, lead: 'An AI agent', rest: ' that digs into issues and pinpoints the root cause' },
   ]
   return (
     <div className="px-8 pt-7 pb-2">
@@ -439,17 +479,20 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
       <h3 className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3">
         Meet Radar Cloud
       </h3>
-      <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
-        The hosted side of Radar: your clusters in one place, run by us.{' '}
-        <b className="text-theme-text-primary font-semibold">
-          The Radar you're running stays free and open source, always.
-        </b>
+      <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-6">
+        The hosted side of Radar: your clusters in one place, run by us.
+        <br />
+        The Radar you're running{' '}
+        <b className="text-theme-text-primary font-semibold">stays free and open source, always.</b>
       </p>
       <ul className="space-y-2.5 mb-4">
-        {highlights.map(({ icon: Icon, text }) => (
-          <li key={text} className="flex items-start gap-2.5 text-[13px] leading-relaxed text-theme-text-secondary">
+        {highlights.map(({ icon: Icon, lead, rest }) => (
+          <li key={lead} className="flex items-start gap-2.5 text-[13px] leading-relaxed text-theme-text-secondary">
             <Icon className="w-4 h-4 shrink-0 mt-[3px] text-emerald-600 dark:text-emerald-400" />
-            {text}
+            <span>
+              <span className="font-medium text-theme-text-primary">{lead}</span>
+              {rest}
+            </span>
           </li>
         ))}
       </ul>
@@ -460,10 +503,10 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
         onClick={() => setMoreOpen((v) => !v)}
         aria-expanded={moreOpen}
         aria-controls={moreId}
-        className="flex items-center gap-1.5 mb-3 text-[12.5px] text-theme-text-secondary underline underline-offset-2 decoration-theme-border hover:text-theme-text-primary transition-colors"
+        className="flex items-center gap-1.5 mt-5 mb-3 text-[12.5px] text-theme-text-secondary underline underline-offset-2 decoration-theme-border hover:text-theme-text-primary transition-colors"
       >
         <CollapseChevron open={moreOpen} className="w-3.5 h-3.5" />
-        How it works
+        How it works and what it costs
       </button>
       <Collapse open={moreOpen}>
         <div id={moreId} className="pt-1 pb-3 pl-[18px] space-y-3.5">
@@ -471,22 +514,26 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
             {/* No heading: the disclosure's own label already names this one. */}
             <p className="text-[12px] leading-relaxed text-theme-text-secondary">
               {lane === 'driver'
-                ? 'Setup runs here in the app: Radar installs a small agent that connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'
-                : 'A small agent in your cluster connects outward to Radar Cloud. You approve the connection before anything is installed.'}
+                ? 'Setup runs here in the app: Radar is installed in your cluster and connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'
+                : 'Radar runs in your cluster and connects outward to Radar Cloud. You approve the connection before anything is installed.'}
             </p>
           </section>
           <section>
             <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">What it costs</h4>
             <p className="text-[12px] leading-relaxed text-theme-text-secondary">
-              There's a free tier. The paid plans above it are what keep the lights on. The Radar you're
-              running stays Apache&nbsp;2.0 either way: every feature, forever.
+              Radar Cloud is {freeLine}. The paid plans beyond that are what keep the lights on. The
+              Radar you're running stays
+              Apache&nbsp;2.0 either way: every feature, forever.{' '}
+              <a href={PRICING_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
+                See pricing →
+              </a>
             </p>
           </section>
           <section>
             <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">Who's behind it</h4>
             <p className="text-[12px] leading-relaxed text-theme-text-secondary">
-              Radar is built in the open by many hands, and overseen by a small team of humans, the kind
-              you can actually talk to.{' '}
+              Radar is built in the open and run by Skyhook, a CNCF Silver member and a small team of
+              humans, the kind you can actually talk to.{' '}
               <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
                 Meet us →
               </a>
@@ -502,8 +549,9 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
         </div>
       </Collapse>
       <div className="mb-5 border-l-2 border-emerald-500/40 pl-3.5">
-        <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-          Just you and one cluster? Stay right here. What you're already running is the product, not a demo.
+        <p className="text-[12px] leading-relaxed text-theme-text-secondary">
+          Don't need Radar Cloud right now? That's fine. What you're running is already a full product,
+          not a demo. We're here if you ever do.
         </p>
       </div>
     </div>

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
 import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
@@ -70,7 +70,13 @@ export function CloudFunnelButton() {
   const [inFlowView, setInFlowView] = useState(false)
   const [detailsView, setDetailsView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
+  // Set when the in-app connect attempt fails before a flow ever existed. The
+  // pitch then offers the browser wizard, which is the only remaining way to
+  // say yes once the driver lane has proven broken on this cluster.
+  const [prepareFailed, setPrepareFailed] = useState(false)
   const bodyScroll = useRef<HTMLDivElement>(null)
+  const heading = useRef<HTMLHeadingElement>(null)
+  const prevDetails = useRef(false)
 
   const capabilities = useCapabilities()
   const lane = capabilities.data?.cloudConnect?.lane ?? 'wizard'
@@ -121,6 +127,7 @@ export function CloudFunnelButton() {
       // Anything else failed before a flow existed. Return to the pitch rather
       // than leaving the flow view armed, where a later status change would
       // pull the user into a screen they did not ask for.
+      setPrepareFailed(true)
       exitFlow()
       showApiError('Could not inspect this cluster for Cloud connect', err instanceof Error ? err.message : undefined)
     },
@@ -133,6 +140,7 @@ export function CloudFunnelButton() {
     setOpen(true)
     setSeen(true)
     setDetailsView(false)
+    setPrepareFailed(false)
     markSeen()
     // Re-open lands on a live flow if one is running.
     if (lane === 'driver' && flowLive) setInFlowView(true)
@@ -140,12 +148,16 @@ export function CloudFunnelButton() {
 
   const startConnect = () => {
     setBlocked(null)
+    setPrepareFailed(false)
     setInFlowView(true)
     prepare.mutate()
   }
 
+  // Leaving the flow returns to the pitch, never to the sub-page: the flow is a
+  // lane change, and landing back in "how it works" reads as a failed exit.
   const exitFlow = () => {
     setInFlowView(false)
+    setDetailsView(false)
     setBlocked(null)
   }
 
@@ -155,11 +167,15 @@ export function CloudFunnelButton() {
     if (open && lane === 'driver' && flowLive) setInFlowView(true)
   }, [open, lane, flowLive])
 
-  // Pitch and details swap inside one scroll container, so the offset carries
-  // across. On a viewport short enough for the incoming view to overflow, that
-  // opens it mid-page with its heading and Back control already scrolled past.
-  useEffect(() => {
+  // Both views share one scroll container and the trigger unmounts itself on
+  // click, so without this the offset carries across (opening the incoming view
+  // mid-page on a short viewport) and focus falls to the document body, outside
+  // a dialog that has no focus trap. Layout effect so neither is ever painted.
+  useLayoutEffect(() => {
+    if (prevDetails.current === detailsView) return
+    prevDetails.current = detailsView
     if (bodyScroll.current) bodyScroll.current.scrollTop = 0
+    heading.current?.focus()
   }, [detailsView])
 
   // The server owns the "nothing to pitch" decision: an already-tunneled
@@ -237,14 +253,16 @@ export function CloudFunnelButton() {
           <>
             <div ref={bodyScroll} className="min-h-0 overflow-y-auto">
               {detailsView ? (
-                <DetailsBody onBack={() => setDetailsView(false)} />
+                <DetailsBody headingRef={heading} lane={lane} onBack={() => setDetailsView(false)} />
               ) : (
-                <PitchBody onDetails={() => setDetailsView(true)} />
+                <PitchBody headingRef={heading} onDetails={() => setDetailsView(true)} />
               )}
             </div>
             <ModalFooter
               lane={lane}
               signupUrl={signupUrl}
+              driverEscapeUrl={signupUrlFor('driver-escape')}
+              prepareFailed={prepareFailed}
               assurances={connectInfo.data?.assurances}
               notice={connectInfo.data?.notice}
               self={inCluster ? self.data : undefined}
@@ -262,7 +280,7 @@ export function CloudFunnelButton() {
   )
 }
 
-// Secondary copy the pitch shouldn't spend vertical space on until asked for.
+// Secondary copy that shouldn't cost vertical space until asked for.
 function Fold({ summary, className = '', children }: { summary: string; className?: string; children: ReactNode }) {
   const [open, setOpen] = useState(false)
   const bodyId = useId()
@@ -290,8 +308,8 @@ function Fold({ summary, className = '', children }: { summary: string; classNam
 function assuranceItems(fromHub?: string[]): string[] {
   const items = fromHub?.length ? fromHub : DEFAULT_ASSURANCES
   if (items.some((item) => item.toLowerCase().includes('soc 2'))) return items
-  // Before the last item: the closer ("data stays in your cluster") is the
-  // longest line and wraps most naturally when it comes last.
+  // Second to last: the closer ("data stays in your cluster") is the longest
+  // line, and trailing it keeps the short chips together on the first row.
   return [...items.slice(0, -1), SOC2_ASSURANCE, items[items.length - 1]]
 }
 
@@ -323,6 +341,8 @@ function Eyebrow() {
 function ModalFooter({
   lane,
   signupUrl,
+  driverEscapeUrl,
+  prepareFailed,
   assurances,
   notice,
   self,
@@ -332,6 +352,10 @@ function ModalFooter({
 }: {
   lane: 'driver' | 'wizard'
   signupUrl: string
+  // Same destination as signupUrl, distinct utm_content so the Hub can tell an
+  // escape from a broken in-app attempt apart from a plain pitch CTA click.
+  driverEscapeUrl: string
+  prepareFailed: boolean
   // Live copy from the Hub; undefined until (or unless) it arrives.
   assurances?: string[]
   notice?: string
@@ -397,12 +421,24 @@ function ModalFooter({
       )}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
         {lane === 'driver' ? (
-          <button
-            onClick={onConnect}
-            className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
-          >
-            Connect this cluster
-          </button>
+          <>
+            <button
+              onClick={onConnect}
+              className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+            >
+              {prepareFailed ? 'Try again' : 'Connect this cluster'}
+            </button>
+            {prepareFailed && (
+              <a
+                href={driverEscapeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="whitespace-nowrap text-[13px] text-theme-text-secondary hover:text-theme-text-primary underline underline-offset-2 transition-colors"
+              >
+                or set up in the browser
+              </a>
+            )}
+          </>
         ) : cliOnly ? null : (
           <a
             href={self?.wizardUrl || signupUrl}
@@ -431,12 +467,14 @@ function ModalFooter({
   )
 }
 
-// The pitch answers what this is, what you get, and whether it can be
-// trusted. The headline names the product — an opener that defuses a fear
-// instead buries what the dialog is even about; one-line highlights carry the
-// value; the anti-sell line is the credibility beat. Anything longer lives one
-// click deeper in DetailsBody, so this stays short enough to read at a glance.
-function PitchBody({ onDetails }: { onDetails: () => void }) {
+// Length-capped on purpose: anything that doesn't fit belongs in DetailsBody.
+function PitchBody({
+  headingRef,
+  onDetails,
+}: {
+  headingRef: RefObject<HTMLHeadingElement | null>
+  onDetails: () => void
+}) {
   const highlights = [
     { icon: Globe, text: 'Your whole fleet in one URL: issues, checks and search across every cluster' },
     { icon: Users, text: "Bring the team: SSO, invites and roles. Your cluster's RBAC has the final say" },
@@ -447,7 +485,11 @@ function PitchBody({ onDetails }: { onDetails: () => void }) {
   return (
     <div className="px-8 pt-7 pb-2">
       <Eyebrow />
-      <h3 className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3 text-balance">
+      <h3
+        ref={headingRef}
+        tabIndex={-1}
+        className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3 outline-none"
+      >
         Meet Radar Cloud
       </h3>
       <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
@@ -479,34 +521,50 @@ function PitchBody({ onDetails }: { onDetails: () => void }) {
   )
 }
 
-// The deeper page earns its click by answering what the pitch raises but
-// leaves open — how the connection works, what it costs, who's behind it —
-// rather than restating the capability list the reader just saw. Copy here
-// must stay consistent with the flow's own claims (plan card, assurances).
-function DetailsBody({ onBack }: { onBack: () => void }) {
+// Answers what the pitch raises but leaves open, rather than restating the
+// capability list the reader just saw. Deliberately states no price or tier:
+// those are Hub-served (and therefore correctable) in the assurance strip, and
+// a second compiled-in copy would contradict it the day the terms change.
+function DetailsBody({
+  headingRef,
+  lane,
+  onBack,
+}: {
+  headingRef: RefObject<HTMLHeadingElement | null>
+  lane: 'driver' | 'wizard'
+  onBack: () => void
+}) {
   return (
     <div className="px-8 pt-6 pb-2">
       <button
         type="button"
         onClick={onBack}
-        className="flex items-center gap-1.5 mb-4 text-[12px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+        className="flex items-center gap-1.5 mb-3 text-[12px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
       >
         <ArrowLeft className="w-3.5 h-3.5" />
         Back
       </button>
+      <h3
+        ref={headingRef}
+        tabIndex={-1}
+        className="text-[17px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-4 outline-none"
+      >
+        How it works and what it costs
+      </h3>
       <div className="space-y-4 mb-4">
         <section>
           <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">How it works</h4>
           <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-            A small agent in your cluster connects outward to Radar Cloud. You approve the connection in
-            your browser before anything is installed, and your cluster data stays in your cluster.
+            {lane === 'driver'
+              ? 'Setup runs here in the app: Radar installs a small agent that connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'
+              : 'A small agent in your cluster connects outward to Radar Cloud. You approve the connection before anything is installed.'}
           </p>
         </section>
         <section>
           <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">What it costs</h4>
           <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-            Free for 3 clusters, no credit card. Paid plans beyond that are what keep the lights on,
-            while this app stays Apache&nbsp;2.0: every feature, forever.
+            There's a free tier, and the paid plans past it are what keep the lights on. This app stays
+            Apache&nbsp;2.0 either way: every feature, forever.
           </p>
         </section>
         <section>
@@ -514,7 +572,7 @@ function DetailsBody({ onBack }: { onBack: () => void }) {
           <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
             Radar is built in the open by many hands, and overseen by a small team of humans, the kind
             you can actually talk to.{' '}
-            <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap underline underline-offset-2 hover:text-theme-text-primary">
+            <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
               Meet us →
             </a>
           </p>

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -461,12 +461,12 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
         className="flex items-center gap-1.5 mb-2 text-[12.5px] font-medium text-theme-text-secondary hover:text-theme-text-primary transition-colors"
       >
         <CollapseChevron open={moreOpen} className="w-3 h-3" />
-        Pricing, how it works, and who's behind it
+        How it works
       </button>
       <Collapse open={moreOpen}>
         <div id={moreId} className="pt-1 pb-3 pl-[18px] space-y-3.5">
           <section>
-            <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">How it works</h4>
+            {/* No heading: the disclosure's own label already names this one. */}
             <p className="text-[12px] leading-relaxed text-theme-text-secondary">
               {lane === 'driver'
                 ? 'Setup runs here in the app: Radar installs a small agent that connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useState, type ReactNode } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Bell, Check, Globe, History, Sparkles, Users, X } from 'lucide-react'
+import { ArrowLeft, Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
 import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
@@ -68,6 +68,7 @@ export function CloudFunnelButton() {
   const [open, setOpen] = useState(false)
   const [seen, setSeen] = useState(readSeen)
   const [inFlowView, setInFlowView] = useState(false)
+  const [detailsView, setDetailsView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
 
   const capabilities = useCapabilities()
@@ -130,6 +131,7 @@ export function CloudFunnelButton() {
   const openModal = () => {
     setOpen(true)
     setSeen(true)
+    setDetailsView(false)
     markSeen()
     // Re-open lands on a live flow if one is running.
     if (lane === 'driver' && flowLive) setInFlowView(true)
@@ -174,7 +176,7 @@ export function CloudFunnelButton() {
     <>
       {/* Tooltip is suppressed while the modal is open — it portals above the
           modal backdrop and would otherwise paint on top of the dialog. */}
-      <Tooltip content="Radar Cloud — all your clusters, one URL" delay={100} position="bottom" disabled={open}>
+      <Tooltip content="Radar Cloud: all your clusters, one URL" delay={100} position="bottom" disabled={open}>
         <button
           onClick={openModal}
           aria-label="Radar Cloud"
@@ -226,12 +228,15 @@ export function CloudFunnelButton() {
         ) : (
           <>
             <div className="min-h-0 overflow-y-auto">
-              <ModalBody />
+              {detailsView ? (
+                <DetailsBody onBack={() => setDetailsView(false)} />
+              ) : (
+                <PitchBody onDetails={() => setDetailsView(true)} />
+              )}
             </div>
             <ModalFooter
               lane={lane}
               signupUrl={signupUrl}
-              driverEscapeUrl={signupUrlFor('driver-escape')}
               assurances={connectInfo.data?.assurances}
               notice={connectInfo.data?.notice}
               self={inCluster ? self.data : undefined}
@@ -310,7 +315,6 @@ function Eyebrow() {
 function ModalFooter({
   lane,
   signupUrl,
-  driverEscapeUrl,
   assurances,
   notice,
   self,
@@ -320,10 +324,6 @@ function ModalFooter({
 }: {
   lane: 'driver' | 'wizard'
   signupUrl: string
-  // The driver branch's "start in the browser" link — same destination as
-  // signupUrl, distinct utm_content so the Hub can tell an escape from an
-  // in-product flow apart from a pitch CTA click.
-  driverEscapeUrl: string
   // Live copy from the Hub; undefined until (or unless) it arrives.
   assurances?: string[]
   notice?: string
@@ -353,24 +353,24 @@ function ModalFooter({
             <>
               Radar found conflicting management metadata on this install, so it can't say whether a Helm
               upgrade or a repository change is the right move. Run{' '}
-              <code className="font-mono text-[11px]">radar cloud install</code> from a machine with kubectl —
-              it inspects the release and refuses rather than guessing.
+              <code className="font-mono text-[11px]">radar cloud install</code> from a machine with
+              kubectl. It inspects the release and refuses rather than guessing.
             </>
           ) : gitops ? (
             <>
               This Radar is managed by{' '}
               <b className="text-theme-text-primary">{self.controller || 'a GitOps controller'}</b>, so
-              connecting it is a values change in your repository — an imperative upgrade would be reverted.{' '}
+              connecting it is a values change in your repository; an imperative upgrade would be reverted.{' '}
               {cliOnly ? (
                 <>
                   Radar found that evidence but couldn't confirm it against the live object, so run{' '}
                   <code className="font-mono text-[11px]">radar cloud install</code> from a machine with
-                  kubectl — it inspects the release before generating anything.
+                  kubectl. It inspects the release before generating anything.
                 </>
               ) : (
                 <>
                   The wizard generates the values patch for that controller, plus the one command that
-                  creates the token Secret — the token never goes into your repository.
+                  creates the token Secret. The token never goes into your repository.
                 </>
               )}
             </>
@@ -387,30 +387,14 @@ function ModalFooter({
       {notice && (
         <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">{notice}</div>
       )}
-      {lane === 'driver' && (
-        <p className="mb-3.5 text-[12px] leading-relaxed text-theme-text-secondary">
-          The guided setup runs right here in the app — Radar installs the Cloud agent on this cluster, and
-          you approve the connection in your browser.
-        </p>
-      )}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
         {lane === 'driver' ? (
-          <>
-            <button
-              onClick={onConnect}
-              className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
-            >
-              Connect this cluster
-            </button>
-            <a
-              href={driverEscapeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="whitespace-nowrap text-[13px] text-theme-text-secondary hover:text-theme-text-primary underline underline-offset-2 transition-colors"
-            >
-              or set up in the browser
-            </a>
-          </>
+          <button
+            onClick={onConnect}
+            className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+          >
+            Connect this cluster
+          </button>
         ) : cliOnly ? null : (
           <a
             href={self?.wizardUrl || signupUrl}
@@ -427,96 +411,114 @@ function ModalFooter({
           Maybe later
         </button>
       </div>
-      <div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-2 text-[11.5px] text-theme-text-tertiary">
+      <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1.5 text-[11.5px] text-theme-text-tertiary">
         {assuranceItems(assurances).map((item) => (
-          <span key={item} className="flex items-start gap-1.5">
-            <Check className="w-3 h-3 mt-[3px] shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <span key={item} className="flex items-center gap-1.5">
+            <Check className="w-3 h-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
             {item}
           </span>
         ))}
       </div>
-      <Fold summary="Prefer to run the control plane in your own VPC?" className="mt-3.5">
-        Self-hosting is fully self-serve — set it up yourself, whenever you're ready.{' '}
-        <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
-          Read the docs
-        </a>
-        .
-      </Fold>
     </div>
   )
 }
 
-// Headline defuses the paywall fear before anything is pitched; the grid
-// carries the concrete capabilities; the anti-sell closes — the credibility
-// beat that makes the sell land.
-function ModalBody() {
-  const features = [
-    {
-      icon: Globe,
-      title: 'All your clusters, one URL',
-      body: 'Fleet-wide issues, checks and search — instead of five browser tabs.',
-    },
-    {
-      icon: Users,
-      title: 'Bring the team',
-      body: "SSO, invites and roles — your cluster's RBAC still has the final say.",
-    },
-    {
-      icon: Bell,
-      title: 'Alerts that find you',
-      body: 'Slack or webhook the moment something breaks — even at 3am.',
-    },
-    {
-      icon: History,
-      title: 'History that sticks around',
-      body: 'A timeline that survives restarts — and keeps getting longer.',
-    },
-    {
-      icon: Sparkles,
-      title: 'An AI agent on your fleet',
-      body: 'Analyzes issues, pinpoints the root cause, and proposes the fix.',
-      wide: true,
-    },
+// The pitch answers what this is, what you get, and whether it can be
+// trusted. The headline names the product — an opener that defuses a fear
+// instead buries what the dialog is even about; one-line highlights carry the
+// value; the anti-sell line is the credibility beat. Anything longer lives one
+// click deeper in DetailsBody, so this stays short enough to read at a glance.
+function PitchBody({ onDetails }: { onDetails: () => void }) {
+  const highlights = [
+    { icon: Globe, text: 'Your whole fleet in one URL: issues, checks and search across every cluster' },
+    { icon: Users, text: "Bring the team: SSO, invites and roles. Your cluster's RBAC has the final say" },
+    { icon: Bell, text: 'Alerts that reach you the moment something breaks' },
+    { icon: History, text: 'Long-term retention: history that survives restarts and keeps growing' },
+    { icon: Sparkles, text: 'An AI agent that digs into issues and pinpoints the root cause' },
   ]
   return (
     <div className="px-8 pt-7 pb-2">
       <Eyebrow />
       <h3 className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3 text-balance">
-        First things first: Radar stays free.
+        Meet Radar Cloud
       </h3>
       <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
-        The app you're looking at is Apache&nbsp;2.0 — every feature, forever, no rug pulls.{' '}
-        <b className="text-theme-text-primary font-semibold">Radar Cloud is how we keep the lights on:</b> the
-        same Radar, plus the parts that are genuinely hard to run on your own.
+        The hosted side of Radar: your clusters in one place, run by us.{' '}
+        <b className="text-theme-text-primary font-semibold">This app stays free and open source, always.</b>
       </p>
-      <div className="grid grid-cols-2 gap-3 mb-5">
-        {features.map(({ icon: Icon, title, body, wide }) => (
-          <div
-            key={title}
-            className={`card-inner-lg p-3.5 flex gap-3 ${
-              wide ? 'col-span-2 bg-emerald-500/[0.06] border-emerald-500/25 dark:bg-emerald-500/[0.08]' : ''
-            }`}
-          >
-            <Icon className="w-4 h-4 shrink-0 mt-0.5 text-emerald-600 dark:text-emerald-400" />
-            <div>
-              <div className="text-[13px] font-semibold text-theme-text-primary">{title}</div>
-              <p className="mt-1 text-[12px] leading-relaxed text-theme-text-tertiary">{body}</p>
-            </div>
-          </div>
+      <ul className="space-y-2.5 mb-4">
+        {highlights.map(({ icon: Icon, text }) => (
+          <li key={text} className="flex items-start gap-2.5 text-[13px] leading-relaxed text-theme-text-secondary">
+            <Icon className="w-4 h-4 shrink-0 mt-[3px] text-emerald-600 dark:text-emerald-400" />
+            {text}
+          </li>
         ))}
-      </div>
+      </ul>
+      <button
+        type="button"
+        onClick={onDetails}
+        className="flex items-center gap-1 mb-5 text-[12.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+      >
+        How it works and what it costs
+        <ChevronRight className="w-3.5 h-3.5" />
+      </button>
       <div className="mb-5 border-l-2 border-emerald-500/40 pl-3.5">
         <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-          If it's just you and one cluster — honestly, stay right here. This app is the product, not a demo.
-        </p>
-        <p className="mt-2 text-[11.5px] leading-relaxed text-theme-text-tertiary">
-          Radar is built in the open by many hands, and overseen by a small team of humans — the kind you
-          can actually talk to.{' '}
-          <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
-            Meet us →
-          </a>
+          Just you and one cluster? Stay right here. This app is the product, not a demo.
         </p>
       </div>
+    </div>
+  )
+}
+
+// The deeper page earns its click by answering what the pitch raises but
+// leaves open — how the connection works, what it costs, who's behind it —
+// rather than restating the capability list the reader just saw. Copy here
+// must stay consistent with the flow's own claims (plan card, assurances).
+function DetailsBody({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="px-8 pt-6 pb-2">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex items-center gap-1.5 mb-4 text-[12px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+      >
+        <ArrowLeft className="w-3.5 h-3.5" />
+        Back
+      </button>
+      <div className="space-y-4 mb-4">
+        <section>
+          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">How it works</h4>
+          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
+            A small agent in your cluster connects outward to Radar Cloud. You approve the connection in
+            your browser before anything is installed, and your cluster data stays in your cluster.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">What it costs</h4>
+          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
+            Free for 3 clusters, no credit card. Paid plans beyond that are what keep the lights on,
+            while this app stays Apache&nbsp;2.0: every feature, forever.
+          </p>
+        </section>
+        <section>
+          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">Who's behind it</h4>
+          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
+            Radar is built in the open by many hands, and overseen by a small team of humans, the kind
+            you can actually talk to.{' '}
+            <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap underline underline-offset-2 hover:text-theme-text-primary">
+              Meet us →
+            </a>
+          </p>
+        </section>
+      </div>
+      <Fold summary="Prefer to run the control plane in your own VPC?" className="mb-5">
+        Self-hosting is fully self-serve. Set it up yourself, whenever you're ready.{' '}
+        <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
+          Read the docs
+        </a>
+        .
+      </Fold>
     </div>
   )
 }

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -442,7 +442,7 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
       <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
         The hosted side of Radar: your clusters in one place, run by us.{' '}
         <b className="text-theme-text-primary font-semibold">
-          The app you're looking at stays free and open source, always.
+          The Radar you're running stays free and open source, always.
         </b>
       </p>
       <ul className="space-y-2.5 mb-4">
@@ -458,10 +458,10 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
         onClick={() => setMoreOpen((v) => !v)}
         aria-expanded={moreOpen}
         aria-controls={moreId}
-        className="flex items-center gap-1.5 mb-2 text-[12.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+        className="flex items-center gap-1.5 mb-2 text-[12.5px] font-medium text-theme-text-secondary hover:text-theme-text-primary transition-colors"
       >
         <CollapseChevron open={moreOpen} className="w-3 h-3" />
-        How it works and what it costs
+        Pricing, how it works, and who's behind it
       </button>
       <Collapse open={moreOpen}>
         <div id={moreId} className="pt-1 pb-3 pl-[18px] space-y-3.5">
@@ -476,8 +476,8 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
           <section>
             <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">What it costs</h4>
             <p className="text-[12px] leading-relaxed text-theme-text-secondary">
-              There's a free tier, and the paid plans past it are what keep the lights on. Radar itself,
-              the app you're running now, stays Apache&nbsp;2.0 either way: every feature, forever.
+              There's a free tier. The paid plans above it are what keep the lights on. The Radar you're
+              running stays Apache&nbsp;2.0 either way: every feature, forever.
             </p>
           </section>
           <section>
@@ -491,7 +491,7 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
             </p>
           </section>
           <p className="text-[12px] leading-relaxed text-theme-text-secondary">
-            Prefer your own VPC? Self-hosting is fully self-serve.{' '}
+            Prefer your own VPC? You can run the Radar Cloud control plane yourself.{' '}
             <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
               Read the docs
             </a>
@@ -501,7 +501,7 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
       </Collapse>
       <div className="mb-5 border-l-2 border-emerald-500/40 pl-3.5">
         <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-          Just you and one cluster? Stay right here. This app is the product, not a demo.
+          Just you and one cluster? Stay right here. What you're already running is the product, not a demo.
         </p>
       </div>
     </div>

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -453,14 +453,16 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
           </li>
         ))}
       </ul>
+      {/* Accented on purpose: at the bullet list's own color and size, and
+          with a leading glyph, it otherwise reads as one more bullet. */}
       <button
         type="button"
         onClick={() => setMoreOpen((v) => !v)}
         aria-expanded={moreOpen}
         aria-controls={moreId}
-        className="flex items-center gap-1.5 mb-2 text-[12.5px] font-medium text-theme-text-secondary hover:text-theme-text-primary transition-colors"
+        className="flex items-center gap-1.5 mb-3 text-[12.5px] font-semibold text-emerald-600 dark:text-emerald-400 hover:underline underline-offset-2 transition-colors"
       >
-        <CollapseChevron open={moreOpen} className="w-3 h-3" />
+        <CollapseChevron open={moreOpen} className="w-3.5 h-3.5" />
         How it works
       </button>
       <Collapse open={moreOpen}>

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -494,7 +494,9 @@ function PitchBody({
       </h3>
       <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
         The hosted side of Radar: your clusters in one place, run by us.{' '}
-        <b className="text-theme-text-primary font-semibold">This app stays free and open source, always.</b>
+        <b className="text-theme-text-primary font-semibold">
+          The app you're looking at stays free and open source, always.
+        </b>
       </p>
       <ul className="space-y-2.5 mb-4">
         {highlights.map(({ icon: Icon, text }) => (

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -453,14 +453,14 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
           </li>
         ))}
       </ul>
-      {/* Accented on purpose: at the bullet list's own color and size, and
+      {/* Underlined on purpose: at the bullet list's own color and size, and
           with a leading glyph, it otherwise reads as one more bullet. */}
       <button
         type="button"
         onClick={() => setMoreOpen((v) => !v)}
         aria-expanded={moreOpen}
         aria-controls={moreId}
-        className="flex items-center gap-1.5 mb-3 text-[12.5px] font-semibold text-emerald-600 dark:text-emerald-400 hover:underline underline-offset-2 transition-colors"
+        className="flex items-center gap-1.5 mb-3 text-[12.5px] text-theme-text-secondary underline underline-offset-2 decoration-theme-border hover:text-theme-text-primary transition-colors"
       >
         <CollapseChevron open={moreOpen} className="w-3.5 h-3.5" />
         How it works

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -69,9 +69,9 @@ export function CloudFunnelButton() {
   const [seen, setSeen] = useState(readSeen)
   const [inFlowView, setInFlowView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
-  // Set when the in-app connect attempt fails before a flow ever existed. The
-  // pitch then offers the browser wizard, which is the only remaining way to
-  // say yes once the driver lane has proven broken on this cluster.
+  // Set once an in-app attempt has actually failed, so the pitch offers the
+  // browser wizard alongside a retry. Deliberately survives closing the modal:
+  // whatever broke is a property of this cluster, not of the dialog session.
   const [prepareFailed, setPrepareFailed] = useState(false)
 
   const capabilities = useCapabilities()
@@ -135,7 +135,6 @@ export function CloudFunnelButton() {
   const openModal = () => {
     setOpen(true)
     setSeen(true)
-    setPrepareFailed(false)
     markSeen()
     // Re-open lands on a live flow if one is running.
     if (lane === 'driver' && flowLive) setInFlowView(true)
@@ -148,7 +147,11 @@ export function CloudFunnelButton() {
     prepare.mutate()
   }
 
-  const exitFlow = () => {
+  // A flow that ended in failure leaves the pitch as the only surface left, so
+  // the pitch has to carry the browser alternative. The caller passes the
+  // outcome because dismissing already overwrote the status by this point.
+  const exitFlow = (failed = false) => {
+    if (failed) setPrepareFailed(true)
     setInFlowView(false)
     setBlocked(null)
   }
@@ -227,7 +230,7 @@ export function CloudFunnelButton() {
               blocked={blocked}
               signupUrl={signupUrlFor('flow-escape')}
               onStatus={applyStatus}
-              onExit={exitFlow}
+              onExit={() => exitFlow(flowForView.state === 'failed')}
             />
           </div>
         ) : (
@@ -256,7 +259,6 @@ export function CloudFunnelButton() {
     </>
   )
 }
-
 
 function assuranceItems(fromHub?: string[]): string[] {
   const items = fromHub?.length ? fromHub : DEFAULT_ASSURANCES
@@ -420,9 +422,7 @@ function ModalFooter({
   )
 }
 
-// Length-capped on purpose: the detail sits behind a disclosure so the first
-// screen stays short, without costing the reader the product context a
-// separate page would have taken away.
+// The detail sits behind a disclosure so the first screen stays short.
 function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
   const [moreOpen, setMoreOpen] = useState(false)
   const moreId = useId()
@@ -507,4 +507,3 @@ function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
     </div>
   )
 }
-

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState, type ReactNode } from 'react'
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
 import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
@@ -70,6 +70,7 @@ export function CloudFunnelButton() {
   const [inFlowView, setInFlowView] = useState(false)
   const [detailsView, setDetailsView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
+  const bodyScroll = useRef<HTMLDivElement>(null)
 
   const capabilities = useCapabilities()
   const lane = capabilities.data?.cloudConnect?.lane ?? 'wizard'
@@ -154,6 +155,13 @@ export function CloudFunnelButton() {
     if (open && lane === 'driver' && flowLive) setInFlowView(true)
   }, [open, lane, flowLive])
 
+  // Pitch and details swap inside one scroll container, so the offset carries
+  // across. On a viewport short enough for the incoming view to overflow, that
+  // opens it mid-page with its heading and Back control already scrolled past.
+  useEffect(() => {
+    if (bodyScroll.current) bodyScroll.current.scrollTop = 0
+  }, [detailsView])
+
   // The server owns the "nothing to pitch" decision: an already-tunneled
   // deployment gets no cloudConnect capability at all. Waiting for
   // capabilities (rather than defaulting to visible) keeps the funnel from
@@ -227,7 +235,7 @@ export function CloudFunnelButton() {
           </div>
         ) : (
           <>
-            <div className="min-h-0 overflow-y-auto">
+            <div ref={bodyScroll} className="min-h-0 overflow-y-auto">
               {detailsView ? (
                 <DetailsBody onBack={() => setDetailsView(false)} />
               ) : (

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Bell, Check, ChevronRight, Globe, History, Sparkles, Users, X } from 'lucide-react'
+import { Bell, Check, Globe, History, Sparkles, Users, X } from 'lucide-react'
 import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Collapse'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
@@ -68,15 +68,11 @@ export function CloudFunnelButton() {
   const [open, setOpen] = useState(false)
   const [seen, setSeen] = useState(readSeen)
   const [inFlowView, setInFlowView] = useState(false)
-  const [detailsView, setDetailsView] = useState(false)
   const [blocked, setBlocked] = useState<CloudInstallBlocked | null>(null)
   // Set when the in-app connect attempt fails before a flow ever existed. The
   // pitch then offers the browser wizard, which is the only remaining way to
   // say yes once the driver lane has proven broken on this cluster.
   const [prepareFailed, setPrepareFailed] = useState(false)
-  const bodyScroll = useRef<HTMLDivElement>(null)
-  const heading = useRef<HTMLHeadingElement>(null)
-  const prevDetails = useRef(false)
 
   const capabilities = useCapabilities()
   const lane = capabilities.data?.cloudConnect?.lane ?? 'wizard'
@@ -139,7 +135,6 @@ export function CloudFunnelButton() {
   const openModal = () => {
     setOpen(true)
     setSeen(true)
-    setDetailsView(false)
     setPrepareFailed(false)
     markSeen()
     // Re-open lands on a live flow if one is running.
@@ -153,11 +148,8 @@ export function CloudFunnelButton() {
     prepare.mutate()
   }
 
-  // Leaving the flow returns to the pitch, never to the sub-page: the flow is a
-  // lane change, and landing back in "how it works" reads as a failed exit.
   const exitFlow = () => {
     setInFlowView(false)
-    setDetailsView(false)
     setBlocked(null)
   }
 
@@ -166,17 +158,6 @@ export function CloudFunnelButton() {
   useEffect(() => {
     if (open && lane === 'driver' && flowLive) setInFlowView(true)
   }, [open, lane, flowLive])
-
-  // Both views share one scroll container and the trigger unmounts itself on
-  // click, so without this the offset carries across (opening the incoming view
-  // mid-page on a short viewport) and focus falls to the document body, outside
-  // a dialog that has no focus trap. Layout effect so neither is ever painted.
-  useLayoutEffect(() => {
-    if (prevDetails.current === detailsView) return
-    prevDetails.current = detailsView
-    if (bodyScroll.current) bodyScroll.current.scrollTop = 0
-    heading.current?.focus()
-  }, [detailsView])
 
   // The server owns the "nothing to pitch" decision: an already-tunneled
   // deployment gets no cloudConnect capability at all. Waiting for
@@ -251,12 +232,8 @@ export function CloudFunnelButton() {
           </div>
         ) : (
           <>
-            <div ref={bodyScroll} className="min-h-0 overflow-y-auto">
-              {detailsView ? (
-                <DetailsBody headingRef={heading} lane={lane} onBack={() => setDetailsView(false)} />
-              ) : (
-                <PitchBody headingRef={heading} onDetails={() => setDetailsView(true)} />
-              )}
+            <div className="min-h-0 overflow-y-auto">
+              <PitchBody lane={lane} />
             </div>
             <ModalFooter
               lane={lane}
@@ -280,30 +257,6 @@ export function CloudFunnelButton() {
   )
 }
 
-// Secondary copy that shouldn't cost vertical space until asked for.
-function Fold({ summary, className = '', children }: { summary: string; className?: string; children: ReactNode }) {
-  const [open, setOpen] = useState(false)
-  const bodyId = useId()
-  return (
-    <div className={className}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls={bodyId}
-        className="flex items-center gap-1.5 text-[11.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
-      >
-        <CollapseChevron open={open} className="w-3 h-3" />
-        {summary}
-      </button>
-      <Collapse open={open}>
-        <p id={bodyId} className="mt-2 pl-[18px] text-[11.5px] leading-relaxed text-theme-text-tertiary">
-          {children}
-        </p>
-      </Collapse>
-    </div>
-  )
-}
 
 function assuranceItems(fromHub?: string[]): string[] {
   const items = fromHub?.length ? fromHub : DEFAULT_ASSURANCES
@@ -467,14 +420,12 @@ function ModalFooter({
   )
 }
 
-// Length-capped on purpose: anything that doesn't fit belongs in DetailsBody.
-function PitchBody({
-  headingRef,
-  onDetails,
-}: {
-  headingRef: RefObject<HTMLHeadingElement | null>
-  onDetails: () => void
-}) {
+// Length-capped on purpose: the detail sits behind a disclosure so the first
+// screen stays short, without costing the reader the product context a
+// separate page would have taken away.
+function PitchBody({ lane }: { lane: 'driver' | 'wizard' }) {
+  const [moreOpen, setMoreOpen] = useState(false)
+  const moreId = useId()
   const highlights = [
     { icon: Globe, text: 'Your whole fleet in one URL: issues, checks and search across every cluster' },
     { icon: Users, text: "Bring the team: SSO, invites and roles. Your cluster's RBAC has the final say" },
@@ -485,11 +436,7 @@ function PitchBody({
   return (
     <div className="px-8 pt-7 pb-2">
       <Eyebrow />
-      <h3
-        ref={headingRef}
-        tabIndex={-1}
-        className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3 outline-none"
-      >
+      <h3 className="text-[22px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-3">
         Meet Radar Cloud
       </h3>
       <p className="text-[14px] leading-relaxed text-theme-text-secondary mb-5">
@@ -508,12 +455,50 @@ function PitchBody({
       </ul>
       <button
         type="button"
-        onClick={onDetails}
-        className="flex items-center gap-1 mb-5 text-[12.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
+        onClick={() => setMoreOpen((v) => !v)}
+        aria-expanded={moreOpen}
+        aria-controls={moreId}
+        className="flex items-center gap-1.5 mb-2 text-[12.5px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
       >
+        <CollapseChevron open={moreOpen} className="w-3 h-3" />
         How it works and what it costs
-        <ChevronRight className="w-3.5 h-3.5" />
       </button>
+      <Collapse open={moreOpen}>
+        <div id={moreId} className="pt-1 pb-3 pl-[18px] space-y-3.5">
+          <section>
+            <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">How it works</h4>
+            <p className="text-[12px] leading-relaxed text-theme-text-secondary">
+              {lane === 'driver'
+                ? 'Setup runs here in the app: Radar installs a small agent that connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'
+                : 'A small agent in your cluster connects outward to Radar Cloud. You approve the connection before anything is installed.'}
+            </p>
+          </section>
+          <section>
+            <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">What it costs</h4>
+            <p className="text-[12px] leading-relaxed text-theme-text-secondary">
+              There's a free tier, and the paid plans past it are what keep the lights on. Radar itself,
+              the app you're running now, stays Apache&nbsp;2.0 either way: every feature, forever.
+            </p>
+          </section>
+          <section>
+            <h4 className="text-[12.5px] font-semibold text-theme-text-primary mb-0.5">Who's behind it</h4>
+            <p className="text-[12px] leading-relaxed text-theme-text-secondary">
+              Radar is built in the open by many hands, and overseen by a small team of humans, the kind
+              you can actually talk to.{' '}
+              <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
+                Meet us →
+              </a>
+            </p>
+          </section>
+          <p className="text-[12px] leading-relaxed text-theme-text-secondary">
+            Prefer your own VPC? Self-hosting is fully self-serve.{' '}
+            <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
+              Read the docs
+            </a>
+            .
+          </p>
+        </div>
+      </Collapse>
       <div className="mb-5 border-l-2 border-emerald-500/40 pl-3.5">
         <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
           Just you and one cluster? Stay right here. This app is the product, not a demo.
@@ -523,70 +508,3 @@ function PitchBody({
   )
 }
 
-// Answers what the pitch raises but leaves open, rather than restating the
-// capability list the reader just saw. Deliberately states no price or tier:
-// those are Hub-served (and therefore correctable) in the assurance strip, and
-// a second compiled-in copy would contradict it the day the terms change.
-function DetailsBody({
-  headingRef,
-  lane,
-  onBack,
-}: {
-  headingRef: RefObject<HTMLHeadingElement | null>
-  lane: 'driver' | 'wizard'
-  onBack: () => void
-}) {
-  return (
-    <div className="px-8 pt-6 pb-2">
-      <button
-        type="button"
-        onClick={onBack}
-        className="flex items-center gap-1.5 mb-3 text-[12px] text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
-      >
-        <ArrowLeft className="w-3.5 h-3.5" />
-        Back
-      </button>
-      <h3
-        ref={headingRef}
-        tabIndex={-1}
-        className="text-[17px] font-semibold leading-tight tracking-tight text-theme-text-primary mb-4 outline-none"
-      >
-        How it works and what it costs
-      </h3>
-      <div className="space-y-4 mb-4">
-        <section>
-          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">How it works</h4>
-          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-            {lane === 'driver'
-              ? 'Setup runs here in the app: Radar installs a small agent that connects outward to Radar Cloud. You review the plan and approve in your browser before anything is installed.'
-              : 'A small agent in your cluster connects outward to Radar Cloud. You approve the connection before anything is installed.'}
-          </p>
-        </section>
-        <section>
-          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">What it costs</h4>
-          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-            There's a free tier, and the paid plans past it are what keep the lights on. This app stays
-            Apache&nbsp;2.0 either way: every feature, forever.
-          </p>
-        </section>
-        <section>
-          <h4 className="text-[13px] font-semibold text-theme-text-primary mb-1">Who's behind it</h4>
-          <p className="text-[12.5px] leading-relaxed text-theme-text-secondary">
-            Radar is built in the open by many hands, and overseen by a small team of humans, the kind
-            you can actually talk to.{' '}
-            <a href={ABOUT_URL} target="_blank" rel="noopener noreferrer" className="whitespace-nowrap text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
-              Meet us →
-            </a>
-          </p>
-        </section>
-      </div>
-      <Fold summary="Prefer to run the control plane in your own VPC?" className="mb-5">
-        Self-hosting is fully self-serve. Set it up yourself, whenever you're ready.{' '}
-        <a href={SELF_HOSTED_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-theme-text-secondary underline underline-offset-2 hover:text-theme-text-primary">
-          Read the docs
-        </a>
-        .
-      </Fold>
-    </div>
-  )
-}


### PR DESCRIPTION
## Why

The OSS → Cloud modal wasn't communicating what Radar Cloud is. It led with a fear-defusal headline instead of naming the product, spent ~200 words and a five-card feature grid before the CTA, offered six competing links, and compiled its trust chips into the binary where they could go stale.

## The modal now

**The pitch** is one short scannable screen: eyebrow, **Meet Radar Cloud**, a one-line definition with the free-forever promise on its own line, five one-line highlights with bold lead-ins ("Your whole fleet in one URL", "Bring the team", "Alerts", "Long-term retention", "An AI agent"), and a quiet aside — *"Don't need Radar Cloud right now? That's fine. What you're running is already a full product, not a demo. We're here if you ever do."* Typography does the density work: anchors → supporting text → whispers, with grouping gaps marking where the pitch ends.

**Everything longer** sits behind a collapsed **"How it works and what it costs"** disclosure: a lane-aware setup explainer, the cost model, who's behind it (Skyhook, a CNCF Silver member), and self-hosting the Cloud control plane. The cost section states the free tier from a Hub-served `freeTier` prose fragment and links the pricing page — no tier number is compiled into the binary, so nothing shipped can go stale.

**The footer** pins one primary CTA. Driver lane: **"Connect this cluster…"** (trailing ellipsis: further input follows the click) with small print stating the mechanics — nothing installs on click; Radar inspects the cluster, shows a plan, and you approve in the browser. The browser wizard sits beside it as a quiet, always-visible link: it is a different workflow for a different operator, not a recovery path. `utm_content` distinguishes preference (`driver-alt`) from a broken in-app attempt (`driver-escape`). After a failed attempt the CTA relabels to "Try again"; that state survives closing the modal but resets on kubeconfig context switch — the failure belongs to the cluster, not the session. "Maybe later" sits at the row's far edge.

**The trust row** renders the Hub's assurance list verbatim — no client-side additions, so the Hub owns the wording (SOC 2 included) and can update it without a binary release. The compiled fallback (offline / self-hosted Hub) leads with what matters most when connecting a cluster — network posture, reversibility, attestation, billing — and describes the outbound connection model. Chips lay out as a balanced two-column grid.

**The connect flow** speaks about Radar, not an "agent": Radar is what gets installed in the cluster — in the plan card (mode-aware: fresh install vs upgrade-and-connect), the progress steps, the connected card, and the server-side recovery guidance. Preflight notes and rollback guidance use the app-standard animated Collapse. Copy drops em dashes throughout the dialog.

## Companion PRs (private repos)

- **skyhook-dev/radar-hub#212** — `/api/connect/info` serves the updated assurance set + `freeTier` fragment. Deploy order is safe both ways: older binaries ignore `freeTier` and dedupe SOC 2; this binary renders the Hub list verbatim.
- **skyhook-dev/radar-hub-web#278** — aligns "agent" copy in the Hub app.

## Reviewer notes

- The funnel is behind the 30% staged rollout — `RADAR_CLOUD_FUNNEL=on` to review locally.
- Connect-flow plumbing untouched: lanes, GitOps self-classification, Hub-served copy fetch, single-flight 409 attach.
- Paid tiers stay unnamed in the binary by design; pricing lives Hub-side and on the linked pricing page.

## Testing

`make tsc` and the full `make test` suite pass; targeted `go test ./internal/server ./internal/cloudinstall` green. Verified live against a kind cluster: driver-lane pitch, disclosure states, plan card and failure footer in dark theme; wizard lane (in-cluster mode) in light theme, confirming lane-correct CTA, no driver-only elements, and the chip grid.

## Follow-ups

- Before the rollout gate reaches in-cluster installs: the ambiguous-ownership card needs a pointer to installing the CLI it prescribes, and the preflight-denial copy a "share with your platform team" path.
- Marketing site: SOC 2 / CNCF seals belong on the pricing page the disclosure links, not in the modal.