### PR TITLE
fix(upgrade): attribute incomplete evidence precisely

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -227,6 +227,7 @@ Disabled by default for security:
 | Helm Write | `rbac.helm: true` | Install/upgrade/rollback/uninstall Helm releases. Under auth or cloud-mode, also emits a split helm add-on ClusterRole — `radar-helm` (member-safe: CRDs, storage, namespaces) and `radar-helm-admin` (owner-only: RBAC, webhooks, ApiServices) |
 | RBAC view | `rbac.viewRBAC: true` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default — cache-served reads bypass per-user RBAC, so this exposes the cluster's authorization graph to every authenticated Radar user. Auto-enabled under auth or cloud mode (every read is re-checked per user there). |
 | Webhooks view | `rbac.viewWebhooks: true` | Show MutatingWebhookConfigurations and ValidatingWebhookConfigurations in the resource browser. Off by default — the configurations reveal which admission controls are enforced (Gatekeeper / Kyverno policies, image scanners, DLP) and where the gaps are, which is recon value for a low-trust viewer. Auto-enabled under auth or cloud mode. |
+| Node runtime evidence | `rbac.viewNodeRuntime: true` | Let upgrade-impact checks inspect kubelet metrics and effective configuration through `nodes/proxy`. Off by default because this exposes node-level runtime and configuration details to anyone who can reach a no-auth Radar install. Under auth, grant `get` on `nodes/proxy` to each Kubernetes identity that should inspect this evidence. |
 
 ### In-app Agent Upgrades (opt-in, for Radar Cloud users)
 

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -167,6 +167,16 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
 
+  {{- if .Values.rbac.viewNodeRuntime }}
+  # Kubelet runtime evidence (opt-in): upgrade-impact checks inspect kubelet
+  # metrics and effective configuration through the Node proxy. In no-auth
+  # mode this makes node-level details visible to anyone who can reach Radar.
+  - apiGroups: [""]
+    resources:
+      - nodes/proxy
+    verbs: ["get"]
+  {{- end }}
+
   {{- if .Values.rbac.podLogs }}
   # Pod logs (opt-in - enables log viewer)
   - apiGroups: [""]

--- a/deploy/helm/radar/tests/upgrade_impact_rbac_test.yaml
+++ b/deploy/helm/radar/tests/upgrade_impact_rbac_test.yaml
@@ -63,3 +63,18 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: grants node runtime evidence only when explicitly enabled
+    set:
+      rbac:
+        viewNodeRuntime: true
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes/proxy"]
+            verbs: ["get"]

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -91,6 +91,13 @@ rbac:
   # plane visibility.
   viewWebhooks: false
 
+  # Allow the no-auth in-cluster Radar identity to read kubelet metrics and
+  # effective configuration through nodes/proxy for upgrade-impact checks.
+  # This exposes node-level runtime and configuration details to anyone who
+  # can reach that Radar instance. Enable only when that audience is trusted.
+  # Authenticated users need this permission on their own Kubernetes identity.
+  viewNodeRuntime: false
+
   # Allow pod exec (enables terminal feature)
   podExec: false
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -212,6 +212,8 @@ Some features require additional permissions. Most are disabled by default for s
 | Logs | `rbac.podLogs: true` | `true` | View pod logs |
 | Helm Write | `rbac.helm: true` | `false` | Install/upgrade/rollback/uninstall Helm releases (grants broad write access; auto-enables secrets). When auth or cloud is on, also emits a split helm add-on: `radar-helm` (CRDs/storage/PDBs/namespaces, bound to owner+member) and `radar-helm-admin` (RBAC/webhooks/APIServices, owner-only) — see [authentication.md](authentication.md#cloud-mode-helm-bindings) |
 | RBAC view | `rbac.viewRBAC: true` | `false` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default: cache-served reads bypass per-user RBAC, so granting this exposes the cluster's authorization graph to every authenticated Radar user |
+| Webhooks view | `rbac.viewWebhooks: true` | `false` | Show admission webhook configurations. Off by default because they expose the cluster's admission-control posture; auto-enabled when auth or cloud mode enforces each user's own RBAC |
+| Node runtime evidence | `rbac.viewNodeRuntime: true` | `false` | Let upgrade-impact checks inspect kubelet metrics and effective configuration through `nodes/proxy`. Enable only for a trusted no-auth audience; authenticated users need this permission on their own Kubernetes identity |
 | Traffic TLS | `rbac.traffic: true` | `true` | Read Hubble relay TLS certs for Cilium traffic observation |
 
 > **Node management** (cordon, uncordon, drain) is available via the MCP server and API. These operations require `patch` on nodes, `list` on pods, and `create` on `pods/eviction`, which are not included in the default ClusterRole. Add them via `rbac.additionalRules` or use [per-user authentication](authentication.md) so each user's own RBAC governs node operations.
@@ -397,6 +399,8 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `rbac.secrets` | Show secrets in resource list | `false` |
 | `rbac.helm` | Enable Helm write operations | `false` |
 | `rbac.viewRBAC` | Show RBAC objects in resource browser | `false` |
+| `rbac.viewWebhooks` | Show admission webhook configurations | `false` |
+| `rbac.viewNodeRuntime` | Inspect kubelet metrics and effective configuration for upgrade impact | `false` |
 | `rbac.traffic` | Read Hubble TLS certs | `true` |
 | `rbac.crdGroups.all` | Wildcard CRD read access | `false` |
 

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -241,29 +241,34 @@ func canReadClusterScopedKind(ctx context.Context, kind, group, verb string) boo
 // Returns true (passthrough) when no user is on context — auth-mode=none
 // applies the SA's RBAC at the cache layer.
 func canReadInNamespace(ctx context.Context, group, resource, namespace, verb string) bool {
+	allowed, _ := canReadInNamespaceDecision(ctx, group, resource, namespace, verb)
+	return allowed
+}
+
+func canReadInNamespaceDecision(ctx context.Context, group, resource, namespace, verb string) (bool, bool) {
 	user, perms := resolveUserPerms(ctx)
 	if user == nil {
-		return true
+		return true, true
 	}
 	if perms != nil {
 		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
-			return v
+			return v, true
 		}
 	}
 	client := k8s.GetClient()
 	if client == nil {
 		log.Printf("[mcp] canReadInNamespace: no K8s client, denying %s on %s/%s in %q for %s", k8s.SanitizeForLog(verb), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), k8s.SanitizeForLog(user.Username))
-		return false
+		return false, false
 	}
 	allowed, err := subjectCanI(ctx, client, user.Username, user.Groups, namespace, group, resource, verb)
 	if err != nil {
 		log.Printf("[mcp] canReadInNamespace SAR failed for %s on %s/%s in %q: %v", k8s.SanitizeForLog(user.Username), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), err)
-		return false
+		return false, false
 	}
 	if perms != nil {
 		perms.SetCanI(verb, group, resource, namespace, allowed)
 	}
-	return allowed
+	return allowed, true
 }
 
 // filterNamespacesByCanRead returns the subset of `namespaces` where the

--- a/internal/mcp/tools_upgrade.go
+++ b/internal/mcp/tools_upgrade.go
@@ -115,28 +115,29 @@ func (a mcpUpgradeAuthorizer) Namespaces() []string {
 	return filterNamespacesForUser(a.ctx, nil)
 }
 
-func (a mcpUpgradeAuthorizer) CanList(group, resource, namespace string) bool {
-	return canReadInNamespace(a.ctx, group, resource, namespace, "list")
+func (a mcpUpgradeAuthorizer) CanList(group, resource, namespace string) upgrade.EvidenceAuthorizationDecision {
+	allowed, authoritative := canReadInNamespaceDecision(a.ctx, group, resource, namespace, "list")
+	return upgrade.EvidenceAuthorizationDecision{Allowed: allowed, Authoritative: authoritative}
 }
 
 // subjectCanISubresource is overridden in tests to bypass the live apiserver.
 var subjectCanISubresource = pkgauth.SubjectCanISubresource
 
-func (a mcpUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) bool {
+func (a mcpUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) upgrade.EvidenceAuthorizationDecision {
 	user := pkgauth.UserFromContext(a.ctx)
 	if user == nil {
-		return true
+		return upgrade.EvidenceAuthorizationDecision{Allowed: true, Authoritative: true}
 	}
 	client := k8s.GetClient()
 	if client == nil {
-		return false
+		return upgrade.EvidenceAuthorizationDecision{}
 	}
 	allowed, err := subjectCanISubresource(a.ctx, client, user.Username, user.Groups, "", group, resource, subresource, "get")
 	if err != nil {
 		log.Printf("[mcp] upgrade authorization failed for get on %s/%s: %v", resource, subresource, err)
-		return false
+		return upgrade.EvidenceAuthorizationDecision{}
 	}
-	return allowed
+	return upgrade.EvidenceAuthorizationDecision{Allowed: allowed, Authoritative: true}
 }
 
 func (a mcpUpgradeAuthorizer) FilterNamespacesByCanList(group, resource string, namespaces []string) []string {

--- a/internal/mcp/tools_upgrade_auth_test.go
+++ b/internal/mcp/tools_upgrade_auth_test.go
@@ -26,20 +26,20 @@ func TestMCPUpgradeAuthorizerDecisionMatrix(t *testing.T) {
 
 	authz := mcpUpgradeAuthorizer{ctx: ctx}
 	for _, tc := range []struct {
-		group, resource, namespace string
-		want                       bool
+		group, resource, namespace     string
+		wantAllowed, wantAuthoritative bool
 	}{
-		{"", "nodes", "", true},
-		{"", "persistentvolumes", "", false},
-		{"storage.k8s.io", "csidrivers", "", true},
-		{"admissionregistration.k8s.io", "validatingwebhookconfigurations", "", true},
-		{"scheduling.k8s.io", "workloads", "team-a", true},
+		{"", "nodes", "", true, true},
+		{"", "persistentvolumes", "", false, true},
+		{"storage.k8s.io", "csidrivers", "", true, true},
+		{"admissionregistration.k8s.io", "validatingwebhookconfigurations", "", true, true},
+		{"scheduling.k8s.io", "workloads", "team-a", true, true},
 		// Unseeded → SAR against a nil client → fail closed. Cluster-wide pod
 		// visibility must not imply cluster-scoped reads.
-		{"apiregistration.k8s.io", "apiservices", "", false},
+		{"apiregistration.k8s.io", "apiservices", "", false, false},
 	} {
-		if got := authz.CanList(tc.group, tc.resource, tc.namespace); got != tc.want {
-			t.Fatalf("CanList(%q,%q,%q) = %v, want %v", tc.group, tc.resource, tc.namespace, got, tc.want)
+		if got := authz.CanList(tc.group, tc.resource, tc.namespace); got.Allowed != tc.wantAllowed || got.Authoritative != tc.wantAuthoritative {
+			t.Fatalf("CanList(%q,%q,%q) = %+v, want allowed=%v authoritative=%v", tc.group, tc.resource, tc.namespace, got, tc.wantAllowed, tc.wantAuthoritative)
 		}
 	}
 	filtered := authz.FilterNamespacesByCanList("", "secrets", []string{"team-a", "team-b"})
@@ -48,11 +48,11 @@ func TestMCPUpgradeAuthorizerDecisionMatrix(t *testing.T) {
 	}
 	// Subresource SARs are not memoized; with no apiserver they fail closed
 	// for an authenticated user and pass through when auth is off.
-	if authz.CanGetSubresource("", "nodes", "proxy") {
-		t.Fatal("authenticated nodes/proxy with no apiserver to ask must fail closed")
+	if decision := authz.CanGetSubresource("", "nodes", "proxy"); decision.Allowed || decision.Authoritative {
+		t.Fatalf("authenticated nodes/proxy with no apiserver = %+v, want non-authoritative failure", decision)
 	}
-	if noAuth := (mcpUpgradeAuthorizer{ctx: context.Background()}); !noAuth.CanGetSubresource("", "nodes", "proxy") {
-		t.Fatal("auth-off subresource check must pass through (SA RBAC applies at the client layer)")
+	if decision := (mcpUpgradeAuthorizer{ctx: context.Background()}).CanGetSubresource("", "nodes", "proxy"); !decision.Allowed || !decision.Authoritative {
+		t.Fatalf("auth-off subresource decision = %+v, want authoritative pass-through", decision)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1503,9 +1503,14 @@ func noNamespaceAccess(namespaces []string) bool {
 //
 // Pass namespace="" for a cluster-scoped check.
 func (s *Server) canRead(r *http.Request, group, resource, namespace, verb string) bool {
+	allowed, _ := s.canReadDecision(r, group, resource, namespace, verb)
+	return allowed
+}
+
+func (s *Server) canReadDecision(r *http.Request, group, resource, namespace, verb string) (bool, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil || s.permCache == nil {
-		return true
+		return true, true
 	}
 	if s.permCache.Get(user.Username) == nil {
 		// Trigger namespace discovery so SAR cache has a parent UserPermissions
@@ -1513,7 +1518,7 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 		// this; if it hasn't run yet, canReadUser falls through to a fresh SAR.
 		_ = s.getUserNamespaces(r, []string{})
 	}
-	return s.canReadUser(r.Context(), user, group, resource, namespace, verb)
+	return s.canReadUserDecision(r.Context(), user, group, resource, namespace, verb)
 }
 
 // canReadUser is the request-free core of canRead: it authorizes a single
@@ -1528,13 +1533,18 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 // Fail-closed: no apiserver / SAR error → deny. Returns true only when auth is
 // disabled (nil user) or the SAR allows it.
 func (s *Server) canReadUser(ctx context.Context, user *auth.User, group, resource, namespace, verb string) bool {
+	allowed, _ := s.canReadUserDecision(ctx, user, group, resource, namespace, verb)
+	return allowed
+}
+
+func (s *Server) canReadUserDecision(ctx context.Context, user *auth.User, group, resource, namespace, verb string) (bool, bool) {
 	if user == nil || s.permCache == nil {
-		return true
+		return true, true
 	}
 	perms := s.permCache.Get(user.Username)
 	if perms != nil {
 		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
-			return v
+			return v, true
 		}
 	}
 	allowed, authoritative := s.canReadUserSAR(ctx, user, group, resource, namespace, verb)
@@ -1544,7 +1554,7 @@ func (s *Server) canReadUser(ctx context.Context, user *auth.User, group, resour
 	if authoritative && perms != nil {
 		perms.SetCanI(verb, group, resource, namespace, allowed)
 	}
-	return allowed
+	return allowed, authoritative
 }
 
 // canReadUserSAR runs a single fresh SubjectAccessReview for (group, resource,

--- a/internal/server/upgrade_readiness_authz_test.go
+++ b/internal/server/upgrade_readiness_authz_test.go
@@ -21,31 +21,31 @@ func TestHTTPUpgradeAuthorizerDecisionMatrix(t *testing.T) {
 	r := requestWithUser("GET", "/api/upgrade-readiness", &auth.User{Username: "upgrade-matrix"})
 	authz := httpUpgradeAuthorizer{s: s, r: r}
 	for _, tc := range []struct {
-		group, resource, namespace string
-		want                       bool
+		group, resource, namespace     string
+		wantAllowed, wantAuthoritative bool
 	}{
-		{"", "nodes", "", true},
-		{"", "persistentvolumes", "", false},
-		{"storage.k8s.io", "csidrivers", "", true},
-		{"admissionregistration.k8s.io", "validatingwebhookconfigurations", "", true},
-		{"scheduling.k8s.io", "workloads", "team-a", true},
+		{"", "nodes", "", true, true},
+		{"", "persistentvolumes", "", false, true},
+		{"storage.k8s.io", "csidrivers", "", true, true},
+		{"admissionregistration.k8s.io", "validatingwebhookconfigurations", "", true, true},
+		{"scheduling.k8s.io", "workloads", "team-a", true, true},
 		// Unseeded → SAR against a nil client → fail closed. Cluster-wide pod
 		// visibility must not imply cluster-scoped reads.
-		{"apiregistration.k8s.io", "apiservices", "", false},
+		{"apiregistration.k8s.io", "apiservices", "", false, false},
 	} {
-		if got := authz.CanList(tc.group, tc.resource, tc.namespace); got != tc.want {
-			t.Fatalf("CanList(%q,%q,%q) = %v, want %v", tc.group, tc.resource, tc.namespace, got, tc.want)
+		if got := authz.CanList(tc.group, tc.resource, tc.namespace); got.Allowed != tc.wantAllowed || got.Authoritative != tc.wantAuthoritative {
+			t.Fatalf("CanList(%q,%q,%q) = %+v, want allowed=%v authoritative=%v", tc.group, tc.resource, tc.namespace, got, tc.wantAllowed, tc.wantAuthoritative)
 		}
 	}
 	filtered := authz.FilterNamespacesByCanList("", "secrets", []string{"team-a", "team-b"})
 	if len(filtered) != 1 || filtered[0] != "team-a" {
 		t.Fatalf("FilterNamespacesByCanList = %v, want [team-a]", filtered)
 	}
-	if authz.CanGetSubresource("", "nodes", "proxy") {
-		t.Fatal("authenticated nodes/proxy with no apiserver to ask must fail closed")
+	if decision := authz.CanGetSubresource("", "nodes", "proxy"); decision.Allowed || decision.Authoritative {
+		t.Fatalf("authenticated nodes/proxy with no apiserver = %+v, want non-authoritative failure", decision)
 	}
 	noAuthReq := requestWithUser("GET", "/api/upgrade-readiness", nil)
-	if noAuth := (httpUpgradeAuthorizer{s: s, r: noAuthReq}); !noAuth.CanGetSubresource("", "nodes", "proxy") {
-		t.Fatal("auth-off subresource check must pass through (SA RBAC applies at the client layer)")
+	if decision := (httpUpgradeAuthorizer{s: s, r: noAuthReq}).CanGetSubresource("", "nodes", "proxy"); !decision.Allowed || !decision.Authoritative {
+		t.Fatalf("auth-off subresource decision = %+v, want authoritative pass-through", decision)
 	}
 }

--- a/internal/server/upgrade_readiness_handler.go
+++ b/internal/server/upgrade_readiness_handler.go
@@ -74,20 +74,25 @@ func (s *Server) upgradeReadinessNamespaces(r *http.Request) []string {
 }
 
 func (s *Server) canReadSubresource(r *http.Request, group, resource, subresource, namespace, verb string) bool {
+	allowed, _ := s.canReadSubresourceDecision(r, group, resource, subresource, namespace, verb)
+	return allowed
+}
+
+func (s *Server) canReadSubresourceDecision(r *http.Request, group, resource, subresource, namespace, verb string) (bool, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		return true
+		return true, true
 	}
 	client := k8s.GetClient()
 	if client == nil {
-		return false
+		return false, false
 	}
 	allowed, err := auth.SubjectCanISubresource(r.Context(), client, user.Username, user.Groups, namespace, group, resource, subresource, verb)
 	if err != nil {
 		log.Printf("[upgrade-impact] authorization failed for %s on %s/%s: %v", verb, resource, subresource, err)
-		return false
+		return false, false
 	}
-	return allowed
+	return allowed, true
 }
 
 // httpUpgradeAuthorizer adapts (*Server, *http.Request) to the upgrade
@@ -102,12 +107,14 @@ func (a httpUpgradeAuthorizer) Namespaces() []string {
 	return a.s.upgradeReadinessNamespaces(a.r)
 }
 
-func (a httpUpgradeAuthorizer) CanList(group, resource, namespace string) bool {
-	return a.s.canRead(a.r, group, resource, namespace, "list")
+func (a httpUpgradeAuthorizer) CanList(group, resource, namespace string) upgrade.EvidenceAuthorizationDecision {
+	allowed, authoritative := a.s.canReadDecision(a.r, group, resource, namespace, "list")
+	return upgrade.EvidenceAuthorizationDecision{Allowed: allowed, Authoritative: authoritative}
 }
 
-func (a httpUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) bool {
-	return a.s.canReadSubresource(a.r, group, resource, subresource, "", "get")
+func (a httpUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) upgrade.EvidenceAuthorizationDecision {
+	allowed, authoritative := a.s.canReadSubresourceDecision(a.r, group, resource, subresource, "", "get")
+	return upgrade.EvidenceAuthorizationDecision{Allowed: allowed, Authoritative: authoritative}
 }
 
 func (a httpUpgradeAuthorizer) FilterNamespacesByCanList(group, resource string, namespaces []string) []string {

--- a/internal/upgrade/collectors.go
+++ b/internal/upgrade/collectors.go
@@ -129,7 +129,7 @@ var (
 
 func collectUpgradeAPIServices(ctx context.Context, authz EvidenceAuthorizer) []*unstructured.Unstructured {
 	client := k8s.DynamicClientFromContext(ctx)
-	if client == nil || !authz.CanList(apiServiceGVR.Group, apiServiceGVR.Resource, "") {
+	if client == nil || !canListEvidence(authz, apiServiceGVR.Group, apiServiceGVR.Resource, "") {
 		return nil
 	}
 	return collectUpgradeAPIServicesWithClient(ctx, client)
@@ -149,7 +149,7 @@ func collectUpgradeAPIServicesWithClient(ctx context.Context, client dynamic.Int
 
 func collectUpgradeCSIDrivers(ctx context.Context, authz EvidenceAuthorizer) []*storagev1.CSIDriver {
 	client := k8s.ClientFromContext(ctx)
-	if client == nil || !authz.CanList("storage.k8s.io", "csidrivers", "") {
+	if client == nil || !canListEvidence(authz, "storage.k8s.io", "csidrivers", "") {
 		return nil
 	}
 	list, err := client.StorageV1().CSIDrivers().List(ctx, metav1.ListOptions{})
@@ -191,7 +191,7 @@ func collectSchedulingV1Alpha2Evidence(ctx context.Context, authz EvidenceAuthor
 		gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1alpha2", Resource: resource.Name}
 		resourceUnavailable := false
 		if !resource.Namespaced || namespaces == nil {
-			if !authz.CanList(gvr.Group, gvr.Resource, "") {
+			if !canListEvidence(authz, gvr.Group, gvr.Resource, "") {
 				unavailable = append(unavailable, resource.Kind)
 				continue
 			}
@@ -200,7 +200,7 @@ func collectSchedulingV1Alpha2Evidence(ctx context.Context, authz EvidenceAuthor
 			resourceUnavailable = listErr != nil
 		} else {
 			for _, namespace := range namespaces {
-				if !authz.CanList(gvr.Group, gvr.Resource, namespace) {
+				if !canListEvidence(authz, gvr.Group, gvr.Resource, namespace) {
 					resourceUnavailable = true
 					continue
 				}
@@ -242,58 +242,71 @@ func listAllUpgradeObjects(ctx context.Context, resource dynamic.ResourceInterfa
 	}
 }
 
-func collectUpgradeWebhookEvidence(ctx context.Context, authz EvidenceAuthorizer) (configs []*unstructured.Unstructured, unavailableConfigKinds []string, crds []*unstructured.Unstructured, endpointSlices []*discoveryv1.EndpointSlice, services []*corev1.Service) {
-	defer func() { sort.Strings(unavailableConfigKinds) }()
+func collectUpgradeWebhookEvidence(ctx context.Context, authz EvidenceAuthorizer) (configs []*unstructured.Unstructured, unavailableConfigKinds, deniedConfigKinds []string, crds []*unstructured.Unstructured, endpointSlices []*discoveryv1.EndpointSlice, services []*corev1.Service) {
 	dynamicClient := k8s.DynamicClientFromContext(ctx)
 	typedClient := k8s.ClientFromContext(ctx)
 	if dynamicClient == nil || typedClient == nil {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
-	configs = []*unstructured.Unstructured{}
+	configs, unavailableConfigKinds, deniedConfigKinds = collectUpgradeWebhookConfigurations(ctx, dynamicClient, authz)
 	endpointSlices = []*discoveryv1.EndpointSlice{}
 	services = []*corev1.Service{}
-	for _, gvr := range []schema.GroupVersionResource{validatingWebhookGVR, mutatingWebhookGVR} {
-		if !authz.CanList(gvr.Group, gvr.Resource, "") {
-			unavailableConfigKinds = append(unavailableConfigKinds, gvr.Resource)
-			continue
-		}
-		list, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			unavailableConfigKinds = append(unavailableConfigKinds, gvr.Resource)
-			continue
-		}
-		for i := range list.Items {
-			configs = append(configs, list.Items[i].DeepCopy())
-		}
-	}
-	if authz.CanList(crdGVR.Group, crdGVR.Resource, "") {
+	if canListEvidence(authz, crdGVR.Group, crdGVR.Resource, "") {
 		crds = collectUpgradeCRDs(ctx, dynamicClient)
 	}
 	referenced := webhookServiceNamespaces(configs, crds)
 	for _, namespace := range referenced {
-		if !authz.CanList("", "services", namespace) || !authz.CanList(endpointSliceGVR.Group, endpointSliceGVR.Resource, namespace) {
-			return configs, unavailableConfigKinds, crds, nil, nil
+		if !canListEvidence(authz, "", "services", namespace) || !canListEvidence(authz, endpointSliceGVR.Group, endpointSliceGVR.Resource, namespace) {
+			return configs, unavailableConfigKinds, deniedConfigKinds, crds, nil, nil
 		}
 		svcList, err := typedClient.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return configs, unavailableConfigKinds, crds, nil, nil
+			return configs, unavailableConfigKinds, deniedConfigKinds, crds, nil, nil
 		}
 		for i := range svcList.Items {
 			services = append(services, svcList.Items[i].DeepCopy())
 		}
 		sliceList, err := dynamicClient.Resource(endpointSliceGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return configs, unavailableConfigKinds, crds, nil, nil
+			return configs, unavailableConfigKinds, deniedConfigKinds, crds, nil, nil
 		}
 		for i := range sliceList.Items {
 			var slice discoveryv1.EndpointSlice
 			if runtime.DefaultUnstructuredConverter.FromUnstructured(sliceList.Items[i].Object, &slice) != nil {
-				return configs, unavailableConfigKinds, crds, nil, nil
+				return configs, unavailableConfigKinds, deniedConfigKinds, crds, nil, nil
 			}
 			endpointSlices = append(endpointSlices, &slice)
 		}
 	}
-	return configs, unavailableConfigKinds, crds, endpointSlices, services
+	return configs, unavailableConfigKinds, deniedConfigKinds, crds, endpointSlices, services
+}
+
+func collectUpgradeWebhookConfigurations(ctx context.Context, dynamicClient dynamic.Interface, authz EvidenceAuthorizer) (configs []*unstructured.Unstructured, unavailableKinds, deniedKinds []string) {
+	configs = []*unstructured.Unstructured{}
+	for _, gvr := range []schema.GroupVersionResource{validatingWebhookGVR, mutatingWebhookGVR} {
+		decision := authz.CanList(gvr.Group, gvr.Resource, "")
+		if !decision.Allowed {
+			unavailableKinds = append(unavailableKinds, gvr.Resource)
+			if decision.Authoritative {
+				deniedKinds = append(deniedKinds, gvr.Resource)
+			}
+			continue
+		}
+		list, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			unavailableKinds = append(unavailableKinds, gvr.Resource)
+			if apierrors.IsForbidden(err) {
+				deniedKinds = append(deniedKinds, gvr.Resource)
+			}
+			continue
+		}
+		for i := range list.Items {
+			configs = append(configs, list.Items[i].DeepCopy())
+		}
+	}
+	sort.Strings(unavailableKinds)
+	sort.Strings(deniedKinds)
+	return configs, unavailableKinds, deniedKinds
 }
 
 func collectUpgradeCRDs(ctx context.Context, client dynamic.Interface) []*unstructured.Unstructured {

--- a/internal/upgrade/collectors_live.go
+++ b/internal/upgrade/collectors_live.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -189,13 +190,13 @@ func collectUpgradePrometheusRules(ctx context.Context, authz EvidenceAuthorizer
 		return []*unstructured.Unstructured{}, false, true, nil
 	}
 	if len(namespaces) == 0 {
-		if !authz.CanList(gvr.Group, gvr.Resource, "") {
+		if !canListEvidence(authz, gvr.Group, gvr.Resource, "") {
 			return nil, true, true, nil
 		}
 	} else {
 		readable := make([]string, 0, len(namespaces))
 		for _, namespace := range namespaces {
-			if authz.CanList(gvr.Group, gvr.Resource, namespace) {
+			if canListEvidence(authz, gvr.Group, gvr.Resource, namespace) {
 				readable = append(readable, namespace)
 			} else {
 				unavailableNamespaces = append(unavailableNamespaces, namespace)
@@ -257,15 +258,27 @@ func listSyncedUpgradeResources(cache upgradeResourceLister, gvr schema.GroupVer
 	return rules, err == nil, err
 }
 
-func collectUpgradeNodeRuntimeEvidence(ctx context.Context, nodes []*corev1.Node, includeConfig bool) []upgradereadiness.NodeRuntimeEvidence {
+func collectUpgradeNodeRuntimeEvidence(ctx context.Context, nodes []*corev1.Node, includeConfig bool) ([]upgradereadiness.NodeRuntimeEvidence, bool) {
 	client := k8s.ClientFromContext(ctx)
 	if client == nil || client.CoreV1().RESTClient() == nil {
-		return nil
+		return nil, false
 	}
+	return collectUpgradeNodeRuntimeEvidenceWithClient(ctx, client.CoreV1().RESTClient(), nodes, includeConfig)
+}
+
+func collectUpgradeNodeRuntimeEvidenceWithClient(ctx context.Context, client rest.Interface, nodes []*corev1.Node, includeConfig bool) ([]upgradereadiness.NodeRuntimeEvidence, bool) {
 	results := make([]upgradereadiness.NodeRuntimeEvidence, len(nodes))
+	forbiddenByNode := make([]bool, len(nodes))
+	failureCountByNode := make([]int, len(nodes))
+	firstFailureByNode := make([]error, len(nodes))
 	type nodeRuntimeJob struct {
 		index int
 		node  *corev1.Node
+	}
+	type nodeRuntimeFetch struct {
+		evidence  upgradereadiness.NodeRuntimeEvidence
+		forbidden bool
+		err       error
 	}
 	jobs := make(chan nodeRuntimeJob)
 	workerCount := min(8, len(nodes))
@@ -276,43 +289,66 @@ func collectUpgradeNodeRuntimeEvidence(ctx context.Context, nodes []*corev1.Node
 			defer wg.Done()
 			for job := range jobs {
 				result := upgradereadiness.NodeRuntimeEvidence{NodeName: job.node.Name}
-				metricsCh := make(chan upgradereadiness.NodeRuntimeEvidence, 1)
-				configCh := make(chan upgradereadiness.NodeRuntimeEvidence, 1)
+				metricsCh := make(chan nodeRuntimeFetch, 1)
+				configCh := make(chan nodeRuntimeFetch, 1)
 				if strings.EqualFold(job.node.Status.NodeInfo.OperatingSystem, "windows") {
-					metricsCh <- upgradereadiness.NodeRuntimeEvidence{}
+					metricsCh <- nodeRuntimeFetch{}
 				} else {
 					go func() {
-						raw, err := fetchUpgradeNodeEvidence(ctx, client.CoreV1().RESTClient(), job.node.Name, "metrics")
+						raw, err := fetchUpgradeNodeEvidence(ctx, client, job.node.Name, "metrics")
 						if err != nil {
-							metricsCh <- upgradereadiness.NodeRuntimeEvidence{}
+							forbidden := apierrors.IsForbidden(err)
+							if forbidden {
+								err = nil
+							}
+							metricsCh <- nodeRuntimeFetch{forbidden: forbidden, err: err}
 							return
 						}
 						parsed, err := parseUpgradeNodeMetrics(raw)
 						if err != nil {
 							parsed = upgradereadiness.NodeRuntimeEvidence{}
 						}
-						metricsCh <- parsed
+						metricsCh <- nodeRuntimeFetch{evidence: parsed, err: err}
 					}()
 				}
 				if includeConfig {
 					go func() {
-						raw, err := fetchUpgradeNodeEvidence(ctx, client.CoreV1().RESTClient(), job.node.Name, "configz")
+						raw, err := fetchUpgradeNodeEvidence(ctx, client, job.node.Name, "configz")
 						if err != nil {
-							configCh <- upgradereadiness.NodeRuntimeEvidence{}
+							forbidden := apierrors.IsForbidden(err)
+							if forbidden {
+								err = nil
+							}
+							configCh <- nodeRuntimeFetch{forbidden: forbidden, err: err}
 							return
 						}
 						parsed, err := parseUpgradeNodeConfig(raw)
 						if err != nil {
 							parsed = upgradereadiness.NodeRuntimeEvidence{}
 						}
-						configCh <- parsed
+						configCh <- nodeRuntimeFetch{evidence: parsed, err: err}
 					}()
 				} else {
-					configCh <- upgradereadiness.NodeRuntimeEvidence{}
+					configCh <- nodeRuntimeFetch{}
 				}
-				mergeNodeRuntimeEvidence(&result, <-metricsCh)
-				mergeNodeRuntimeEvidence(&result, <-configCh)
+				metricsResult := <-metricsCh
+				configResult := <-configCh
+				mergeNodeRuntimeEvidence(&result, metricsResult.evidence)
+				mergeNodeRuntimeEvidence(&result, configResult.evidence)
 				results[job.index] = result
+				forbiddenByNode[job.index] = metricsResult.forbidden || configResult.forbidden
+				for _, fetch := range []struct {
+					endpoint string
+					result   nodeRuntimeFetch
+				}{{"metrics", metricsResult}, {"configz", configResult}} {
+					if fetch.result.err == nil {
+						continue
+					}
+					failureCountByNode[job.index]++
+					if firstFailureByNode[job.index] == nil {
+						firstFailureByNode[job.index] = fmt.Errorf("%s/%s: %w", job.node.Name, fetch.endpoint, fetch.result.err)
+					}
+				}
 			}
 		}()
 	}
@@ -333,7 +369,26 @@ dispatch:
 	}
 	close(jobs)
 	wg.Wait()
-	return results
+	forbiddenObserved := false
+	failedRequests := 0
+	failedNodes := 0
+	var firstFailure error
+	for i, forbidden := range forbiddenByNode {
+		if forbidden {
+			forbiddenObserved = true
+		}
+		if failureCountByNode[i] > 0 {
+			failedRequests += failureCountByNode[i]
+			failedNodes++
+			if firstFailure == nil {
+				firstFailure = firstFailureByNode[i]
+			}
+		}
+	}
+	if failedRequests > 0 {
+		log.Printf("[upgrade-impact] node runtime evidence had %d non-authorization failures across %d/%d nodes (first: %v)", failedRequests, failedNodes, len(nodes), firstFailure)
+	}
+	return results, forbiddenObserved
 }
 
 func fetchUpgradeNodeEvidence(ctx context.Context, client rest.Interface, nodeName, endpoint string) ([]byte, error) {

--- a/internal/upgrade/collectors_live_test.go
+++ b/internal/upgrade/collectors_live_test.go
@@ -3,9 +3,12 @@ package upgrade
 import (
 	"bytes"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -13,7 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -220,5 +225,29 @@ func TestMergeNodeRuntimeEvidenceKeepsIndependentSources(t *testing.T) {
 	mergeNodeRuntimeEvidence(&target, upgradereadiness.NodeRuntimeEvidence{ConfigAvailable: true, EventRecordQPSAvailable: true, EventRecordQPS: 50, FeatureGates: map[string]bool{"AnyVolumeDataSource": true}})
 	if !target.MetricsAvailable || !target.ConfigAvailable || target.CgroupVersion != 2 || target.EventRecordQPS != 50 || target.SELinuxMismatchWarnings != 4 || !target.FeatureGates["AnyVolumeDataSource"] {
 		t.Fatalf("merged evidence = %+v", target)
+	}
+}
+
+func TestCollectUpgradeNodeRuntimeEvidenceClassifiesObservedForbidden(t *testing.T) {
+	requestedPath := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"forbidden","reason":"Forbidden","code":403}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes := []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}, Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{OperatingSystem: "linux"}}}}
+	evidence, forbidden := collectUpgradeNodeRuntimeEvidenceWithClient(t.Context(), client.CoreV1().RESTClient(), nodes, false)
+	if !forbidden || len(evidence) != 1 || evidence[0].NodeName != "node-a" || evidence[0].MetricsAvailable {
+		t.Fatalf("node runtime result = evidence=%+v forbidden=%v, want observed forbidden with unavailable metrics", evidence, forbidden)
+	}
+	if requestedPath != "/api/v1/nodes/node-a/proxy/metrics" {
+		t.Fatalf("request path = %q, want node metrics proxy path", requestedPath)
 	}
 }

--- a/internal/upgrade/collectors_test.go
+++ b/internal/upgrade/collectors_test.go
@@ -3,8 +3,10 @@ package upgrade
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -184,5 +186,61 @@ func TestCollectUpgradeAPIServicesReturnsObjects(t *testing.T) {
 	got := collectUpgradeAPIServicesWithClient(context.Background(), client)
 	if len(got) != 1 || got[0].GetName() != "v1.example.io" {
 		t.Fatalf("APIServices = %#v, want v1.example.io", got)
+	}
+}
+
+func TestCollectUpgradeWebhookConfigurationsSeparatesDeniedFromErrored(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		validatingWebhookGVR: "ValidatingWebhookConfigurationList",
+		mutatingWebhookGVR:   "MutatingWebhookConfigurationList",
+	})
+	client.PrependReactor("list", "validatingwebhookconfigurations", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("transient apiserver failure")
+	})
+	authz := &fakeUpgradeAuthorizer{canList: map[string]bool{
+		validatingWebhookGVR.Group + "/" + validatingWebhookGVR.Resource + "/": true,
+		mutatingWebhookGVR.Group + "/" + mutatingWebhookGVR.Resource + "/":     false,
+	}}
+
+	configs, unavailable, denied := collectUpgradeWebhookConfigurations(t.Context(), client, authz)
+	if len(configs) != 0 || !slices.Equal(unavailable, []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"}) || !slices.Equal(denied, []string{"mutatingwebhookconfigurations"}) {
+		t.Fatalf("webhook evidence = configs=%v unavailable=%v denied=%v", configs, unavailable, denied)
+	}
+}
+
+func TestCollectUpgradeWebhookConfigurationsClassifiesObservedForbidden(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		validatingWebhookGVR: "ValidatingWebhookConfigurationList",
+		mutatingWebhookGVR:   "MutatingWebhookConfigurationList",
+	})
+	client.PrependReactor("list", "validatingwebhookconfigurations", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(validatingWebhookGVR.GroupResource(), "", errors.New("denied"))
+	})
+	authz := &fakeUpgradeAuthorizer{canList: map[string]bool{
+		validatingWebhookGVR.Group + "/" + validatingWebhookGVR.Resource + "/": true,
+		mutatingWebhookGVR.Group + "/" + mutatingWebhookGVR.Resource + "/":     true,
+	}}
+
+	configs, unavailable, denied := collectUpgradeWebhookConfigurations(t.Context(), client, authz)
+	if len(configs) != 0 || !slices.Equal(unavailable, []string{"validatingwebhookconfigurations"}) || !slices.Equal(denied, []string{"validatingwebhookconfigurations"}) {
+		t.Fatalf("webhook evidence = configs=%v unavailable=%v denied=%v", configs, unavailable, denied)
+	}
+}
+
+func TestCollectUpgradeWebhookConfigurationsDoesNotClassifyFailedAuthorizationAsDenial(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		validatingWebhookGVR: "ValidatingWebhookConfigurationList",
+		mutatingWebhookGVR:   "MutatingWebhookConfigurationList",
+	})
+	authz := &fakeUpgradeAuthorizer{listDecisions: map[string]EvidenceAuthorizationDecision{
+		validatingWebhookGVR.Group + "/" + validatingWebhookGVR.Resource + "/": {},
+		mutatingWebhookGVR.Group + "/" + mutatingWebhookGVR.Resource + "/": {
+			Allowed: true, Authoritative: true,
+		},
+	}}
+
+	configs, unavailable, denied := collectUpgradeWebhookConfigurations(t.Context(), client, authz)
+	if len(configs) != 0 || !slices.Equal(unavailable, []string{"validatingwebhookconfigurations"}) || len(denied) != 0 {
+		t.Fatalf("webhook evidence = configs=%v unavailable=%v denied=%v, want an unattributed authorization-check failure", configs, unavailable, denied)
 	}
 }

--- a/internal/upgrade/evidence.go
+++ b/internal/upgrade/evidence.go
@@ -31,13 +31,24 @@ type EvidenceAuthorizer interface {
 	Namespaces() []string
 	// CanList authorizes a single list. namespace "" is a cluster-scoped
 	// check.
-	CanList(group, resource, namespace string) bool
+	CanList(group, resource, namespace string) EvidenceAuthorizationDecision
 	// CanGetSubresource authorizes a cluster-scoped subresource get
 	// (nodes/proxy for kubelet metrics and effective configuration).
-	CanGetSubresource(group, resource, subresource string) bool
+	CanGetSubresource(group, resource, subresource string) EvidenceAuthorizationDecision
 	// FilterNamespacesByCanList returns the subset of namespaces where the
 	// identity can list the resource.
 	FilterNamespacesByCanList(group, resource string, namespaces []string) []string
+}
+
+// EvidenceAuthorizationDecision keeps an explicit denial distinct from an
+// authorization check that could not reach an authoritative result.
+type EvidenceAuthorizationDecision struct {
+	Allowed       bool
+	Authoritative bool
+}
+
+func canListEvidence(authz EvidenceAuthorizer, group, resource, namespace string) bool {
+	return authz.CanList(group, resource, namespace).Allowed
 }
 
 // noNamespaceAccess returns true when a namespace filter explicitly grants no
@@ -67,7 +78,7 @@ func ResolveHelmNamespaces(ctx context.Context, authz EvidenceAuthorizer, namesp
 			if fallback := helm.ResolveNoAuthListNamespaces(ctx); len(fallback) > 0 {
 				return fallback, true
 			}
-		} else if !authz.CanList("", "secrets", "") {
+		} else if !canListEvidence(authz, "", "secrets", "") {
 			// Authenticated user with cluster-wide pod access but NOT
 			// cluster-wide `list secrets`. Helm storage is Secrets, so a single
 			// cluster-wide list would 403 wholesale and blank the view. Resolve
@@ -87,7 +98,7 @@ func resolveCachedEvidenceNamespaces(authz EvidenceAuthorizer, group, resource s
 	if noNamespaceAccess(namespaces) {
 		return []string{}
 	}
-	if authz.CanList(group, resource, "") {
+	if canListEvidence(authz, group, resource, "") {
 		return cloneStrings(namespaces)
 	}
 	candidates := namespaces
@@ -146,10 +157,12 @@ func runUpgradeReadinessScan(ctx context.Context, authz EvidenceAuthorizer, name
 	var sourceObjectUnavailableKinds []string
 	var admissionConfigs, crds []*unstructured.Unstructured
 	var admissionConfigUnavailableKinds []string
+	var admissionConfigDeniedKinds []string
 	var apiServices []*unstructured.Unstructured
 	var endpointSlices []*discoveryv1.EndpointSlice
 	var additionalServices []*corev1.Service
 	var nodeRuntimeEvidence []upgradereadiness.NodeRuntimeEvidence
+	var nodeProxyForbidden bool
 	var csiDrivers []*storagev1.CSIDriver
 	var schedulingV1Alpha2Objects []*unstructured.Unstructured
 	var schedulingV1Alpha2UnavailableKinds []string
@@ -157,7 +170,13 @@ func runUpgradeReadinessScan(ctx context.Context, authz EvidenceAuthorizer, name
 	configMapNamespaces := cloneStrings(namespaces)
 	persistentVolumeClaimNamespaces := cloneStrings(namespaces)
 	eventNamespaces := cloneStrings(namespaces)
-	canReadNodes := !noAccess && authz.CanList("", "nodes", "")
+	canReadNodes := !noAccess && canListEvidence(authz, "", "nodes", "")
+	nodeProxyDecision := EvidenceAuthorizationDecision{}
+	if !noAccess {
+		nodeProxyDecision = authz.CanGetSubresource("", "nodes", "proxy")
+	}
+	canGetNodeProxy := nodeProxyDecision.Allowed
+	nodeProxyForbidden = canReadNodes && nodeProxyDecision.Authoritative && !nodeProxyDecision.Allowed
 	if !noAccess {
 		if helmNamespaces, ok := ResolveHelmNamespaces(ctx, authz, namespaces); ok {
 			manifestResources, helmUnavailableNamespaces, manifestParseErrors = collectUpgradeHelmManifests(ctx, helmNamespaces)
@@ -171,7 +190,7 @@ func runUpgradeReadinessScan(ctx context.Context, authz EvidenceAuthorizer, name
 		sourceObjectCtx, cancelSourceObjectCollection := context.WithTimeout(ctx, upgradeSourceObjectCollectionTimeout)
 		sourceObjects, sourceObjectUnavailableKinds = collectUpgradeSourceObjects(sourceObjectCtx, namespaces)
 		cancelSourceObjectCollection()
-		admissionConfigs, admissionConfigUnavailableKinds, crds, endpointSlices, additionalServices = collectUpgradeWebhookEvidence(ctx, authz)
+		admissionConfigs, admissionConfigUnavailableKinds, admissionConfigDeniedKinds, crds, endpointSlices, additionalServices = collectUpgradeWebhookEvidence(ctx, authz)
 		apiServices = collectUpgradeAPIServices(ctx, authz)
 		if collect137Evidence {
 			csiDrivers = collectUpgradeCSIDrivers(ctx, authz)
@@ -184,10 +203,12 @@ func runUpgradeReadinessScan(ctx context.Context, authz EvidenceAuthorizer, name
 		if collect135Evidence || collect137Evidence {
 			eventNamespaces = resolveCachedEvidenceNamespaces(authz, "", "events", namespaces)
 		}
-		if canReadNodes && authz.CanGetSubresource("", "nodes", "proxy") && cache.Nodes() != nil {
+		if canReadNodes && canGetNodeProxy && cache.Nodes() != nil {
 			nodes, _ := cache.Nodes().List(labels.Everything())
 			nodeRuntimeCtx, cancelNodeRuntimeCollection := context.WithTimeout(ctx, upgradeNodeRuntimeCollectionTimeout)
-			nodeRuntimeEvidence = collectUpgradeNodeRuntimeEvidence(nodeRuntimeCtx, nodes, collect137Evidence)
+			var observedForbidden bool
+			nodeRuntimeEvidence, observedForbidden = collectUpgradeNodeRuntimeEvidence(nodeRuntimeCtx, nodes, collect137Evidence)
+			nodeProxyForbidden = nodeProxyForbidden || observedForbidden
 			cancelNodeRuntimeCollection()
 		}
 	}
@@ -213,11 +234,13 @@ func runUpgradeReadinessScan(ctx context.Context, authz EvidenceAuthorizer, name
 		PersistentVolumeClaimNamespaces:      persistentVolumeClaimNamespaces,
 		EventNamespaces:                      eventNamespaces,
 		CanReadNodes:                         canReadNodes,
-		CanReadPersistentVolumes:             !noAccess && authz.CanList("", "persistentvolumes", ""),
+		NodeProxyForbidden:                   nodeProxyForbidden,
+		CanReadPersistentVolumes:             !noAccess && canListEvidence(authz, "", "persistentvolumes", ""),
 		SourceObjects:                        sourceObjects,
 		SourceObjectUnavailableKinds:         sourceObjectUnavailableKinds,
 		AdmissionWebhookConfigurations:       admissionConfigs,
 		AdmissionWebhookUnavailableKinds:     admissionConfigUnavailableKinds,
+		AdmissionWebhookDeniedKinds:          admissionConfigDeniedKinds,
 		CustomResourceDefinitions:            crds,
 		APIServices:                          apiServices,
 		EndpointSlices:                       endpointSlices,

--- a/internal/upgrade/evidence_test.go
+++ b/internal/upgrade/evidence_test.go
@@ -9,18 +9,27 @@ import (
 )
 
 type fakeUpgradeAuthorizer struct {
-	namespaces  []string
-	canList     map[string]bool
-	filterCalls []string
-	filtered    []string
+	namespaces        []string
+	canList           map[string]bool
+	listDecisions     map[string]EvidenceAuthorizationDecision
+	nodeProxyDecision *EvidenceAuthorizationDecision
+	filterCalls       []string
+	filtered          []string
 }
 
 func (f *fakeUpgradeAuthorizer) Namespaces() []string { return f.namespaces }
-func (f *fakeUpgradeAuthorizer) CanList(group, resource, namespace string) bool {
-	return f.canList[group+"/"+resource+"/"+namespace]
+func (f *fakeUpgradeAuthorizer) CanList(group, resource, namespace string) EvidenceAuthorizationDecision {
+	key := group + "/" + resource + "/" + namespace
+	if decision, ok := f.listDecisions[key]; ok {
+		return decision
+	}
+	return EvidenceAuthorizationDecision{Allowed: f.canList[key], Authoritative: true}
 }
-func (f *fakeUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) bool {
-	return false
+func (f *fakeUpgradeAuthorizer) CanGetSubresource(group, resource, subresource string) EvidenceAuthorizationDecision {
+	if f.nodeProxyDecision != nil {
+		return *f.nodeProxyDecision
+	}
+	return EvidenceAuthorizationDecision{Authoritative: true}
 }
 func (f *fakeUpgradeAuthorizer) FilterNamespacesByCanList(group, resource string, namespaces []string) []string {
 	f.filterCalls = append(f.filterCalls, group+"/"+resource)

--- a/internal/upgrade/runner.go
+++ b/internal/upgrade/runner.go
@@ -36,10 +36,12 @@ type Options struct {
 	PersistentVolumeClaimNamespaces      []string
 	EventNamespaces                      []string
 	CanReadNodes                         bool
+	NodeProxyForbidden                   bool
 	CanReadPersistentVolumes             bool
 	SourceObjects                        []metav1.Object
 	AdmissionWebhookConfigurations       []*unstructured.Unstructured
 	AdmissionWebhookUnavailableKinds     []string
+	AdmissionWebhookDeniedKinds          []string
 	CustomResourceDefinitions            []*unstructured.Unstructured
 	APIServices                          []*unstructured.Unstructured
 	EndpointSlices                       []*discoveryv1.EndpointSlice
@@ -62,8 +64,10 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts Options) (
 		WebhookServices:                      opts.WebhookServices,
 		AdmissionWebhookConfigurations:       opts.AdmissionWebhookConfigurations,
 		AdmissionWebhookUnavailableKinds:     opts.AdmissionWebhookUnavailableKinds,
+		AdmissionWebhookDeniedKinds:          opts.AdmissionWebhookDeniedKinds,
 		CustomResourceDefinitions:            opts.CustomResourceDefinitions,
 		APIServices:                          opts.APIServices,
+		NodeProxyForbidden:                   opts.NodeProxyForbidden,
 		NodeRuntimeEvidence:                  opts.NodeRuntimeEvidence,
 		SourceObjects:                        opts.SourceObjects,
 		SourceObjectUnavailableKinds:         opts.SourceObjectUnavailableKinds,

--- a/pkg/upgradereadiness/checks_137.go
+++ b/pkg/upgradereadiness/checks_137.go
@@ -215,7 +215,7 @@ func scanRemovedFeatureGates(input *Input) Check {
 		}
 	}
 	if missingNodes > 0 {
-		check.Caveat = appendCaveat(check.Caveat, fmt.Sprintf("Effective kubelet configuration was unavailable for %d %s.", missingNodes, plural(missingNodes, "node", "nodes")))
+		check.Caveat = appendCaveat(check.Caveat, nodeRuntimeCoverageCaveat(input, fmt.Sprintf("Effective kubelet configuration was unavailable for %d %s.", missingNodes, plural(missingNodes, "node", "nodes"))))
 		if len(check.Findings) == 0 {
 			check.Status = CheckUnknown
 			check.Summary = "No removed feature gates were found in readable component configuration, but kubelet configuration coverage is incomplete."
@@ -397,8 +397,13 @@ func scanRemovedKubeletCAdvisorOptions() Check {
 
 func scanKubeletEventQPS(input *Input) Check {
 	check := Check{ID: "kubelet-event-qps-change", Category: "Node configuration", Title: "Kubelet event throttling behavior", Status: CheckPassed, Summary: "No readable kubelet config sets eventRecordQPS to zero.", Scope: "Effective kubelet configuration", AppliesFrom: "1.37", References: append([]Reference(nil), eventRecordQPSReferences137...)}
-	if input.Nodes == nil || input.NodeRuntimeEvidence == nil {
+	if input.Nodes == nil {
 		check.Status, check.Summary = CheckUnknown, "Effective kubelet configuration was unavailable."
+		return check
+	}
+	if input.NodeRuntimeEvidence == nil {
+		check.Status, check.Summary = CheckUnknown, "Effective kubelet configuration was unavailable."
+		check.Caveat = nodeRuntimeCoverageCaveat(input, "eventRecordQPS could not be inspected.")
 		return check
 	}
 	evidenceByNode := make(map[string]NodeRuntimeEvidence, len(input.NodeRuntimeEvidence))
@@ -422,7 +427,7 @@ func scanKubeletEventQPS(input *Input) Check {
 		check.Findings = append(check.Findings, Finding{RuleID: check.ID, Title: "eventRecordQPS zero becomes unlimited", Level: LevelWarning, Resource: &ResourceRef{Kind: "Node", Name: node.Name}, Evidence: Evidence{Source: "kubelet configz", Path: "kubeletconfig.eventRecordQPS", Detail: "0"}, AppliesFrom: check.AppliesFrom, Impact: "Kubernetes 1.37 makes an explicit zero mean unlimited event recording. In Kubernetes 1.36, that zero reached client-go and used its fallback limit of 5 events per second, so event traffic can increase sharply.", Remediation: "Choose an explicit limit before upgrading. The Kubernetes upgrade note recommends 50, the normal kubelet default. Use 5 only when intentionally matching the old explicit-zero runtime limit, or choose another value after reviewing event volume.", References: append([]Reference(nil), check.References...)})
 	}
 	if missing > 0 {
-		check.Caveat = fmt.Sprintf("eventRecordQPS was unavailable for %d %s; kubelets with debugging handlers disabled do not serve configz.", missing, plural(missing, "node", "nodes"))
+		check.Caveat = nodeRuntimeCoverageCaveat(input, fmt.Sprintf("eventRecordQPS was unavailable for %d %s; kubelets with debugging handlers disabled do not serve configz.", missing, plural(missing, "node", "nodes")))
 		if len(check.Findings) == 0 {
 			check.Status, check.Summary = CheckUnknown, "No eventRecordQPS behavior change was found in readable kubelet configuration, but coverage is incomplete."
 		}
@@ -887,7 +892,7 @@ func scanSELinuxMountTransition(input *Input, targetAllowsOptOut bool) Check {
 	if !runtimeEvidenceAvailable {
 		check.Caveat = appendCaveat(check.Caveat, "Node evidence was unavailable, so kubelet SELinux conflict metrics could not be inspected.")
 	} else if missingRuntime > 0 {
-		check.Caveat = appendCaveat(check.Caveat, fmt.Sprintf("Kubelet SELinux conflict metrics were unavailable for %d %s.", missingRuntime, plural(missingRuntime, "Linux node", "Linux nodes")))
+		check.Caveat = appendCaveat(check.Caveat, nodeRuntimeCoverageCaveat(input, fmt.Sprintf("Kubelet SELinux conflict metrics were unavailable for %d %s.", missingRuntime, plural(missingRuntime, "Linux node", "Linux nodes"))))
 	}
 	if input.Namespaces != nil {
 		check.Caveat = appendCaveat(check.Caveat, scopedCoverageNote(input.Namespaces, "Pods, PersistentVolumeClaims and Events"))

--- a/pkg/upgradereadiness/checks_137.go
+++ b/pkg/upgradereadiness/checks_137.go
@@ -427,7 +427,11 @@ func scanKubeletEventQPS(input *Input) Check {
 		check.Findings = append(check.Findings, Finding{RuleID: check.ID, Title: "eventRecordQPS zero becomes unlimited", Level: LevelWarning, Resource: &ResourceRef{Kind: "Node", Name: node.Name}, Evidence: Evidence{Source: "kubelet configz", Path: "kubeletconfig.eventRecordQPS", Detail: "0"}, AppliesFrom: check.AppliesFrom, Impact: "Kubernetes 1.37 makes an explicit zero mean unlimited event recording. In Kubernetes 1.36, that zero reached client-go and used its fallback limit of 5 events per second, so event traffic can increase sharply.", Remediation: "Choose an explicit limit before upgrading. The Kubernetes upgrade note recommends 50, the normal kubelet default. Use 5 only when intentionally matching the old explicit-zero runtime limit, or choose another value after reviewing event volume.", References: append([]Reference(nil), check.References...)})
 	}
 	if missing > 0 {
-		check.Caveat = nodeRuntimeCoverageCaveat(input, fmt.Sprintf("eventRecordQPS was unavailable for %d %s; kubelets with debugging handlers disabled do not serve configz.", missing, plural(missing, "node", "nodes")))
+		unavailable := fmt.Sprintf("eventRecordQPS was unavailable for %d %s.", missing, plural(missing, "node", "nodes"))
+		if !input.NodeProxyForbidden {
+			unavailable += " Kubelets with debugging handlers disabled do not serve configz."
+		}
+		check.Caveat = nodeRuntimeCoverageCaveat(input, unavailable)
 		if len(check.Findings) == 0 {
 			check.Status, check.Summary = CheckUnknown, "No eventRecordQPS behavior change was found in readable kubelet configuration, but coverage is incomplete."
 		}

--- a/pkg/upgradereadiness/checks_137_test.go
+++ b/pkg/upgradereadiness/checks_137_test.go
@@ -321,8 +321,19 @@ func TestKubeletEventRecordQPS137(t *testing.T) {
 	input = completeInput()
 	input.NodeRuntimeEvidence[0].EventRecordQPSAvailable = false
 	check = checkByID(t, scan137(t, input), "kubelet-event-qps-change")
-	if check.Status != CheckUnknown {
+	if check.Status != CheckUnknown || !strings.Contains(check.Caveat, "debugging handlers disabled") {
 		t.Fatalf("missing eventRecordQPS = %+v, want unknown", check)
+	}
+}
+
+func TestKubeletEventQPSObservedProxyDenialDoesNotBlameDebuggingHandlers(t *testing.T) {
+	input := completeInput()
+	input.NodeProxyForbidden = true
+	input.NodeRuntimeEvidence = []NodeRuntimeEvidence{{NodeName: "node-a", FeatureGates: map[string]bool{}}}
+
+	check := checkByID(t, scan137(t, input), "kubelet-event-qps-change")
+	if !strings.Contains(check.Caveat, "nodes/proxy request was forbidden") || strings.Contains(check.Caveat, "debugging handlers disabled") {
+		t.Fatalf("observed proxy denial caveat = %q, want RBAC attribution without a configz explanation", check.Caveat)
 	}
 }
 

--- a/pkg/upgradereadiness/checks_evidenced.go
+++ b/pkg/upgradereadiness/checks_evidenced.go
@@ -102,6 +102,11 @@ func scanContainerRuntimeSupport(input *Input, target *utilversion.Version) Chec
 		check.Status, check.Summary = CheckNotApplicable, "Container runtime support for this upgrade does not apply to Windows nodes."
 		return check
 	}
+	if input.NodeRuntimeEvidence == nil {
+		check.Status, check.Summary = CheckUnknown, "Container runtime support metrics were unavailable."
+		check.Caveat = nodeRuntimeCoverageCaveat(input, "Container runtime support metrics could not be inspected.")
+		return check
+	}
 	metrics := make(map[string]NodeRuntimeEvidence, len(input.NodeRuntimeEvidence))
 	for _, evidence := range input.NodeRuntimeEvidence {
 		metrics[evidence.NodeName] = evidence

--- a/pkg/upgradereadiness/checks_evidenced.go
+++ b/pkg/upgradereadiness/checks_evidenced.go
@@ -3,6 +3,7 @@ package upgradereadiness
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -37,6 +38,7 @@ func scanNodeCgroupCompatibility(input *Input) Check {
 	}
 	if input.NodeRuntimeEvidence == nil {
 		check.Status, check.Summary = CheckUnknown, "Kubelet cgroup version metrics were unavailable."
+		check.Caveat = nodeRuntimeCoverageCaveat(input, "Kubelet cgroup version metrics could not be inspected.")
 		return check
 	}
 	metrics := make(map[string]NodeRuntimeEvidence, len(input.NodeRuntimeEvidence))
@@ -61,7 +63,7 @@ func scanNodeCgroupCompatibility(input *Input) Check {
 		}
 	}
 	if missing > 0 {
-		check.Caveat = fmt.Sprintf("The cgroup metric was unavailable on %d %s.", missing, plural(missing, "node", "nodes"))
+		check.Caveat = nodeRuntimeCoverageCaveat(input, fmt.Sprintf("The cgroup metric was unavailable on %d %s.", missing, plural(missing, "node", "nodes")))
 		if len(check.Findings) == 0 {
 			check.Status, check.Summary = CheckUnknown, "No cgroup v1 nodes were observed, but node coverage is incomplete."
 		}
@@ -139,7 +141,7 @@ func scanContainerRuntimeSupport(input *Input, target *utilversion.Version) Chec
 		}
 	}
 	if unknown > 0 {
-		check.Caveat = fmt.Sprintf("Runtime support could not be proven for %d %s.", unknown, plural(unknown, "node", "nodes"))
+		check.Caveat = nodeRuntimeCoverageCaveat(input, fmt.Sprintf("Runtime support could not be proven for %d %s.", unknown, plural(unknown, "node", "nodes")))
 		if len(check.Findings) == 0 {
 			check.Status, check.Summary = CheckUnknown, "No unsupported runtimes were identified, but runtime evidence is incomplete."
 		}
@@ -378,10 +380,11 @@ func scanAdmissionWebhookReadiness(input *Input) Check {
 	check := Check{ID: "admission-webhook-readiness", Category: "Admission control", Title: "Admission webhook readiness", Status: CheckPassed, Summary: "Inspected admission webhooks have reachable Service backends and upgrade-safe matching behavior.", Scope: "Admission webhook configurations, Services, and EndpointSlices", References: append([]Reference(nil), admissionReferences...)}
 	if input.AdmissionWebhookConfigurations == nil {
 		check.Status, check.Summary = CheckUnknown, "Admission webhook configuration evidence was unavailable."
+		check.Caveat = admissionWebhookCoverageCaveat(input.AdmissionWebhookUnavailableKinds, input.AdmissionWebhookDeniedKinds)
 		return check
 	}
 	if len(input.AdmissionWebhookUnavailableKinds) > 0 {
-		check.Caveat = appendCaveat(check.Caveat, "Admission webhook configurations could not be inspected for: "+strings.Join(input.AdmissionWebhookUnavailableKinds, ", ")+".")
+		check.Caveat = appendCaveat(check.Caveat, admissionWebhookCoverageCaveat(input.AdmissionWebhookUnavailableKinds, input.AdmissionWebhookDeniedKinds))
 	}
 	check.Inspected = len(input.AdmissionWebhookConfigurations)
 	backendEvidenceAvailable := input.WebhookServices != nil && input.EndpointSlices != nil
@@ -458,6 +461,22 @@ func scanAdmissionWebhookReadiness(input *Input) Check {
 		check.Summary = fmt.Sprintf("%d admission webhook %s.", len(check.Findings), plural(len(check.Findings), "condition requires action or review", "conditions require action or review"))
 	}
 	return check
+}
+
+func admissionWebhookCoverageCaveat(unavailableKinds, deniedKinds []string) string {
+	caveat := "Admission webhook configurations could not be inspected"
+	if len(unavailableKinds) == 0 {
+		return caveat + "."
+	}
+	caveat += " for: " + strings.Join(unavailableKinds, ", ") + "."
+	if len(deniedKinds) > 0 {
+		if slices.Equal(unavailableKinds, deniedKinds) {
+			caveat += " The current identity cannot list them; ask a cluster administrator to grant list access if admission-plane visibility is appropriate."
+		} else {
+			caveat += " The current identity cannot list: " + strings.Join(deniedKinds, ", ") + "; ask a cluster administrator to grant list access if admission-plane visibility is appropriate."
+		}
+	}
+	return caveat
 }
 
 func readyEndpointServices(slices []*discoveryv1.EndpointSlice) map[string]bool {

--- a/pkg/upgradereadiness/checks_evidenced_test.go
+++ b/pkg/upgradereadiness/checks_evidenced_test.go
@@ -105,7 +105,7 @@ func TestNodeCompatibilityEvidence(t *testing.T) {
 
 	input = completeInput()
 	input.Nodes[0].Status.NodeInfo.OperatingSystem = "windows"
-	input.NodeRuntimeEvidence[0] = NodeRuntimeEvidence{NodeName: input.Nodes[0].Name}
+	input.NodeRuntimeEvidence = nil
 	result, _ = Scan(input, "1.34", "1.35")
 	cgroup = checkByID(t, result, "node-cgroup-v1")
 	if cgroup.Status != CheckNotApplicable || cgroup.Inspected != 0 {
@@ -403,6 +403,9 @@ func TestNodeRuntimeCoverageExplainsMissingNodeProxyPermission(t *testing.T) {
 		check := checkByID(t, result, id)
 		if !strings.Contains(check.Caveat, "nodes/proxy request was forbidden") || !strings.Contains(check.Caveat, "grant the current identity get access to nodes/proxy") {
 			t.Fatalf("%s caveat = %q, want actionable nodes/proxy RBAC attribution", id, check.Caveat)
+		}
+		if id == "container-runtime-support" && check.Inspected != 0 {
+			t.Fatalf("%s inspected = %d, want zero when all runtime evidence is unavailable", id, check.Inspected)
 		}
 	}
 }

--- a/pkg/upgradereadiness/checks_evidenced_test.go
+++ b/pkg/upgradereadiness/checks_evidenced_test.go
@@ -357,6 +357,7 @@ func TestAdmissionWebhookConfigurationWithoutWebhooksIsInspectedEmpty(t *testing
 func TestAdmissionWebhookConfigurationPartialRBACPreservesReadableEvidence(t *testing.T) {
 	input := completeInput()
 	input.AdmissionWebhookUnavailableKinds = []string{"mutatingwebhookconfigurations"}
+	input.AdmissionWebhookDeniedKinds = []string{"mutatingwebhookconfigurations"}
 	input.AdmissionWebhookConfigurations = []*unstructured.Unstructured{{Object: map[string]any{
 		"apiVersion": "admissionregistration.k8s.io/v1", "kind": "ValidatingWebhookConfiguration", "metadata": map[string]any{"name": "policy"},
 		"webhooks": []any{map[string]any{"name": "policy.example", "matchPolicy": "Exact"}},
@@ -364,8 +365,57 @@ func TestAdmissionWebhookConfigurationPartialRBACPreservesReadableEvidence(t *te
 
 	check := scanAdmissionWebhookReadiness(input)
 	finalizeCheck(&check)
-	if check.Status != CheckReview || len(check.Findings) != 1 || !strings.Contains(check.Caveat, "mutatingwebhookconfigurations") {
+	if check.Status != CheckReview || len(check.Findings) != 1 || strings.Count(check.Caveat, "mutatingwebhookconfigurations") != 1 || !strings.Contains(check.Caveat, "current identity cannot list them") || !strings.Contains(check.Caveat, "grant list access") {
 		t.Fatalf("partially readable admission configurations = %+v, want readable findings plus a coverage caveat", check)
+	}
+}
+
+func TestAdmissionWebhookTransientFailureDoesNotSuggestRBAC(t *testing.T) {
+	input := completeInput()
+	input.AdmissionWebhookUnavailableKinds = []string{"mutatingwebhookconfigurations"}
+
+	check := scanAdmissionWebhookReadiness(input)
+	if !strings.Contains(check.Caveat, "mutatingwebhookconfigurations") || strings.Contains(check.Caveat, "current identity") || strings.Contains(check.Caveat, "grant list access") {
+		t.Fatalf("transient admission failure caveat = %q, want unattributed unavailable evidence", check.Caveat)
+	}
+}
+
+func TestAdmissionWebhookUnavailableWithoutPermissionEvidenceStaysGeneric(t *testing.T) {
+	input := completeInput()
+	input.AdmissionWebhookConfigurations = nil
+
+	check := scanAdmissionWebhookReadiness(input)
+	if check.Status != CheckUnknown || !strings.Contains(check.Caveat, "could not be inspected") || strings.Contains(check.Caveat, "rbac.viewWebhooks") {
+		t.Fatalf("unattributed admission configuration failure = %+v, want a generic coverage caveat", check)
+	}
+}
+
+func TestNodeRuntimeCoverageExplainsMissingNodeProxyPermission(t *testing.T) {
+	input := completeInput()
+	input.NodeProxyForbidden = true
+	input.NodeRuntimeEvidence = nil
+
+	result, err := Scan(input, "1.34", "1.37")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"node-cgroup-v1", "container-runtime-support", "removed-feature-gates", "kubelet-event-qps-change", "selinux-mount-transition"} {
+		check := checkByID(t, result, id)
+		if !strings.Contains(check.Caveat, "nodes/proxy request was forbidden") || !strings.Contains(check.Caveat, "grant the current identity get access to nodes/proxy") {
+			t.Fatalf("%s caveat = %q, want actionable nodes/proxy RBAC attribution", id, check.Caveat)
+		}
+	}
+}
+
+func TestNodeRuntimeCoverageDoesNotBlameNodeProxyWhenNodesAreUnavailable(t *testing.T) {
+	input := completeInput()
+	input.Nodes = nil
+	input.NodeProxyForbidden = true
+	input.NodeRuntimeEvidence = nil
+
+	check := checkByID(t, scan137(t, input), "selinux-mount-transition")
+	if strings.Contains(check.Caveat, "nodes/proxy") {
+		t.Fatalf("SELinux caveat = %q, must not attribute missing Node list evidence to nodes/proxy", check.Caveat)
 	}
 }
 

--- a/pkg/upgradereadiness/scan.go
+++ b/pkg/upgradereadiness/scan.go
@@ -248,7 +248,6 @@ func scanUpgradePath(current, target *utilversion.Version) Check {
 			Title:       "Unsupported control plane version jump",
 			Level:       LevelBlocker,
 			Evidence:    Evidence{Source: "version policy", Path: "controlPlane", Detail: sequence},
-			AppliesFrom: minorString(target),
 			Impact:      "Kubernetes control planes must follow the supported one-minor upgrade sequence; a direct major-version jump is unsupported.",
 			Remediation: fmt.Sprintf("Choose Kubernetes %d.%d as the next target, then re-run upgrade impact for each subsequent step.", current.Major(), current.Minor()+1),
 			References:  append([]Reference(nil), versionSkewReferences...),
@@ -275,7 +274,6 @@ func scanUpgradePath(current, target *utilversion.Version) Check {
 		Title:       "Unsupported control plane version jump",
 		Level:       LevelBlocker,
 		Evidence:    Evidence{Source: "version policy", Path: "controlPlane", Detail: sequence},
-		AppliesFrom: minorString(target),
 		Impact:      "Kubernetes control planes must be upgraded one minor version at a time; skipping minors is unsupported.",
 		Remediation: "Plan the control plane upgrades in sequence: " + sequence + ". Re-run upgrade impact for each step.",
 		References:  append([]Reference(nil), versionSkewReferences...),
@@ -1196,6 +1194,13 @@ func appendCaveat(existing, addition string) string {
 		return existing
 	}
 	return existing + " " + addition
+}
+
+func nodeRuntimeCoverageCaveat(input *Input, unavailable string) string {
+	if input.Nodes == nil || !input.NodeProxyForbidden {
+		return unavailable
+	}
+	return appendCaveat(unavailable, "At least one nodes/proxy request was forbidden; ask a cluster administrator to grant the current identity get access to nodes/proxy to inspect kubelet metrics and effective configuration.")
 }
 
 func appendSourceManifestCoverageCaveats(check *Check, input *Input, lastAppliedParseErrors int) {

--- a/pkg/upgradereadiness/scan_test.go
+++ b/pkg/upgradereadiness/scan_test.go
@@ -258,7 +258,7 @@ func TestScanMultiMinorControlPlaneJumpIsBlocked(t *testing.T) {
 		t.Fatal(err)
 	}
 	check := checkByID(t, got, "control-plane-upgrade-path")
-	if check.Status != CheckBlocked || len(check.Findings) != 1 || check.Findings[0].Evidence.Detail != "1.32 → 1.33 → 1.34 → 1.35 → 1.36" {
+	if check.Status != CheckBlocked || len(check.Findings) != 1 || check.Findings[0].Evidence.Detail != "1.32 → 1.33 → 1.34 → 1.35 → 1.36" || check.Findings[0].AppliesFrom != "" {
 		t.Fatalf("unexpected upgrade path result: %+v", check)
 	}
 }
@@ -269,7 +269,7 @@ func TestScanMajorControlPlaneJumpIsBlocked(t *testing.T) {
 		t.Fatal(err)
 	}
 	check := checkByID(t, got, "control-plane-upgrade-path")
-	if check.Status != CheckBlocked || len(check.Findings) != 1 || check.Findings[0].Evidence.Detail != "1.35 → 2.0" || !strings.Contains(check.Findings[0].Remediation, "1.36") {
+	if check.Status != CheckBlocked || len(check.Findings) != 1 || check.Findings[0].Evidence.Detail != "1.35 → 2.0" || check.Findings[0].AppliesFrom != "" || !strings.Contains(check.Findings[0].Remediation, "1.36") {
 		t.Fatalf("unexpected major-version path result: %+v", check)
 	}
 }

--- a/pkg/upgradereadiness/types.go
+++ b/pkg/upgradereadiness/types.go
@@ -84,8 +84,14 @@ type Input struct {
 	// kinds that could not be listed while preserving evidence from readable
 	// kinds.
 	AdmissionWebhookUnavailableKinds []string
-	CustomResourceDefinitions        []*unstructured.Unstructured
-	APIServices                      []*unstructured.Unstructured
+	// AdmissionWebhookDeniedKinds is the subset of unavailable webhook
+	// configuration kinds whose list request was denied.
+	AdmissionWebhookDeniedKinds []string
+	CustomResourceDefinitions   []*unstructured.Unstructured
+	APIServices                 []*unstructured.Unstructured
+	// NodeProxyForbidden records that authorization or an observed request
+	// denied access to kubelet metrics or effective configuration.
+	NodeProxyForbidden bool
 	// NodeRuntimeEvidence is nil when kubelet metrics and configuration could not be inspected.
 	NodeRuntimeEvidence []NodeRuntimeEvidence
 

--- a/web/src/components/audit/UpgradeReadinessView.test.ts
+++ b/web/src/components/audit/UpgradeReadinessView.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { ApiError } from '../../api/client'
-import { UPGRADE_IMPACT_DOCS_URL, UPGRADE_IMPACT_MIN_RADAR_VERSION, UpgradeReadinessError, groupFindings, incompleteUpgradeCheckCount, issueSpecificReferences, summaryMeta, upgradeEvaluationSummary } from './UpgradeReadinessView'
+import { UPGRADE_IMPACT_DOCS_URL, UPGRADE_IMPACT_MIN_RADAR_VERSION, UpgradeReadinessError, groupFindings, incompleteUpgradeCheckCount, issueSpecificReferences, summaryMeta, upgradeEvaluationSummary, upgradeEvidenceCoverageLabel, upgradeUnavailableKindsMessage } from './UpgradeReadinessView'
 
 describe('UpgradeReadinessError', () => {
   it('maps an unmatched endpoint 404 to the v1.9 upgrade message', () => {
@@ -40,7 +40,7 @@ describe('upgradeEvaluationSummary', () => {
       unknown: 1,
       notApplicable: 2,
       findings: 1,
-    })).toBe('18 evaluated · 16 applicable · 1 with partial evidence · 2 not applicable')
+    })).toBe('18 evaluated · 16 applicable · 1 with incomplete evidence · 2 not applicable')
   })
 
   it('does not imply incomplete coverage when every applicable check completed', () => {
@@ -65,6 +65,30 @@ describe('upgradeEvaluationSummary', () => {
       { status: 'unknown' },
       { status: 'passed' },
     ])).toBe(2)
+  })
+})
+
+describe('upgradeUnavailableKindsMessage', () => {
+  it('does not guess why webhook evidence is unavailable', () => {
+    const message = upgradeUnavailableKindsMessage(['mutatingwebhookconfigurations', 'validatingwebhookconfigurations'])
+
+    expect(message).toContain('Affected checks are marked incomplete')
+    expect(message).not.toContain('rbac.viewWebhooks')
+    expect(message).not.toContain('grant')
+  })
+
+  it('does not suggest webhook access for unrelated evidence gaps', () => {
+    expect(upgradeUnavailableKindsMessage(['apiservices'])).not.toContain('rbac.viewWebhooks')
+  })
+})
+
+describe('upgradeEvidenceCoverageLabel', () => {
+  it('distinguishes absent evidence from partial evidence', () => {
+    expect(upgradeEvidenceCoverageLabel({ status: 'unknown', caveat: 'unavailable' })).toBe('No evidence')
+    expect(upgradeEvidenceCoverageLabel({ status: 'unknown', inspected: 0, caveat: 'unavailable' })).toBe('No evidence')
+    expect(upgradeEvidenceCoverageLabel({ status: 'unknown', inspected: 1, caveat: 'one object malformed' })).toBe('Partial evidence')
+    expect(upgradeEvidenceCoverageLabel({ status: 'blocked', inspected: 1, caveat: 'some nodes unavailable' })).toBe('Partial evidence')
+    expect(upgradeEvidenceCoverageLabel({ status: 'passed', inspected: 1 })).toBe('')
   })
 })
 

--- a/web/src/components/audit/UpgradeReadinessView.tsx
+++ b/web/src/components/audit/UpgradeReadinessView.tsx
@@ -202,7 +202,7 @@ export function UpgradeReadinessView({ namespaces, onNavigateToResource }: Upgra
       {data.coverage.state !== 'no_access' && (data.coverage.unavailableKinds?.length ?? 0) > 0 && (
         <CoverageNotice
           headline="Some live resources were unavailable"
-          body={`Radar could not inspect: ${(data.coverage.unavailableKinds ?? []).join(', ')}. Affected checks are marked incomplete.`}
+          body={upgradeUnavailableKindsMessage(data.coverage.unavailableKinds ?? [])}
         />
       )}
       {data.coverage.state !== 'no_access' && scopedKinds.length > 0 && (
@@ -212,7 +212,7 @@ export function UpgradeReadinessView({ namespaces, onNavigateToResource }: Upgra
         />
       )}
       {data.coverage.state === 'partial' && !data.coverage.scopedNamespaces?.length && !data.coverage.unavailableKinds?.length && scopedKinds.length === 0 && (
-        <CoverageNotice headline="Some evidence is incomplete" body="Rows marked Partial evidence explain what Radar could not verify." />
+        <CoverageNotice headline="Some evidence is incomplete" body="Evidence labels on affected rows explain what Radar could not verify." />
       )}
       {data.coverage.state === 'no_access' ? (
         <section className="shrink-0">
@@ -291,8 +291,17 @@ export function incompleteUpgradeCheckCount(checks: Pick<UpgradeReadinessCheck, 
 
 export function upgradeEvaluationSummary(total: number, summary: UpgradeReadinessResponse['summary'], incomplete = summary.unknown) {
   const applicable = Math.max(0, total - summary.notApplicable)
-  const partialEvidenceLabel = incomplete > 0 ? ` · ${incomplete} with partial evidence` : ''
-  return `${total} evaluated · ${applicable} applicable${partialEvidenceLabel} · ${summary.notApplicable} not applicable`
+  const incompleteEvidenceLabel = incomplete > 0 ? ` · ${incomplete} with incomplete evidence` : ''
+  return `${total} evaluated · ${applicable} applicable${incompleteEvidenceLabel} · ${summary.notApplicable} not applicable`
+}
+
+export function upgradeUnavailableKindsMessage(unavailableKinds: string[]) {
+  return `Radar could not inspect: ${unavailableKinds.join(', ')}. Affected checks are marked incomplete.`
+}
+
+export function upgradeEvidenceCoverageLabel(check: Pick<UpgradeReadinessCheck, 'status' | 'inspected' | 'caveat'>) {
+  if (!check.caveat) return ''
+  return check.status === 'unknown' && (check.inspected ?? 0) === 0 ? 'No evidence' : 'Partial evidence'
 }
 
 function CoverageMethodology({ data }: { data: UpgradeReadinessResponse }) {
@@ -323,7 +332,7 @@ function CoverageMethodology({ data }: { data: UpgradeReadinessResponse }) {
           </p>
           <p>
             Results use live cluster resources and the row-specific evidence scope shown below. {unavailable.length > 0
-              ? `Radar could not inspect ${unavailable.join(', ')}; affected checks are marked incomplete.`
+              ? upgradeUnavailableKindsMessage(unavailable)
               : scopedKinds.length > 0
                 ? `Cached evidence has per-kind namespace ceilings for ${formatScopedKinds(scopedKinds)}.`
               : data.coverage.state === 'complete'
@@ -433,6 +442,7 @@ function CheckRow({ check, onNavigateToResource }: { check: UpgradeReadinessChec
   const detailID = `upgrade-check-${check.id}`
   const findingGroups = groupFindings(check.findings)
   const label = evidenceLabel(check)
+  const coverageLabel = upgradeEvidenceCoverageLabel(check)
   const checkReferences = check.references ?? []
   return (
     <div>
@@ -456,10 +466,10 @@ function CheckRow({ check, onNavigateToResource }: { check: UpgradeReadinessChec
           <div className="min-w-0">
             <Badge severity={meta.badgeSeverity}>{meta.label}</Badge>
             {label && <div className="mt-1 text-[11px] text-theme-text-tertiary">{label}</div>}
-            {check.caveat && (
+            {coverageLabel && (
               <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 dark:text-amber-300">
                 <AlertTriangle className="h-3 w-3 shrink-0" />
-                Partial evidence
+                {coverageLabel}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Follow-up to #1481: make Kubernetes upgrade impact honest and actionable when Radar cannot collect all of the live evidence needed for the 1.37 checks. Operators now see the difference between no evidence and partial evidence, explicit authorization denials and transient collection failures, and timeless upgrade-path policy versus release-gated findings.

This matters for Kubernetes 1.37 because several checks depend on kubelet metrics/effective configuration and admission-plane resources that the default in-cluster identity deliberately cannot read. A missing permission must not look like a compatibility failure, a clean bill of health, or an unexplained Unknown.

## Kubernetes 1.37 context

Radar's 1.37 review covers the operationally relevant removals and transitions documented by Kubernetes, including removed or locked feature gates, kubeadm configuration changes, kubelet `eventRecordQPS`, removed cAdvisor flags/metrics, the scheduling `v1alpha2` removal, SELinux mount behavior, webhook readiness, and the required one-minor control-plane upgrade sequence.

Authoritative references:

- [Kubernetes v1.37 release announcement](https://kubernetes.io/blog/2026/08/26/kubernetes-v1-37-release/)
- [Kubernetes 1.37 changelog](https://github.com/kubernetes/kubernetes/blob/release-1.37/CHANGELOG/CHANGELOG-1.37.md)
- [Kubernetes version-skew policy](https://kubernetes.io/releases/version-skew-policy/)
- [kind v0.33.0 release](https://github.com/kubernetes-sigs/kind/releases/tag/v0.33.0)
- [GKE alpha-cluster creation](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-alpha-cluster)

## What changed

### Precise evidence attribution

- Authorization decisions now preserve whether the result was authoritative. A cached or successful SAR denial can produce permission guidance; a nil client, timeout, or SAR error remains a generic evidence gap.
- The same decision model is used by the HTTP and MCP upgrade-readiness surfaces.
- Actual `Forbidden` responses from kubelet node-proxy requests and webhook list requests remain authoritative even when a permissive no-auth preflight allowed the attempt.
- Webhook collection separately records unavailable kinds and the denied subset, so transient API failures do not tell operators to request RBAC they may already have.
- Non-authorization kubelet collection failures are logged once per scan as an aggregate instead of up to two lines per node.

### Safe node-runtime access

- Adds `rbac.viewNodeRuntime`, default `false`, granting only `get` on `nodes/proxy` when explicitly enabled.
- Keeps the permission off by default because kubelet metrics and effective configuration expose node-level runtime details to the audience of a no-auth Radar instance.
- Authenticated Radar requests continue to impersonate the user, so those users need `nodes/proxy` on their own Kubernetes identity; enabling the ServiceAccount grant does not bypass per-user RBAC.
- Documents the toggle and trust boundary in the chart README, values, and in-cluster installation guide. Helm tests pin both the default absence and exact opt-in rule.

### Honest upgrade-impact communication

- Rows with an Unknown result, a caveat, and zero inspected objects show **No evidence**; rows that inspected some evidence show **Partial evidence**.
- Summary copy uses **incomplete evidence** rather than implying every gap is partial.
- Webhook coverage copy stays deployment-neutral in the reusable scanner/UI, while exact identity-level remediation comes from the backend evidence.
- Upgrade-path findings no longer claim an `Applies from` release: the one-minor sequencing policy is timeless, including a live 1.37 → 1.39 path.

## Validation

### Live Kubernetes validation

- **Shared GKE nonprod, read-only:** Kubernetes `v1.35.6-gke.1710000`, 9/9 nodes Ready. Radar evaluated 1.35 → 1.37 with `reviewedThrough=1.37`; the UI rendered the required `1.35 → 1.36 → 1.37` sequence and 73 grounded findings with no console errors. Independent EndpointSlice reads confirmed the unavailable webhook backends cited by fail-closed blockers and fail-open warnings. The access path rejected mutating HTTP verbs and CONNECT; node count was unchanged, while one already-running Pod became NotReady during the observation window and was treated as ambient nonprod drift.
- **Controlled kind 1.36.1 → 1.37:** injected live feature-gate, component-flag, kubeadm, kubelet `eventRecordQPS`, and Prometheus metric-consumer evidence. The API values matched the injected settings, and the expected blocker/warning/review/N/A classifications rendered with zero console errors. The cluster was restored and deleted after capture.
- **Official Kubernetes 1.37.0 runtime:** disposable kind v0.33.0 cluster using `kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5`; API server and Ready node both reported v1.37.0 with containerd 2.3.4. Published Radar 1.12.1 (`ghcr.io/skyhook-io/radar@sha256:a95ec5d9a50e7a874ddc85ec9fecd216eaebb95d90be4e3d36500436273c2e35`) was Ready with zero restarts; health, cluster-info, resource-counts, upgrade-readiness, and the Overview UI passed. The follow-up branch also ran under the default chart ServiceAccount and rendered at 1280×800 and 1920×1080 with zero console errors.
- **GKE 1.37 availability:** Cloud SDK 578.0.0 and a clean 582.0.0 both observed `1.37.0-gke.1173000+preview` in Rapid preview versions, but the documented alpha create request returned HTTP 400 and listed Rapid create support only through 1.36.3. No cluster, VM, disk, forwarding rule, address, or firewall was created. This is recorded only as an advertised-preview/create-API availability mismatch; no provider root cause is inferred.

The final authoritative-SAR distinction, observed-403 attribution, and zero-evidence wire-shape correction were made after the live browser captures. They are covered by HTTP-level collector, HTTP/MCP authorizer, scanner, and frontend tests rather than represented as additional live-cluster proof.

### Local QA

- `go test ./...`
- `cd pkg && go test ./...`
- `make tsc`
- `npx vitest run src/components/audit/UpgradeReadinessView.test.ts` — 14 passed
- `helm unittest -f 'tests/upgrade_impact_rbac_test.yaml' deploy/helm/radar` — 3 passed
- `./scripts/test-chart.sh`
- `make build` — frontend build, embed, and Go binary
- `git diff --check`

## Security and residual risk

The only new permission is explicit, narrowly scoped, and default-off. The main failure mode is incomplete evidence, not an incorrect compatibility verdict: unavailable sources keep affected checks Unknown/incomplete and explain the evidence boundary. Final copy/authorization corrections are test-backed but were not re-captured on the deleted disposable cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization for upgrade evidence and adds an opt-in `nodes/proxy` grant; misconfiguration could expose node runtime details on no-auth installs, but defaults stay off and denied/missing evidence is surfaced as incomplete rather than false compatibility verdicts.
> 
> **Overview**
> Upgrade impact now separates **authoritative RBAC denials** from **non-authoritative** auth check failures (missing client, SAR errors, timeouts). HTTP and MCP upgrade authorizers expose `EvidenceAuthorizationDecision` (`Allowed` + `Authoritative`); webhook collection tracks **denied** kinds separately from transient list failures; kubelet `nodes/proxy` fetches record observed **403** so checks can cite permission gaps instead of generic “missing evidence.”
> 
> Adds opt-in Helm value **`rbac.viewNodeRuntime`** (default `false`) granting only `get` on `nodes/proxy` for no-auth in-cluster Radar, with README/docs and a unittest for the exact ClusterRole rule.
> 
> **Scanner and UI** propagate `NodeProxyForbidden` and `AdmissionWebhookDeniedKinds` into caveats with actionable remediation; node-runtime gaps no longer blame disabled configz when proxy was forbidden. Upgrade-path blockers drop misleading **`AppliesFrom`** on timeless sequencing policy. **Upgrade Readiness UI** labels rows **No evidence** vs **Partial evidence**, says “incomplete evidence” in summaries, and avoids guessing Helm RBAC keys in coverage banners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77f1ca4e4ab1cb26cd5b351aa5e92dc97e4845c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
