### PR TITLE
Perf/delay pod list first paint

### DIFF
--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -87,14 +87,20 @@ func collectTypedInput(cache *k8s.ResourceCache, namespaces []string) *bp.CheckI
 }
 
 func collectWorkloadInput(cache *k8s.ResourceCache, namespaces []string) *bp.CheckInput {
-	return &bp.CheckInput{
-		Pods:         listNamespaced(cache.Pods(), namespaces),
+	input := &bp.CheckInput{
 		Deployments:  listNamespaced(cache.Deployments(), namespaces),
 		StatefulSets: listNamespaced(cache.StatefulSets(), namespaces),
 		DaemonSets:   listNamespaced(cache.DaemonSets(), namespaces),
 		Jobs:         listNamespaced(cache.Jobs(), namespaces),
 		CronJobs:     listNamespaced(cache.CronJobs(), namespaces),
 	}
+	// isEnabled-gated lister is non-nil over an empty store while the
+	// delayed/promoted Pod LIST is in flight. Nil skips pod checks and
+	// lands in MissingInputs instead of "zero pods" findings.
+	if !cache.IsDeferredPending(k8score.Pods) {
+		input.Pods = listNamespaced(cache.Pods(), namespaces)
+	}
+	return input
 }
 
 // listCrossplaneDynamic enumerates the dynamic cache's already-watching

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -1167,7 +1167,8 @@ func typedObjectToUnstructured(obj runtime.Object, gvr schema.GroupVersionResour
 // through to the dynamic cache.
 //
 // The deferred check runs BEFORE the lister read: several deferred kinds
-// (ServiceAccounts, ReplicaSets, HPAs, LimitRanges, ResourceQuotas) expose
+// (ServiceAccounts, ReplicaSets, HPAs, LimitRanges, ResourceQuotas) and
+// kinds promoted off the critical path (Pods after first paint) expose
 // a non-nil lister as soon as they're enabled, so during the warmup window
 // they'd otherwise serve empty stores as confident NotFound/empty results.
 // After it, a nil-lister "forbidden" error can only mean the RBAC probe

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -81,17 +81,24 @@ var deferredResources = map[string]bool{
 }
 
 // minimalFirstPaintSet is the subset of critical informers the home
-// dashboard needs to feel coherent. Pods are included despite being
-// typically the largest kind — without pods the topology graph and
-// resource counts are empty. The patience window absorbs pod-sync
-// latency on healthy clusters; on slow ones, the user sees a working
-// home view sooner with a "still loading" hint for the rest.
+// dashboard needs to feel coherent. Pods are deliberately excluded:
+// they are the fattest LIST on large clusters and are started in a
+// second wave (delayStartFirstPaint) once these kinds have synced, so
+// first paint is not gated on the Pod LIST. Home shows empty pod
+// counts until that LIST lands; PartialData lists Pod as still loading.
 var minimalFirstPaintSet = map[string]bool{
-	"pods":        true,
 	"namespaces":  true,
 	"nodes":       true,
 	"services":    true,
 	"deployments": true,
+}
+
+// delayStartFirstPaint kinds stay critical but their LIST does not start
+// until minimalFirstPaintSet has synced. Pods are the only member: on
+// large clusters they are tens of thousands of objects and starve
+// Service/Deployment on the shared HTTP/2 connection if started at t=0.
+var delayStartFirstPaint = map[string]bool{
+	"pods": true,
 }
 
 // firstPaintPatience is how long we wait for ALL critical informers before
@@ -372,6 +379,7 @@ func InitResourceCache(ctx context.Context) error {
 			TimingLogger:            logTiming,
 			PatienceWindow:          firstPaintPatience,
 			MinimalSet:              minimalFirstPaintSet,
+			DelayStart:              delayStartFirstPaint,
 			SyncTimeout:             FirstPaintBackstop,
 			SyncProgress:            emitSyncProgress,
 			DeferredSyncTimeout:     3 * time.Minute,

--- a/internal/k8s/first_paint_delay_test.go
+++ b/internal/k8s/first_paint_delay_test.go
@@ -1,0 +1,22 @@
+package k8s
+
+import "testing"
+
+func TestFirstPaintDelayStartPins(t *testing.T) {
+	if minimalFirstPaintSet["pods"] {
+		t.Fatal("pods must not gate first paint — they are the largest LIST")
+	}
+	for _, key := range []string{"services", "deployments", "nodes", "namespaces"} {
+		if !minimalFirstPaintSet[key] {
+			t.Errorf("minimalFirstPaintSet missing %s", key)
+		}
+	}
+	if !delayStartFirstPaint["pods"] {
+		t.Fatal("pods must be DelayStart so the 29k LIST does not start with wave 1")
+	}
+	for key := range delayStartFirstPaint {
+		if minimalFirstPaintSet[key] {
+			t.Errorf("DelayStart %q is also in MinimalSet — first paint would deadlock", key)
+		}
+	}
+}

--- a/internal/server/logs.go
+++ b/internal/server/logs.go
@@ -55,6 +55,10 @@ func (s *Server) handlePodLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if cache.IsDeferredPending(k8score.Pods) || cache.Pods() == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "pods are still loading, please retry shortly")
+		return
+	}
 	pod, err := cache.Pods().Pods(namespace).Get(podName)
 	if err != nil {
 		s.writeError(w, http.StatusNotFound, fmt.Sprintf("Pod not found: %v", err))
@@ -143,7 +147,7 @@ func (s *Server) handlePodLogsStream(w http.ResponseWriter, r *http.Request) {
 	// If no container specified, get the first one
 	if container == "" {
 		cache := k8s.GetResourceCache()
-		if cache != nil {
+		if cache != nil && !cache.IsDeferredPending(k8score.Pods) && cache.Pods() != nil {
 			pod, err := cache.Pods().Pods(namespace).Get(podName)
 			if err == nil && len(pod.Spec.Containers) > 0 {
 				container = pod.Spec.Containers[0].Name

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2058,8 +2058,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	// Try typed cache for known resource types first
 	switch kind {
 	case "pods":
-		if cache.Pods() == nil {
-			forbiddenMsg("pods")
+		if cache.IsDeferredPending("pods") || cache.Pods() == nil {
+			notReadyOrForbidden("pods")
 			return
 		}
 		result, err = listPerNs(
@@ -2532,8 +2532,8 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 	// Try typed cache for known resource types first
 	switch kind {
 	case "pods", "pod":
-		if cache.Pods() == nil {
-			forbiddenGet("pods")
+		if cache.IsDeferredPending("pods") || cache.Pods() == nil {
+			notReadyOrForbiddenGet("pods")
 			return
 		}
 		resource, err = cache.Pods().Pods(namespace).Get(name)

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -350,6 +350,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 	cfg.ResourceScopeNamespaces = cloneScopeNamespaces(cfg.ResourceScopeNamespaces)
 	cfg.DeferredTypes = maps.Clone(cfg.DeferredTypes)
 	cfg.MinimalSet = maps.Clone(cfg.MinimalSet)
+	cfg.DelayStart = maps.Clone(cfg.DelayStart)
 
 	// Derive a per-kind scope view that captures both modes:
 	//   - ResourceScopes (when set) is authoritative.
@@ -481,11 +482,12 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 	// Track per-informer sync status, HasSynced funcs, and the informer
 	// handle (needed for staggered start).
 	type informerEntry struct {
-		kind     string
-		key      string
-		deferred bool
-		synced   cache.InformerSynced
-		run      func(stopCh <-chan struct{})
+		kind       string
+		key        string
+		deferred   bool
+		delayStart bool
+		synced     cache.InformerSynced
+		run        func(stopCh <-chan struct{})
 	}
 	var allEntries []informerEntry
 
@@ -589,7 +591,12 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		}
 
 		isDeferred := deferredTypes[s.key]
-		entry := informerEntry{kind: s.kind, key: s.key, deferred: isDeferred, synced: synced, run: run}
+		// DelayStart only applies on the patience+minimal-set path, and
+		// never to a kind that also gates first paint (that deadlocks:
+		// paint waits for a LIST that never starts).
+		delayStart := !isDeferred && cfg.DelayStart[s.key] &&
+			cfg.PatienceWindow > 0 && len(cfg.MinimalSet) > 0 && !cfg.MinimalSet[s.key]
+		entry := informerEntry{kind: s.kind, key: s.key, deferred: isDeferred, delayStart: delayStart, synced: synced, run: run}
 		allEntries = append(allEntries, entry)
 
 		if isDeferred && s.isEvent {
@@ -621,23 +628,38 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		return rc, nil
 	}
 
-	// Start critical informers first. Deferred informers are started after
-	// Phase 1 completes to reduce concurrent LIST pressure on the API server.
-	// On large clusters (300+ nodes), ~10 concurrent LISTs is significantly
-	// lighter than ~19, giving the heaviest resource (Pods) more API server
-	// bandwidth during the critical path.
+	// Start critical informers first. DelayStart kinds (Pods) wait until
+	// the first-paint set has synced so their LIST does not share the
+	// HTTP/2 connection with Service/Deployment. Deferred informers start
+	// after Phase 1.
+	var delayedKinds []string
+	var wave1Kinds []string
 	for _, e := range allEntries {
-		if !e.deferred {
-			go e.run(stopCh)
+		if e.deferred {
+			continue
 		}
+		if e.delayStart {
+			delayedKinds = append(delayedKinds, e.kind)
+			continue
+		}
+		wave1Kinds = append(wave1Kinds, e.kind)
+		go e.run(stopCh)
+	}
+	if overlap := delayStartMinimalOverlap(cfg.DelayStart, cfg.MinimalSet); len(overlap) > 0 {
+		stdlog.Printf("WARNING: DelayStart kinds also in MinimalSet (not delayed, would deadlock first paint): %s",
+			strings.Join(overlap, ", "))
+	}
+	if len(delayedKinds) > 0 {
+		stdlog.Printf("Delaying %s LIST until first-paint wave 1 syncs (%s)",
+			strings.Join(delayedKinds, ", "), strings.Join(wave1Kinds, ", "))
 	}
 
 	if len(backgroundKeys) > 0 {
-		stdlog.Printf("Starting resource cache: %d critical + %d deferred + %d background informers (%d total)",
-			len(criticalSyncFuncs), len(deferredSyncFuncs), len(backgroundSyncFuncs), enabledCount)
+		stdlog.Printf("Starting resource cache: %d critical + %d deferred + %d background informers (%d total, delayed start: %d)",
+			len(criticalSyncFuncs), len(deferredSyncFuncs), len(backgroundSyncFuncs), enabledCount, len(delayedKinds))
 	} else {
-		stdlog.Printf("Starting resource cache: %d critical + %d deferred informers (%d total, deferred start after critical sync)",
-			len(criticalSyncFuncs), len(deferredSyncFuncs), enabledCount)
+		stdlog.Printf("Starting resource cache: %d critical + %d deferred informers (%d total, delayed start: %d)",
+			len(criticalSyncFuncs), len(deferredSyncFuncs), enabledCount, len(delayedKinds))
 	}
 	syncStart := time.Now()
 	rc.syncStartTime = syncStart
@@ -660,8 +682,14 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			tag := "critical"
 			if entry.deferred {
 				tag = "deferred"
+			} else if entry.delayStart {
+				tag = "delayed"
 			}
 			logf("    Informer synced: %-28s %v (%s)", entry.kind, time.Since(t), tag)
+			if entry.delayStart {
+				stdlog.Printf("Delayed %s LIST synced in %v (%d items) — first-paint was not gated on this kind",
+					entry.kind, time.Since(t), rc.GetKindObjectCounts()[entry.kind])
+			}
 			rc.informerMu.Lock()
 			rc.informerStatuses[idx].Synced = true
 			rc.informerStatuses[idx].SyncedAt = time.Now().Format(time.RFC3339)
@@ -682,6 +710,31 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 	useMinimalSet := cfg.PatienceWindow > 0 && len(cfg.MinimalSet) > 0
 	timedOut := false
 	patienceElapsed := false
+
+	var delayedEntries []informerEntry
+	for _, e := range allEntries {
+		if e.delayStart {
+			delayedEntries = append(delayedEntries, e)
+		}
+	}
+	delayedStarted := false
+	var delayedStartedAt time.Time
+	startDelayed := func(reason string) {
+		if delayedStarted || len(delayedEntries) == 0 {
+			return
+		}
+		delayedStarted = true
+		delayedStartedAt = time.Now()
+		var names []string
+		for _, e := range delayedEntries {
+			names = append(names, e.kind)
+			go e.run(stopCh)
+		}
+		stdlog.Printf("Starting delayed LIST (%s) after %v — %s — wave 1 counts: %s",
+			reason, time.Since(syncStart), strings.Join(names, ", "),
+			formatKindCounts(rc.GetKindObjectCounts(), wave1Kinds))
+	}
+
 	if len(criticalSyncFuncs) > 0 {
 		// Build the index of "must-sync" entries for the minimal-set check.
 		// Filter to entries that are critical AND in MinimalSet (deferred
@@ -775,6 +828,10 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		}
 
 		for {
+			if !delayedStarted && useMinimalSet && minimalReady() {
+				startDelayed("wave 1 ready")
+			}
+
 			allSynced := true
 			for _, fn := range criticalSyncFuncs {
 				if !fn() {
@@ -829,6 +886,22 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 							len(synced), len(synced)+len(pendingParts), time.Since(syncStart).Seconds(), strings.Join(pendingParts, ", "))
 					}
 				}
+				if len(delayedEntries) > 0 && !delayedStarted {
+					stdlog.Printf("Delayed LIST not started (%.0fs elapsed) — waiting for wave 1: %s",
+						time.Since(syncStart).Seconds(), strings.Join(minimalPending, ", "))
+				} else if delayedStarted {
+					var delayedPending []string
+					for _, e := range delayedEntries {
+						if !e.synced() {
+							delayedPending = append(delayedPending, fmt.Sprintf("%s(%d)", e.kind, counts[e.kind]))
+						}
+					}
+					if len(delayedPending) > 0 {
+						stdlog.Printf("Delayed LIST in flight (%.0fs since start, %.0fs since LIST began) — pending: %s",
+							time.Since(syncStart).Seconds(), time.Since(delayedStartedAt).Seconds(),
+							strings.Join(delayedPending, ", "))
+					}
+				}
 				emitProgress(useMinimalSet && patienceElapsed && minimalReady())
 			default:
 				time.Sleep(100 * time.Millisecond)
@@ -838,6 +911,10 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			}
 		}
 	}
+
+	// If Phase 1 exited before wave 1 was ready (timeout), still start
+	// the delayed LIST so Pods are not left unwatched.
+	startDelayed("phase 1 complete")
 
 	// Reclassify any critical informer still pending as deferred so the
 	// cache can return. No-op on the all-synced path.
@@ -863,8 +940,13 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			len(criticalSyncFuncs), len(promoted), time.Since(syncStart))
 		rc.promotedKinds = promoted
 	case patienceElapsed && len(promoted) > 0:
-		stdlog.Printf("First-paint ready after %v: minimal set synced; %d slower informers continue in background: %s",
-			time.Since(syncStart), len(promoted), strings.Join(promoted, ", "))
+		delayedNote := ""
+		if delayedStarted && !delayedStartedAt.IsZero() {
+			delayedNote = fmt.Sprintf("; delayed LIST began %v after start", delayedStartedAt.Sub(syncStart))
+		}
+		stdlog.Printf("First-paint ready after %v: wave 1 synced %s; %d slower informers continue in background: %s%s",
+			time.Since(syncStart), formatKindCounts(rc.GetKindObjectCounts(), wave1Kinds),
+			len(promoted), strings.Join(promoted, ", "), delayedNote)
 		logf("    Phase 1 minimal-set sync (%d/%d critical, %d still loading): %v",
 			len(criticalSyncFuncs)-len(promoted), len(criticalSyncFuncs), len(promoted), time.Since(syncStart))
 		rc.promotedKinds = promoted
@@ -1751,6 +1833,31 @@ func (kl kindLister) CountKey() string {
 
 // GetKindObjectCounts returns the number of cached objects per resource kind.
 // Only includes kinds that are enabled. Returns nil if cache is nil.
+func delayStartMinimalOverlap(delayStart, minimal map[string]bool) []string {
+	if len(delayStart) == 0 || len(minimal) == 0 {
+		return nil
+	}
+	var overlap []string
+	for k := range delayStart {
+		if minimal[k] {
+			overlap = append(overlap, k)
+		}
+	}
+	sort.Strings(overlap)
+	return overlap
+}
+
+func formatKindCounts(counts map[string]int, kinds []string) string {
+	if len(kinds) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		parts = append(parts, fmt.Sprintf("%s(%d)", kind, counts[kind]))
+	}
+	return strings.Join(parts, " ")
+}
+
 func (rc *ResourceCache) GetKindObjectCounts() map[string]int {
 	if rc == nil {
 		return nil

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -1900,8 +1900,12 @@ func (rc *ResourceCache) isReady(key string) bool {
 // IsDeferredPending returns true when the resource type passed RBAC checks
 // (informer is enabled) but deferred sync has not completed yet. Callers
 // can use this to distinguish "no permission" (return 403) from "not ready
-// yet" (return 503) when a lister returns nil.
-// Returns false once deferred sync has permanently failed (avoids infinite spinner).
+// yet" (return 503) when a lister returns nil — or when a lister is
+// isEnabled-gated and non-nil over an unsynced store (promoted kinds).
+//
+// Originally-deferred types and kinds promoted off the critical path
+// (DelayStart / patience) both land in deferredSynced. Returns false
+// once deferred sync has permanently failed (avoids infinite spinner).
 func (rc *ResourceCache) IsDeferredPending(key string) bool {
 	if rc == nil {
 		return false
@@ -1909,13 +1913,17 @@ func (rc *ResourceCache) IsDeferredPending(key string) bool {
 	if !rc.isEnabled(key) {
 		return false
 	}
-	if rc.config.DeferredTypes == nil || !rc.config.DeferredTypes[key] {
-		return false
-	}
 	if rc.deferredFailed.Load() {
 		return false
 	}
 	rc.deferredMu.RLock()
 	defer rc.deferredMu.RUnlock()
-	return !rc.deferredSynced[key]
+	if rc.deferredSynced == nil {
+		return rc.config.DeferredTypes[key]
+	}
+	synced, tracked := rc.deferredSynced[key]
+	if !tracked {
+		return false
+	}
+	return !synced
 }

--- a/pkg/k8score/delay_start_test.go
+++ b/pkg/k8score/delay_start_test.go
@@ -1,0 +1,208 @@
+package k8score
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// firstPaintEnabledTypes is the home-dashboard kind set with Pods still
+// enabled but not gating paint: Services/Deployments/Nodes/Namespaces
+// can render while the Pod LIST is still in flight.
+func firstPaintEnabledTypes() map[string]bool {
+	return map[string]bool{
+		Pods:        true,
+		Services:    true,
+		Deployments: true,
+		Nodes:       true,
+		Namespaces:  true,
+	}
+}
+
+func firstPaintMinimalSet() map[string]bool {
+	return map[string]bool{
+		Services:    true,
+		Deployments: true,
+		Nodes:       true,
+		Namespaces:  true,
+	}
+}
+
+func holdList(hold <-chan struct{}) k8stesting.ReactionFunc {
+	return func(k8stesting.Action) (bool, runtime.Object, error) {
+		<-hold
+		return false, nil, nil
+	}
+}
+
+func countList(n *atomic.Int32) k8stesting.ReactionFunc {
+	return func(k8stesting.Action) (bool, runtime.Object, error) {
+		n.Add(1)
+		return false, nil, nil
+	}
+}
+
+// TestDelayStart_PodListWaitsForWave1: Service/Deployment/Node/Namespace
+// LISTs are still in flight. The Pod LIST must not start until those
+// wave-1 kinds unstick — otherwise it contends on the same HTTP/2
+// connection and first paint waits on the largest kind.
+func TestDelayStart_PodListWaitsForWave1(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	client := fake.NewSimpleClientset()
+	hold := make(chan struct{})
+	var podLists atomic.Int32
+
+	for _, resource := range []string{"services", "deployments", "nodes", "namespaces"} {
+		client.PrependReactor("list", resource, holdList(hold))
+	}
+	client.PrependReactor("list", "pods", countList(&podLists))
+
+	done := make(chan *ResourceCache, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		rc, err := NewResourceCache(CacheConfig{
+			Client:         client,
+			ResourceTypes:  firstPaintEnabledTypes(),
+			PatienceWindow: 200 * time.Millisecond,
+			MinimalSet:     firstPaintMinimalSet(),
+			DelayStart:     map[string]bool{Pods: true},
+			SyncTimeout:    5 * time.Second,
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		done <- rc
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	if n := podLists.Load(); n != 0 {
+		t.Fatalf("Pod LIST started while wave 1 still blocked: %d calls", n)
+	}
+
+	close(hold)
+
+	var rc *ResourceCache
+	select {
+	case rc = <-done:
+	case err := <-errCh:
+		t.Fatalf("NewResourceCache failed: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("NewResourceCache did not return after wave 1 released")
+	}
+	defer rc.Stop()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for podLists.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if podLists.Load() == 0 {
+		t.Fatal("Pod LIST never started after wave 1 synced")
+	}
+}
+
+// TestDelayStart_FirstPaintDoesNotWaitForPods: wave 1 is ready, Pod LIST
+// is stuck. NewResourceCache must return after patience instead of
+// blocking on Pods.
+func TestDelayStart_FirstPaintDoesNotWaitForPods(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated stuck Pod LIST")
+	})
+
+	start := time.Now()
+	rc, err := NewResourceCache(CacheConfig{
+		Client:         client,
+		ResourceTypes:  firstPaintEnabledTypes(),
+		PatienceWindow: 200 * time.Millisecond,
+		MinimalSet:     firstPaintMinimalSet(),
+		DelayStart:     map[string]bool{Pods: true},
+		SyncTimeout:    5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+	elapsed := time.Since(start)
+
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("expected return after patience (200ms), got %v", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("first paint waited on Pods; elapsed=%v", elapsed)
+	}
+
+	promoted := rc.PromotedKinds()
+	if len(promoted) != 1 || promoted[0] != "Pod" {
+		t.Errorf("expected Pod to be promoted as still-loading, got %v", promoted)
+	}
+	if rc.Services() == nil || rc.Deployments() == nil {
+		t.Error("expected wave-1 listers available at first paint")
+	}
+}
+
+// TestDelayStart_FastPathNoPatienceRegression: small cluster, everything
+// syncs. Delayed Pod LIST must start as soon as wave 1 is ready so
+// all-critical can finish inside the patience window — otherwise healthy
+// clusters wait 8s for nothing.
+func TestDelayStart_FastPathNoPatienceRegression(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	start := time.Now()
+	rc, err := NewResourceCache(CacheConfig{
+		Client:         client,
+		ResourceTypes:  firstPaintEnabledTypes(),
+		PatienceWindow: 2 * time.Second,
+		MinimalSet:     firstPaintMinimalSet(),
+		DelayStart:     map[string]bool{Pods: true},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Errorf("fast path waited on patience; elapsed=%v", elapsed)
+	}
+	if got := rc.PromotedKinds(); len(got) != 0 {
+		t.Errorf("expected no promotion on fast path, got %v", got)
+	}
+	if rc.Pods() == nil {
+		t.Error("expected Pods() lister after fast-path sync")
+	}
+}
+
+func TestDelayStart_IgnoredWhenAlsoInMinimalSet(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	start := time.Now()
+	rc, err := NewResourceCache(CacheConfig{
+		Client:         client,
+		ResourceTypes:  map[string]bool{Pods: true},
+		PatienceWindow: 2 * time.Second,
+		MinimalSet:     map[string]bool{Pods: true},
+		DelayStart:     map[string]bool{Pods: true},
+		SyncTimeout:    2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Errorf("DelayStart∩MinimalSet delayed Pods — first paint deadlocked until timeout; elapsed=%v", elapsed)
+	}
+	if rc.Pods() == nil {
+		t.Error("expected Pods() lister")
+	}
+}

--- a/pkg/k8score/delay_start_test.go
+++ b/pkg/k8score/delay_start_test.go
@@ -149,6 +149,15 @@ func TestDelayStart_FirstPaintDoesNotWaitForPods(t *testing.T) {
 	if rc.Services() == nil || rc.Deployments() == nil {
 		t.Error("expected wave-1 listers available at first paint")
 	}
+
+	// Lister is isEnabled-gated — non-nil over an empty store. Handlers
+	// must see pending so they return 503 instead of 404 / empty 200.
+	if rc.Pods() == nil {
+		t.Fatal("Pods() must stay non-nil while the delayed LIST is in flight")
+	}
+	if !rc.IsDeferredPending(Pods) {
+		t.Fatal("promoted Pod LIST must be IsDeferredPending so REST/audit do not treat the empty store as truth")
+	}
 }
 
 // TestDelayStart_FastPathNoPatienceRegression: small cluster, everything
@@ -179,6 +188,9 @@ func TestDelayStart_FastPathNoPatienceRegression(t *testing.T) {
 	}
 	if rc.Pods() == nil {
 		t.Error("expected Pods() lister after fast-path sync")
+	}
+	if rc.IsDeferredPending(Pods) {
+		t.Error("Pods synced on the fast path; IsDeferredPending must be false")
 	}
 }
 

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -222,6 +222,14 @@ type CacheConfig struct {
 	// that are deferred or absent are ignored.
 	MinimalSet map[string]bool
 
+	// DelayStart lists critical kinds whose initial LIST is held until
+	// MinimalSet has synced. Used to keep a high-cardinality kind (Pods)
+	// off the HTTP/2 connection that first paint is waiting on. Ignored
+	// when PatienceWindow/MinimalSet are unset, when the kind is already
+	// deferred, or when the kind is also in MinimalSet (that combination
+	// would deadlock first paint).
+	DelayStart map[string]bool
+
 	// SyncProgress is invoked roughly every second during the critical
 	// sync phase, and once more when first paint is ready. `synced` and
 	// `total` count critical informers; `minimalReady` is true when the


### PR DESCRIPTION
## Description

Pods are the fattest LIST on a large cluster and they were gating first paint. Starting them at t=0 alongside Service/Deployment/Node/Namespace means the Pod LIST streams over the same HTTP/2 connection as the kinds the home dashboard is actually waiting on, so first paint pays for a kind it doesn't need yet.

This splits the critical phase into two waves:

- **Wave 1 (gates first paint):** Services, Deployments, Nodes, Namespaces. Pods are removed from `minimalFirstPaintSet`.
- **Wave 2 (`DelayStart`):** the Pod informer stays *critical* — it is not demoted to deferred — but its LIST does not start until wave 1 has synced, or until phase 1 exits, whichever comes first.

`DelayStart map[string]bool` is a new `CacheConfig` knob in `pkg/k8score`; `internal/k8s` wires `delayStartFirstPaint = {pods}` into it. The combination `DelayStart ∩ MinimalSet` would deadlock first paint (paint waits for a LIST that never starts), so it is refused at construction, logged as a WARNING, and pinned by a test in both packages.

### Serving an unsynced Pod store

The Pod lister is `isEnabled`-gated, so it stays **non-nil over an empty store** while the delayed LIST is in flight. Without a guard, every caller reads "zero pods" as truth.

`IsDeferredPending` previously only consulted `config.DeferredTypes`, so it answered `false` for Pods and the guard was unavailable. It now reads the `deferredSynced` tracking map, which already covers originally-deferred types, background types, *and* kinds promoted off the critical path — so a delayed or promoted kind reports pending correctly. Semantics for every previously-tracked kind are unchanged.

Callers updated to check it before reading the lister:

| Surface | Before | After |
|---|---|---|
| `GET /api/resources/pods` | `200 []` | `503` |
| `GET /api/resources/pods/{ns}/{name}` | `404` | `503` |
| `GET /api/pods/{ns}/{name}/logs` | `404 Pod not found` | `503` |
| pod log stream (container auto-pick) | `Get` on empty store | skipped |
| audit `collectWorkloadInput` | zero-pod findings | `Pods` left nil → `MissingInputs` |

First paint already reports still-loading kinds through `promotedKinds` → `PartialData`, so the home banner reads "Still loading: Pod" during the window.

### Diagnostics

The startup log now records the wave split, wave-1 object counts at handoff, when the delayed LIST began relative to cache start, and how long it took once it did — so the wave-1 wait and the LIST itself can be told apart in a support snapshot.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Behaviour change without an API break: pod reads that previously returned an empty/404 answer during warmup now return 503.

## How has this been tested?

- [x] Added/updated unit tests
- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster

`pkg/k8score/delay_start_test.go` drives a fake clientset with LIST reactors:

- `TestDelayStart_PodListWaitsForWave1` — wave-1 LISTs held open; asserts zero Pod LIST calls, then that the LIST fires once wave 1 is released.
- `TestDelayStart_FirstPaintDoesNotWaitForPods` — Pod LIST fails permanently; asserts first paint still returns after the patience window, that `Pod` is reported promoted, that `Pods()` stays non-nil, and that `IsDeferredPending(Pods)` is true.
- `TestDelayStart_FastPathNoPatienceRegression` — everything syncs; asserts no promotion, no patience wait, `IsDeferredPending` false.
- `TestDelayStart_IgnoredWhenAlsoInMinimalSet` — the deadlock combination returns promptly instead of hanging to `SyncTimeout`.

`internal/k8s/first_paint_delay_test.go` pins the tier split so Pods can't drift back into `minimalFirstPaintSet` and so the two maps can't overlap.

**Not yet measured.** No large-cluster number has been taken for this change — see the open question below.

## Open questions

1. **What is the actual first-paint gain?** This needs a before/after on the reporter-shape harness (interleaved A/B) before it can be judged. Sibling PR #1442 was closed because a measured 3.73s → 2.51s was too small for the warmup-correctness cost it carried; this change has a larger blast radius, so it needs a larger number.
2. **Fast-path cost on small clusters.** Wave 2 no longer overlaps wave 1, and the fast path still waits for all critical informers, so small-cluster startup is now serialised (wave 1 → up to ~100ms poll → Pod LIST). The fake-client test can't see this. Needs a real-cluster measurement.
3. **Ungated pod consumers.** `IsDeferredPending` is checked in 5 places; `.Pods()` is read in ~73. Notably ungated during the window: `internal/server/dashboard.go` (the home health ring renders `0`), `internal/server/resource_counts.go`, `internal/k8s/topology_adapter.go` (empty topology graph), `internal/issues/provider.go`, `internal/mcp/tools.go`.
4. **The 503 has no frontend branch.** `useResources` doesn't special-case 503 and `ResourcesView` only tests for 403, so a 503 currently renders as "No pods found" — the same statement the 503 was introduced to avoid.

## Related issues

Part of #1303 (large-cluster startup regression). Sibling: #1442 (closed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cache startup, readiness semantics, and pod-facing API paths; behavior changes during warmup (empty pod counts, 503 retries) but is covered by new tests and deadlock guards for DelayStart∩MinimalSet.
> 
> **Overview**
> **Defers the Pod informer LIST** so first paint is not blocked by the largest cluster LIST on HTTP/2. Pods are removed from the minimal first-paint set; **Services, Deployments, Nodes, and Namespaces** still gate initial render. Pod sync starts in a second wave once that set is ready (or after phase 1 either way).
> 
> Adds **`DelayStart`** on the shared resource cache and wires **`delayStartFirstPaint`** for pods. **`IsDeferredPending`** now covers promoted/delayed kinds, not only originally deferred types, so enabled listers over empty stores are treated as **not ready (503)** instead of authoritative empty/404.
> 
> REST **pod list/get**, **pod logs**, and **audit workload input** check pending state so the UI can show partial loading and audits avoid false “zero pods” findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f835d618172e7414811b2e63a6a112fc43bcde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
