### PR TITLE
fix: sweep the remaining raw Quantity parsers (quota ratios, capacity rows)

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.test.ts
+++ b/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { quotaUsageRatio } from './NamespaceRenderer'
+
+describe('quotaUsageRatio', () => {
+  // status.used is computed with quantity arithmetic, so a used pod count of
+  // 1000 serializes canonically as "1k". A raw-float read sees 1 and reports a
+  // saturated quota as barely used.
+  it('reads count quantities with SI suffixes on either side of the ratio', () => {
+    expect(quotaUsageRatio('pods', '1k', '1k')).toBe(1)
+    expect(quotaUsageRatio('pods', '900', '1k')).toBeCloseTo(0.9)
+    expect(quotaUsageRatio('count/pods', '1k', '2k')).toBeCloseTo(0.5)
+  })
+
+  it('leaves plain counts unchanged', () => {
+    expect(quotaUsageRatio('pods', '5', '10')).toBe(0.5)
+    expect(quotaUsageRatio('services', '0', '10')).toBe(0)
+  })
+
+  it('parses cpu and memory with their own unit parsers', () => {
+    expect(quotaUsageRatio('cpu', '500m', '1')).toBeCloseTo(0.5)
+    expect(quotaUsageRatio('requests.cpu', '2', '4')).toBeCloseTo(0.5)
+    expect(quotaUsageRatio('memory', '512Mi', '1Gi')).toBeCloseTo(0.5)
+    expect(quotaUsageRatio('requests.storage', '1Gi', '2Gi')).toBeCloseTo(0.5)
+  })
+
+  it('yields null when hard is unset or unparseable so the row falls back to raw strings', () => {
+    expect(quotaUsageRatio('pods', '5', '')).toBeNull()
+    expect(quotaUsageRatio('pods', '5', 'garbage')).toBeNull()
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.tsx
@@ -5,7 +5,7 @@ import type { RBACNamespaceResponse, RBACBindingWithSubjects, RBACSubject, Resou
 import { rbacKindBadgeClass } from '../../../utils/rbac-badges'
 import { RBACErrorSection } from './RBACErrorSection'
 import { SEVERITY_TEXT, SEVERITY_DOT } from '../../../utils/badge-colors'
-import { parseCPUToNanocores, parseMemoryToBytes } from '../../../utils/format'
+import { parseCPUToNanocores, parseMemoryToBytes, parseQuantityToNumber } from '../../../utils/format'
 
 interface NamespaceRendererProps {
   data: any
@@ -95,11 +95,15 @@ export function NamespaceRenderer({ data, rbacData, rbacLoading, rbacError, quot
 // right unit parser by resource name (cpu → millicores, memory/storage →
 // bytes, everything else → plain count). Returns null when hard is unset or
 // unparseable so the row falls back to showing the raw strings.
-function quotaUsageRatio(resourceName: string, used: string, hard: string): number | null {
+// Count values are Quantities too: the quota controller computes status.used
+// with quantity arithmetic, which re-serializes canonically — a used pod count
+// of 1000 arrives as "1k". Read with parseFloat that is 1, and a saturated
+// quota renders as barely used.
+export function quotaUsageRatio(resourceName: string, used: string, hard: string): number | null {
   if (!hard) return null
   const isCPU = /(^|\.)cpu$/i.test(resourceName)
   const isBytes = /(memory|storage)$/i.test(resourceName)
-  const parse = isCPU ? parseCPUToNanocores : isBytes ? parseMemoryToBytes : (v: string) => parseFloat(v) || 0
+  const parse = isCPU ? parseCPUToNanocores : isBytes ? parseMemoryToBytes : parseQuantityToNumber
   const h = parse(hard)
   if (!h) return null
   return parse(used || '0') / h

--- a/packages/k8s-ui/src/utils/format.test.ts
+++ b/packages/k8s-ui/src/utils/format.test.ts
@@ -32,6 +32,15 @@ describe('parseMemoryToBytes', () => {
     expect(parseMemoryToBytes('-1Ki')).toBe(-1024)
     expect(parseMemoryToBytes('1Ki')).toBe(1024)
   })
+
+  // Aggregate cluster memory reaches suffixes a single node never carries —
+  // "1Pi" must not fall through to the bare-number fallback and read as 1 byte.
+  it('parses the large suffixes an aggregate capacity can carry', () => {
+    expect(parseMemoryToBytes('1Pi')).toBe(1024 ** 5)
+    expect(parseMemoryToBytes('1Ei')).toBe(1024 ** 6)
+    expect(parseMemoryToBytes('1P')).toBe(1000 ** 5)
+    expect(parseMemoryToBytes('1E')).toBe(1000 ** 6)
+  })
 })
 
 describe('parseQuantityToNumber', () => {

--- a/packages/k8s-ui/src/utils/format.ts
+++ b/packages/k8s-ui/src/utils/format.ts
@@ -126,12 +126,15 @@ export function parseMemoryToBytes(memString: string): number {
   const num = parseFloat(match[1])
   const suffix = match[2]
 
-  // Binary suffixes (powers of 1024)
+  // Binary suffixes (powers of 1024). Pi/Ei are real inputs at cluster scale —
+  // an aggregate of a thousand 1TiB nodes serializes as "1Pi".
   const binarySuffixes: Record<string, number> = {
     'Ki': 1024,
     'Mi': 1024 ** 2,
     'Gi': 1024 ** 3,
     'Ti': 1024 ** 4,
+    'Pi': 1024 ** 5,
+    'Ei': 1024 ** 6,
   }
 
   // Decimal suffixes (powers of 1000)
@@ -141,6 +144,8 @@ export function parseMemoryToBytes(memString: string): number {
     'M': 1000 ** 2,
     'G': 1000 ** 3,
     'T': 1000 ** 4,
+    'P': 1000 ** 5,
+    'E': 1000 ** 6,
   }
 
   if (suffix in binarySuffixes) {

--- a/web/src/components/capacity/ClusterSchedulingCard.tsx
+++ b/web/src/components/capacity/ClusterSchedulingCard.tsx
@@ -7,7 +7,7 @@ import {
 import { Badge } from "@skyhook-io/k8s-ui/components/ui/Badge";
 import {
   parseCPUToNanocores,
-  parseMemoryToBytes,
+  parseQuantityToNumber,
 } from "@skyhook-io/k8s-ui/utils/format";
 import {
   CertaintyGlyph,
@@ -96,16 +96,15 @@ export function quantityToNumber(
     }
     return null;
   }
-  // Milli quantities before the byte parser — it ignores the `m` suffix and
-  // would read 3000m as 3000, a 1000× distortion.
-  const milli = /^(-?\d+(?:\.\d+)?)m$/.exec(value);
-  if (milli) return Number(milli[1]) / 1000;
-  const parsed = parseMemoryToBytes(value);
-  if (Number.isFinite(parsed) && (parsed !== 0 || /^[0.]+\D*$/.test(value))) {
+  // The shared parser knows the full suffix table — the byte parser stops at
+  // Ti, so a 1PiB aggregate would read as 1 byte. It returns 0 for input it
+  // cannot parse, so distinguish a real zero to preserve the null (= unknown,
+  // not zero) contract of this card.
+  const parsed = parseQuantityToNumber(value);
+  if (parsed !== 0 || /^[+-]?[0.]+\D*$/.test(value)) {
     return parsed;
   }
-  const plain = Number(value);
-  return Number.isFinite(plain) ? plain : null;
+  return null;
 }
 
 function worstCertainty(

--- a/web/src/components/capacity/schedulingBar.test.ts
+++ b/web/src/components/capacity/schedulingBar.test.ts
@@ -202,6 +202,16 @@ describe("quantityToNumber", () => {
     expect(quantityToNumber("example.com/widget", "3000m")).toBe(3);
     expect(quantityToNumber("cpu", "1500m")).toBe(1.5e9);
   });
+
+  // Aggregate memory on a large cluster reaches suffixes the byte parser
+  // never knew (its table stops at Ti) — "1Pi" must not read as 1 byte.
+  it("parses the large suffixes an aggregate capacity can carry", () => {
+    expect(quantityToNumber("memory", "1Pi")).toBe(1024 ** 5);
+    expect(quantityToNumber("memory", "1Ei")).toBe(1024 ** 6);
+    expect(quantityToNumber("pods", "1k")).toBe(1000);
+    expect(quantityToNumber("pods", "1e3")).toBe(1000);
+    expect(quantityToNumber("memory", "0Gi")).toBe(0);
+  });
 });
 
 describe("claimStagesDetail", () => {


### PR DESCRIPTION
Found while reviewing #1451 — the same bug class on a second surface.

## The bug

The namespace detail's Resource Quotas section computes usage ratios in `quotaUsageRatio`, which picked `parseCPUToNanocores` for CPU, `parseMemoryToBytes` for memory/storage, and fell back to `parseFloat` for everything else — i.e. every count quota (`pods`, `services`, `count/*`, …).

`parseFloat("1k") === 1`. The quota controller computes `status.used` with quantity arithmetic, which drops the original string and re-serializes canonically — so a used pod count of 1000 arrives as `"1k"`. A quota at `1000/1000` pods rendered as `1/1000` — a **saturated quota showing as barely used**, hiding exactly the signal this section exists to surface ("why did this namespace stop admitting pods?"). The inverse failure of #1441, where the bar overshot; here it flatlines.

## The fix

Route the count branch through `parseQuantityToNumber` (added in #1451). Its 0-for-unparseable contract composes with the existing `if (!h) return null` guard: an unreadable hard limit makes the row fall back to raw strings, same as before. CPU and memory branches are untouched.

`quotaUsageRatio` is now exported for the new test file — 4 tests covering the `"1k"` case on both sides of the ratio, plain counts, the CPU/memory branches, and the null fallback.

## Verification

```
packages/k8s-ui  vitest NamespaceRenderer.test.ts   4 passed
web              npm run tsc                        0 errors
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only quantity parsing for quota and capacity bars; no auth, API, or data-write changes. Wrong parse still misleads operators, but the change is well-tested and scoped.
> 
> **Overview**
> Fixes two remaining Quantity-parse bugs so usage bars no longer under-report saturation or cluster-scale memory.
> 
> Namespace Resource Quota ratios now parse count resources (`pods`, `count/*`, …) with `parseQuantityToNumber` instead of `parseFloat`. Canonical `"1k"` used/hard values no longer read as 1, so a full pod quota no longer looks barely used.
> 
> Capacity rows and `parseMemoryToBytes` now honor Pi/Ei (and decimal P/E). Cluster scheduling quantities go through the shared parser instead of the byte parser plus a milli special-case, so `"1Pi"` aggregates and `"1k"` pod counts stay correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b02a74d68e2c900e10b5da31b6cf2f9f1c3aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->