### PR TITLE
feat: make Upgrade impact easier to find

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skyhook-io/radar/internal/traffic"
 	"github.com/skyhook-io/radar/pkg/health"
 	topology "github.com/skyhook-io/radar/pkg/topology"
+	"github.com/skyhook-io/radar/pkg/upgradereadiness"
 )
 
 // DashboardResponse is the aggregated response for the home dashboard
@@ -61,6 +62,10 @@ type DashboardCluster struct {
 	Platform  string `json:"platform"`
 	Version   string `json:"version"`
 	Connected bool   `json:"connected"`
+	// UpgradeReviewedThrough is the newest Kubernetes minor the upgrade-impact
+	// catalog covers. A static catalog fact, so Home can hint that the cluster
+	// is behind without triggering the (expensive) upgrade-readiness scan.
+	UpgradeReviewedThrough string `json:"upgradeReviewedThrough,omitempty"`
 }
 
 type DashboardHealth struct {
@@ -487,10 +492,11 @@ func (s *Server) getDashboardCluster(ctx context.Context) DashboardCluster {
 		return DashboardCluster{Connected: false}
 	}
 	return DashboardCluster{
-		Name:      info.Cluster,
-		Platform:  info.Platform,
-		Version:   info.KubernetesVersion,
-		Connected: true,
+		Name:                   info.Cluster,
+		Platform:               info.Platform,
+		Version:                info.KubernetesVersion,
+		Connected:              true,
+		UpgradeReviewedThrough: upgradereadiness.ReviewedThrough,
 	}
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2039,6 +2039,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             topology={topology}
             fallbackClusterLoadState={showHomeClusterLoadFallback ? clusterLoadState : undefined}
             onNavigateToView={setMainView}
+            // Upgrade impact lives under /checks, which a Cloud host takes
+            // over wholesale — its fleet pages have no upgrade sub-route, so
+            // the version line stays plain text there.
+            onNavigateToUpgradeImpact={takeover.checks ? undefined : () => {
+              const newParams = new URLSearchParams()
+              const globalNamespaces = searchParams.get('namespaces')
+              if (globalNamespaces) newParams.set('namespaces', globalNamespaces)
+              navigate({ pathname: '/checks/upgrade', search: newParams.toString() })
+            }}
             onNavigateToResourceKind={(kind, apiGroup, filters) => {
               // Navigate to resources view with kind in URL path
               console.debug('[filters] App.onNavigateToResourceKind:', { kind, apiGroup, filters })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -292,6 +292,9 @@ export interface DashboardCluster {
   platform: string;
   version: string;
   connected: boolean;
+  // Newest Kubernetes minor the upgrade-impact catalog covers (e.g. "1.37").
+  // Static catalog fact — safe to compare against `version` without a scan.
+  upgradeReviewedThrough?: string;
 }
 
 export interface DashboardHealth {

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -88,9 +88,14 @@ function BestPracticesView({ namespaces, onNavigateToResource }: AuditViewProps)
 
   return (
     <div className="flex-1 flex flex-col min-h-0 p-4 gap-4 overflow-auto">
+      {/* Tabs above the header: the header describes best practices only, so
+          tabs rendered below it read as part of that page rather than as the
+          switch between the two Checks surfaces. */}
+      <ChecksViewTabs />
+
       <PageHeader
         icon={ShieldCheck}
-        title="Checks"
+        title="Best practices"
         description="Security, reliability, and efficiency best practices (NSA/CISA, CIS, Polaris, Kubescape), grouped into a remediation queue."
         actions={
           <>
@@ -114,8 +119,6 @@ function BestPracticesView({ namespaces, onNavigateToResource }: AuditViewProps)
           </>
         }
       />
-
-      <ChecksViewTabs />
 
       <ChecksView
         checks={data.groupedChecks ?? []}

--- a/web/src/components/audit/UpgradeReadinessView.tsx
+++ b/web/src/components/audit/UpgradeReadinessView.tsx
@@ -127,6 +127,8 @@ export function UpgradeReadinessView({ namespaces, onNavigateToResource }: Upgra
 
   return (
     <div aria-busy={isFetching} className="flex-1 flex flex-col min-h-0 p-4 gap-4 overflow-auto">
+      <ChecksViewTabs />
+
       <PageHeader
         icon={ShieldAlert}
         title="Upgrade impact"
@@ -161,8 +163,6 @@ export function UpgradeReadinessView({ namespaces, onNavigateToResource }: Upgra
           </>
         }
       />
-
-      <ChecksViewTabs />
 
       {showingPreviousTarget && (
         <CoverageNotice

--- a/web/src/components/home/ClusterHealthCard.test.ts
+++ b/web/src/components/home/ClusterHealthCard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { minorsBehind } from "./ClusterHealthCard";
+
+describe("minorsBehind", () => {
+  it("counts minors between plain versions", () => {
+    expect(minorsBehind("1.33", "1.37")).toBe(4);
+    expect(minorsBehind("1.36", "1.37")).toBe(1);
+  });
+
+  it("returns 0 when current matches or exceeds the catalog", () => {
+    expect(minorsBehind("1.37", "1.37")).toBe(0);
+    expect(minorsBehind("1.38", "1.37")).toBe(0);
+  });
+
+  it("handles distribution version suffixes", () => {
+    expect(minorsBehind("v1.33.6+k3s1", "1.37")).toBe(4);
+    expect(minorsBehind("1.31.5-gke.1023000", "1.37")).toBe(6);
+    expect(minorsBehind("v1.32.4-eks-abc123", "1.37")).toBe(5);
+  });
+
+  it("stays quiet on cross-major or unparseable input", () => {
+    expect(minorsBehind("2.0.0", "1.37")).toBe(0);
+    expect(minorsBehind("unknown", "1.37")).toBe(0);
+    expect(minorsBehind("", "1.37")).toBe(0);
+  });
+
+  it("stays quiet when the catalog version is missing", () => {
+    expect(minorsBehind("1.33", undefined)).toBe(0);
+    expect(minorsBehind("1.33", "")).toBe(0);
+  });
+});

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -33,6 +33,8 @@ interface ClusterHealthCardProps {
   nodeVersionSkew: DashboardResponse['nodeVersionSkew']
   onNavigateToKind: (kind: string, group?: string) => void
   onNavigateToView: () => void
+  // Left unset in Cloud takeover mode, where /checks is owned by the host.
+  onNavigateToUpgradeImpact?: () => void
   onWarningEventsClick?: () => void
   onIssuesClick?: () => void
   // Freshness/refresh control for the dashboard poll — rendered under the
@@ -130,6 +132,7 @@ export function ClusterHealthCard({
   nodeVersionSkew,
   onNavigateToKind,
   onNavigateToView,
+  onNavigateToUpgradeImpact,
   onWarningEventsClick,
   onIssuesClick,
   freshness,
@@ -251,7 +254,11 @@ export function ClusterHealthCard({
                 </Tooltip>
               )}
               {cluster.version && (
-                <span>Kubernetes {cluster.version}</span>
+                <KubernetesVersionLine
+                  version={cluster.version}
+                  reviewedThrough={cluster.upgradeReviewedThrough}
+                  onNavigate={onNavigateToUpgradeImpact}
+                />
               )}
               <span><span className="font-mono">{counts.namespaces}</span> namespaces</span>
               {/* Show raw kubeconfig context as muted metadata only when
@@ -516,6 +523,60 @@ export function ClusterHealthCard({
         </div>
       </div>
     </div>
+  )
+}
+
+function parseMajorMinor(version: string): { major: number; minor: number } | null {
+  const m = /^v?(\d+)\.(\d+)/.exec(version.trim())
+  if (!m) return null
+  return { major: Number(m[1]), minor: Number(m[2]) }
+}
+
+// How many minors the running version trails the newest one the upgrade-impact
+// catalog covers. Cross-major comparisons return 0 — better a missing hint than
+// a wrong count on an exotic version string.
+export function minorsBehind(current: string, reviewedThrough?: string): number {
+  const cur = parseMajorMinor(current)
+  const latest = reviewedThrough ? parseMajorMinor(reviewedThrough) : null
+  if (!cur || !latest || latest.major !== cur.major) return 0
+  return Math.max(0, latest.minor - cur.minor)
+}
+
+function KubernetesVersionLine({
+  version,
+  reviewedThrough,
+  onNavigate,
+}: {
+  version: string
+  reviewedThrough?: string
+  onNavigate?: () => void
+}) {
+  if (!onNavigate) {
+    return <span>Kubernetes {version}</span>
+  }
+
+  const behind = minorsBehind(version, reviewedThrough)
+
+  return (
+    <Tooltip
+      content={
+        behind > 0
+          ? `Radar's upgrade checks cover Kubernetes through ${reviewedThrough}. Click to assess the next minor upgrade.`
+          : 'Assess the next minor Kubernetes upgrade.'
+      }
+      wrapperClassName="w-fit"
+    >
+      <button
+        onClick={onNavigate}
+        className="group flex items-center gap-1 hover:text-theme-text-secondary transition-colors"
+      >
+        <span>Kubernetes {version}</span>
+        {behind > 0 && (
+          <span>· Upgrade impact</span>
+        )}
+        <ArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+      </button>
+    </Tooltip>
   )
 }
 

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -45,9 +45,11 @@ interface HomeViewProps {
    * standalone OSS → the card drills into secrets as before.
    */
   onNavigateToCerts?: () => void
+  // Omitted when an embedded host owns /checks, leaving the version as plain text.
+  onNavigateToUpgradeImpact?: () => void
 }
 
-export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts }: HomeViewProps) {
+export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts, onNavigateToUpgradeImpact }: HomeViewProps) {
   // The card itself decides whether the cluster has a capacity story
   // (available, softened-denied, or karpenterless-with-managers/groups) and
   // returns null otherwise — the outer gate only excludes states with nothing
@@ -143,6 +145,7 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
           nodeVersionSkew={data.nodeVersionSkew}
           onNavigateToKind={onNavigateToResourceKind}
           onNavigateToView={() => onNavigateToView('resources')}
+          onNavigateToUpgradeImpact={onNavigateToUpgradeImpact}
           onWarningEventsClick={() => onNavigateToView('timeline', { view: 'list', filter: 'warnings', time: 'all' })}
           onIssuesClick={() => onNavigateToView('issues')}
         />


### PR DESCRIPTION
## Summary

Upgrade impact is useful but easy to miss inside Checks. This adds a quiet, contextual entry point beside the cluster's Kubernetes version and makes the two Checks views read as sibling pages, without promoting Upgrade impact to primary navigation or presenting catalog coverage as release availability.

## What changed

### Contextual Home entry point

- The Kubernetes version line links to `/checks/upgrade`.
- When Radar's upgrade catalog covers newer minors, the line adds a muted `· Upgrade impact` cue.
- The tooltip attributes the newer version to Radar's check coverage. Clicking opens the default next-minor assessment rather than preselecting the newest catalog version.
- A static `upgradeReviewedThrough` field on the dashboard payload powers the cue; loading Home does not run an upgrade scan.
- In Cloud takeover mode, where the host owns `/checks`, the version remains plain text.

### Clear Checks hierarchy

- Best practices / Upgrade impact tabs sit above the page header on both child views.
- The `/checks` page heading is `Best practices`, matching its active tab and page-specific description.

## Scope

This remains a small discoverability improvement: no new navigation item, Home card, banner, omnibar result, provider-release detection, or support-status claim.

## Testing

- `make tsc`
- `make test`
- Web tests: 499 passed
- `make build`
- Live smoke test against a Kubernetes 1.34 demo cluster: Home and dashboard API loaded successfully with zero browser console errors.
- Visual test at 1920x1080: Home cue and tooltip; click opened the 1.34 to 1.35 assessment with the version-sequence check passing; Best practices heading verified.
