### PR TITLE
perf(k8s): defer Ingress/Job/CronJob informers out of the critical tier

### DIFF
--- a/internal/audit/deferred_pending_test.go
+++ b/internal/audit/deferred_pending_test.go
@@ -1,0 +1,107 @@
+package audit
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+// TestCollectInputDeferredPendingLandsInMissingInputs pins the "couldn't check ≠
+// passing" rule for the deferred kinds whose lister stays non-nil while their
+// store warms (Ingresses, Jobs, CronJobs). listNamespaced can't tell an empty
+// store from an unsynced one, so without the IsDeferredPending gate a scan run
+// during warmup reports a clean bill of health on every Ingress/Job/CronJob
+// check instead of admitting it couldn't look.
+func TestCollectInputDeferredPendingLandsInMissingInputs(t *testing.T) {
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+
+	client := fake.NewClientset()
+	blockList := func(resource string, empty runtime.Object) {
+		client.PrependReactor("list", resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+			<-release
+			return true, empty, nil
+		})
+	}
+	blockList("ingresses", &networkingv1.IngressList{})
+	blockList("jobs", &batchv1.JobList{})
+	blockList("cronjobs", &batchv1.CronJobList{})
+
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client: client,
+		ResourceTypes: map[string]bool{
+			k8score.Pods:        true,
+			k8score.Deployments: true,
+			k8score.Ingresses:   true,
+			k8score.Jobs:        true,
+			k8score.CronJobs:    true,
+		},
+		DeferredTypes: map[string]bool{
+			k8score.Ingresses: true,
+			k8score.Jobs:      true,
+			k8score.CronJobs:  true,
+		},
+		// Must outlast the assertions below: once the deadline fires the cache
+		// gives up on stragglers and IsDeferredPending flips to false.
+		DeferredSyncTimeout: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	cache := &k8s.ResourceCache{ResourceCache: core}
+
+	for _, kind := range []string{k8score.Ingresses, k8score.Jobs, k8score.CronJobs} {
+		if !cache.IsDeferredPending(kind) {
+			t.Fatalf("%s should be deferred-pending while its LIST is blocked", kind)
+		}
+	}
+
+	input := collectTypedInput(cache, nil)
+	if input.Ingresses != nil || input.Jobs != nil || input.CronJobs != nil {
+		t.Errorf("warming inputs must stay nil, got ingresses=%d jobs=%d cronjobs=%d",
+			len(input.Ingresses), len(input.Jobs), len(input.CronJobs))
+	}
+	if input.Deployments == nil {
+		t.Error("Deployments synced with the critical tier; its input must not be suppressed")
+	}
+
+	missing := map[string]bool{}
+	for _, in := range bp.RunChecks(input).MissingInputs {
+		missing[in] = true
+	}
+	for _, kind := range []string{"ingresses", "jobs", "cronjobs"} {
+		if !missing[kind] {
+			t.Errorf("%q absent from MissingInputs — a warming store would read as a passing scan", kind)
+		}
+	}
+
+	releaseOnce()
+	select {
+	case <-core.DeferredDone():
+	case <-time.After(30 * time.Second):
+		t.Fatal("deferred sync never completed after unblocking LIST")
+	}
+
+	input = collectTypedInput(cache, nil)
+	if input.Ingresses == nil || input.Jobs == nil || input.CronJobs == nil {
+		t.Fatalf("after deferred sync the inputs must be non-nil (empty is fine): ingresses=%v jobs=%v cronjobs=%v",
+			input.Ingresses, input.Jobs, input.CronJobs)
+	}
+	for _, in := range bp.RunChecks(input).MissingInputs {
+		if in == "ingresses" || in == "jobs" || in == "cronjobs" {
+			t.Errorf("%q must not be reported missing once its informer synced", in)
+		}
+	}
+}

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -75,7 +75,13 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 func collectTypedInput(cache *k8s.ResourceCache, namespaces []string) *bp.CheckInput {
 	input := collectWorkloadInput(cache, namespaces)
 	input.Services = listNamespaced(cache.Services(), namespaces)
-	input.Ingresses = listNamespaced(cache.Ingresses(), namespaces)
+	// Ingresses/Jobs/CronJobs are deferred but keep a non-nil lister while their
+	// store warms, so listNamespaced can't tell "none exist" from "not loaded
+	// yet". Leaving the field nil routes them to MissingInputs instead of
+	// reporting a warming cluster as passing every Ingress/Job check.
+	if !cache.IsDeferredPending(k8score.Ingresses) {
+		input.Ingresses = listNamespaced(cache.Ingresses(), namespaces)
+	}
 	input.HorizontalPodAutoscalers = listNamespaced(cache.HorizontalPodAutoscalers(), namespaces)
 	input.PodDisruptionBudgets = listNamespaced(cache.PodDisruptionBudgets(), namespaces)
 	input.ConfigMaps = listNamespaced(cache.ConfigMaps(), namespaces)
@@ -87,14 +93,19 @@ func collectTypedInput(cache *k8s.ResourceCache, namespaces []string) *bp.CheckI
 }
 
 func collectWorkloadInput(cache *k8s.ResourceCache, namespaces []string) *bp.CheckInput {
-	return &bp.CheckInput{
+	input := &bp.CheckInput{
 		Pods:         listNamespaced(cache.Pods(), namespaces),
 		Deployments:  listNamespaced(cache.Deployments(), namespaces),
 		StatefulSets: listNamespaced(cache.StatefulSets(), namespaces),
 		DaemonSets:   listNamespaced(cache.DaemonSets(), namespaces),
-		Jobs:         listNamespaced(cache.Jobs(), namespaces),
-		CronJobs:     listNamespaced(cache.CronJobs(), namespaces),
 	}
+	if !cache.IsDeferredPending(k8score.Jobs) {
+		input.Jobs = listNamespaced(cache.Jobs(), namespaces)
+	}
+	if !cache.IsDeferredPending(k8score.CronJobs) {
+		input.CronJobs = listNamespaced(cache.CronJobs(), namespaces)
+	}
+	return input
 }
 
 // listCrossplaneDynamic enumerates the dynamic cache's already-watching

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -63,7 +63,7 @@ var initialSyncComplete bool
 // deferredResources lists informer keys that are NOT required for the initial
 // dashboard render. These sync in the background after the critical informers
 // complete, so the UI can render immediately with core resources.
-// Critical: pods, deployments, services, statefulsets, daemonsets, nodes, namespaces, ingresses, jobs, cronjobs.
+// Critical: pods, deployments, services, statefulsets, daemonsets, nodes, namespaces.
 var deferredResources = map[string]bool{
 	"secrets":                  true,
 	"events":                   true,
@@ -78,6 +78,17 @@ var deferredResources = map[string]bool{
 	"serviceaccounts":          true, // audit inheritance lookups, not first-render
 	"limitranges":              true, // audit inheritance lookups, not first-render
 	"resourcequotas":           true, // scheduling/admission diagnostics, not first-render
+	// None of the three below gates the first-paint minimal set
+	// (pods/services/deployments/nodes/namespaces), and at large-cluster
+	// scale (a measured shape: 17k Ingresses, 20k Jobs, 4k CronJobs) they
+	// are among the heaviest LISTs, streaming over the same HTTP/2
+	// connection as the Pod LIST during exactly the window that decides
+	// time to first paint. Deferring them trades seconds of lag on their
+	// own views for first paint on large clusters; on small clusters they
+	// sync within a second of phase 1 either way.
+	"ingresses": true,
+	"jobs":      true,
+	"cronjobs":  true,
 }
 
 // minimalFirstPaintSet is the subset of critical informers the home

--- a/internal/k8s/first_paint_tiers_test.go
+++ b/internal/k8s/first_paint_tiers_test.go
@@ -1,0 +1,32 @@
+package k8s
+
+import "testing"
+
+// TestFirstPaintTierAssignments pins the production tier split. The deferred
+// tier exists so kinds that can carry tens of thousands of objects on large
+// clusters don't stream their initial LISTs during the window that decides
+// time to first paint; the minimal set is what the home dashboard needs to
+// render at all. Moving a kind across this boundary is a first-paint latency
+// decision, not a housekeeping edit — this test makes that move deliberate.
+func TestFirstPaintTierAssignments(t *testing.T) {
+	for kind := range minimalFirstPaintSet {
+		if deferredResources[kind] {
+			t.Errorf("%s is in minimalFirstPaintSet but deferred — first paint would render without a kind the dashboard requires", kind)
+		}
+	}
+
+	heavyAtScale := []string{
+		"replicasets",
+		"events",
+		"secrets",
+		"configmaps",
+		"ingresses",
+		"jobs",
+		"cronjobs",
+	}
+	for _, kind := range heavyAtScale {
+		if !deferredResources[kind] {
+			t.Errorf("%s is not deferred — at large-cluster scale its initial LIST would stream during the first-paint window", kind)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1993,6 +1993,10 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	// notReadyOrForbidden returns 503 when a deferred resource is still syncing,
 	// or 403 when RBAC denied access. Callers use this for deferred resource types
 	// (configmaps, secrets, events, etc.) where a nil lister can mean either case.
+	// Deferred kinds whose lister is gated on isEnabled rather than isReady
+	// (ingresses, jobs, cronjobs) hand back a non-nil lister over a store that
+	// has not synced yet, so those callers must test IsDeferredPending BEFORE the
+	// nil check — otherwise a warming store answers as an authoritative empty list.
 	notReadyOrForbidden := func(resourceKind string) {
 		if cache.IsDeferredPending(resourceKind) {
 			s.writeError(w, http.StatusServiceUnavailable, fmt.Sprintf("%s are still loading, please retry shortly", resourceKind))
@@ -2114,8 +2118,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 			func(ns string) (any, error) { return cache.ReplicaSets().ReplicaSets(ns).List(labels.Everything()) },
 		)
 	case "ingresses":
-		if cache.Ingresses() == nil {
-			forbiddenMsg("ingresses")
+		if cache.IsDeferredPending("ingresses") || cache.Ingresses() == nil {
+			notReadyOrForbidden("ingresses")
 			return
 		}
 		result, err = listPerNs(
@@ -2192,8 +2196,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		}
 		result, err = cache.ClusterRoleBindings().List(labels.Everything())
 	case "jobs":
-		if cache.Jobs() == nil {
-			forbiddenMsg("jobs")
+		if cache.IsDeferredPending("jobs") || cache.Jobs() == nil {
+			notReadyOrForbidden("jobs")
 			return
 		}
 		result, err = listPerNs(
@@ -2201,8 +2205,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 			func(ns string) (any, error) { return cache.Jobs().Jobs(ns).List(labels.Everything()) },
 		)
 	case "cronjobs":
-		if cache.CronJobs() == nil {
-			forbiddenMsg("cronjobs")
+		if cache.IsDeferredPending("cronjobs") || cache.CronJobs() == nil {
+			notReadyOrForbidden("cronjobs")
 			return
 		}
 		result, err = listPerNs(
@@ -2476,7 +2480,10 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusForbidden, fmt.Sprintf("insufficient permissions to access %s", resourceKind))
 	}
 
-	// notReadyOrForbiddenGet is the single-resource counterpart of notReadyOrForbidden (see handleListResources).
+	// notReadyOrForbiddenGet is the single-resource counterpart of notReadyOrForbidden
+	// (see handleListResources for why isEnabled-gated deferred kinds must test
+	// IsDeferredPending before the nil check — here a warming store would otherwise
+	// answer a live resource with a confident 404).
 	notReadyOrForbiddenGet := func(resourceKind string) {
 		if cache.IsDeferredPending(resourceKind) {
 			s.writeError(w, http.StatusServiceUnavailable, fmt.Sprintf("%s are still loading, please retry shortly", resourceKind))
@@ -2568,8 +2575,8 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		}
 		resource, err = cache.ReplicaSets().ReplicaSets(namespace).Get(name)
 	case "ingresses", "ingress":
-		if cache.Ingresses() == nil {
-			forbiddenGet("ingresses")
+		if cache.IsDeferredPending("ingresses") || cache.Ingresses() == nil {
+			notReadyOrForbiddenGet("ingresses")
 			return
 		}
 		resource, err = cache.Ingresses().Ingresses(namespace).Get(name)
@@ -2605,14 +2612,14 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		}
 		resource, err = cache.HorizontalPodAutoscalers().HorizontalPodAutoscalers(namespace).Get(name)
 	case "jobs", "job":
-		if cache.Jobs() == nil {
-			forbiddenGet("jobs")
+		if cache.IsDeferredPending("jobs") || cache.Jobs() == nil {
+			notReadyOrForbiddenGet("jobs")
 			return
 		}
 		resource, err = cache.Jobs().Jobs(namespace).Get(name)
 	case "cronjobs", "cronjob":
-		if cache.CronJobs() == nil {
-			forbiddenGet("cronjobs")
+		if cache.IsDeferredPending("cronjobs") || cache.CronJobs() == nil {
+			notReadyOrForbiddenGet("cronjobs")
 			return
 		}
 		resource, err = cache.CronJobs().CronJobs(namespace).Get(name)

--- a/pkg/k8score/first_paint_test.go
+++ b/pkg/k8score/first_paint_test.go
@@ -1,0 +1,152 @@
+package k8score
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// heavySecondaryKinds are kinds that can carry tens of thousands of objects
+// on large clusters while contributing nothing to the first dashboard render.
+// Their initial LISTs stream over the same HTTP/2 connection as the Pod LIST,
+// so whether they sit in the critical or deferred tier decides how long
+// NewResourceCache holds first paint hostage on such clusters.
+var heavySecondaryKinds = []string{Ingresses, Jobs, CronJobs}
+
+// newHeavySecondaryListClient returns a fake clientset where every LIST of a
+// heavy secondary kind blocks until release is closed — a stand-in for the
+// multi-second initial LISTs those kinds produce at large-cluster scale. The
+// kinds the dashboard renders first stay small and list instantly.
+func newHeavySecondaryListClient(release <-chan struct{}) *fake.Clientset {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "prod"}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"}},
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "migrate", Namespace: "prod"}},
+		&batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "prod"}},
+		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"}},
+	)
+	for _, resource := range heavySecondaryKinds {
+		client.PrependReactor("list", resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+			select {
+			case <-release:
+			case <-time.After(30 * time.Second):
+				// Backstop so a regression cannot wedge the test binary; the
+				// assertions below fail long before this fires.
+			}
+			return false, nil, nil // fall through to the tracker's default reactor
+		})
+	}
+	return client
+}
+
+func firstPaintTestConfig(client *fake.Clientset, deferred map[string]bool) CacheConfig {
+	return CacheConfig{
+		Client: client,
+		ResourceTypes: map[string]bool{
+			Pods:        true,
+			Services:    true,
+			Deployments: true,
+			Nodes:       true,
+			Namespaces:  true,
+			Ingresses:   true,
+			Jobs:        true,
+			CronJobs:    true,
+		},
+		DeferredTypes: deferred,
+		// PatienceWindow/MinimalSet stay off: the fallback only rescues first
+		// paint when the minimal set itself syncs fast, and on large clusters
+		// the heavy LISTs starve the Pod LIST sharing their connection — a
+		// contention a fake clientset cannot reproduce. What this test pins
+		// is the tier contract: which kinds gate the Phase 1 return at all.
+		SyncTimeout: 10 * time.Second,
+	}
+}
+
+// TestFirstPaintTierGatingUnderHeavyLists simulates the large-cluster shape
+// where Ingress/Job/CronJob LISTs take multi-second (blocked here) while the
+// first-render kinds list instantly, and pins which tier gates first paint.
+func TestFirstPaintTierGatingUnderHeavyLists(t *testing.T) {
+	t.Run("heavy kinds critical: first paint held until their LISTs complete", func(t *testing.T) {
+		release := make(chan struct{})
+		var once sync.Once
+		releaseHeavyLists := func() { once.Do(func() { close(release) }) }
+		t.Cleanup(releaseHeavyLists)
+
+		client := newHeavySecondaryListClient(release)
+
+		type result struct {
+			rc  *ResourceCache
+			err error
+		}
+		done := make(chan result, 1)
+		go func() {
+			rc, err := NewResourceCache(firstPaintTestConfig(client, nil))
+			done <- result{rc, err}
+		}()
+
+		select {
+		case res := <-done:
+			if res.rc != nil {
+				res.rc.Stop()
+			}
+			t.Fatalf("NewResourceCache returned while heavy critical LISTs were still streaming (err=%v) — the critical gate no longer waits for its informers", res.err)
+		case <-time.After(750 * time.Millisecond):
+			// Held, as expected: first paint is hostage to the heavy LISTs.
+		}
+
+		releaseHeavyLists()
+		select {
+		case res := <-done:
+			if res.err != nil {
+				t.Fatalf("NewResourceCache failed after release: %v", res.err)
+			}
+			res.rc.Stop()
+		case <-time.After(10 * time.Second):
+			t.Fatal("NewResourceCache did not return after heavy LISTs were released")
+		}
+	})
+
+	t.Run("heavy kinds deferred: first paint returns while their LISTs still stream", func(t *testing.T) {
+		release := make(chan struct{})
+		var once sync.Once
+		releaseHeavyLists := func() { once.Do(func() { close(release) }) }
+		t.Cleanup(releaseHeavyLists)
+
+		client := newHeavySecondaryListClient(release)
+
+		deferred := make(map[string]bool, len(heavySecondaryKinds))
+		for _, kind := range heavySecondaryKinds {
+			deferred[kind] = true
+		}
+
+		start := time.Now()
+		rc, err := NewResourceCache(firstPaintTestConfig(client, deferred))
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("NewResourceCache failed: %v", err)
+		}
+		defer rc.Stop()
+		defer releaseHeavyLists()
+
+		// release is still open here, so the heavy LISTs are provably still
+		// in flight: the return above cannot have waited on them.
+		if len(rc.promotedKinds) != 0 {
+			t.Fatalf("first paint only returned because SyncTimeout promoted stuck critical informers (%v) — deferred tiering is not keeping heavy kinds off the gate", rc.promotedKinds)
+		}
+		if elapsed >= 5*time.Second {
+			t.Fatalf("first paint took %v with heavy kinds deferred; expected near-instant return", elapsed)
+		}
+	})
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1140,9 +1140,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     },
     onConnectionStateChange: updateConnectionFromSSE,
     onDeferredReady: () => {
-      // Deferred informers (secrets, events, configmaps, etc.) have finished syncing.
-      // Refetch dashboard so counts, warning events, and cert health fill in.
+      // Deferred informers (secrets, events, configmaps, ingresses, jobs,
+      // cronjobs) have finished syncing. Refetch dashboard so counts, warning
+      // events, and cert health fill in — plus the resource lists and their
+      // counts: a list opened during warmup got a 503 and the initial store
+      // load emits no k8s_event, so nothing else would ever refetch it before
+      // the 2-minute safety poll.
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ queryKey: ['resources'] })
+      queryClient.invalidateQueries({ queryKey: ['resource-counts'] })
     },
     onK8sEvent: handleK8sEvent,
   }, forceNamespaceFilter, showPolicyEffect)


### PR DESCRIPTION
None of the three gates the first-paint minimal set, and at large-cluster scale (a measured shape: 17k Ingresses, 20k Jobs, 4k CronJobs) they are among the heaviest LISTs, streaming over the same HTTP/2 connection as the Pod LIST during exactly the window that decides time to first paint. Measured on a reporter-shape kind harness: first paint 3.73s -> 2.51s.

Adds a gating simulation test (heavy LISTs blocked via reactors) and a tier pin test so kinds can't silently migrate back to critical.

## Description

Brief description of the changes in this PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have added comments where necessary
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache startup timing, API readiness semantics, and audit completeness during warmup; incorrect gating could cause false 503s, missed audit inputs, or regress first-paint gains.
> 
> **Overview**
> **Improves first-paint latency on large clusters** by moving **Ingress**, **Job**, and **CronJob** initial LISTs out of the critical informer phase so they no longer block dashboard startup alongside Pods (measured ~3.7s → ~2.5s on a heavy-cluster harness).
> 
> Because those kinds keep a **non-nil lister** while their store is still warming, callers now check **`IsDeferredPending`** before listing: **HTTP list/get** returns **503** instead of an authoritative empty result or false **404**; **audit** leaves Ingress/Job/CronJob inputs **nil** so scans report **`MissingInputs`** rather than passing checks during warmup. After deferred sync completes, behavior is unchanged.
> 
> The UI **invalidates** `resources` and `resource-counts` when deferred informers finish so lists opened during warmup refetch. **Tests** pin the tier split and the deferred-pending semantics under blocked LISTs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb5ce13cc2a8941dce4e254d3b1d5a108eae434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->