### PR TITLE
test(loadtest): deflake orphan-skeleton assertions with client-list reads

### DIFF
--- a/internal/loadtest/generator_test.go
+++ b/internal/loadtest/generator_test.go
@@ -197,12 +197,39 @@ func TestScaleDownAfterPartialProgressLeavesNoOrphanApps(t *testing.T) {
 	if !res.Converged || count("Pod") != 200 {
 		t.Fatalf("pods=%d converged=%v want 200/true", count("Pod"), res.Converged)
 	}
-	// 200 pods / 200 per app = 1 app. Every other app kind must match — no orphans.
-	for _, kind := range []string{"Deployment", "Service", "ConfigMap"} {
-		if got := count(kind); got != 1 {
-			t.Fatalf("orphan %s skeletons: %s=%d want 1", kind, kind, got)
+	// 200 pods / 200 per app = 1 app. Every other app kind must match — no
+	// orphans. Assert against the client (authoritative truth): ScaleTo only
+	// paces the Deployment informer and converges on Pods, so the other kinds'
+	// informer stores may still be draining delete events when it returns.
+	assertClientCount := func(kind string, list func() (int, error)) {
+		n, err := list()
+		if err != nil {
+			t.Fatalf("list %s: %v", kind, err)
+		}
+		if n != 1 {
+			t.Fatalf("orphan %s skeletons in client: %d want 1", kind, n)
 		}
 	}
+	assertClientCount("Deployment", func() (int, error) {
+		l, e := client.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertClientCount("ReplicaSet", func() (int, error) {
+		l, e := client.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertClientCount("Service", func() (int, error) {
+		l, e := client.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertClientCount("ConfigMap", func() (int, error) {
+		l, e := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
+	assertClientCount("Secret", func() (int, error) {
+		l, e := client.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
+		return len(l.Items), e
+	})
 }
 
 // TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps reproduces a scale-up


### PR DESCRIPTION
Fixes #1498

`TestScaleDownAfterPartialProgressLeavesNoOrphanApps` asserted `Service`/`ConfigMap` counts from **informer stores** immediately after `ScaleTo` returned. `ScaleTo` paces its delete batches against the Deployment informer only and its convergence gate waits on Pods only — each kind's informer drains its own fake watch channel independently, so on a loaded CI machine the ConfigMap informer could still be processing delete events at assertion time (`ConfigMap=2 want 1`). Passed 20/20 locally, failed intermittently in CI (run 32907574210).

The fix asserts against the **fake client** instead — the authoritative state, already settled when the deletes returned — which is the exact pattern the sibling test `TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps` established for the same reason (its comment: "authoritative truth, no informer lag"). Also extends coverage from 3 skeleton kinds to all 5 the test's doc comment names (adds ReplicaSet, Secret).

The Pod assertion stays informer-based: that's `ScaleTo`'s actual convergence contract.

Verified: 30 consecutive runs with `-race` + full package `-count=3`, all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths affected.
> 
> **Overview**
> **Deflakes** `TestScaleDownAfterPartialProgressLeavesNoOrphanApps` by checking orphan app skeleton counts via **fake client `List` calls** instead of informer store sizes right after `ScaleTo` returns.
> 
> `ScaleTo` only waits on Pod convergence and paces deletes against the Deployment informer, so Service/ConfigMap (and other) informers can still be processing deletes on slow CI — causing intermittent failures like `ConfigMap=2 want 1`. The client reflects state already updated when deletes complete; the same approach as `TestScaleUpCreateFailureThenScaleDownLeavesNoOrphanApps`.
> 
> Coverage now asserts all five skeleton kinds named in the test doc (**ReplicaSet** and **Secret** added). **Pod** count assertions stay informer-based because that matches `ScaleTo`'s convergence contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33a9cc4ec211425a5a03a15a78a94c6d38f60c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->