### PR TITLE
fix(discovery): prefer list/watch-capable resource on bare-kind collision

### DIFF
--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -271,9 +271,11 @@ func (d *ResourceDiscovery) indexResourceLocked(resource APIResource) {
 	//      lacks those verbs (e.g. a real CRD over an aggregated APIService),
 	//   4. a deterministic sorted-group tie-break so the winner does not depend
 	//      on discovery order when two groups are otherwise indistinguishable.
-	// Rules 3-4 fix bare-kind collisions across groups (e.g. localqueues in
-	// kueue.x-k8s.io vs visibility.kueue.x-k8s.io), which the older rules left
-	// as nondeterministic first-writer-wins.
+	// Rules 3-4 resolve bare-kind collisions across groups deterministically: for
+	// localqueues in kueue.x-k8s.io vs visibility.kueue.x-k8s.io, the list/watch-
+	// capable real CRD wins over the aggregated APIService that lacks those verbs,
+	// and when candidates are otherwise indistinguishable the lowest group name
+	// wins so the result does not depend on discovery order.
 	kindKey := strings.ToLower(resource.Kind)
 	if existing, ok := d.resourceMap[kindKey]; !ok || preferResource(resource, existing) {
 		d.resourceMap[kindKey] = resource
@@ -398,8 +400,11 @@ func (d *ResourceDiscovery) GetAPIResources() ([]APIResource, error) {
 }
 
 // GetGVR returns the GroupVersionResource for a given kind or plural name.
-// WARNING: If multiple CRDs share the same Kind across different API groups,
-// this returns whichever was discovered first. Use GetGVRWithGroup to disambiguate.
+// NOTE: When multiple resources share the same Kind across different API groups,
+// this resolves the collision deterministically: a list/watch-capable resource
+// wins over one lacking those verbs, then the lowest group name breaks ties, so
+// the result does not depend on discovery order. Still use GetGVRWithGroup when a
+// caller needs a specific API group.
 func (d *ResourceDiscovery) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) {
 	if d == nil {
 		return schema.GroupVersionResource{}, false

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -264,23 +264,73 @@ func (d *ResourceDiscovery) indexResourceLocked(resource APIResource) {
 		Resource: resource.Name,
 	}
 
-	// Store in map by lowercase kind for lookup. Prefer non-CRD over CRD,
-	// then stable versions within the same group.
+	// Store in map by lowercase kind for lookup. Precedence, in order:
+	//   1. non-CRD over CRD,
+	//   2. within the same group + CRD-ness, a more stable version,
+	//   3. among same CRD-ness, a list/watch-capable resource over one that
+	//      lacks those verbs (e.g. a real CRD over an aggregated APIService),
+	//   4. a deterministic sorted-group tie-break so the winner does not depend
+	//      on discovery order when two groups are otherwise indistinguishable.
+	// Rules 3-4 fix bare-kind collisions across groups (e.g. localqueues in
+	// kueue.x-k8s.io vs visibility.kueue.x-k8s.io), which the older rules left
+	// as nondeterministic first-writer-wins.
 	kindKey := strings.ToLower(resource.Kind)
-	if existing, ok := d.resourceMap[kindKey]; !ok ||
-		(!resource.IsCRD && existing.IsCRD) ||
-		(resource.IsCRD == existing.IsCRD && existing.Group == resource.Group && IsMoreStableVersion(resource.Version, existing.Version)) {
+	if existing, ok := d.resourceMap[kindKey]; !ok || preferResource(resource, existing) {
 		d.resourceMap[kindKey] = resource
 		d.gvrMap[kindKey] = gvr
 	}
 
 	nameKey := strings.ToLower(resource.Name)
-	if existing, ok := d.resourceMap[nameKey]; !ok ||
-		(!resource.IsCRD && existing.IsCRD) ||
-		(resource.IsCRD == existing.IsCRD && existing.Group == resource.Group && IsMoreStableVersion(resource.Version, existing.Version)) {
+	if existing, ok := d.resourceMap[nameKey]; !ok || preferResource(resource, existing) {
 		d.resourceMap[nameKey] = resource
 		d.gvrMap[nameKey] = gvr
 	}
+}
+
+// preferResource reports whether resource should replace existing as the
+// bare-kind/name winner in the lookup maps. It encodes the precedence documented
+// in indexResourceLocked.
+func preferResource(resource, existing APIResource) bool {
+	// Non-CRD over CRD.
+	if !resource.IsCRD && existing.IsCRD {
+		return true
+	}
+	if resource.IsCRD != existing.IsCRD {
+		return false
+	}
+
+	// Same CRD-ness beyond this point.
+	// More stable version within the same group.
+	if existing.Group == resource.Group {
+		return IsMoreStableVersion(resource.Version, existing.Version)
+	}
+
+	// Different groups: prefer a list/watch-capable resource so a browsable
+	// resource wins over a list/watch-less aggregated API.
+	resourceLW := hasListWatch(resource.Verbs)
+	existingLW := hasListWatch(existing.Verbs)
+	if resourceLW != existingLW {
+		return resourceLW
+	}
+
+	// Otherwise break the tie deterministically by sorted group name so the
+	// result is stable regardless of discovery order.
+	return resource.Group < existing.Group
+}
+
+// hasListWatch reports whether verbs include both list and watch.
+func hasListWatch(verbs []string) bool {
+	hasList := false
+	hasWatch := false
+	for _, verb := range verbs {
+		if verb == "list" {
+			hasList = true
+		}
+		if verb == "watch" {
+			hasWatch = true
+		}
+	}
+	return hasList && hasWatch
 }
 
 // Stats returns lightweight stats without triggering a refresh.
@@ -458,17 +508,7 @@ func (d *ResourceDiscovery) SupportsWatch(kindOrName string) bool {
 	if !ok {
 		return false
 	}
-	hasList := false
-	hasWatch := false
-	for _, verb := range res.Verbs {
-		if verb == "list" {
-			hasList = true
-		}
-		if verb == "watch" {
-			hasWatch = true
-		}
-	}
-	return hasList && hasWatch
+	return hasListWatch(res.Verbs)
 }
 
 // SupportsWatchGVR checks if a GVR supports list and watch verbs.
@@ -484,17 +524,7 @@ func (d *ResourceDiscovery) SupportsWatchGVR(gvr schema.GroupVersionResource) bo
 		if res.Group != gvr.Group || res.Version != gvr.Version || res.Name != gvr.Resource {
 			continue
 		}
-		hasList := false
-		hasWatch := false
-		for _, verb := range res.Verbs {
-			if verb == "list" {
-				hasList = true
-			}
-			if verb == "watch" {
-				hasWatch = true
-			}
-		}
-		return hasList && hasWatch
+		return hasListWatch(res.Verbs)
 	}
 	return false
 }

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -178,3 +178,61 @@ func TestSupportsWatchGVRCoreResourceUsesExactEmptyGroup(t *testing.T) {
 		t.Fatal("Knative Service GVR should not inherit watch support from core Service")
 	}
 }
+
+// TestGetGVRBareKindPrefersListWatchAcrossGroups covers the kueue LocalQueue
+// collision: the plural "localqueues" exists as a real CRD in kueue.x-k8s.io
+// (supports list/watch) and as kueue's aggregated visibility APIService in
+// visibility.kueue.x-k8s.io (no list/watch). Both are CRD-typed and live in
+// different groups, so the older precedence rules never fired and the bare-kind
+// pick was strict first-writer-wins — nondeterministic in production because
+// cross-group discovery order is unstable. GetGVR must resolve to the
+// list/watch-capable CRD regardless of insertion order.
+func TestGetGVRBareKindPrefersListWatchAcrossGroups(t *testing.T) {
+	visibility := APIResource{
+		Group:      "visibility.kueue.x-k8s.io",
+		Version:    "v1beta2",
+		Kind:       "LocalQueue",
+		Name:       "localqueues",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get"},
+	}
+	realCRD := APIResource{
+		Group:      "kueue.x-k8s.io",
+		Version:    "v1beta1",
+		Kind:       "LocalQueue",
+		Name:       "localqueues",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list", "watch"},
+	}
+	want := schema.GroupVersionResource{Group: "kueue.x-k8s.io", Version: "v1beta1", Resource: "localqueues"}
+
+	cases := []struct {
+		name  string
+		first APIResource
+		last  APIResource
+	}{
+		{name: "visibility discovered first", first: visibility, last: realCRD},
+		{name: "real CRD discovered first", first: realCRD, last: visibility},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &ResourceDiscovery{
+				resourceMap: make(map[string]APIResource),
+				gvrMap:      make(map[string]schema.GroupVersionResource),
+			}
+			d.AddAPIResource(tc.first)
+			d.AddAPIResource(tc.last)
+
+			gvr, ok := d.GetGVR("localqueues")
+			if !ok {
+				t.Fatal("expected bare-kind localqueues lookup to resolve")
+			}
+			if gvr != want {
+				t.Fatalf("GetGVR(localqueues) = %v, want %v (list/watch-capable CRD)", gvr, want)
+			}
+		})
+	}
+}

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -183,10 +183,9 @@ func TestSupportsWatchGVRCoreResourceUsesExactEmptyGroup(t *testing.T) {
 // collision: the plural "localqueues" exists as a real CRD in kueue.x-k8s.io
 // (supports list/watch) and as kueue's aggregated visibility APIService in
 // visibility.kueue.x-k8s.io (no list/watch). Both are CRD-typed and live in
-// different groups, so the older precedence rules never fired and the bare-kind
-// pick was strict first-writer-wins — nondeterministic in production because
-// cross-group discovery order is unstable. GetGVR must resolve to the
-// list/watch-capable CRD regardless of insertion order.
+// different groups, so the bare-kind pick is decided by the list/watch verbs:
+// GetGVR must resolve to the list/watch-capable CRD regardless of insertion
+// order, since cross-group discovery order is unstable in production.
 func TestGetGVRBareKindPrefersListWatchAcrossGroups(t *testing.T) {
 	visibility := APIResource{
 		Group:      "visibility.kueue.x-k8s.io",


### PR DESCRIPTION
## Problem

Fixes #1170. Bare-kind resolution (REST `GET /api/resources/{plural}` with no `group` param, and MCP) could nondeterministically resolve a plural that exists in two API groups to the wrong one.

On a kueue cluster, `localqueues` sometimes resolved to the aggregated visibility APIService `localqueues.visibility.kueue.x-k8s.io` (no list/watch verbs) instead of the real CRD `localqueues.kueue.x-k8s.io`, returning `500 {"error":"resource localqueues.visibility.kueue.x-k8s.io/v1beta2 does not support list/watch"}`. The same request on the same cluster could also succeed - the pick was map/discovery-order nondeterministic. `?group=kueue.x-k8s.io` always worked, so only bare-kind REST/MCP callers hit it.

## Root cause

`pkg/k8score/discovery.go` `indexResourceLocked` precedence guard for the shared kind/name keys only replaced the current winner on: a new key, non-CRD-over-CRD, or same-CRD-ness + same-group + more-stable-version. Both `localqueues` entries are CRD-typed and live in **different** groups, so none of those clauses fired -> strict first-writer-wins. Cross-group discovery order is not stable, so the pick was nondeterministic.

## Fix

Extract the precedence decision into `preferResource` and add two clauses, applied among the same CRD-ness across different groups:

1. Prefer a resource whose verbs include both `list` and `watch` over one that lacks them, so a browsable resource wins over a list/watch-less aggregated API.
2. When list/watch capability is equal, break the tie deterministically by sorted group name, so the winner is stable regardless of discovery order.

Existing rules (non-CRD over CRD; more stable version within a group) are preserved unchanged. The verb check is factored into a `hasListWatch` helper reused by `SupportsWatch` and `SupportsWatchGVR` (removes two duplicated loops).

## Verification

New test `TestGetGVRBareKindPrefersListWatchAcrossGroups` registers the two `localqueues` entries in **both insertion orders** (subtests `visibility discovered first` / `real CRD discovered first`) and asserts `GetGVR("localqueues")` returns the `kueue.x-k8s.io` CRD GVR in both.

- Before the fix: `visibility discovered first` failed - `GetGVR(localqueues) = visibility.kueue.x-k8s.io/v1beta2 ... want kueue.x-k8s.io/v1beta1`.
- After the fix: both subtests pass.
- `go build ./...` and `go test ./pkg/k8score/...` green in both modules; gofmt clean; no existing discovery tests regressed.

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S



---

## Behavior change & regression analysis

`preferResource` preserves the existing precedence for every case the old inline condition already decided: a non-CRD wins over a CRD, and within the same group + same CRD-ness the more stable version wins. The only new behavior is for same-type collisions across **different** API groups, which the old rules left as first-writer-wins — nondeterministic, because cross-group discovery order is unstable.

For that previously-undefined case, resolution is now deterministic: a resource whose verbs include both `list` and `watch` wins over one lacking them (a bare-kind lookup feeds browse/list/watch paths, so the browsable resource is the correct pick — this is exactly what fixes the intermittent `localqueues` 500 against kueue's list/watch-less aggregated API), and otherwise the lowest group name breaks the tie so the result no longer depends on discovery order.

- **No previously-intentional cross-group preference existed to regress** — this only makes an undefined case defined. (The determinism now also covers the rare non-CRD-vs-non-CRD cross-group collision, in the same sensible direction.)
- **Callers needing an exact API group are unaffected** — they use `GetGVRWithGroup`.
- `hasListWatch` is the pre-existing verb check extracted verbatim and reused by `SupportsWatch` / `SupportsWatchGVR`; no semantic change.

Tradeoff to note: the cross-group tie-break compares group names, not version stability (version preference still applies only within a group). So two list/watch CRDs in different groups tie-break on group name — a `v1beta1` in an earlier-sorted group beats a `v1` in a later one. Deterministic and acceptable for the goal (kill nondeterminism, prefer browsable); revisit only if a real cross-group version-preference need appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core discovery precedence for all bare-kind lookups; behavior shifts for ambiguous plurals but is intended to be more stable and list-friendly.
> 
> **Overview**
> Fixes nondeterministic bare-kind/plural resolution when the same name exists in multiple API groups (e.g. Kueue `localqueues` in `kueue.x-k8s.io` vs aggregated `visibility.kueue.x-k8s.io`), which could flip REST/MCP list calls between success and `does not support list/watch` errors.
> 
> **`indexResourceLocked`** now delegates collision handling to **`preferResource`**, keeping non-CRD-over-CRD and same-group version stability, then for cross-group ties preferring resources with both **list** and **watch** verbs, and finally the lexicographically smaller API group so discovery order no longer picks the winner.
> 
> **`hasListWatch`** centralizes verb checks (also used by **`SupportsWatch`** / **`SupportsWatchGVR`**). **`GetGVR`** docs describe the new deterministic rules. A test asserts **`GetGVR("localqueues")`** always returns the list/watch-capable CRD regardless of registration order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ef277f2dece06f7d0cff59700b817d73a8f1e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
