### PR TITLE
fix(traffic): dial Hubble Relay directly before falling back to port-forward

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -221,7 +221,7 @@ Disabled by default for security:
 |---------|-------|-------------|
 | Secrets | `rbac.secrets: true` | View secrets in resource list |
 | Terminal | `rbac.podExec: true` | Shell access to pods |
-| Port Forward | `rbac.portForward: true` | Port forwarding to pods |
+| Port Forward | `rbac.portForward: true` | Port forwarding to pods. Also the fallback for traffic sources (Hubble/Caretta) — Radar dials the relay/metrics Service directly first, so in-cluster installs only need this when a NetworkPolicy or routing blocks Radar's namespace from reaching the service |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |
 | Helm Write | `rbac.helm: true` | Install/upgrade/rollback/uninstall Helm releases. Under auth or cloud-mode, also emits a split helm add-on ClusterRole — `radar-helm` (member-safe: CRDs, storage, namespaces) and `radar-helm-admin` (owner-only: RBAC, webhooks, ApiServices) |
 | RBAC view | `rbac.viewRBAC: true` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default — cache-served reads bypass per-user RBAC, so this exposes the cluster's authorization graph to every authenticated Radar user. Auto-enabled under auth or cloud mode (every read is re-checked per user there). |

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -98,7 +98,11 @@ rbac:
   # This is relatively safe - only reads logs, no write access
   podLogs: true
 
-  # Allow port forwarding (enables port forward feature)
+  # Allow port forwarding (enables port forward feature).
+  # Also the fallback path for traffic sources (Hubble/Caretta): Radar dials
+  # the metrics/relay Service directly first, so in-cluster installs normally
+  # don't need this — only enable it if network policy or routing blocks
+  # Radar's namespace from reaching the service directly.
   portForward: false
 
   # Allow Radar Cloud to trigger one-click in-app upgrades without customers

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -192,7 +192,7 @@ Some features require additional permissions. Most are disabled by default for s
 |---------|-------|---------|-------------|
 | Secrets | `rbac.secrets: true` | `false` | Show secrets in resource list |
 | Terminal | `rbac.podExec: true` | `false` | Shell access to pods |
-| Port Forward | `rbac.portForward: true` | `false` | Port forwarding to pods/services |
+| Port Forward | `rbac.portForward: true` | `false` | Port forwarding to pods/services. Also the traffic-source fallback (Hubble/Caretta): Radar dials the relay/metrics Service directly first, so this is only needed when a NetworkPolicy or routing blocks that direct path |
 | Logs | `rbac.podLogs: true` | `true` | View pod logs |
 | Helm Write | `rbac.helm: true` | `false` | Install/upgrade/rollback/uninstall Helm releases (grants broad write access; auto-enables secrets). When auth or cloud is on, also emits a split helm add-on: `radar-helm` (CRDs/storage/PDBs/namespaces, bound to owner+member) and `radar-helm-admin` (RBAC/webhooks/APIServices, owner-only) — see [authentication.md](authentication.md#cloud-mode-helm-bindings) |
 | RBAC view | `rbac.viewRBAC: true` | `false` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default: cache-served reads bypass per-user RBAC, so granting this exposes the cluster's authorization graph to every authenticated Radar user |

--- a/internal/traffic/beyla.go
+++ b/internal/traffic/beyla.go
@@ -126,6 +126,16 @@ func (s *BeylaSource) Connect(ctx context.Context, contextName string) (*portfor
 	return info, nil
 }
 
+// ConnectionInfo implements ConnectionReporter. Beyla's data path is the
+// shared Prometheus client, so its status is the only honest answer here.
+func (s *BeylaSource) ConnectionInfo() *portforward.ConnectionInfo {
+	client := promclient.GetClient()
+	if client == nil {
+		return &portforward.ConnectionInfo{Connected: false}
+	}
+	return connectionInfoFromPromStatus(client.GetStatus())
+}
+
 func (s *BeylaSource) Close() error { return nil }
 
 func (s *BeylaSource) Detect(ctx context.Context) (*DetectionResult, error) {

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -663,6 +663,34 @@ func (c *CarettaSource) revalidateBoundLocked(ctx context.Context, addr string) 
 	return true
 }
 
+// ConnectionInfo implements ConnectionReporter. A binding that rides a managed
+// forward defers to the live registry — a forward that has since died must not
+// read as connected — while direct in-cluster and manual-URL bindings report
+// the stored state their queries actually use.
+func (c *CarettaSource) ConnectionInfo() *portforward.ConnectionInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	addr := c.prometheusAddr
+	if addr == "" {
+		return &portforward.ConnectionInfo{Connected: false}
+	}
+	if c.metricsURL == "" && strings.HasPrefix(addr, "http://localhost:") {
+		// Bound through a managed forward (traffic's own, or a reused peer's) —
+		// alive only while the registry still holds that exact address.
+		if live := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, c.metricsNamespace, c.metricsService); live != addr {
+			return &portforward.ConnectionInfo{Connected: false}
+		}
+	}
+	return &portforward.ConnectionInfo{
+		Connected:   true,
+		Address:     addr,
+		Namespace:   c.metricsNamespace,
+		ServiceName: c.metricsService,
+		ContextName: c.currentContext,
+	}
+}
+
 // stopStaleTrafficForward drops the traffic-owned forward when it points at a
 // service other than the one being bound. A candidate refused mid-walk can leave
 // its forward running, which would make the reported connection name a different

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -91,6 +91,7 @@ type CarettaSource struct {
 	backendVerified     bool   // bound backend proved it holds Caretta metrics
 	boundIsCarettaStore bool   // bound backend is Caretta's own store, trusted on identity
 	backendWarning      string // why no backend could be bound, surfaced to the UI
+	closed              bool   // set by Close; a late Connect must not resurrect the source
 	mu                  sync.RWMutex
 }
 
@@ -885,6 +886,7 @@ func (c *CarettaSource) Close() error {
 	c.boundIsCarettaStore = false
 	c.backendVerified = false
 	c.backendWarning = ""
+	c.closed = true
 	return nil
 }
 
@@ -893,6 +895,16 @@ func (c *CarettaSource) Close() error {
 func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portforward.ConnectionInfo, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// A Connect that raced Close (context switch) must not resurrect the
+	// source — its forward would point at the previous cluster and outlive
+	// Reset's cleanup.
+	if c.closed {
+		return &portforward.ConnectionInfo{
+			Connected: false,
+			Error:     "traffic source closed (context switched)",
+		}, nil
+	}
 
 	// If already connected to the same context, check if still valid
 	if c.prometheusAddr != "" && c.currentContext == contextName {

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -324,10 +324,14 @@ func (h *HubbleSource) resolveTargetPort(ctx context.Context, svc *corev1.Servic
 
 const (
 	// directDialTimeout bounds the TCP reachability pre-check for the direct
-	// lane. Blackholed traffic (NetworkPolicy drop, off-cluster ClusterIP)
-	// costs exactly this much before the port-forward fallback starts;
-	// refused/unroutable fails in milliseconds.
-	directDialTimeout = 3 * time.Second
+	// lane. Blackholed traffic (NetworkPolicy drop, or a laptop dialing an
+	// unroutable ClusterIP — the usual local case) costs exactly this much on
+	// the first connect before the port-forward fallback starts, so it is
+	// deliberately tight: the pre-check is a single TCP handshake (one
+	// round-trip), which finishes well under a second on any network where it
+	// can succeed at all, including high-latency VPNs into the cluster.
+	// Refused/unroutable fails in milliseconds.
+	directDialTimeout = 1500 * time.Millisecond
 
 	// directConnectBudget bounds the full gRPC/TLS/SAN sequence against a
 	// TCP-reachable relay. Generous on purpose: once the endpoint answered TCP

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -57,7 +57,14 @@ type HubbleSource struct {
 	tlsConfig      *tls.Config
 	isConnected    bool
 	closed         bool // Set by Close; a late Connect must not resurrect the source
-	mu             sync.RWMutex
+
+	// Cached direct-lane reachability, probed off the request path (kicked at
+	// detection) so Connect's lane decision costs nothing inline. Keyed by the
+	// probed address: a stale entry for a different endpoint is a cache miss.
+	probedAddr     string
+	probeReachable bool
+
+	mu sync.RWMutex
 }
 
 // NewHubbleSource creates a new Hubble traffic source
@@ -140,7 +147,14 @@ func (h *HubbleSource) Detect(ctx context.Context) (*DetectionResult, error) {
 	h.clusterIP = relaySvc.Spec.ClusterIP
 	h.useTLS = useTLS
 	h.tlsConfig = tlsConfig
+	directAddr := h.directAddressLocked(relayNamespace)
 	h.mu.Unlock()
+
+	// Detection always precedes Connect in the UI flow, so probing here means
+	// the lane decision is already cached when the user connects — the common
+	// local case (unroutable ClusterIP) skips the direct lane without paying
+	// the pre-check timeout inline.
+	go h.probeDirectAsync(directAddr)
 
 	// Determine if this is GKE native Hubble
 	isNative := h.isNativeHubble(ctx)
@@ -403,7 +417,15 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	// normal per-step timeouts intact.
 	directAddr := h.directAddressLocked(namespace)
 	var directErr error
-	if tcpReachable(directAddr, directDialTimeout) {
+	if h.probedAddr == directAddr && !h.probeReachable {
+		// The background probe already found the address unreachable — the
+		// usual off-cluster case. Skip the lane without paying the pre-check
+		// timeout, and re-probe off the request path so a network change (a
+		// VPN coming up) can restore the direct lane on a later connect.
+		directErr = errDirectUnreachable
+		go h.probeDirectAsync(directAddr)
+	} else if tcpReachable(directAddr, directDialTimeout) {
+		h.probedAddr, h.probeReachable = directAddr, true
 		directCtx, cancelDirect := context.WithTimeout(ctx, directConnectBudget)
 		directErr = h.connectGRPCLocked(directCtx, directAddr)
 		cancelDirect()
@@ -415,6 +437,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 			return h.connectionInfoLocked(namespace, contextName), nil
 		}
 	} else {
+		h.probedAddr, h.probeReachable = directAddr, false
 		directErr = errDirectUnreachable
 	}
 	if err := ctx.Err(); err != nil {
@@ -491,6 +514,20 @@ func tcpReachable(addr string, timeout time.Duration) bool {
 	}
 	conn.Close()
 	return true
+}
+
+// probeDirectAsync measures TCP reachability of the direct relay address off
+// the request path and caches the outcome for Connect's lane decision. The
+// dial runs before taking the lock, so an in-flight Connect is never blocked.
+func (h *HubbleSource) probeDirectAsync(addr string) {
+	reachable := tcpReachable(addr, directDialTimeout)
+	h.mu.Lock()
+	h.probedAddr = addr
+	h.probeReachable = reachable
+	h.mu.Unlock()
+	if !reachable {
+		log.Printf("[hubble] Direct address %s unreachable (background probe); connects will use port-forward", addr)
+	}
 }
 
 // errDirectUnreachable marks a direct lane that failed at TCP reachability

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -467,11 +467,16 @@ func (h *HubbleSource) connectionInfoLocked(namespace, contextName string) *port
 // Service) deliberately stops at ".svc" so clusters with a custom cluster
 // domain still resolve it through their search domains.
 func (h *HubbleSource) directAddressLocked(namespace string) string {
-	port := fmt.Sprintf("%d", h.servicePort)
 	if h.clusterIP != "" && h.clusterIP != corev1.ClusterIPNone {
-		return net.JoinHostPort(h.clusterIP, port)
+		return net.JoinHostPort(h.clusterIP, fmt.Sprintf("%d", h.servicePort))
 	}
-	return net.JoinHostPort(fmt.Sprintf("%s.%s.svc", hubbleRelayService, namespace), port)
+	name := fmt.Sprintf("%s.%s.svc", hubbleRelayService, namespace)
+	if h.clusterIP == corev1.ClusterIPNone {
+		// Headless DNS resolves to pod IPs, which do no service-to-container
+		// port mapping — dial the container port.
+		return net.JoinHostPort(name, fmt.Sprintf("%d", h.relayPort))
+	}
+	return net.JoinHostPort(name, fmt.Sprintf("%d", h.servicePort))
 }
 
 // tcpReachable reports whether addr accepts a TCP connection within timeout.

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -61,8 +61,12 @@ type HubbleSource struct {
 	// Cached direct-lane reachability, probed off the request path (kicked at
 	// detection) so Connect's lane decision costs nothing inline. Keyed by the
 	// probed address: a stale entry for a different endpoint is a cache miss.
+	// Generations order concurrent writers so an older in-flight probe can't
+	// overwrite a newer verdict.
 	probedAddr     string
 	probeReachable bool
+	probeSeq       uint64 // last launched probe generation
+	probeApplied   uint64 // generation whose result is cached
 
 	mu sync.RWMutex
 }
@@ -414,41 +418,53 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 
 	// Direct lane. A raw TCP dial decides whether the address is reachable at
 	// all; only then does the full gRPC/TLS sequence run against it, with its
-	// normal per-step timeouts intact.
+	// normal per-step timeouts intact. A cached-unreachable verdict from the
+	// background probe skips the lane without paying the pre-check timeout —
+	// but only as a fast-path hint: if the fallback also fails, the lane is
+	// retried for real below.
 	directAddr := h.directAddressLocked(namespace)
 	var directErr error
-	if h.probedAddr == directAddr && !h.probeReachable {
-		// The background probe already found the address unreachable — the
-		// usual off-cluster case. Skip the lane without paying the pre-check
-		// timeout, and re-probe off the request path so a network change (a
-		// VPN coming up) can restore the direct lane on a later connect.
+	skippedDirect := h.probedAddr == directAddr && !h.probeReachable
+	if skippedDirect {
 		directErr = errDirectUnreachable
+		// Re-probe off the request path so a network change (a VPN coming up)
+		// can restore the direct lane on a later connect.
 		go h.probeDirectAsync(directAddr)
-	} else if tcpReachable(directAddr, directDialTimeout) {
-		h.probedAddr, h.probeReachable = directAddr, true
-		directCtx, cancelDirect := context.WithTimeout(ctx, directConnectBudget)
-		directErr = h.connectGRPCLocked(directCtx, directAddr)
-		cancelDirect()
-		if directErr == nil {
-			h.viaPortForward = false
-			h.localPort = 0
-			h.stopOwnStaleForwardLocked(namespace)
-			log.Printf("[hubble] Connected to Hubble Relay directly at %s", directAddr)
-			return h.connectionInfoLocked(namespace, contextName), nil
-		}
 	} else {
-		h.probedAddr, h.probeReachable = directAddr, false
-		directErr = errDirectUnreachable
+		directErr = h.tryDirectLocked(ctx, directAddr)
+		if directErr == nil {
+			return h.commitDirectLocked(directAddr, namespace, contextName), nil
+		}
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	log.Printf("[hubble] Direct connection to %s failed (%v); falling back to port-forward", directAddr, directErr)
 
+	// The cached verdict that skipped the direct lane may itself be stale (a
+	// probe that raced relay startup); once the fallback is dead too, paying
+	// the pre-check inline is free — try the lane for real before reporting
+	// failure. Covers every fallback failure, including a reused forward that
+	// turns out to be broken.
+	retryDirectAfterSkip := func() *portforward.ConnectionInfo {
+		if !skippedDirect || ctx.Err() != nil {
+			return nil
+		}
+		if retryErr := h.tryDirectLocked(ctx, directAddr); retryErr == nil {
+			return h.commitDirectLocked(directAddr, namespace, contextName)
+		} else {
+			directErr = retryErr
+		}
+		return nil
+	}
+
 	// Fallback lane: managed port-forward, which needs pods/portforward RBAC.
 	log.Printf("[hubble] Starting port-forward to %s/%s:%d", namespace, hubbleRelayService, h.relayPort)
 	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, namespace, hubbleRelayService, h.relayPort, contextName)
 	if err != nil {
+		if info := retryDirectAfterSkip(); info != nil {
+			return info, nil
+		}
 		return &portforward.ConnectionInfo{
 			Connected:   false,
 			Namespace:   namespace,
@@ -466,6 +482,9 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	if err := h.connectGRPCLocked(ctx, grpcAddr); err != nil {
 		portforward.Stop(portforward.OwnerTraffic)
 		h.localPort = 0
+		if info := retryDirectAfterSkip(); info != nil {
+			return info, nil
+		}
 		return &portforward.ConnectionInfo{
 			Connected: false,
 			Error:     fmt.Sprintf("Failed to connect to Hubble Relay via port-forward: %v (direct connection to %s also failed: %v)", err, directAddr, directErr),
@@ -473,6 +492,30 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	}
 	h.viaPortForward = true
 	return h.connectionInfoLocked(namespace, contextName), nil
+}
+
+// tryDirectLocked attempts the direct lane: TCP pre-check, then the full
+// gRPC/TLS sequence. Records the reachability observation either way. Caller
+// must hold h.mu.
+func (h *HubbleSource) tryDirectLocked(ctx context.Context, directAddr string) error {
+	if !tcpReachable(directAddr, directDialTimeout) {
+		h.recordProbeLocked(directAddr, false)
+		return errDirectUnreachable
+	}
+	h.recordProbeLocked(directAddr, true)
+	directCtx, cancel := context.WithTimeout(ctx, directConnectBudget)
+	defer cancel()
+	return h.connectGRPCLocked(directCtx, directAddr)
+}
+
+// commitDirectLocked finalizes a successful direct connection. Caller must
+// hold h.mu.
+func (h *HubbleSource) commitDirectLocked(directAddr, namespace, contextName string) *portforward.ConnectionInfo {
+	h.viaPortForward = false
+	h.localPort = 0
+	h.stopOwnStaleForwardLocked(namespace)
+	log.Printf("[hubble] Connected to Hubble Relay directly at %s", directAddr)
+	return h.connectionInfoLocked(namespace, contextName)
 }
 
 // connectionInfoLocked builds the ConnectionInfo for the live connection.
@@ -518,16 +561,43 @@ func tcpReachable(addr string, timeout time.Duration) bool {
 
 // probeDirectAsync measures TCP reachability of the direct relay address off
 // the request path and caches the outcome for Connect's lane decision. The
-// dial runs before taking the lock, so an in-flight Connect is never blocked.
+// dial runs before taking the lock, so an in-flight Connect is never blocked;
+// the generation check keeps a slow older probe from overwriting a newer
+// verdict (including Connect's own inline observations).
 func (h *HubbleSource) probeDirectAsync(addr string) {
-	reachable := tcpReachable(addr, directDialTimeout)
 	h.mu.Lock()
-	h.probedAddr = addr
-	h.probeReachable = reachable
+	h.probeSeq++
+	gen := h.probeSeq
 	h.mu.Unlock()
-	if !reachable {
+
+	reachable := tcpReachable(addr, directDialTimeout)
+
+	if h.applyProbeResult(gen, addr, reachable) && !reachable {
 		log.Printf("[hubble] Direct address %s unreachable (background probe); connects will use port-forward", addr)
 	}
+}
+
+// applyProbeResult commits a probe outcome unless a newer generation already
+// landed; reports whether the write was applied.
+func (h *HubbleSource) applyProbeResult(gen uint64, addr string, reachable bool) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if gen <= h.probeApplied {
+		return false
+	}
+	h.probeApplied = gen
+	h.probedAddr = addr
+	h.probeReachable = reachable
+	return true
+}
+
+// recordProbeLocked caches an inline reachability observation as the newest
+// verdict. Caller must hold h.mu.
+func (h *HubbleSource) recordProbeLocked(addr string, reachable bool) {
+	h.probeSeq++
+	h.probeApplied = h.probeSeq
+	h.probedAddr = addr
+	h.probeReachable = reachable
 }
 
 // errDirectUnreachable marks a direct lane that failed at TCP reachability
@@ -538,7 +608,7 @@ var errDirectUnreachable = errors.New("tcp dial failed (unreachable or blocked)"
 // composeConnectError reports both failed lanes so the user sees the whole
 // picture; an RBAC-denied port-forward additionally names the real fixes.
 func composeConnectError(directAddr string, directErr, pfErr error) string {
-	msg := fmt.Sprintf("direct connection to %s failed (%v); port-forward fallback failed: %v", directAddr, directErr, pfErr)
+	msg := fmt.Sprintf("direct connection to %s (%s) failed (%v); port-forward fallback failed: %v", hubbleRelayService, directAddr, directErr, pfErr)
 	if isForbiddenPortForward(pfErr) {
 		msg += " — grant Radar port-forward permission (Helm: rbac.portForward=true)"
 		if errors.Is(directErr, errDirectUnreachable) {

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -44,11 +45,14 @@ type HubbleSource struct {
 	k8sClient      kubernetes.Interface
 	grpcConn       *grpc.ClientConn
 	observerClient observerpb.ObserverClient
-	localPort      int    // Port-forward local port
+	localPort      int    // Port-forward local port (0 when connected directly)
 	currentContext string // K8s context for port-forward validation
 	relayNamespace string // Discovered namespace where hubble-relay lives
 	relayPort      int    // Hubble relay container port (for port-forward)
-	servicePort    int    // Hubble relay service port (443 hints TLS, 80 hints plaintext)
+	servicePort    int    // Hubble relay service port (direct dial; 443 hints TLS)
+	clusterIP      string // Hubble relay service ClusterIP (direct dial)
+	connectedAddr  string // Address of the live gRPC connection
+	viaPortForward bool   // Connection rides the traffic-owned port-forward
 	useTLS         bool   // Whether TLS certs are available
 	tlsConfig      *tls.Config
 	isConnected    bool
@@ -132,6 +136,7 @@ func (h *HubbleSource) Detect(ctx context.Context) (*DetectionResult, error) {
 	h.relayNamespace = relayNamespace
 	h.relayPort = h.resolveTargetPort(ctx, relaySvc)
 	h.servicePort = servicePort
+	h.clusterIP = relaySvc.Spec.ClusterIP
 	h.useTLS = useTLS
 	h.tlsConfig = tlsConfig
 	h.mu.Unlock()
@@ -209,7 +214,7 @@ func (h *HubbleSource) loadTLSConfig(ctx context.Context, namespace string) (*tl
 // discoverTLSServerName probes the server certificate to discover the correct TLS ServerName.
 // This handles environments like AKS where the Hubble Relay cert has a different SAN
 // (e.g., *.hubble-relay.cilium.io) than the default k8s service DNS name.
-func (h *HubbleSource) discoverTLSServerName(address string) (string, error) {
+func (h *HubbleSource) discoverTLSServerName(ctx context.Context, address string) (string, error) {
 	probeCfg := &tls.Config{
 		InsecureSkipVerify: true,
 	}
@@ -218,11 +223,13 @@ func (h *HubbleSource) discoverTLSServerName(address string) (string, error) {
 		probeCfg.Certificates = h.tlsConfig.Certificates
 	}
 
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 3 * time.Second}, "tcp", address, probeCfg)
+	dialer := &tls.Dialer{NetDialer: &net.Dialer{Timeout: 3 * time.Second}, Config: probeCfg}
+	rawConn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return "", fmt.Errorf("failed to probe server certificate: %w", err)
 	}
-	defer conn.Close()
+	defer rawConn.Close()
+	conn := rawConn.(*tls.Conn)
 
 	certs := conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
@@ -314,7 +321,24 @@ func (h *HubbleSource) resolveTargetPort(ctx context.Context, svc *corev1.Servic
 	return 80
 }
 
-// Connect establishes connection to Hubble Relay via port-forward and gRPC
+const (
+	// directDialTimeout bounds the TCP reachability pre-check for the direct
+	// lane. Blackholed traffic (NetworkPolicy drop, off-cluster ClusterIP)
+	// costs exactly this much before the port-forward fallback starts;
+	// refused/unroutable fails in milliseconds.
+	directDialTimeout = 3 * time.Second
+
+	// directConnectBudget bounds the full gRPC/TLS/SAN sequence against a
+	// TCP-reachable relay. Generous on purpose: once the endpoint answered TCP
+	// it deserves the sequence's normal per-step timeouts (plaintext test +
+	// TLS + SAN probe + TLS retry are up to ~3s each).
+	directConnectBudget = 15 * time.Second
+)
+
+// Connect establishes a gRPC connection to Hubble Relay. The relay Service is
+// dialed directly first — in-cluster (or on a network that routes ClusterIPs)
+// that path needs no pods/portforward RBAC — with a managed port-forward as
+// the fallback when the direct address is unreachable.
 func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portforward.ConnectionInfo, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -328,14 +352,12 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	if h.grpcConn != nil && h.currentContext == contextName {
 		// Test the connection
 		if h.testConnection(ctx) {
-			return &portforward.ConnectionInfo{
-				Connected:   true,
-				LocalPort:   h.localPort,
-				Address:     fmt.Sprintf("localhost:%d", h.localPort),
-				Namespace:   namespace,
-				ServiceName: hubbleRelayService,
-				ContextName: contextName,
-			}, nil
+			if !h.viaPortForward {
+				// Direct mode uses no forward, so any traffic-owned one (left by
+				// a source switch while we stayed connected) is stale.
+				portforward.Stop(portforward.OwnerTraffic)
+			}
+			return h.connectionInfoLocked(namespace, contextName), nil
 		}
 		// Connection lost, clean up
 		h.closeConnectionLocked()
@@ -347,8 +369,10 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 		h.currentContext = contextName
 	}
 
-	// Get the relay port from detection if not already set
-	if h.relayPort == 0 {
+	// Resolve ports from the Service if detection hasn't already. Fills both the
+	// service port (direct dial) and the container port (port-forward bypasses
+	// the Service) — they routinely differ (e.g. 80 -> 4245).
+	if h.servicePort == 0 || h.relayPort == 0 {
 		relaySvc, err := h.k8sClient.CoreV1().Services(namespace).Get(ctx, hubbleRelayService, metav1.GetOptions{})
 		if err != nil {
 			return &portforward.ConnectionInfo{
@@ -356,10 +380,41 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 				Error:     fmt.Sprintf("Hubble Relay service not found in %s: %v", namespace, err),
 			}, nil
 		}
+		if len(relaySvc.Spec.Ports) > 0 {
+			h.servicePort = int(relaySvc.Spec.Ports[0].Port)
+		}
 		h.relayPort = h.resolveTargetPort(ctx, relaySvc)
+		h.clusterIP = relaySvc.Spec.ClusterIP
 	}
 
-	// Start port-forward to Hubble Relay
+	// Direct lane. A raw TCP dial decides whether the address is reachable at
+	// all; only then does the full gRPC/TLS sequence run against it, with its
+	// normal per-step timeouts intact.
+	directAddr := h.directAddressLocked(namespace)
+	var directErr error
+	if tcpReachable(directAddr, directDialTimeout) {
+		directCtx, cancelDirect := context.WithTimeout(ctx, directConnectBudget)
+		directErr = h.connectGRPCLocked(directCtx, directAddr)
+		cancelDirect()
+		if directErr == nil {
+			h.viaPortForward = false
+			h.localPort = 0
+			// A leftover traffic-owned forward (a previous source's, or our own
+			// from an earlier connect) is no longer the data path; keeping it
+			// would make the reported connection name something we aren't using.
+			portforward.Stop(portforward.OwnerTraffic)
+			log.Printf("[hubble] Connected to Hubble Relay directly at %s", directAddr)
+			return h.connectionInfoLocked(namespace, contextName), nil
+		}
+	} else {
+		directErr = errDirectUnreachable
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	log.Printf("[hubble] Direct connection to %s failed (%v); falling back to port-forward", directAddr, directErr)
+
+	// Fallback lane: managed port-forward, which needs pods/portforward RBAC.
 	log.Printf("[hubble] Starting port-forward to %s/%s:%d", namespace, hubbleRelayService, h.relayPort)
 	connInfo, err := portforward.Start(portforward.OwnerTraffic, ctx, namespace, hubbleRelayService, h.relayPort, contextName)
 	if err != nil {
@@ -367,7 +422,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 			Connected:   false,
 			Namespace:   namespace,
 			ServiceName: hubbleRelayService,
-			Error:       fmt.Sprintf("Failed to start port-forward: %v", err),
+			Error:       composeConnectError(directAddr, directErr, err),
 		}, nil
 	}
 
@@ -377,7 +432,115 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 
 	h.localPort = connInfo.LocalPort
 	grpcAddr := fmt.Sprintf("localhost:%d", h.localPort)
+	if err := h.connectGRPCLocked(ctx, grpcAddr); err != nil {
+		portforward.Stop(portforward.OwnerTraffic)
+		h.localPort = 0
+		return &portforward.ConnectionInfo{
+			Connected: false,
+			Error:     fmt.Sprintf("Failed to connect to Hubble Relay via port-forward: %v (direct connection to %s also failed: %v)", err, directAddr, directErr),
+		}, nil
+	}
+	h.viaPortForward = true
+	return h.connectionInfoLocked(namespace, contextName), nil
+}
 
+// connectionInfoLocked builds the ConnectionInfo for the live connection.
+// Caller must hold h.mu (read or write).
+func (h *HubbleSource) connectionInfoLocked(namespace, contextName string) *portforward.ConnectionInfo {
+	return &portforward.ConnectionInfo{
+		Connected:   true,
+		LocalPort:   h.localPort,
+		Address:     h.connectedAddr,
+		Namespace:   namespace,
+		ServiceName: hubbleRelayService,
+		ContextName: contextName,
+	}
+}
+
+// directAddressLocked builds the relay Service address for a direct dial.
+// ClusterIP is preferred — dialing an IP can't wedge in the resolver the way
+// unresolvable cluster DNS names can off-cluster. The DNS fallback (headless
+// Service) deliberately stops at ".svc" so clusters with a custom cluster
+// domain still resolve it through their search domains.
+func (h *HubbleSource) directAddressLocked(namespace string) string {
+	port := fmt.Sprintf("%d", h.servicePort)
+	if h.clusterIP != "" && h.clusterIP != corev1.ClusterIPNone {
+		return net.JoinHostPort(h.clusterIP, port)
+	}
+	return net.JoinHostPort(fmt.Sprintf("%s.%s.svc", hubbleRelayService, namespace), port)
+}
+
+// tcpReachable reports whether addr accepts a TCP connection within timeout.
+func tcpReachable(addr string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// errDirectUnreachable marks a direct lane that failed at TCP reachability
+// (as opposed to reaching the relay but failing TLS/gRPC) — only that failure
+// mode makes "open the network path" valid remediation.
+var errDirectUnreachable = errors.New("tcp dial failed (unreachable or blocked)")
+
+// composeConnectError reports both failed lanes so the user sees the whole
+// picture; an RBAC-denied port-forward additionally names the real fixes.
+func composeConnectError(directAddr string, directErr, pfErr error) string {
+	msg := fmt.Sprintf("direct connection to %s failed (%v); port-forward fallback failed: %v", directAddr, directErr, pfErr)
+	if isForbiddenPortForward(pfErr) {
+		msg += " — grant Radar port-forward permission (Helm: rbac.portForward=true)"
+		if errors.Is(directErr, errDirectUnreachable) {
+			msg += ", or allow network traffic from Radar's namespace to hubble-relay so the direct connection works"
+		}
+	}
+	return msg
+}
+
+func isForbiddenPortForward(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "is forbidden") && strings.Contains(s, "portforward")
+}
+
+// ConnectionInfo implements ConnectionReporter. In direct mode the stored
+// state is authoritative; in port-forward mode the live registry decides —
+// but only a forward that still targets hubble-relay in our context counts: a
+// dead forward, or one replaced by another source, must not read as connected.
+func (h *HubbleSource) ConnectionInfo() *portforward.ConnectionInfo {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if !h.isConnected {
+		return &portforward.ConnectionInfo{Connected: false}
+	}
+	namespace := h.relayNamespace
+	if namespace == "" {
+		namespace = "kube-system"
+	}
+	if h.viaPortForward {
+		pf := portforward.GetConnectionInfo(portforward.OwnerTraffic)
+		if !forwardMatches(pf, namespace, hubbleRelayService, h.currentContext) {
+			return &portforward.ConnectionInfo{Connected: false}
+		}
+		return pf
+	}
+	return h.connectionInfoLocked(namespace, h.currentContext)
+}
+
+// forwardMatches reports whether a registry forward is live and targets the
+// given service in the given context.
+func forwardMatches(pf *portforward.ConnectionInfo, namespace, serviceName, contextName string) bool {
+	return pf != nil && pf.Connected &&
+		pf.Namespace == namespace && pf.ServiceName == serviceName && pf.ContextName == contextName
+}
+
+// connectGRPCLocked runs the plaintext/TLS/SAN-discovery connection sequence
+// against grpcAddr and commits the connection state on success. Caller must
+// hold h.mu.
+func (h *HubbleSource) connectGRPCLocked(ctx context.Context, grpcAddr string) error {
 	// Use service port as heuristic: port 443 suggests TLS, otherwise try plaintext first
 	// This avoids unnecessary latency from failed connection attempts
 	tryTLSFirst := h.servicePort == 443 && h.tlsConfig != nil
@@ -445,7 +608,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 
 		// TLS may have failed due to ServerName mismatch (e.g., AKS cert uses *.hubble-relay.cilium.io).
 		// Probe the server certificate to discover the correct ServerName.
-		discoveredName, err := h.discoverTLSServerName(grpcAddr)
+		discoveredName, err := h.discoverTLSServerName(ctx, grpcAddr)
 		if err != nil {
 			log.Printf("[hubble] Could not discover server name: %v", err)
 			lastErr = fmt.Errorf("TLS gRPC connection test failed")
@@ -475,23 +638,13 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	}
 
 	if connected {
-		return &portforward.ConnectionInfo{
-			Connected:   true,
-			LocalPort:   h.localPort,
-			Address:     grpcAddr,
-			Namespace:   namespace,
-			ServiceName: hubbleRelayService,
-			ContextName: contextName,
-		}, nil
+		h.connectedAddr = grpcAddr
+		return nil
 	}
-
-	// Both attempts failed
-	portforward.Stop(portforward.OwnerTraffic)
-	h.localPort = 0
-	return &portforward.ConnectionInfo{
-		Connected: false,
-		Error:     fmt.Sprintf("Failed to connect to Hubble Relay: %v", lastErr),
-	}, nil
+	if lastErr == nil {
+		lastErr = fmt.Errorf("connection failed")
+	}
+	return lastErr
 }
 
 // testConnection tests the gRPC connection by calling ServerStatus
@@ -520,6 +673,8 @@ func (h *HubbleSource) closeConnectionLocked() {
 	h.observerClient = nil
 	h.isConnected = false
 	h.localPort = 0
+	h.connectedAddr = ""
+	h.viaPortForward = false
 }
 
 // GetFlows retrieves flows from Hubble via gRPC

--- a/internal/traffic/hubble.go
+++ b/internal/traffic/hubble.go
@@ -56,6 +56,7 @@ type HubbleSource struct {
 	useTLS         bool   // Whether TLS certs are available
 	tlsConfig      *tls.Config
 	isConnected    bool
+	closed         bool // Set by Close; a late Connect must not resurrect the source
 	mu             sync.RWMutex
 }
 
@@ -343,6 +344,16 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	// A Connect that raced Close (context switch) must not resurrect the
+	// source — its forward would point at the previous cluster and outlive
+	// Reset's cleanup.
+	if h.closed {
+		return &portforward.ConnectionInfo{
+			Connected: false,
+			Error:     "traffic source closed (context switched)",
+		}, nil
+	}
+
 	namespace := h.relayNamespace
 	if namespace == "" {
 		namespace = "kube-system" // fallback
@@ -352,11 +363,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 	if h.grpcConn != nil && h.currentContext == contextName {
 		// Test the connection
 		if h.testConnection(ctx) {
-			if !h.viaPortForward {
-				// Direct mode uses no forward, so any traffic-owned one (left by
-				// a source switch while we stayed connected) is stale.
-				portforward.Stop(portforward.OwnerTraffic)
-			}
+			h.stopOwnStaleForwardLocked(namespace)
 			return h.connectionInfoLocked(namespace, contextName), nil
 		}
 		// Connection lost, clean up
@@ -399,10 +406,7 @@ func (h *HubbleSource) Connect(ctx context.Context, contextName string) (*portfo
 		if directErr == nil {
 			h.viaPortForward = false
 			h.localPort = 0
-			// A leftover traffic-owned forward (a previous source's, or our own
-			// from an earlier connect) is no longer the data path; keeping it
-			// would make the reported connection name something we aren't using.
-			portforward.Stop(portforward.OwnerTraffic)
+			h.stopOwnStaleForwardLocked(namespace)
 			log.Printf("[hubble] Connected to Hubble Relay directly at %s", directAddr)
 			return h.connectionInfoLocked(namespace, contextName), nil
 		}
@@ -535,6 +539,22 @@ func (h *HubbleSource) ConnectionInfo() *portforward.ConnectionInfo {
 func forwardMatches(pf *portforward.ConnectionInfo, namespace, serviceName, contextName string) bool {
 	return pf != nil && pf.Connected &&
 		pf.Namespace == namespace && pf.ServiceName == serviceName && pf.ContextName == contextName
+}
+
+// stopOwnStaleForwardLocked drops a traffic-owned forward left from our own
+// earlier port-forward connect once the direct connection is the data path.
+// Deliberately scoped to forwards targeting hubble-relay in our context: a
+// stale Connect can race a source switch, and an unconditional Stop here
+// would kill the forward the newly active source just established. Caller
+// must hold h.mu.
+func (h *HubbleSource) stopOwnStaleForwardLocked(namespace string) {
+	if h.viaPortForward {
+		return
+	}
+	pf := portforward.GetConnectionInfo(portforward.OwnerTraffic)
+	if forwardMatches(pf, namespace, hubbleRelayService, h.currentContext) {
+		portforward.Stop(portforward.OwnerTraffic)
+	}
 }
 
 // connectGRPCLocked runs the plaintext/TLS/SAN-discovery connection sequence
@@ -1018,6 +1038,7 @@ func (h *HubbleSource) Close() error {
 	h.closeConnectionLocked()
 	h.currentContext = ""
 	h.relayNamespace = ""
+	h.closed = true
 	return nil
 }
 

--- a/internal/traffic/hubble_test.go
+++ b/internal/traffic/hubble_test.go
@@ -189,7 +189,7 @@ func TestComposeConnectErrorForbiddenRemediation(t *testing.T) {
 	}
 }
 
-func TestConnectSkipsDirectLaneOnCachedUnreachable(t *testing.T) {
+func TestStaleUnreachableCacheHealsViaDirectRetry(t *testing.T) {
 	port := startStubRelay(t, nil)
 	client := fake.NewSimpleClientset(relayService(port, intstr.FromInt(4245)))
 
@@ -198,8 +198,10 @@ func TestConnectSkipsDirectLaneOnCachedUnreachable(t *testing.T) {
 	h.servicePort = port
 	h.relayPort = 4245
 	h.clusterIP = "127.0.0.1"
-	// Cached probe verdict: unreachable — even though the stub actually
-	// answers. Connect must trust the cache and skip the direct lane.
+	// Stale cached verdict: unreachable, though the relay actually answers —
+	// e.g. a background probe that raced relay startup. The port-forward
+	// fallback is dead here too (no K8s clients wired), so Connect must
+	// retry the direct lane for real instead of failing on the stale cache.
 	h.probedAddr = fmt.Sprintf("127.0.0.1:%d", port)
 	h.probeReachable = false
 
@@ -207,26 +209,50 @@ func TestConnectSkipsDirectLaneOnCachedUnreachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
-	if info.Connected {
-		t.Fatal("expected direct lane to be skipped on cached-unreachable")
+	if !info.Connected {
+		t.Fatalf("stale cache should not defeat a reachable relay: %s", info.Error)
 	}
-	if !strings.Contains(info.Error, "direct connection to") {
-		t.Errorf("error %q should report the skipped direct lane", info.Error)
+	if info.LocalPort != 0 {
+		t.Errorf("LocalPort = %d, want 0 (direct mode)", info.LocalPort)
+	}
+	h.mu.RLock()
+	healed := h.probeReachable
+	h.mu.RUnlock()
+	if !healed {
+		t.Error("successful retry should refresh the cached verdict")
+	}
+}
+
+func TestProbeGenerationsKeepNewestVerdict(t *testing.T) {
+	h := NewHubbleSource(fake.NewSimpleClientset())
+
+	// A probe launches, then an inline observation lands first as a newer
+	// generation: the probe's late write must be refused.
+	h.mu.Lock()
+	h.probeSeq++
+	earlyGen := h.probeSeq
+	h.recordProbeLocked("10.0.0.1:80", true)
+	h.mu.Unlock()
+
+	if h.applyProbeResult(earlyGen, "10.0.0.1:80", false) {
+		t.Error("stale probe generation was applied over a newer verdict")
+	}
+	h.mu.RLock()
+	reachable := h.probeReachable
+	h.mu.RUnlock()
+	if !reachable {
+		t.Error("older probe overwrote a newer inline verdict")
 	}
 
-	// The skip fires a background re-probe; against the live stub it must
-	// flip the cache so a later connect can use the direct lane again.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		h.mu.RLock()
-		flipped := h.probeReachable
-		h.mu.RUnlock()
-		if flipped {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	// A probe launched after the inline observation is newer information and
+	// must win.
+	h.mu.Lock()
+	h.probeSeq++
+	lateGen := h.probeSeq
+	h.mu.Unlock()
+	if !h.applyProbeResult(lateGen, "10.0.0.1:80", false) {
+		t.Error("newer probe generation was refused")
 	}
-	t.Error("background re-probe did not refresh the cached verdict")
 }
 
 func TestDetectKicksBackgroundProbe(t *testing.T) {

--- a/internal/traffic/hubble_test.go
+++ b/internal/traffic/hubble_test.go
@@ -189,6 +189,83 @@ func TestComposeConnectErrorForbiddenRemediation(t *testing.T) {
 	}
 }
 
+func TestConnectSkipsDirectLaneOnCachedUnreachable(t *testing.T) {
+	port := startStubRelay(t, nil)
+	client := fake.NewSimpleClientset(relayService(port, intstr.FromInt(4245)))
+
+	h := NewHubbleSource(client)
+	h.relayNamespace = "kube-system"
+	h.servicePort = port
+	h.relayPort = 4245
+	h.clusterIP = "127.0.0.1"
+	// Cached probe verdict: unreachable — even though the stub actually
+	// answers. Connect must trust the cache and skip the direct lane.
+	h.probedAddr = fmt.Sprintf("127.0.0.1:%d", port)
+	h.probeReachable = false
+
+	info, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if info.Connected {
+		t.Fatal("expected direct lane to be skipped on cached-unreachable")
+	}
+	if !strings.Contains(info.Error, "direct connection to") {
+		t.Errorf("error %q should report the skipped direct lane", info.Error)
+	}
+
+	// The skip fires a background re-probe; against the live stub it must
+	// flip the cache so a later connect can use the direct lane again.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.RLock()
+		flipped := h.probeReachable
+		h.mu.RUnlock()
+		if flipped {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Error("background re-probe did not refresh the cached verdict")
+}
+
+func TestDetectKicksBackgroundProbe(t *testing.T) {
+	port := startStubRelay(t, nil)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hubble-relay-abc", Namespace: "kube-system",
+			Labels: map[string]string{"k8s-app": "hubble-relay"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	client := fake.NewSimpleClientset(pod, relayService(port, intstr.FromInt(4245)))
+
+	h := NewHubbleSource(client)
+	result, err := h.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !result.Available {
+		t.Fatalf("expected detection, got: %s", result.Message)
+	}
+
+	wantAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.RLock()
+		addr, reachable := h.probedAddr, h.probeReachable
+		h.mu.RUnlock()
+		if addr == wantAddr {
+			if !reachable {
+				t.Errorf("probe of live stub reported unreachable")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Error("Detect did not populate the background probe cache")
+}
+
 func TestConnectRefusedAfterClose(t *testing.T) {
 	h := NewHubbleSource(fake.NewSimpleClientset())
 	h.relayNamespace = "kube-system"

--- a/internal/traffic/hubble_test.go
+++ b/internal/traffic/hubble_test.go
@@ -189,6 +189,33 @@ func TestComposeConnectErrorForbiddenRemediation(t *testing.T) {
 	}
 }
 
+func TestConnectRefusedAfterClose(t *testing.T) {
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	h.relayNamespace = "kube-system"
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	info, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if info.Connected || !strings.Contains(info.Error, "closed") {
+		t.Errorf("closed source Connect = {connected:%v err:%q}, want refusal", info.Connected, info.Error)
+	}
+
+	c := &CarettaSource{}
+	if err := c.Close(); err != nil {
+		t.Fatalf("caretta Close: %v", err)
+	}
+	cInfo, err := c.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("caretta Connect: %v", err)
+	}
+	if cInfo.Connected || !strings.Contains(cInfo.Error, "closed") {
+		t.Errorf("closed caretta Connect = {connected:%v err:%q}, want refusal", cInfo.Connected, cInfo.Error)
+	}
+}
+
 func TestForwardMatches(t *testing.T) {
 	live := &portforward.ConnectionInfo{
 		Connected: true, Namespace: "kube-system", ServiceName: hubbleRelayService, ContextName: "ctx-a",

--- a/internal/traffic/hubble_test.go
+++ b/internal/traffic/hubble_test.go
@@ -349,8 +349,10 @@ func TestDirectAddress(t *testing.T) {
 		t.Errorf("clusterIP address = %q", got)
 	}
 
-	headless := &HubbleSource{servicePort: 443, clusterIP: corev1.ClusterIPNone}
-	if got := headless.directAddressLocked("cilium"); got != "hubble-relay.cilium.svc:443" {
+	// Headless DNS resolves to pod IPs — the container port is the only one
+	// that answers there.
+	headless := &HubbleSource{servicePort: 443, relayPort: 4245, clusterIP: corev1.ClusterIPNone}
+	if got := headless.directAddressLocked("cilium"); got != "hubble-relay.cilium.svc:4245" {
 		t.Errorf("headless address = %q", got)
 	}
 }

--- a/internal/traffic/hubble_test.go
+++ b/internal/traffic/hubble_test.go
@@ -1,0 +1,372 @@
+package traffic
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/internal/portforward"
+)
+
+type stubObserver struct {
+	observerpb.UnimplementedObserverServer
+}
+
+func (s *stubObserver) ServerStatus(ctx context.Context, req *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
+	return &observerpb.ServerStatusResponse{}, nil
+}
+
+// startStubRelay serves a minimal Hubble observer on 127.0.0.1 and returns its
+// port. Pass nil creds for plaintext.
+func startStubRelay(t *testing.T, creds credentials.TransportCredentials) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	var opts []grpc.ServerOption
+	if creds != nil {
+		opts = append(opts, grpc.Creds(creds))
+	}
+	srv := grpc.NewServer(opts...)
+	observerpb.RegisterObserverServer(srv, &stubObserver{})
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	return lis.Addr().(*net.TCPAddr).Port
+}
+
+func relayService(port int, targetPort intstr.IntOrString) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: hubbleRelayService, Namespace: "kube-system"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Ports:     []corev1.ServicePort{{Port: int32(port), TargetPort: targetPort}},
+		},
+	}
+}
+
+func TestConnectDirectPlaintext(t *testing.T) {
+	port := startStubRelay(t, nil)
+	client := fake.NewSimpleClientset(relayService(port, intstr.FromInt(4245)))
+
+	h := NewHubbleSource(client)
+	h.relayNamespace = "kube-system"
+
+	info, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !info.Connected {
+		t.Fatalf("expected connected, got error: %s", info.Error)
+	}
+	wantAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	if info.Address != wantAddr {
+		t.Errorf("Address = %q, want %q", info.Address, wantAddr)
+	}
+	if info.LocalPort != 0 {
+		t.Errorf("LocalPort = %d, want 0 (no port-forward in direct mode)", info.LocalPort)
+	}
+	if pf := portforward.GetConnectionInfo(portforward.OwnerTraffic); pf.Connected {
+		t.Error("direct connect must not involve the port-forward registry")
+	}
+
+	// The lazy Service fetch must fill both ports, not just the container port.
+	if h.servicePort != port {
+		t.Errorf("servicePort = %d, want %d", h.servicePort, port)
+	}
+	if h.relayPort != 4245 {
+		t.Errorf("relayPort = %d, want 4245", h.relayPort)
+	}
+
+	// Repeat Connect reuses the live connection and reports the real address,
+	// not a reconstructed localhost:0.
+	info2, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("repeat Connect: %v", err)
+	}
+	if !info2.Connected || info2.Address != wantAddr {
+		t.Errorf("repeat Connect = {connected:%v addr:%q}, want {true %q}", info2.Connected, info2.Address, wantAddr)
+	}
+
+	// Reporter: direct mode is authoritative from stored state.
+	ci := h.ConnectionInfo()
+	if !ci.Connected || ci.Address != wantAddr {
+		t.Errorf("ConnectionInfo = {connected:%v addr:%q}, want {true %q}", ci.Connected, ci.Address, wantAddr)
+	}
+}
+
+func TestConnectDirectTLSWithSANDiscovery(t *testing.T) {
+	cert, pool := selfSignedCert(t, "relay.test.example")
+	port := startStubRelay(t, credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{cert}}))
+	client := fake.NewSimpleClientset(relayService(port, intstr.FromInt(4245)))
+
+	h := NewHubbleSource(client)
+	h.relayNamespace = "kube-system"
+	h.useTLS = true
+	// Deliberately wrong ServerName: SAN discovery must find the real one.
+	h.tlsConfig = &tls.Config{
+		RootCAs:    pool,
+		ServerName: "hubble-relay.kube-system.svc.cluster.local",
+		MinVersion: tls.VersionTLS12,
+	}
+
+	info, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !info.Connected {
+		t.Fatalf("expected TLS connect via SAN discovery, got error: %s", info.Error)
+	}
+	if info.LocalPort != 0 {
+		t.Errorf("LocalPort = %d, want 0 (direct mode)", info.LocalPort)
+	}
+}
+
+func TestConnectBothLanesFailReportsBoth(t *testing.T) {
+	closedPort := reserveClosedPort(t)
+	client := fake.NewSimpleClientset(relayService(closedPort, intstr.FromInt(4245)))
+
+	h := NewHubbleSource(client)
+	h.relayNamespace = "kube-system"
+
+	info, err := h.Connect(context.Background(), "test-ctx")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if info.Connected {
+		t.Fatal("expected failure")
+	}
+	for _, want := range []string{"direct connection to", "port-forward fallback failed"} {
+		if !strings.Contains(info.Error, want) {
+			t.Errorf("error %q missing %q", info.Error, want)
+		}
+	}
+}
+
+func TestComposeConnectErrorForbiddenRemediation(t *testing.T) {
+	forbidden := errors.New(`port-forward failed: error upgrading connection: pods "hubble-relay-x" is forbidden: User "system:serviceaccount:radar:radar" cannot create resource "pods/portforward" in API group "" in the namespace "kube-system"`)
+
+	// Unreachable direct lane + forbidden forward: both remediations apply.
+	msg := composeConnectError("10.0.0.1:80", errDirectUnreachable, forbidden)
+	for _, want := range []string{"rbac.portForward=true", "allow network traffic"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("forbidden error %q missing remediation %q", msg, want)
+		}
+	}
+
+	// Direct lane reached the relay but failed TLS: opening the network path
+	// would fix nothing, so only the RBAC remediation applies.
+	tlsFailed := composeConnectError("10.0.0.1:80", errors.New("TLS gRPC connection test failed"), forbidden)
+	if !strings.Contains(tlsFailed, "rbac.portForward=true") {
+		t.Errorf("forbidden error %q missing RBAC remediation", tlsFailed)
+	}
+	if strings.Contains(tlsFailed, "allow network traffic") {
+		t.Errorf("TLS failure should not suggest opening the network path: %q", tlsFailed)
+	}
+
+	plain := composeConnectError("10.0.0.1:80", errDirectUnreachable, errors.New("port-forward timed out"))
+	if strings.Contains(plain, "rbac.portForward") {
+		t.Errorf("non-RBAC failure should not carry RBAC remediation: %q", plain)
+	}
+}
+
+func TestForwardMatches(t *testing.T) {
+	live := &portforward.ConnectionInfo{
+		Connected: true, Namespace: "kube-system", ServiceName: hubbleRelayService, ContextName: "ctx-a",
+	}
+	if !forwardMatches(live, "kube-system", hubbleRelayService, "ctx-a") {
+		t.Error("matching live forward rejected")
+	}
+	foreign := &portforward.ConnectionInfo{
+		Connected: true, Namespace: "caretta", ServiceName: "caretta-vm", ContextName: "ctx-a",
+	}
+	if forwardMatches(foreign, "kube-system", hubbleRelayService, "ctx-a") {
+		t.Error("another source's forward accepted as hubble's")
+	}
+	otherCluster := &portforward.ConnectionInfo{
+		Connected: true, Namespace: "kube-system", ServiceName: hubbleRelayService, ContextName: "ctx-b",
+	}
+	if forwardMatches(otherCluster, "kube-system", hubbleRelayService, "ctx-a") {
+		t.Error("previous cluster's forward accepted")
+	}
+	if forwardMatches(&portforward.ConnectionInfo{Connected: false}, "kube-system", hubbleRelayService, "ctx-a") {
+		t.Error("dead forward accepted")
+	}
+}
+
+func TestHubbleConnectionInfoPortForwardModeUsesRegistry(t *testing.T) {
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	h.isConnected = true
+	h.viaPortForward = true
+	h.connectedAddr = "localhost:55555"
+
+	// No live forward in the registry: a dead forward must not read as connected.
+	if ci := h.ConnectionInfo(); ci.Connected {
+		t.Error("dead port-forward reported as connected")
+	}
+}
+
+func TestHubbleConnectionInfoDisconnected(t *testing.T) {
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	if ci := h.ConnectionInfo(); ci.Connected {
+		t.Error("fresh source reported as connected")
+	}
+}
+
+func TestManagerGetConnectionInfoUsesReporter(t *testing.T) {
+	h := NewHubbleSource(fake.NewSimpleClientset())
+	h.isConnected = true
+	h.connectedAddr = "10.0.0.7:80"
+	h.relayNamespace = "kube-system"
+
+	m := &Manager{activeSource: h}
+	ci := m.GetConnectionInfo()
+	if !ci.Connected || ci.Address != "10.0.0.7:80" {
+		t.Errorf("GetConnectionInfo = {connected:%v addr:%q}, want direct reporter state", ci.Connected, ci.Address)
+	}
+
+	// No active source: registry fallback.
+	m2 := &Manager{}
+	if ci := m2.GetConnectionInfo(); ci.Connected {
+		t.Error("empty manager reported as connected")
+	}
+}
+
+func TestCarettaConnectionInfoModes(t *testing.T) {
+	direct := &CarettaSource{
+		prometheusAddr:   "http://caretta-vm.caretta.svc.cluster.local:8428",
+		metricsNamespace: "caretta",
+		metricsService:   "caretta-vm",
+		currentContext:   "test-ctx",
+	}
+	if ci := direct.ConnectionInfo(); !ci.Connected || ci.ServiceName != "caretta-vm" {
+		t.Errorf("direct binding = {connected:%v svc:%q}, want {true caretta-vm}", ci.Connected, ci.ServiceName)
+	}
+
+	deadForward := &CarettaSource{
+		prometheusAddr:   "http://localhost:54321",
+		metricsNamespace: "caretta",
+		metricsService:   "caretta-vm",
+		currentContext:   "test-ctx",
+	}
+	if ci := deadForward.ConnectionInfo(); ci.Connected {
+		t.Error("dead forward binding reported as connected")
+	}
+
+	manual := &CarettaSource{
+		prometheusAddr: "http://localhost:9090",
+		metricsURL:     "http://localhost:9090",
+		currentContext: "test-ctx",
+	}
+	if ci := manual.ConnectionInfo(); !ci.Connected {
+		t.Error("manual localhost URL reported as disconnected")
+	}
+
+	if ci := (&CarettaSource{}).ConnectionInfo(); ci.Connected {
+		t.Error("unbound source reported as connected")
+	}
+}
+
+func TestResolveRelayPorts(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hubble-relay-abc", Namespace: "kube-system",
+			Labels: map[string]string{"k8s-app": "hubble-relay"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "hubble-relay",
+			Ports: []corev1.ContainerPort{{Name: "grpc", ContainerPort: 4245}},
+		}}},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: hubbleRelayService, Namespace: "kube-system"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.0.10",
+			Selector:  map[string]string{"k8s-app": "hubble-relay"},
+			Ports:     []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromString("grpc")}},
+		},
+	}
+	client := fake.NewSimpleClientset(pod, svc)
+
+	h := NewHubbleSource(client)
+	h.relayNamespace = "kube-system"
+
+	got := h.resolveTargetPort(context.Background(), svc)
+	if got != 4245 {
+		t.Errorf("resolveTargetPort = %d, want 4245 (named port)", got)
+	}
+}
+
+func TestDirectAddress(t *testing.T) {
+	h := &HubbleSource{servicePort: 80, clusterIP: "10.96.0.10"}
+	if got := h.directAddressLocked("kube-system"); got != "10.96.0.10:80" {
+		t.Errorf("clusterIP address = %q", got)
+	}
+
+	headless := &HubbleSource{servicePort: 443, clusterIP: corev1.ClusterIPNone}
+	if got := headless.directAddressLocked("cilium"); got != "hubble-relay.cilium.svc:443" {
+		t.Errorf("headless address = %q", got)
+	}
+}
+
+func selfSignedCert(t *testing.T, san string) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: san},
+		DNSNames:              []string{san},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}, pool
+}
+
+// reserveClosedPort returns a port that briefly listened and is now closed, so
+// dialing it is refused immediately.
+func reserveClosedPort(t *testing.T) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	lis.Close()
+	return port
+}

--- a/internal/traffic/istio.go
+++ b/internal/traffic/istio.go
@@ -488,6 +488,32 @@ func (s *IstioSource) Connect(ctx context.Context, contextName string) (*portfor
 	return info, nil
 }
 
+// ConnectionInfo implements ConnectionReporter. Istio's data path is the
+// shared Prometheus client (whose forwards belong to the prometheus owner, not
+// traffic), so its status is the only honest answer here.
+func (s *IstioSource) ConnectionInfo() *portforward.ConnectionInfo {
+	client, err := s.getPrometheusClient()
+	if err != nil {
+		return &portforward.ConnectionInfo{Connected: false}
+	}
+	return connectionInfoFromPromStatus(client.GetStatus())
+}
+
+// connectionInfoFromPromStatus maps the shared Prometheus client's status into
+// traffic connection info — used by the sources whose data path is that client.
+func connectionInfoFromPromStatus(status prom.Status) *portforward.ConnectionInfo {
+	info := &portforward.ConnectionInfo{
+		Connected:   status.Connected,
+		Address:     status.Address,
+		ContextName: status.ContextName,
+	}
+	if status.Service != nil {
+		info.Namespace = status.Service.Namespace
+		info.ServiceName = status.Service.Name
+	}
+	return info
+}
+
 // Close cleans up resources (no-op since we use the shared prometheus client)
 func (s *IstioSource) Close() error {
 	return nil

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -578,6 +578,10 @@ func Reset() {
 	if manager != nil {
 		manager.Close()
 	}
+	// Stop again after Close: an in-flight Connect (Close blocks on the source
+	// mutex until it finishes) may have published a forward for the old cluster
+	// after the first Stop.
+	portforward.Stop(portforward.OwnerTraffic)
 	manager = nil
 	initOnce = sync.Once{}
 }
@@ -624,13 +628,31 @@ func (m *Manager) Connect(ctx context.Context) (*portforward.ConnectionInfo, err
 	}
 }
 
-// GetConnectionInfo returns live traffic connection status — traffic's own
-// metrics forward, read from the live registry so a forward that has since been
-// stopped isn't reported as connected. It deliberately does NOT report another
-// owner's forward: traffic's data path always uses its own (Caretta/Hubble bring
-// one up), so a Prometheus forward for the same context means Prometheus is
-// connected, not traffic.
+// ConnectionReporter is implemented by sources that can report their own live
+// connection state. Necessary because "traffic has an active port-forward" is
+// not the same thing as "traffic is connected": every source prefers a direct
+// in-cluster connection with no forward behind it, and the Prometheus-backed
+// sources (Istio, Beyla) ride the prometheus owner's forward, not traffic's.
+type ConnectionReporter interface {
+	ConnectionInfo() *portforward.ConnectionInfo
+}
+
+// GetConnectionInfo returns live traffic connection status, as reported by the
+// active source when it can (see ConnectionReporter). The registry fallback
+// deliberately does NOT report another owner's forward: a Prometheus forward
+// for the same context means Prometheus is connected, not traffic.
 func (m *Manager) GetConnectionInfo() *portforward.ConnectionInfo {
+	m.mu.RLock()
+	source := m.activeSource
+	m.mu.RUnlock()
+
+	if source == nil {
+		// A leftover forward with nothing querying it is not a connection.
+		return &portforward.ConnectionInfo{Connected: false}
+	}
+	if reporter, ok := source.(ConnectionReporter); ok {
+		return reporter.ConnectionInfo()
+	}
 	return portforward.GetConnectionInfo(portforward.OwnerTraffic)
 }
 


### PR DESCRIPTION
Fixes #1099

## Problem

Viewing Hubble traffic with an in-cluster install required `rbac.portForward: true` — an undocumented dependency on the powerful `pods/portforward` grant — because `HubbleSource.Connect` unconditionally port-forwarded to hubble-relay. Every other source (Prometheus/Istio, Caretta) already tries the in-cluster Service address first; Hubble was the outlier. The default chart even anticipated direct access (`rbac.traffic: true` grants the relay TLS-cert secret read), but the code never used it without the forward.

## Fix

**Direct-first connect** (`internal/traffic/hubble.go`):
- A TCP reachability pre-check gates the direct lane (ClusterIP preferred; `hubble-relay.<ns>.svc:<containerPort>` for headless — cluster-domain independent). Reachability is probed **in the background at detection time** and cached by address (generation-ordered writes), so the lane decision costs nothing inline: locals with unroutable ClusterIPs skip straight to port-forward with zero added latency, while a cached verdict is only a fast-path hint — any fallback failure retries the direct lane for real, so a probe that raced relay startup can never fail an in-cluster connect. Reachable → the full existing gRPC/TLS/SAN-discovery sequence runs directly with its normal per-step timeouts.
- The lazy Service fetch now fills **both** the service port (direct dial) and the container port (port-forward) — previously it filled only the container port.
- `discoverTLSServerName` is context-aware; repeat `Connect` reports the real connected address instead of reconstructing `localhost:<port>`.
- When both lanes fail, the error reports both failures, and an RBAC-denied fallback adds remediation matched to what actually failed: `rbac.portForward=true` always, "open the network path" only when the direct lane failed at TCP reachability (not on a TLS/gRPC failure where that advice would be wrong).

**Source-aware connection status** (`manager.go` + all four sources): `GET /api/traffic/connection` used to equate "traffic owns an active port-forward" with "connected", which was wrong for every direct connection and for the Prometheus-backed sources (their forwards belong to the prometheus owner). Each source now implements `ConnectionReporter`; forward-riding bindings defer to the live registry (a dead or replaced forward doesn't read as connected), direct bindings report the state their queries actually use.

**Hardening**: `Reset()` stops the traffic forward again after `Close()`, closing a pre-existing window where an in-flight `Connect` could publish a forward for the old cluster after the first stop.

**Docs**: chart `values.yaml`/README + `docs/in-cluster.md` now say `rbac.portForward` is only the traffic-source fallback for when NetworkPolicy/routing blocks the direct path.

## Verification

- 16 unit tests: direct plaintext + TLS/SAN-discovery lanes against a stub gRPC observer (zero port-forward involvement asserted), service-vs-target port resolution, both-lanes-fail error contract + forbidden remediation gating, stale-cache heal via direct retry, probe generation ordering, reporter modes for Hubble/Caretta/manager, closed-source guards, forward-match validation. Full suite green with `-race`.
- **Live regression matrix on the final tip** (kind + Cilium 1.18.5, and `make beyla-demo`):
  - *Hubble in-cluster, default RBAC* (`can-i create pods/portforward` → `no`): background probe kicked at detection, direct connect at the relay ClusterIP, `/api/traffic/connection` reports it, 1000 real flows retrieved — no forward ever created.
  - *Hubble off-cluster* (laptop → kind): probe caches unreachable during detection; connect measured at **60ms** (cache-skip straight to port-forward, zero added latency vs. pre-PR); pf-mode status reporter returns the live forward.
  - *Beyla*: detection, connect via the shared Prometheus client, real TCP flows; `/api/traffic/connection` now correctly reports connected (pre-PR it always returned `connected: false` for Prometheus-backed sources — their forwards belong to the prometheus owner).
  - *Istio / Caretta*: no live pass (no demo clusters); Istio's `Connect` is untouched and Caretta's delta is the additive reporter + a 4-line closed guard, both pinned by unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster connect paths, port-forward lifecycle, and context-switch races for all traffic sources; behavior change is intentional and heavily unit-tested but affects production traffic visibility.
> 
> **Overview**
> **Hubble traffic no longer requires `pods/portforward` RBAC for typical in-cluster installs.** `HubbleSource.Connect` now tries the relay Service directly (ClusterIP or short DNS, with a cached background TCP probe after `Detect`) before starting the traffic-owned port-forward; gRPC/TLS/SAN handling is shared via `connectGRPCLocked`. Dual-lane failures surface both errors, with Helm `rbac.portForward` and optional network-path hints only when appropriate.
> 
> **Connection status is source-accurate:** a new `ConnectionReporter` on Hubble, Caretta, Beyla, and Istio drives `Manager.GetConnectionInfo` instead of assuming any traffic port-forward means connected. Forward-based bindings check the live registry; direct bindings report the address actually queried. `Close`/`Connect` races and context `Reset` get a `closed` guard and a second `portforward.Stop` after source close.
> 
> Helm README, `values.yaml`, and `docs/in-cluster.md` clarify that **`rbac.portForward` is mainly a fallback** when NetworkPolicy or routing blocks direct access to Hubble/Caretta metrics. A large `hubble_test.go` suite covers direct/TLS connect, probe cache, reporters, and error remediation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1e9e017df79c8cf8935bbbf6645d8c77d80cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

