### PR TITLE
fix(metrics): branch discovery probes on run mode (in-cluster vs local)

### DIFF
--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/portforward"
 	"github.com/skyhook-io/radar/pkg/prom"
 )
@@ -65,6 +66,15 @@ type Client struct {
 	k8sClient   kubernetes.Interface
 	k8sConfig   *rest.Config
 	contextName string
+
+	// inCluster records how Radar reaches the cluster, captured once at
+	// construction from the same detection the connection context reports as
+	// "in-cluster". In-cluster, discovery connects over the direct Service-address
+	// probe and does not fall back to a port-forward it cannot open (pods/
+	// portforward is normally denied); the port-forward fallback runs only when
+	// local. The direct probe pass itself runs in both modes — off-cluster it is
+	// bounded (see directProbeBudget) and also connects on routed networks.
+	inCluster bool
 
 	// Shared HTTP client used when constructing the underlying pkg/prom.Client.
 	httpClient *http.Client
@@ -132,6 +142,7 @@ func Initialize(client kubernetes.Interface, config *rest.Config, contextName st
 		k8sClient:     client,
 		k8sConfig:     config,
 		contextName:   contextName,
+		inCluster:     k8s.IsInCluster(),
 		httpClient:    &http.Client{Timeout: 10 * time.Second},
 		mcpHTTPClient: newMCPHTTPClient(),
 	}
@@ -263,6 +274,7 @@ func Reinitialize(client kubernetes.Interface, config *rest.Config, contextName 
 		k8sClient:     client,
 		k8sConfig:     config,
 		contextName:   contextName,
+		inCluster:     k8s.IsInCluster(),
 		manualURL:     manualURL,
 		headers:       headers,
 		httpClient:    &http.Client{Timeout: 10 * time.Second},

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -158,12 +158,28 @@ func (c *Client) discover(ctx context.Context, gen uint64) (string, string, erro
 		logDiscoveryEnded(start, err)
 		return "", "", err
 	}
+
+	// In-cluster, the direct Service-address probe is the whole story: pods/
+	// portforward is normally denied, so falling back to a forward here only
+	// burns ~10s per candidate on an attempt that cannot open. Fail closed on the
+	// direct pass instead of chasing a port-forward Radar can't establish.
+	if c.inCluster {
+		log.Printf("[prometheus] no candidate reachable via direct probe (%s); in-cluster, not attempting port-forward", took(directStart))
+		c.mu.Lock()
+		c.discoveryService = nil
+		c.mu.Unlock()
+		if !discoveryDiagnosticsSuppressed(ctx) {
+			errorlog.Record("prometheus", "warning", "no Prometheus service reachable in cluster")
+		}
+		return "", "", ErrPrometheusNotFound
+	}
+
 	log.Printf("[prometheus] no candidate reachable via direct probe (%s); falling back to port-forward", took(directStart))
 
 	// Fallback: try port-forwarding candidates in priority order. This is the
 	// primary path off-cluster (where Service DNS can't resolve from the user's
-	// machine) and a backstop in-cluster. Serial by necessity — port-forwarding
-	// mutates the owner's shared forward state.
+	// machine). Serial by necessity — port-forwarding mutates the owner's shared
+	// forward state.
 	var lastErr error
 	for _, cand := range candidates {
 		// Bail promptly if the run was superseded mid-fallback (Reset / context

--- a/internal/prometheus/discovery_test.go
+++ b/internal/prometheus/discovery_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/skyhook-io/radar/pkg/prom"
 )
 
@@ -264,6 +268,34 @@ func TestDiscover_StaleFlightGenerationDoesNotCommit(t *testing.T) {
 	}
 	if c.baseURL != "" {
 		t.Fatalf("stale-generation discovery published baseURL=%q", c.baseURL)
+	}
+}
+
+// In-cluster, pods/portforward is normally denied, so when no candidate answers
+// the direct Service-address probe discovery must fail closed rather than burn
+// ~10s per candidate on a port-forward it cannot open. A well-known Prometheus
+// exists (so enumeration yields a candidate) but its cluster address is
+// unreachable from the test — the fixed code returns ErrPrometheusNotFound; the
+// pre-fix code fell through to the port-forward fallback and returned its error.
+func TestDiscover_InClusterDoesNotFallBackToPortForward(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring", Name: "prometheus-server"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.50",
+			Ports:     []corev1.ServicePort{{Name: "http", Port: 9090}},
+		},
+	})
+
+	c := &Client{
+		httpClient:  &http.Client{Timeout: time.Second},
+		k8sClient:   cs,
+		contextName: "in-cluster",
+		inCluster:   true,
+	}
+
+	_, _, err := c.discover(context.Background(), c.discoveryGen)
+	if !errors.Is(err, ErrPrometheusNotFound) {
+		t.Fatalf("in-cluster discovery fell back to port-forward: err=%v, want ErrPrometheusNotFound", err)
 	}
 }
 

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/portforward"
 	"github.com/skyhook-io/radar/pkg/prom"
 )
@@ -36,6 +37,8 @@ const (
 
 	// maxMetricsCandidates bounds how many backends Connect will port-forward to
 	// and probe before giving up. Each rejected candidate costs a forward setup.
+	// It bounds the local walk only: in-cluster, candidates are reached by cluster
+	// address in single-digit ms and never port-forwarded, so the cap is dropped.
 	maxMetricsCandidates = 4
 )
 
@@ -92,7 +95,15 @@ type CarettaSource struct {
 	boundIsCarettaStore bool   // bound backend is Caretta's own store, trusted on identity
 	backendWarning      string // why no backend could be bound, surfaced to the UI
 	closed              bool   // set by Close; a late Connect must not resurrect the source
-	mu                  sync.RWMutex
+	// inCluster records how Radar reaches the cluster, captured once at
+	// construction from the same detection the connection context reports as
+	// "in-cluster". It flips discovery's cost model: in-cluster a Service address
+	// resolves and answers in single-digit ms but pods/portforward is normally
+	// denied, so discovery probes every candidate by cluster address and never
+	// port-forwards; local is the reverse — a cluster address can't resolve and
+	// costs a guaranteed dead-wait, so discovery skips it and port-forwards.
+	inCluster bool
+	mu        sync.RWMutex
 }
 
 // applyHeaders attaches the configured custom headers to a Prometheus
@@ -114,6 +125,7 @@ func NewCarettaSource(client kubernetes.Interface) *CarettaSource {
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		inCluster: k8s.IsInCluster(),
 	}
 }
 
@@ -387,30 +399,36 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 	for _, info := range candidates {
 		wrongData := false
 
-		// Reuse an existing managed port-forward only if it targets the SAME service
-		// we just discovered. A generic reachability probe can't tell caretta-vm apart
-		// from the cluster's general Prometheus (both answer /api/v1/query), so match
-		// on (namespace, service) — otherwise we'd adopt the general-metrics forward
-		// and query it for caretta_links_observed, which returns 0 flows silently.
-		if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, info.namespace, info.name); pfAddr != "" {
-			switch c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) {
+		if c.inCluster {
+			// In-cluster: the Service address resolves and answers in single-digit
+			// ms. Probe it directly — a managed forward isn't expected here (no
+			// pods/portforward RBAC), so a cluster-address probe is the only path.
+			switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
 			case backendAccepted:
-				log.Printf("[caretta] Using managed port-forward at %s for %s/%s", pfAddr, info.namespace, info.name)
-				c.bindLocked(pfAddr, info)
-				return pfAddr
+				log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
+				c.bindLocked(info.clusterAddr, info)
+				return info.clusterAddr
 			case backendNoCarettaData:
 				wrongData = true
 			}
-		}
-
-		// Try cluster address (works when running in-cluster)
-		switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
-		case backendAccepted:
-			log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
-			c.bindLocked(info.clusterAddr, info)
-			return info.clusterAddr
-		case backendNoCarettaData:
-			wrongData = true
+		} else {
+			// Local: a cluster address can't resolve from here, so only an already
+			// running managed forward is reachable. Reuse one only if it targets the
+			// SAME service we just discovered. A generic reachability probe can't tell
+			// caretta-vm apart from the cluster's general Prometheus (both answer
+			// /api/v1/query), so match on (namespace, service) — otherwise we'd adopt
+			// the general-metrics forward and query it for caretta_links_observed,
+			// which returns 0 flows silently. Starting a new forward is Connect()'s job.
+			if pfAddr := portforward.GetAddressForService(portforward.OwnerTraffic, c.currentContext, info.namespace, info.name); pfAddr != "" {
+				switch c.acceptBackendLocked(ctx, info, pfAddr+info.basePath) {
+				case backendAccepted:
+					log.Printf("[caretta] Using managed port-forward at %s for %s/%s", pfAddr, info.namespace, info.name)
+					c.bindLocked(pfAddr, info)
+					return pfAddr
+				case backendNoCarettaData:
+					wrongData = true
+				}
+			}
 		}
 
 		if wrongData {
@@ -456,10 +474,12 @@ func (c *CarettaSource) discoverServiceLocked(ctx context.Context) []*metricsSer
 		add(c.discoverMetricsServiceDynamic(ctx))
 	}
 
-	// The cap bounds how long a Connect can take — every candidate past the first
-	// costs a probe and possibly a port-forward. Log what it drops: a silent
-	// truncation reads as "nothing else was available".
-	if len(candidates) > maxMetricsCandidates {
+	// The cap bounds how long a local Connect can take — every candidate past the
+	// first costs a port-forward attempt. In-cluster each candidate costs only a
+	// cheap cluster-address probe and is never port-forwarded, so the cap is
+	// dropped there and every candidate is considered. Log what a local truncation
+	// drops: a silent truncation reads as "nothing else was available".
+	if !c.inCluster && len(candidates) > maxMetricsCandidates {
 		for _, dropped := range candidates[maxMetricsCandidates:] {
 			log.Printf("[caretta] Not trying %s/%s: candidate limit of %d reached", dropped.namespace, dropped.name, maxMetricsCandidates)
 		}
@@ -969,29 +989,38 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	for _, info := range candidates {
 		target := fmt.Sprintf("%s/%s", info.namespace, info.name)
 
-		// Try cluster-internal address first (works when running in-cluster)
-		switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
-		case backendAccepted:
-			log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
-			// Queries go to the cluster address from here, so the traffic module needs
-			// no forward of its own. An earlier candidate in this same walk may have
-			// left one up after being refused — keeping it would make the reported
-			// connection name a different service than the one being queried.
-			portforward.Stop(portforward.OwnerTraffic)
-			c.bindLocked(info.clusterAddr, info)
-			return &portforward.ConnectionInfo{
-				Connected:   true,
-				Address:     info.clusterAddr,
-				Namespace:   info.namespace,
-				ServiceName: info.name,
-				ContextName: contextName,
-			}, nil
-		case backendNoCarettaData:
-			// Already reached it and it holds no Caretta data — a port-forward to the
-			// same service would only reach the same database.
-			noData = append(noData, target)
+		if c.inCluster {
+			// In-cluster: the Service address resolves and answers in single-digit ms,
+			// and pods/portforward is normally denied — so probe the cluster address
+			// and never fall back to a forward that can't be opened. A rejected
+			// candidate here is terminal: record why and move to the next.
+			switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
+			case backendAccepted:
+				log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
+				// Queries go to the cluster address from here, so the traffic module needs
+				// no forward of its own. An earlier candidate in this same walk may have
+				// left one up after being refused — keeping it would make the reported
+				// connection name a different service than the one being queried.
+				portforward.Stop(portforward.OwnerTraffic)
+				c.bindLocked(info.clusterAddr, info)
+				return &portforward.ConnectionInfo{
+					Connected:   true,
+					Address:     info.clusterAddr,
+					Namespace:   info.namespace,
+					ServiceName: info.name,
+					ContextName: contextName,
+				}, nil
+			case backendNoCarettaData:
+				noData = append(noData, target)
+			case backendUnreachable:
+				unreachable = append(unreachable, target)
+			}
 			continue
 		}
+
+		// Local: a cluster address can't resolve from here, and probing it costs a
+		// guaranteed multi-second dead-wait per candidate — so skip it and go
+		// straight to a port-forward.
 
 		// Check if there's already a valid managed port-forward for this context that
 		// targets the SAME service we discovered. Matching on (namespace, service)
@@ -1296,31 +1325,37 @@ func (c *CarettaSource) discoverMetricsServiceDynamic(ctx context.Context) *metr
 			candidates[i].score, candidates[i].info.basePath)
 	}
 
-	// Validate top candidates via API probe (works when running in-cluster)
-	for i := range limit {
-		cand := &candidates[i]
-		addr := cand.info.clusterAddr
+	// Validate top candidates via API probe — only in-cluster, where a cluster
+	// address resolves. Locally the probe can't succeed and costs a dead-wait per
+	// candidate, so skip straight to returning the best candidate for the caller
+	// to port-forward.
+	if c.inCluster {
+		for i := range limit {
+			cand := &candidates[i]
+			addr := cand.info.clusterAddr
 
-		// Try root path first
-		if c.tryMetricsEndpointLocked(ctx, addr) {
-			log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s", cand.info.namespace, cand.info.name, addr)
-			cand.info.basePath = ""
-			return &cand.info
-		}
-
-		// If candidate has a sub-path (e.g. vmselect), try that too
-		if cand.info.basePath != "" {
-			subAddr := addr + cand.info.basePath
-			if c.tryMetricsEndpointLocked(ctx, subAddr) {
-				log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s (sub-path: %s)",
-					cand.info.namespace, cand.info.name, addr, cand.info.basePath)
+			// Try root path first
+			if c.tryMetricsEndpointLocked(ctx, addr) {
+				log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s", cand.info.namespace, cand.info.name, addr)
+				cand.info.basePath = ""
 				return &cand.info
+			}
+
+			// If candidate has a sub-path (e.g. vmselect), try that too
+			if cand.info.basePath != "" {
+				subAddr := addr + cand.info.basePath
+				if c.tryMetricsEndpointLocked(ctx, subAddr) {
+					log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s (sub-path: %s)",
+						cand.info.namespace, cand.info.name, addr, cand.info.basePath)
+					return &cand.info
+				}
 			}
 		}
 	}
 
-	// No candidate was reachable in-cluster (common when running locally).
-	// Return the highest-scored candidate — the caller can establish a port-forward.
+	// No candidate was reachable in-cluster (or running locally, where the probe
+	// was skipped). Return the highest-scored candidate — the caller can establish
+	// a port-forward.
 	best := &candidates[0]
 	log.Printf("[caretta] Dynamic discovery: no candidates reachable in-cluster, returning best candidate: %s/%s (score=%d)",
 		best.info.namespace, best.info.name, best.score)

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -395,14 +395,16 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 		return ""
 	}
 
-	var noData []string
+	var noData, unreachable []string
 	for _, info := range candidates {
 		wrongData := false
 
 		if c.inCluster {
 			// In-cluster: the Service address resolves and answers in single-digit
 			// ms. Probe it directly — a managed forward isn't expected here (no
-			// pods/portforward RBAC), so a cluster-address probe is the only path.
+			// pods/portforward RBAC), so a cluster-address probe is the only path,
+			// and one that can't be reached is a real diagnosis (not the local
+			// "Connect() will port-forward" case), so record it.
 			switch c.acceptBackendLocked(ctx, info, info.clusterAddr+info.basePath) {
 			case backendAccepted:
 				log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
@@ -410,6 +412,8 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 				return info.clusterAddr
 			case backendNoCarettaData:
 				wrongData = true
+			case backendUnreachable:
+				unreachable = append(unreachable, fmt.Sprintf("%s/%s", info.namespace, info.name))
 			}
 		} else {
 			// Local: a cluster address can't resolve from here, so only an already
@@ -436,11 +440,16 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 		}
 	}
 
-	// Nothing bound. Either the candidates aren't reachable in-cluster (the local
-	// case — Connect() port-forwards to them) or none of them holds Caretta data.
-	// Only the latter is a diagnosis; unreachable here is the normal local case.
-	log.Printf("[caretta] No Caretta-backed metrics service reachable in-cluster. Call Connect() for port-forward.")
-	c.backendWarning = noBackendWarning(noData, nil)
+	// Nothing bound. In-cluster, a candidate that couldn't be reached is a real
+	// diagnosis, so name it. Local, a cluster address unreachable here is the
+	// normal case — Connect() port-forwards to the candidates — so nothing is
+	// recorded as unreachable and the warning falls back to the generic message.
+	if c.inCluster {
+		log.Printf("[caretta] No Caretta-backed metrics service reachable in-cluster.")
+	} else {
+		log.Printf("[caretta] No Caretta-backed metrics service reachable locally. Call Connect() for port-forward.")
+	}
+	c.backendWarning = noBackendWarning(noData, unreachable)
 	return ""
 }
 

--- a/internal/traffic/caretta_discovery_test.go
+++ b/internal/traffic/caretta_discovery_test.go
@@ -3,11 +3,13 @@ package traffic
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -398,7 +400,8 @@ func TestWellKnownLayerOffersEveryMatch(t *testing.T) {
 	}
 }
 
-// The candidate list is walked with a port-forward per attempt, so it stays bounded.
+// Local, the candidate list is walked with a port-forward per attempt, so it
+// stays bounded by the cap.
 func TestCandidateListIsCapped(t *testing.T) {
 	svcs := kubePrometheusStackSvcs()
 	svcs = append(svcs,
@@ -407,10 +410,85 @@ func TestCandidateListIsCapped(t *testing.T) {
 		metricsSvc("monitoring", "prometheus-server", 9090, "10.0.0.11", nil),
 		metricsSvc("prometheus", "prometheus-server", 9090, "10.0.0.12", nil),
 	)
-	c := sourceWithServices(t, "caretta", svcs...)
+	c := sourceWithServices(t, "caretta", svcs...) // inCluster defaults to false (local)
 
 	if got := discover(t, c); len(got) > maxMetricsCandidates {
 		t.Errorf("got %d candidates, want at most %d", len(got), maxMetricsCandidates)
+	}
+}
+
+// recordingTransport captures every URL a probe dials and fails the request, so
+// a test can assert which addresses discovery attempted without a live backend.
+type recordingTransport struct {
+	mu   sync.Mutex
+	urls []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.urls = append(rt.urls, req.URL.String())
+	rt.mu.Unlock()
+	return nil, fmt.Errorf("recorded, not dialed")
+}
+
+func (rt *recordingTransport) probedClusterAddress() bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, u := range rt.urls {
+		if strings.Contains(u, "svc.cluster.local") {
+			return true
+		}
+	}
+	return false
+}
+
+// In-cluster each candidate costs only a cheap cluster-address probe and is never
+// port-forwarded, so the local port-forward cap must not truncate the list — a cap
+// there silently drops reachable backends from consideration.
+func TestInClusterProbesEveryCandidateNoCap(t *testing.T) {
+	svcs := kubePrometheusStackSvcs()
+	svcs = append(svcs,
+		metricsSvc("monitoring", "victoria-metrics-single-server", 8428, "10.0.0.9", nil),
+		metricsSvc("monitoring", "vmsingle", 8428, "10.0.0.10", nil),
+		metricsSvc("monitoring", "prometheus-server", 9090, "10.0.0.11", nil),
+		metricsSvc("prometheus", "prometheus-server", 9090, "10.0.0.12", nil),
+	)
+	c := sourceWithServices(t, "caretta", svcs...)
+	c.inCluster = true
+
+	if got := discover(t, c); len(got) <= maxMetricsCandidates {
+		t.Errorf("in-cluster returned %d candidates, want more than the local cap of %d", len(got), maxMetricsCandidates)
+	}
+}
+
+// Local, a cluster address (*.svc.cluster.local) cannot resolve and each probe
+// costs a guaranteed multi-second dead-wait. Discovery must skip it and rely on
+// port-forwards (started by Connect), never probe the cluster address.
+func TestLocalDiscoveryDoesNotProbeClusterAddresses(t *testing.T) {
+	rec := &recordingTransport{}
+	c := sourceWithServices(t, "caretta", append(kubePrometheusStackSvcs(), carettaStoreSvc("caretta", "caretta-vm"))...)
+	c.httpClient = &http.Client{Transport: rec, Timeout: time.Second}
+	c.inCluster = false
+
+	_ = c.discoverPrometheus(context.Background())
+
+	if rec.probedClusterAddress() {
+		t.Errorf("local discovery probed a cluster address; probed=%v", rec.urls)
+	}
+}
+
+// In-cluster the cluster address resolves in single-digit ms, so discovery must
+// probe it directly (the fast path this whole branch exists to take).
+func TestInClusterDiscoveryProbesClusterAddress(t *testing.T) {
+	rec := &recordingTransport{}
+	c := sourceWithServices(t, "caretta", carettaStoreSvc("caretta", "caretta-vm"))
+	c.httpClient = &http.Client{Transport: rec, Timeout: time.Second}
+	c.inCluster = true
+
+	_ = c.discoverPrometheus(context.Background())
+
+	if !rec.probedClusterAddress() {
+		t.Errorf("in-cluster discovery did not probe the cluster address; probed=%v", rec.urls)
 	}
 }
 


### PR DESCRIPTION
## Problem

Metrics and traffic discovery treated an in-cluster run and a laptop run identically, but the two have opposite cost profiles:

| probe | from a laptop | from inside the cluster |
|-------|---------------|-------------------------|
| cluster address (`*.svc.cluster.local`) | ~2s per probe and always fails (resolver does not fail fast) | 3-11ms, succeeds |
| port-forward | works | normally denied (no `pods/portforward` RBAC) |

The old walk paid both costs in both modes:

- **Locally**, every candidate first burned a guaranteed multi-second cluster-address probe that could never succeed, before reaching the port-forward it always needed. A long candidate list turned a UI button press into tens of seconds of dead waiting.
- **In-cluster**, a candidate cap that exists only to bound port-forward attempts truncated cheap, reachable candidates, and when a cluster-address probe was rejected the code fell back to a port-forward it could not open.

## Fix

Branch discovery on the run mode, reusing the existing in-cluster detection (`k8s.IsInCluster()` - the same signal the connection context reports as `in-cluster`), captured once at construction:

- **In-cluster**: probe every candidate by cluster address; never port-forward; drop the candidate cap (each probe is single-digit ms).
- **Local**: skip the cluster-address probe and go straight to port-forwards, bounded by the cap as before.

Applied to both `internal/traffic/caretta.go` and `internal/prometheus/discovery.go`.

Prometheus keeps its bounded, concurrent direct-probe pass in both modes - it already caps the off-cluster dead-wait to a single ~4s window and serves routed/VPN clusters where cluster addresses do resolve. The change there is narrower: stop the doomed in-cluster port-forward fallback.

## Preserved from prior discovery work

- Caretta's own metrics store is still the **first** candidate, which the cap can never drop.
- A local truncation still **logs every skipped candidate** - it fails honestly rather than reading as "nothing else was available".

## Test evidence

New unit tests use the fake-client patterns and a recording HTTP transport - no live cluster.

**Before the fix (bug visible):**
```
--- FAIL: TestInClusterProbesEveryCandidateNoCap
    in-cluster returned 4 candidates, want more than the local cap of 4
--- FAIL: TestLocalDiscoveryDoesNotProbeClusterAddresses
    local discovery probed a cluster address; probed=[http://caretta-vm.caretta.svc.cluster.local:8428/... ...]
--- FAIL: TestDiscover_InClusterDoesNotFallBackToPortForward
    in-cluster discovery fell back to port-forward: err=port-forward to monitoring/prometheus-server failed..., want ErrPrometheusNotFound
```

**After the fix:** all pass. Local skips cluster-address probes; in-cluster probes every candidate with no cap and no port-forward.

```
ok  github.com/skyhook-io/radar/internal/traffic
ok  github.com/skyhook-io/radar/internal/prometheus
```

https://claude.ai/code/session_01U8xFi2aiFN3LptTKnWyCWa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core metrics/traffic connection paths for both in-cluster and off-cluster deployments; behavior shifts are intentional but affect how Radar finds Prometheus and Caretta backends at startup and on Connect.
> 
> **Overview**
> Metrics and Prometheus discovery no longer use the same probe path on a laptop and inside the cluster. Both stacks now record **in-cluster vs local** once at construction via `k8s.IsInCluster()` and branch on it.
> 
> **In-cluster:** Caretta probes every candidate by **cluster Service address** (fast), **drops the local-only candidate cap**, and **does not port-forward** when direct probes fail. Prometheus discovery **skips the port-forward fallback** after a failed direct probe and returns `ErrPrometheusNotFound` instead of spending ~10s per candidate on forwards that RBAC usually denies.
> 
> **Local:** Caretta **skips** `*.svc.cluster.local` probes (multi-second dead-waits) and relies on **existing or new port-forwards**, still bounded by `maxMetricsCandidates`. Unreachable vs “wrong backend” warnings are split so in-cluster unreachable services are surfaced honestly.
> 
> Unit tests cover in-cluster no port-forward fallback, local no cluster-address probes, in-cluster uncapped candidate lists, and recording transport assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd2674b0fb05c6bd6d5e500299cd0baabe853eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->