### PR TITLE
ci: retry the helm-charts push on a concurrent write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,21 @@ jobs:
 
           if git diff --staged --quiet; then
             echo "No changes to Helm chart"
-          else
-            git commit -m "Update radar chart to v$VERSION"
-            git push origin main
+            exit 0
           fi
+          git commit -m "Update radar chart to v$VERSION"
+
+          # Push with rebase-retry: radar-hub's chart sync writes to the same
+          # helm-charts main and can land between our clone and our push, making
+          # this a non-fast-forward reject. Mirrors the loop in radar-hub's
+          # publish-ghcr.yml. Until 2026-08 the hub job never got this far, so the
+          # collision could not happen; it can now.
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt) — rebasing on origin/main"
+            git pull --rebase origin main
+          done
+          echo "::error::could not push chart update to helm-charts main after retries (persistent concurrent writes)."
+          exit 1


### PR DESCRIPTION
The chart sync pushes to `helm-charts` main once, with no retry. `radar-hub`'s equivalent job has a five-attempt rebase-retry for exactly this case.

The collision has been impossible so far, because `radar-hub`'s chart job never got as far as pushing — it has failed at authentication on every release. That is being fixed, so both repos will soon write to `helm-charts` main and a non-fast-forward reject becomes reachable.

This mirrors the loop `radar-hub` already uses, so the two stay consistent.

Also flattens the if/else so the no-op branch exits explicitly instead of falling through. Behaviour is unchanged — a no-op still reports success.

https://claude.ai/code/session_012i8eE8QTPw4ERASzr318SN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Git push retry logic for the external helm-charts repo; no runtime or application code affected.
> 
> **Overview**
> Release workflow **helm chart sync** now handles races when pushing to `helm-charts` `main`.
> 
> When chart files actually change, the job still commits once, then **pushes with up to five attempts**: on a rejected push it rebases onto `origin/main` and retries, matching `radar-hub`'s chart publish loop. Persistent failure after retries fails the step with a clear workflow error.
> 
> The **no-op path** (staged diff empty) now **`exit 0` immediately** instead of nesting commit/push in an `else`; success behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736185bd6fe789f1c16fd0e17d87232f11051dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->