### PR TITLE
fix(ui): center cluster name vertically in the scope pill segment

### DIFF
--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -243,7 +243,10 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
           // context inline (per-row secondary line), and an extra hover
           // tooltip would just overlap the search input.
           <>
-            <span className={variant === 'segment' ? 'min-w-0 flex-1' : 'min-w-0'}>
+            {/* flex (not a plain span): ClusterName is inline-flex and would
+                otherwise baseline-align inside this wrapper's line box,
+                sitting a couple px above the segment's vertical center. */}
+            <span className={variant === 'segment' ? 'flex items-center min-w-0 flex-1' : 'flex items-center min-w-0'}>
               <ClusterName
                 name={currentName}
                 fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}


### PR DESCRIPTION
## Summary

The cluster name in the header's scope pill sat ~2px above the segment's vertical center, with visible whitespace below it — misaligned against the "All namespaces" segment and its own chevron.

**Root cause:** `ClusterName` renders as `inline-flex`, and its wrapper in the segment trigger was a plain `<span>`. Inline-flex boxes default to baseline alignment inside the parent's line box, so the name + provider icon rode the text baseline, leaving the descender gap empty below.

**Fix:** make the wrapper a flex container (`flex items-center`) in both trigger variants so the name centers like every other child of the button's `items-center` row.

Verified live: cluster button, provider icon, cluster name, namespace text, and the status dot now all measure the identical vertical midline (24.75px); before, the name content measured ~1.9px high.

## Test plan
- `make tsc` passes
- Manual: header scope pill inspected in the browser against a connected cluster (GKE context) — name and namespace segments read as one level line; midlines confirmed equal via getBoundingClientRect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout/CSS change in the cluster switcher trigger with no logic, data, or security impact.
> 
> **Overview**
> Fixes **vertical misalignment** of the cluster name in the header scope pill segment (~2px above center vs. the namespace segment and chevron).
> 
> The `ClusterName` trigger wrapper was a plain `<span>` while `ClusterName` is `inline-flex`, so baseline alignment left empty space below the name. The wrapper now uses **`flex items-center`** for both chip and segment trigger variants so the name and provider icon align with the button’s other `items-center` children.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824be8d4180428da27aad308b0be024e11d89551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->