### PR TITLE
feat(diagnostics): expose topology, SSE and cache metrics in the bundle

### DIFF
--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -226,6 +226,7 @@ func (b *SSEBroadcaster) requestTopologyBroadcast() {
 	case b.topoTrigger <- struct{}{}:
 	default:
 		// A request is already queued; it will pick up the current state.
+		perfstats.IncSSECoalesced()
 	}
 }
 
@@ -252,6 +253,7 @@ func (b *SSEBroadcaster) topologyWorker() {
 			case <-b.stopCh:
 				return
 			case <-time.After(topologyRetryDelay):
+				perfstats.IncSSERetry()
 				b.requestTopologyBroadcast()
 			}
 		}
@@ -610,6 +612,10 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 			if !ok {
 				return
 			}
+			// Sampled here rather than at the producer: this is the only point
+			// that sees the queue as the consumer left it, which is what says
+			// whether the consumer is keeping up.
+			perfstats.RecordChangeReceived(len(changes), cap(changes))
 
 			// Broadcast K8s event immediately for important events
 			if change.Kind == "Event" || change.Operation == "delete" ||
@@ -659,6 +665,7 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 				if warmupComplete {
 					dur = topologyDebounceFor(b.lastBroadcastMaxEstimated.Load(), cache)
 				}
+				perfstats.SetSSEDebounce(dur)
 				debounceTimer.Reset(dur)
 				pendingUpdate = true
 			}
@@ -702,6 +709,18 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() bool {
 		b.lastBroadcastMaxEstimated.Store(0)
 		return true
 	}
+
+	// Clock starts past the no-clients exit: that path does no work, and
+	// recording it would bury real cycles under zero-duration samples.
+	// Recorded from a defer so the epoch checks below — which return after the
+	// full build, and again after each group's build and marshal — report the
+	// wall time they spent rather than looking like they never ran.
+	cycleStart := time.Now()
+	var clientGroupCount, authGroupCount int
+	var marshalTotal time.Duration
+	defer func() {
+		perfstats.RecordBroadcastCycle(time.Since(cycleStart), clientGroupCount, authGroupCount, marshalTotal)
+	}()
 
 	// Checked before the full-topology build, which is the most expensive one
 	// in the cycle (every namespace, ReplicaSets included): a switch that has
@@ -762,6 +781,7 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() bool {
 		}
 		clientGroups[key].clients[ch] = info
 	}
+	clientGroupCount = len(clientGroups)
 
 	// Build topology for each group and send. Pre-marshal once per group so
 	// the same bytes go out to every client in the group (the per-client SSE
@@ -822,12 +842,15 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() bool {
 			}
 			nodeClassGroups[authKey].channels = append(nodeClassGroups[authKey].channels, ch)
 		}
+		authGroupCount += len(nodeClassGroups)
 		for _, authGroup := range nodeClassGroups {
 			filtered := cloneTopology(topo)
 			filtered.StripNodeClassesExcept(authGroup.allowed)
 			filtered.StripClusterScopedDynamicExcept(authGroup.allowedDynamic)
 			filtered.StripCalicoPoliciesExcept(authGroup.allowedCalico)
+			marshalStart := time.Now()
 			data, marshalErr := json.Marshal(filtered)
+			marshalTotal += time.Since(marshalStart)
 			if marshalErr != nil {
 				log.Printf("Error marshaling topology for broadcast: %v", marshalErr)
 				continue
@@ -1187,7 +1210,9 @@ func (b *SSEBroadcaster) GetCachedTopologyWithIndex() (*topology.Topology, *topo
 	}
 
 	// Build outside the lock — IndexByResource is O(edges).
+	indexStart := time.Now()
 	built := topology.IndexByResource(topo)
+	perfstats.RecordRelationshipIndex(time.Since(indexStart))
 	b.cachedTopologyMu.Lock()
 	if b.cachedTopology == topo {
 		b.cachedTopologyIndex = built
@@ -1203,6 +1228,12 @@ func (b *SSEBroadcaster) rebuildCachedTopology() bool {
 	if cache == nil {
 		return false
 	}
+	// Only reached from GetCachedTopology's dirty path, i.e. on whichever
+	// request goroutine happened to read next. A full build here blocks that
+	// request for its entire duration.
+	rebuildStart := time.Now()
+	defer func() { perfstats.RecordRelationshipRebuild(time.Since(rebuildStart)) }()
+
 	epoch := b.topoEpoch.Load()
 	if fullTopo, err := buildFullTopology(); err == nil {
 		// A rejected write leaves nothing cached for the new cluster, so the
@@ -1221,6 +1252,7 @@ func (b *SSEBroadcaster) rebuildCachedTopology() bool {
 // topology". Reports the cycle as run — the reset queued its own trigger, so
 // there is nothing for the worker to re-arm.
 func (b *SSEBroadcaster) abandonCycleForNewCluster() bool {
+	perfstats.IncSSEAbandoned()
 	b.markCachedTopologyDirty()
 	return true
 }

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -51,6 +51,8 @@ type ResourceCache struct {
 	informerMu       sync.RWMutex
 	promotedKinds    []string // set when SyncTimeout fires; empty on normal sync
 	syncStartTime    time.Time
+	criticalSyncMs   atomic.Int64
+	deferredSyncMs   atomic.Int64
 }
 
 // InformerSyncStatus tracks the sync state of a single informer.
@@ -78,9 +80,13 @@ const (
 
 // CacheSyncStatus is the overall sync status exposed for diagnostics.
 type CacheSyncStatus struct {
-	Phase           SyncPhase            `json:"phase"`
-	SyncStarted     string               `json:"syncStarted,omitempty"` // RFC3339
-	ElapsedSec      float64              `json:"elapsedSec"`
+	Phase       SyncPhase `json:"phase"`
+	SyncStarted string    `json:"syncStarted,omitempty"` // RFC3339
+	ElapsedSec  float64   `json:"elapsedSec"`
+	// Wall time of each phase, set once that phase ends. Deferred covers the
+	// informers phase 2 waits on; Events sync independently and are not in it.
+	CriticalSyncMs  int64                `json:"criticalSyncMs,omitempty"`
+	DeferredSyncMs  int64                `json:"deferredSyncMs,omitempty"`
 	CriticalTotal   int                  `json:"criticalTotal"`
 	CriticalSynced  int                  `json:"criticalSynced"`
 	DeferredTotal   int                  `json:"deferredTotal"`
@@ -872,6 +878,10 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		logf("    Phase 1 sync (%d critical informers): %v", len(criticalSyncFuncs), time.Since(syncStart))
 		stdlog.Printf("Critical resource caches synced in %v — UI can render", time.Since(syncStart))
 	}
+	// Recorded for every exit of the switch, timeout and patience included: a
+	// phase that ended early because it gave up still describes what the user
+	// waited through.
+	rc.criticalSyncMs.Store(time.Since(syncStart).Milliseconds())
 
 	if cfg.SyncProgress != nil {
 		// Count via e.synced() (same source as the Phase 1 loop) rather than
@@ -1027,6 +1037,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 				logf("    Phase 2 sync (%d deferred informers): %v", len(deferredSyncFuncs), time.Since(deferredStart))
 				stdlog.Printf("Deferred resource caches synced in %v (total: %v)", time.Since(deferredStart), time.Since(syncStart))
 			}
+			rc.deferredSyncMs.Store(time.Since(deferredStart).Milliseconds())
 			close(deferredDone)
 		}()
 	} else {
@@ -1646,6 +1657,8 @@ func (rc *ResourceCache) GetSyncStatus() CacheSyncStatus {
 	result := CacheSyncStatus{
 		Phase:           phase,
 		ElapsedSec:      time.Since(rc.syncStartTime).Seconds(),
+		CriticalSyncMs:  rc.criticalSyncMs.Load(),
+		DeferredSyncMs:  rc.deferredSyncMs.Load(),
 		CriticalTotal:   critTotal,
 		CriticalSynced:  critSynced,
 		DeferredTotal:   defTotal,

--- a/pkg/perfstats/perfstats.go
+++ b/pkg/perfstats/perfstats.go
@@ -18,10 +18,47 @@ import (
 // meaningful but memory stays trivial (100 × int64 = 800 bytes per metric).
 const ringSize = 100
 
+// changeSampleEvery throttles ring appends on the resource-change path, which
+// can run at ~1k/s on a large cluster. The high-water mark is still updated on
+// every change; only the distribution is sampled.
+const changeSampleEvery = 100
+
+// BuildKind distinguishes the three shapes of topology build by the scope they
+// cover, which is what drives their cost. Without it a single duration window
+// averages a multi-second cluster-wide build together with a 20ms
+// namespace-scoped one, and the resulting p95 describes neither.
+type BuildKind string
+
+const (
+	// BuildFull covers every namespace — no namespace filter was applied.
+	BuildFull BuildKind = "full"
+	// BuildScoped is bounded by a namespace filter.
+	BuildScoped BuildKind = "scoped"
+	// BuildRefused is a build the large-cluster guard declined to run.
+	BuildRefused BuildKind = "refused"
+)
+
+var buildKinds = [...]BuildKind{BuildFull, BuildScoped, BuildRefused}
+
+func (k BuildKind) index() int {
+	switch k {
+	case BuildFull:
+		return 0
+	case BuildRefused:
+		return 2
+	default:
+		return 1
+	}
+}
+
 // Snapshot is the rendered view of all counters + sample windows.
 type Snapshot struct {
-	Topology TopologyStats `json:"topology"`
-	SSE      SSEStats      `json:"sse"`
+	Topology          TopologyStats          `json:"topology"`
+	TopologyByKind    TopologyKindStats      `json:"topologyByKind"`
+	SSE               SSEStats               `json:"sse"`
+	SSECycle          SSECycleStats          `json:"sseCycle"`
+	Changes           ChangeStats            `json:"changes"`
+	RelationshipCache RelationshipCacheStats `json:"relationshipCache"`
 }
 
 // TopologyStats covers the topology build hot path.
@@ -34,10 +71,69 @@ type TopologyStats struct {
 	EstimatedNodes SampleWindow `json:"estimatedNodes"`
 }
 
-// SSEStats covers the SSE broadcaster.
+// TopologyKindStats splits the build stats by BuildKind. A fixed struct rather
+// than a map so JSON key order — and therefore the diagnostics markdown — is
+// deterministic across snapshots.
+type TopologyKindStats struct {
+	Full    TopologyKindWindow `json:"full"`
+	Scoped  TopologyKindWindow `json:"scoped"`
+	Refused TopologyKindWindow `json:"refused"`
+}
+
+// TopologyKindWindow is TopologyStats minus PayloadBytes. Payload size is
+// recorded where a graph is marshaled, which is downstream of the build and
+// carries no record of which kind produced it — so a per-kind payload field
+// could only ever report zero, and a zero that means "never measured" is worse
+// than an absent field.
+type TopologyKindWindow struct {
+	TotalBuilds    int64        `json:"totalBuilds"`
+	DurationUs     SampleWindow `json:"durationUs"`
+	NodeCount      SampleWindow `json:"nodeCount"`
+	EdgeCount      SampleWindow `json:"edgeCount"`
+	EstimatedNodes SampleWindow `json:"estimatedNodes"`
+}
+
+// SSEStats covers the SSE broadcaster's counters. Kept free of sample windows
+// so the Prometheus collector can read it on every scrape without snapshotting
+// (and sorting) any ring buffers.
 type SSEStats struct {
 	TotalBroadcasts int64 `json:"totalBroadcasts"`
 	TotalDrops      int64 `json:"totalDrops"`
+	Abandoned       int64 `json:"abandoned"`
+	Coalesced       int64 `json:"coalesced"`
+	Retries         int64 `json:"retries"`
+	DebounceMs      int64 `json:"debounceMs"`
+}
+
+// SSECycleStats describes the cost and fan-out of one broadcast cycle. AuthGroups
+// is the multiplier that matters: each one is an independent clone + strip +
+// marshal of the whole graph, so a slow cycle is as often "we did it 40 times"
+// as it is "the build was slow".
+type SSECycleStats struct {
+	CycleDurationUs SampleWindow `json:"cycleDurationUs"`
+	ClientGroups    SampleWindow `json:"clientGroups"`
+	AuthGroups      SampleWindow `json:"authGroups"`
+	MarshalUs       SampleWindow `json:"marshalUs"`
+}
+
+// ChangeStats tracks the resource-change channel feeding the SSE watcher.
+// Drops are already recorded downstream once the channel overflows; depth is
+// what shows the approach to that cliff, and Received/uptime gives the rate.
+type ChangeStats struct {
+	Received   int64        `json:"received"`
+	QueueDepth SampleWindow `json:"queueDepth"`
+	QueueCap   int          `json:"queueCap"`
+	HighWater  int64        `json:"highWater"`
+}
+
+// RelationshipCacheStats covers full topology builds that run on a request
+// goroutine because the cached graph was dirty — the shape that made resource
+// detail views block for seconds on large clusters.
+type RelationshipCacheStats struct {
+	OnDemandRebuilds  int64        `json:"onDemandRebuilds"`
+	OnDemandRebuildUs SampleWindow `json:"onDemandRebuildUs"`
+	IndexBuilds       int64        `json:"indexBuilds"`
+	IndexBuildUs      SampleWindow `json:"indexBuildUs"`
 }
 
 // SampleWindow is the rendered view of one ring buffer.
@@ -106,16 +202,71 @@ func percentile(sorted []int64, p float64) int64 {
 	return sorted[idx]
 }
 
+// topologyRings is one build shape's sample windows. The aggregate and each
+// BuildKind get their own instance.
+type topologyRings struct {
+	builds         atomic.Int64
+	duration       ringBuffer
+	nodeCount      ringBuffer
+	edgeCount      ringBuffer
+	payloadBytes   ringBuffer
+	estimatedNodes ringBuffer
+}
+
+func (t *topologyRings) record(d time.Duration, nodes, edges, estimated int) {
+	t.builds.Add(1)
+	t.duration.add(d.Microseconds())
+	t.nodeCount.add(int64(nodes))
+	t.edgeCount.add(int64(edges))
+	t.estimatedNodes.add(int64(estimated))
+}
+
+func (t *topologyRings) kindSnapshot() TopologyKindWindow {
+	return TopologyKindWindow{
+		TotalBuilds:    t.builds.Load(),
+		DurationUs:     t.duration.snapshot(),
+		NodeCount:      t.nodeCount.snapshot(),
+		EdgeCount:      t.edgeCount.snapshot(),
+		EstimatedNodes: t.estimatedNodes.snapshot(),
+	}
+}
+
+func (t *topologyRings) snapshot() TopologyStats {
+	return TopologyStats{
+		TotalBuilds:    t.builds.Load(),
+		DurationUs:     t.duration.snapshot(),
+		NodeCount:      t.nodeCount.snapshot(),
+		EdgeCount:      t.edgeCount.snapshot(),
+		PayloadBytes:   t.payloadBytes.snapshot(),
+		EstimatedNodes: t.estimatedNodes.snapshot(),
+	}
+}
+
 type store struct {
-	topologyBuilds         atomic.Int64
-	topologyDuration       ringBuffer
-	topologyNodeCount      ringBuffer
-	topologyEdgeCount      ringBuffer
-	topologyPayloadBytes   ringBuffer
-	topologyEstimatedNodes ringBuffer
+	topology       topologyRings
+	topologyByKind [len(buildKinds)]topologyRings
 
 	sseBroadcasts atomic.Int64
 	sseDrops      atomic.Int64
+	sseAbandoned  atomic.Int64
+	sseCoalesced  atomic.Int64
+	sseRetries    atomic.Int64
+	sseDebounceMs atomic.Int64
+
+	sseCycleDuration ringBuffer
+	sseClientGroups  ringBuffer
+	sseAuthGroups    ringBuffer
+	sseMarshal       ringBuffer
+
+	changesReceived  atomic.Int64
+	changeQueueDepth ringBuffer
+	changeQueueCap   atomic.Int64
+	changeHighWater  atomic.Int64
+
+	relRebuilds  atomic.Int64
+	relRebuildUs ringBuffer
+	relIndexes   atomic.Int64
+	relIndexUs   ringBuffer
 }
 
 var global = &store{}
@@ -124,13 +275,11 @@ var global = &store{}
 // resulting graph size, plus the estimator's pre-build node count guess
 // (the same value used to drive large-cluster optimizations and debounce
 // tuning — exposing it here lets us see when the estimator drifts from
-// reality).
-func RecordTopologyBuild(d time.Duration, nodes, edges, estimated int) {
-	global.topologyBuilds.Add(1)
-	global.topologyDuration.add(d.Microseconds())
-	global.topologyNodeCount.add(int64(nodes))
-	global.topologyEdgeCount.add(int64(edges))
-	global.topologyEstimatedNodes.add(int64(estimated))
+// reality). Recorded twice: once into the aggregate, once into the window
+// for its BuildKind.
+func RecordTopologyBuild(kind BuildKind, d time.Duration, nodes, edges, estimated int) {
+	global.topology.record(d, nodes, edges, estimated)
+	global.topologyByKind[kind.index()].record(d, nodes, edges, estimated)
 }
 
 // RecordTopologyPayload records the marshaled byte size of one /api/topology
@@ -138,7 +287,7 @@ func RecordTopologyBuild(d time.Duration, nodes, edges, estimated int) {
 // wire (post-JSON encoding) — the metric most relevant to "did the frontend
 // OOM on parse" bug reports.
 func RecordTopologyPayload(bytes int) {
-	global.topologyPayloadBytes.add(int64(bytes))
+	global.topology.payloadBytes.add(int64(bytes))
 }
 
 // IncSSEBroadcast increments the SSE broadcast counter (one per
@@ -148,12 +297,77 @@ func IncSSEBroadcast() { global.sseBroadcasts.Add(1) }
 // IncSSEDrop increments the silent-drop counter (safeSend default case).
 func IncSSEDrop() { global.sseDrops.Add(1) }
 
-// GetSSEStats returns the current SSE counters without snapshotting topology
+// IncSSEAbandoned counts cycles thrown away because the cluster changed
+// mid-build. Work that was done and never reached a client.
+func IncSSEAbandoned() { global.sseAbandoned.Add(1) }
+
+// IncSSECoalesced counts broadcast requests that folded into an already-queued
+// one. Persistently high means the worker never catches up with the change rate.
+func IncSSECoalesced() { global.sseCoalesced.Add(1) }
+
+// IncSSERetry counts triggers the worker re-armed after finding the cluster
+// view torn down.
+func IncSSERetry() { global.sseRetries.Add(1) }
+
+// SetSSEDebounce records the debounce interval currently in force, so a report
+// shows which rung of the ladder the cluster settled on.
+func SetSSEDebounce(d time.Duration) { global.sseDebounceMs.Store(d.Milliseconds()) }
+
+// RecordBroadcastCycle records the cost and fan-out of one broadcast cycle.
+// clientGroups counts distinct namespace/RBAC/view-mode groups (one graph build
+// each); authGroups counts the provider-permission subgroups across all of them
+// (one clone + strip + marshal each).
+func RecordBroadcastCycle(d time.Duration, clientGroups, authGroups int, marshal time.Duration) {
+	global.sseCycleDuration.add(d.Microseconds())
+	global.sseClientGroups.add(int64(clientGroups))
+	global.sseAuthGroups.add(int64(authGroups))
+	global.sseMarshal.add(marshal.Microseconds())
+}
+
+// RecordChangeReceived samples the resource-change channel as the SSE watcher
+// drains it. The high-water mark is updated on every call; the distribution is
+// sampled every changeSampleEvery-th call to keep a ~1k/s path lock-free most
+// of the time.
+func RecordChangeReceived(depth, capacity int) {
+	n := global.changesReceived.Add(1)
+	global.changeQueueCap.Store(int64(capacity))
+
+	d := int64(depth)
+	for {
+		hw := global.changeHighWater.Load()
+		if d <= hw || global.changeHighWater.CompareAndSwap(hw, d) {
+			break
+		}
+	}
+
+	if n%changeSampleEvery == 0 {
+		global.changeQueueDepth.add(d)
+	}
+}
+
+// RecordRelationshipRebuild records a full topology rebuild that ran because a
+// reader found the relationship cache dirty — i.e. on a request goroutine.
+func RecordRelationshipRebuild(d time.Duration) {
+	global.relRebuilds.Add(1)
+	global.relRebuildUs.add(d.Microseconds())
+}
+
+// RecordRelationshipIndex records one IndexByResource build (O(edges)).
+func RecordRelationshipIndex(d time.Duration) {
+	global.relIndexes.Add(1)
+	global.relIndexUs.add(d.Microseconds())
+}
+
+// GetSSEStats returns the current SSE counters without snapshotting any
 // sample windows.
 func GetSSEStats() SSEStats {
 	return SSEStats{
 		TotalBroadcasts: global.sseBroadcasts.Load(),
 		TotalDrops:      global.sseDrops.Load(),
+		Abandoned:       global.sseAbandoned.Load(),
+		Coalesced:       global.sseCoalesced.Load(),
+		Retries:         global.sseRetries.Load(),
+		DebounceMs:      global.sseDebounceMs.Load(),
 	}
 }
 
@@ -161,15 +375,31 @@ func GetSSEStats() SSEStats {
 // and sample windows for inclusion in /api/diagnostics responses.
 func GetSnapshot() Snapshot {
 	return Snapshot{
-		Topology: TopologyStats{
-			TotalBuilds:    global.topologyBuilds.Load(),
-			DurationUs:     global.topologyDuration.snapshot(),
-			NodeCount:      global.topologyNodeCount.snapshot(),
-			EdgeCount:      global.topologyEdgeCount.snapshot(),
-			PayloadBytes:   global.topologyPayloadBytes.snapshot(),
-			EstimatedNodes: global.topologyEstimatedNodes.snapshot(),
+		Topology: global.topology.snapshot(),
+		TopologyByKind: TopologyKindStats{
+			Full:    global.topologyByKind[BuildFull.index()].kindSnapshot(),
+			Scoped:  global.topologyByKind[BuildScoped.index()].kindSnapshot(),
+			Refused: global.topologyByKind[BuildRefused.index()].kindSnapshot(),
 		},
 		SSE: GetSSEStats(),
+		SSECycle: SSECycleStats{
+			CycleDurationUs: global.sseCycleDuration.snapshot(),
+			ClientGroups:    global.sseClientGroups.snapshot(),
+			AuthGroups:      global.sseAuthGroups.snapshot(),
+			MarshalUs:       global.sseMarshal.snapshot(),
+		},
+		Changes: ChangeStats{
+			Received:   global.changesReceived.Load(),
+			QueueDepth: global.changeQueueDepth.snapshot(),
+			QueueCap:   int(global.changeQueueCap.Load()),
+			HighWater:  global.changeHighWater.Load(),
+		},
+		RelationshipCache: RelationshipCacheStats{
+			OnDemandRebuilds:  global.relRebuilds.Load(),
+			OnDemandRebuildUs: global.relRebuildUs.snapshot(),
+			IndexBuilds:       global.relIndexes.Load(),
+			IndexBuildUs:      global.relIndexUs.snapshot(),
+		},
 	}
 }
 

--- a/pkg/perfstats/perfstats_test.go
+++ b/pkg/perfstats/perfstats_test.go
@@ -8,7 +8,7 @@ import (
 func TestRingBufferPercentiles(t *testing.T) {
 	Reset()
 	for i := 1; i <= 50; i++ {
-		RecordTopologyBuild(time.Duration(i)*time.Microsecond, i*10, i*20, i)
+		RecordTopologyBuild(BuildScoped, time.Duration(i)*time.Microsecond, i*10, i*20, i)
 	}
 	snap := GetSnapshot()
 	if snap.Topology.TotalBuilds != 50 {
@@ -39,7 +39,7 @@ func TestRingBufferPercentiles(t *testing.T) {
 func TestRingBufferWrapsAt100(t *testing.T) {
 	Reset()
 	for i := 1; i <= 250; i++ {
-		RecordTopologyBuild(time.Duration(i)*time.Microsecond, 0, 0, 0)
+		RecordTopologyBuild(BuildScoped, time.Duration(i)*time.Microsecond, 0, 0, 0)
 	}
 	snap := GetSnapshot()
 	if snap.Topology.TotalBuilds != 250 {
@@ -88,5 +88,100 @@ func TestSSECounters(t *testing.T) {
 	snap := GetSnapshot()
 	if snap.SSE != stats {
 		t.Errorf("GetSnapshot().SSE = %+v, want %+v", snap.SSE, stats)
+	}
+}
+
+func TestBuildKindsAreIsolated(t *testing.T) {
+	Reset()
+	RecordTopologyBuild(BuildFull, 12*time.Second, 4000, 9000, 4200)
+	RecordTopologyBuild(BuildScoped, 20*time.Millisecond, 80, 120, 90)
+	RecordTopologyBuild(BuildScoped, 30*time.Millisecond, 90, 130, 95)
+	RecordTopologyBuild(BuildRefused, time.Millisecond, 0, 0, 60000)
+
+	snap := GetSnapshot()
+	if snap.Topology.TotalBuilds != 4 {
+		t.Errorf("aggregate TotalBuilds = %d, want 4", snap.Topology.TotalBuilds)
+	}
+	if got := snap.TopologyByKind.Full.TotalBuilds; got != 1 {
+		t.Errorf("full TotalBuilds = %d, want 1", got)
+	}
+	if got := snap.TopologyByKind.Scoped.TotalBuilds; got != 2 {
+		t.Errorf("scoped TotalBuilds = %d, want 2", got)
+	}
+	if got := snap.TopologyByKind.Refused.TotalBuilds; got != 1 {
+		t.Errorf("refused TotalBuilds = %d, want 1", got)
+	}
+	// The whole point of the split: a 12s full build must not be averaged into
+	// the scoped window, where it would hide behind two 20ms samples.
+	if got := snap.TopologyByKind.Full.DurationUs.Max; got != 12_000_000 {
+		t.Errorf("full max = %dus, want 12000000", got)
+	}
+	if got := snap.TopologyByKind.Scoped.DurationUs.Max; got != 30_000 {
+		t.Errorf("scoped max = %dus, want 30000", got)
+	}
+	if got := snap.TopologyByKind.Refused.EstimatedNodes.Last; got != 60000 {
+		t.Errorf("refused estimatedNodes = %d, want 60000", got)
+	}
+}
+
+func TestChangeQueueHighWaterTracksEveryCall(t *testing.T) {
+	Reset()
+	// The spike lands between ring samples: it must still be visible.
+	for i := 1; i <= changeSampleEvery; i++ {
+		depth := 5
+		if i == changeSampleEvery/2 {
+			depth = 9800
+		}
+		RecordChangeReceived(depth, 10000)
+	}
+
+	snap := GetSnapshot()
+	if snap.Changes.Received != int64(changeSampleEvery) {
+		t.Errorf("Received = %d, want %d", snap.Changes.Received, changeSampleEvery)
+	}
+	if snap.Changes.HighWater != 9800 {
+		t.Errorf("HighWater = %d, want 9800 (a spike between ring samples must still register)", snap.Changes.HighWater)
+	}
+	if snap.Changes.QueueCap != 10000 {
+		t.Errorf("QueueCap = %d, want 10000", snap.Changes.QueueCap)
+	}
+	if snap.Changes.QueueDepth.Count != 1 {
+		t.Errorf("QueueDepth.Count = %d, want 1 sample per %d changes", snap.Changes.QueueDepth.Count, changeSampleEvery)
+	}
+}
+
+func TestBroadcastCycleAndRelationshipStats(t *testing.T) {
+	Reset()
+	RecordBroadcastCycle(4*time.Second, 3, 11, 900*time.Millisecond)
+	RecordRelationshipRebuild(8 * time.Second)
+	RecordRelationshipIndex(90 * time.Millisecond)
+	IncSSEAbandoned()
+	IncSSECoalesced()
+	IncSSECoalesced()
+	IncSSERetry()
+	SetSSEDebounce(15 * time.Second)
+
+	snap := GetSnapshot()
+	if got := snap.SSECycle.CycleDurationUs.Last; got != 4_000_000 {
+		t.Errorf("CycleDurationUs.Last = %d, want 4000000", got)
+	}
+	// authGroups > clientGroups is the fan-out multiplier we could not see before.
+	if snap.SSECycle.ClientGroups.Last != 3 || snap.SSECycle.AuthGroups.Last != 11 {
+		t.Errorf("groups = %d client / %d auth, want 3 / 11", snap.SSECycle.ClientGroups.Last, snap.SSECycle.AuthGroups.Last)
+	}
+	if got := snap.SSECycle.MarshalUs.Last; got != 900_000 {
+		t.Errorf("MarshalUs.Last = %d, want 900000", got)
+	}
+	if snap.SSE.Abandoned != 1 || snap.SSE.Coalesced != 2 || snap.SSE.Retries != 1 {
+		t.Errorf("counters = %+v, want abandoned 1 / coalesced 2 / retries 1", snap.SSE)
+	}
+	if snap.SSE.DebounceMs != 15000 {
+		t.Errorf("DebounceMs = %d, want 15000", snap.SSE.DebounceMs)
+	}
+	if snap.RelationshipCache.OnDemandRebuilds != 1 || snap.RelationshipCache.OnDemandRebuildUs.Last != 8_000_000 {
+		t.Errorf("rebuild stats = %+v, want 1 rebuild of 8s", snap.RelationshipCache)
+	}
+	if snap.RelationshipCache.IndexBuilds != 1 || snap.RelationshipCache.IndexBuildUs.Last != 90_000 {
+		t.Errorf("index stats = %+v, want 1 index of 90ms", snap.RelationshipCache)
 	}
 }

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -57,7 +57,7 @@ func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 	// ForRelationshipCache bypasses this guard — internal builds need the full graph
 	// for resource detail "Related Resources" lookups.
 	if isLargeCluster && len(opts.Namespaces) == 0 && !opts.ForRelationshipCache {
-		perfstats.RecordTopologyBuild(time.Since(start), 0, 0, estimatedNodes)
+		perfstats.RecordTopologyBuild(perfstats.BuildRefused, time.Since(start), 0, 0, estimatedNodes)
 		return &Topology{
 			Nodes:                   []Node{},
 			Edges:                   []Edge{},
@@ -101,7 +101,14 @@ func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 	topo.EstimatedNodes = estimatedNodes
 	topo.SummaryMode = opts.SummaryMode
 
-	perfstats.RecordTopologyBuild(time.Since(start), len(topo.Nodes), len(topo.Edges), estimatedNodes)
+	// Keyed on scope, not on ForRelationshipCache: a namespace filter is what
+	// bounds the cost, and both the broadcaster and the relationship-cache
+	// callers produce cluster-wide and scoped builds alike.
+	kind := perfstats.BuildScoped
+	if len(opts.Namespaces) == 0 {
+		kind = perfstats.BuildFull
+	}
+	perfstats.RecordTopologyBuild(kind, time.Since(start), len(topo.Nodes), len(topo.Edges), estimatedNodes)
 	return topo, nil
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6353,6 +6353,9 @@ export interface DiagCacheSyncStatus {
   phase: DiagSyncPhase;
   syncStarted?: string;
   elapsedSec: number;
+  /** Wall time of each phase, set once that phase ends. */
+  criticalSyncMs?: number;
+  deferredSyncMs?: number;
   criticalTotal: number;
   criticalSynced: number;
   deferredTotal: number;
@@ -6373,18 +6376,59 @@ export interface DiagSampleWindow {
   max: number;
 }
 
+export interface DiagTopologyStats {
+  totalBuilds: number;
+  durationUs: DiagSampleWindow;
+  nodeCount: DiagSampleWindow;
+  edgeCount: DiagSampleWindow;
+  payloadBytes: DiagSampleWindow;
+  estimatedNodes: DiagSampleWindow;
+}
+
+/** Per-kind stats carry no payload size: payload is measured at marshal time,
+ *  downstream of the build and with no record of which kind produced it. */
+export interface DiagTopologyKindWindow {
+  totalBuilds: number;
+  durationUs: DiagSampleWindow;
+  nodeCount: DiagSampleWindow;
+  edgeCount: DiagSampleWindow;
+  estimatedNodes: DiagSampleWindow;
+}
+
 export interface DiagPerfSnapshot {
-  topology: {
-    totalBuilds: number;
-    durationUs: DiagSampleWindow;
-    nodeCount: DiagSampleWindow;
-    edgeCount: DiagSampleWindow;
-    payloadBytes: DiagSampleWindow;
-    estimatedNodes: DiagSampleWindow;
+  topology: DiagTopologyStats;
+  topologyByKind?: {
+    full: DiagTopologyKindWindow;
+    scoped: DiagTopologyKindWindow;
+    refused: DiagTopologyKindWindow;
   };
   sse: {
     totalBroadcasts: number;
     totalDrops: number;
+    abandoned?: number;
+    coalesced?: number;
+    retries?: number;
+    debounceMs?: number;
+  };
+  sseCycle?: {
+    cycleDurationUs: DiagSampleWindow;
+    /** One graph build each. */
+    clientGroups: DiagSampleWindow;
+    /** One clone + strip + marshal each — the real fan-out multiplier. */
+    authGroups: DiagSampleWindow;
+    marshalUs: DiagSampleWindow;
+  };
+  changes?: {
+    received: number;
+    queueDepth: DiagSampleWindow;
+    queueCap: number;
+    highWater: number;
+  };
+  relationshipCache?: {
+    onDemandRebuilds: number;
+    onDemandRebuildUs: DiagSampleWindow;
+    indexBuilds: number;
+    indexBuildUs: DiagSampleWindow;
   };
 }
 
@@ -6434,11 +6478,19 @@ export interface DiagnosticsSnapshot {
   };
   timeline?: {
     storageType: string;
+    degraded?: boolean;
+    degradedReason?: string;
     totalEvents: number;
     oldestEvent?: string;
     newestEvent?: string;
+    storageBytes?: number;
     storeErrors: number;
     totalDrops: number;
+    retentionAge?: string;
+    maxStorageBytes?: number;
+    lastCleanupAt?: string;
+    lastCleanupDeletedRows?: number;
+    lastCleanupError?: string;
   };
   eventPipeline?: {
     received: Record<string, number>;

--- a/web/src/components/ui/DiagnosticsOverlay.test.ts
+++ b/web/src/components/ui/DiagnosticsOverlay.test.ts
@@ -73,3 +73,145 @@ describe('formatForGitHub desktop section', () => {
     expect(md).toContain('Desktop: `(unset)`')
   })
 })
+
+const emptyWindow = { count: 0, last: 0, min: 0, p50: 0, p95: 0, p99: 0, max: 0 }
+const sampleWindow = (v: number) => ({ count: 10, last: v, min: v, p50: v, p95: v, p99: v, max: v })
+const kindStats = (builds: number, us: number) => ({
+  totalBuilds: builds,
+  durationUs: builds > 0 ? sampleWindow(us) : emptyWindow,
+  nodeCount: emptyWindow,
+  edgeCount: emptyWindow,
+  payloadBytes: emptyWindow,
+  estimatedNodes: emptyWindow,
+})
+
+describe('formatForGitHub performance section', () => {
+  it('reports full and scoped builds apart so one does not hide inside the other', () => {
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      perf: {
+        topology: kindStats(3, 4_000_000),
+        topologyByKind: {
+          full: kindStats(1, 12_000_000),
+          scoped: kindStats(2, 20_000),
+          refused: kindStats(0, 0),
+        },
+        sse: { totalBroadcasts: 5, totalDrops: 0 },
+      },
+    }, undefined, false)
+
+    expect(md).toContain('- full: 1 builds')
+    expect(md).toContain('max 12000.0ms')
+    expect(md).toContain('- scoped: 2 builds')
+    // A kind with no samples would print a row of zeroes that reads as "fast".
+    expect(md).not.toContain('- refused:')
+  })
+
+  it('reports the auth-group fan-out and change-queue pressure', () => {
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      perf: {
+        topology: kindStats(1, 1000),
+        sse: { totalBroadcasts: 12, totalDrops: 4, coalesced: 300, abandoned: 2, retries: 1, debounceMs: 15000 },
+        sseCycle: {
+          cycleDurationUs: sampleWindow(4_000_000),
+          clientGroups: sampleWindow(3),
+          authGroups: sampleWindow(11),
+          marshalUs: sampleWindow(900_000),
+        },
+        changes: { received: 236775, queueDepth: sampleWindow(120), queueCap: 10000, highWater: 9800 },
+        relationshipCache: {
+          onDemandRebuilds: 6,
+          onDemandRebuildUs: sampleWindow(8_000_000),
+          indexBuilds: 43,
+          indexBuildUs: sampleWindow(90_000),
+        },
+      },
+    }, undefined, false)
+
+    expect(md).toContain('300 coalesced')
+    expect(md).toContain('2 abandoned')
+    expect(md).toContain('debounce 15s')
+    expect(md).toContain('client groups p95 3 / max 3 → auth groups p95 11 / max 11')
+    expect(md).toContain('Change Queue: 236,775 received')
+    expect(md).toContain('high-water 9,800 / 10,000')
+    expect(md).toContain('6 on-demand rebuilds')
+    expect(md).toContain('43 index builds')
+  })
+
+  it('does not report an unsampled queue depth as a measured zero', () => {
+    // The ring samples every 100th change, so a short-lived session has a
+    // populated counter and an empty window. Printing p95 0 / max 0 there reads
+    // as "the queue was empty", which is the opposite of "we never looked".
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      perf: {
+        topology: kindStats(1, 1000),
+        sse: { totalBroadcasts: 1, totalDrops: 0 },
+        changes: { received: 42, queueDepth: emptyWindow, queueCap: 10000, highWater: 3 },
+      },
+    }, undefined, false)
+
+    expect(md).toContain('Change Queue: 42 received · depth not sampled')
+    expect(md).not.toContain('depth p95 0')
+  })
+
+  it('never flags the section on high-water alone, since it never decays', () => {
+    // high-water is a monotonic all-time max that survives context switches, so
+    // a startup burst would otherwise latch the warning for the whole process.
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      perf: {
+        topology: kindStats(1, 1000),
+        sse: { totalBroadcasts: 1, totalDrops: 0 },
+        changes: { received: 500000, queueDepth: sampleWindow(20), queueCap: 10000, highWater: 10000 },
+      },
+    }, undefined, false)
+
+    expect(md).toContain('high-water 10,000 / 10,000')
+  })
+
+  it('omits every optional line when the backend reports nothing beyond the aggregate', () => {
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      perf: { topology: kindStats(1, 1000), sse: { totalBroadcasts: 1, totalDrops: 0 } },
+    }, undefined, false)
+
+    // A healthy small cluster must not pay for instrumentation it never tripped.
+    expect(md).not.toContain('Change Queue')
+    expect(md).not.toContain('Relationship Cache')
+    expect(md).not.toContain('Fan-out')
+    expect(md).not.toContain('NaN')
+    expect(md).not.toContain('undefined')
+  })
+})
+
+describe('formatForGitHub informers section', () => {
+  it('reports how long each sync phase took', () => {
+    const md = formatForGitHub({
+      ...baseSnapshot,
+      informers: {
+        typedCount: 28,
+        dynamicCount: 4,
+        watchedCRDs: [],
+        syncStatus: {
+          phase: 'complete',
+          elapsedSec: 36,
+          criticalSyncMs: 4200,
+          deferredSyncMs: 31700,
+          criticalTotal: 10,
+          criticalSynced: 10,
+          deferredTotal: 8,
+          deferredSynced: 8,
+          informers: [
+            { kind: 'Secret', key: 'secrets', deferred: true, synced: true, items: 41233 },
+            { kind: 'ReplicaSet', key: 'replicasets', deferred: true, synced: true, items: 43033 },
+            { kind: 'Pod', key: 'pods', deferred: false, synced: true, items: 29455 },
+          ],
+        },
+      },
+    }, undefined, false)
+
+    expect(md).toContain('Phase Durations: critical 4.2s · deferred 31.7s')
+  })
+})

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { openExternal } from '../../utils/navigation'
 import { useDiagnostics } from '../../api/client'
-import type { DiagnosticsSnapshot, DiagEnvVar, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase, DiagSampleWindow } from '../../api/client'
+import type { DiagnosticsSnapshot, DiagEnvVar, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase, DiagSampleWindow, DiagPerfSnapshot } from '../../api/client'
 import { getK8sUIPerfSnapshot, type K8sUIPerfSnapshot } from '@skyhook-io/k8s-ui'
 
 interface DiagnosticsOverlayProps {
@@ -346,6 +346,9 @@ function InformersSection({ data }: { data: DiagnosticsSnapshot }) {
             label="Deferred Synced"
             value={`${sync.deferredSynced} / ${sync.deferredTotal}`}
           />
+          {((sync.criticalSyncMs ?? 0) > 0 || (sync.deferredSyncMs ?? 0) > 0) && (
+            <Row label="Phase Durations" value={formatSyncPhases(sync)} />
+          )}
           {promoted.length > 0 && (
             <Row label="Promoted to Deferred" value={promoted.join(', ')} warn />
           )}
@@ -387,6 +390,18 @@ function getPendingInformers(sync: DiagCacheSyncStatus): DiagInformerSyncStatus[
   return sync.informers
     .filter((i) => pendingNames.has(i.kind))
     .sort((a, b) => Number(a.deferred) - Number(b.deferred) || a.kind.localeCompare(b.kind))
+}
+
+function formatSyncPhases(sync: DiagCacheSyncStatus): string {
+  const parts: string[] = []
+  if (sync.criticalSyncMs) parts.push(`critical ${formatMs(sync.criticalSyncMs)}`)
+  if (sync.deferredSyncMs) parts.push(`deferred ${formatMs(sync.deferredSyncMs)}`)
+  return parts.join(' \u00b7 ')
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
 }
 
 function formatSyncPhase(phase: DiagSyncPhase): string {
@@ -463,6 +478,10 @@ function APIDiscoverySection({ data }: { data: DiagnosticsSnapshot }) {
   )
 }
 
+// A rebuild past this point stalled the request that triggered it long enough
+// for the user to feel it.
+const SLOW_REBUILD_US = 1_000_000
+
 function PerfSection({ data }: { data: DiagnosticsSnapshot }) {
   const backend = data.perf
   const frontend = getK8sUIPerfSnapshot()
@@ -470,9 +489,16 @@ function PerfSection({ data }: { data: DiagnosticsSnapshot }) {
   // Warn when SSE has dropped frames, the topology payload window's p95 exceeds
   // 5 MB, or the frontend ELK layout p95 exceeds 1s — these are the load-bearing
   // thresholds for "the tab is going to feel bad."
+  const queue = backend?.changes
+  // An on-demand rebuild is ordinary — the broadcaster dirties the cache
+  // whenever no client is watching or warmup is still running, so a healthy
+  // session records one. Only a rebuild slow enough to stall the request that
+  // triggered it is worth flagging.
+  const slowRebuild = (backend?.relationshipCache?.onDemandRebuildUs.p95 ?? 0) > SLOW_REBUILD_US
   const warn =
     (backend?.sse.totalDrops ?? 0) > 0 ||
     (backend?.topology.payloadBytes.p95 ?? 0) > 5 * 1024 * 1024 ||
+    slowRebuild ||
     frontend.layoutMs.p95 > 1000
   return (
     <Section title="Performance" warn={warn}>
@@ -484,8 +510,33 @@ function PerfSection({ data }: { data: DiagnosticsSnapshot }) {
           <Row label="  Edge Count" value={formatSampleCount(backend.topology.edgeCount)} />
           <Row label="  Payload" value={formatSampleBytes(backend.topology.payloadBytes)} warn={backend.topology.payloadBytes.p95 > 5 * 1024 * 1024} />
           <Row label="  Estimated Nodes" value={formatSampleCount(backend.topology.estimatedNodes)} />
+          <BuildKindRows byKind={backend.topologyByKind} />
           <Row label="SSE Broadcasts" value={backend.sse.totalBroadcasts.toLocaleString()} />
           <Row label="SSE Drops" value={backend.sse.totalDrops.toLocaleString()} warn={backend.sse.totalDrops > 0} />
+          <Row label="SSE Cycles" value={formatCycleCounters(backend.sse)} />
+          {backend.sseCycle && backend.sseCycle.cycleDurationUs.count > 0 && (
+            <>
+              <Row label="  Cycle Duration" value={formatSampleDuration(backend.sseCycle.cycleDurationUs)} />
+              <Row label="  Fan-out" value={formatFanout(backend.sseCycle)} />
+              <Row label="  Marshal" value={formatSampleDuration(backend.sseCycle.marshalUs)} />
+            </>
+          )}
+          {queue && queue.received > 0 && (
+            <Row label="Change Queue" value={formatChangeQueue(queue)} />
+          )}
+          {backend.relationshipCache && backend.relationshipCache.onDemandRebuilds > 0 && (
+            <Row
+              label="On-demand Rebuilds"
+              value={`${backend.relationshipCache.onDemandRebuilds.toLocaleString()} · ${formatSampleDuration(backend.relationshipCache.onDemandRebuildUs)}`}
+              warn={slowRebuild}
+            />
+          )}
+          {backend.relationshipCache && backend.relationshipCache.indexBuilds > 0 && (
+            <Row
+              label="Relationship Index"
+              value={`${backend.relationshipCache.indexBuilds.toLocaleString()} builds · ${formatSampleDuration(backend.relationshipCache.indexBuildUs)}`}
+            />
+          )}
         </>
       )}
       {(frontend.totalLayouts > 0 || frontend.totalStructureKeyComputes > 0) && (
@@ -499,6 +550,50 @@ function PerfSection({ data }: { data: DiagnosticsSnapshot }) {
       )}
     </Section>
   )
+}
+
+function BuildKindRows({ byKind }: { byKind?: DiagPerfSnapshot['topologyByKind'] }) {
+  if (!byKind) return null
+  const rows = ([
+    ['full', byKind.full],
+    ['scoped', byKind.scoped],
+    ['refused', byKind.refused],
+  ] as const).filter(([, s]) => s.totalBuilds > 0)
+  if (rows.length === 0) return null
+  return (
+    <>
+      {rows.map(([kind, stats]) => (
+        <Row
+          key={kind}
+          label={`  by kind: ${kind}`}
+          value={`${stats.totalBuilds.toLocaleString()} builds · ${formatSampleDuration(stats.durationUs)}`}
+        />
+      ))}
+    </>
+  )
+}
+
+function formatCycleCounters(sse: DiagPerfSnapshot['sse']): string {
+  const parts = [`${sse.totalBroadcasts.toLocaleString()} published`]
+  if (sse.coalesced) parts.push(`${sse.coalesced.toLocaleString()} coalesced`)
+  if (sse.abandoned) parts.push(`${sse.abandoned.toLocaleString()} abandoned`)
+  if (sse.retries) parts.push(`${sse.retries.toLocaleString()} retries`)
+  if (sse.debounceMs) parts.push(`debounce ${(sse.debounceMs / 1000).toFixed(0)}s`)
+  return parts.join(' \u00b7 ')
+}
+
+// Auth groups exceed client groups when users in one namespace group hold
+// different provider permissions: each is an independent clone + marshal of the
+// whole graph, so this ratio is what turns one slow build into a slow cycle.
+function formatFanout(cycle: NonNullable<DiagPerfSnapshot['sseCycle']>): string {
+  return `${formatSampleCount(cycle.clientGroups)} client groups \u2192 ${formatSampleCount(cycle.authGroups)} auth groups`
+}
+
+function formatChangeQueue(changes: NonNullable<DiagPerfSnapshot['changes']>): string {
+  const depth = changes.queueDepth.count > 0
+    ? `depth p95 ${changes.queueDepth.p95.toLocaleString()} / max ${changes.queueDepth.max.toLocaleString()}`
+    : 'depth not sampled'
+  return `${changes.received.toLocaleString()} received \u00b7 ${depth} \u00b7 high-water ${changes.highWater.toLocaleString()} / ${changes.queueCap.toLocaleString()}`
 }
 
 function formatSampleDuration(w: DiagSampleWindow): string {
@@ -695,6 +790,9 @@ export function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIP
       const sync = inf.syncStatus
       lines.push(`- Sync Phase: \`${sync.phase}\` (${formatElapsed(sync.elapsedSec)})`)
       lines.push(`- Critical: ${sync.criticalSynced}/${sync.criticalTotal} synced | Deferred: ${sync.deferredSynced}/${sync.deferredTotal} synced`)
+      if ((sync.criticalSyncMs ?? 0) > 0 || (sync.deferredSyncMs ?? 0) > 0) {
+        lines.push(`- Phase Durations: ${formatSyncPhases(sync)}`)
+      }
       if (sync.promotedKinds && sync.promotedKinds.length > 0) {
         lines.push(`- **Promoted to Deferred:** ${sync.promotedKinds.join(', ')}`)
       }
@@ -771,7 +869,30 @@ export function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIP
         lines.push(`  - Payload: last ${fmtKB(p.topology.payloadBytes.last)} · p95 ${fmtKB(p.topology.payloadBytes.p95)} · max ${fmtKB(p.topology.payloadBytes.max)}`)
         lines.push(`  - Estimated Nodes: last ${p.topology.estimatedNodes.last} · p95 ${p.topology.estimatedNodes.p95}`)
       }
-      lines.push(`- SSE: ${p.sse.totalBroadcasts.toLocaleString()} broadcasts, ${p.sse.totalDrops.toLocaleString()} drops`)
+      if (p.topologyByKind) {
+        // Full and scoped builds differ by orders of magnitude; the aggregate
+        // p95 above describes neither on its own.
+        for (const [kind, stats] of [['full', p.topologyByKind.full], ['scoped', p.topologyByKind.scoped], ['refused', p.topologyByKind.refused]] as const) {
+          if (stats.totalBuilds === 0) continue
+          lines.push(`  - ${kind}: ${stats.totalBuilds.toLocaleString()} builds \u00b7 p50 ${fmtMs(stats.durationUs.p50)}ms \u00b7 p95 ${fmtMs(stats.durationUs.p95)}ms \u00b7 max ${fmtMs(stats.durationUs.max)}ms`)
+        }
+      }
+      lines.push(`- SSE: ${p.sse.totalBroadcasts.toLocaleString()} broadcasts, ${p.sse.totalDrops.toLocaleString()} drops${p.sse.coalesced ? `, ${p.sse.coalesced.toLocaleString()} coalesced` : ''}${p.sse.abandoned ? `, ${p.sse.abandoned.toLocaleString()} abandoned` : ''}${p.sse.retries ? `, ${p.sse.retries.toLocaleString()} retries` : ''}${p.sse.debounceMs ? ` (debounce ${(p.sse.debounceMs / 1000).toFixed(0)}s)` : ''}`)
+      if (p.sseCycle && p.sseCycle.cycleDurationUs.count > 0) {
+        const c = p.sseCycle
+        lines.push(`  - Cycle (ms): p50 ${fmtMs(c.cycleDurationUs.p50)} \u00b7 p95 ${fmtMs(c.cycleDurationUs.p95)} \u00b7 max ${fmtMs(c.cycleDurationUs.max)}`)
+        lines.push(`  - Fan-out: client groups p95 ${c.clientGroups.p95} / max ${c.clientGroups.max} \u2192 auth groups p95 ${c.authGroups.p95} / max ${c.authGroups.max} \u00b7 marshal p95 ${fmtMs(c.marshalUs.p95)}ms`)
+      }
+      if (p.changes && p.changes.received > 0) {
+        lines.push(`- Change Queue: ${formatChangeQueue(p.changes)}`)
+      }
+      if (p.relationshipCache && (p.relationshipCache.onDemandRebuilds > 0 || p.relationshipCache.indexBuilds > 0)) {
+        const r = p.relationshipCache
+        const parts: string[] = []
+        if (r.onDemandRebuilds > 0) parts.push(`${r.onDemandRebuilds.toLocaleString()} on-demand rebuilds (p95 ${fmtMs(r.onDemandRebuildUs.p95)}ms, max ${fmtMs(r.onDemandRebuildUs.max)}ms)`)
+        if (r.indexBuilds > 0) parts.push(`${r.indexBuilds.toLocaleString()} index builds (p95 ${fmtMs(r.indexBuildUs.p95)}ms)`)
+        lines.push(`- Relationship Cache: ${parts.join(' \u00b7 ')}`)
+      }
     }
     if (frontendPerf && (frontendPerf.totalLayouts > 0 || frontendPerf.totalStructureKeyComputes > 0)) {
       const fmt = (v: number) => v < 100 ? v.toFixed(1) : Math.round(v).toString()


### PR DESCRIPTION
## Description

Issue #1303 was slow to diagnose because the data needed to locate the bottleneck never reached us. The phase-level numbers were gated behind --dev and printed to stderr, which no bug reporter sends, and the one always-on store answered only "how long did a topology build take" with every build shape averaged into a single percentile.

Everything here lands in pkg/perfstats and surfaces through /api/diagnostics and the overlay. No new stdout logging, no new flags, and every line is conditional so a healthy cluster grows the report by about five lines.

- Split topology build stats by scope (full / scoped / refused). A namespace filter is what bounds the cost, so one duration window can no longer average a cluster-wide build with a namespace-scoped one.
- Record the broadcast cycle: wall time, client groups, auth groups and marshal time. Auth groups are the fan-out multiplier that turns one slow build into a slow cycle, and were previously invisible. Recorded from a defer so cycles abandoned for a cluster switch report the time they spent instead of looking free.
- Count abandoned, coalesced and retried cycles, plus the active debounce rung.
- Sample the resource-change queue. Drops already surfaced once the channel overflowed; depth and the high-water mark show the approach to that cliff, and the received count gives the rate.
- Time full topology rebuilds that run on a request goroutine because the relationship cache was dirty, and the edge-index builds with them.
- Record how long the critical and deferred informer phases took.

Per-kind stats deliberately carry no payload size: payload is measured at marshal time, downstream of the build and with no record of which kind produced it, so the field could only ever report zero.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: atomic counters and sampled ring buffers on existing paths; no auth, data, or broadcast logic changes beyond recording metrics.
> 
> **Overview**
> Adds **always-on performance instrumentation** in `pkg/perfstats` and wires it through the SSE broadcaster, topology builder, and informer cache so bug reports and `/api/diagnostics` can show *where* time goes—not a single blended topology-build percentile.
> 
> **Topology** builds are recorded as **full / scoped / refused** (`BuildKind`), so a multi-second cluster-wide build no longer hides inside namespace-scoped p95s. The builder tags refused large-cluster guard paths separately from completed graphs.
> 
> **SSE** gains counters for **coalesced** broadcast requests, **abandoned** cycles after cluster switches, **retries** when the worker re-arms, and the active **debounce** ladder rung. Each broadcast cycle records wall time, **client-group** vs **auth-group** fan-out (clone/strip/marshal multiplier), and aggregate marshal time. The change watcher samples **queue depth** (throttled) and tracks **high-water** on the resource-change channel.
> 
> **Relationship cache** paths time **on-demand full rebuilds** on request goroutines and **IndexByResource** builds.
> 
> **Informer sync** exposes **critical** and **deferred** phase wall times in cache sync status. The web diagnostics overlay and GitHub export show these fields conditionally so quiet clusters stay short.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52dfe525f4dcde046b6f2d23273ad0e6d94ff327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->