### PR TITLE
fix(timeline): merge cluster-scoped resources into their app group

### DIFF
--- a/pkg/timeline/grouping.go
+++ b/pkg/timeline/grouping.go
@@ -105,14 +105,13 @@ func groupByOwner(events []TimelineEvent) []EventGroup {
 
 func groupByApp(events []TimelineEvent) []EventGroup {
 	groupMap := make(map[string]*EventGroup)
+	// appNameToKey maps a real app label to the group key of the first namespaced
+	// group carrying it, so the second pass can merge cluster-scoped resources
+	// (Namespace == "") into their app's group instead of keying them under the
+	// empty namespace (which would never collide with "namespace/app").
+	appNameToKey := make(map[string]string)
 
-	for _, event := range events {
-		appLabel := event.GetAppLabel()
-		if appLabel == "" {
-			appLabel = "__ungrouped__"
-		}
-
-		key := event.Namespace + "/" + appLabel
+	addToGroup := func(key, name string, event TimelineEvent) {
 		if group, exists := groupMap[key]; exists {
 			group.Events = append(group.Events, event)
 			group.EventCount++
@@ -121,13 +120,49 @@ func groupByApp(events []TimelineEvent) []EventGroup {
 			groupMap[key] = &EventGroup{
 				ID:          key,
 				Kind:        "App",
-				Name:        appLabel,
+				Name:        name,
 				Namespace:   event.Namespace,
 				Events:      []TimelineEvent{event},
 				EventCount:  1,
 				HealthState: event.HealthState,
 			}
 		}
+	}
+
+	// First pass: namespaced events (and cluster-scoped events with no app label)
+	// group by "namespace/appLabel", exactly as before. Cluster-scoped events that
+	// carry a real app label are deferred so they can merge into a namespaced group.
+	var clusterScoped []TimelineEvent
+	for _, event := range events {
+		appLabel := event.GetAppLabel()
+		if event.Namespace == "" && appLabel != "" {
+			clusterScoped = append(clusterScoped, event)
+			continue
+		}
+
+		name := appLabel
+		if name == "" {
+			name = "__ungrouped__"
+		}
+		key := event.Namespace + "/" + name
+		addToGroup(key, name, event)
+		if appLabel != "" && event.Namespace != "" {
+			if _, ok := appNameToKey[appLabel]; !ok {
+				appNameToKey[appLabel] = key
+			}
+		}
+	}
+
+	// Second pass: attach each cluster-scoped event to the existing namespaced
+	// group for its app label when one exists; otherwise fall back to an
+	// appLabel-only bucket (keyed solely by label, namespace "").
+	for _, event := range clusterScoped {
+		appLabel := event.GetAppLabel()
+		key, ok := appNameToKey[appLabel]
+		if !ok {
+			key = appLabel
+		}
+		addToGroup(key, appLabel, event)
 	}
 
 	var groups []EventGroup

--- a/pkg/timeline/grouping_test.go
+++ b/pkg/timeline/grouping_test.go
@@ -8,7 +8,8 @@ import (
 // TestGroupByApp_ClusterScopedMergesWithApp verifies that a cluster-scoped
 // resource (Namespace == "") carrying an app label is merged into the existing
 // namespaced group for that same app, instead of landing in its own isolated
-// group. Regression test for #1501.
+// group. Cluster-scoped resources with an app label merge into the matching
+// namespaced app group.
 func TestGroupByApp_ClusterScopedMergesWithApp(t *testing.T) {
 	events := []TimelineEvent{
 		{ID: "1", Kind: "Deployment", Namespace: "myns", Name: "my-app",

--- a/pkg/timeline/grouping_test.go
+++ b/pkg/timeline/grouping_test.go
@@ -1,0 +1,84 @@
+package timeline
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGroupByApp_ClusterScopedMergesWithApp verifies that a cluster-scoped
+// resource (Namespace == "") carrying an app label is merged into the existing
+// namespaced group for that same app, instead of landing in its own isolated
+// group. Regression test for #1501.
+func TestGroupByApp_ClusterScopedMergesWithApp(t *testing.T) {
+	events := []TimelineEvent{
+		{ID: "1", Kind: "Deployment", Namespace: "myns", Name: "my-app",
+			Labels: map[string]string{"app.kubernetes.io/name": "my-app"}, Timestamp: time.Now()},
+		{ID: "2", Kind: "ClusterSecretStore", Namespace: "", Name: "my-app-store",
+			Labels: map[string]string{"app.kubernetes.io/name": "my-app"}, Timestamp: time.Now()},
+	}
+
+	groups := GroupEvents(events, GroupByApp)
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group (cluster-scoped merged into namespaced app), got %d: %+v", len(groups), groups)
+	}
+
+	g := findGroupByName(groups, "my-app")
+	if g == nil {
+		t.Fatal("Expected group for 'my-app'")
+	}
+	if g.EventCount != 2 {
+		t.Errorf("Expected 2 events in 'my-app' group, got %d", g.EventCount)
+	}
+	if g.Namespace != "myns" {
+		t.Errorf("Expected group namespace 'myns', got %q", g.Namespace)
+	}
+}
+
+// TestGroupByApp_ClusterScopedNoMatchGetsOwnBucket verifies that a cluster-scoped
+// event whose app label matches no namespaced group still gets its own
+// appLabel-only bucket (no regression).
+func TestGroupByApp_ClusterScopedNoMatchGetsOwnBucket(t *testing.T) {
+	events := []TimelineEvent{
+		{ID: "1", Kind: "Deployment", Namespace: "myns", Name: "my-app",
+			Labels: map[string]string{"app.kubernetes.io/name": "my-app"}, Timestamp: time.Now()},
+		{ID: "2", Kind: "ClusterIssuer", Namespace: "", Name: "lonely",
+			Labels: map[string]string{"app.kubernetes.io/name": "other-app"}, Timestamp: time.Now()},
+	}
+
+	groups := GroupEvents(events, GroupByApp)
+
+	if len(groups) != 2 {
+		t.Fatalf("Expected 2 groups, got %d: %+v", len(groups), groups)
+	}
+
+	other := findGroupByName(groups, "other-app")
+	if other == nil {
+		t.Fatal("Expected own bucket for 'other-app'")
+	}
+	if other.EventCount != 1 {
+		t.Errorf("Expected 1 event in 'other-app' group, got %d", other.EventCount)
+	}
+}
+
+// TestGroupByApp_LabellessUnaffected verifies that label-less events (namespaced
+// and cluster-scoped) keep their prior grouping behavior.
+func TestGroupByApp_LabellessUnaffected(t *testing.T) {
+	events := []TimelineEvent{
+		{ID: "1", Kind: "ConfigMap", Namespace: "myns", Name: "cfg", Timestamp: time.Now()},
+		{ID: "2", Kind: "ClusterRole", Namespace: "", Name: "role", Timestamp: time.Now()},
+	}
+
+	groups := GroupEvents(events, GroupByApp)
+
+	// One __ungrouped__ bucket per distinct namespace ("myns" and "") — same as
+	// pre-fix behavior for label-less events.
+	if len(groups) != 2 {
+		t.Fatalf("Expected 2 ungrouped groups, got %d: %+v", len(groups), groups)
+	}
+	for _, g := range groups {
+		if g.Name != "__ungrouped__" {
+			t.Errorf("Expected label-less events in '__ungrouped__', got group name %q", g.Name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1501.

## Problem
`groupByApp` never merges cluster-scoped resources (`ClusterSecretStore`, `ClusterIssuer`, `ClusterRole`, `ClusterExternalSecret`, etc.) into their app's group. In the Timeline "By App" view they always appear as separate, flat top-level entries even when their `app.kubernetes.io/name` label matches a namespaced app.

## Root cause
`pkg/timeline/grouping.go` keyed every event as `event.Namespace + "/" + appLabel` (was line 115). Cluster-scoped resources always have `Namespace == ""`, so the key became `"/myapp"` and could never collide with the namespaced app's `"myns/myapp"` key. The cluster-scoped resource landed in its own isolated group.

## Fix
Replace the single pass with two passes:
1. Namespaced events (and cluster-scoped events with no app label) group by `"namespace/appLabel"` exactly as before, recording each app label's first namespaced group key.
2. Cluster-scoped events carrying a real app label attach to that existing namespaced group when one exists; otherwise fall back to an appLabel-only bucket (keyed solely by label).

Behavior is unchanged for events with no app label and for purely namespaced apps.

## Verification
New `pkg/timeline/grouping_test.go`:
- `TestGroupByApp_ClusterScopedMergesWithApp` - a `Deployment` in `myns` and a cluster-scoped `ClusterSecretStore`, both labeled `app.kubernetes.io/name: my-app`, now yield ONE `my-app` group of 2 events (namespace `myns`). Failed before the fix (produced 2 groups: `myns/my-app` + `/my-app`).
- `TestGroupByApp_ClusterScopedNoMatchGetsOwnBucket` - a cluster-scoped event whose label matches no namespaced app still gets its own appLabel-only bucket (no regression).
- `TestGroupByApp_LabellessUnaffected` - label-less events (namespaced + cluster-scoped) keep prior grouping.

`go build ./...` and `go test ./timeline/...` green; changed files gofmt-clean.

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S



---

## Behavior change & regression analysis

The first pass keys namespaced events by `namespace/appLabel` exactly as before, so grouping is unchanged for every namespaced resource and for label-less events. The only new behavior: a cluster-scoped resource (`Namespace == ""`) carrying `app.kubernetes.io/name` now merges into the matching namespaced app group instead of forming a lonely `/{app}` orphan group.

- **No-match cluster-scoped resource** still gets its own bucket. Its key changes from `/{app}` to `{app}`, which is collision-safe because namespaced keys are always `ns/app`.
- **Displayed namespace**: a merged group keeps the namespaced member's namespace; individual rows still carry their own (empty) namespace.
- **Label-less events**: untouched.

Known tradeoff (rare, not a blocker): if the same `app.kubernetes.io/name` exists in **two** namespaces, the cluster-scoped resource attaches to whichever namespaced group is encountered first (input-order dependent) and lands in one group, not both. This is still strictly better than the pre-fix orphan group, and only affects multi-namespace same-named apps. Tightening this to "merge only when exactly one namespace matches, else keep its own bucket" is a possible follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to timeline display grouping with regression tests; no auth, data, or API surface impact.
> 
> **Overview**
> **Timeline “By App” grouping** no longer leaves cluster-scoped resources (e.g. `ClusterSecretStore`, `ClusterIssuer`) in a separate top-level group when they share `app.kubernetes.io/name` with a namespaced app.
> 
> `groupByApp` now runs in two passes: namespaced events still key on `namespace/appLabel` and record the first group key per app label; cluster-scoped events with an app label are deferred and then merged into that namespaced group when it exists, otherwise they use an app-label-only bucket. Label-less events and unmatched cluster-scoped labels behave as before. Logic is centralized in a new `addToGroup` helper.
> 
> Adds `grouping_test.go` with cases for merge, orphan cluster-scoped bucket, and unchanged label-less grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74e92a19666db7fc995efdcfe9f1ded494d9609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
