### PR TITLE
fix(updater): surface Close errors when extracting the new binary

### DIFF
--- a/internal/updater/apply_linux.go
+++ b/internal/updater/apply_linux.go
@@ -152,7 +152,11 @@ func extractTarGz(archivePath, destDir string) error {
 				outFile.Close()
 				return err
 			}
-			outFile.Close()
+			// A failed close can mean a truncated write; swallowing it would let
+			// the updater install a corrupt binary.
+			if err := outFile.Close(); err != nil {
+				return fmt.Errorf("close %s: %w", header.Name, err)
+			}
 		}
 	}
 	return nil

--- a/internal/updater/extract_zip.go
+++ b/internal/updater/extract_zip.go
@@ -54,8 +54,13 @@ func extractZip(zipPath, destDir string) error {
 			return err
 		}
 
-		outFile.Close()
+		// A failed close can mean a truncated write; swallowing it would let
+		// the updater install a corrupt binary.
+		closeErr := outFile.Close()
 		rc.Close()
+		if closeErr != nil {
+			return fmt.Errorf("close %s: %w", f.Name, closeErr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes code-scanning alerts #228/#229 (`go/unhandled-writable-file-close`).

A failed `Close()` after `io.Copy` can mean a truncated write (disk full, deferred write-back error). Both archive extractors swallowed it, so the self-updater could extract a truncated binary, swap it into place, and report success — leaving the user with a corrupt install.

- `apply_linux.go` (`extractTarGz`): check the success-path `Close` and return the error (the flagged sites).
- `extract_zip.go` (`extractZip`, macOS/Windows): same pattern existed unflagged; fixed as well.

`copyFile` already returned `out.Close()` correctly, so the binary-swap step itself was safe — the gap was only in extraction.

Verified: `go build` for GOOS=linux/darwin/windows + `go vet` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling fix in archive extraction; it only fails closed on write errors and does not change update apply or swap logic.
> 
> **Overview**
> The self-updater now fails extraction if writing the new binary cannot be fully flushed, instead of ignoring `Close` errors after `io.Copy`.
> 
> `extractTarGz` (Linux) and `extractZip` (macOS/Windows) return a wrapped close error on the success path so a truncated write (e.g. disk full) cannot be installed as a successful update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829d57ef37bdc76a3b964fb5480e12720e0128c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->