### PR TITLE
fix(prom): reach headless Prometheus by its own service DNS

### DIFF
--- a/pkg/prom/discovery.go
+++ b/pkg/prom/discovery.go
@@ -281,7 +281,7 @@ func Discover(ctx context.Context, k8sClient kubernetes.Interface, opts Discover
 			Name:        svc.Name,
 			Port:        port,
 			TargetPort:  resolveTargetPort(svc, port),
-			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, port),
 			BasePath:    bp,
 			Score:       score,
 			Source:      CandidateSourceDynamic,
@@ -349,7 +349,7 @@ func collectWellKnownLocations(ctx context.Context, k8sClient kubernetes.Interfa
 			Name:        svc.Name,
 			Port:        port,
 			TargetPort:  resolveTargetPort(*svc, port),
-			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+			ClusterAddr: buildClusterAddr(svc.Name, svc.Namespace, port),
 			BasePath:    loc.BasePath,
 			Source:      CandidateSourceWellKnown,
 		})
@@ -513,12 +513,13 @@ func resolveTargetPort(svc corev1.Service, servicePort int) int {
 	return servicePort
 }
 
-// buildClusterAddr returns the in-cluster HTTP URL for a service. Headless
-// services (ClusterIP=None) use a pod-0 hostname; this is best-effort and
-// really meant for stateful Prometheus deployments with predictable names.
-func buildClusterAddr(name, namespace, clusterIP string, port int) string {
-	if clusterIP == "None" {
-		return fmt.Sprintf("http://%s-0.%s.%s.svc.cluster.local:%d", name, name, namespace, port)
-	}
+// buildClusterAddr returns the in-cluster HTTP URL for a service.
+// A headless Service publishes A records for its ready pods under its own name,
+// so the plain service address works for both kinds. Addressing a headless one as
+// {service}-0.{service} assumes the StatefulSet is named after the Service: true
+// for caretta-vm, false for kube-prometheus-stack's prometheus-operated, whose
+// pod is prometheus-{release}-kube-prometheus-stack-prometheus-0. That guess made
+// a reachable backend look unreachable in-cluster.
+func buildClusterAddr(name, namespace string, port int) string {
 	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", name, namespace, port)
 }

--- a/pkg/prom/discovery_test.go
+++ b/pkg/prom/discovery_test.go
@@ -501,7 +501,7 @@ func TestDiscover_SkipsDynamicWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestDiscover_HeadlessServiceProducesPod0Addr(t *testing.T) {
+func TestDiscover_HeadlessServiceUsesPlainServiceDNS(t *testing.T) {
 	headless := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "prometheus-server", Namespace: "monitoring"},
 		Spec: corev1.ServiceSpec{
@@ -517,7 +517,10 @@ func TestDiscover_HeadlessServiceProducesPod0Addr(t *testing.T) {
 	if len(cands) != 1 {
 		t.Fatalf("want 1 candidate, got %d", len(cands))
 	}
-	want := "http://prometheus-server-0.prometheus-server.monitoring.svc.cluster.local:9090"
+	// A headless Service publishes A records for its ready pods under its own
+	// name; the old {service}-0. pod prefix assumed the StatefulSet was named
+	// after the Service and left non-conforming backends unreachable.
+	want := "http://prometheus-server.monitoring.svc.cluster.local:9090"
 	if cands[0].ClusterAddr != want {
 		t.Errorf("cluster addr = %q, want %q", cands[0].ClusterAddr, want)
 	}
@@ -778,5 +781,32 @@ func TestScoreService_IdentityRequiresFamilySignal(t *testing.T) {
 				t.Fatalf("identity=%v, want %v", identity, tc.wantIdent)
 			}
 		})
+	}
+}
+
+// A headless Service publishes A records for its ready pods under its own name.
+// Addressing it as {service}-0.{service} assumes the StatefulSet is named after
+// the Service — true for caretta-vm, false for kube-prometheus-stack's
+// prometheus-operated, whose pod is
+// prometheus-{release}-kube-prometheus-stack-prometheus-0 — and made a reachable
+// backend look unreachable in-cluster.
+func TestBuildClusterAddrUsesPlainServiceDNS(t *testing.T) {
+	tests := []struct {
+		name, namespace string
+		port            int
+		want            string
+	}{
+		// Headless kube-prometheus-stack Service: its pod is not named
+		// prometheus-operated-0, so the old {service}-0. prefix never resolved.
+		{"prometheus-operated", "monitoring", 9090, "http://prometheus-operated.monitoring.svc.cluster.local:9090"},
+		// Headless caretta store: must still resolve under its own name.
+		{"caretta-vm", "default", 8428, "http://caretta-vm.default.svc.cluster.local:8428"},
+		// Regular ClusterIP Service: unchanged.
+		{"kube-prometheus-stack-prometheus", "monitoring", 9090, "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"},
+	}
+	for _, tc := range tests {
+		if got := buildClusterAddr(tc.name, tc.namespace, tc.port); got != tc.want {
+			t.Errorf("buildClusterAddr(%s/%s) = %q, want %q", tc.namespace, tc.name, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## What was broken

In-cluster (how Radar Hub runs), a headless Prometheus - the kube-prometheus-stack default - was unreachable. Discovery fell back to port-forward, the in-cluster service account lacks `pods/portforward` in the monitoring namespace, and the UI showed blank CPU/memory charts behind a misleading RBAC error.

## Why

`pkg/prom/discovery.go` `buildClusterAddr` special-cased headless Services (`ClusterIP=None`) by addressing pod-0:

```
{service}-0.{service}.{namespace}.svc.cluster.local
```

That assumes the backing StatefulSet is named after the Service. True for Caretta's `caretta-vm`, but false for kube-prometheus-stack's `prometheus-operated`, whose pod is `prometheus-{release}-kube-prometheus-stack-prometheus-0`. The address never resolved, so a reachable backend looked unreachable.

## The fix

A headless Service already publishes A records for its ready pods under its own name, so the pod prefix was never needed. Drop the special case and address every Service by its own DNS name:

```
{service}.{namespace}.svc.cluster.local:{port}
```

This mirrors `internal/traffic` `buildClusterAddr` (landed in #1409). The now-unused `clusterIP` parameter is removed; both call sites in `pkg/prom` are updated. The traffic package is untouched - `pkg/prom` has its own consumers (resource metrics, FinOps/rightsizing, Istio).

## How it was verified

Empirical repro first: the new table test failed against the unfixed code, producing `http://prometheus-operated-0.prometheus-operated.monitoring.svc.cluster.local:9090` (and the same `-0.` form for `caretta-vm`); after the fix it produces `http://prometheus-operated.monitoring.svc.cluster.local:9090`.

- `TestBuildClusterAddrUsesPlainServiceDNS` - asserts plain-DNS form for headless `prometheus-operated`, headless `caretta-vm` (regression guard that it still resolves), and a regular ClusterIP Service.
- `TestDiscover_HeadlessServiceUsesPlainServiceDNS` - end-to-end through `Discover`, a headless Service candidate now gets the plain-DNS `ClusterAddr` (previously asserted the buggy `-0.` form).

`go build ./...` and `go test ./prom/...` green; `gofmt` clean.

Full in-cluster e2e (kind + kube-prometheus-stack) is a follow-up.

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S



---

## Behavior change & regression analysis

The removed `clusterIP` parameter was only ever a headless flag (`== "None"`), never used as an address. The non-headless branch already returned the service DNS name, not the IP literal — so nothing that used the ClusterIP is being taken away.

| Service type | OLD address | NEW address | Change |
|---|---|---|---|
| ClusterIP (has an IP) | `{name}.{ns}.svc.cluster.local` | `{name}.{ns}.svc.cluster.local` | identical |
| Headless (`ClusterIP: None`) | `{name}-0.{name}.{ns}.svc.cluster.local` (pod-0 guess) | `{name}.{ns}.svc.cluster.local` | broken guess → correct |

- **ClusterIP services are addressed exactly as before.** kube-dns resolves `{name}.{ns}.svc.cluster.local` to the service's ClusterIP, so it reaches the same endpoint. Using the DNS name that resolves to the ClusterIP vs the raw IP literal is the same destination — and the old code always used the name. No capability lost.
- **Headless services** move from a wrong pod-0 assumption to the correct own-name resolution (a headless Service publishes A records for its ready pods under its own name). That is the fix.

Edge cases checked, none regress:
- **caretta-vm** (headless, StatefulSet named after the Service — the one case the pod-0 form happened to work): the plain name still resolves via the headless A records. RAD-370's measured table shows HTTP 200 for it, and it has a dedicated unit-test case.
- **Headless with zero ready endpoints**: no A record → no resolve — but the old `{name}-0` form did not resolve then either. Equal, not worse.
- **Headless HA (multiple replicas)**: the plain name round-robins across ready pods instead of pinning pod-0 — equal-or-better availability for a probe/discovery call.

Net: ClusterIP addressing is byte-identical; only the broken headless path changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all discovered Prometheus backends are addressed in-cluster; behavior is narrower and aligns with `internal/traffic`, but any deployment that relied on the old `{service}-0` URL would need that naming convention.
> 
> **Overview**
> Fixes in-cluster Prometheus discovery when kube-prometheus-stack exposes a **headless** Service (`prometheus-operated`). Discovery was building `ClusterAddr` as `{service}-0.{service}.{namespace}.svc.cluster.local`, which only works when the StatefulSet name matches the Service; kube-prometheus-stack pods use a different name, so direct HTTP failed and callers fell back to port-forward (often blocked by RBAC), leaving charts empty.
> 
> **`buildClusterAddr`** in `pkg/prom` now always uses `http://{service}.{namespace}.svc.cluster.local:{port}` and drops the unused `clusterIP` argument at both discovery call sites. Headless Services already resolve via their service name, so the pod-0 guess is removed.
> 
> Tests were updated to expect plain service DNS for headless discovery, plus **`TestBuildClusterAddrUsesPlainServiceDNS`** for `prometheus-operated`, `caretta-vm`, and a normal ClusterIP service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0827c1f29b86332ce8f350ae5fc44b2c77bb605e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
