### PR TITLE
diagnostics: report the Linux desktop rendering environment

### DIFF
--- a/cmd/desktop/boot_env_linux.go
+++ b/cmd/desktop/boot_env_linux.go
@@ -6,21 +6,22 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	"github.com/skyhook-io/radar/internal/desktopenv"
 )
 
 // logBootEnv prints Linux desktop environment context at startup so bug
 // reports include the info needed to diagnose Wayland/X11, compositor, and
 // WebKit rendering issues without the reporter having to run extra commands.
+//
+// Users launching from the .desktop entry never see stdout, so the same values
+// are also served in the diagnostics snapshot — see internal/desktopenv.
 func logBootEnv() {
-	session := []string{"XDG_SESSION_TYPE", "XDG_CURRENT_DESKTOP", "WAYLAND_DISPLAY", "DISPLAY"}
-	overrides := []string{"GDK_BACKEND", "GSK_RENDERER", "WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE", "GTK_THEME"}
-	sandbox := []string{"SNAP", "FLATPAK_ID", "container"}
-
-	log.Printf("[desktop] session: %s", joinEnv(session, true))
-	if s := joinEnv(overrides, false); s != "" {
+	log.Printf("[desktop] session: %s", joinEnv(desktopenv.SessionKeys, true))
+	if s := joinEnv(desktopenv.OverrideKeys, false); s != "" {
 		log.Printf("[desktop] render overrides: %s", s)
 	}
-	if s := joinEnv(sandbox, false); s != "" {
+	if s := joinEnv(desktopenv.SandboxKeys, false); s != "" {
 		log.Printf("[desktop] sandbox: %s", s)
 	}
 }

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skyhook-io/radar/internal/app"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/config"
+	"github.com/skyhook-io/radar/internal/desktopenv"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/updater"
 	versionpkg "github.com/skyhook-io/radar/internal/version"
@@ -26,6 +27,23 @@ import (
 var (
 	version = "dev"
 )
+
+// linuxGPUPolicy is declared once so the value the webview is configured with
+// and the value diagnostics reports can never drift apart.
+const linuxGPUPolicy = linux.WebviewGpuPolicyOnDemand
+
+func gpuPolicyName(p linux.WebviewGpuPolicy) string {
+	switch p {
+	case linux.WebviewGpuPolicyAlways:
+		return "always"
+	case linux.WebviewGpuPolicyOnDemand:
+		return "on-demand"
+	case linux.WebviewGpuPolicyNever:
+		return "never"
+	default:
+		return "unknown"
+	}
+}
 
 func main() {
 	// Load persistent config (~/.radar/config.json) for flag defaults.
@@ -157,6 +175,7 @@ func main() {
 
 	app.SetGlobals(cfg)
 	versionpkg.SetDesktop(true)
+	desktopenv.SetGPUPolicy(gpuPolicyName(linuxGPUPolicy))
 
 	// Clean up leftover files from previous update
 	updater.CleanupOldUpdate()
@@ -244,7 +263,7 @@ func main() {
 
 		Linux: &linux.Options{
 			ProgramName:      "radar",
-			WebviewGpuPolicy: linux.WebviewGpuPolicyOnDemand,
+			WebviewGpuPolicy: linuxGPUPolicy,
 		},
 	})
 

--- a/internal/desktopenv/desktopenv.go
+++ b/internal/desktopenv/desktopenv.go
@@ -1,0 +1,64 @@
+// Package desktopenv reports the host rendering environment the desktop app
+// is running in. On Linux the display server, compositor and WebKit render
+// overrides decide whether the webview works at all, and none of it is
+// derivable from anything else Radar already collects.
+package desktopenv
+
+import "sync/atomic"
+
+// Env var groups. Shared so startup logging and the diagnostics snapshot can
+// never report different sets.
+var (
+	SessionKeys  = []string{"XDG_SESSION_TYPE", "XDG_CURRENT_DESKTOP", "WAYLAND_DISPLAY", "DISPLAY"}
+	OverrideKeys = []string{"GDK_BACKEND", "GSK_RENDERER", "WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE", "GTK_THEME"}
+	SandboxKeys  = []string{"SNAP", "FLATPAK_ID", "container"}
+)
+
+// EnvVar is one environment variable. A slice preserves declaration order, so
+// two snapshots of the same host always read the same way.
+type EnvVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	// Set separates an explicitly empty value from an absent one. The
+	// difference decides behavior: the desktop app's WebKit defaults are
+	// skipped whenever a variable is merely present, so an empty
+	// WEBKIT_DISABLE_DMABUF_RENDERER leaves the DMABUF renderer on while
+	// looking, to os.Getenv, exactly like an untouched host.
+	Set bool `json:"set"`
+}
+
+// Snapshot describes the desktop rendering environment.
+type Snapshot struct {
+	SessionType        string `json:"sessionType,omitempty"`
+	DesktopEnvironment string `json:"desktopEnvironment,omitempty"`
+	// DisplayServer is derived from WAYLAND_DISPLAY and DISPLAY rather than
+	// XDG_SESSION_TYPE, which login managers frequently leave unset.
+	DisplayServer string `json:"displayServer,omitempty"`
+	// RenderOverrides lists every key in OverrideKeys, including unset ones —
+	// "the compositing override was not applied" is as diagnostic as its value.
+	RenderOverrides []EnvVar `json:"renderOverrides,omitempty"`
+	Sandbox         []EnvVar `json:"sandbox,omitempty"`
+	// WebKitLibrary is the webview library actually mapped into this process,
+	// which is the version that matters and not necessarily the one the
+	// package manager reports.
+	WebKitLibrary string `json:"webkitLibrary,omitempty"`
+	GPUPolicy     string `json:"gpuPolicy,omitempty"`
+}
+
+var gpuPolicy atomic.Value
+
+// SetGPUPolicy records the webview hardware-acceleration policy the app asked
+// for. Called by the desktop binary; the CLI leaves it unset.
+func SetGPUPolicy(p string) {
+	gpuPolicy.Store(p)
+}
+
+// GPUPolicy returns the recorded policy, or "" if none was set.
+func GPUPolicy() string {
+	p, _ := gpuPolicy.Load().(string)
+	return p
+}
+
+// Collect returns the current environment, or nil on platforms where none of
+// this applies.
+func Collect() *Snapshot { return collect() }

--- a/internal/desktopenv/desktopenv_linux.go
+++ b/internal/desktopenv/desktopenv_linux.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package desktopenv
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func collect() *Snapshot {
+	s := &Snapshot{
+		SessionType:        os.Getenv("XDG_SESSION_TYPE"),
+		DesktopEnvironment: os.Getenv("XDG_CURRENT_DESKTOP"),
+		DisplayServer:      displayServer(),
+		RenderOverrides:    readAll(OverrideKeys),
+		Sandbox:            readSet(SandboxKeys),
+		WebKitLibrary:      webKitLibrary("/proc/self/maps"),
+		GPUPolicy:          GPUPolicy(),
+	}
+	return s
+}
+
+func displayServer() string {
+	var parts []string
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		parts = append(parts, "wayland")
+	}
+	if os.Getenv("DISPLAY") != "" {
+		parts = append(parts, "x11")
+	}
+	return strings.Join(parts, "+")
+}
+
+// readAll returns every key, including absent ones, so a reader can tell an
+// override that was never applied from one that was applied as empty.
+func readAll(keys []string) []EnvVar {
+	out := make([]EnvVar, 0, len(keys))
+	for _, k := range keys {
+		v, set := os.LookupEnv(k)
+		out = append(out, EnvVar{Key: k, Value: v, Set: set})
+	}
+	return out
+}
+
+// readSet returns only the keys carrying a value. An empty sandbox marker says
+// nothing, so unlike readAll there is no tri-state worth reporting here.
+func readSet(keys []string) []EnvVar {
+	var out []EnvVar
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			out = append(out, EnvVar{Key: k, Value: v, Set: true})
+		}
+	}
+	return out
+}
+
+// webKitLibrary returns the basename of the webview library mapped into this
+// process. The soname's trailing version identifies the WebKitGTK build, which
+// a bug report otherwise has no way to state. The prefix is matched loosely
+// because the library is named per GTK generation (libwebkit2gtk-4.x on GTK3,
+// libwebkitgtk-6.0 on GTK4) and reporting nothing is the worst outcome.
+func webKitLibrary(mapsPath string) string {
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// A maps line ends with the mapped file's path, if it has one.
+		idx := strings.IndexByte(line, '/')
+		if idx < 0 {
+			continue
+		}
+		path := strings.TrimSuffix(line[idx:], " (deleted)")
+		base := filepath.Base(path)
+		if strings.HasPrefix(base, "libwebkit") {
+			return base
+		}
+	}
+	return ""
+}

--- a/internal/desktopenv/desktopenv_linux_test.go
+++ b/internal/desktopenv/desktopenv_linux_test.go
@@ -1,0 +1,170 @@
+//go:build linux
+
+package desktopenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMaps(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "maps")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestWebKitLibrary(t *testing.T) {
+	tests := []struct {
+		name string
+		maps string
+		want string
+	}{
+		{
+			name: "finds the mapped webkit library",
+			maps: `55a1b2c00000-55a1b2c21000 r--p 00000000 08:01 1000  /usr/bin/radar-desktop
+7f8c1c000000-7f8c1c021000 rw-p 00000000 00:00 0  [heap]
+7f8c1d000000-7f8c1f000000 r--p 00000000 08:01 2000  /usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so.0.13.6
+7f8c20000000-7f8c20100000 r--p 00000000 08:01 3000  /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2405.32
+`,
+			want: "libwebkit2gtk-4.1.so.0.13.6",
+		},
+		{
+			name: "strips the deleted marker left by a package upgrade",
+			maps: "7f8c1d000000-7f8c1f000000 r--p 00000000 08:01 2000  /usr/lib/libwebkit2gtk-4.1.so.0.13.6 (deleted)\n",
+			want: "libwebkit2gtk-4.1.so.0.13.6",
+		},
+		{
+			name: "finds the GTK4-generation library name",
+			maps: "7f8c1d000000-7f8c1f000000 r--p 00000000 08:01 2000  /usr/lib/x86_64-linux-gnu/libwebkitgtk-6.0.so.4.8.0\n",
+			want: "libwebkitgtk-6.0.so.4.8.0",
+		},
+		{
+			name: "reports nothing when no webview is loaded",
+			maps: `55a1b2c00000-55a1b2c21000 r--p 00000000 08:01 1000  /usr/bin/radar
+7f8c1c000000-7f8c1c021000 rw-p 00000000 00:00 0  [stack]
+`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := webKitLibrary(writeMaps(t, tt.maps)); got != tt.want {
+				t.Errorf("webKitLibrary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebKitLibraryMissingFile(t *testing.T) {
+	if got := webKitLibrary(filepath.Join(t.TempDir(), "absent")); got != "" {
+		t.Errorf("webKitLibrary() = %q, want empty", got)
+	}
+}
+
+func TestDisplayServer(t *testing.T) {
+	tests := []struct {
+		name    string
+		wayland string
+		x11     string
+		want    string
+	}{
+		{"wayland only", "wayland-0", "", "wayland"},
+		{"x11 only", "", ":0", "x11"},
+		{"xwayland reports both", "wayland-0", ":0", "wayland+x11"},
+		{"headless", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("WAYLAND_DISPLAY", tt.wayland)
+			t.Setenv("DISPLAY", tt.x11)
+			if got := displayServer(); got != tt.want {
+				t.Errorf("displayServer() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Absent overrides must still be reported — "the compositing override was not
+// applied" is what distinguishes a fixed host from an unfixed one.
+func TestReadAllKeepsAbsentKeys(t *testing.T) {
+	t.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
+	os.Unsetenv("WEBKIT_DISABLE_COMPOSITING_MODE")
+
+	got := readAll(OverrideKeys)
+	if len(got) != len(OverrideKeys) {
+		t.Fatalf("readAll() returned %d vars, want %d", len(got), len(OverrideKeys))
+	}
+
+	byKey := map[string]EnvVar{}
+	for i, v := range got {
+		if v.Key != OverrideKeys[i] {
+			t.Errorf("readAll()[%d].Key = %q, want %q (declaration order)", i, v.Key, OverrideKeys[i])
+		}
+		byKey[v.Key] = v
+	}
+	if dmabuf := byKey["WEBKIT_DISABLE_DMABUF_RENDERER"]; dmabuf.Value != "1" || !dmabuf.Set {
+		t.Errorf("DMABUF override = %+v, want value \"1\" and Set", dmabuf)
+	}
+	if comp := byKey["WEBKIT_DISABLE_COMPOSITING_MODE"]; comp.Value != "" || comp.Set {
+		t.Errorf("compositing override = %+v, want empty and not Set", comp)
+	}
+}
+
+// An override set to the empty string is NOT the same as an absent one: the
+// desktop app skips its own WebKit defaults for any variable that is merely
+// present, so this state leaves the DMABUF renderer enabled. Collapsing the two
+// would hide exactly the cause this section exists to surface.
+func TestReadAllDistinguishesEmptyFromAbsent(t *testing.T) {
+	t.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "")
+	os.Unsetenv("WEBKIT_DISABLE_COMPOSITING_MODE")
+
+	byKey := map[string]EnvVar{}
+	for _, v := range readAll(OverrideKeys) {
+		byKey[v.Key] = v
+	}
+
+	empty := byKey["WEBKIT_DISABLE_DMABUF_RENDERER"]
+	if !empty.Set || empty.Value != "" {
+		t.Errorf("empty-but-set override = %+v, want Set with empty value", empty)
+	}
+	absent := byKey["WEBKIT_DISABLE_COMPOSITING_MODE"]
+	if absent.Set {
+		t.Errorf("absent override = %+v, want not Set", absent)
+	}
+}
+
+func TestReadSetDropsUnsetKeys(t *testing.T) {
+	t.Setenv("SNAP", "")
+	t.Setenv("FLATPAK_ID", "io.skyhook.Radar")
+	t.Setenv("container", "")
+
+	got := readSet(SandboxKeys)
+	if len(got) != 1 {
+		t.Fatalf("readSet() = %v, want exactly one entry", got)
+	}
+	if got[0].Key != "FLATPAK_ID" || got[0].Value != "io.skyhook.Radar" || !got[0].Set {
+		t.Errorf("readSet()[0] = %+v, want FLATPAK_ID=io.skyhook.Radar and Set", got[0])
+	}
+}
+
+func TestCollectReportsGPUPolicy(t *testing.T) {
+	SetGPUPolicy("on-demand")
+	t.Cleanup(func() { SetGPUPolicy("") })
+
+	snap := Collect()
+	if snap == nil {
+		t.Fatal("Collect() = nil on linux")
+	}
+	if snap.GPUPolicy != "on-demand" {
+		t.Errorf("GPUPolicy = %q, want \"on-demand\"", snap.GPUPolicy)
+	}
+	if len(snap.RenderOverrides) != len(OverrideKeys) {
+		t.Errorf("RenderOverrides has %d entries, want %d", len(snap.RenderOverrides), len(OverrideKeys))
+	}
+}

--- a/internal/desktopenv/desktopenv_other.go
+++ b/internal/desktopenv/desktopenv_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package desktopenv
+
+// collect reports nothing off Linux. macOS (WKWebView) and Windows (WebView2)
+// have no equivalent set of host render knobs to surface.
+func collect() *Snapshot { return nil }

--- a/internal/desktopenv/desktopenv_other_test.go
+++ b/internal/desktopenv/desktopenv_other_test.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package desktopenv
+
+import "testing"
+
+// The diagnostics section must stay absent on platforms with no host render
+// knobs, rather than rendering an empty box in every macOS bug report.
+func TestCollectIsNilOffLinux(t *testing.T) {
+	SetGPUPolicy("on-demand")
+	t.Cleanup(func() { SetGPUPolicy("") })
+
+	if snap := Collect(); snap != nil {
+		t.Errorf("Collect() = %+v, want nil", snap)
+	}
+}

--- a/internal/desktopenv/desktopenv_test.go
+++ b/internal/desktopenv/desktopenv_test.go
@@ -1,0 +1,17 @@
+package desktopenv
+
+import "testing"
+
+func TestGPUPolicyDefaultsToEmpty(t *testing.T) {
+	t.Cleanup(func() { SetGPUPolicy("") })
+
+	SetGPUPolicy("")
+	if got := GPUPolicy(); got != "" {
+		t.Errorf("GPUPolicy() = %q, want empty", got)
+	}
+
+	SetGPUPolicy("never")
+	if got := GPUPolicy(); got != "never" {
+		t.Errorf("GPUPolicy() = %q, want \"never\"", got)
+	}
+}

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/skyhook-io/radar/internal/desktopenv"
 	"github.com/skyhook-io/radar/internal/errorlog"
 	"github.com/skyhook-io/radar/internal/k8s"
 	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
@@ -56,6 +57,7 @@ type DiagnosticsSnapshot struct {
 	APIDiscovery        *DiagAPIDiscovery            `json:"apiDiscovery,omitempty"`
 	SSE                 *DiagSSE                     `json:"sse,omitempty"`
 	Perf                *perfstats.Snapshot          `json:"perf,omitempty"`
+	Desktop             *desktopenv.Snapshot         `json:"desktop,omitempty"`
 	Runtime             *DiagRuntime                 `json:"runtime,omitempty"`
 	Config              *DiagConfig                  `json:"config,omitempty"`
 	RecentErrors        []errorlog.ErrorEntry        `json:"recentErrors,omitempty"`
@@ -494,6 +496,16 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	collectSafe("perf", &errs, func() {
 		perf := perfstats.GetSnapshot()
 		snap.Perf = &perf
+	})
+
+	// Desktop host environment — the display server and WebKit render
+	// overrides decide whether the webview renders at all, and the CLI shares
+	// this endpoint, so gate on actually being the desktop app.
+	collectSafe("desktop", &errs, func() {
+		if !version.IsDesktop() {
+			return
+		}
+		snap.Desktop = desktopenv.Collect()
 	})
 
 	// Runtime

--- a/internal/server/diagnostics_desktop_test.go
+++ b/internal/server/diagnostics_desktop_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/desktopenv"
+	"github.com/skyhook-io/radar/internal/version"
+)
+
+// The CLI and the desktop app share this endpoint. A CLI snapshot must not
+// carry a Desktop section at all — an empty one in a bug report reads as
+// "we looked and the host reported nothing", which is a different claim.
+func TestDiagnosticsOmitsDesktopSectionForCLI(t *testing.T) {
+	version.SetDesktop(false)
+	t.Cleanup(func() { version.SetDesktop(false) })
+
+	if _, ok := diagnosticsBody(t)["desktop"]; ok {
+		t.Error("CLI diagnostics carry a desktop section, want none")
+	}
+}
+
+// Under the desktop app the section is present exactly when the platform has
+// host render settings to report — every Linux desktop run, no macOS or
+// Windows run.
+func TestDiagnosticsIncludesDesktopSectionForDesktopApp(t *testing.T) {
+	version.SetDesktop(true)
+	t.Cleanup(func() { version.SetDesktop(false) })
+
+	_, got := diagnosticsBody(t)["desktop"]
+	want := desktopenv.Collect() != nil
+	if got != want {
+		t.Errorf("desktop section present = %v, want %v for this platform", got, want)
+	}
+}
+
+func diagnosticsBody(t *testing.T) map[string]json.RawMessage {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	(&Server{}).handleDiagnostics(rec, httptest.NewRequest(http.MethodGet, "/api/diagnostics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode diagnostics: %v", err)
+	}
+	return body
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6215,6 +6215,14 @@ export interface DiagErrorEntry {
   level: string;
 }
 
+export interface DiagEnvVar {
+  key: string;
+  value: string;
+  /** Whether the variable exists at all. An empty value with set=true is a
+   *  distinct state — it suppresses the desktop app's own WebKit defaults. */
+  set: boolean;
+}
+
 export type DiagSyncPhase =
   "not_started" | "syncing_critical" | "syncing_deferred" | "complete";
 
@@ -6364,6 +6372,17 @@ export interface DiagnosticsSnapshot {
     connectedClients: number;
   };
   perf?: DiagPerfSnapshot;
+  /** Desktop app on Linux only — the host rendering environment. */
+  desktop?: {
+    sessionType?: string;
+    desktopEnvironment?: string;
+    displayServer?: string;
+    /** Every override key, including ones the host never set. */
+    renderOverrides?: DiagEnvVar[];
+    sandbox?: DiagEnvVar[];
+    webkitLibrary?: string;
+    gpuPolicy?: string;
+  };
   runtime?: {
     heapMB: number;
     heapObjectsK: number;

--- a/web/src/components/ui/DiagnosticsOverlay.test.ts
+++ b/web/src/components/ui/DiagnosticsOverlay.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatEnvValue, formatForGitHub } from './DiagnosticsOverlay'
+import type { DiagnosticsSnapshot } from '../../api/client'
+
+const baseSnapshot: DiagnosticsSnapshot = {
+  timestamp: '2026-08-19T10:00:00Z',
+  radarVersion: '1.9.0',
+  goVersion: 'go1.26.5',
+  goos: 'linux',
+  goarch: 'amd64',
+  uptime: '11s',
+  uptimeSec: 11,
+}
+
+const desktop: NonNullable<DiagnosticsSnapshot['desktop']> = {
+  sessionType: 'wayland',
+  desktopEnvironment: 'ubuntu:GNOME',
+  displayServer: 'wayland+x11',
+  renderOverrides: [
+    { key: 'GDK_BACKEND', value: '', set: false },
+    { key: 'WEBKIT_DISABLE_DMABUF_RENDERER', value: '1', set: true },
+    { key: 'WEBKIT_DISABLE_COMPOSITING_MODE', value: '', set: true },
+  ],
+  sandbox: [{ key: 'SNAP', value: '/snap/radar-desktop/42', set: true }],
+  webkitLibrary: 'libwebkit2gtk-4.1.so.0.13.6',
+  gpuPolicy: 'on-demand',
+}
+
+describe('formatEnvValue', () => {
+  it('separates a variable that was never set from one set to empty', () => {
+    // Only the second suppresses the desktop app's own WebKit defaults, so
+    // collapsing them would hide the cause of a rendering failure.
+    expect(formatEnvValue({ key: 'GDK_BACKEND', value: '', set: false })).toBe('(unset)')
+    expect(formatEnvValue({ key: 'GDK_BACKEND', value: '', set: true })).toBe('(empty)')
+  })
+
+  it('passes a real value through unchanged', () => {
+    expect(formatEnvValue({ key: 'GTK_THEME', value: 'Adwaita:dark', set: true })).toBe('Adwaita:dark')
+  })
+})
+
+describe('formatForGitHub desktop section', () => {
+  it('omits the section entirely when the backend reports no desktop data', () => {
+    expect(formatForGitHub(baseSnapshot, undefined, false)).not.toContain('### Desktop')
+  })
+
+  it('reports the host rendering environment', () => {
+    const md = formatForGitHub({ ...baseSnapshot, desktop }, undefined, false)
+
+    expect(md).toContain('### Desktop')
+    expect(md).toContain('Display Server: `wayland+x11`')
+    expect(md).toContain('Session Type: `wayland`')
+    expect(md).toContain('Desktop: `ubuntu:GNOME`')
+    expect(md).toContain('Webview Library: `libwebkit2gtk-4.1.so.0.13.6`')
+    expect(md).toContain('Webview GPU Policy: `on-demand`')
+    expect(md).toContain('Sandbox: `SNAP=/snap/radar-desktop/42`')
+  })
+
+  it('renders each override state distinguishably', () => {
+    const md = formatForGitHub({ ...baseSnapshot, desktop }, undefined, false)
+
+    expect(md).toContain('`GDK_BACKEND=(unset)`')
+    expect(md).toContain('`WEBKIT_DISABLE_DMABUF_RENDERER=1`')
+    expect(md).toContain('`WEBKIT_DISABLE_COMPOSITING_MODE=(empty)`')
+  })
+
+  it('degrades to placeholders rather than blanks when the host reports nothing', () => {
+    const md = formatForGitHub({ ...baseSnapshot, desktop: {} }, undefined, false)
+
+    expect(md).toContain('Display Server: `(none)`')
+    expect(md).toContain('Session Type: `(unset)`')
+    expect(md).toContain('Desktop: `(unset)`')
+  })
+})

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { openExternal } from '../../utils/navigation'
 import { useDiagnostics } from '../../api/client'
-import type { DiagnosticsSnapshot, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase, DiagSampleWindow } from '../../api/client'
+import type { DiagnosticsSnapshot, DiagEnvVar, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase, DiagSampleWindow } from '../../api/client'
 import { getK8sUIPerfSnapshot, type K8sUIPerfSnapshot } from '@skyhook-io/k8s-ui'
 
 interface DiagnosticsOverlayProps {
@@ -119,6 +119,7 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
               <PermissionsSection data={data} />
               <APIDiscoverySection data={data} />
               <PerfSection data={data} />
+              <DesktopSection data={data} />
               <RuntimeSection data={data} />
               <ConfigSection data={data} />
               {data.errors && data.errors.length > 0 && (
@@ -529,6 +530,35 @@ function formatFrontendUs(w: { count: number; last: number; p50: number; p95: nu
   return `last ${fmt(w.last)} · p50 ${fmt(w.p50)} · p95 ${fmt(w.p95)} · max ${fmt(w.max)} (n=${w.count})`
 }
 
+// An override present but empty is not the same as one that was never set —
+// merely existing is enough to suppress the desktop app's WebKit defaults.
+export function formatEnvValue(v: DiagEnvVar): string {
+  if (!v.set) return '(unset)'
+  return v.value === '' ? '(empty)' : v.value
+}
+
+function DesktopSection({ data }: { data: DiagnosticsSnapshot }) {
+  if (!data.desktop) return null
+  const d = data.desktop
+  const overrides = d.renderOverrides ?? []
+  const sandbox = d.sandbox ?? []
+  return (
+    <Section title="Desktop">
+      {d.displayServer && <Row label="Display Server" value={d.displayServer} />}
+      <Row label="Session Type" value={d.sessionType || '(unset)'} />
+      <Row label="Desktop Environment" value={d.desktopEnvironment || '(unset)'} />
+      {d.webkitLibrary && <Row label="Webview Library" value={d.webkitLibrary} />}
+      {d.gpuPolicy && <Row label="Webview GPU Policy" value={d.gpuPolicy} />}
+      {overrides.map((v) => (
+        <Row key={v.key} label={v.key} value={formatEnvValue(v)} />
+      ))}
+      {sandbox.map((v) => (
+        <Row key={v.key} label={`Sandbox: ${v.key}`} value={v.value} />
+      ))}
+    </Section>
+  )
+}
+
 function RuntimeSection({ data }: { data: DiagnosticsSnapshot }) {
   if (!data.runtime) return null
   const rt = data.runtime
@@ -580,7 +610,7 @@ function CopyButton({ label, onClick, copied }: { label: string; onClick: () => 
 
 // --- GitHub-friendly formatting ---
 
-function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIPerfSnapshot, includeRawJson = true): string {
+export function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIPerfSnapshot, includeRawJson = true): string {
   const lines: string[] = []
   lines.push(`## Radar Diagnostics`)
   lines.push(``)
@@ -754,6 +784,21 @@ function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIPerfSnap
         const fmtUs = (v: number) => v < 1000 ? `${Math.round(v)}μs` : `${(v / 1000).toFixed(2)}ms`
         lines.push(`  - structureKey: ${frontendPerf.totalStructureKeyComputes.toLocaleString()} computes · p50 ${fmtUs(frontendPerf.structureKeyUs.p50)} · p95 ${fmtUs(frontendPerf.structureKeyUs.p95)} · max ${fmtUs(frontendPerf.structureKeyUs.max)}`)
       }
+    }
+    lines.push(``)
+  }
+
+  if (data.desktop) {
+    const d = data.desktop
+    lines.push(`### Desktop`)
+    lines.push(`- Display Server: \`${d.displayServer || '(none)'}\` | Session Type: \`${d.sessionType || '(unset)'}\` | Desktop: \`${d.desktopEnvironment || '(unset)'}\``)
+    if (d.webkitLibrary) lines.push(`- Webview Library: \`${d.webkitLibrary}\``)
+    if (d.gpuPolicy) lines.push(`- Webview GPU Policy: \`${d.gpuPolicy}\``)
+    if (d.renderOverrides && d.renderOverrides.length > 0) {
+      lines.push(`- Render Overrides: ${d.renderOverrides.map((v) => `\`${v.key}=${formatEnvValue(v)}\``).join(' ')}`)
+    }
+    if (d.sandbox && d.sandbox.length > 0) {
+      lines.push(`- Sandbox: ${d.sandbox.map((v) => `\`${v.key}=${v.value}\``).join(' ')}`)
     }
     lines.push(``)
   }


### PR DESCRIPTION
## Why

A user reported that the desktop app crashes when opening the YAML editor on Ubuntu ([#1360](https://github.com/skyhook-io/radar/issues/1360)). Their diagnostics snapshot arrived with 20 sections covering Kubernetes, cache, metrics, informers and the Go runtime — and nothing at all about the machine the webview renders on. No display server, no desktop environment, no WebKit version, no record of which render overrides were in effect. The report could not be diagnosed from what it contained.

Most of that data is already collected. `logBootEnv` prints it at startup. But it goes to stdout, and `deploy/linux/radar-desktop.desktop` sets `Terminal=false`, so users launching from their app menu — which is nearly all of them — never see it.

## What

A Desktop section in the diagnostics snapshot, carrying:

- display server (Wayland, X11, or both under XWayland), session type, desktop environment
- every WebKit render override, including the ones the host never set
- sandbox markers (Snap, Flatpak, container)
- the webview library actually mapped into the process, whose soname identifies the WebKitGTK build
- the configured webview GPU policy

It appears in both the overlay and the copyable markdown. The **Report Bug** button already funnels through that same formatter, so it lands in new issues automatically.

## Notes on the design

**Overrides are tri-state, not a bare string.** The desktop app skips its own WebKit defaults for any variable that merely *exists* — `applyWebKitDefaults` gates on `LookupEnv`. So a host with `WEBKIT_DISABLE_DMABUF_RENDERER=` set to empty silently keeps the DMABUF renderer enabled, which is a real cause of the failures we ship that default to prevent. Read with `os.Getenv` that state is indistinguishable from an untouched machine, so the snapshot would have reported `(unset)` and hidden the cause. Values now render as a real value, `(empty)`, or `(unset)`.

Sandbox markers stay two-state on purpose: an empty `SNAP` carries no meaning, so there is no third state worth reporting.

**Two gates.** The CLI shares this endpoint, so collection is gated on running as the desktop app, and returns nothing off Linux where there is no equivalent set of knobs. A CLI snapshot has no `desktop` key at all — an empty section would read as "we looked and the host reported nothing", which is a different claim.

**No duplicated sources of truth.** The startup log now reads its key lists from the shared package, so it and the snapshot cannot report different sets. The GPU policy is declared once and used both to configure the webview and to report it.

**Library detection** matches the `libwebkit` prefix rather than a specific generation, so it survives a future GTK4 move without enumerating names that cannot occur today.

## Scope

This is the reporting gap only. The suspected cause of #1360 — WebKit switching on accelerated compositing mid-session when Monaco first asks for it, under `WebviewGpuPolicyOnDemand` — is unconfirmed and waiting on the reporter. No behavior change is attempted here.

## Testing

- 11 tests in the new package, 7 of them Linux-only and run in a Linux container
- 2 handler tests covering the gate in both directions, green on macOS and Linux
- 6 frontend tests covering the three override states and the markdown export
- Verified end to end: the CLI response omits `desktop`; the section renders and exports correctly in the running UI

https://claude.ai/code/session_01KEyZgyPtfpXdbWqPPsTXZe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: no change to WebKit defaults or rendering behavior; new diagnostics fields are gated to the desktop app on Linux.
> 
> **Overview**
> Bug reports from the desktop app often lacked **Wayland/X11, WebKit overrides, and mapped webview library** context because that data only went to stdout. This PR exposes the same information in **`/api/diagnostics`** and the diagnostics overlay / copyable markdown (including Report Bug).
> 
> A new **`internal/desktopenv`** package centralizes env key lists, builds a Linux snapshot (display server derivation, tri-state render overrides via `LookupEnv`, sandbox markers, WebKit soname from `/proc/self/maps`, recorded GPU policy), and returns **`nil` off Linux**. Collection runs only when **`version.IsDesktop()`** is true so the CLI omits a `desktop` key entirely.
> 
> **`logBootEnv`** now reads **`SessionKeys` / `OverrideKeys` / `SandboxKeys`** from that package. The desktop binary declares **`linuxGPUPolicy` once**, configures Wails with it, and calls **`desktopenv.SetGPUPolicy`** so diagnostics matches the configured webview policy.
> 
> The frontend adds a **Desktop** section and **`formatEnvValue`** so overrides show as real values, `(empty)`, or `(unset)` in both the overlay and **`formatForGitHub`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4afaf9843abb1e3552c2f295c1934ad91da0c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->