### PR TITLE
chore(codeql): exclude go/log-injection via shared config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+name: Radar CodeQL config
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  # Radar's logs are diagnostic printf output, not an audit trail. In the
+  # dominant local single-user deployment the only person who can reach the
+  # API is the one reading stderr, and in multi-user deployments nothing
+  # consumes these logs for security decisions — while the rule buries real
+  # findings under 100+ alerts. Convention for user-derived strings in new
+  # log lines is %q, which neutralizes newline injection. If Radar ever
+  # grows a real audit log, that writer must sanitize its fields.
+  - exclude:
+      id: go/log-injection

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
Excludes `go/log-injection` from CodeQL analysis — it accounts for 141 of the 174 open code-scanning alerts and buries the findings that matter.

Rationale:
- Radar's logs are diagnostic printf output, not an audit trail — nothing consumes them for security decisions.
- In the dominant local single-user deployment, the only person who can reach the API is the one reading stderr (attacker = log reader).
- In multi-user deployments, anyone who can hit these endpoints already holds RBAC-scoped cluster read access; forging a debug log line gains nothing on top.
- Convention for user-derived strings in new log lines remains `%q` (already used across the auth package), which neutralizes newline injection.
- If Radar ever grows a real audit log, that dedicated writer must sanitize its fields — revisit this exclusion then.

Mechanics: query-suite selection (`security-and-quality`, unchanged) moves from the workflow's `queries:` input into `.github/codeql/codeql-config.yml`, where the `query-filters` exclusion lives. The existing alerts auto-close on the next analysis of `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI scanning config only; no application or security-control code changes. Excluding a noisy rule can hide real log-injection issues if logging later becomes an audit trail.
> 
> **Overview**
> Moves CodeQL query selection into `.github/codeql/codeql-config.yml` and excludes `go/log-injection`, which was drowning out other alerts.
> 
> The `security-and-quality` suite is unchanged; only the noisy log-injection rule is filtered. Existing alerts for that rule should auto-close on the next `main` analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e896539a721997f27af3cefe16bdd8e51edccd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->