### PR TITLE
fix(nodes): parse pod capacity as a Quantity, not a raw integer (#1441)

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -137,6 +137,7 @@ import {
 import { SEVERITY_BADGE, EVENT_TYPE_COLORS } from '../../utils/badge-colors'
 import { pluralize } from '../../utils/pluralize'
 import { getPodGpuCount, getNodeGpuCount } from '../../utils/extended-resources'
+import { parseQuantityToNumber } from '../../utils/format'
 import { type CustomColumnDef, type CustomColumnSource, customColumnKey, readCustomColumnValue, sanitizeCustomColumnDefs } from '../../utils/custom-columns'
 import { FreshnessControl, type FreshnessConnection } from '../ui/FreshnessControl'
 import { Tooltip } from '../ui/Tooltip'
@@ -7335,8 +7336,10 @@ function NodeCell({ resource, column, majorityNodeMinorVersion }: { resource: an
       const allocatable = resource.status?.allocatable?.pods
       const podCount = m?.podCount ?? 0
       if (!allocatable) return <span className="text-sm text-theme-text-tertiary font-mono">{podCount || '-'}</span>
-      const max = parseInt(allocatable, 10)
-      if (isNaN(max) || max <= 0) return <span className="text-sm text-theme-text-tertiary font-mono">{podCount || '-'}</span>
+      // Allocatable pods is a Quantity, so a 1000-pod node reports "1k" —
+      // parseInt read that as 1 and pegged the bar at 21600% (#1441).
+      const max = parseQuantityToNumber(allocatable)
+      if (!Number.isFinite(max) || max <= 0) return <span className="text-sm text-theme-text-tertiary font-mono">{podCount || '-'}</span>
       const pct = (podCount / max) * 100
       return <ResourceBar used={String(podCount)} total={String(max)} percent={pct} colorScheme="count" />
     }

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -7337,7 +7337,7 @@ function NodeCell({ resource, column, majorityNodeMinorVersion }: { resource: an
       const podCount = m?.podCount ?? 0
       if (!allocatable) return <span className="text-sm text-theme-text-tertiary font-mono">{podCount || '-'}</span>
       // Allocatable pods is a Quantity, so a 1000-pod node reports "1k" —
-      // parseInt read that as 1 and pegged the bar at 21600% (#1441).
+      // a raw-integer read would see 1 and peg the bar at 21600%.
       const max = parseQuantityToNumber(allocatable)
       if (!Number.isFinite(max) || max <= 0) return <span className="text-sm text-theme-text-tertiary font-mono">{podCount || '-'}</span>
       const pct = (podCount / max) * 100

--- a/packages/k8s-ui/src/utils/extended-resources.ts
+++ b/packages/k8s-ui/src/utils/extended-resources.ts
@@ -2,7 +2,7 @@
 // the GPU views. Keep all effective-request math here — K8s semantics for
 // extended resources are subtle and must not be reimplemented per call site.
 
-import { parseMemoryToBytes } from './format'
+import { parseQuantityToNumber } from './format'
 
 const STANDARD_NODE_RESOURCES = new Set(['cpu', 'memory', 'pods', 'ephemeral-storage'])
 
@@ -48,14 +48,14 @@ export function getEffectiveResources(resources: any): Record<string, string> {
 }
 
 // K8s quantity → number. Counts are usually plain integers, but quantities may
-// legally carry suffixes: "3000m" is 3, "3k" is 3000.
+// legally carry suffixes: "3000m" is 3, "3k" is 3000. This went through the
+// memory parser, which covered the suffixes an extended resource realistically
+// carries but was the wrong contract to borrow — and left the same class of bug
+// live wherever a count had no parser at all (#1441). The shared quantity
+// parser is now the one place that knows the suffix table.
 function asCount(value: unknown): number {
   if (typeof value === 'number') return Number.isFinite(value) ? value : 0
-  const s = String(value ?? '').trim()
-  if (!s) return 0
-  if (/^\d+(\.\d+)?m$/.test(s)) return Number(s.slice(0, -1)) / 1000
-  const n = parseMemoryToBytes(s)
-  return Number.isFinite(n) ? n : 0
+  return parseQuantityToNumber(String(value ?? ''))
 }
 
 function containerGpuCount(container: any): number {

--- a/packages/k8s-ui/src/utils/extended-resources.ts
+++ b/packages/k8s-ui/src/utils/extended-resources.ts
@@ -48,11 +48,8 @@ export function getEffectiveResources(resources: any): Record<string, string> {
 }
 
 // K8s quantity → number. Counts are usually plain integers, but quantities may
-// legally carry suffixes: "3000m" is 3, "3k" is 3000. This went through the
-// memory parser, which covered the suffixes an extended resource realistically
-// carries but was the wrong contract to borrow — and left the same class of bug
-// live wherever a count had no parser at all (#1441). The shared quantity
-// parser is now the one place that knows the suffix table.
+// legally carry suffixes: "3000m" is 3, "3k" is 3000. The shared quantity
+// parser is the one place that knows the suffix table.
 function asCount(value: unknown): number {
   if (typeof value === 'number') return Number.isFinite(value) ? value : 0
   return parseQuantityToNumber(String(value ?? ''))

--- a/packages/k8s-ui/src/utils/format.test.ts
+++ b/packages/k8s-ui/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatCPUString, formatMemoryString, parseMemoryToBytes } from './format'
+import { formatCPUString, formatMemoryString, parseMemoryToBytes, parseQuantityToNumber } from './format'
 
 describe('formatCPUString', () => {
   it('renders exact zero as zero, not a fabricated near-zero', () => {
@@ -31,5 +31,78 @@ describe('parseMemoryToBytes', () => {
   it('parses signed quantities instead of silently zeroing them', () => {
     expect(parseMemoryToBytes('-1Ki')).toBe(-1024)
     expect(parseMemoryToBytes('1Ki')).toBe(1024)
+  })
+})
+
+describe('parseQuantityToNumber', () => {
+  // The reported bug. A Quantity's canonical form collapses trailing zeros into
+  // an SI suffix, so a node started with --max-pods=1000 reports "1k". Read as
+  // a raw integer that is 1, and a node running 216 pods rendered as 216 / 1
+  // with the usage bar pegged at 21600%.
+  it('reads a pod capacity of 1000 as 1000, not 1', () => {
+    expect(parseQuantityToNumber('1k')).toBe(1000)
+    expect((216 / parseQuantityToNumber('1k')) * 100).toBeCloseTo(21.6)
+  })
+
+  it('only collapses zeros in groups of three, so nearby counts are unchanged', () => {
+    expect(parseQuantityToNumber('2k')).toBe(2000)
+    expect(parseQuantityToNumber('1020')).toBe(1020)
+    expect(parseQuantityToNumber('990')).toBe(990)
+    expect(parseQuantityToNumber('216')).toBe(216)
+  })
+
+  it('handles the sub-unit decimal suffixes a count can legally carry', () => {
+    expect(parseQuantityToNumber('3000m')).toBe(3)
+    expect(parseQuantityToNumber('1500m')).toBe(1.5)
+    expect(parseQuantityToNumber('1000000u')).toBe(1)
+    expect(parseQuantityToNumber('1000000000n')).toBe(1)
+  })
+
+  it('handles the whole decimal SI range', () => {
+    expect(parseQuantityToNumber('5M')).toBe(5e6)
+    expect(parseQuantityToNumber('5G')).toBe(5e9)
+    expect(parseQuantityToNumber('5T')).toBe(5e12)
+    expect(parseQuantityToNumber('5P')).toBe(5e15)
+    expect(parseQuantityToNumber('5E')).toBe(5e18)
+  })
+
+  it('handles binary suffixes in powers of 1024', () => {
+    expect(parseQuantityToNumber('1Ki')).toBe(1024)
+    expect(parseQuantityToNumber('2Gi')).toBe(2 * 1024 ** 3)
+    expect(parseQuantityToNumber('1Ei')).toBe(1024 ** 6)
+  })
+
+  // "1E3" is the exponent form (1000), while "1E" is exa. Deciding the exponent
+  // first is what keeps the two apart.
+  it('reads the decimal-exponent form without confusing it for exa', () => {
+    expect(parseQuantityToNumber('1e3')).toBe(1000)
+    expect(parseQuantityToNumber('1E3')).toBe(1000)
+    expect(parseQuantityToNumber('1.5e3')).toBe(1500)
+    expect(parseQuantityToNumber('1e-3')).toBe(0.001)
+    expect(parseQuantityToNumber('1E')).toBe(1e18)
+  })
+
+  it('preserves the sign', () => {
+    expect(parseQuantityToNumber('-1k')).toBe(-1000)
+    expect(parseQuantityToNumber('+1k')).toBe(1000)
+  })
+
+  // A number this cannot read is reported as unknown so the caller can fall back,
+  // rather than becoming a plausible-looking wrong number on screen.
+  it('yields zero for input it cannot parse rather than guessing', () => {
+    expect(parseQuantityToNumber('1z')).toBe(0)
+    expect(parseQuantityToNumber('1KB')).toBe(0)
+    expect(parseQuantityToNumber('abc')).toBe(0)
+    expect(parseQuantityToNumber('')).toBe(0)
+    expect(parseQuantityToNumber('   ')).toBe(0)
+    expect(parseQuantityToNumber(null)).toBe(0)
+    expect(parseQuantityToNumber(undefined)).toBe(0)
+  })
+
+  it('passes through numbers the API already decoded, and rejects non-finite ones', () => {
+    expect(parseQuantityToNumber(216)).toBe(216)
+    expect(parseQuantityToNumber(0)).toBe(0)
+    expect(parseQuantityToNumber(Number.NaN)).toBe(0)
+    expect(parseQuantityToNumber(Number.POSITIVE_INFINITY)).toBe(0)
   })
 })

--- a/packages/k8s-ui/src/utils/format.ts
+++ b/packages/k8s-ui/src/utils/format.ts
@@ -165,6 +165,80 @@ export function formatMemoryString(memString: string): string {
 }
 
 // =============================================================================
+// Quantity Parsing (counts)
+// =============================================================================
+
+/**
+ * Every suffix a `resource.Quantity` can carry, in the API's own groupings:
+ * decimal SI in powers of 1000 (including the sub-unit n/u/m), and binary SI in
+ * powers of 1024. `K` is not canonical Kubernetes — only lowercase `k` is — but
+ * it is accepted here for the same leniency `parseMemoryToBytes` already has.
+ */
+const QUANTITY_SUFFIXES: Record<string, number> = {
+  n: 1e-9,
+  u: 1e-6,
+  m: 1e-3,
+  k: 1e3,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+}
+
+/**
+ * Parse a Kubernetes `resource.Quantity` into a plain number.
+ *
+ * Counts are the surface that needs this. A Quantity's canonical serialization
+ * collapses trailing zeros into an SI suffix, so a node started with
+ * `--max-pods=1000` reports `"1k"` and not `"1000"`. Read with `parseInt` that
+ * is 1, which rendered a node running 216 pods as `216 / 1` and pegged its
+ * usage bar at 21600% (#1441). Any count that is a multiple of 1000 hits it.
+ *
+ * Unlike `parseMemoryToBytes`, an unrecognised suffix yields 0 rather than the
+ * bare number: a Quantity this cannot read is better reported as unknown by the
+ * caller than silently turned into a plausible-looking wrong number.
+ *
+ * @param quantity - K8s quantity like "1k", "216", "3000m", "2Gi", "1e3"
+ * @returns The value as a number, or 0 when it cannot be parsed
+ */
+export function parseQuantityToNumber(quantity: string | number | null | undefined): number {
+  if (typeof quantity === 'number') return Number.isFinite(quantity) ? quantity : 0
+  if (!quantity) return 0
+
+  const str = String(quantity).trim()
+  if (!str) return 0
+
+  // Decimal-exponent form. A Quantity's suffix is either an SI suffix or an
+  // exponent, never both, so this is decided before the suffix table — which
+  // also keeps "1E3" (1000) from being read as exa (1e18).
+  const exponent = str.match(/^([+-]?\d+(?:\.\d+)?)[eE]([+-]?\d+)$/)
+  if (exponent) {
+    const value = Number(`${exponent[1]}e${exponent[2]}`)
+    return Number.isFinite(value) ? value : 0
+  }
+
+  const match = str.match(/^([+-]?\d+(?:\.\d+)?)\s*([A-Za-z]*)$/)
+  if (!match) return 0
+
+  const num = parseFloat(match[1])
+  if (!Number.isFinite(num)) return 0
+
+  const suffix = match[2]
+  if (!suffix) return num
+
+  const multiplier = QUANTITY_SUFFIXES[suffix]
+  return multiplier === undefined ? 0 : num * multiplier
+}
+
+// =============================================================================
 // Dashboard Metrics Formatting (different units from metrics-server)
 // =============================================================================
 

--- a/packages/k8s-ui/src/utils/format.ts
+++ b/packages/k8s-ui/src/utils/format.ts
@@ -198,9 +198,9 @@ const QUANTITY_SUFFIXES: Record<string, number> = {
  *
  * Counts are the surface that needs this. A Quantity's canonical serialization
  * collapses trailing zeros into an SI suffix, so a node started with
- * `--max-pods=1000` reports `"1k"` and not `"1000"`. Read with `parseInt` that
- * is 1, which rendered a node running 216 pods as `216 / 1` and pegged its
- * usage bar at 21600% (#1441). Any count that is a multiple of 1000 hits it.
+ * `--max-pods=1000` reports `"1k"` and not `"1000"` — read as a raw integer
+ * that is 1, so a usage bar divides by 1 instead of 1000. Any count that is
+ * a multiple of 1000 hits it.
  *
  * Unlike `parseMemoryToBytes`, an unrecognised suffix yields 0 rather than the
  * bare number: a Quantity this cannot read is better reported as unknown by the


### PR DESCRIPTION
Fixes #1441.

## The bug

`ResourcesView.tsx` read allocatable pods with `parseInt`:

```ts
const max = parseInt(allocatable, 10)   // parseInt("1k", 10) === 1
```

A `resource.Quantity`'s canonical serialization collapses trailing zeros into an SI suffix, so a node started with `--max-pods=1000` reports `"1k"`, not `"1000"`. That made a node running 216 pods render as `216 / 1` with the bar pegged at **21600%**. CPU and memory in the same row were correct, which is what made it read like a real capacity emergency rather than a display defect.

Any count that is a multiple of 1000 hits it. `1020` and `990` do not, which is why this survived: the value has to be exactly divisible by 1000 before the API abbreviates it.

## The fix

The reporter suggested a shared `parseQuantityToNumber()` in `format.ts`, and the tree already agreed with them in two places — this was the third surface, and the only one with no parser at all:

| surface | had | 
| --- | --- |
| memory | `parseMemoryToBytes` (Ki…Ti, k…T) |
| extended resources / GPU counts | private `asCount`, whose comment already said *"3k is 3000"* |
| **pod counts in the Nodes list** | **`parseInt`** |

So `parseQuantityToNumber` is added to `format.ts`, and both the pods cell and `asCount` now go through it.

The parser covers every suffix form the API can emit rather than the ones memory happens to use:

- decimal SI including the sub-unit range — `n`, `u`, `m`, `k`, `M`, `G`, `T`, `P`, `E`
- binary SI up to `Ei`
- the decimal-exponent form

`"1E3"` is 1000 and `"1E"` is exa, so the exponent form is decided *before* the suffix table — otherwise `1E3` would be read as exa. An unrecognised suffix yields `0` rather than the bare number, which is deliberate and differs from `parseMemoryToBytes`: the pods cell already falls back to showing the count alone when it gets a non-positive max, so returning 0 makes an unreadable Quantity show as "unknown" instead of drawing a confidently wrong percentage.

`asCount` previously borrowed `parseMemoryToBytes`. That covered the suffixes an extended resource realistically carries, but it was the wrong contract to borrow, and it left the same class of bug live wherever a count had no parser. It now shares the count parser and picks up `P`/`E`/`Pi`/`Ei` and exponents as a side effect.

I did **not** touch the detail view (`NodeRenderer.tsx:140-141`). It renders the Quantity string as-is, so it already shows `1k` — as the issue says, at least not wrong.

## Verification

The reported case, as a test:

```ts
expect(parseQuantityToNumber('1k')).toBe(1000)
expect((216 / parseQuantityToNumber('1k')) * 100).toBeCloseTo(21.6)
```

which is the `216 / 1000` and `21.6%` the issue asks for. Nine test cases in total cover the reported bug, the near-misses that must stay unchanged (`1020`, `990`), each suffix family, the exponent/exa ambiguity, signs, unparseable input, and already-decoded numbers.

```
packages/k8s-ui   npm test          131 files, 2323 passed, 1 skipped
web               npm run tsc       0 errors
web               npm run lint      0 errors (302 pre-existing warnings)
web               npm run build     ok
```

Three things I checked rather than assumed, in case they save you time:

- **`packages/k8s-ui` `npm run tsc` reports 7 errors, all pre-existing.** They are in `src/components/trace/reachGraphModel.test.ts` and `reachInspector.test.ts`, which this PR does not touch, and the identical 7 appear on an unmodified checkout. CI does not run `tsc` for the `k8s-ui` package (only for `web`, which is clean), so they are not newly exposed either.
- **`web`'s `client.authRedirect.test.ts` is flaky under load, independently of this change.** "navigates to /auth/login exactly once for a burst of concurrent 401s" times out at exactly the 5000 ms default. Across full-suite runs I measured 2 failures in 5 on an unmodified checkout and 2 in 3 with this change; it passes every time when run alone. The test mocks `./config` and imports only `./client`, so it has no import path to any module here. My machine's load average was 12/31/40, which is the likeliest driver. Flagging it rather than filing it, since you may already know.
- **Prettier is not clean on these files, and was not before this change either.** All four fail `prettier --check` on an unmodified checkout, and no workflow references prettier, so I matched the surrounding style by hand rather than running `--write` — that would have reformatted whole files and buried a 160-line change in reformatting noise. Happy to run it if you would rather have it.

One thing I could not verify: I have no cluster with `--max-pods=1000`, so the fix is tested at the parser and not against a live node. The reporter's `kubectl` output (`{"capacityPods":"1k","allocatablePods":"1k"}` with 217 pods scheduled) is what the test encodes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only quantity parsing for node/GPU counts; no API, auth, or data-path changes. Unrecognized suffixes now yield 0 instead of a guessed number.
> 
> **Overview**
> Fixes the Nodes list pods usage bar treating allocatable `"1k"` as `1` (`parseInt`), which pegged a 216-pod node at 21600%.
> 
> Adds shared `parseQuantityToNumber` in `format.ts` (SI, binary, millicounts, exponent form) and uses it for the pods cell and GPU/`asCount` helpers. Unparseable suffixes return 0 so the bar falls back instead of showing a wrong percent. Tests cover `"1k"` → 1000 and the nearby counts that must stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efe40e7c76399fac1b8e229104c2907396b4d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->