### PR TITLE
ci(release): exclude scoped docs/test/chore commits from the changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,9 +55,13 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
-      - '^chore:'
+      # The optional (scope) group matters: '^docs:' is a literal prefix, so it
+      # matches "docs: x" but not "docs(mcp): x". Scoped commits have been
+      # leaking into public release notes because of it.
+      - '^docs(\(.+\))?:'
+      - '^test(\(.+\))?:'
+      - '^chore(\(.+\))?:'
+      - '^deps(\(.+\))?:'
       - Merge pull request
       - Merge branch
 


### PR DESCRIPTION
## The bug

`.goreleaser.yaml`'s changelog excludes are literal prefixes:

```yaml
- '^docs:'
- '^test:'
- '^chore:'
```

`^docs:` matches `docs: x` but not `docs(mcp): x`. Same for `test` and `chore`. Since most commits here are scoped, the filters catch almost nothing.

This is not theoretical — it has already shipped. v1.10.0's public release notes contain:

```
* 3fd44f3e51c48f741f9e5913a2bc83909395a4f8 test(crossplane-demo): cover v1 claim + v2 namespaced XR on Crossplane 2.x (#1404)
```

## Effect on the next release

Two commits currently in the v1.11.0 range are filtered out by this change:

```
- deps: combine 9 soaked Dependabot bumps (#1460)
- docs(mcp): cross-link the Reachability doc from the diagnose tool (#1429)
```

Neither belongs in customer-facing notes.

## Change

An optional `(scope)` group on each pattern, plus `deps` — a bare dependency roll-up had no pattern covering it at all.

Worth landing before `v1.11.0` is tagged so the release notes come out clean, but it does not block the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-note filtering only; no runtime, auth, or application behavior changes.
> 
> **Overview**
> **GoReleaser release changelog filters** now treat conventional-commit scopes correctly so internal commits stop appearing in public GitHub release notes.
> 
> In `.goreleaser.yaml`, the `changelog.filters.exclude` patterns for `docs`, `test`, and `chore` were updated from literal prefixes like `^docs:` to `^docs(\(.+\))?:` (and the same for `test` and `chore`), so both `docs: …` and `docs(scope): …` are excluded. A new `^deps(\(.+\))?:` rule was added for dependency roll-up commits. A short comment documents why the optional scope group is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e550bac88ca8bacae6c02159998a6a4af51f732b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->