### PR TITLE
Perf/slim pod replicaset list rows

### DIFF
--- a/docs/loadtest.md
+++ b/docs/loadtest.md
@@ -80,6 +80,8 @@ batches, so it never overflows and always converges.
   Core-group kinds (Pods, Services, ConfigMaps, Secrets) show counts. Wiring
   discovery (via `InitTestDynamicResourceCache`) is the same step CRD kinds such
   as HTTPRoutes need, and is the natural next extension.
-- Above ~25,000 pods in scope the Pods table shows a "too many to show" guard and
-  asks you to narrow the namespace — a real Radar responsiveness limit this
-  harness is well suited to exercise.
+- The Pods and ReplicaSets tables fetch `?include=summary` rows (only the fields
+  the table reads, 5–8x smaller than full objects at realistic pod weight) and
+  guard above 50,000 rows in scope; Events and EndpointSlices still guard at
+  25,000. Both limits are real Radar responsiveness boundaries this harness is
+  well suited to exercise.

--- a/internal/server/resource_list_payload_test.go
+++ b/internal/server/resource_list_payload_test.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// The resource list views block themselves client-side once the row count
+// crosses their guard (web/src/components/resources/ResourcesView.tsx):
+// 25k for kinds served raw (Events, EndpointSlices), 50k for the kinds the
+// server slims with ?include=summary (Pods, ReplicaSets). The raw guard
+// exists because full objects are heavy: a production-shaped pod serializes
+// to several KB, ~95% of it in subtrees the table never reads (env, volumes,
+// probes, tolerations), so a guard-scale raw response is hundreds of MB
+// decoded — gzip helps the wire, not the JSON.parse or the tab's heap.
+//
+// These tests are the executable form of that sizing story, at both guards:
+// the raw test FAILS THE DAY ITS ANSWER FLIPS — if a guard-scale raw list
+// ever fits the browser budget, the guard (and the test) must be revisited,
+// not left to rot — and the summary test pins the payload contract that made
+// raising the Pods/ReplicaSets guard safe in the first place.
+const (
+	// Mirrors LARGE_RESOURCE_LIST_LIMIT in web/src/components/resources/ResourcesView.tsx.
+	largeResourceListGuardLimit = 25000
+	// Mirrors SUMMARY_LIST_LIMIT there — the guard for summary-served kinds.
+	summaryListGuardLimit = 50000
+
+	// A single JSON list response beyond this is browser-hostile: main-thread
+	// parse takes seconds and the resulting object graph multiplies in heap.
+	browserPayloadBudgetBytes = 50 << 20
+
+	// Per-row ceiling for summary rows, measured against a deliberately
+	// pessimistic fixture (~2.4KB: every container restarted so lastState is
+	// populated throughout, GPU requests, checksum annotations). Typical rows
+	// are ~half this; at the 50k guard the decoded payload lands ~60–115MB
+	// depending on crash-richness. A row growing past the ceiling means a
+	// heavy subtree leaked back into the keep-list.
+	summaryRowBudgetBytes = 3072
+)
+
+// realisticListPod mirrors what the informer cache actually holds for a
+// production pod after field stripping (no managedFields, no last-applied):
+// two app containers plus an init container, real env/probe/volume/toleration
+// weight, and full statuses. Lean synthetic pods understate list payloads
+// by an order of magnitude, which is exactly the mistake that made the raw
+// list look affordable.
+func realisticListPod(i int) *corev1.Pod {
+	ns := fmt.Sprintf("team-%02d", i%40)
+	name := fmt.Sprintf("checkout-api-6d9f7b9c4d-%05d", i)
+	created := metav1.NewTime(time.Unix(1750000000+int64(i%86400), 0))
+	started := metav1.NewTime(created.Add(7 * time.Second))
+	envs := make([]corev1.EnvVar, 0, 14)
+	for e := 0; e < 11; e++ {
+		envs = append(envs, corev1.EnvVar{
+			Name:  fmt.Sprintf("CHECKOUT_SETTING_%d", e),
+			Value: fmt.Sprintf("https://internal.svc.cluster.local:84%02d/path/v2?feature=enabled", e),
+		})
+	}
+	envs = append(envs,
+		corev1.EnvVar{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.name"}}},
+		corev1.EnvVar{Name: "DB_PASSWORD", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "checkout-db"}, Key: "password"}}},
+		corev1.EnvVar{Name: "FEATURE_FLAGS", ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "checkout-flags"}, Key: "flags"}}},
+	)
+	probe := func(path string, port int) *corev1.Probe {
+		return &corev1.Probe{
+			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: path, Port: intstr.FromInt32(int32(port)), Scheme: corev1.URISchemeHTTP}},
+			InitialDelaySeconds: 10, TimeoutSeconds: 3, PeriodSeconds: 15, SuccessThreshold: 1, FailureThreshold: 3,
+		}
+	}
+	requests := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("512Mi")}
+	limits := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("1Gi")}
+	mounts := []corev1.VolumeMount{
+		{Name: "config", MountPath: "/etc/checkout", ReadOnly: true},
+		{Name: "tls-certs", MountPath: "/etc/tls", ReadOnly: true},
+		{Name: "cache", MountPath: "/var/cache/checkout"},
+		{Name: "kube-api-access-x7k2m", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true},
+	}
+	container := func(cname, image string, port int) corev1.Container {
+		return corev1.Container{
+			Name:  cname,
+			Image: image,
+			Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: int32(port), Protocol: corev1.ProtocolTCP}},
+			Env:   envs,
+			EnvFrom: []corev1.EnvFromSource{
+				{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "checkout-common"}}},
+			},
+			Resources:                corev1.ResourceRequirements{Requests: requests, Limits: limits},
+			VolumeMounts:             mounts,
+			LivenessProbe:            probe("/healthz", port),
+			ReadinessProbe:           probe("/readyz", port),
+			StartupProbe:             probe("/healthz", port),
+			Lifecycle:                &corev1.Lifecycle{PreStop: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "sleep 5"}}}},
+			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				ReadOnlyRootFilesystem:   boolPtr(true),
+				RunAsNonRoot:             boolPtr(true),
+				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			},
+		}
+	}
+	containerStatus := func(cname, image string, restarts int32) corev1.ContainerStatus {
+		return corev1.ContainerStatus{
+			Name:         cname,
+			Ready:        true,
+			Started:      boolPtr(true),
+			RestartCount: restarts,
+			Image:        image,
+			ImageID:      "registry.example.com/shop/" + cname + "@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			ContainerID:  fmt.Sprintf("containerd://%064d", i),
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: started}},
+			LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Error", ExitCode: 137, StartedAt: created, FinishedAt: started,
+				ContainerID: fmt.Sprintf("containerd://%064d", i-1),
+			}},
+		}
+	}
+	cond := func(t corev1.PodConditionType) corev1.PodCondition {
+		return corev1.PodCondition{Type: t, Status: corev1.ConditionTrue, LastTransitionTime: started}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         ns,
+			UID:               types.UID(fmt.Sprintf("6a1d3f0e-4b2c-4d5e-8f9a-%012d", i)),
+			ResourceVersion:   fmt.Sprintf("%d", 900000000+i),
+			Generation:        1,
+			CreationTimestamp: created,
+			Labels: map[string]string{
+				"app": "checkout-api", "app.kubernetes.io/name": "checkout-api",
+				"app.kubernetes.io/instance": "checkout-api-prod", "app.kubernetes.io/version": "2.14.3",
+				"pod-template-hash": "6d9f7b9c4d", "team": "payments",
+			},
+			Annotations: map[string]string{
+				"checksum/config":                                "8f43b1c2a9d7e6f5checksum0a1b2c3d4e5f66778899aabbccddeeff00112233",
+				"prometheus.io/scrape":                           "true",
+				"prometheus.io/port":                             "9090",
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "checkout-api-6d9f7b9c4d",
+				UID: "0e2f4a6c-8b1d-4e3f-9a5c-7d0e1f2a3b4c", Controller: boolPtr(true), BlockOwnerDeletion: boolPtr(true),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:           fmt.Sprintf("ip-10-42-%d-%d.eu-west-1.compute.internal", i%64, i%250),
+			ServiceAccountName: "checkout-api",
+			NodeSelector:       map[string]string{"kubernetes.io/arch": "amd64", "node.kubernetes.io/lifecycle": "on-demand"},
+			Priority:           int32Ptr(0),
+			DNSPolicy:          corev1.DNSClusterFirst,
+			RestartPolicy:      corev1.RestartPolicyAlways,
+			SchedulerName:      "default-scheduler",
+			Tolerations: []corev1.Toleration{
+				{Key: "node.kubernetes.io/not-ready", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: int64Ptr(300)},
+				{Key: "node.kubernetes.io/unreachable", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: int64Ptr(300)},
+				{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "payments", Effect: corev1.TaintEffectNoSchedule},
+			},
+			Affinity: &corev1.Affinity{PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "checkout-api"}},
+						TopologyKey:   "kubernetes.io/hostname",
+					},
+				}},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "checkout-config"}, DefaultMode: int32Ptr(420)}}},
+				{Name: "tls-certs", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "checkout-tls", DefaultMode: int32Ptr(420)}}},
+				{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "kube-api-access-x7k2m", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: int32Ptr(420),
+					Sources: []corev1.VolumeProjection{
+						{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{ExpirationSeconds: int64Ptr(3607), Path: "token"}},
+						{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "kube-root-ca.crt"}, Items: []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}}}},
+					},
+				}}},
+			},
+			InitContainers: []corev1.Container{container("run-migrations", "registry.example.com/shop/checkout-migrate:2.14.3", 8080)},
+			Containers: []corev1.Container{
+				container("checkout-api", "registry.example.com/shop/checkout-api:2.14.3", 8080),
+				container("envoy-sidecar", "registry.example.com/infra/envoy:1.29.4", 15000),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				cond(corev1.PodScheduled), cond(corev1.PodInitialized),
+				cond(corev1.ContainersReady), cond(corev1.PodReady),
+			},
+			HostIP:    fmt.Sprintf("10.42.%d.%d", i%64, i%250),
+			HostIPs:   []corev1.HostIP{{IP: fmt.Sprintf("10.42.%d.%d", i%64, i%250)}},
+			PodIP:     fmt.Sprintf("10.44.%d.%d", i%250, (i/250)%250),
+			PodIPs:    []corev1.PodIP{{IP: fmt.Sprintf("10.44.%d.%d", i%250, (i/250)%250)}},
+			StartTime: &started,
+			QOSClass:  corev1.PodQOSBurstable,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "run-migrations", Ready: true, RestartCount: 0,
+				Image:   "registry.example.com/shop/checkout-migrate:2.14.3",
+				ImageID: "registry.example.com/shop/checkout-migrate@sha256:aa86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason: "Completed", ExitCode: 0, StartedAt: created, FinishedAt: started,
+				}},
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				containerStatus("checkout-api", "registry.example.com/shop/checkout-api:2.14.3", int32(i%4)),
+				containerStatus("envoy-sidecar", "registry.example.com/infra/envoy:1.29.4", 0),
+			},
+		},
+	}
+}
+
+func TestRawPodListPayloadStillJustifiesLargeListGuard(t *testing.T) {
+	// 1/10 guard scale keeps the test fast and small; payload extrapolates
+	// linearly because rows are homogeneous.
+	const n = largeResourceListGuardLimit / 10
+	pods := make([]*corev1.Pod, 0, n)
+	for i := 0; i < n; i++ {
+		pods = append(pods, realisticListPod(i))
+	}
+
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	(&Server{}).writeJSON(rec, pods)
+	encodeDuration := time.Since(start)
+
+	gotBytes := rec.Body.Len()
+	perRow := gotBytes / n
+	atGuardScale := int64(perRow) * largeResourceListGuardLimit
+	t.Logf("raw pod list: %d rows = %.1fMB (%d bytes/row), encoded in %v; extrapolated to %d rows = %.0fMB",
+		n, float64(gotBytes)/(1<<20), perRow, encodeDuration, largeResourceListGuardLimit, float64(atGuardScale)/(1<<20))
+
+	if atGuardScale < browserPayloadBudgetBytes {
+		t.Fatalf("a guard-scale raw pod list is now %.0fMB (< %.0fMB budget): the LARGE_RESOURCE_LIST_LIMIT guard no longer protects anything — revisit or remove it (web/src/components/resources/ResourcesView.tsx)",
+			float64(atGuardScale)/(1<<20), float64(browserPayloadBudgetBytes)/(1<<20))
+	}
+}
+
+// The summary counterpart: the same pods through summarizeTypedList must stay
+// several-fold smaller than raw, and each row must stay under its byte
+// ceiling — that pair is what makes the 50k summary guard honest.
+func TestSummaryPodListPayloadStaysWithinRowBudget(t *testing.T) {
+	const n = summaryListGuardLimit / 20
+	pods := make([]*corev1.Pod, 0, n)
+	for i := 0; i < n; i++ {
+		pods = append(pods, realisticListPod(i))
+	}
+
+	rawRec := httptest.NewRecorder()
+	(&Server{}).writeJSON(rawRec, pods)
+	rawBytes := rawRec.Body.Len()
+
+	sumRec := httptest.NewRecorder()
+	start := time.Now()
+	(&Server{}).writeJSON(sumRec, summarizeTypedList("pods", pods))
+	encodeDuration := time.Since(start)
+
+	sumBytes := sumRec.Body.Len()
+	perRow := sumBytes / n
+	atGuardScale := int64(perRow) * summaryListGuardLimit
+	t.Logf("summary pod list: %d rows = %.1fMB (%d bytes/row), encoded in %v; extrapolated to %d rows = %.0fMB (raw is %.1fx bigger)",
+		n, float64(sumBytes)/(1<<20), perRow, encodeDuration, summaryListGuardLimit, float64(atGuardScale)/(1<<20), float64(rawBytes)/float64(sumBytes))
+
+	if perRow > summaryRowBudgetBytes {
+		t.Fatalf("summary pod rows grew to %d bytes (> %d budget) — a heavy subtree leaked back into the keep-list, or the 50k guard needs revisiting", perRow, summaryRowBudgetBytes)
+	}
+	if sumBytes*4 > rawBytes {
+		t.Fatalf("summary is only %.1fx smaller than raw (want ≥4x) — the strip no longer pays for itself", float64(rawBytes)/float64(sumBytes))
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+func int64Ptr(v int64) *int64 { return &v }

--- a/internal/server/resource_summary.go
+++ b/internal/server/resource_summary.go
@@ -15,8 +15,11 @@ import (
 // large fleets but that list consumers (the fleet GitOps board) never read.
 // Each profile deletes only those subtrees; every field the board normalizers
 // read must survive intact — resource_summary_test.go pins that contract.
-// Kinds without a profile pass through unchanged, so summary is best-effort
-// and the response stays a bare array of full-shaped objects.
+// Typed kinds get their summary from the keep-list row builders in
+// resource_summary_typed.go instead — same caller contract (same wire shape,
+// only lighter), different mechanism. Kinds with neither pass through
+// unchanged, so summary is best-effort and the response stays a bare array
+// of K8s-wire-shaped objects.
 // Profiles are DATA over pkg/prune's shared mechanism — the keep-list
 // policy lives here (validated by the contract tests below/in *_test.go);
 // the tree surgery, deep-copy discipline, and tail-trim semantics live in
@@ -39,9 +42,10 @@ var summaryStripProfiles = map[string]prune.Profile{
 	},
 }
 
-// Profiles must target CRD kinds (group contains a dot): the summary strip
-// only runs on the dynamic (unstructured) list path — a typed-kind profile
-// would be accepted and silently never apply. Fail loudly at init instead.
+// Profiles must target CRD kinds (group contains a dot): the profile strip
+// only runs on the dynamic (unstructured) list path, so a typed-kind profile
+// would be accepted and silently never apply — typed kinds belong in
+// summarizeTypedList instead. Fail loudly at init.
 func init() {
 	for key := range summaryStripProfiles {
 		if !strings.Contains(key, ".") {

--- a/internal/server/resource_summary_e2e_test.go
+++ b/internal/server/resource_summary_e2e_test.go
@@ -169,6 +169,37 @@ func TestListResourcesIncludeSummaryE2E(t *testing.T) {
 	}
 }
 
+// Typed-path wiring: the smoke fixture pod carries container images; a
+// summary list must shed them while the raw list keeps them, and the
+// informer-cache object must stay intact (the row builders share slices with
+// it but never mutate).
+func TestListPodsIncludeSummaryE2E(t *testing.T) {
+	var summarized []map[string]any
+	assertOK(t, get(t, "/api/resources/pods?include=summary"), &summarized)
+	if len(summarized) == 0 {
+		t.Fatal("no pods in summary response")
+	}
+	containers := mustNested(t, summarized[0], "spec", "containers").([]any)
+	c0, _ := containers[0].(map[string]any)
+	if c0["image"] != nil {
+		t.Errorf("summary pod kept containers[0].image: %v", c0["image"])
+	}
+	if c0["name"] == nil {
+		t.Error("summary pod lost containers[0].name — container squares read it")
+	}
+	if mustNested(t, summarized[0], "metadata", "name") == "" {
+		t.Error("summary pod lost metadata.name")
+	}
+
+	var full []map[string]any
+	assertOK(t, get(t, "/api/resources/pods"), &full)
+	fullContainers := mustNested(t, full[0], "spec", "containers").([]any)
+	fc0, _ := fullContainers[0].(map[string]any)
+	if fc0["image"] == nil {
+		t.Error("raw pod response lost containers[0].image — summary leaked into the raw path or mutated the cache")
+	}
+}
+
 func TestListResourcesUnknownIncludeRejected(t *testing.T) {
 	setupArgoApplicationsDynamicCache(t)
 

--- a/internal/server/resource_summary_typed.go
+++ b/internal/server/resource_summary_typed.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Typed-path counterpart of the CRD summary profiles in resource_summary.go:
+// ?include=summary for the two guarded typed kinds whose full objects dominate
+// wire size on large clusters. A summarized pod serializes 5–8x smaller than
+// the full object — nearly all of the difference is subtrees the resources
+// table never reads — which is why the 25k-row guard existed at all.
+//
+// Rows are KEEP-lists rebuilt from scratch, not drop-lists: only the fields
+// the k8s-ui list flow reads (columns, sort, filters, problem badges, custom
+// label/annotation columns, owner deep-links) survive, so new upstream pod
+// fields can never silently grow the payload back. The field set comes from a
+// full audit of the table flow; resource_summary_typed_test.go pins both
+// directions — every kept path and the heavyweight drops. The detail drawer
+// is unaffected: row clicks always refetch the full object.
+//
+// The row shapes are dedicated structs rather than zeroed corev1 copies
+// because the corev1 types serialize their absences: non-omitempty fields
+// emit `"image":""`, `"lastProbeTime":null` and friends on every row, which
+// at tens of thousands of rows is a third of the payload. JSON names mirror
+// the K8s wire format exactly — the frontend accessors must not know the
+// difference.
+//
+// Rows share slices/maps with the informer-cache objects (labels, conditions,
+// owner references). That is safe under the same discipline as serving cache
+// objects directly, which the raw path has always done: responses are
+// marshaled, never mutated.
+
+func summarizeTypedList(kind string, result any) any {
+	switch kind {
+	case "pods":
+		return mapTypedRows(result, summarizePodRow)
+	case "replicasets":
+		return mapTypedRows(result, summarizeReplicaSetRow)
+	}
+	return result
+}
+
+// mapTypedRows handles the two shapes the typed switch produces: a lister's
+// []*T (single-namespace or cluster-wide) and listPerNs's merged []any.
+// Unexpected element types pass through untouched (fail open, same posture
+// as applySummaryStrip).
+func mapTypedRows[T any](result any, row func(*T) any) any {
+	switch items := result.(type) {
+	case []*T:
+		out := make([]any, 0, len(items))
+		for _, item := range items {
+			out = append(out, row(item))
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(items))
+		for _, item := range items {
+			if t, ok := item.(*T); ok {
+				out = append(out, row(t))
+			} else {
+				out = append(out, item)
+			}
+		}
+		return out
+	}
+	return result
+}
+
+// rowMeta keeps identity, lifecycle, the full label/annotation maps
+// (user-defined custom columns read arbitrary keys), ownerReferences (the
+// RS Owner column and the workload→pods deep-link filter) and generation —
+// the convergence-grace check compares it to status.observedGeneration, and
+// a row without it would grade controller lag as an outage.
+type rowMeta struct {
+	Name              string                  `json:"name,omitempty"`
+	Namespace         string                  `json:"namespace,omitempty"`
+	UID               types.UID               `json:"uid,omitempty"`
+	Generation        int64                   `json:"generation,omitempty"`
+	CreationTimestamp *metav1.Time            `json:"creationTimestamp,omitempty"`
+	DeletionTimestamp *metav1.Time            `json:"deletionTimestamp,omitempty"`
+	Labels            map[string]string       `json:"labels,omitempty"`
+	Annotations       map[string]string       `json:"annotations,omitempty"`
+	OwnerReferences   []metav1.OwnerReference `json:"ownerReferences,omitempty"`
+}
+
+func summaryRowMeta(m *metav1.ObjectMeta) rowMeta {
+	out := rowMeta{
+		Name:              m.Name,
+		Namespace:         m.Namespace,
+		UID:               m.UID,
+		Generation:        m.Generation,
+		DeletionTimestamp: m.DeletionTimestamp,
+		Labels:            m.Labels,
+		Annotations:       m.Annotations,
+		OwnerReferences:   m.OwnerReferences,
+	}
+	if !m.CreationTimestamp.IsZero() {
+		out.CreationTimestamp = &m.CreationTimestamp
+	}
+	return out
+}
+
+type podRow struct {
+	Metadata rowMeta      `json:"metadata"`
+	Spec     podRowSpec   `json:"spec"`
+	Status   podRowStatus `json:"status"`
+}
+
+type podRowSpec struct {
+	NodeName       string            `json:"nodeName,omitempty"`
+	Containers     []podRowContainer `json:"containers,omitempty"`
+	InitContainers []podRowContainer `json:"initContainers,omitempty"`
+}
+
+type podRowContainer struct {
+	Name string `json:"name"`
+	// RestartPolicy is the native-sidecar marker — dropping it would
+	// silently mis-badge sidecar crash loops in podCrashHistoryLevel.
+	RestartPolicy *corev1.ContainerRestartPolicy `json:"restartPolicy,omitempty"`
+	// Resources kept whole (not just the GPU keys the column reads today):
+	// cpu/memory cost little and keep any future non-metrics fallback honest.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+type podRowStatus struct {
+	Phase                 corev1.PodPhase         `json:"phase,omitempty"`
+	Reason                string                  `json:"reason,omitempty"`
+	Message               string                  `json:"message,omitempty"`
+	PodIP                 string                  `json:"podIP,omitempty"`
+	PodIPs                []corev1.PodIP          `json:"podIPs,omitempty"`
+	Conditions            []podRowCondition       `json:"conditions,omitempty"`
+	ContainerStatuses     []podRowContainerStatus `json:"containerStatuses,omitempty"`
+	InitContainerStatuses []podRowContainerStatus `json:"initContainerStatuses,omitempty"`
+}
+
+type podRowCondition struct {
+	Type    corev1.PodConditionType `json:"type"`
+	Status  corev1.ConditionStatus  `json:"status"`
+	Reason  string                  `json:"reason,omitempty"`
+	Message string                  `json:"message,omitempty"`
+}
+
+// podRowContainerStatus keeps the crash-forensics fields (state, lastState,
+// restartCount, ready) and sheds the identifier strings and per-container
+// resource echoes the table never reads.
+type podRowContainerStatus struct {
+	Name         string                 `json:"name"`
+	State        *corev1.ContainerState `json:"state,omitempty"`
+	LastState    *corev1.ContainerState `json:"lastState,omitempty"`
+	Ready        bool                   `json:"ready"`
+	RestartCount int32                  `json:"restartCount"`
+}
+
+func summarizePodRow(p *corev1.Pod) any {
+	return &podRow{
+		Metadata: summaryRowMeta(&p.ObjectMeta),
+		Spec: podRowSpec{
+			NodeName:       p.Spec.NodeName,
+			Containers:     summaryContainers(p.Spec.Containers, false),
+			InitContainers: summaryContainers(p.Spec.InitContainers, true),
+		},
+		Status: podRowStatus{
+			Phase:                 p.Status.Phase,
+			Reason:                p.Status.Reason,
+			Message:               p.Status.Message,
+			PodIP:                 p.Status.PodIP,
+			PodIPs:                p.Status.PodIPs,
+			Conditions:            summaryPodConditions(p.Status.Conditions),
+			ContainerStatuses:     summaryContainerStatuses(p.Status.ContainerStatuses),
+			InitContainerStatuses: summaryContainerStatuses(p.Status.InitContainerStatuses),
+		},
+	}
+}
+
+func summaryContainers(containers []corev1.Container, withRestartPolicy bool) []podRowContainer {
+	if containers == nil {
+		return nil
+	}
+	out := make([]podRowContainer, 0, len(containers))
+	for i := range containers {
+		c := &containers[i]
+		row := podRowContainer{Name: c.Name}
+		if withRestartPolicy {
+			row.RestartPolicy = c.RestartPolicy
+		}
+		if len(c.Resources.Requests) > 0 || len(c.Resources.Limits) > 0 {
+			row.Resources = &c.Resources
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func summaryPodConditions(conditions []corev1.PodCondition) []podRowCondition {
+	if conditions == nil {
+		return nil
+	}
+	out := make([]podRowCondition, 0, len(conditions))
+	for _, c := range conditions {
+		out = append(out, podRowCondition{Type: c.Type, Status: c.Status, Reason: c.Reason, Message: c.Message})
+	}
+	return out
+}
+
+func summaryContainerStatuses(statuses []corev1.ContainerStatus) []podRowContainerStatus {
+	if statuses == nil {
+		return nil
+	}
+	out := make([]podRowContainerStatus, 0, len(statuses))
+	for i := range statuses {
+		cs := &statuses[i]
+		row := podRowContainerStatus{
+			Name:         cs.Name,
+			Ready:        cs.Ready,
+			RestartCount: cs.RestartCount,
+		}
+		if cs.State != (corev1.ContainerState{}) {
+			row.State = &cs.State
+		}
+		if cs.LastTerminationState != (corev1.ContainerState{}) {
+			row.LastState = &cs.LastTerminationState
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+type replicaSetRow struct {
+	Metadata rowMeta             `json:"metadata"`
+	Spec     replicaSetRowSpec   `json:"spec"`
+	Status   replicaSetRowStatus `json:"status"`
+}
+
+type replicaSetRowSpec struct {
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
+type replicaSetRowStatus struct {
+	Replicas           int32 `json:"replicas"`
+	ReadyReplicas      int32 `json:"readyReplicas,omitempty"`
+	AvailableReplicas  int32 `json:"availableReplicas,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+}
+
+// summarizeReplicaSetRow drops spec.template — the embedded PodSpec is nearly
+// the whole object — plus selector and conditions. The table renders only
+// name/namespace/ready/owner/status/age from the counters and metadata,
+// plus observedGeneration for the convergence-grace check.
+func summarizeReplicaSetRow(rs *appsv1.ReplicaSet) any {
+	return &replicaSetRow{
+		Metadata: summaryRowMeta(&rs.ObjectMeta),
+		Spec:     replicaSetRowSpec{Replicas: rs.Spec.Replicas},
+		Status: replicaSetRowStatus{
+			Replicas:           rs.Status.Replicas,
+			ReadyReplicas:      rs.Status.ReadyReplicas,
+			AvailableReplicas:  rs.Status.AvailableReplicas,
+			ObservedGeneration: rs.Status.ObservedGeneration,
+		},
+	}
+}

--- a/internal/server/resource_summary_typed_test.go
+++ b/internal/server/resource_summary_typed_test.go
@@ -1,0 +1,291 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Contract tests for the typed ?include=summary keep-lists. Two directions,
+// both load-bearing:
+//   - kept paths feed live table cells, sorts, filters and problem badges —
+//     losing one breaks a column silently;
+//   - dropped paths are why the summary exists — one leaking back quietly
+//     regrows the payload toward the 25k-guard problem.
+
+func fatPod() *corev1.Pod {
+	restartAlways := corev1.ContainerRestartPolicyAlways
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web-0",
+			Namespace:         "prod",
+			UID:               "uid-1",
+			ResourceVersion:   "12345",
+			Generation:        7,
+			Finalizers:        []string{"example.com/guard"},
+			CreationTimestamp: metav1.Unix(1700000000, 0),
+			Labels:            map[string]string{"app": "web", "team": "core"},
+			Annotations:       map[string]string{"example.com/build": "abc123"},
+			OwnerReferences:   []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "web-rs"}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:           "node-7",
+			ServiceAccountName: "web-sa",
+			NodeSelector:       map[string]string{"zone": "a"},
+			Tolerations:        []corev1.Toleration{{Key: "dedicated"}},
+			Volumes:            []corev1.Volume{{Name: "data"}},
+			InitContainers: []corev1.Container{{
+				Name:          "sidecar",
+				Image:         "sidecar:1",
+				RestartPolicy: &restartAlways,
+				Env:           []corev1.EnvVar{{Name: "MODE", Value: "sidecar"}},
+			}},
+			Containers: []corev1.Container{{
+				Name:  "web",
+				Image: "web:1.2.3",
+				Env:   []corev1.EnvVar{{Name: "SECRET", Value: "x"}},
+				EnvFrom: []corev1.EnvFromSource{{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"}},
+				}},
+				VolumeMounts:   []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+				LivenessProbe:  &corev1.Probe{},
+				ReadinessProbe: &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("100m"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Reason:     "",
+			PodIP:      "10.0.0.9",
+			PodIPs:     []corev1.PodIP{{IP: "10.0.0.9"}},
+			HostIP:     "192.168.1.1",
+			QOSClass:   corev1.PodQOSBurstable,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "web",
+				Ready:        true,
+				RestartCount: 3,
+				Image:        "web:1.2.3",
+				ImageID:      "sha256:deadbeef",
+				ContainerID:  "containerd://abc",
+				State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Unix(1700000100, 0)}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason: "OOMKilled", ExitCode: 137,
+				}},
+			}},
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "sidecar", Ready: true, RestartCount: 1,
+				Image: "sidecar:1",
+			}},
+		},
+	}
+}
+
+func asJSONMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+func dig(t *testing.T, m map[string]any, path ...string) any {
+	t.Helper()
+	var cur any = m
+	for i, seg := range path {
+		asMap, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("path %v: segment %d (%s) is not an object", path, i, seg)
+		}
+		cur = asMap[seg]
+	}
+	return cur
+}
+
+func firstElem(t *testing.T, v any) map[string]any {
+	t.Helper()
+	arr, ok := v.([]any)
+	if !ok || len(arr) == 0 {
+		t.Fatalf("expected non-empty array, got %T", v)
+	}
+	m, ok := arr[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected object element, got %T", arr[0])
+	}
+	return m
+}
+
+func TestSummarizePodRowKeepsTableFields(t *testing.T) {
+	m := asJSONMap(t, summarizePodRow(fatPod()))
+
+	meta := dig(t, m, "metadata").(map[string]any)
+	for _, k := range []string{"name", "namespace", "uid", "generation", "creationTimestamp", "labels", "annotations", "ownerReferences"} {
+		if meta[k] == nil {
+			t.Errorf("metadata.%s dropped — table identity/filter field", k)
+		}
+	}
+	if got := dig(t, m, "spec", "nodeName"); got != "node-7" {
+		t.Errorf("spec.nodeName = %v", got)
+	}
+	c := firstElem(t, dig(t, m, "spec", "containers"))
+	if c["name"] != "web" {
+		t.Errorf("containers[0].name = %v", c["name"])
+	}
+	requests := dig(t, c, "resources", "requests").(map[string]any)
+	if requests["nvidia.com/gpu"] == nil {
+		t.Error("GPU request dropped — GPU column reads it")
+	}
+	ic := firstElem(t, dig(t, m, "spec", "initContainers"))
+	if ic["restartPolicy"] != "Always" {
+		t.Errorf("initContainers[0].restartPolicy = %v — native-sidecar marker for podCrashHistoryLevel", ic["restartPolicy"])
+	}
+	if dig(t, m, "status", "phase") != "Running" || dig(t, m, "status", "podIP") != "10.0.0.9" {
+		t.Error("status.phase/podIP dropped")
+	}
+	if dig(t, m, "status", "podIPs") == nil || dig(t, m, "status", "conditions") == nil {
+		t.Error("status.podIPs/conditions dropped — problem detection reads them")
+	}
+	cs := firstElem(t, dig(t, m, "status", "containerStatuses"))
+	if cs["restartCount"] != float64(3) || cs["ready"] != true {
+		t.Errorf("containerStatuses restartCount/ready dropped: %v", cs)
+	}
+	if dig(t, cs, "state", "running") == nil {
+		t.Error("containerStatuses[0].state dropped — container squares read it")
+	}
+	if got := dig(t, cs, "lastState", "terminated", "reason"); got != "OOMKilled" {
+		t.Errorf("lastState.terminated.reason = %v — crash tooltip reads it", got)
+	}
+	ics := firstElem(t, dig(t, m, "status", "initContainerStatuses"))
+	if ics["name"] != "sidecar" {
+		t.Errorf("initContainerStatuses dropped: %v", ics)
+	}
+}
+
+func TestSummarizePodRowDropsHeavyFields(t *testing.T) {
+	m := asJSONMap(t, summarizePodRow(fatPod()))
+
+	spec := dig(t, m, "spec").(map[string]any)
+	for _, k := range []string{"volumes", "tolerations", "nodeSelector", "serviceAccountName", "serviceAccount"} {
+		if spec[k] != nil {
+			t.Errorf("spec.%s survived the strip", k)
+		}
+	}
+	c := firstElem(t, dig(t, m, "spec", "containers"))
+	for _, k := range []string{"env", "envFrom", "volumeMounts", "livenessProbe", "readinessProbe", "image"} {
+		if c[k] != nil {
+			t.Errorf("spec.containers[0].%s survived the strip", k)
+		}
+	}
+	status := dig(t, m, "status").(map[string]any)
+	for _, k := range []string{"hostIP", "qosClass"} {
+		if status[k] != nil {
+			t.Errorf("status.%s survived the strip", k)
+		}
+	}
+	cs := firstElem(t, dig(t, m, "status", "containerStatuses"))
+	for _, k := range []string{"imageID", "containerID"} {
+		if v, ok := cs[k]; ok && v != "" {
+			t.Errorf("containerStatuses[0].%s survived the strip: %v", k, v)
+		}
+	}
+	meta := dig(t, m, "metadata").(map[string]any)
+	for _, k := range []string{"resourceVersion", "finalizers", "managedFields"} {
+		if meta[k] != nil {
+			t.Errorf("metadata.%s survived the strip", k)
+		}
+	}
+}
+
+func TestSummarizePodRowDoesNotMutateInput(t *testing.T) {
+	p := fatPod()
+	summarizePodRow(p)
+	if len(p.Spec.Containers[0].Env) != 1 || len(p.Spec.Volumes) != 1 || p.Status.HostIP == "" {
+		t.Fatal("summarizePodRow mutated the cache object")
+	}
+}
+
+func TestSummarizeReplicaSetRow(t *testing.T) {
+	replicas := int32(4)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-rs", Namespace: "prod", UID: "uid-2", Generation: 5,
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "web"}},
+			Labels:          map[string]string{"app": "web"},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "web", Image: "web:1", Env: []corev1.EnvVar{{Name: "X", Value: "y"}}}},
+			}},
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas: 4, ReadyReplicas: 3, AvailableReplicas: 3, ObservedGeneration: 4,
+			Conditions: []appsv1.ReplicaSetCondition{{Type: appsv1.ReplicaSetReplicaFailure}},
+		},
+	}
+
+	m := asJSONMap(t, summarizeReplicaSetRow(rs))
+
+	if got := dig(t, m, "spec", "replicas"); got != float64(4) {
+		t.Errorf("spec.replicas = %v — Active/Old badge reads it", got)
+	}
+	status := dig(t, m, "status").(map[string]any)
+	for _, k := range []string{"replicas", "readyReplicas", "availableReplicas"} {
+		if status[k] == nil {
+			t.Errorf("status.%s dropped — ready column/status filter reads it", k)
+		}
+	}
+	if got := dig(t, m, "metadata", "generation"); got != float64(5) {
+		t.Errorf("metadata.generation = %v — convergence-grace compares it to observedGeneration", got)
+	}
+	if got := dig(t, m, "status", "observedGeneration"); got != float64(4) {
+		t.Errorf("status.observedGeneration = %v — convergence-grace reads it", got)
+	}
+	if dig(t, m, "metadata", "ownerReferences") == nil {
+		t.Error("ownerReferences dropped — Owner column reads it")
+	}
+
+	spec := dig(t, m, "spec").(map[string]any)
+	if spec["template"] != nil {
+		t.Errorf("spec.template survived the strip: %v", spec["template"])
+	}
+	if spec["selector"] != nil {
+		t.Errorf("spec.selector survived the strip: %v", spec["selector"])
+	}
+	if status["conditions"] != nil {
+		t.Error("status.conditions survived the strip")
+	}
+}
+
+func TestSummarizeTypedListShapes(t *testing.T) {
+	pods := []*corev1.Pod{fatPod(), fatPod()}
+	if out, ok := summarizeTypedList("pods", pods).([]any); !ok || len(out) != 2 {
+		t.Fatalf("lister-shape input not summarized: %T", summarizeTypedList("pods", pods))
+	}
+	merged := []any{fatPod(), fatPod()}
+	if out, ok := summarizeTypedList("pods", merged).([]any); !ok || len(out) != 2 {
+		t.Fatalf("merged-shape input not summarized")
+	} else if _, isRow := out[0].(*podRow); !isRow {
+		t.Fatalf("merged-shape element not a summarized pod row: %T", out[0])
+	}
+	// Unprofiled kinds pass through untouched.
+	svcs := []*corev1.Service{{}}
+	if _, ok := summarizeTypedList("services", svcs).([]*corev1.Service); !ok {
+		t.Fatalf("unprofiled kind was transformed")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2353,6 +2353,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if includeSummary {
+		result = summarizeTypedList(kind, result)
 		result = applySummaryStrip(result)
 	}
 	s.writeJSON(w, result)

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -49,6 +49,13 @@ const LARGE_RESOURCE_LIST_GUARD_KEYS = new Set([
   'apps/ReplicaSet',
   'discovery.k8s.io/EndpointSlice',
 ])
+// Kinds the server slims with ?include=summary: rows carry only the fields the
+// table reads (5–8x smaller for pods — a production pod is ~9–13KB raw,
+// ~1–2.5KB slimmed), so the browser holds far more rows before the guard must
+// block. The detail drawer is unaffected — row clicks always refetch the full
+// object.
+const SUMMARY_LIST_KINDS = new Set(['Pod', 'apps/ReplicaSet'])
+const SUMMARY_LIST_LIMIT = 50000
 
 const deniedWorkloadWrites: WorkloadWritePermissions = {
   deployments: false,
@@ -189,13 +196,17 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const selectedCountKnown = selectedCountKey ? hasResourceCount(countsData?.counts, selectedCountKey) : false
   const selectedCountUnavailable = selectedCountKey ? countsData?.unavailable?.includes(selectedCountKey) ?? false : false
   const isSelectedKindGuarded = selectedCountKey !== '' && LARGE_RESOURCE_LIST_GUARD_KEYS.has(selectedCountKey)
+  const selectedKindSummaryServed = SUMMARY_LIST_KINDS.has(selectedCountKey)
+  const selectedKindRowLimit = selectedKindSummaryServed ? SUMMARY_LIST_LIMIT : LARGE_RESOURCE_LIST_LIMIT
   const waitingForGuardCount = isSelectedKindGuarded && !countsData && !countsIsError
-  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCountKnown && (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT))
+  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCountKnown && (selectedCount ?? 0) > selectedKindRowLimit))
   const selectedKindQueryBlocked = waitingForGuardCount || largeListBlocked
   const podCount = countsData?.counts.Pod
   const podCountKnown = hasResourceCount(countsData?.counts, 'Pod')
   const podCountUnavailable = countsData?.unavailable?.includes('Pod') ?? false
-  const podCountAllowsBulkMetrics = countsData != null && podCountKnown && !podCountUnavailable && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
+  // Metrics rows are ~100B each (ns/name + cpu/mem), so they track the pods
+  // guard rather than the raw-list limit.
+  const podCountAllowsBulkMetrics = countsData != null && podCountKnown && !podCountUnavailable && (podCount ?? 0) <= SUMMARY_LIST_LIMIT
   const selectedKindName = selectedKind?.name.toLowerCase() ?? ''
   const topPodMetricsEnabled = selectedKindName === 'pods' && podCountAllowsBulkMetrics
   // Node metrics back the Nodes table and, for the Pods table, the pod-vs-node
@@ -210,7 +221,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
         kind: selectedKind.name,
         count: selectedCountUnavailable ? undefined : selectedCount,
         reason: selectedCountUnavailable ? 'count-unavailable' as const : 'too-many' as const,
-        limit: LARGE_RESOURCE_LIST_LIMIT,
+        limit: selectedKindRowLimit,
         namespaces,
       }
     : null
@@ -223,6 +234,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       const params = new URLSearchParams()
       if (namespaces.length > 0) params.set('namespaces', namespacesParam)
       if (isSelectedCrd && selectedKind.group) params.set('group', selectedKind.group)
+      if (selectedKindSummaryServed) params.set('include', 'summary')
       const startedAt = performance.now()
       debugNamespaceLog('resources:selected-kind-fetch-start', {
         kind: selectedKind.name,


### PR DESCRIPTION
On large clusters the Pods view blocks itself with "cannot display more than
25,000 pods". The guard exists because `/api/resources/{kind}` ships full
objects: a production-shaped pod serializes to ~9–13KB, ~95% of it in subtrees
the table never reads (env, volumes, probes, tolerations). At guard scale
that's a ~312MB decoded response — gzip helps the wire, not the JSON.parse or
the tab's heap — so the guard was the only thing standing between a large
cluster and a frozen tab.

This gives `?include=summary` (already shipped for GitOps CRDs on the dynamic
path) a typed-path counterpart, and lifts the wall for the two kinds it
covers:

- **Pod and ReplicaSet rows are rebuilt as keep-lists** carrying only what the
  k8s-ui list flow reads — columns, sort, filters, problem badges, container
  squares and crash forensics, custom label/annotation columns, owner
  deep-links, and the generation/observedGeneration pair the convergence-grace
  check compares. Keep-lists over drop-lists, so new upstream fields can never
  silently regrow the payload. ReplicaSets drop `spec.template` entirely.
- **Dedicated row structs with tight wire tags** rather than zeroed corev1
  copies — the corev1 types serialize their absences (`"image":""`,
  `"lastProbeTime":null`), which was roughly a fifth of the payload at scale.
  JSON names mirror the K8s wire format exactly; frontend accessors can't tell
  the difference.
- **Frontend requests summary for those two kinds and their guard moves
  25k → 50k.** Events and EndpointSlices keep the 25k guard until they get the
  same treatment. Bulk pod metrics gate on the new pod guard.

Measured (tests print this): rows 5–8x smaller, serialization ~5x faster;
2.4KB/row on a deliberately pessimistic fixture (every container restarted,
GPU requests) → ~115MB worst-case at 50k rows, typical roughly half — versus
312MB at 25k raw.

Not affected: the detail drawer (row clicks always refetch the full object),
the default response shape (`include=summary` is opt-in, so `@skyhook-io/radar-app`
consumers and existing callers see no change), and the GitOps summary profiles.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- Contract tests pin every kept path, the heavyweight drops, and non-mutation
  of cache objects (rows share slices with the informer cache).
- E2E test drives the real HTTP path: summary sheds fields, raw stays raw, the
  cached object survives intact.
- Payload tests pin the sizing story at both guards: the raw assertion is a
  tripwire that fails the day a guard-scale raw list fits the browser budget
  (so the guard gets revisited instead of rotting); the summary assertion
  bounds rows to a 3KB ceiling and ≥4x under raw.
- `go test ./...` (both modules), `make tsc`, and the web vitest suite (410
  tests) all green.

- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings

Related Issue: #1303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core list payload shape for Pods/ReplicaSets in the UI and raises scale limits; risk is mainly regressions in table columns/badges if a kept field is dropped, mitigated by extensive contract and E2E tests.
> 
> **Overview**
> Large Pods views used to block above **25k** rows because full pod JSON is huge (~9–13KB/row); gzip does not fix `JSON.parse` or heap cost. This PR adds a **typed** `?include=summary` path for **Pods** and **ReplicaSets** and raises their guard to **50k** while Events/EndpointSlices stay at 25k.
> 
> **Server:** `summarizeTypedList` rebuilds list rows as explicit keep-lists (table columns, filters, badges, owner links, crash forensics) via dedicated structs so omitted fields do not serialize as empty/null noise. ReplicaSet rows drop `spec.template`. Wired in `handleListResources` before the existing CRD prune strip. Contract, E2E, and payload tests pin kept/dropped fields, cache non-mutation, and row-size budgets (≥4x vs raw).
> 
> **Frontend:** `ResourcesView` requests `include=summary` for Pod and `apps/ReplicaSet`, uses per-kind row limits for the large-list guard, and aligns bulk pod metrics gating with the 50k pod ceiling.
> 
> Detail drawer behavior is unchanged (full object refetch on row click); default list API shape without `include=summary` is unchanged for other callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f9cc01fb3e1bf7dabe4a4ffa2539f060177ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

