### PR TITLE
deps(radar-app): require k8s-ui 1.13.0 for the new policy and backup types

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
-    "@skyhook-io/k8s-ui": ">=1.12.0",
+    "@skyhook-io/k8s-ui": ">=1.13.0",
     "@tanstack/react-query": ">=5",
     "@xyflow/react": ">=12.0.0",
     "clsx": ">=2",


### PR DESCRIPTION
Release prerequisite for radar 1.11.0 / radar-app 1.11.0. Blocks the `radar-app-v1.11.0` tag.

## The problem

`web/src/api/policy.ts` type-imports six symbols from `@skyhook-io/k8s-ui`, while `web/package.json` still declares a floor of `>=1.12.0`.

Five of the six do not exist in the published 1.12.0 tarball. Checked against the artifact, not the version number:

```
npm pack @skyhook-io/k8s-ui@1.12.0 && tar -xzf *.tgz && grep -r <type> package/
```

| Type | In published 1.12.0? |
|---|---|
| `PolicyResourceResponse` | yes |
| `PolicyCoverageResponse` | no |
| `PolicyQueuedResponse` | no |
| `CNPGCatalogUsersResponse` | no |
| `VeleroStoredBackupsResponse` | no |
| `VeleroRunMessagesResponse` | no |

All five arrive in k8s-ui 1.13.0, alongside the per-policy coverage, CloudNativePG backup destination and Velero work.

## Why it matters

`publish-radar-app.yml` publishes `web/package.json`'s `peerDependencies` verbatim. Shipped as-is, radar-app 1.11.0 would declare a peer range it does not compile against — a consumer resolving that range literally gets a build failure, not a version-number nit. npm versions are immutable, so this is not fixable after publish.

## Change

One line: `>=1.12.0` -> `>=1.13.0`.

Same shape as #1427 last cycle.

## Ordering

Must merge before `k8s-ui-v1.13.0` and `radar-app-v1.11.0` are tagged. Both tags should land on the same commit as `v1.11.0` and `pkg/v1.12.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version floor change with no runtime logic; aligns package metadata with existing type imports before release.
> 
> **Overview**
> Raises the **`@skyhook-io/k8s-ui` peer dependency** floor in `web/package.json` from **`>=1.12.0`** to **`>=1.13.0`**.
> 
> This matches what **`web/src/api/policy.ts`** already imports (`PolicyCoverageResponse`, `PolicyQueuedResponse`, CNPG and Velero response types, etc.), which are not in the published **1.12.0** package. Without the bump, consumers resolving peers at 1.12.x would hit **TypeScript/build failures**, and the published radar-app peer range would be wrong for an immutable npm release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b93c3890ea36b205daf4819fe8e7e9c1283377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->