### PR TITLE
feat(cnpg): report a backup schedule that stopped running

### DIFF
--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -46,6 +46,12 @@ var cnpgTerminalPhases = map[string]bool{
 // as "mid-operation" before the generic detector is allowed to report it.
 const cnpgTransientConditionGrace = 30 * time.Minute
 
+// cnpgScheduledBackupGrace absorbs the gap between the moment a backup comes due
+// and the moment the operator gets round to starting it. It is reconcile
+// latency, not a backup policy: nothing here decides how often backups should
+// run, only that the schedule missed a time it set for itself.
+const cnpgScheduledBackupGrace = 10 * time.Minute
+
 // cnpgAttentionPhases are stalled waiting on a human. Under
 // primaryUpdateStrategy: supervised this is the documented resting state, so it
 // only raises an issue under an unsupervised strategy.
@@ -127,8 +133,53 @@ func detectCNPGIssues(gvr schema.GroupVersionResource, kind string, u *unstructu
 		return detectCNPGBackupIssues(gvr, kind, u)
 	case "Database", "Publication", "Subscription":
 		return detectCNPGDeclarativeIssues(gvr, kind, u)
+	case "ScheduledBackup":
+		return detectCNPGScheduledBackupIssues(gvr, kind, u)
 	}
 	return nil
+}
+
+// The operator publishes when it expects the next backup to run. Once that
+// moment has passed and no backup has happened, backups have stopped.
+//
+// This is the one backup failure with nothing else to see: every other detector
+// here fires on something the operator reported as failed. A schedule that
+// simply stops firing reports nothing, so the cluster stays green while its
+// recovery point ages. The last-backup timestamp is the only evidence, and
+// until now nothing compared it to the present.
+//
+// The expectation is the operator's, not ours. We never decide how often a
+// backup should run — that is the cluster owner's policy. We only report that
+// the schedule missed the time it set for itself.
+func detectCNPGScheduledBackupIssues(gvr schema.GroupVersionResource, kind string, u *unstructured.Unstructured) []Issue {
+	// Suspended is a deliberate state. The operator stops updating
+	// nextScheduleTime, so the stored value goes stale immediately and reporting
+	// it as missed would fire on every intentionally paused schedule.
+	if suspended, found, err := unstructured.NestedBool(u.Object, "spec", "suspend"); err == nil && found && suspended {
+		return nil
+	}
+
+	next, found, err := unstructured.NestedString(u.Object, "status", "nextScheduleTime")
+	if err != nil || !found || next == "" {
+		return nil
+	}
+	due, err := time.Parse(time.RFC3339, next)
+	if err != nil {
+		return nil
+	}
+
+	overdue := time.Since(due)
+	if overdue <= cnpgScheduledBackupGrace {
+		return nil
+	}
+
+	ns, name := u.GetNamespace(), u.GetName()
+	// The elapsed time rides on `since` rather than the message so it renders
+	// through the same "how long has this been broken" path as every other issue.
+	return []Issue{newConditionIssue(gvr, kind, ns, name, SeverityWarning,
+		"CNPGScheduledBackupMissed",
+		"No backup has run since this schedule was due",
+		overdue, "CNPGScheduledBackupMissed", u.GetCreationTimestamp().Time)}
 }
 
 // A declared object the operator could not apply.

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -597,5 +598,73 @@ func TestCNPGDeclarativeNotApplied(t *testing.T) {
 		if !strings.Contains(out[0].Message, "gave no reason") {
 			t.Errorf("%s with no operator message should say so: %q", kind, out[0].Message)
 		}
+	}
+}
+
+var cnpgScheduledBackupGVR = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "scheduledbackups"}
+
+func cnpgScheduledBackup(suspend bool, nextScheduleTime string) *unstructured.Unstructured {
+	spec := map[string]any{"schedule": "0 0 0 * * *", "suspend": suspend}
+	status := map[string]any{}
+	if nextScheduleTime != "" {
+		status["nextScheduleTime"] = nextScheduleTime
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "ScheduledBackup",
+		"metadata":   map[string]any{"name": "nightly", "namespace": "pg"},
+		"spec":       spec,
+		"status":     status,
+	}}
+}
+
+// A schedule that stops firing is the one backup failure with nothing else to
+// see: no condition goes False, no object reports an error, and the cluster
+// stays green while its recovery point ages.
+func TestCNPGScheduledBackupMissed(t *testing.T) {
+	rfc := func(d time.Duration) string { return time.Now().Add(d).Format(time.RFC3339) }
+
+	tests := []struct {
+		name    string
+		obj     *unstructured.Unstructured
+		wantHit bool
+	}{
+		{"due 200 days ago and nothing ran", cnpgScheduledBackup(false, rfc(-200*24*time.Hour)), true},
+		{"due just past the grace window", cnpgScheduledBackup(false, rfc(-cnpgScheduledBackupGrace-time.Minute)), true},
+		// The operator has simply not picked it up yet. Firing here would raise an
+		// issue on every healthy schedule for the seconds around each run.
+		{"due moments ago, inside the grace window", cnpgScheduledBackup(false, rfc(-time.Minute)), false},
+		{"not due yet", cnpgScheduledBackup(false, rfc(time.Hour)), false},
+		// Suspended stops the operator maintaining the field, so the stored value
+		// goes stale at once and would report every paused schedule as missed.
+		{"suspended long past its last next-run time", cnpgScheduledBackup(true, rfc(-200*24*time.Hour)), false},
+		{"operator has not published a next run", cnpgScheduledBackup(false, ""), false},
+		{"unparseable next run", cnpgScheduledBackup(false, "not-a-timestamp"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectCNPGIssues(cnpgScheduledBackupGVR, "ScheduledBackup", tc.obj)
+			if tc.wantHit {
+				iss := findIssue(t, got, "CNPGScheduledBackupMissed")
+				if iss.Severity != SeverityWarning {
+					t.Errorf("severity = %v, want warning", iss.Severity)
+				}
+				// It must file as a backup problem, or the backup filter answers a
+				// different question than it claims to. Classified through the
+				// production path so the test cannot drift from how rows are
+				// actually labelled.
+				classifyIssue(&iss)
+				if iss.Category != issuesapi.CategoryBackupFailed {
+					t.Errorf("category = %v, want backup_failed", iss.Category)
+				}
+				return
+			}
+			for _, i := range got {
+				if i.Reason == "CNPGScheduledBackupMissed" {
+					t.Fatalf("unexpected missed-backup issue: %s", i.Message)
+				}
+			}
+		})
 	}
 }

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -83,3 +83,36 @@ describe('the WAL banner must not claim nothing else looks wrong when something 
     expect(html(walFailing(phase, 2))).not.toContain(CLAIM)
   })
 })
+
+describe('recovery points must be readable as ages, not raw machine timestamps', () => {
+  const withBackup = (lastSuccessful: string) => ({
+    apiVersion: 'postgresql.cnpg.io/v1',
+    kind: 'Cluster',
+    metadata: { name: 'pg', namespace: 'db' },
+    spec: { instances: 2, backup: { barmanObjectStore: { destinationPath: 's3://bucket' } } },
+    status: {
+      phase: 'Cluster in healthy state',
+      readyInstances: 2,
+      lastSuccessfulBackup: lastSuccessful,
+      firstRecoverabilityPoint: lastSuccessful,
+    },
+  })
+
+  it('states how old the last successful backup is', () => {
+    const old = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString()
+    const html = renderToString(<CNPGClusterRenderer data={withBackup(old)} />)
+    // The age is the whole point: a raw ISO string requires the reader to do
+    // date arithmetic to notice their newest backup is 200 days old.
+    expect(html).toContain('200d ago')
+    // And the ISO form with its milliseconds must not survive as the display value.
+    expect(html).not.toContain(old)
+  })
+
+  it('keeps the absolute timestamp beside the age', () => {
+    // Age alone is the wrong unit here: "1d ago" next to "1d ago" is the same
+    // string for events a week apart in a failure history.
+    const at = '2026-01-30T09:40:37.000Z'
+    const html = renderToString(<CNPGClusterRenderer data={withBackup(at)} />)
+    expect(html).toContain('2026-01-30 09:40:37 UTC')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -26,6 +26,7 @@ import {
   CNPG_BARMAN_OBJECTSTORE_GROUP,
 } from '../resource-utils-cnpg'
 import { formatAge } from '../resource-utils'
+import { RecoveryTime } from './CNPGShared'
 
 interface CNPGClusterRendererProps {
   /** Filled by the host with the Databases, Publications and Subscriptions
@@ -402,13 +403,13 @@ export function CNPGClusterRenderer({ data, onNavigate, declared}: CNPGClusterRe
               <Property label="Retention" value={backupConfig.retentionPolicy} />
             )}
             {backupConfig.lastSuccessfulBackup && (
-              <Property label="Last Successful" value={backupConfig.lastSuccessfulBackup} />
+              <Property label="Last Successful" value={<RecoveryTime at={backupConfig.lastSuccessfulBackup} />} />
             )}
             {lastFailedBackup && (
-              <Property label="Last Failed" value={lastFailedBackup} />
+              <Property label="Last Failed" value={<RecoveryTime at={lastFailedBackup} />} />
             )}
             {backupConfig.firstRecoverabilityPoint && (
-              <Property label="First Recoverability" value={backupConfig.firstRecoverabilityPoint} />
+              <Property label="First Recoverability" value={<RecoveryTime at={backupConfig.firstRecoverabilityPoint} />} />
             )}
           </PropertyList>
           {/* Without this note the section renders empty on plugin-migrated

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGObjectStoreRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGObjectStoreRenderer.tsx
@@ -2,7 +2,7 @@ import { Archive, Clock, HardDrive } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { HEALTH_BADGE_COLORS } from '../../../utils/badge-colors'
-import { formatAge } from '../resource-utils'
+import { RecoveryTime } from './CNPGShared'
 import {
   getCNPGObjectStoreProvider,
   getCNPGObjectStoreCredentialSecret,
@@ -21,25 +21,6 @@ import {
  * own. Until this renderer existed that sentence pointed at a page showing raw
  * fields, so the restorable range was effectively unreachable in the product.
  */
-/**
- * A recovery point, stated absolutely with the interval beside it.
- *
- * "1d ago" is the wrong unit for this question. An RPO conversation needs a
- * timestamp — and "Last Successful Backup 1d ago" next to "Last Failed Attempt
- * 1d ago" is the same string for events a week apart in the failure history,
- * which is precisely when you are reading this screen. Same treatment the
- * certificate rows already use.
- */
-function RecoveryTime({ at }: { at: string }) {
-  const d = new Date(at)
-  if (Number.isNaN(d.getTime())) return <>{at}</>
-  return (
-    <span className="inline-flex items-baseline gap-2 min-w-0">
-      <span>{d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}</span>
-      <span className="text-xs text-theme-text-tertiary shrink-0">{formatAge(at)} ago</span>
-    </span>
-  )
-}
 
 export function CNPGObjectStoreRenderer({
   data,

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGShared.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGShared.tsx
@@ -1,0 +1,27 @@
+import { formatAge } from '../resource-utils'
+
+/**
+ * A recovery point, stated absolutely with the interval beside it.
+ *
+ * "1d ago" is the wrong unit for this question on its own. An RPO conversation
+ * needs a timestamp — and "Last Successful Backup 1d ago" next to "Last Failed
+ * Attempt 1d ago" is the same string for events a week apart in the failure
+ * history, which is precisely when you are reading this screen. Same treatment
+ * the certificate rows already use.
+ *
+ * Shared by the Cluster and ObjectStore pages: the same recovery point is
+ * reachable from both depending on whether backups run through the plugin, and
+ * the two must not describe it differently.
+ */
+export function RecoveryTime({ at }: { at: string }) {
+  const d = new Date(at)
+  if (Number.isNaN(d.getTime())) return <>{at}</>
+  return (
+    <span className="inline-flex items-baseline gap-2 min-w-0">
+      <span>{d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}</span>
+      {/* One interpolation, so the age and its unit stay a single text node
+          rather than being split by a renderer comment marker. */}
+      <span className="text-xs text-theme-text-tertiary shrink-0">{`${formatAge(at)} ago`}</span>
+    </span>
+  )
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
+  getCNPGScheduledBackupStatus,
+  getCNPGScheduledBackupNextSchedule,
   getCNPGClusterCertificateExpirations,
   getCNPGClusterStatus,
   getCNPGBackupStatus,
@@ -660,5 +662,57 @@ describe('volume health', () => {
   it('ignores malformed entries rather than rendering them', () => {
     const h = getCNPGVolumeHealth({ status: { pvcCount: 1, healthyPVC: ['ok', 42, null] } })
     expect(h?.healthy).toEqual(['ok'])
+  })
+})
+
+describe('CNPG scheduled backup lateness', () => {
+  const at = (ms: number) => new Date(Date.now() + ms).toISOString()
+  const MIN = 60 * 1000
+
+  const sb = (suspend: boolean, next?: string, lastScheduleTime?: string) => ({
+    spec: { schedule: '0 0 0 * * *', suspend },
+    status: { ...(next ? { nextScheduleTime: next } : {}), ...(lastScheduleTime ? { lastScheduleTime } : {}) },
+  })
+
+  it('reports a schedule that missed its own next-run time', () => {
+    // Ran once, then stopped. Both lastScheduleTime and nextScheduleTime are
+    // present, which is exactly the shape that used to read healthy.
+    const badge = getCNPGScheduledBackupStatus(sb(false, at(-200 * 24 * 60 * MIN), at(-200 * 24 * 60 * MIN)))
+    expect(badge.level).toBe('degraded')
+    expect(badge.text).toBe('Overdue')
+  })
+
+  it('stays healthy inside the operator reconcile window', () => {
+    const badge = getCNPGScheduledBackupStatus(sb(false, at(-1 * MIN), at(-24 * 60 * MIN)))
+    expect(badge.level).toBe('healthy')
+  })
+
+  it('keeps suspended as a deliberate state, not a missed backup', () => {
+    // The operator stops maintaining nextScheduleTime once suspended, so the
+    // stale value must not be read as a missed run.
+    const badge = getCNPGScheduledBackupStatus(sb(true, at(-200 * 24 * 60 * MIN)))
+    expect(badge.text).toBe('Suspended')
+  })
+
+  it('never says overdue while the badge still says healthy', () => {
+    // The two read from one test. Before this they disagreed: the badge said
+    // Active while this field said overdue on the same row.
+    const justPastDue = sb(false, at(-1 * MIN), at(-24 * 60 * MIN))
+    expect(getCNPGScheduledBackupStatus(justPastDue).level).toBe('healthy')
+    expect(getCNPGScheduledBackupNextSchedule(justPastDue)).toBe('due now')
+
+    const longPastDue = sb(false, at(-200 * 24 * 60 * MIN), at(-200 * 24 * 60 * MIN))
+    expect(getCNPGScheduledBackupStatus(longPastDue).level).toBe('degraded')
+    expect(getCNPGScheduledBackupNextSchedule(longPastDue)).toContain('overdue by')
+  })
+
+  it('does not count down to a run that is not coming', () => {
+    expect(getCNPGScheduledBackupNextSchedule(sb(true, at(60 * MIN)))).toBe('suspended')
+    expect(getCNPGScheduledBackupNextSchedule(sb(true, at(-60 * MIN)))).toBe('suspended')
+  })
+
+  it('says nothing when the operator published no next-run time', () => {
+    expect(getCNPGScheduledBackupNextSchedule(sb(false))).toBe('-')
+    expect(getCNPGScheduledBackupStatus(sb(false, undefined, at(-24 * 60 * MIN))).level).toBe('healthy')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -763,11 +763,46 @@ export function getCNPGBackupTarget(resource: any): string {
 // CNPG SCHEDULED BACKUP UTILITIES
 // ============================================================================
 
+/**
+ * Reconcile latency between a backup coming due and the operator starting it.
+ * Not a backup policy — nothing here decides how often backups should run.
+ * Kept in step with the detector that raises the matching issue.
+ */
+const CNPG_SCHEDULED_BACKUP_GRACE_MS = 10 * 60 * 1000
+
+/**
+ * How far past its own next-run time this schedule is, or null when it is not
+ * meaningfully overdue.
+ *
+ * The expectation belongs to the operator: CNPG publishes `nextScheduleTime`
+ * and updates it whenever it runs a backup. A value still in the past therefore
+ * means no backup happened. Suspended schedules are excluded because the
+ * operator stops maintaining the field, so the stale value would read as missed
+ * on every deliberately paused schedule.
+ */
+export function getCNPGScheduledBackupOverdueMs(resource: any): number | null {
+  if (resource?.spec?.suspend === true) return null
+  const next = resource?.status?.nextScheduleTime
+  if (!next) return null
+  const dueAt = new Date(next).getTime()
+  if (Number.isNaN(dueAt)) return null
+  const overdue = Date.now() - dueAt
+  return overdue > CNPG_SCHEDULED_BACKUP_GRACE_MS ? overdue : null
+}
+
 export function getCNPGScheduledBackupStatus(resource: any): StatusBadge {
   const isSuspended = resource.spec?.suspend === true
 
   if (isSuspended) {
     return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  // The operator said when the next backup was due and it has not happened.
+  // Checked before lastScheduleTime: a schedule that ran once and then stopped
+  // has both, and reporting it healthy contradicted the next-run figure sitting
+  // on the same row.
+  if (getCNPGScheduledBackupOverdueMs(resource) !== null) {
+    return { text: 'Overdue', color: healthColors.degraded, level: 'degraded' }
   }
 
   // If we have a last schedule time, it's active
@@ -802,10 +837,20 @@ export function getCNPGScheduledBackupLastSchedule(resource: any): string {
 export function getCNPGScheduledBackupNextSchedule(resource: any): string {
   const next = resource.status?.nextScheduleTime
   if (!next) return '-'
+  // A suspended schedule keeps whatever next-run time it had when it was
+  // paused, and the operator stops maintaining it. Counting down to it, or
+  // calling it due, would both describe a run that is not coming.
+  if (resource.spec?.suspend === true) return 'suspended'
   const nextDate = new Date(next)
   const now = new Date()
   const diffMs = nextDate.getTime() - now.getTime()
-  if (diffMs <= 0) return 'overdue'
+  // Past due, but inside the window where the operator has simply not picked it
+  // up yet. Calling that "overdue" while the badge still reads healthy is the
+  // contradiction this pair is meant to avoid.
+  if (diffMs <= 0) {
+    const overdue = getCNPGScheduledBackupOverdueMs(resource)
+    return overdue === null ? 'due now' : `overdue by ${formatDuration(overdue)}`
+  }
   return `in ${formatDuration(diffMs)}`
 }
 


### PR DESCRIPTION
A backup schedule can stop firing without anything failing. No condition goes False, no object records an error, and the cluster keeps reporting healthy while its recovery point ages.

Measured against the shipped code before this change — a schedule whose last run was 200 days ago:

| | |
|---|---|
| badge | `Active`, green |
| Problems list | nothing |
| next-run field, same row | **`overdue`** |

Radar was already doing the comparison. The badge just ignored it, so one row said two different things.

## What changed

**The badge reports `Overdue`** once the operator's own `status.nextScheduleTime` has passed. CNPG updates that field on every run, so a value still in the past means no backup happened.

**A warning issue carries it to the Problems list**, filed under backups. Without it the only evidence lives on one object's page, and the whole failure mode is that nobody is looking at that page.

**The Cluster page states backup times as ages** beside the absolute timestamp — `2026-01-30 12:48:37 UTC · 200d ago` — instead of passing the raw ISO string through. The ObjectStore page already did this; its component moved to a shared module rather than being written twice, so the two pages cannot describe the same recovery point differently.

## The expectation is the operator's, not Radar's

Nothing here decides how often a backup should run. That is the cluster owner's policy, and inventing a number would make this a monitoring product rather than a visibility one. Radar only reports that the schedule missed a time **it set for itself**.

The single constant is a grace window absorbing the gap between a backup coming due and the operator starting it. It is reconcile latency, not a recovery-point target.

**Suspended is excluded.** The operator stops maintaining `nextScheduleTime` once suspended, so the stale value would report every deliberately paused schedule as missed. The next-run field says `suspended` rather than counting down to a run that is not coming.

## Verified on a live cluster

CloudNativePG 1.27, operator frozen so a written status holds:

| state | result |
|---|---|
| overdue, running | warning raised, badge amber, `overdue by 1h` |
| not yet due | nothing |
| suspended while long overdue | nothing |

Issue timing reads `started_after_resource_was_healthy` on realistic data — the schedule was fine, then stopped.

The tests were confirmed to **fail when the check is removed**, so they pin the behaviour rather than passing by construction.

## Scope

Velero is not covered. Its Schedule publishes only `lastBackup`, `lastSkipped`, `phase` and `validationErrors` — no next-run time (confirmed against the 12.1.0 chart CRD). Judging it late means evaluating the cron expression, including the timezone-prefixed form, which is a larger decision than this. `lastSkipped` looks like the cheaper first move and is worth checking before writing any cron maths.

Replication lag is unrelated and still absent.

## Testing

`go test ./...` clean · `make tsc` clean · k8s-ui 2460 passing.

Seven detector cases including the grace boundary, suspended, absent and unparseable next-run times, with the category asserted through the production classification path so the test cannot drift from how rows are actually labelled. Six UI cases, including one that pins the badge and the next-run field to the same answer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only detection and display logic for CNPG scheduled backups with explicit grace and suspend guards; no auth, data mutation, or cross-service behavior changes.
> 
> **Overview**
> **CNPG `ScheduledBackup` objects that stop firing** can now surface as problems when `status.nextScheduleTime` is past due (with a **10-minute reconcile grace**), **`spec.suspend` is false**, and the timestamp is valid. A new Go detector emits **`CNPGScheduledBackupMissed`** as a **warning** in the **backup** category; the UI badge becomes **`Overdue`** and the next-run text uses **`due now`** vs **`overdue by …`** so it matches the badge.
> 
> **Cluster backup timestamps** on the Cluster page now use shared **`RecoveryTime`** (absolute UTC + relative age), moved out of `CNPGObjectStoreRenderer` into **`CNPGShared`** so Cluster and ObjectStore describe recovery points the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f69c565f1db8fab40c1817c32116981a78a13b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->