### PR TITLE
desktop: log which webview library actually loaded

### DIFF
--- a/cmd/desktop/boot_env_linux.go
+++ b/cmd/desktop/boot_env_linux.go
@@ -18,6 +18,11 @@ import (
 // are also served in the diagnostics snapshot — see internal/desktopenv.
 func logBootEnv() {
 	log.Printf("[desktop] session: %s", joinEnv(desktopenv.SessionKeys, true))
+	// The webview build decides which rendering bugs apply, and the package
+	// manager's answer is not necessarily the library that got loaded.
+	if lib := desktopenv.WebviewLibrary(); lib != "" {
+		log.Printf("[desktop] webview: %s", lib)
+	}
 	if s := joinEnv(desktopenv.OverrideKeys, false); s != "" {
 		log.Printf("[desktop] render overrides: %s", s)
 	}

--- a/internal/desktopenv/desktopenv.go
+++ b/internal/desktopenv/desktopenv.go
@@ -62,3 +62,8 @@ func GPUPolicy() string {
 // Collect returns the current environment, or nil on platforms where none of
 // this applies.
 func Collect() *Snapshot { return collect() }
+
+// WebviewLibrary returns the webview library mapped into this process, or ""
+// where that cannot be determined. Exposed separately from Collect so startup
+// logging can name the build before anything else has run.
+func WebviewLibrary() string { return webviewLibrary() }

--- a/internal/desktopenv/desktopenv_linux.go
+++ b/internal/desktopenv/desktopenv_linux.go
@@ -16,7 +16,7 @@ func collect() *Snapshot {
 		DisplayServer:      displayServer(),
 		RenderOverrides:    readAll(OverrideKeys),
 		Sandbox:            readSet(SandboxKeys),
-		WebKitLibrary:      webKitLibrary("/proc/self/maps"),
+		WebKitLibrary:      webviewLibrary(),
 		GPUPolicy:          GPUPolicy(),
 	}
 	return s
@@ -55,6 +55,8 @@ func readSet(keys []string) []EnvVar {
 	}
 	return out
 }
+
+func webviewLibrary() string { return webKitLibrary("/proc/self/maps") }
 
 // webKitLibrary returns the basename of the webview library mapped into this
 // process. The soname's trailing version identifies the WebKitGTK build, which

--- a/internal/desktopenv/desktopenv_other.go
+++ b/internal/desktopenv/desktopenv_other.go
@@ -5,3 +5,5 @@ package desktopenv
 // collect reports nothing off Linux. macOS (WKWebView) and Windows (WebView2)
 // have no equivalent set of host render knobs to surface.
 func collect() *Snapshot { return nil }
+
+func webviewLibrary() string { return "" }


### PR DESCRIPTION
## Why

Chasing a desktop crash on Ubuntu ([#1360](https://github.com/skyhook-io/radar/issues/1360)) meant asking the reporter which WebKitGTK build they had, because nothing in the app said so. Which rendering bugs apply depends entirely on that, and it is the first thing anyone needs.

## What

One line at startup on Linux:

```
[desktop] webview: libwebkit2gtk-4.1.so.0.13.6
```

Read from the process's own mappings, so it reports the library that was actually loaded rather than what the package manager thinks is installed. The lookup already exists for the diagnostics snapshot; this exposes it early enough for the startup log, which is what lands in the journal excerpt people paste into bug reports — and what they can still reach when the app will not stay open.

Passive. No behaviour change, no UI, nothing to opt into.

## Scope

This PR previously also carried a crash-versus-quit signal built on marker files. That half is now split out: it went through four review rounds and each one found a correctness bug in it, while this part drew none. It is not worth holding a fifteen-line, zero-finding change behind it, so the marker work will be proposed separately and judged on its own.

## Testing

Covered by the existing `internal/desktopenv` tests, including a fixture for the GTK4-generation library name. Builds clean for linux, windows and darwin.

https://claude.ai/code/session_01KEyZgyPtfpXdbWqPPsTXZe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only refactor with no behavior or security changes; failure to read maps simply omits the line.
> 
> **Overview**
> Linux desktop startup logging now prints which **webview** `.so` is actually mapped into the process (from `/proc/self/maps`), so journal excerpts name the WebKitGTK build without manual `ldd` or package-manager guesses.
> 
> `desktopenv` exposes a new **`WebviewLibrary()`** API that reuses the existing maps scan (via a small `webviewLibrary()` wrapper) so **`logBootEnv`** can log early; diagnostics **`Collect()`** uses the same helper instead of calling the maps parser inline. Non-Linux builds return an empty string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c34edf6b017d7ea2dc9308d9d0c861fb909b187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->