### PR TITLE
fix(ui): prevent drawer layout shift

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1664,8 +1664,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {/* `relative` makes this column the containing block for the absolute
           overlays it hosts (BottomDock, expanded ResourceDetailDrawer) so they
           span the content area AFTER the rail rather than the full viewport
-          under it. `fixed` splashes (connecting/switching) are unaffected. */}
-      <div className="relative flex flex-col flex-1 min-w-0 h-full">
+          under it. Horizontal clipping keeps translated-offscreen drawers from
+          contributing document overflow. `fixed` splashes are unaffected. */}
+      <div className="relative flex flex-col flex-1 min-w-0 h-full overflow-x-clip">
       {/* Header — suppressed in chromeless embed; the host owns the chrome.
           @container: the header's responsive layout keys off its OWN width (≈ viewport
           − nav rail), not the viewport, so it collapses gracefully on narrow windows.


### PR DESCRIPTION
## Summary

Prevents right-side drawers from briefly introducing page overflow and shifting the underlying UI during open and close animations.

## What changed

- Clips horizontal overflow at the positioned app column that contains resource drawers.
- Keeps vertical and drawer-local overflow unchanged.
- Covers the shared layout used by resource details and other right-side surfaces.

## Testing

- make tsc
- make test
- make build
- Live visual verification against kind-radar-c3 at 1280x800, 1920x1080, and 2560x1440
- Resource drawer open, close, and expanded states; Helm drawer transitions; AI side panel

Closes #1295

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-class CSS layout tweak on the main shell; no logic, auth, or data-path changes. Possible residual risk is clipping other horizontally overflowing UI in that column.
> 
> **Overview**
> Stops right-side drawers from briefly widening the page (and shifting the UI) while they slide in or out.
> 
> Adds `overflow-x-clip` on the main content column that hosts those overlays, so translated-offscreen drawers no longer create document overflow. Vertical and in-drawer scrolling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27201418ff551c61f5cfa12e08f889d4d2c0b3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->