### PR TITLE
ci: publish npm packages via trusted publishing (OIDC) instead of tokens

### DIFF
--- a/.github/workflows/publish-k8s-ui.yml
+++ b/.github/workflows/publish-k8s-ui.yml
@@ -32,7 +32,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 bundles 10.x
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-radar-app.yml
+++ b/.github/workflows/publish-radar-app.yml
@@ -41,7 +41,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 bundles 10.x
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The v1.12.0 radar-app publish ([run 33012231011](https://github.com/skyhook-io/radar/actions/runs/33012231011)) failed with `E404` on the registry PUT — npm masks auth failures as 404 for scoped packages. Root cause: the `NPM_TOKEN` granular access token (set 2026-05-23) hit its 90-day expiry around Aug 21. npm is also restricting bypass-2FA tokens starting Aug 2026 and ending token-based direct publishing in Jan 2027, so rotating tokens is a dead end.

## What

Switch both publish workflows (`@skyhook-io/radar-app`, `@skyhook-io/k8s-ui`) from token auth to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC):

- Drop `NODE_AUTH_TOKEN` from the publish steps — no stored credential involved.
- Add an `npm install -g npm@latest` step: trusted publishing needs npm ≥ 11.5.1, and Node 20 bundles npm 10.x.
- `permissions: id-token: write` was already present (used for provenance) — that's the same OIDC mechanism.

Trusted Publisher connections for both packages are already configured on npmjs.com (`skyhook-io/radar` + the respective workflow filename, `npm publish` action).

## After merge

1. Re-point the `radar-app-v1.12.0` tag at a main commit containing this change so the publish runs token-free (a re-run of the failed run would use the old workflow at the tag's original commit).
2. Once the publish succeeds: flip both packages to "require 2FA and disallow bypass-2fa tokens" on npmjs.com and delete the expired `NPM_TOKEN` repo secret.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only publish credential changes with no application runtime impact; publish success depends on npm trusted-publisher config matching these workflows.
> 
> **Overview**
> Both tag-driven npm publish workflows (`publish-k8s-ui.yml`, `publish-radar-app.yml`) no longer pass **`NODE_AUTH_TOKEN`** / **`secrets.NPM_TOKEN`** on publish. **`npm publish --provenance --access public`** now relies on **npm trusted publishing (OIDC)** using the existing **`id-token: write`** permission.
> 
> Each workflow adds a step to **`npm install -g npm@latest`** before publish, because trusted publishing needs **npm ≥ 11.5.1** while Node 20 ships npm 10.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee60a6f1e6dc8b887cdbb583080ffecc420c108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->