### PR TITLE
chore(chart): replace stale chart version/appVersion with 0.0.0-dev placeholder

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -214,7 +214,7 @@ make release-binaries-dry
 2. Tag the release: `git tag v0.X.Y && git push origin v0.X.Y`
 3. Run release: `make release`
 
-The `helm` job in `.github/workflows/release.yml` rewrites the chart's `version` / `appVersion` / image-tag annotation to match the release tag and pushes the chart to `skyhook-io/helm-charts`. No manual chart edit is needed; in fact, hand-edited values in `deploy/helm/radar/Chart.yaml` will be overwritten. The job fails fast if `radar-<version>` is already tagged in helm-charts — bump the release version higher in that case.
+The `helm` job in `.github/workflows/release.yml` rewrites the chart's `version` / `appVersion` / image-tag annotation to match the release tag and pushes the chart to `skyhook-io/helm-charts`. No manual chart edit is needed; in fact, hand-edited values in `deploy/helm/radar/Chart.yaml` will be overwritten — which is why those fields sit at the `0.0.0-dev` placeholder on `main`. The job fails fast if `radar-<version>` is already tagged in helm-charts — bump the release version higher in that case.
 
 ## Code Style
 

--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,8 +2,13 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.7.1
-appVersion: "1.7.6"
+# version and appVersion are placeholders — the release workflow stamps both
+# (and the image tag annotation below) from the release tag at publish time,
+# so published chart versions always match their git tag. Do not bump these
+# manually. Installing straight from this checkout requires setting image.tag
+# to a published release, since no 0.0.0-dev image exists.
+version: 0.0.0-dev
+appVersion: "0.0.0-dev"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:
   - kubernetes
@@ -38,7 +43,7 @@ annotations:
       url: https://radarhq.io/community/chat
   artifacthub.io/images: |
     - name: radar
-      image: ghcr.io/skyhook-io/radar:1.7.6
+      image: ghcr.io/skyhook-io/radar:0.0.0-dev
   artifacthub.io/screenshots: |
     - title: Multi-cluster topology
       url: https://github.com/skyhook-io/radar/raw/main/docs/screenshots/topology-view.png

--- a/internal/helm/prepared_upgrade_test.go
+++ b/internal/helm/prepared_upgrade_test.go
@@ -256,6 +256,10 @@ func TestPrepareCloudUpgradePinsReleaseAndUpgradesToChartAppVersion(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The on-disk chart carries a 0.0.0-dev placeholder, which the stable-version
+	// eligibility check rightly rejects — pin a stable version like a real release.
+	targetChart.Metadata.Version = "1.7.0"
+	targetChart.Metadata.AppVersion = "1.7.2"
 	server := preparedChartServer(t, targetChart)
 	defer server.Close()
 	request := InstallRequest{
@@ -321,6 +325,8 @@ func TestResolvePreparedChartSummaryUsesVerifiedArchive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	loaded.Metadata.Version = "1.7.0"
+	loaded.Metadata.AppVersion = "1.7.2"
 	server := preparedChartServer(t, loaded)
 	defer server.Close()
 	client := &Client{}


### PR DESCRIPTION
## Summary

Fixes the confusing half of #1165: `deploy/helm/radar/Chart.yaml` on `main` carried stale but real-looking `version: 1.7.1` / `appVersion: "1.7.6"` values. Those fields are overwritten by the `helm` job in `release.yml` at publish time, so they never reflect what gets published — but a plausible number invites readers to treat it as the current chart version and pin it (exactly what happened in #1165).

## Changes

- `Chart.yaml`: `version` / `appVersion` / the `artifacthub.io/images` tag → `0.0.0-dev`, with a comment explaining that the release workflow stamps all three from the git tag.
- `DEVELOPMENT.md`: note the placeholder in the release-checklist paragraph that already documents the stamping.

## Notes

- `0.0.0-dev` is valid semver (bare `1.0` fails `helm lint`), unambiguously not a release, and sorts below every published version.
- Installing straight from a checkout without `image.tag` now fails fast on a nonexistent `0.0.0-dev` image instead of silently running an old 1.7.6 image; the Chart.yaml comment calls this out. In-repo consumers (CI lint/template/unittest, `scripts/test-chart.sh`) never pull images and are unaffected.

## Verification

- `helm lint` passes; `./scripts/test-chart.sh` passes.
- Simulated the release workflow's three `sed` stamps against the new file: all three fields stamp correctly and the comment block is untouched (the seds are line-anchored).
- `helm unittest` has 2 pre-existing service-annotation failures that reproduce identically on unmodified `main` — unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart metadata and docs only; release stamping behavior is unchanged and tests were updated to match the placeholder.
> 
> **Overview**
> Replaces **misleading** `1.7.1` / `1.7.6` values in `deploy/helm/radar/Chart.yaml` with **`0.0.0-dev` placeholders** for `version`, `appVersion`, and the Artifact Hub image tag, plus inline comments that the release workflow overwrites all three from the git tag.
> 
> **DEVELOPMENT.md** now explains that those fields stay at `0.0.0-dev` on `main` for that reason. **Helm upgrade tests** that load the real chart from disk pin stable metadata (`1.7.0` / `1.7.2`) so prepared-install stable-version checks still behave like a real release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba8ae9e7bac29c5cadd4f894f82486cf29aa414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->