### PR TITLE
perf(sse): run topology broadcasts on a dedicated worker

### DIFF
--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -57,6 +57,8 @@ func main() {
 	namespaces := flag.Int("namespaces", 0, "load-test: number of namespaces to spread apps across (0 = default)")
 	podsPerApp := flag.Int("pods-per-app", 0, "load-test: pods per Deployment/ReplicaSet (0 = default)")
 	adminPort := flag.Int("admin-port", 0, "load-test: admin listener port for live scaling (0 = <port>+1)")
+	censusProfile := flag.String("census", "", "load-test: seed a named census profile (e.g. large-eks) instead of -pods")
+	censusScale := flag.Float64("census-scale", 1.0, "load-test: scale factor applied to -census counts")
 	flag.Parse()
 
 	// Isolate config/settings writes to a temp directory so e2e tests
@@ -74,7 +76,18 @@ func main() {
 		fakeClient *fake.Clientset
 		gen        *loadtest.Generator
 	)
-	if *pods > 0 {
+	if *censusProfile != "" {
+		c, ok := loadtest.Profiles[*censusProfile]
+		if !ok {
+			log.Fatalf("unknown -census profile %q", *censusProfile)
+		}
+		c = c.Scale(*censusScale)
+		start := time.Now()
+		objs := loadtest.CensusObjects(c, "registry.example/app:v1")
+		fakeClient = fake.NewClientset(objs...)
+		fmt.Fprintf(os.Stderr, "Seeding census %q scale %.3f: %d objects (%s)\n",
+			*censusProfile, *censusScale, len(objs), time.Since(start).Round(time.Millisecond))
+	} else if *pods > 0 {
 		gen = loadtest.New(loadtest.Config{
 			Pods: *pods, Nodes: *nodes, Namespaces: *namespaces, PodsPerApp: *podsPerApp,
 		})
@@ -90,7 +103,13 @@ func main() {
 
 	// --- Initialize subsystems ---
 
-	if err := k8s.InitTestResourceCache(fakeClient); err != nil {
+	// The census path measures startup, which only exists when the cache has the
+	// live deferred/critical split; InitTestResourceCache syncs everything at once.
+	if *censusProfile != "" {
+		if err := k8s.InitLoadTestResourceCache(fakeClient); err != nil {
+			log.Fatalf("InitLoadTestResourceCache: %v", err)
+		}
+	} else if err := k8s.InitTestResourceCache(fakeClient); err != nil {
 		log.Fatalf("InitTestResourceCache: %v", err)
 	}
 

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -11,6 +12,58 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
 
+// InitLoadTestResourceCache creates a resource cache from a fake client using
+// the live path's deferred-informer split, so the critical/deferred phases and
+// the warmup window they drive actually exist. InitTestResourceCache syncs
+// everything at once, which is what unit tests want and makes it useless for
+// measuring anything that depends on startup phases.
+//
+// Intended for load-test harnesses, not unit tests.
+func InitLoadTestResourceCache(client kubernetes.Interface) error {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	enabled := allTestResourceTypes()
+	deferred := make(map[string]bool, len(deferredResources))
+	maps.Copy(deferred, deferredResources)
+
+	secretWriteTimes := newSecretDataManagerWriteIndex()
+	cronJobScheduleObservations := newCronJobScheduleObservationTracker()
+	cfg := k8score.CacheConfig{
+		Client:        client,
+		ResourceTypes: enabled,
+		DeferredTypes: deferred,
+		OnTransform: func(obj any) {
+			secretWriteTimes.capture(obj)
+		},
+		OnObservedChange: func(change k8score.ResourceChange, obj, _ any) {
+			secretWriteTimes.reconcile(change, obj)
+			if cj, ok := obj.(*batchv1.CronJob); ok {
+				cronJobScheduleObservations.observe(change.Operation, cj)
+			}
+		},
+	}
+
+	core, err := k8score.NewResourceCache(cfg)
+	if err != nil {
+		return err
+	}
+
+	initialSyncComplete = core.IsSyncComplete()
+
+	resourceCache = &ResourceCache{
+		ResourceCache:               core,
+		secretsEnabled:              true,
+		cronJobScheduleObservations: cronJobScheduleObservations,
+		secretWriteTimes:            secretWriteTimes,
+	}
+
+	cacheOnce = new(sync.Once)
+	cacheOnce.Do(func() {})
+
+	return nil
+}
+
 // InitTestResourceCache creates a resource cache from a fake or test client,
 // bypassing RBAC checks and the normal Initialize/InitResourceCache flow.
 // All resource types are enabled. Call ResetTestState to clean up.
@@ -20,36 +73,7 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 
-	enabled := map[string]bool{
-		"pods":                     true,
-		"services":                 true,
-		"deployments":              true,
-		"daemonsets":               true,
-		"statefulsets":             true,
-		"replicasets":              true,
-		"ingresses":                true,
-		"configmaps":               true,
-		"secrets":                  true,
-		"events":                   true,
-		"persistentvolumeclaims":   true,
-		"resourcequotas":           true,
-		"nodes":                    true,
-		"namespaces":               true,
-		"jobs":                     true,
-		"cronjobs":                 true,
-		"horizontalpodautoscalers": true,
-		"persistentvolumes":        true,
-		"storageclasses":           true,
-		"poddisruptionbudgets":     true,
-		"roles":                    true,
-		"clusterroles":             true,
-		"rolebindings":             true,
-		"clusterrolebindings":      true,
-		"serviceaccounts":          true,
-		"ingressclasses":           true,
-		"networkpolicies":          true,
-		"limitranges":              true,
-	}
+	enabled := allTestResourceTypes()
 
 	secretWriteTimes := newSecretDataManagerWriteIndex()
 	cronJobScheduleObservations := newCronJobScheduleObservationTracker()
@@ -257,4 +281,38 @@ func ResetTestState() {
 
 	// Reset operation context so stale cancellations don't leak between tests
 	CancelOngoingOperations()
+}
+
+// allTestResourceTypes enables every kind the typed cache knows about.
+func allTestResourceTypes() map[string]bool {
+	return map[string]bool{
+		"pods":                     true,
+		"services":                 true,
+		"deployments":              true,
+		"daemonsets":               true,
+		"statefulsets":             true,
+		"replicasets":              true,
+		"ingresses":                true,
+		"configmaps":               true,
+		"secrets":                  true,
+		"events":                   true,
+		"persistentvolumeclaims":   true,
+		"resourcequotas":           true,
+		"nodes":                    true,
+		"namespaces":               true,
+		"jobs":                     true,
+		"cronjobs":                 true,
+		"horizontalpodautoscalers": true,
+		"persistentvolumes":        true,
+		"storageclasses":           true,
+		"poddisruptionbudgets":     true,
+		"roles":                    true,
+		"clusterroles":             true,
+		"rolebindings":             true,
+		"clusterrolebindings":      true,
+		"serviceaccounts":          true,
+		"ingressclasses":           true,
+		"networkpolicies":          true,
+		"limitranges":              true,
+	}
 }

--- a/internal/loadtest/census.go
+++ b/internal/loadtest/census.go
@@ -1,0 +1,704 @@
+package loadtest
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// fixedClock timestamps every generated object. A wall-clock read would make
+// the population non-deterministic, and two runs seeded minutes apart would
+// not be comparable measurements.
+var fixedClock = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// Census is an explicit per-kind object count, keyed by Kind. It replaces the
+// pods-and-apps model when the population needs to match a real cluster's
+// shape rather than a uniform one: kind ratios, not pod count, are what drive
+// topology edge-matching and informer memory.
+type Census map[string]int
+
+// LargeMultiTenantEKS is the census of a ~250-node, 432-namespace EKS cluster
+// running Crossplane, Kyverno, Argo CD, Traefik and VictoriaMetrics — a shape
+// where workload kinds outnumber pods and Events dominate everything.
+//
+// The ratios are what matter and they are deliberately un-round: ReplicaSets
+// run 2.2x Deployments (revision history), Deployments run 0.68x Pods (most
+// workloads are 1-2 replicas), and Events outnumber every other kind combined
+// by 3x.
+var LargeMultiTenantEKS = Census{
+	"Event":                   435554,
+	"ReplicaSet":              43033,
+	"Pod":                     29455,
+	"Secret":                  26668,
+	"Service":                 23547,
+	"Deployment":              19924,
+	"Job":                     19861,
+	"Ingress":                 16977,
+	"CronJob":                 4291,
+	"ConfigMap":               3894,
+	"NetworkPolicy":           1480,
+	"PersistentVolume":        816,
+	"PersistentVolumeClaim":   787,
+	"ServiceAccount":          545,
+	"Namespace":               432,
+	"StatefulSet":             388,
+	"HorizontalPodAutoscaler": 385,
+	"Node":                    248,
+	"ClusterRole":             216,
+	"ClusterRoleBinding":      168,
+	"RoleBinding":             66,
+	"Role":                    60,
+	"PodDisruptionBudget":     12,
+	"DaemonSet":               9,
+	"StorageClass":            5,
+	"IngressClass":            3,
+}
+
+// Profiles maps a -profile flag value to its census.
+var Profiles = map[string]Census{
+	"large-eks": LargeMultiTenantEKS,
+}
+
+func (c Census) get(kind string) int {
+	if n := c[kind]; n > 0 {
+		return n
+	}
+	return 0
+}
+
+// Total reports how many objects the census materializes.
+func (c Census) Total() int {
+	total := 0
+	for _, n := range c {
+		total += n
+	}
+	return total
+}
+
+// censusLayout precomputes the divisors every builder indexes against. Each
+// kind's object i attaches to app i%apps, so a kind with fewer objects than
+// apps covers a prefix of them and a kind with more wraps — which is how the
+// real ratios (2.2 ReplicaSets per Deployment, 0.2 ConfigMaps) reproduce
+// without special-casing each kind.
+type censusLayout struct {
+	apps       int
+	namespaces int
+	nodes      int
+	// configMaps bounds which apps mount one. Real clusters hold far fewer
+	// ConfigMaps than workloads, and a pod template naming one that does not
+	// exist yields no edge — so the shortfall has to be modelled as "most
+	// workloads mount nothing", not "every workload mounts a dangling ref".
+	configMaps int
+	// cronJobs owns the Job population. In a cluster with this many CronJobs
+	// almost every Job is one of their runs, and an owned Job collapses under
+	// its parent in topology instead of standing alone — so leaving Jobs as
+	// orphans inflates the graph.
+	cronJobs int
+}
+
+func newCensusLayout(c Census) censusLayout {
+	return censusLayout{
+		apps:       max(c.get("Deployment"), 1),
+		namespaces: max(c.get("Namespace"), 1),
+		nodes:      max(c.get("Node"), 1),
+		configMaps: c.get("ConfigMap"),
+		cronJobs:   c.get("CronJob"),
+	}
+}
+
+func (l censusLayout) cronJobIndex(i int) int   { return i % max(l.cronJobs, 1) }
+func (l censusLayout) cronJobName(i int) string { return fmt.Sprintf("cron-%05d", l.cronJobIndex(i)) }
+func (l censusLayout) cronJobUID(i int) types.UID {
+	return types.UID(fmt.Sprintf("loadtest-cron-%05d", l.cronJobIndex(i)))
+}
+
+// cronJobNS keys off the CronJob index, not the Job index: an owned Job must
+// share its owner's namespace or the ownership edge never resolves.
+func (l censusLayout) cronJobNS(i int) string {
+	if l.cronJobs == 0 {
+		return l.ns(i)
+	}
+	return fmt.Sprintf("loadtest-%03d", l.cronJobIndex(i)%l.namespaces)
+}
+
+func (l censusLayout) hasConfigMap(app int) bool { return app%l.apps < l.configMaps }
+
+// Replica distribution. A census fixes totals, not shape, and shape is what
+// the graph is built from: topology renders each pod individually up to 5 per
+// workload and collapses anything above that into one group node. Spreading
+// replicas evenly therefore never groups and inflates the node count, while a
+// real cluster is a long tail — a handful of large services, mostly
+// singletons, and some workloads scaled to zero.
+//
+// The tail size is calibrated against the reported graph, not derived from it:
+// a diagnostics snapshot carries per-kind totals but not per-workload replica
+// counts, so this is the one parameter fitted rather than observed.
+const (
+	censusTailWorkloads = 225
+	censusTailReplicas  = 50
+)
+
+func (l censusLayout) app(i int) int { return i % l.apps }
+
+// podApp maps a pod index to its workload under the long-tail distribution:
+// the first censusTailWorkloads apps take censusTailReplicas pods each, and
+// every remaining pod is the sole replica of its own app.
+func (l censusLayout) podApp(i int) int {
+	tail := censusTailWorkloads * censusTailReplicas
+	if i < tail {
+		return i / censusTailReplicas
+	}
+	return (censusTailWorkloads + (i - tail)) % l.apps
+}
+
+func (l censusLayout) replicasForApp(app int) int32 {
+	if app < censusTailWorkloads {
+		return censusTailReplicas
+	}
+	return 1
+}
+
+func (l censusLayout) podName(i int) string {
+	return fmt.Sprintf("app-%05d-%06d", l.podApp(i), i)
+}
+
+func (l censusLayout) podNS(i int) string {
+	return fmt.Sprintf("loadtest-%03d", l.podApp(i)%l.namespaces)
+}
+func (l censusLayout) ns(i int) string   { return fmt.Sprintf("loadtest-%03d", l.app(i)%l.namespaces) }
+func (l censusLayout) node(i int) string { return fmt.Sprintf("loadtest-node-%03d", i%l.nodes) }
+
+func (l censusLayout) appName(i int) string { return fmt.Sprintf("app-%05d", l.app(i)) }
+func (l censusLayout) labels(i int) map[string]string {
+	return map[string]string{"app": l.appName(i), "loadtest": "true"}
+}
+func (l censusLayout) deployUID(i int) types.UID {
+	return types.UID(fmt.Sprintf("loadtest-deploy-%05d", l.app(i)))
+}
+func (l censusLayout) rsName(i int) string { return fmt.Sprintf("app-%05d-rs-%d", l.app(i), i/l.apps) }
+func (l censusLayout) rsUID(i int) types.UID {
+	return types.UID(fmt.Sprintf("loadtest-rs-%05d-%d", l.app(i), i/l.apps))
+}
+
+// CensusObjects materializes the census. Objects are emitted kind by kind in
+// descending count order so the largest LISTs are contiguous in the tracker,
+// matching how an apiserver would page them.
+func CensusObjects(c Census, image string) []runtime.Object {
+	if image == "" {
+		image = DefaultImage
+	}
+	l := newCensusLayout(c)
+	objs := make([]runtime.Object, 0, c.Total())
+
+	for i := 0; i < c.get("Namespace"); i++ {
+		objs = append(objs, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("loadtest-%03d", i), Labels: map[string]string{"loadtest": "true"}},
+			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		})
+	}
+	for i := 0; i < c.get("Node"); i++ {
+		objs = append(objs, censusNode(i))
+	}
+	for i := 0; i < c.get("Deployment"); i++ {
+		objs = append(objs, censusDeployment(l, i, image))
+	}
+	for i := 0; i < c.get("ReplicaSet"); i++ {
+		objs = append(objs, censusReplicaSet(l, i, image))
+	}
+	for i := 0; i < c.get("Pod"); i++ {
+		objs = append(objs, censusPod(l, i, image))
+	}
+	for i := 0; i < c.get("Service"); i++ {
+		objs = append(objs, censusService(l, i))
+	}
+	for i := 0; i < c.get("Secret"); i++ {
+		objs = append(objs, censusSecret(l, i))
+	}
+	for i := 0; i < c.get("ConfigMap"); i++ {
+		objs = append(objs, censusConfigMap(l, i))
+	}
+	for i := 0; i < c.get("Event"); i++ {
+		objs = append(objs, censusEvent(l, i, c.get("Pod")))
+	}
+	for i := 0; i < c.get("Job"); i++ {
+		objs = append(objs, censusJob(l, i, image))
+	}
+	for i := 0; i < c.get("CronJob"); i++ {
+		objs = append(objs, censusCronJob(l, i, image))
+	}
+	for i := 0; i < c.get("Ingress"); i++ {
+		objs = append(objs, censusIngress(l, i))
+	}
+	for i := 0; i < c.get("StatefulSet"); i++ {
+		objs = append(objs, censusStatefulSet(l, i, image))
+	}
+	for i := 0; i < c.get("DaemonSet"); i++ {
+		objs = append(objs, censusDaemonSet(l, i, image))
+	}
+	for i := 0; i < c.get("HorizontalPodAutoscaler"); i++ {
+		objs = append(objs, censusHPA(l, i))
+	}
+	for i := 0; i < c.get("PersistentVolumeClaim"); i++ {
+		objs = append(objs, censusPVC(l, i))
+	}
+	for i := 0; i < c.get("PersistentVolume"); i++ {
+		objs = append(objs, censusPV(i))
+	}
+	for i := 0; i < c.get("NetworkPolicy"); i++ {
+		objs = append(objs, censusNetworkPolicy(l, i))
+	}
+	for i := 0; i < c.get("ServiceAccount"); i++ {
+		objs = append(objs, censusServiceAccount(l, i))
+	}
+	for i := 0; i < c.get("Role"); i++ {
+		objs = append(objs, censusRole(l, i))
+	}
+	for i := 0; i < c.get("RoleBinding"); i++ {
+		objs = append(objs, censusRoleBinding(l, i))
+	}
+	for i := 0; i < c.get("ClusterRole"); i++ {
+		objs = append(objs, censusClusterRole(i))
+	}
+	for i := 0; i < c.get("ClusterRoleBinding"); i++ {
+		objs = append(objs, censusClusterRoleBinding(i))
+	}
+	for i := 0; i < c.get("PodDisruptionBudget"); i++ {
+		objs = append(objs, censusPDB(l, i))
+	}
+	for i := 0; i < c.get("StorageClass"); i++ {
+		objs = append(objs, censusStorageClass(i))
+	}
+	for i := 0; i < c.get("IngressClass"); i++ {
+		objs = append(objs, censusIngressClass(i))
+	}
+	return objs
+}
+
+func censusNode(i int) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("loadtest-node-%03d", i), Labels: map[string]string{"loadtest": "true"}},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("110"),
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourcePods:   resource.MustParse("110"),
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			},
+		},
+	}
+}
+
+func censusPodSpec(l censusLayout, i int, image string) corev1.PodSpec {
+	spec := corev1.PodSpec{
+		NodeName:           l.node(i),
+		ServiceAccountName: fmt.Sprintf("sa-%04d", l.app(i)%512),
+		Containers: []corev1.Container{{
+			Name:  "app",
+			Image: image,
+			EnvFrom: []corev1.EnvFromSource{{
+				SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: censusSecretName(l, l.app(i))}},
+			}},
+			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			}},
+		}},
+	}
+	if l.hasConfigMap(l.app(i)) {
+		spec.Volumes = []corev1.Volume{{
+			Name: "config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("app-%05d-config", l.app(i))}},
+			},
+		}}
+	}
+	return spec
+}
+
+func censusPodTemplate(l censusLayout, i int, image string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: l.labels(i)},
+		Spec:       censusPodSpec(l, i, image),
+	}
+}
+
+func censusDeployment(l censusLayout, i int, image string) *appsv1.Deployment {
+	r := l.replicasForApp(l.app(i))
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: l.appName(i), Namespace: l.ns(i), UID: l.deployUID(i), Labels: l.labels(i),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &r,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+			Template: censusPodTemplate(l, i, image),
+		},
+		Status: appsv1.DeploymentStatus{Replicas: r, ReadyReplicas: r, AvailableReplicas: r, UpdatedReplicas: r},
+	}
+}
+
+func censusReplicaSet(l censusLayout, i int, image string) *appsv1.ReplicaSet {
+	// Only the current revision (the first wrap) carries replicas; the rest are
+	// the scaled-to-zero history a Deployment accumulates, which is why real
+	// clusters hold far more ReplicaSets than Deployments.
+	r := int32(0)
+	if i < l.apps {
+		r = l.replicasForApp(l.app(i))
+	}
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: l.rsName(i), Namespace: l.ns(i), UID: l.rsUID(i), Labels: l.labels(i),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: l.appName(i),
+				UID: l.deployUID(i), Controller: boolPtr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &r,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+			Template: censusPodTemplate(l, i, image),
+		},
+		Status: appsv1.ReplicaSetStatus{Replicas: r, ReadyReplicas: r, AvailableReplicas: r},
+	}
+}
+
+func censusPod(l censusLayout, i int, image string) *corev1.Pod {
+	app := l.podApp(i)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: l.podName(i), Namespace: l.podNS(i), Labels: l.labels(app),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: l.rsName(app),
+				UID: l.rsUID(app), Controller: boolPtr(true),
+			}},
+		},
+		Spec: censusPodSpec(l, app, image),
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app", Ready: true, Started: boolPtr(true),
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+}
+
+func censusService(l censusLayout, i int) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("app-%05d-svc-%d", l.app(i), i/l.apps), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": l.appName(i)},
+			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}},
+		},
+	}
+}
+
+// censusSecret carries ManagedFields naming a data owner. The informer
+// transform parses exactly this to recover Secret write times, so a Secret
+// without it makes that path free — and invisible to a measurement.
+// censusSecretName is the Secret a workload's pod template consumes: the
+// first one generated for its app. Pod specs and Secret objects must agree on
+// it or the ConfigMap/Secret-to-workload edges never form, and the graph under
+// measurement is missing a whole edge class.
+func censusSecretName(l censusLayout, app int) string {
+	return fmt.Sprintf("app-%05d-secret-0", app%l.apps)
+}
+
+func censusSecret(l censusLayout, i int) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("app-%05d-secret-%d", l.app(i), i/l.apps), Namespace: l.ns(i), Labels: l.labels(i),
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    "helm",
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: "v1",
+				Time:       &metav1.Time{Time: fixedClock},
+				FieldsType: "FieldsV1",
+				FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:data":{".":{},"f:token":{}},"f:type":{}}`)},
+			}},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"token": []byte("c3ludGhldGljLWxvYWR0ZXN0LXNlY3JldC12YWx1ZQ==")},
+	}
+}
+
+func censusConfigMap(l censusLayout, i int) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("app-%05d-config", l.app(i)), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Data: map[string]string{"app.conf": fmt.Sprintf("name=%s\n", l.appName(i))},
+	}
+}
+
+func censusEvent(l censusLayout, i, pods int) *corev1.Event {
+	reasons := []string{"Scheduled", "Pulled", "Created", "Started", "BackOff", "Killing", "Unhealthy", "FailedMount"}
+	target := i
+	if pods > 0 {
+		target = i % pods
+	}
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%08x", l.podName(target), i), Namespace: l.podNS(target),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod", Namespace: l.podNS(target), Name: l.podName(target),
+			APIVersion: "v1", UID: types.UID(fmt.Sprintf("loadtest-pod-%06d", target)),
+		},
+		Reason:         reasons[i%len(reasons)],
+		Message:        fmt.Sprintf("synthetic event %d for load testing the timeline pipeline", i),
+		Type:           corev1.EventTypeNormal,
+		Count:          int32(1 + i%5),
+		Source:         corev1.EventSource{Component: "kubelet", Host: l.node(target)},
+		FirstTimestamp: metav1.Time{Time: fixedClock},
+		LastTimestamp:  metav1.Time{Time: fixedClock},
+	}
+}
+
+func censusJob(l censusLayout, i int, image string) *batchv1.Job {
+	one := int32(1)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%08d", l.cronJobName(i), i), Namespace: l.cronJobNS(i), Labels: l.labels(i),
+		},
+		Spec:   batchv1.JobSpec{Completions: &one, Parallelism: &one, Template: censusPodTemplate(l, i, image)},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	if l.cronJobs > 0 {
+		job.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "batch/v1", Kind: "CronJob", Name: l.cronJobName(i),
+			UID: l.cronJobUID(i), Controller: boolPtr(true),
+		}}
+	}
+	return job
+}
+
+func censusCronJob(l censusLayout, i int, image string) *batchv1.CronJob {
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: l.cronJobName(i), Namespace: l.cronJobNS(i), UID: l.cronJobUID(i), Labels: l.labels(i),
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{Template: censusPodTemplate(l, i, image)},
+			},
+		},
+	}
+}
+
+func censusIngress(l censusLayout, i int) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	class := "alb"
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("app-%05d-ing-%d", l.app(i), i/l.apps), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &class,
+			Rules: []networkingv1.IngressRule{{
+				Host: fmt.Sprintf("app-%05d.loadtest.example.com", l.app(i)),
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path: "/", PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: fmt.Sprintf("app-%05d-svc-0", l.app(i)),
+									Port: networkingv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+}
+
+func censusStatefulSet(l censusLayout, i int, image string) *appsv1.StatefulSet {
+	r := int32(2)
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("sts-%05d", i), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &r,
+			ServiceName: fmt.Sprintf("app-%05d-svc-0", l.app(i)),
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+			Template:    censusPodTemplate(l, i, image),
+		},
+		Status: appsv1.StatefulSetStatus{Replicas: r, ReadyReplicas: r},
+	}
+}
+
+func censusDaemonSet(l censusLayout, i int, image string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("ds-%03d", i), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+			Template: censusPodTemplate(l, i, image),
+		},
+		Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 248, NumberReady: 248},
+	}
+}
+
+func censusHPA(l censusLayout, i int) *autoscalingv2.HorizontalPodAutoscaler {
+	minR := int32(2)
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("app-%05d-hpa", l.app(i)), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: l.appName(i),
+			},
+			MinReplicas: &minR,
+			MaxReplicas: 10,
+		},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 2, DesiredReplicas: 2},
+	}
+}
+
+func censusPVC(l censusLayout, i int) *corev1.PersistentVolumeClaim {
+	sc := "gp3"
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("pvc-%05d", i), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &sc,
+			VolumeName:       fmt.Sprintf("pv-%05d", i),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+}
+
+func censusPV(i int) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pv-%05d", i), Labels: map[string]string{"loadtest": "true"}},
+		Spec: corev1.PersistentVolumeSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: "gp3",
+			Capacity:         corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: "ebs.csi.aws.com", VolumeHandle: fmt.Sprintf("vol-%05d", i)},
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
+	}
+}
+
+func censusNetworkPolicy(l censusLayout, i int) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("netpol-%05d", i), Namespace: l.ns(i), Labels: l.labels(i),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"loadtest": "true"}},
+				}},
+			}},
+		},
+	}
+}
+
+func censusServiceAccount(l censusLayout, i int) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("sa-%04d", i), Namespace: l.ns(i), Labels: map[string]string{"loadtest": "true"},
+		},
+	}
+}
+
+func censusRole(l censusLayout, i int) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("role-%04d", i), Namespace: l.ns(i)},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""}, Resources: []string{"pods", "configmaps"}, Verbs: []string{"get", "list", "watch"},
+		}},
+	}
+}
+
+func censusRoleBinding(l censusLayout, i int) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("rb-%04d", i), Namespace: l.ns(i)},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: fmt.Sprintf("role-%04d", i)},
+		Subjects: []rbacv1.Subject{{
+			Kind: "ServiceAccount", Name: fmt.Sprintf("sa-%04d", i), Namespace: l.ns(i),
+		}},
+	}
+}
+
+func censusClusterRole(i int) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("clusterrole-%04d", i)},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"},
+		}},
+	}
+}
+
+func censusClusterRoleBinding(i int) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("crb-%04d", i)},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: fmt.Sprintf("clusterrole-%04d", i)},
+		Subjects: []rbacv1.Subject{{
+			Kind: "ServiceAccount", Name: fmt.Sprintf("sa-%04d", i), Namespace: "loadtest-000",
+		}},
+	}
+}
+
+func censusPDB(l censusLayout, i int) *policyv1.PodDisruptionBudget {
+	minAvail := intstr.FromInt(1)
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pdb-%03d", i), Namespace: l.ns(i)},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvail,
+			Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": l.appName(i)}},
+		},
+	}
+}
+
+func censusStorageClass(i int) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: fmt.Sprintf("sc-%02d", i)},
+		Provisioner: "ebs.csi.aws.com",
+	}
+}
+
+func censusIngressClass(i int) *networkingv1.IngressClass {
+	return &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("ingressclass-%02d", i)},
+		Spec:       networkingv1.IngressClassSpec{Controller: "ingress.k8s.aws/alb"},
+	}
+}

--- a/internal/loadtest/census.go
+++ b/internal/loadtest/census.go
@@ -107,6 +107,11 @@ type censusLayout struct {
 	// its parent in topology instead of standing alone — so leaving Jobs as
 	// orphans inflates the graph.
 	cronJobs int
+	// serviceAccounts bounds which namespaces have an identity to run under.
+	// Workloads share one per namespace (see serviceAccountName), so this only
+	// bites on a census with fewer ServiceAccounts than namespaces — there the
+	// remainder must name nothing rather than a name nothing materializes.
+	serviceAccounts int
 }
 
 func newCensusLayout(c Census) censusLayout {
@@ -116,6 +121,8 @@ func newCensusLayout(c Census) censusLayout {
 		nodes:      max(c.get("Node"), 1),
 		configMaps: c.get("ConfigMap"),
 		cronJobs:   c.get("CronJob"),
+
+		serviceAccounts: c.get("ServiceAccount"),
 	}
 }
 
@@ -135,6 +142,22 @@ func (l censusLayout) cronJobNS(i int) string {
 }
 
 func (l censusLayout) hasConfigMap(app int) bool { return app%l.apps < l.configMaps }
+
+// serviceAccountName is the identity an app's pod template runs under. Apps
+// sharing a namespace share it, which is the real shape: a cluster holds far
+// fewer ServiceAccounts than workloads because most workloads run under their
+// namespace's default. Indexing it by namespace is also what makes it resolve —
+// censusServiceAccount places ServiceAccount i in app i's namespace, so a name
+// picked on any other axis lands in the wrong namespace, and topology's
+// (namespace, name) join then drops the edge as silently as a name nothing
+// materializes. Empty when the census is too small to cover the namespace.
+func (l censusLayout) serviceAccountName(app int) string {
+	index := l.nsIndex(app)
+	if index >= l.serviceAccounts {
+		return ""
+	}
+	return fmt.Sprintf("sa-%04d", index)
+}
 
 // Replica distribution. A census fixes totals, not shape, and shape is what
 // the graph is built from: topology renders each pod individually up to 5 per
@@ -178,7 +201,8 @@ func (l censusLayout) podName(i int) string {
 func (l censusLayout) podNS(i int) string {
 	return fmt.Sprintf("loadtest-%03d", l.podApp(i)%l.namespaces)
 }
-func (l censusLayout) ns(i int) string   { return fmt.Sprintf("loadtest-%03d", l.app(i)%l.namespaces) }
+func (l censusLayout) nsIndex(i int) int { return l.app(i) % l.namespaces }
+func (l censusLayout) ns(i int) string   { return fmt.Sprintf("loadtest-%03d", l.nsIndex(i)) }
 func (l censusLayout) node(i int) string { return fmt.Sprintf("loadtest-node-%03d", i%l.nodes) }
 
 func (l censusLayout) appName(i int) string { return fmt.Sprintf("app-%05d", l.app(i)) }
@@ -309,7 +333,7 @@ func censusNode(i int) *corev1.Node {
 func censusPodSpec(l censusLayout, i int, image string) corev1.PodSpec {
 	spec := corev1.PodSpec{
 		NodeName:           l.node(i),
-		ServiceAccountName: fmt.Sprintf("sa-%04d", l.app(i)%512),
+		ServiceAccountName: l.serviceAccountName(l.app(i)),
 		Containers: []corev1.Container{{
 			Name:  "app",
 			Image: image,

--- a/internal/loadtest/census_scale.go
+++ b/internal/loadtest/census_scale.go
@@ -1,0 +1,20 @@
+package loadtest
+
+// Scale returns a census with every kind's count multiplied by factor,
+// preserving the ratios that drive topology edge-matching. Tests need the
+// shape of a reported cluster without materializing its object count; a
+// scaled census trips the same code paths (large-cluster guard, summary
+// mode, owner collapsing) at a fraction of the cost.
+//
+// Counts floor at 1 for any kind the source census populates, so scaling
+// down never silently drops a kind and changes the graph's topology.
+func (c Census) Scale(factor float64) Census {
+	scaled := make(Census, len(c))
+	for kind, n := range c {
+		if n <= 0 {
+			continue
+		}
+		scaled[kind] = max(int(float64(n)*factor), 1)
+	}
+	return scaled
+}

--- a/internal/loadtest/census_test.go
+++ b/internal/loadtest/census_test.go
@@ -17,6 +17,13 @@ import (
 // drift makes a comparison against the real cluster unsound.
 const maxCensusDrift = 0.0
 
+// unitTestCensusScale keeps this suite off the reported census. Every kind
+// materializes exactly the count it is given at any scale, so the property is
+// unchanged, whereas the reported census materializes 628k objects and about a
+// gigabyte of resident memory per run. Scale floors every declared kind at 1,
+// so scaling down drops no kind from the check.
+const unitTestCensusScale = 0.01
+
 func kindOf(obj runtime.Object) string {
 	t := fmt.Sprintf("%T", obj)
 	if i := strings.LastIndex(t, "."); i >= 0 {
@@ -34,14 +41,15 @@ func countByKind(objs []runtime.Object) map[string]int {
 }
 
 func TestCensusObjectsMatchDeclaredCounts(t *testing.T) {
-	objs := CensusObjects(LargeMultiTenantEKS, "")
+	census := LargeMultiTenantEKS.Scale(unitTestCensusScale)
+	objs := CensusObjects(census, "")
 	got := countByKind(objs)
 
-	if len(objs) != LargeMultiTenantEKS.Total() {
-		t.Errorf("materialized %d objects, census declares %d", len(objs), LargeMultiTenantEKS.Total())
+	if len(objs) != census.Total() {
+		t.Errorf("materialized %d objects, census declares %d", len(objs), census.Total())
 	}
 
-	for kind, want := range LargeMultiTenantEKS {
+	for kind, want := range census {
 		have := got[kind]
 		drift := float64(have-want) / float64(want) * 100
 		if drift < 0 {
@@ -53,7 +61,7 @@ func TestCensusObjectsMatchDeclaredCounts(t *testing.T) {
 	}
 
 	for kind, have := range got {
-		if _, declared := LargeMultiTenantEKS[kind]; !declared {
+		if _, declared := census[kind]; !declared {
 			t.Errorf("%s: materialized %d objects but the census declares none", kind, have)
 		}
 	}

--- a/internal/loadtest/census_test.go
+++ b/internal/loadtest/census_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,6 +264,83 @@ func TestCensusWorkloadConfigRefsResolve(t *testing.T) {
 	}
 	if checked == 0 {
 		t.Fatal("no pods materialized")
+	}
+}
+
+// Workload identity is joined by (namespace, name) like the config refs above,
+// so a name that resolves in the wrong namespace erases the ServiceAccount edge
+// class just as completely as a name nothing materializes.
+func TestCensusWorkloadServiceAccountRefsResolve(t *testing.T) {
+	tests := []struct {
+		name        string
+		census      Census
+		wantUnnamed bool
+	}{
+		// Enough ServiceAccounts for every namespace: nothing runs unnamed.
+		{
+			name:   "every namespace covered",
+			census: Census{"Namespace": 4, "Node": 2, "Deployment": 20, "Pod": 40, "ServiceAccount": 6},
+		},
+		// The real census has far more workloads than ServiceAccounts, and
+		// enough of them to wrap any fixed-modulus mapping.
+		{
+			name:   "more workloads than ServiceAccounts",
+			census: Census{"Namespace": 7, "Node": 2, "Deployment": 600, "Pod": 40, "ServiceAccount": 9},
+		},
+		// Fewer ServiceAccounts than namespaces: the uncovered ones must name
+		// nothing rather than a name that exists in someone else's namespace.
+		{
+			name:        "fewer ServiceAccounts than namespaces",
+			census:      Census{"Namespace": 4, "Node": 2, "Deployment": 20, "Pod": 40, "ServiceAccount": 2},
+			wantUnnamed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := CensusObjects(tt.census, "")
+
+			serviceAccounts := map[string]bool{}
+			for _, o := range objs {
+				if sa, ok := o.(*corev1.ServiceAccount); ok {
+					serviceAccounts[sa.Namespace+"/"+sa.Name] = true
+				}
+			}
+
+			// Both shapes topology reads an identity from: the workload's pod
+			// template and the running Pod.
+			type identity struct{ kind, id, namespace, serviceAccount string }
+			var identities []identity
+			for _, o := range objs {
+				switch v := o.(type) {
+				case *appsv1.Deployment:
+					identities = append(identities, identity{"Deployment", v.Name, v.Namespace, v.Spec.Template.Spec.ServiceAccountName})
+				case *corev1.Pod:
+					identities = append(identities, identity{"Pod", v.Name, v.Namespace, v.Spec.ServiceAccountName})
+				}
+			}
+
+			named, unnamed := 0, 0
+			for _, got := range identities {
+				if got.serviceAccount == "" {
+					unnamed++
+					continue
+				}
+				named++
+				if key := got.namespace + "/" + got.serviceAccount; !serviceAccounts[key] {
+					t.Errorf("%s %s/%s runs as ServiceAccount %q, which was never materialized in that namespace",
+						got.kind, got.namespace, got.id, key)
+				}
+			}
+
+			if named == 0 {
+				t.Fatal("nothing names a ServiceAccount; the edge class is absent from the measured graph")
+			}
+			if got := unnamed > 0; got != tt.wantUnnamed {
+				t.Errorf("workloads running unnamed = %v (%d of %d), want %v",
+					got, unnamed, len(identities), tt.wantUnnamed)
+			}
+		})
 	}
 }
 

--- a/internal/loadtest/census_test.go
+++ b/internal/loadtest/census_test.go
@@ -1,0 +1,275 @@
+package loadtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// maxCensusDrift is how far a materialized kind may fall from its declared
+// count. It is zero: the census is the measurement's control variable, so any
+// drift makes a comparison against the real cluster unsound.
+const maxCensusDrift = 0.0
+
+func kindOf(obj runtime.Object) string {
+	t := fmt.Sprintf("%T", obj)
+	if i := strings.LastIndex(t, "."); i >= 0 {
+		return t[i+1:]
+	}
+	return t
+}
+
+func countByKind(objs []runtime.Object) map[string]int {
+	got := map[string]int{}
+	for _, o := range objs {
+		got[kindOf(o)]++
+	}
+	return got
+}
+
+func TestCensusObjectsMatchDeclaredCounts(t *testing.T) {
+	objs := CensusObjects(LargeMultiTenantEKS, "")
+	got := countByKind(objs)
+
+	if len(objs) != LargeMultiTenantEKS.Total() {
+		t.Errorf("materialized %d objects, census declares %d", len(objs), LargeMultiTenantEKS.Total())
+	}
+
+	for kind, want := range LargeMultiTenantEKS {
+		have := got[kind]
+		drift := float64(have-want) / float64(want) * 100
+		if drift < 0 {
+			drift = -drift
+		}
+		if drift > maxCensusDrift {
+			t.Errorf("%s: got %d, census declares %d (%.2f%% drift)", kind, have, want, drift)
+		}
+	}
+
+	for kind, have := range got {
+		if _, declared := LargeMultiTenantEKS[kind]; !declared {
+			t.Errorf("%s: materialized %d objects but the census declares none", kind, have)
+		}
+	}
+}
+
+// The ownership chain is what topology walks; a census with the right counts
+// but dangling owner references would measure the wrong graph.
+func TestCensusPreservesOwnershipChain(t *testing.T) {
+	c := Census{"Namespace": 2, "Node": 2, "Deployment": 3, "ReplicaSet": 7, "Pod": 11}
+	objs := CensusObjects(c, "")
+
+	deployUIDs := map[types.UID]bool{}
+	rsUIDs := map[types.UID]bool{}
+	rsNames := map[string]bool{}
+	for _, o := range objs {
+		m := o.(metav1.Object)
+		switch kindOf(o) {
+		case "Deployment":
+			deployUIDs[m.GetUID()] = true
+		case "ReplicaSet":
+			rsUIDs[m.GetUID()] = true
+			rsNames[m.GetName()] = true
+		}
+	}
+
+	for _, o := range objs {
+		m := o.(metav1.Object)
+		refs := m.GetOwnerReferences()
+		if len(refs) == 0 {
+			continue
+		}
+		ref := refs[0]
+		switch kindOf(o) {
+		case "ReplicaSet":
+			if !deployUIDs[ref.UID] {
+				t.Errorf("ReplicaSet %s owned by unknown Deployment %s", m.GetName(), ref.UID)
+			}
+		case "Pod":
+			if !rsUIDs[ref.UID] {
+				t.Errorf("Pod %s owned by unknown ReplicaSet %s (%s)", m.GetName(), ref.UID, ref.Name)
+			}
+			if !rsNames[ref.Name] {
+				t.Errorf("Pod %s names a ReplicaSet %q that was never materialized", m.GetName(), ref.Name)
+			}
+		}
+	}
+}
+
+// An owned Job in a different namespace from its CronJob is an unresolvable
+// reference, and topology would render it as an orphan — inflating the graph
+// exactly where a real cluster collapses it.
+func TestCensusJobsResolveToOwningCronJobInSameNamespace(t *testing.T) {
+	objs := CensusObjects(Census{
+		"Namespace": 7, "Node": 2, "Deployment": 9, "CronJob": 4, "Job": 13,
+	}, "")
+
+	cronJobs := map[types.UID]string{}
+	for _, o := range objs {
+		if cj, ok := o.(*batchv1.CronJob); ok {
+			cronJobs[cj.UID] = cj.Namespace + "/" + cj.Name
+		}
+	}
+	if len(cronJobs) != 4 {
+		t.Fatalf("materialized %d CronJobs, want 4", len(cronJobs))
+	}
+
+	jobs := 0
+	for _, o := range objs {
+		job, ok := o.(*batchv1.Job)
+		if !ok {
+			continue
+		}
+		jobs++
+		if len(job.OwnerReferences) == 0 {
+			t.Errorf("Job %s/%s has no owning CronJob", job.Namespace, job.Name)
+			continue
+		}
+		ref := job.OwnerReferences[0]
+		owner, known := cronJobs[ref.UID]
+		if !known {
+			t.Errorf("Job %s/%s owned by unknown CronJob %s", job.Namespace, job.Name, ref.UID)
+			continue
+		}
+		if want := job.Namespace + "/" + ref.Name; owner != want {
+			t.Errorf("Job %s/%s names CronJob %s but that CronJob lives at %s", job.Namespace, job.Name, want, owner)
+		}
+	}
+	if jobs != 13 {
+		t.Fatalf("materialized %d Jobs, want 13", jobs)
+	}
+}
+
+// Secret write-time recovery parses ManagedFields inside the informer
+// transform. A census whose Secrets carry none makes that path free, and a
+// measurement taken against it would understate startup cost.
+func TestCensusSecretsCarryDataOwnerManagedFields(t *testing.T) {
+	objs := CensusObjects(Census{"Namespace": 1, "Deployment": 1, "Secret": 3}, "")
+
+	found := 0
+	for _, o := range objs {
+		s, ok := o.(*corev1.Secret)
+		if !ok {
+			continue
+		}
+		found++
+		if len(s.ManagedFields) == 0 {
+			t.Fatalf("Secret %s carries no ManagedFields", s.Name)
+		}
+		e := s.ManagedFields[0]
+		if e.Time == nil || e.FieldsV1 == nil {
+			t.Fatalf("Secret %s ManagedFields entry lacks Time or FieldsV1", s.Name)
+		}
+		if !strings.Contains(string(e.FieldsV1.Raw), `"f:data"`) {
+			t.Errorf("Secret %s ManagedFields does not claim ownership of data", s.Name)
+		}
+		if e.Operation != metav1.ManagedFieldsOperationUpdate && e.Operation != metav1.ManagedFieldsOperationApply {
+			t.Errorf("Secret %s ManagedFields operation %q is neither Update nor Apply", s.Name, e.Operation)
+		}
+	}
+	if found != 3 {
+		t.Fatalf("materialized %d Secrets, want 3", found)
+	}
+}
+
+// Events are the largest kind in a real cluster and the reason its heap is
+// what it is; they must resolve to pods that exist.
+func TestCensusEventsReferenceMaterializedPods(t *testing.T) {
+	objs := CensusObjects(Census{"Namespace": 2, "Node": 1, "Deployment": 2, "Pod": 5, "Event": 12}, "")
+
+	pods := map[string]bool{}
+	for _, o := range objs {
+		if p, ok := o.(*corev1.Pod); ok {
+			pods[p.Namespace+"/"+p.Name] = true
+		}
+	}
+	events := 0
+	for _, o := range objs {
+		e, ok := o.(*corev1.Event)
+		if !ok {
+			continue
+		}
+		events++
+		key := e.InvolvedObject.Namespace + "/" + e.InvolvedObject.Name
+		if !pods[key] {
+			t.Errorf("Event %s references pod %s which was never materialized", e.Name, key)
+		}
+	}
+	if events != 12 {
+		t.Fatalf("materialized %d Events, want 12", events)
+	}
+}
+
+// A pod template naming a ConfigMap or Secret that the census never
+// materializes silently deletes an entire edge class from the graph, which is
+// the exact thing these measurements compare against.
+func TestCensusWorkloadConfigRefsResolve(t *testing.T) {
+	// ConfigMaps are deliberately scarcer than Deployments, mirroring the real
+	// ratio: most workloads must mount nothing rather than a dangling name.
+	objs := CensusObjects(Census{
+		"Namespace": 4, "Node": 2, "Deployment": 20, "Pod": 40, "Secret": 25, "ConfigMap": 5,
+	}, "")
+
+	secrets := map[string]bool{}
+	configMaps := map[string]bool{}
+	for _, o := range objs {
+		switch v := o.(type) {
+		case *corev1.Secret:
+			secrets[v.Namespace+"/"+v.Name] = true
+		case *corev1.ConfigMap:
+			configMaps[v.Namespace+"/"+v.Name] = true
+		}
+	}
+
+	checked := 0
+	for _, o := range objs {
+		p, ok := o.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+		checked++
+		for _, c := range p.Spec.Containers {
+			for _, ef := range c.EnvFrom {
+				if ef.SecretRef == nil {
+					continue
+				}
+				if key := p.Namespace + "/" + ef.SecretRef.Name; !secrets[key] {
+					t.Errorf("pod %s/%s consumes Secret %q which was never materialized", p.Namespace, p.Name, key)
+				}
+			}
+		}
+		for _, v := range p.Spec.Volumes {
+			if v.ConfigMap == nil {
+				continue
+			}
+			if key := p.Namespace + "/" + v.ConfigMap.Name; !configMaps[key] {
+				t.Errorf("pod %s/%s mounts ConfigMap %q which was never materialized", p.Namespace, p.Name, key)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no pods materialized")
+	}
+}
+
+func TestCensusIsDeterministic(t *testing.T) {
+	first := CensusObjects(Census{"Namespace": 2, "Deployment": 3, "Pod": 7, "Event": 5}, "")
+	second := CensusObjects(Census{"Namespace": 2, "Deployment": 3, "Pod": 7, "Event": 5}, "")
+
+	if len(first) != len(second) {
+		t.Fatalf("object counts differ across runs: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		a, b := first[i].(metav1.Object), second[i].(metav1.Object)
+		if a.GetName() != b.GetName() || a.GetNamespace() != b.GetNamespace() {
+			t.Fatalf("object %d differs across runs: %s/%s vs %s/%s",
+				i, a.GetNamespace(), a.GetName(), b.GetNamespace(), b.GetName())
+		}
+	}
+}

--- a/internal/server/cached_topology_index_test.go
+++ b/internal/server/cached_topology_index_test.go
@@ -27,7 +27,7 @@ func TestGetCachedTopologyWithIndex(t *testing.T) {
 	}
 
 	topoA := topoWithEdge("deployment/ns/web", "replicaset/ns/web-1")
-	b.updateCachedTopology(topoA)
+	b.updateCachedTopology(topoA, b.topoEpoch.Load())
 
 	gotTopo, idxA := b.GetCachedTopologyWithIndex()
 	if gotTopo != topoA {
@@ -49,7 +49,7 @@ func TestGetCachedTopologyWithIndex(t *testing.T) {
 
 	// Replacing the topology invalidates the index; the next call builds a fresh one.
 	topoB := topoWithEdge("statefulset/ns/db", "pod/ns/db-0")
-	b.updateCachedTopology(topoB)
+	b.updateCachedTopology(topoB, b.topoEpoch.Load())
 	gotTopoB, idxB := b.GetCachedTopologyWithIndex()
 	if gotTopoB != topoB {
 		t.Fatalf("expected the replaced topology pointer back")
@@ -66,7 +66,7 @@ func TestGetCachedTopologyWithIndex(t *testing.T) {
 	}
 
 	// Clearing the topology (context-switch semantics) returns (nil, nil).
-	b.updateCachedTopology(nil)
+	b.updateCachedTopology(nil, b.topoEpoch.Load())
 	if topo, idx := b.GetCachedTopologyWithIndex(); topo != nil || idx != nil {
 		t.Fatalf("expected (nil, nil) after clearing topology, got (%v, %v)", topo, idx)
 	}

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -41,6 +41,10 @@ var (
 	testServerSrv *Server
 )
 
+// testFakeClient is the shared cluster fixture built in TestMain. Tests that
+// replace the resource cache restore it from here.
+var testFakeClient *fake.Clientset
+
 func TestMain(m *testing.M) {
 	// The Cloud-funnel rollout gate mints an install ID in ~/.radar on first
 	// use; redirect HOME so no test run touches the developer's real settings.
@@ -56,7 +60,9 @@ func TestMain(m *testing.M) {
 	deployUID := "deploy-uid-1234"
 	rsUID := "rs-uid-5678"
 
-	fakeClient := fake.NewClientset(
+	// Package-level so tests that swap in their own cluster shape (census-scale
+	// measurements) can restore the shared fixture the rest of the suite reads.
+	testFakeClient = fake.NewClientset(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
 			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -344,7 +350,7 @@ func TestMain(m *testing.M) {
 	)
 
 	// Initialize cache from fake client (bypasses RBAC checks)
-	if err := k8s.InitTestResourceCache(fakeClient); err != nil {
+	if err := k8s.InitTestResourceCache(testFakeClient); err != nil {
 		panic("InitTestResourceCache: " + err.Error())
 	}
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -77,6 +77,17 @@ type SSEBroadcaster struct {
 	// every publish re-checks it, so an in-flight build is discarded rather
 	// than shown or cached.
 	topoEpoch atomic.Uint64
+
+	// topoEpochAtCycleStart reads the epoch a cycle is built against. A real
+	// context switch lands on another goroutine at an arbitrary point inside a
+	// build, so injecting the capture is the only deterministic way to exercise
+	// a build that spans one.
+	topoEpochAtCycleStart func() uint64
+
+	// topoBuild is the cycle the worker runs per trigger. A seam for the same
+	// reason: the worker's scheduling (what a trigger arriving mid-build does)
+	// is otherwise only observable by running real multi-second builds.
+	topoBuild func() bool
 }
 
 // ClientInfo stores information about a connected client
@@ -171,7 +182,7 @@ func safeSend(ch chan SSEEvent, event SSEEvent) {
 
 // NewSSEBroadcaster creates a new SSE broadcaster
 func NewSSEBroadcaster() *SSEBroadcaster {
-	return &SSEBroadcaster{
+	b := &SSEBroadcaster{
 		clients:     make(map[chan SSEEvent]ClientInfo),
 		register:    make(chan clientRegistration),
 		unregister:  make(chan chan SSEEvent),
@@ -180,6 +191,9 @@ func NewSSEBroadcaster() *SSEBroadcaster {
 		warmupDone:  make(chan struct{}),
 		topoTrigger: make(chan struct{}, 1),
 	}
+	b.topoEpochAtCycleStart = b.topoEpoch.Load
+	b.topoBuild = b.broadcastTopologyUpdate
+	return b
 }
 
 // Start begins the broadcaster's main loop
@@ -215,6 +229,13 @@ func (b *SSEBroadcaster) requestTopologyBroadcast() {
 	}
 }
 
+// topologyRetryDelay is how long the worker waits before re-arming a trigger it
+// consumed while the cluster view was torn down. Reconnect and context switch
+// both queue their own trigger, so this only covers the window where neither
+// fires — but the token it consumed stood for every request that coalesced into
+// it, so dropping it silently strands the graph until the next cluster change.
+const topologyRetryDelay = 2 * time.Second
+
 // topologyWorker owns every broadcast build, so concurrent triggers (debounce
 // fire, context switch, CRD discovery) coalesce into a single build instead of
 // racing several multi-second ones.
@@ -224,7 +245,15 @@ func (b *SSEBroadcaster) topologyWorker() {
 		case <-b.stopCh:
 			return
 		case <-b.topoTrigger:
-			b.broadcastTopologyUpdate()
+			if b.topoBuild() || b.ClientCount() == 0 {
+				continue
+			}
+			select {
+			case <-b.stopCh:
+				return
+			case <-time.After(topologyRetryDelay):
+				b.requestTopologyBroadcast()
+			}
 		}
 	}
 }
@@ -643,18 +672,19 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 	}
 }
 
-// broadcastTopologyUpdate sends the current topology to all clients
-func (b *SSEBroadcaster) broadcastTopologyUpdate() {
+// broadcastTopologyUpdate sends the current topology to all clients. Reports
+// false when the cluster view was torn down and nothing could be built, so the
+// worker can re-arm the trigger it consumed instead of dropping it.
+func (b *SSEBroadcaster) broadcastTopologyUpdate() bool {
 	// Skip if resource cache is torn down (e.g. during context switch).
-	// The next successful connection will trigger a fresh build.
 	if k8s.GetResourceCache() == nil {
-		return
+		return false
 	}
 
 	// The cluster this cycle describes. A switch landing mid-cycle re-triggers
 	// the worker, so abandoning here costs nothing and keeps the previous
 	// cluster's graph off the wire.
-	epoch := b.topoEpoch.Load()
+	epoch := b.topoEpochAtCycleStart()
 
 	b.mu.RLock()
 	clients := make(map[chan SSEEvent]ClientInfo, len(b.clients))
@@ -664,39 +694,43 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	if len(clients) == 0 {
 		// No clients — mark the relationship cache as dirty so it gets
 		// rebuilt on next GetCachedTopology() call. Skip the expensive build.
-		b.cachedTopologyMu.Lock()
-		b.cachedTopologyDirty = true
-		b.cachedTopologyMu.Unlock()
+		b.markCachedTopologyDirty()
 		// Forget the last cycle's estimate so a future session doesn't inherit
 		// a disconnected session's debounce (a small namespace shouldn't keep a
 		// big one's 15s cadence). topologyDebounceFor falls back to the resource-
 		// count proxy until the next broadcast records a real estimate.
 		b.lastBroadcastMaxEstimated.Store(0)
-		return
+		return true
 	}
 
-	// One broadcast cycle = one debounce fire that reaches clients. Counted
-	// here (not in the per-group loop below) so the metric reflects cycles,
-	// not the number of distinct namespace/view/policy groups.
-	perfstats.IncSSEBroadcast()
+	// Checked before the full-topology build, which is the most expensive one
+	// in the cycle (every namespace, ReplicaSets included): a switch that has
+	// already landed makes it wrong before it costs anything, and the reset
+	// queued its own trigger to replace it.
+	if b.topoEpoch.Load() != epoch {
+		return b.abandonCycleForNewCluster()
+	}
 
 	// During warmup, skip the expensive full-topology cache build. Nobody is
 	// clicking into resource details while the connecting spinner is showing,
 	// so the relationship cache isn't needed yet. Mark dirty for lazy rebuild.
 	if b.isWarmingUp() {
-		b.cachedTopologyMu.Lock()
-		b.cachedTopologyDirty = true
-		b.cachedTopologyMu.Unlock()
+		b.markCachedTopologyDirty()
 	} else {
 		if fullTopo, err := buildFullTopology(); err == nil {
-			b.updateCachedTopology(fullTopo, epoch)
+			// A rejected write leaves the new cluster with nothing cached, so
+			// leave the cache dirty for the next reader to rebuild — the same
+			// rule the on-demand rebuild path follows.
+			if !b.updateCachedTopology(fullTopo, epoch) {
+				b.markCachedTopologyDirty()
+			}
 		} else {
 			log.Printf("Error building full topology for cache: %v", err)
 		}
 	}
 
 	if b.topoEpoch.Load() != epoch {
-		return
+		return b.abandonCycleForNewCluster()
 	}
 
 	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
@@ -736,12 +770,13 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	// estimated node count across active groups — the latter drives the
 	// next cycle's debounce ladder.
 	var maxEstimated int64
+	published := false
 	for key, group := range clientGroups {
 		// Re-checked per group, not just once: a cycle with many groups is
 		// many builds long, and every one after the switch is both wrong and
 		// time the new cluster's build spends waiting for this one to finish.
 		if b.topoEpoch.Load() != epoch {
-			return
+			return b.abandonCycleForNewCluster()
 		}
 
 		opts := topology.DefaultBuildOptions()
@@ -757,7 +792,7 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			continue
 		}
 		if b.topoEpoch.Load() != epoch {
-			return
+			return b.abandonCycleForNewCluster()
 		}
 		topo.StripNodeKinds(group.deniedKinds)
 
@@ -799,13 +834,23 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			for _, ch := range authGroup.channels {
 				safeSend(ch, event)
 			}
+			published = true
 		}
+	}
+
+	// One broadcast cycle = one debounce fire that reached clients. Counted on
+	// the way out rather than on entry so a cycle abandoned for the previous
+	// cluster, or one where every group's build errored, isn't reported as a
+	// broadcast that happened.
+	if published {
+		perfstats.IncSSEBroadcast()
 	}
 
 	// Store the max for the next cycle's debounce decision. Stored even
 	// when maxEstimated stayed 0 (eg. every build errored) — that just
 	// falls through to the bootstrap proxy in topologyDebounceFor.
 	b.lastBroadcastMaxEstimated.Store(maxEstimated)
+	return true
 }
 
 // deniedKindsKey builds a stable grouping key from a denied-kinds set so that
@@ -1137,6 +1182,27 @@ func (b *SSEBroadcaster) rebuildCachedTopology() bool {
 	}
 }
 
+// abandonCycleForNewCluster drops a cycle whose cluster the UI has already left.
+// The relationship cache is flagged on the way out: whatever it holds was built
+// for the previous cluster, and the reset that bumped the epoch left it empty
+// and clean, which a reader would otherwise take as "this cluster has no
+// topology". Reports the cycle as run — the reset queued its own trigger, so
+// there is nothing for the worker to re-arm.
+func (b *SSEBroadcaster) abandonCycleForNewCluster() bool {
+	b.markCachedTopologyDirty()
+	return true
+}
+
+// markCachedTopologyDirty flags the relationship cache for rebuild on the next
+// read. Used wherever a cycle declines to store a graph — no clients, warmup, or
+// a build rejected for the previous cluster — so a reader rebuilds rather than
+// being told an empty cache is current.
+func (b *SSEBroadcaster) markCachedTopologyDirty() {
+	b.cachedTopologyMu.Lock()
+	b.cachedTopologyDirty = true
+	b.cachedTopologyMu.Unlock()
+}
+
 // updateCachedTopology stores a full topology for relationship lookups, unless
 // the cluster view was reset while it was being built. Reports whether it
 // stored.
@@ -1211,6 +1277,10 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 
 	// Send initial topology immediately (only if connected)
 	if status.State == k8s.StateConnected {
+		// Same rule as the broadcast cycle: this build reads the caches for as
+		// long as any other, so a switch landing inside it would otherwise make
+		// the previous cluster's graph this client's first frame.
+		epoch := b.topoEpoch.Load()
 		builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
 		opts := topology.DefaultBuildOptions()
 		opts.Namespaces = namespaces
@@ -1218,7 +1288,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 			opts.ViewMode = topology.ViewModeTraffic
 		}
 		opts.ShowPolicyEffect = policyEffect
-		if topo, err := builder.Build(opts); err == nil {
+		if topo, err := builder.Build(opts); err == nil && b.topoEpoch.Load() == epoch {
 			topo.StripNodeKinds(deniedKinds)
 			topo.StripNodeClassesExcept(authorizedNodeClassTuples(topo, nodeClassAuthorizer(authorize)))
 			topo.StripClusterScopedDynamicExcept(authorizedClusterScopedDynamicTuples(topo, nodeClassAuthorizer(authorize)))

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -57,6 +57,18 @@ type SSEBroadcaster struct {
 	// topology broadcasts use longer debounce and skip the expensive full-topology
 	// cache build. Protected by watchMu (same as watchStopCh).
 	warmupDone chan struct{}
+
+	// topoTrigger carries broadcast requests to the topology worker. One slot:
+	// a request already waiting subsumes any later one, so a full slot means
+	// coalesce, not queue.
+	//
+	// Keeping the build off the caller is load-bearing. It takes seconds on a
+	// large cluster, and it used to run on the sole reader of the resource-change
+	// channel — the same goroutine that fans k8s_event frames out to clients. For
+	// as long as it built, no change was drained and no live update was
+	// delivered; past a few seconds per cycle the channel overflows on top of
+	// that and changes are lost outright.
+	topoTrigger chan struct{}
 }
 
 // ClientInfo stores information about a connected client
@@ -158,6 +170,7 @@ func NewSSEBroadcaster() *SSEBroadcaster {
 		stopCh:      make(chan struct{}),
 		watchStopCh: make(chan struct{}),
 		warmupDone:  make(chan struct{}),
+		topoTrigger: make(chan struct{}, 1),
 	}
 }
 
@@ -178,9 +191,34 @@ func (b *SSEBroadcaster) Start() {
 	b.registerCRDDiscoveryCallback()
 
 	go b.run()
+	go b.topologyWorker()
 	go b.watchResourceChanges()
 	go b.watchDeferredSync()
 	go b.heartbeat()
+}
+
+// requestTopologyBroadcast asks the topology worker to run a broadcast cycle.
+// Never blocks and never runs the build on the caller's goroutine.
+func (b *SSEBroadcaster) requestTopologyBroadcast() {
+	select {
+	case b.topoTrigger <- struct{}{}:
+	default:
+		// A request is already queued; it will pick up the current state.
+	}
+}
+
+// topologyWorker owns every broadcast build, so concurrent triggers (debounce
+// fire, context switch, CRD discovery) coalesce into a single build instead of
+// racing several multi-second ones.
+func (b *SSEBroadcaster) topologyWorker() {
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		case <-b.topoTrigger:
+			b.broadcastTopologyUpdate()
+		}
+	}
 }
 
 // registerCRDDiscoveryCallback registers for CRD discovery completion
@@ -188,7 +226,7 @@ func (b *SSEBroadcaster) Start() {
 func (b *SSEBroadcaster) registerCRDDiscoveryCallback() {
 	k8s.OnCRDDiscoveryComplete(func() {
 		log.Printf("SSE broadcaster: CRD discovery complete, broadcasting topology update")
-		b.broadcastTopologyUpdate()
+		b.requestTopologyBroadcast()
 	})
 }
 
@@ -235,7 +273,7 @@ func (b *SSEBroadcaster) watchDeferredSync() {
 					Event: "deferred_ready",
 					Data:  map[string]any{},
 				})
-				b.broadcastTopologyUpdate()
+				b.requestTopologyBroadcast()
 
 				// Signal warmup complete — debounce can drop to normal.
 				// Close the local copy (not b.warmupDone) so a context switch
@@ -288,7 +326,7 @@ func (b *SSEBroadcaster) registerConnectionStateCallback() {
 		// When we become connected, build and broadcast topology to all clients
 		if status.State == k8s.StateConnected {
 			log.Printf("SSE broadcaster: connection became connected, scheduling topology broadcast")
-			go b.broadcastTopologyUpdate()
+			b.requestTopologyBroadcast()
 		}
 	})
 }
@@ -342,17 +380,17 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 			},
 		})
 
-		// Broadcast the new topology so clients can complete the switch
-		// Run in goroutine to not block the context switch
+		// Broadcast the new topology so clients can complete the switch.
+		// Handed to the worker so the context switch isn't blocked on a build.
 		log.Printf("SSE broadcaster: scheduling topology broadcast")
-		go b.broadcastTopologyUpdate()
+		b.requestTopologyBroadcast()
 	})
 
 	k8s.OnNamespaceRescope(func(namespace string) {
 		log.Printf("SSE broadcaster: namespace cache rescoped to %q, clearing cached topology", k8s.SanitizeForLog(namespace))
 		resetCacheView()
 		log.Printf("SSE broadcaster: scheduling topology broadcast")
-		go b.broadcastTopologyUpdate()
+		b.requestTopologyBroadcast()
 	})
 }
 
@@ -584,7 +622,7 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 		case <-debounceTimer.C:
 			if pendingUpdate {
 				pendingUpdate = false
-				b.broadcastTopologyUpdate()
+				b.requestTopologyBroadcast()
 			}
 		}
 	}

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -69,6 +69,14 @@ type SSEBroadcaster struct {
 	// delivered; past a few seconds per cycle the channel overflows on top of
 	// that and changes are lost outright.
 	topoTrigger chan struct{}
+
+	// topoEpoch counts resets of the cluster view (context switch, namespace
+	// rescope). A build reads the process-global caches for seconds, so one
+	// that started before a reset describes a cluster the UI has already left
+	// by the time it finishes. Every build captures the epoch up front and
+	// every publish re-checks it, so an in-flight build is discarded rather
+	// than shown or cached.
+	topoEpoch atomic.Uint64
 }
 
 // ClientInfo stores information about a connected client
@@ -345,6 +353,11 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 	})
 
 	resetCacheView := func() {
+		// Bump before clearing: a build already in flight against the previous
+		// cluster must fail its epoch check no matter where it is, including
+		// between this clear and its own write.
+		b.topoEpoch.Add(1)
+
 		// Clear cached topology and dirty flag for the old context
 		b.cachedTopologyMu.Lock()
 		b.cachedTopology = nil
@@ -396,6 +409,7 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 
 // initCachedTopology builds the initial topology cache
 func (b *SSEBroadcaster) initCachedTopology() {
+	epoch := b.topoEpoch.Load()
 	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
 	opts := topology.DefaultBuildOptions()
 	opts.ViewMode = topology.ViewModeResources
@@ -404,8 +418,9 @@ func (b *SSEBroadcaster) initCachedTopology() {
 	opts.ForRelationshipCache = true
 
 	if topo, err := builder.Build(opts); err == nil {
-		b.updateCachedTopology(topo)
-		log.Printf("Initialized topology cache with %d nodes and %d edges", len(topo.Nodes), len(topo.Edges))
+		if b.updateCachedTopology(topo, epoch) {
+			log.Printf("Initialized topology cache with %d nodes and %d edges", len(topo.Nodes), len(topo.Edges))
+		}
 	} else {
 		log.Printf("Warning: Failed to initialize topology cache: %v", err)
 	}
@@ -636,6 +651,11 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		return
 	}
 
+	// The cluster this cycle describes. A switch landing mid-cycle re-triggers
+	// the worker, so abandoning here costs nothing and keeps the previous
+	// cluster's graph off the wire.
+	epoch := b.topoEpoch.Load()
+
 	b.mu.RLock()
 	clients := make(map[chan SSEEvent]ClientInfo, len(b.clients))
 	maps.Copy(clients, b.clients)
@@ -669,10 +689,14 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		b.cachedTopologyMu.Unlock()
 	} else {
 		if fullTopo, err := buildFullTopology(); err == nil {
-			b.updateCachedTopology(fullTopo)
+			b.updateCachedTopology(fullTopo, epoch)
 		} else {
 			log.Printf("Error building full topology for cache: %v", err)
 		}
+	}
+
+	if b.topoEpoch.Load() != epoch {
+		return
 	}
 
 	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
@@ -713,6 +737,13 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	// next cycle's debounce ladder.
 	var maxEstimated int64
 	for key, group := range clientGroups {
+		// Re-checked per group, not just once: a cycle with many groups is
+		// many builds long, and every one after the switch is both wrong and
+		// time the new cluster's build spends waiting for this one to finish.
+		if b.topoEpoch.Load() != epoch {
+			return
+		}
+
 		opts := topology.DefaultBuildOptions()
 		opts.Namespaces = group.namespaces
 		if key.viewMode == "traffic" {
@@ -724,6 +755,9 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		if err != nil {
 			log.Printf("Error building topology for broadcast: %v", err)
 			continue
+		}
+		if b.topoEpoch.Load() != epoch {
+			return
 		}
 		topo.StripNodeKinds(group.deniedKinds)
 
@@ -1092,22 +1126,30 @@ func (b *SSEBroadcaster) rebuildCachedTopology() bool {
 	if cache == nil {
 		return false
 	}
+	epoch := b.topoEpoch.Load()
 	if fullTopo, err := buildFullTopology(); err == nil {
-		b.updateCachedTopology(fullTopo)
-		return true
+		// A rejected write leaves nothing cached for the new cluster, so the
+		// caller must re-dirty and let the next read rebuild against it.
+		return b.updateCachedTopology(fullTopo, epoch)
 	} else {
 		log.Printf("Error rebuilding topology cache on demand: %v", err)
 		return false
 	}
 }
 
-// updateCachedTopology stores a full topology for relationship lookups
-func (b *SSEBroadcaster) updateCachedTopology(topo *topology.Topology) {
+// updateCachedTopology stores a full topology for relationship lookups, unless
+// the cluster view was reset while it was being built. Reports whether it
+// stored.
+func (b *SSEBroadcaster) updateCachedTopology(topo *topology.Topology, epoch uint64) bool {
 	b.cachedTopologyMu.Lock()
 	defer b.cachedTopologyMu.Unlock()
+	if b.topoEpoch.Load() != epoch {
+		return false
+	}
 	b.cachedTopology = topo
 	b.cachedTopologyIndex = nil // rebuilt lazily on next relationship lookup
 	b.cachedTopologyDirty = false
+	return true
 }
 
 // buildFullTopology constructs a full topology (all namespaces, resources view)

--- a/internal/server/sse_topology_worker_measure_test.go
+++ b/internal/server/sse_topology_worker_measure_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/loadtest"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestMeasureConsumerStallPerDebounceFire measures what the resource-change
+// consumer pays at a debounce fire, before and after the topology worker.
+//
+// Before, the consumer called broadcastTopologyUpdate directly, so it paid a
+// full topology build and drained nothing for the duration. After, it hands the
+// work to the worker and returns. Both costs are measured here against the same
+// census and the same build, so the comparison is measured rather than
+// projected, and the derived arrival count uses the #1303 diagnostics rates:
+// 236,775 changes over 261s (~907/s) into the 10,000-slot change channel.
+//
+// Whether those arrivals overflow depends on how long the build takes, which is
+// why the count is derived rather than asserted: indexing Jobs by namespace
+// (#1408) cut the build enough that they now fit. The stall itself is the thing
+// under test — no change is delivered while it lasts, overflow or not.
+//
+// Scale defaults low enough for CI. RADAR_CENSUS_SCALE=1.0 reproduces the
+// reported census (628k objects) — slow and memory hungry.
+func TestMeasureConsumerStallPerDebounceFire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("measurement test; runs full topology builds")
+	}
+
+	scale := 0.05
+	if v := os.Getenv("RADAR_CENSUS_SCALE"); v != "" {
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			t.Fatalf("RADAR_CENSUS_SCALE=%q: %v", v, err)
+		}
+		scale = parsed
+	}
+
+	const (
+		changesPerSec = 907   // 236,775 changes / 261s uptime
+		channelSlots  = 10000 // k8score change channel capacity
+	)
+
+	census := loadtest.LargeMultiTenantEKS.Scale(scale)
+	client := fake.NewSimpleClientset(loadtest.CensusObjects(census, "registry.example/app:v1")...)
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("init census-shaped resource cache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := k8s.InitTestResourceCache(testFakeClient); err != nil {
+			t.Fatalf("restore package fixture cache: %v", err)
+		}
+	})
+
+	// What the consumer used to pay per debounce fire: a full build, inline.
+	start := time.Now()
+	topo, err := buildFullTopology()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	buildCost := time.Since(start)
+
+	// What it pays now: a handoff to the worker. Measured with the worker busy,
+	// which is the case that used to serialize builds behind each other.
+	b := NewSSEBroadcaster()
+	release := blockWorker(t, b)
+	defer release()
+
+	start = time.Now()
+	b.requestTopologyBroadcast()
+	handoffCost := time.Since(start)
+
+	stalledChanges := int(buildCost.Seconds() * changesPerSec)
+	dropped := max(stalledChanges-channelSlots, 0)
+
+	t.Logf("census scale %.3f: %d objects, topology %d nodes / %d edges",
+		scale, census.Total(), len(topo.Nodes), len(topo.Edges))
+	t.Logf("consumer stall per debounce fire: inline build %v -> worker handoff %v (%.0fx faster)",
+		buildCost.Round(time.Millisecond), handoffCost.Round(time.Microsecond),
+		float64(buildCost)/float64(max(handoffCost, time.Nanosecond)))
+	t.Logf("at %d changes/s: %d changes arrive during an inline build, %d overflow the %d-slot channel and are dropped; "+
+		"with the worker the consumer keeps draining throughout",
+		changesPerSec, stalledChanges, dropped, channelSlots)
+
+	// Ratio assertion, not a wall-clock budget, so this holds on any machine.
+	if handoffCost*100 > buildCost {
+		t.Errorf("worker handoff %v is not decisively cheaper than a %v build; "+
+			"the consumer is still paying build-scale cost per debounce fire", handoffCost, buildCost)
+	}
+}

--- a/internal/server/sse_topology_worker_measure_test.go
+++ b/internal/server/sse_topology_worker_measure_test.go
@@ -26,8 +26,11 @@ import (
 // (#1408) cut the build enough that they now fit. The stall itself is the thing
 // under test — no change is delivered while it lasts, overflow or not.
 //
-// Scale defaults low enough for CI. RADAR_CENSUS_SCALE=1.0 reproduces the
-// reported census (628k objects) — slow and memory hungry.
+// Scale defaults low enough for CI, where the build is milliseconds and the
+// derived arrival count is a handful of changes — at that scale this is a smoke
+// test that the comparison still runs, not a measurement of anything.
+// RADAR_CENSUS_SCALE=1.0 reproduces the reported census (628k objects) and the
+// numbers in the commit message; it is slow and memory hungry.
 func TestMeasureConsumerStallPerDebounceFire(t *testing.T) {
 	if testing.Short() {
 		t.Skip("measurement test; runs full topology builds")
@@ -48,11 +51,16 @@ func TestMeasureConsumerStallPerDebounceFire(t *testing.T) {
 	)
 
 	census := loadtest.LargeMultiTenantEKS.Scale(scale)
-	client := fake.NewSimpleClientset(loadtest.CensusObjects(census, "registry.example/app:v1")...)
+	client := fake.NewClientset(loadtest.CensusObjects(census, "registry.example/app:v1")...)
+	// Init swaps the global without stopping what was there, so the caches are
+	// stopped explicitly on the way in and out. Otherwise the census informers
+	// and their objects stay resident for the rest of the package's run.
+	k8s.ResetResourceCache()
 	if err := k8s.InitTestResourceCache(client); err != nil {
 		t.Fatalf("init census-shaped resource cache: %v", err)
 	}
 	t.Cleanup(func() {
+		k8s.ResetResourceCache()
 		if err := k8s.InitTestResourceCache(testFakeClient); err != nil {
 			t.Fatalf("restore package fixture cache: %v", err)
 		}

--- a/internal/server/sse_topology_worker_test.go
+++ b/internal/server/sse_topology_worker_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	topology "github.com/skyhook-io/radar/pkg/topology"
+)
+
+// The topology worker exists so that a multi-second topology build never runs
+// on the goroutine that drains the resource-change channel. These tests pin the
+// two properties that make that true: requesting a broadcast never blocks the
+// caller, and concurrent requests coalesce instead of queueing up builds.
+
+// blockWorker occupies the topology worker with a build that only finishes when
+// the returned release func is called, and reports when the worker has actually
+// started. It stands in for a real large-cluster build without needing a census.
+func blockWorker(t *testing.T, b *SSEBroadcaster) (release func()) {
+	t.Helper()
+
+	started := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		select {
+		case <-b.topoTrigger:
+			close(started)
+			<-held
+		case <-time.After(2 * time.Second):
+			close(started)
+		}
+	}()
+
+	b.requestTopologyBroadcast()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stand-in worker never picked up the trigger")
+	}
+
+	released := false
+	return func() {
+		if !released {
+			released = true
+			close(held)
+		}
+	}
+}
+
+func TestRequestTopologyBroadcastDoesNotBlockWhileBuildInFlight(t *testing.T) {
+	b := NewSSEBroadcaster()
+	release := blockWorker(t, b)
+	defer release()
+
+	// A build is now in flight. The change-consumer goroutine reaches this call
+	// on every debounce fire; if it blocks here, changes stop being drained and
+	// the resource-change channel overflows.
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		b.requestTopologyBroadcast()
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		// Generous bound: the point is "returns without waiting for the build",
+		// not a latency budget. A blocking implementation waits indefinitely.
+		if elapsed > 250*time.Millisecond {
+			t.Errorf("requestTopologyBroadcast blocked for %v while a build was in flight; "+
+				"the change consumer must never wait on a build", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("requestTopologyBroadcast blocked while a build was in flight; " +
+			"the change consumer would stall and drop resource changes")
+	}
+}
+
+func TestConcurrentTopologyRequestsCoalesce(t *testing.T) {
+	b := NewSSEBroadcaster()
+	release := blockWorker(t, b)
+	defer release()
+
+	// Every trigger source (debounce fire, context switch, CRD discovery,
+	// connection state) can fire while a build runs. They must collapse into a
+	// single pending request rather than each queueing another full build.
+	for range 50 {
+		b.requestTopologyBroadcast()
+	}
+
+	if got := len(b.topoTrigger); got > 1 {
+		t.Errorf("pending topology requests = %d, want at most 1: concurrent triggers must coalesce", got)
+	}
+}
+
+// A relationship read is answered from the cluster as it is now, not as it was.
+// Owner edges and cascade previews are acted on — a stale answer is worse than a
+// slow one — so a dirty cache is rebuilt on the reader's own goroutine before it
+// returns.
+func TestDirtyCacheReadRebuildsInlineRatherThanServingStale(t *testing.T) {
+	if k8s.GetResourceCache() == nil {
+		t.Fatal("package fixture cache missing")
+	}
+
+	b := NewSSEBroadcaster()
+	// No worker running: the rebuild has to happen on this goroutine or not at all.
+	stale := &topology.Topology{Nodes: []topology.Node{{ID: "stale"}}}
+	b.cachedTopologyMu.Lock()
+	b.cachedTopology = stale
+	b.cachedTopologyDirty = true
+	b.cachedTopologyMu.Unlock()
+
+	got := b.GetCachedTopology()
+
+	if got == stale {
+		t.Error("dirty read returned the previous graph; a reader must rebuild before answering")
+	}
+	if got == nil {
+		t.Fatal("dirty read returned nothing; the rebuild must produce a graph")
+	}
+
+	b.cachedTopologyMu.RLock()
+	dirty := b.cachedTopologyDirty
+	b.cachedTopologyMu.RUnlock()
+	if dirty {
+		t.Error("cache still dirty after an inline rebuild")
+	}
+}
+
+// TestWarmupBroadcastMarksDirtyInsteadOfBuilding pins the rule that decides
+// whether a dirty read can hit a cold cache: while deferred informers are still
+// syncing, a broadcast cycle only flags the relationship cache, it does not
+// build it. That is what leaves the cache stale for HTTP readers throughout
+// warmup — on a large cluster that window is minutes long.
+func TestWarmupBroadcastMarksDirtyInsteadOfBuilding(t *testing.T) {
+	if k8s.GetResourceCache() == nil {
+		t.Fatal("package fixture cache missing")
+	}
+
+	b := NewSSEBroadcaster()
+	go b.run()
+	t.Cleanup(b.Stop)
+
+	// broadcastTopologyUpdate returns early with no clients, so subscribe one.
+	ch := b.Subscribe(nil, "resources", nil, nil)
+	t.Cleanup(func() { b.Unsubscribe(ch) })
+	for range 100 {
+		if b.ClientCount() > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if b.ClientCount() == 0 {
+		t.Fatal("client never registered")
+	}
+
+	// Warming up: warmupDone is open.
+	b.broadcastTopologyUpdate()
+
+	b.cachedTopologyMu.RLock()
+	dirtyDuringWarmup := b.cachedTopologyDirty
+	topoDuringWarmup := b.cachedTopology
+	b.cachedTopologyMu.RUnlock()
+
+	if !dirtyDuringWarmup {
+		t.Error("during warmup the cache was not marked dirty; a broadcast must flag it for later refresh")
+	}
+	if topoDuringWarmup != nil {
+		t.Error("during warmup the relationship cache was built; warmup is supposed to skip that build")
+	}
+
+	// Warmup complete.
+	b.watchMu.Lock()
+	close(b.warmupDone)
+	b.watchMu.Unlock()
+
+	b.broadcastTopologyUpdate()
+
+	b.cachedTopologyMu.RLock()
+	topoAfterWarmup := b.cachedTopology
+	dirtyAfterWarmup := b.cachedTopologyDirty
+	b.cachedTopologyMu.RUnlock()
+
+	if topoAfterWarmup == nil {
+		t.Error("after warmup the relationship cache was still not built")
+	}
+	if dirtyAfterWarmup {
+		t.Error("after warmup the cache is still dirty; a completed build must clear the flag")
+	}
+}
+
+// A cluster that stops changing stops rebuilding: the debounce timer is armed by
+// incoming changes, never by a clock. A clean graph can therefore sit untouched
+// for hours and still describe the cluster exactly, because nothing happened for
+// it to miss — so a read must not pay a build for it.
+func TestCleanCacheIsServedWithoutRebuilding(t *testing.T) {
+	if k8s.GetResourceCache() == nil {
+		t.Fatal("package fixture cache missing")
+	}
+
+	b := NewSSEBroadcaster()
+	clean := &topology.Topology{Nodes: []topology.Node{{ID: "clean"}}}
+	b.cachedTopologyMu.Lock()
+	b.cachedTopology = clean
+	b.cachedTopologyDirty = false
+	b.cachedTopologyMu.Unlock()
+
+	if got := b.GetCachedTopology(); got != clean {
+		t.Errorf("GetCachedTopology returned %v, want the cached graph untouched", got)
+	}
+}
+
+func TestTopologyWorkerStopsWithBroadcaster(t *testing.T) {
+	b := NewSSEBroadcaster()
+
+	stopped := make(chan struct{})
+	go func() {
+		b.topologyWorker()
+		close(stopped)
+	}()
+
+	b.Stop()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("topologyWorker did not exit after Stop; goroutine leaked")
+	}
+}

--- a/internal/server/sse_topology_worker_test.go
+++ b/internal/server/sse_topology_worker_test.go
@@ -210,6 +210,104 @@ func TestCleanCacheIsServedWithoutRebuilding(t *testing.T) {
 	}
 }
 
+// A build reads the process-global caches for seconds. If a kubeconfig context
+// switch lands while one is in flight, everything it produced describes the
+// cluster the user just left — so it must be dropped rather than cached, even
+// though it finished after the switch.
+func TestBuildFromThePreviousClusterIsNotCached(t *testing.T) {
+	b := NewSSEBroadcaster()
+
+	epoch := b.topoEpoch.Load() // what a build in flight would have captured
+	b.topoEpoch.Add(1)          // the switch lands
+
+	previousCluster := &topology.Topology{Nodes: []topology.Node{{ID: "old-cluster"}}}
+	if b.updateCachedTopology(previousCluster, epoch) {
+		t.Error("a build started before the context switch reported itself as cached")
+	}
+
+	b.cachedTopologyMu.RLock()
+	cached := b.cachedTopology
+	b.cachedTopologyMu.RUnlock()
+	if cached != nil {
+		t.Errorf("cached %v after a context switch; relationship lookups would answer from the previous cluster", cached)
+	}
+
+	// The new cluster's build still lands.
+	newCluster := &topology.Topology{Nodes: []topology.Node{{ID: "new-cluster"}}}
+	if !b.updateCachedTopology(newCluster, b.topoEpoch.Load()) {
+		t.Fatal("a build started after the switch was rejected too")
+	}
+}
+
+// Same rule on the wire: a cycle that started against the previous cluster must
+// not reach clients, or the UI shows the old cluster's graph after it has
+// already been told the context changed.
+func TestBroadcastFromThePreviousClusterIsNotPublished(t *testing.T) {
+	if k8s.GetResourceCache() == nil {
+		t.Fatal("package fixture cache missing")
+	}
+
+	b := NewSSEBroadcaster()
+	go b.run()
+	t.Cleanup(b.Stop)
+
+	ch := b.Subscribe(nil, "resources", nil, nil)
+	t.Cleanup(func() { b.Unsubscribe(ch) })
+	for range 100 {
+		if b.ClientCount() > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if b.ClientCount() == 0 {
+		t.Fatal("client never registered")
+	}
+
+	// Control: with no switch, this same cycle does publish. Without it the
+	// assertion below would hold for a broadcaster that never publishes at all.
+	b.broadcastTopologyUpdate()
+	if !drainForTopologyFrame(ch) {
+		t.Fatal("no topology frame published without a context switch; the test below would prove nothing")
+	}
+
+	// Hold the client registry so the cycle is provably mid-flight — it has
+	// captured its epoch and cannot yet have published — when the switch lands.
+	b.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.broadcastTopologyUpdate()
+	}()
+	time.Sleep(50 * time.Millisecond)
+	b.topoEpoch.Add(1) // context switch
+	b.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("broadcast never finished")
+	}
+
+	if drainForTopologyFrame(ch) {
+		t.Fatal("published a topology frame built against the previous cluster; " +
+			"the UI would render it after context_changed")
+	}
+}
+
+func drainForTopologyFrame(ch chan SSEEvent) bool {
+	found := false
+	for {
+		select {
+		case event := <-ch:
+			if event.Event == "topology" {
+				found = true
+			}
+		default:
+			return found
+		}
+	}
+}
+
 func TestTopologyWorkerStopsWithBroadcaster(t *testing.T) {
 	b := NewSSEBroadcaster()
 

--- a/internal/server/sse_topology_worker_test.go
+++ b/internal/server/sse_topology_worker_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -76,21 +77,82 @@ func TestRequestTopologyBroadcastDoesNotBlockWhileBuildInFlight(t *testing.T) {
 	}
 }
 
-func TestConcurrentTopologyRequestsCoalesce(t *testing.T) {
+// Every trigger source (debounce fire, context switch, CRD discovery,
+// connection state) can fire while a build runs. However many arrive, the
+// worker owes exactly one more build afterwards — not one per trigger, and not
+// zero.
+func TestConcurrentTopologyRequestsCoalesceIntoOneFollowUpBuild(t *testing.T) {
 	b := NewSSEBroadcaster()
-	release := blockWorker(t, b)
-	defer release()
 
-	// Every trigger source (debounce fire, context switch, CRD discovery,
-	// connection state) can fire while a build runs. They must collapse into a
-	// single pending request rather than each queueing another full build.
+	var builds atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	b.topoBuild = func() bool {
+		if builds.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		return true
+	}
+
+	go b.topologyWorker()
+	t.Cleanup(b.Stop)
+
+	b.requestTopologyBroadcast()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never started the first build")
+	}
+
 	for range 50 {
 		b.requestTopologyBroadcast()
 	}
+	close(release)
 
-	if got := len(b.topoTrigger); got > 1 {
-		t.Errorf("pending topology requests = %d, want at most 1: concurrent triggers must coalesce", got)
+	waitFor(t, 2*time.Second, func() bool { return builds.Load() >= 2 })
+
+	// Give any surplus queued build time to run before declaring one.
+	time.Sleep(100 * time.Millisecond)
+	if got := builds.Load(); got != 2 {
+		t.Errorf("builds = %d, want 2 (the one in flight plus a single coalesced follow-up)", got)
 	}
+}
+
+// The worker consumes one token per cycle, and that token stands for every
+// request that coalesced into it. Dropping it because the cluster view happens
+// to be torn down strands the graph until something else triggers a build.
+func TestTriggerConsumedWhileClusterViewIsDownIsRetried(t *testing.T) {
+	b := NewSSEBroadcaster()
+
+	var attempts atomic.Int64
+	b.topoBuild = func() bool {
+		attempts.Add(1)
+		return false // cluster view unavailable
+	}
+	// The retry is skipped when nobody is watching, so register a client.
+	go b.run()
+	t.Cleanup(b.Stop)
+	ch := b.Subscribe(nil, "resources", nil, nil)
+	t.Cleanup(func() { b.Unsubscribe(ch) })
+	waitFor(t, 2*time.Second, func() bool { return b.ClientCount() > 0 })
+
+	go b.topologyWorker()
+
+	b.requestTopologyBroadcast()
+	waitFor(t, topologyRetryDelay*3, func() bool { return attempts.Load() >= 2 })
+}
+
+func waitFor(t *testing.T, limit time.Duration, done func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if done() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", limit)
 }
 
 // A relationship read is answered from the cluster as it is now, not as it was.
@@ -270,27 +332,61 @@ func TestBroadcastFromThePreviousClusterIsNotPublished(t *testing.T) {
 		t.Fatal("no topology frame published without a context switch; the test below would prove nothing")
 	}
 
-	// Hold the client registry so the cycle is provably mid-flight — it has
-	// captured its epoch and cannot yet have published — when the switch lands.
-	b.mu.Lock()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		b.broadcastTopologyUpdate()
-	}()
-	time.Sleep(50 * time.Millisecond)
-	b.topoEpoch.Add(1) // context switch
-	b.mu.Unlock()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("broadcast never finished")
+	// The switch lands the instant the cycle captures its epoch, which is the
+	// worst case and the one a sleep can only approximate.
+	b.topoEpochAtCycleStart = func() uint64 {
+		epoch := b.topoEpoch.Load()
+		b.topoEpoch.Add(1)
+		return epoch
 	}
+
+	b.broadcastTopologyUpdate()
 
 	if drainForTopologyFrame(ch) {
 		t.Fatal("published a topology frame built against the previous cluster; " +
 			"the UI would render it after context_changed")
+	}
+}
+
+// A cycle that declines to store its graph must leave the cache dirty. Nil and
+// clean reads as "this cluster has no topology", which a relationship lookup
+// then answers with instead of rebuilding.
+func TestBroadcastRejectedForThePreviousClusterLeavesTheCacheDirty(t *testing.T) {
+	if k8s.GetResourceCache() == nil {
+		t.Fatal("package fixture cache missing")
+	}
+
+	b := NewSSEBroadcaster()
+	go b.run()
+	t.Cleanup(b.Stop)
+
+	ch := b.Subscribe(nil, "resources", nil, nil)
+	t.Cleanup(func() { b.Unsubscribe(ch) })
+	waitFor(t, 2*time.Second, func() bool { return b.ClientCount() > 0 })
+
+	// Past warmup, so the cycle builds the relationship cache rather than just
+	// flagging it.
+	b.watchMu.Lock()
+	close(b.warmupDone)
+	b.watchMu.Unlock()
+
+	b.topoEpochAtCycleStart = func() uint64 {
+		epoch := b.topoEpoch.Load()
+		b.topoEpoch.Add(1)
+		return epoch
+	}
+
+	b.broadcastTopologyUpdate()
+
+	b.cachedTopologyMu.RLock()
+	cached, dirty := b.cachedTopology, b.cachedTopologyDirty
+	b.cachedTopologyMu.RUnlock()
+
+	if cached != nil {
+		t.Error("stored a graph built for the previous cluster")
+	}
+	if !dirty {
+		t.Error("cache left clean and empty after a rejected write; a reader would be told the cluster has no topology")
 	}
 }
 


### PR DESCRIPTION
## Problem

A full topology build takes seconds on a large cluster, and it ran on the one goroutine that must never be held that long: the sole consumer of the resource-change channel — the same goroutine that fans `k8s_event` frames out to SSE clients.

While it built, nothing was drained. Changes overflowed the 10,000-slot buffer and live updates stopped reaching the browser. That is the `channel_full` drop pressure reported in [#1303](https://github.com/skyhook-io/radar/issues/1303).

## Change

- Every topology broadcast now runs on one dedicated worker goroutine (`topologyWorker`).
- Triggers are a non-blocking send into a one-slot channel, so concurrent sources (debounce fire, context switch, CRD discovery, connection state) **coalesce into a single build** instead of racing several multi-second ones.
- The change consumer never waits on a build, so it keeps draining throughout.

**Relationship reads are unchanged.** A dirty cache is still rebuilt on the reader's own goroutine before it answers. Owner edges and cascade-delete previews are acted on, so a stale answer is worse than a slow one — no stale graph is ever served.

## Cluster identity: a build belongs to the cluster it started against

Serialising builds onto one worker created a second problem, found in review. A build reads the process-global caches for seconds, and nothing tied it to a cluster — so a kubeconfig context switch landing mid-build left that build free to finish afterwards and publish the cluster the user had just left, *after* `context_changed` had already told the browser it moved.

Every cycle now carries an epoch that the context-switch and namespace-rescope resets bump before they clear the cache. It is captured once up front and re-checked before every publish, before every cache write, and per client group. A build spanning a reset is discarded rather than shown.

Consequences of the same rule, applied everywhere:

- The check runs **before** the full-topology build — the most expensive one in the cycle (every namespace, ReplicaSets included) — so a switch that has already landed doesn't pay for it.
- A cycle that abandons leaves the relationship cache **dirty**. The reset clears the cache and marks it clean, so declining to store a graph on top of that would leave readers with an empty cache claiming to be current; they'd return nil instead of rebuilding.
- The initial per-request build in `HandleSSE` takes the same check, so a switch inside it can't make the previous cluster's graph a client's first frame.
- A trigger consumed while the cluster view is torn down is **re-armed** rather than dropped: the worker takes one token per cycle and that token stands for every request coalesced into it.
- `perfstats.IncSSEBroadcast` counts cycles that reached a client, not cycles that were abandoned.

**Not addressed:** a switch arriving *during* the full-topology build still waits it out. Cancelling mid-build needs a `context` threaded through `topology.Builder` — worth its own PR.

## Load-test harness

Adds a census-shaped harness plus `InitLoadTestResourceCache`, which wires the live critical/deferred informer split so startup phases exist to measure at all.

A census is an explicit per-kind object count taken from a real cluster's shape. Kind ratios — not pod count — are what drive topology edge-matching and informer memory, so the ratios are deliberately un-round (ReplicaSets run 2.2× Deployments, Events outnumber everything else combined by 3×).

```bash
# in-process measurement at the reported scale
RADAR_CENSUS_SCALE=1.0 go test ./internal/server -run TestMeasureConsumerStallPerDebounceFire -v

# live server against the same population
go run ./cmd/testserver -port 9357 -census large-eks -census-scale 1.0
```

Two harness fixes, also from review:

**ServiceAccount edges were mostly absent.** Pod templates named `sa-{app%512}` while ServiceAccount *i* was materialized in app *i*'s namespace — the two indexed on different axes, so topology's `(namespace, name)` join dropped almost every reference. Nothing failed, because a name that resolves in the wrong namespace is indistinguishable from no identity at all in the built graph. Identity is now indexed by namespace, which both resolves and matches the real shape: workloads share their namespace's default, so the population is a few nodes with wide fan-out. At 5% of the reported census, **128 → 1,444 ServiceAccount edges**.

**The count check built the whole census.** Every kind materializes exactly the count it is declared at any scale, but the check ran against the reported population, so an ordinary `go test` built all 628,824 objects. Measured on the compiled test binary: **995,004 KB / 1.67s → 33,024 KB / 0.02s**.

## Measurements

At the reported census: **628,824 objects → 125,740 nodes / 104,273 edges**. Per debounce fire, across three runs:

| run | consumer stall (before) | consumer stall (after) | changes stalled | overflowed 10k buffer |
|-----|------------------------|------------------------|-----------------|-----------------------|
| 1 | 5.03s | below timer resolution | 4,564 | 0 |
| 2 | 4.47s | below timer resolution | 4,056 | 0 |
| 3 | 12.92s | below timer resolution | 11,716 | **1,716** |

On the slowest build the stall alone overflowed the change channel; with the worker the consumer keeps draining throughout.

Live instance at full census: home dashboard renders 29,455 pods / 19,924 deployments / 248 nodes, `/api/resources/pods` returns 29,455 rows in 1.5s, dashboard latency 13.6s → 9.9s → 5.2s as the relationship cache warms.

Note that at the CI default scale the measurement test's printed numbers are a smoke check that the comparison still runs, not a measurement of anything — the table above needs `RADAR_CENSUS_SCALE=1.0`.

## Testing

Two seams were added to `SSEBroadcaster` (`topoEpochAtCycleStart`, `topoBuild`), following the `capacityClusterIdentityNow` precedent: both properties involve another goroutine landing at an arbitrary point mid-build, which is otherwise only testable by racing a sleep.

Every new rule was mutation-checked — the rule was removed and the test confirmed to fail:

| mutation | test that catches it |
|---|---|
| all five epoch gates removed | build not cached / frame published / cache left clean |
| abandon without re-dirtying | `…LeavesTheCacheDirty` |
| worker drops the consumed trigger | `…ClusterViewIsDownIsRetried` |
| trigger channel widened to 64 | `…CoalesceIntoOneFollowUpBuild` (51 builds, want 2) |
| census SA name indexed on the old axis | `TestCensusWorkloadServiceAccountRefsResolve` |

That caught two weak tests along the way. The coalescing test asserted `len(topoTrigger) > 1` on a cap-1 channel — impossible, so it proved nothing; it now runs the worker and pins the real property (fifty triggers during a build produce exactly one more build). And the first version of the SA test passed against the broken mapping, because at a small census the app index and namespace index coincide; it's now a three-case table including one census large enough to wrap a fixed modulus.

## Not addressed here

- The other symptom in [#1303](https://github.com/skyhook-io/radar/issues/1303) — *"cannot display more than 25,000 pods"* — still reproduces at this scale. That is a separate frontend table cap and is tracked on its own branch.
- Mid-build cancellation (see above).
- Harness fidelity: `InitLoadTestResourceCache` still omits `ComputeDiff` / `IsNoisyResource` / `OnChange` / `OnDrop`, so no change carries a diff and the consumer's `change.Diff != nil` branch never fires. It measures the stall, not the diff fan-out.

## Test plan

- [x] `make test` passes
- [x] `go build ./...` and `go vet ./internal/server ./internal/loadtest` clean
- [x] New worker/epoch tests pass under `-race` and at `-count=5`
- [x] `RADAR_CENSUS_SCALE=1.0` measurement run passes (3×)
- [x] Live full-census instance exercised in the browser: home, resources, topology counts
- [ ] Reviewer sanity-check against a real large cluster
