### PR TITLE
Detect RKE2 platforms and Canal CNI

### DIFF
--- a/internal/k8s/cluster_detection.go
+++ b/internal/k8s/cluster_detection.go
@@ -46,7 +46,7 @@ func InvalidateServerVersionCache() {
 type ClusterInfo struct {
 	Context            string `json:"context"`  // kubeconfig context name
 	Cluster            string `json:"cluster"`  // cluster name from kubeconfig
-	Platform           string `json:"platform"` // gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, generic
+	Platform           string `json:"platform"` // rke2, gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, openshift, rancher, generic
 	KubernetesVersion  string `json:"kubernetesVersion"`
 	NodeCount          int    `json:"nodeCount"`
 	PodCount           int    `json:"podCount"`
@@ -122,42 +122,24 @@ func GetClusterPlatform(ctx context.Context) (string, error) {
 			return detectPlatformFallback(ctx)
 		}
 		if len(nodeList.Items) == 0 {
-			return "unknown", nil
+			return detectPlatformFallback(ctx)
 		}
 		nodes = nodeList.Items
 	}
 
 	if len(nodes) == 0 {
-		return "unknown", nil
+		return detectPlatformFallback(ctx)
 	}
 
 	node := nodes[0]
 
-	// Primary detection: Provider ID
-	platform := detectByProviderID(node)
+	platform := k8score.DetectNodePlatform(node)
 	if platform != "unknown" {
 		if platform == "gke" {
 			if isAutopilot, _ := IsGKEAutopilot(ctx); isAutopilot {
 				return "gke-autopilot", nil
 			}
 		}
-		return platform, nil
-	}
-
-	// Secondary detection: Platform-specific labels
-	platform = detectByLabels(node)
-	if platform != "unknown" {
-		if platform == "gke" {
-			if isAutopilot, _ := IsGKEAutopilot(ctx); isAutopilot {
-				return "gke-autopilot", nil
-			}
-		}
-		return platform, nil
-	}
-
-	// Tertiary detection: Node name patterns
-	platform = detectByNodeName(node)
-	if platform != "unknown" {
 		return platform, nil
 	}
 
@@ -191,7 +173,7 @@ func IsGKEAutopilot(ctx context.Context) (bool, error) {
 		if val, exists := node.Labels["cloud.google.com/gke-autopilot"]; exists && val == "true" {
 			return true, nil
 		}
-		if !isNodeGKE(node) {
+		if !k8score.IsNodeGKE(node) {
 			return false, nil
 		}
 	}
@@ -240,16 +222,13 @@ func checkAutopilotViaAnnotations(ctx context.Context) (bool, bool) {
 	return false, len(pods) > 0
 }
 
-// Pure helpers delegate to pkg/k8score for reuse without singletons.
-func detectByProviderID(node corev1.Node) string { return k8score.DetectByProviderID(node) }
-func detectByLabels(node corev1.Node) string     { return k8score.DetectByLabels(node) }
-func detectByNodeName(node corev1.Node) string   { return k8score.DetectByNodeName(node) }
-func isNodeGKE(node corev1.Node) bool            { return k8score.IsNodeGKE(node) }
-
 func detectPlatformFallback(ctx context.Context) (string, error) {
 	isAutopilot, found := checkAutopilotViaAnnotations(ctx)
 	if found && isAutopilot {
 		return "gke-autopilot", nil
+	}
+	if platform := k8score.DetectPlatformFromVersion(GetServerVersion()); platform != "unknown" {
+		return platform, nil
 	}
 	return "unknown", nil
 }

--- a/internal/k8s/cluster_detection_test.go
+++ b/internal/k8s/cluster_detection_test.go
@@ -1,0 +1,119 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetClusterPlatform(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         corev1.NodeList
+		pods          corev1.PodList
+		denyNodes     bool
+		serverVersion string
+		want          string
+	}{
+		{
+			name: "RKE2",
+			nodes: corev1.NodeList{Items: []corev1.Node{{
+				Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.31.7+rke2r1"}},
+			}}},
+			want: "rke2",
+		},
+		{
+			name: "GKE Autopilot node label",
+			nodes: corev1.NodeList{Items: []corev1.Node{{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"cloud.google.com/gke-autopilot": "true"}},
+				Spec:       corev1.NodeSpec{ProviderID: "gce://project/zone/node"},
+			}}},
+			want: "gke-autopilot",
+		},
+		{
+			name:          "RKE2 server version fallback",
+			denyNodes:     true,
+			serverVersion: "v1.31.7+rke2r1",
+			want:          "rke2",
+		},
+		{
+			name:          "RKE2 server version fallback without nodes",
+			serverVersion: "v1.31.7+rke2r1",
+			want:          "rke2",
+		},
+		{
+			name:      "GKE Autopilot annotation fallback",
+			denyNodes: true,
+			pods: corev1.PodList{Items: []corev1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"autopilot.gke.io/resource-adjustment": "true"}},
+			}}},
+			want: "gke-autopilot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setClusterDetectionClient(t, tt.nodes, tt.pods, tt.denyNodes, tt.serverVersion)
+
+			got, err := GetClusterPlatform(context.Background())
+			if err != nil {
+				t.Fatalf("GetClusterPlatform() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("GetClusterPlatform() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func setClusterDetectionClient(t *testing.T, nodes corev1.NodeList, pods corev1.PodList, denyNodes bool, serverVersion string) {
+	t.Helper()
+
+	nodes.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "NodeList"}
+	pods.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			_ = json.NewEncoder(w).Encode(version.Info{GitVersion: serverVersion})
+		case "/api/v1/nodes":
+			if denyNodes {
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(metav1.Status{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+					Status:   metav1.StatusFailure,
+					Reason:   metav1.StatusReasonForbidden,
+					Code:     http.StatusForbidden,
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(nodes)
+		case "/api/v1/namespaces/kube-system/pods":
+			_ = json.NewEncoder(w).Encode(pods)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("create Kubernetes client: %v", err)
+	}
+	ResetResourceCache()
+	InvalidateServerVersionCache()
+	previous := SetTestClient(client)
+	t.Cleanup(func() {
+		SetTestClient(previous)
+		ResetResourceCache()
+		InvalidateServerVersionCache()
+	})
+}

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/errorlog"
 	"github.com/skyhook-io/radar/internal/portforward"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // Manager handles traffic source detection and management
@@ -232,6 +233,9 @@ func (m *Manager) detectClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 	} else {
 		info.K8sVersion = version.GitVersion
 		log.Printf("[traffic] K8s version: %s", info.K8sVersion)
+		if platform := k8score.DetectPlatformFromVersion(info.K8sVersion); platform != "unknown" {
+			info.Platform = platform
+		}
 	}
 
 	// Detect platform from nodes
@@ -245,26 +249,19 @@ func (m *Manager) detectClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 		providerID := node.Spec.ProviderID
 		log.Printf("[traffic] Node providerID: %q", providerID)
 
-		// Detect platform
-		switch {
-		case strings.HasPrefix(providerID, "gce://"):
-			info.Platform = "gke"
-			// Extract cluster name from labels
-			if cn, ok := node.Labels["cloud.google.com/gke-nodepool"]; ok {
-				// Parse cluster name from nodepool
-				parts := strings.Split(cn, "-")
-				if len(parts) > 0 {
-					info.ClusterName = parts[0]
+		platform := k8score.DetectNodePlatform(node)
+		if platform == "unknown" {
+			log.Printf("[traffic] Unknown node platform, platform remains generic")
+		} else if info.Platform == "generic" {
+			info.Platform = platform
+			if platform == "gke" {
+				if cn, ok := node.Labels["cloud.google.com/gke-nodepool"]; ok {
+					parts := strings.Split(cn, "-")
+					if len(parts) > 0 {
+						info.ClusterName = parts[0]
+					}
 				}
 			}
-		case strings.HasPrefix(providerID, "aws://"):
-			info.Platform = "eks"
-		case strings.HasPrefix(providerID, "azure://"):
-			info.Platform = "aks"
-		case strings.HasPrefix(providerID, "kind://"):
-			info.Platform = "kind"
-		default:
-			log.Printf("[traffic] Unknown providerID format, platform remains generic")
 		}
 	}
 
@@ -313,6 +310,14 @@ func (m *Manager) detectCNI(ctx context.Context, platform string) (string, bool)
 		log.Printf("[traffic] Found anetd DaemonSet (GKE Dataplane V2)")
 		// anetd is part of GKE Dataplane V2 which uses Cilium
 		return "cilium", hubbleEnabled
+	}
+
+	for _, name := range []string{"rke2-canal", "canal"} {
+		_, err = m.k8sClient.AppsV1().DaemonSets("kube-system").Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			log.Printf("[traffic] Found %s DaemonSet", name)
+			return "canal", false
+		}
 	}
 
 	// Check for Calico
@@ -416,6 +421,14 @@ func (m *Manager) generateRecommendation(info *ClusterInfo, detected []SourceSta
 		return &Recommendation{
 			Name:      "caretta",
 			Reason:    "Caretta provides lightweight eBPF-based traffic visibility for Calico clusters.",
+			HelmChart: carettaHelmChart(),
+			DocsURL:   "https://github.com/groundcover-com/caretta",
+		}
+
+	case "canal":
+		return &Recommendation{
+			Name:      "caretta",
+			Reason:    "Caretta provides lightweight eBPF-based traffic visibility for Canal clusters.",
 			HelmChart: carettaHelmChart(),
 			DocsURL:   "https://github.com/groundcover-com/caretta",
 		}

--- a/internal/traffic/manager_detection_test.go
+++ b/internal/traffic/manager_detection_test.go
@@ -1,0 +1,105 @@
+package traffic
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestDetectCNI(t *testing.T) {
+	tests := []struct {
+		name       string
+		daemonSets []string
+		want       string
+	}{
+		{name: "RKE2 Canal", daemonSets: []string{"rke2-canal"}, want: "canal"},
+		{name: "plain Canal", daemonSets: []string{"canal"}, want: "canal"},
+		{name: "Canal before Calico and Flannel", daemonSets: []string{"calico-node", "kube-flannel-ds", "rke2-canal"}, want: "canal"},
+		{name: "Cilium before Canal", daemonSets: []string{"cilium", "rke2-canal"}, want: "cilium"},
+		{name: "Calico remains Calico", daemonSets: []string{"calico-node"}, want: "calico"},
+		{name: "Flannel remains Flannel", daemonSets: []string{"kube-flannel-ds"}, want: "flannel"},
+		{name: "prefix does not match", daemonSets: []string{"rke2-canal-old"}, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(tt.daemonSets))
+			for _, name := range tt.daemonSets {
+				objects = append(objects, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "kube-system"}})
+			}
+			m := &Manager{k8sClient: fake.NewSimpleClientset(objects...)}
+			got, _ := m.detectCNI(context.Background(), "generic")
+			if got != tt.want {
+				t.Fatalf("detectCNI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectClusterInfoFallsBackToRKE2ServerVersion(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{GitVersion: "v1.31.7+rke2r1"}
+	client.PrependReactor("list", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", errors.New("denied"))
+	})
+
+	info, err := (&Manager{k8sClient: client}).detectClusterInfo(context.Background())
+	if err != nil {
+		t.Fatalf("detectClusterInfo() error = %v", err)
+	}
+	if info.Platform != "rke2" {
+		t.Errorf("platform = %q, want rke2", info.Platform)
+	}
+}
+
+func TestGenerateRecommendationForCanal(t *testing.T) {
+	recommendation := (&Manager{}).generateRecommendation(&ClusterInfo{CNI: "canal"}, nil)
+	if recommendation == nil {
+		t.Fatal("generateRecommendation() = nil")
+	}
+	if recommendation.Name != "caretta" {
+		t.Errorf("name = %q, want caretta", recommendation.Name)
+	}
+	if !strings.Contains(recommendation.Reason, "Canal") {
+		t.Errorf("reason = %q, want Canal-specific guidance", recommendation.Reason)
+	}
+}
+
+func TestDetectSources_ReportsRKE2CanalWithoutRecommendingOverAvailableCaretta(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Node{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.31.7+rke2r1"}}},
+		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "rke2-canal", Namespace: "kube-system"}},
+	)
+	m := &Manager{
+		k8sClient: client,
+		sources: map[string]TrafficSource{
+			"caretta": &stubSource{name: "caretta", result: &DetectionResult{Available: true, Present: true}},
+		},
+	}
+
+	response, err := m.DetectSources(context.Background())
+	if err != nil {
+		t.Fatalf("DetectSources() error = %v", err)
+	}
+	if response.Cluster.Platform != "rke2" {
+		t.Errorf("platform = %q, want rke2", response.Cluster.Platform)
+	}
+	if response.Cluster.CNI != "canal" {
+		t.Errorf("CNI = %q, want canal", response.Cluster.CNI)
+	}
+	if response.Recommended != nil {
+		t.Errorf("available Caretta must suppress recommendations, got %#v", response.Recommended)
+	}
+}

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -1273,8 +1273,8 @@ export interface AggregatedFlow {
 
 // Cluster info for traffic detection
 export interface TrafficClusterInfo {
-  platform: string // gke, eks, aks, generic
-  cni: string // cilium, calico, flannel, vpc-cni, azure-cni
+  platform: string // rke2, gke, eks, aks, minikube, kind, docker-desktop, openshift, rancher, generic
+  cni: string // cilium, canal, calico, flannel, vpc-cni, azure-cni, gke-native, unknown
   dataplaneV2: boolean
   clusterName?: string
   k8sVersion?: string

--- a/pkg/k8score/cluster_detection.go
+++ b/pkg/k8score/cluster_detection.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DetectClusterPlatform detects the Kubernetes platform/provider by inspecting nodes.
-// Returns one of: gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, openshift, rancher, generic, unknown.
+// Returns one of: rke2, gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, openshift, rancher, generic, unknown.
 func DetectClusterPlatform(ctx context.Context, client kubernetes.Interface) (string, error) {
 	if client == nil {
 		return "unknown", nil
@@ -23,32 +23,41 @@ func DetectClusterPlatform(ctx context.Context, client kubernetes.Interface) (st
 
 	node := nodeList.Items[0]
 
-	platform := DetectByProviderID(node)
+	platform := DetectNodePlatform(node)
 	if platform != "unknown" {
 		if platform == "gke" {
 			if isAutopilot, _ := detectAutopilot(ctx, client); isAutopilot {
 				return "gke-autopilot", nil
 			}
 		}
-		return platform, nil
-	}
-
-	platform = DetectByLabels(node)
-	if platform != "unknown" {
-		if platform == "gke" {
-			if isAutopilot, _ := detectAutopilot(ctx, client); isAutopilot {
-				return "gke-autopilot", nil
-			}
-		}
-		return platform, nil
-	}
-
-	platform = DetectByNodeName(node)
-	if platform != "unknown" {
 		return platform, nil
 	}
 
 	return "generic", nil
+}
+
+// DetectNodePlatform classifies a sampled node. Distribution markers take
+// precedence over infrastructure labels because a Rancher-managed RKE2 node is
+// still operationally an RKE2 cluster.
+func DetectNodePlatform(node corev1.Node) string {
+	if platform := DetectPlatformFromVersion(node.Status.NodeInfo.KubeletVersion); platform != "unknown" {
+		return platform
+	}
+	if platform := DetectByProviderID(node); platform != "unknown" {
+		return platform
+	}
+	if platform := DetectByLabels(node); platform != "unknown" {
+		return platform
+	}
+	return DetectByNodeName(node)
+}
+
+// DetectPlatformFromVersion classifies distribution markers embedded in Kubernetes versions.
+func DetectPlatformFromVersion(gitVersion string) string {
+	if strings.Contains(gitVersion, "+rke2r") {
+		return "rke2"
+	}
+	return "unknown"
 }
 
 // DetectByProviderID detects the platform from a node's ProviderID field.
@@ -61,6 +70,8 @@ func DetectByProviderID(node corev1.Node) string {
 		return "eks"
 	case strings.HasPrefix(providerID, "azure://"):
 		return "aks"
+	case strings.HasPrefix(providerID, "kind://"):
+		return "kind"
 	default:
 		return "unknown"
 	}

--- a/pkg/k8score/cluster_detection_test.go
+++ b/pkg/k8score/cluster_detection_test.go
@@ -1,0 +1,114 @@
+package k8score
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDetectNodePlatform(t *testing.T) {
+	tests := []struct {
+		name string
+		node corev1.Node
+		want string
+	}{
+		{name: "RKE2 kubelet", node: nodeWithKubeletVersion("v1.31.7+rke2r1"), want: "rke2"},
+		{name: "RKE2 before Rancher", node: nodeWithSignals("v1.31.7+rke2r1", "", map[string]string{"rke.cattle.io/machine": "worker"}), want: "rke2"},
+		{name: "RKE2 before provider ID", node: nodeWithSignals("v1.31.7+rke2r1", "aws:///zone/node", nil), want: "rke2"},
+		{name: "not an RKE2 suffix", node: nodeWithKubeletVersion("v1.31.7-rke2r1"), want: "unknown"},
+		{name: "GCE provider", node: nodeWithProviderID("gce://project/zone/node"), want: "gke"},
+		{name: "GKE provider", node: nodeWithProviderID("gke://project/zone/node"), want: "gke"},
+		{name: "AWS provider", node: nodeWithProviderID("aws:///zone/node"), want: "eks"},
+		{name: "Azure provider", node: nodeWithProviderID("azure:///subscriptions/node"), want: "aks"},
+		{name: "kind provider", node: nodeWithProviderID("kind://docker/radar/control-plane"), want: "kind"},
+		{name: "GKE label", node: nodeWithLabels(map[string]string{"cloud.google.com/gke-nodepool": "default"}), want: "gke"},
+		{name: "EKS nodegroup label", node: nodeWithLabels(map[string]string{"eks.amazonaws.com/nodegroup": "workers"}), want: "eks"},
+		{name: "EKS capacity label", node: nodeWithLabels(map[string]string{"eks.amazonaws.com/capacityType": "ON_DEMAND"}), want: "eks"},
+		{name: "Azure label", node: nodeWithLabels(map[string]string{"kubernetes.azure.com/cluster": "prod"}), want: "aks"},
+		{name: "OpenShift label", node: nodeWithLabels(map[string]string{"node.openshift.io/os_id": "rhcos"}), want: "openshift"},
+		{name: "Rancher label", node: nodeWithLabels(map[string]string{"rke.cattle.io/machine": "worker"}), want: "rancher"},
+		{name: "kind node name", node: corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "kind-control-plane"}}, want: "kind"},
+		{name: "minikube node name", node: corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "minikube-m02"}}, want: "minikube"},
+		{name: "Docker Desktop node name", node: corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "docker-desktop"}}, want: "docker-desktop"},
+		{name: "unknown", node: corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectNodePlatform(tt.node); got != tt.want {
+				t.Fatalf("DetectNodePlatform() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectPlatformFromVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{version: "v1.31.7+rke2r1", want: "rke2"},
+		{version: "v1.31.7-rke2r1", want: "unknown"},
+		{version: "v1.31.7", want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := DetectPlatformFromVersion(tt.version); got != tt.want {
+			t.Errorf("DetectPlatformFromVersion(%q) = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestDetectClusterPlatform(t *testing.T) {
+	tests := []struct {
+		name   string
+		client kubernetes.Interface
+		want   string
+	}{
+		{name: "nil client", client: nil, want: "unknown"},
+		{name: "no nodes", client: fake.NewSimpleClientset(), want: "unknown"},
+		{name: "generic node", client: fake.NewSimpleClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}), want: "generic"},
+		{name: "RKE2 node", client: fake.NewSimpleClientset(nodePtr(nodeWithKubeletVersion("v1.31.7+rke2r1"))), want: "rke2"},
+		{name: "GKE Autopilot", client: fake.NewSimpleClientset(nodePtr(nodeWithSignals("", "gce://project/zone/node", map[string]string{"cloud.google.com/gke-autopilot": "true"}))), want: "gke-autopilot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetectClusterPlatform(context.Background(), tt.client)
+			if err != nil {
+				t.Fatalf("DetectClusterPlatform() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("DetectClusterPlatform() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func nodeWithKubeletVersion(version string) corev1.Node {
+	return nodeWithSignals(version, "", nil)
+}
+
+func nodeWithProviderID(providerID string) corev1.Node {
+	return nodeWithSignals("", providerID, nil)
+}
+
+func nodeWithLabels(labels map[string]string) corev1.Node {
+	return nodeWithSignals("", "", labels)
+}
+
+func nodeWithSignals(version, providerID string, labels map[string]string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1", Labels: labels},
+		Spec:       corev1.NodeSpec{ProviderID: providerID},
+		Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: version}},
+	}
+}
+
+func nodePtr(node corev1.Node) *corev1.Node {
+	return &node
+}

--- a/pkg/traffic/types.go
+++ b/pkg/traffic/types.go
@@ -148,8 +148,8 @@ type DetectionResult struct {
 
 // ClusterInfo contains cluster platform and CNI information.
 type ClusterInfo struct {
-	Platform    string `json:"platform"`    // gke, eks, aks, generic
-	CNI         string `json:"cni"`         // cilium, calico, flannel, vpc-cni, azure-cni, etc.
+	Platform    string `json:"platform"`    // rke2, gke, eks, aks, minikube, kind, docker-desktop, openshift, rancher, generic
+	CNI         string `json:"cni"`         // cilium, canal, calico, flannel, vpc-cni, azure-cni, gke-native, unknown
 	DataplaneV2 bool   `json:"dataplaneV2"` // GKE-specific: is Dataplane V2 enabled?
 	ClusterName string `json:"clusterName"` // Cluster name if available
 	K8sVersion  string `json:"k8sVersion"`  // Kubernetes version

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -90,6 +90,9 @@ function getPlatformInfo(platform: string): { name: string; icon: string | null 
   if (platformLower.includes('openshift')) {
     return { name: 'OpenShift', icon: null }
   }
+  if (platformLower.includes('rke2')) {
+    return { name: 'RKE2', icon: null }
+  }
   if (platformLower.includes('rancher')) {
     return { name: 'Rancher', icon: null }
   }


### PR DESCRIPTION
## Summary

- Report RKE2 when the kubelet or server GitVersion contains `+rke2r`, including node-restricted and zero-node fallback paths.
- Share sampled-node classification across cluster info and traffic detection while preserving existing provider, label, and node-name rules.
- Detect exact `rke2-canal` and `canal` DaemonSets ahead of Calico and Flannel, add Canal-specific Caretta guidance, and display the platform as `RKE2`.

## Testing

- `make tsc`
- `make test`
- `make build`
- Live regression smoke against the reachable nonprod GKE cluster: the cluster card still rendered GKE, traffic detection returned `gke` / `gke-native`, Caretta became the active source with no recommendation, live flows rendered, and the browser console had no errors.
- Live regression smoke against the existing kind cluster: a real `kind://docker/radar-c3/...` node ProviderID classified as `kind`; traffic detection preserved the existing unknown-CNI result and generic Caretta recommendation.
- Real RKE2/Canal live acceptance was not run because no RKE2 cluster is available in the current environment; the exact RKE2 version and Canal DaemonSet signals are covered by focused tests.

## Notes

- Available Caretta remains independent of platform and CNI detection and suppresses recommendations.
- Existing CNI probe permission behavior and non-Canal RKE2 CNI layouts are unchanged.

Closes #1426