### PR TITLE
perf(k8s): gate CRD warmup/discovery on deferred informer sync

### DIFF
--- a/internal/k8s/crd_warmup_gate_test.go
+++ b/internal/k8s/crd_warmup_gate_test.go
@@ -1,0 +1,285 @@
+package k8s
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+// The CRD warmup/discovery LISTs share the apiserver connection with the
+// deferred typed LISTs (ReplicaSets, Secrets — the heaviest kinds on large
+// clusters). These tests pin the sequencing contract: no CRD traffic until the
+// deferred informers finish their initial sync.
+
+var (
+	fatKnownCRD = schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledjobs"}
+	smallCRD    = schema.GroupVersionResource{Group: "protection.crossplane.io", Version: "v1beta1", Resource: "usages"}
+)
+
+// blockedDeferredCache builds a ResourceCache shaped like the large-cluster
+// startup moment this guards: critical kinds synced (first paint done), the
+// deferred ReplicaSet LIST still in flight. The returned release func unblocks
+// the LIST; it is safe to call more than once and always runs before Stop so
+// the informer goroutine parked in the reactor can exit.
+func blockedDeferredCache(t *testing.T) (*k8score.ResourceCache, *fakeclientset.Clientset, func()) {
+	t.Helper()
+
+	releaseRS := make(chan struct{})
+	release := sync.OnceFunc(func() { close(releaseRS) })
+
+	typedClient := fakeclientset.NewSimpleClientset()
+	typedClient.PrependReactor("list", "replicasets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		<-releaseRS
+		return false, nil, nil
+	})
+
+	rc, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client: typedClient,
+		ResourceTypes: map[string]bool{
+			k8score.Pods:        true,
+			k8score.Services:    true,
+			k8score.Deployments: true,
+			k8score.ReplicaSets: true,
+		},
+		DeferredTypes: map[string]bool{
+			k8score.ReplicaSets: true,
+		},
+	})
+	if err != nil {
+		release()
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	t.Cleanup(func() {
+		release()
+		rc.Stop()
+	})
+
+	select {
+	case <-rc.DeferredDone():
+		t.Fatal("precondition: deferred sync completed while the ReplicaSet LIST was still blocked")
+	default:
+	}
+
+	return rc, typedClient, release
+}
+
+// crdFixture builds a DynamicResourceCache over a fake discovery that serves
+// two CRDs — one known-integration shaped (the WarmupCommonCRDs path) and one
+// small unknown (the DiscoverAllCRDs eager-watch path) — with a reactor
+// counting every LIST the dynamic client issues.
+func crdFixture(t *testing.T, typedClient *fakeclientset.Clientset) (*k8score.DynamicResourceCache, *atomic.Int64) {
+	t.Helper()
+
+	typedClient.Fake.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: fatKnownCRD.Group + "/" + fatKnownCRD.Version,
+			APIResources: []metav1.APIResource{
+				{Name: fatKnownCRD.Resource, Kind: "ScaledJob", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+		{
+			GroupVersion: smallCRD.Group + "/" + smallCRD.Version,
+			APIResources: []metav1.APIResource{
+				{Name: smallCRD.Resource, Kind: "Usage", Namespaced: false, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	discovery, err := k8score.NewResourceDiscovery(typedClient.Discovery())
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery failed: %v", err)
+	}
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			fatKnownCRD: "ScaledJobList",
+			smallCRD:    "UsageList",
+		},
+	)
+	var crdListCalls atomic.Int64
+	dynClient.PrependReactor("list", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+		crdListCalls.Add(1)
+		return false, nil, nil
+	})
+
+	dc, err := k8score.NewDynamicResourceCache(k8score.DynamicCacheConfig{
+		DynamicClient: dynClient,
+		Discovery:     discovery,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	t.Cleanup(dc.Stop)
+
+	return dc, &crdListCalls
+}
+
+func TestCRDWarmupSequenceGatedOnDeferredSync(t *testing.T) {
+	rc, typedClient, release := blockedDeferredCache(t)
+	dc, crdListCalls := crdFixture(t, typedClient)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	warmupRan := make(chan struct{})
+	discoverRan := make(chan struct{})
+	go runCRDWarmupSequence(ctx, rc.DeferredDone(), nil,
+		func() {
+			if err := dc.EnsureWatching(fatKnownCRD); err != nil {
+				t.Errorf("EnsureWatching(%v) failed: %v", fatKnownCRD, err)
+			}
+			close(warmupRan)
+		},
+		func() {
+			dc.DiscoverAllCRDs()
+			close(discoverRan)
+		},
+	)
+
+	select {
+	case <-warmupRan:
+		t.Fatal("CRD warmup step ran while the deferred ReplicaSet LIST was still in flight")
+	case <-time.After(300 * time.Millisecond):
+	}
+	if n := crdListCalls.Load(); n != 0 {
+		t.Fatalf("%d CRD LIST(s) issued while deferred informers were still syncing", n)
+	}
+
+	release()
+	select {
+	case <-rc.DeferredDone():
+	case <-time.After(5 * time.Second):
+		t.Fatal("deferred sync did not complete after releasing the ReplicaSet LIST")
+	}
+
+	select {
+	case <-warmupRan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CRD warmup step did not run after deferred sync completed")
+	}
+	select {
+	case <-discoverRan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CRD discovery step did not run after deferred sync completed")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for dc.GetDiscoveryStatus() != k8score.CRDDiscoveryComplete && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := dc.GetDiscoveryStatus(); got != k8score.CRDDiscoveryComplete {
+		t.Fatalf("CRD discovery status = %v after gate release, want complete", got)
+	}
+	if !dc.WaitForSync(smallCRD, 5*time.Second) {
+		t.Fatalf("small CRD %v was not eagerly watched after gate release", smallCRD)
+	}
+	if crdListCalls.Load() == 0 {
+		t.Fatal("expected CRD LISTs after the gate released")
+	}
+}
+
+func TestCRDWarmupSequenceAbortsOnContextCancel(t *testing.T) {
+	rc, _, _ := blockedDeferredCache(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var stepRan atomic.Bool
+	seqDone := make(chan struct{})
+	go func() {
+		defer close(seqDone)
+		runCRDWarmupSequence(ctx, rc.DeferredDone(), nil, func() { stepRan.Store(true) })
+	}()
+
+	cancel()
+	select {
+	case <-seqDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runCRDWarmupSequence did not return after context cancellation")
+	}
+	if stepRan.Load() {
+		t.Fatal("CRD step ran despite context cancellation while gated")
+	}
+}
+
+// TestCRDWarmupSequenceSurvivesInitContextCancel pins the lifecycle contract
+// InitAllSubsystems must honor: callers cancel the init ctx as soon as critical
+// sync returns, while deferred sync is still in flight. The sequence must ride
+// a longer-lived lifecycle ctx (OperationContext), not the init ctx — otherwise
+// CRD warmup silently never runs on large clusters.
+func TestCRDWarmupSequenceSurvivesInitContextCancel(t *testing.T) {
+	rc, _, release := blockedDeferredCache(t)
+
+	initCtx, initCancel := context.WithCancel(context.Background())
+	lifecycleCtx, lifeCancel := context.WithCancel(context.Background())
+	defer lifeCancel()
+
+	var stepRan atomic.Bool
+	seqDone := make(chan struct{})
+	go func() {
+		defer close(seqDone)
+		runCRDWarmupSequence(lifecycleCtx, rc.DeferredDone(), nil, func() { stepRan.Store(true) })
+	}()
+
+	// Simulate InitializeCluster / switchContext returning and defer-canceling
+	// the init ctx while deferred informers are still blocked.
+	initCancel()
+	select {
+	case <-seqDone:
+		t.Fatal("sequence returned after init-ctx cancel — it must not observe that ctx")
+	case <-time.After(300 * time.Millisecond):
+	}
+	if stepRan.Load() {
+		t.Fatal("CRD step ran while deferred sync was still blocked")
+	}
+	// initCtx is intentionally unused after cancel: the bug was wiring it in.
+	_ = initCtx
+
+	release()
+	select {
+	case <-seqDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sequence did not complete after deferred sync finished")
+	}
+	if !stepRan.Load() {
+		t.Fatal("CRD step did not run after deferred sync; lifecycle ctx was abandoned")
+	}
+}
+
+func TestCRDWarmupSequenceAbortsWhenCachesReplaced(t *testing.T) {
+	rc, _, release := blockedDeferredCache(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var stepRan atomic.Bool
+	alive := atomic.Bool{}
+	alive.Store(true)
+	seqDone := make(chan struct{})
+	go func() {
+		defer close(seqDone)
+		runCRDWarmupSequence(ctx, rc.DeferredDone(), func() bool { return alive.Load() },
+			func() { stepRan.Store(true) },
+		)
+	}()
+
+	alive.Store(false)
+	release()
+	select {
+	case <-seqDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sequence did not return after caches were marked replaced")
+	}
+	if stepRan.Load() {
+		t.Fatal("CRD step ran against a replaced cluster view")
+	}
+}

--- a/internal/k8s/subsystems.go
+++ b/internal/k8s/subsystems.go
@@ -114,32 +114,42 @@ func InitAllSubsystems(ctx context.Context, progress func(string)) error {
 		}
 
 		// CRD warmup and full discovery run in background.
+		// Do NOT use InitAllSubsystems' ctx: callers cancel it as soon as
+		// critical sync returns (InitializeCluster defer cancel /
+		// ContextSwitchTimeout). Deferred typed LISTs can still take minutes
+		// on large clusters — that cancel would abort CRD work entirely.
+		// OperationContext survives until CancelOngoingOperations (context
+		// switch / retry / auth-loss), which is the right lifetime.
 		if dc := GetDynamicResourceCache(); dc != nil {
 			go func() {
 				crdStart := time.Now()
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							buf := make([]byte, 4096)
-							n := runtime.Stack(buf, false)
-							log.Printf("PANIC in CRD warmup: %v\n%s", r, buf[:n])
-						}
-					}()
-					wt := time.Now()
-					RegisterSupportedCRDFallbacks()
-					WarmupCommonCRDs()
-					logTiming("   CRD warmup: %v (background)", time.Since(wt))
-				}()
-				dt := time.Now()
-				dc.DiscoverAllCRDs()
-				logTiming("   CRD full discovery: %v (background)", time.Since(dt))
-				// Conditional Kyverno warmup runs after discovery so the
-				// IsKyvernoInstalled() signal sees every CRD that landed
-				// during WarmupCommonCRDs or DiscoverAllCRDs (admin may
-				// have installed Kyverno after Radar started).
-				pt := time.Now()
-				WarmupKyvernoPolicyReports()
-				logTiming("   Kyverno PolicyReport warmup: %v (background)", time.Since(pt))
+				lifecycleCtx := OperationContext()
+				deferredDone := cache.DeferredDone()
+				stillCurrent := func() bool {
+					return GetDynamicResourceCache() == dc && GetResourceCache() == cache
+				}
+				runCRDWarmupSequence(lifecycleCtx, deferredDone, stillCurrent,
+					func() {
+						wt := time.Now()
+						RegisterSupportedCRDFallbacks()
+						WarmupCommonCRDs()
+						logTiming("   CRD warmup: %v (background)", time.Since(wt))
+					},
+					func() {
+						dt := time.Now()
+						dc.DiscoverAllCRDs()
+						logTiming("   CRD full discovery: %v (background)", time.Since(dt))
+					},
+					func() {
+						// Conditional Kyverno warmup runs after discovery so the
+						// IsKyvernoInstalled() signal sees every CRD that landed
+						// during WarmupCommonCRDs or DiscoverAllCRDs (admin may
+						// have installed Kyverno after Radar started).
+						pt := time.Now()
+						WarmupKyvernoPolicyReports()
+						logTiming("   Kyverno PolicyReport warmup: %v (background)", time.Since(pt))
+					},
+				)
 				logTiming("   CRD total (warmup+discovery): %v (background)", time.Since(crdStart))
 			}()
 		}
@@ -206,6 +216,55 @@ func InitAllSubsystems(ctx context.Context, progress func(string)) error {
 	logTiming(" InitAllSubsystems total: %v", time.Since(subsystemStart))
 
 	return nil
+}
+
+// runCRDWarmupSequence runs the background CRD warmup/discovery steps in
+// order, after the deferred typed informers finish their initial sync. The CRD
+// probes and LISTs share the apiserver connection and rate-limit budget with
+// the deferred LISTs — ReplicaSets and Secrets, the heaviest kinds on large
+// clusters — so letting them race starves the sync that resource views block
+// on. deferredDone always closes, even when deferred sync fails or no kinds
+// are deferred, so the gate cannot wedge; ctx cancellation (context switch /
+// CancelOngoingOperations) abandons the wait and any remaining steps.
+//
+// stillCurrent, when non-nil, is checked after the gate and between steps so a
+// sequence that outlives a context switch does not run against a replaced
+// cache. Pass nil in tests that drive the helper directly.
+func runCRDWarmupSequence(ctx context.Context, deferredDone <-chan struct{}, stillCurrent func() bool, steps ...func()) {
+	if deferredDone != nil {
+		gateStart := time.Now()
+		select {
+		case <-deferredDone:
+			logTiming("   CRD warmup gate: deferred informers done after %v (background)", time.Since(gateStart))
+		case <-ctx.Done():
+			log.Printf("CRD warmup abandoned during deferred gate after %v: %v", time.Since(gateStart), ctx.Err())
+			return
+		}
+	}
+	if stillCurrent != nil && !stillCurrent() {
+		log.Printf("CRD warmup abandoned: cluster caches replaced during deferred gate")
+		return
+	}
+	for _, step := range steps {
+		if ctx.Err() != nil {
+			log.Printf("CRD warmup abandoned between steps: %v", ctx.Err())
+			return
+		}
+		if stillCurrent != nil && !stillCurrent() {
+			log.Printf("CRD warmup abandoned: cluster caches replaced between steps")
+			return
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 4096)
+					n := runtime.Stack(buf, false)
+					log.Printf("PANIC in CRD warmup step: %v\n%s", r, buf[:n])
+				}
+			}()
+			step()
+		}()
+	}
 }
 
 // ResetAllSubsystems tears down all subsystems in reverse order of init.


### PR DESCRIPTION
After first paint, WarmupCommonCRDs and DiscoverAllCRDs fired immediately and raced the deferred typed LISTs (ReplicaSets, Secrets — the heaviest kinds on large clusters) for the same apiserver connection and rate-limit budget, starving the sync that resource views block on. On a reporter-shape cluster (43k ReplicaSets, 26k Secrets, ~370 CRDs) that contention accounts for most of the 65s data-load window.

Wait on DeferredDone() before starting any CRD work. The channel always closes — even on deferred sync failure or with zero deferred informers — so the gate cannot wedge, and on-demand CRD navigation still works during the wait because EnsureWatching only blocks on discovery once it is actually in progress. Context cancellation abandons the sequence.

Tests simulate the reporter shape with a blocked ReplicaSet LIST reactor plus fake-dynamic CRD fixtures: no CRD LIST may fire until deferred sync completes, and discovery must still run to completion afterwards.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have added comments where necessary
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster startup sequencing and background lifecycle wiring; incorrect gating or context handling could delay or skip CRD discovery after context switches, but it does not touch auth or data mutation paths.
> 
> **Overview**
> Background CRD work (**warmup**, **full discovery**, **Kyverno PolicyReport warmup**) no longer starts immediately after dynamic cache init. It now waits on **`DeferredDone()`** so deferred typed LISTs (e.g. ReplicaSets, Secrets) are not competing with CRD LISTs for the same apiserver connection and rate limit on large clusters.
> 
> The sequence is driven by **`runCRDWarmupSequence`**, which runs ordered steps after the gate, honors **`OperationContext()`** instead of the short-lived init context (so early init cancel does not silently skip CRD work), and bails on context cancel or when cluster caches are replaced mid-sequence. Panic recovery is applied per step.
> 
> New tests assert no CRD LISTs until deferred sync completes, correct behavior after the gate releases, abort on cancel/replaced caches, and that lifecycle context survives init-context cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57774ace34652cd2cdf436e99986e356da8d964a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->