### PR TITLE
fix(logs): flush pod-log SSE response before the blocking follow stream

### DIFF
--- a/internal/server/logs.go
+++ b/internal/server/logs.go
@@ -151,6 +151,17 @@ func (s *Server) handlePodLogsStream(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Flush the 200 + SSE headers and a connection event to the client before
+	// opening the follow stream. GetContainerLogs with Follow issues a live,
+	// blocking apiserver call that can stall (and a buffering OIDC/ALB proxy in
+	// front of Radar holds back unflushed bytes); flushing first means the
+	// browser EventSource opens immediately instead of pending with 0 bytes.
+	sendSSEEvent(w, flusher, "connected", map[string]any{
+		"pod":       podName,
+		"namespace": namespace,
+		"container": container,
+	})
+
 	stream, err := k8score.GetContainerLogs(r.Context(), client, namespace, podName, container, k8score.LogOptions{
 		TailLines:    &tailLines,
 		SinceSeconds: sinceSeconds,
@@ -159,17 +170,12 @@ func (s *Server) handlePodLogsStream(w http.ResponseWriter, r *http.Request) {
 		Follow:       true,
 	})
 	if err != nil {
+		// The connection is already open, so surface the failure as an SSE
+		// error event rather than an HTTP error the client would never see.
 		sendSSEError(w, flusher, fmt.Sprintf("Failed to open log stream: %v", err))
 		return
 	}
 	defer stream.Close()
-
-	// Send initial connection event
-	sendSSEEvent(w, flusher, "connected", map[string]any{
-		"pod":       podName,
-		"namespace": namespace,
-		"container": container,
-	})
 
 	// Stream logs line by line
 	reader := bufio.NewReader(stream)

--- a/internal/server/logs_stream_test.go
+++ b/internal/server/logs_stream_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// TestPodLogsStream_FlushesConnectedBeforeFollow asserts the pod-log SSE
+// contract: the handler must flush its 200 + SSE headers + `connected` frame
+// to the client before it opens the blocking follow log stream against the
+// apiserver. Behind a buffering OIDC/ALB proxy a follow stream that stalls
+// (accepts the connection but never sends headers) otherwise leaves the
+// browser EventSource pending with 0 bytes, because nothing was flushed first.
+//
+// The fake apiserver emulates that stall: it accepts the GetLogs
+// (`.../log?follow=true`) request and blocks without ever writing response
+// headers. The client must still receive the 200 status line and the
+// `connected` SSE frame promptly, even though the follow body never flows.
+func TestPodLogsStream_FlushesConnectedBeforeFollow(t *testing.T) {
+	// Fake apiserver: block the follow-log request without sending any bytes,
+	// mimicking a stalled/proxy-buffered upstream stream.
+	apiserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/log") {
+			// Accept the connection but never respond: hang until the client
+			// disconnects (request context cancelled), so the goroutine exits.
+			<-r.Context().Done()
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer apiserver.Close()
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: apiserver.URL})
+	if err != nil {
+		t.Fatalf("build clientset: %v", err)
+	}
+	prev := k8s.SetTestClient(client)
+	t.Cleanup(func() { k8s.SetTestClient(prev) })
+
+	s := &Server{}
+	router := chi.NewRouter()
+	router.Get("/api/pods/{namespace}/{name}/logs/stream", s.handlePodLogsStream)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	type result struct {
+		status int
+		body   string
+		err    error
+	}
+	// Cancel any in-flight request on teardown so the blocked follow stream and
+	// its connections unwind instead of leaking past the test.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	resCh := make(chan result, 1)
+	go func() {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/pods/prod/web/logs/stream?container=app", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			resCh <- result{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		// Read the first flushed chunk (headers arrive with it). The follow
+		// body never flows, so read just enough to see the connected frame.
+		buf := make([]byte, 512)
+		n, _ := resp.Body.Read(buf)
+		resCh <- result{status: resp.StatusCode, body: string(buf[:n])}
+	}()
+
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			t.Fatalf("request failed: %v", res.err)
+		}
+		if res.status != http.StatusOK {
+			t.Fatalf("status = %d, want 200 before the follow stream flows", res.status)
+		}
+		if !strings.Contains(res.body, "event: connected") {
+			t.Fatalf("expected `connected` SSE frame before the blocking follow stream, got: %q", res.body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out: no 200 / connected frame arrived before deadline — pod-log EventSource pends indefinitely")
+	}
+}


### PR DESCRIPTION
## Symptom

With Radar in-cluster (multi-cluster + OIDC), the pod-log UI opens an EventSource to `/api/pods/{ns}/{pod}/logs/stream` and it stays pending with 0 bytes transferred — "Loading logs..." forever. The static log fetch (`/logs`) works; only the streaming follow endpoint hangs. Reported behind an AWS ALB + Azure AD OIDC ingress. Fixes #1473.

## Root cause

`handlePodLogsStream` set the 200 + SSE header values but never flushed them before calling `k8score.GetContainerLogs(..., Follow: true)` — a live, blocking apiserver call. The first flush was the `connected` frame, which only ran *after* that call returned. While the follow stream stalls or is buffered by the OIDC/ALB proxy in front of Radar, the browser gets no status line and 0 bytes, so the EventSource pends indefinitely. The static path never follows, which is why it was unaffected. `follow=true` is the only behavioral difference; the client-selection / auth path is symmetric with the working static endpoint and untouched here.

## Fix

Reorder the handler so the `connected` frame flushes the 200 + SSE headers to the client *before* the follow stream is opened. A stream-open failure is now surfaced as an SSE `error` event on the already-open connection instead of an HTTP error the client would never see. This mirrors the sibling SSE handlers, which flush a connection frame before their first live call:
- topology SSE flushes `connection_state` immediately on connect (`internal/server/sse.go`)
- workload-log SSE sends `connected` before its first follow stream (`internal/server/workload_logs.go`)

## Verification

New test `TestPodLogsStream_FlushesConnectedBeforeFollow` (`internal/server/logs_stream_test.go`) stands up a fake apiserver that accepts the `.../log?follow=true` request and blocks without ever sending response headers (the stalled/proxy-buffered upstream), injects a real clientset via `k8s.SetTestClient`, mounts the route, and asserts the client receives HTTP 200 + the `connected` SSE frame before a 3s deadline even though the follow body never flows.

- Before the fix: times out — `no 200 / connected frame arrived before deadline — pod-log EventSource pends indefinitely` (the pending repro).
- After the fix: passes immediately.

`go build ./...`, `go test ./internal/server/...`, and `go test ./k8score/...` (pkg module) all green. gofmt clean.

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S



---

## Behavior change & regression analysis

The reorder moves the `connected` SSE frame (which commits the 200 + headers) to just before the blocking `GetContainerLogs(Follow: true)` call. All request validation and client/permission resolution still run before that point, so:

- **Pre-stream errors** (bad parameters, container resolution, anything checked before the `connected` frame) still return their normal HTTP status codes — unchanged.
- **Only a failure to open the follow stream** now surfaces as an in-band SSE `error` event on the already-open connection, instead of an HTTP error the browser's EventSource could never read anyway. For SSE clients this is strictly more actionable, not less.

One consequence to be explicit about: the `pods/log` subresource authorization happens inside `GetContainerLogs`, which now runs after the `connected` frame. So a log-read RBAC denial comes back as a `200` + SSE `error` event rather than a `403` status. EventSource clients cannot act on a 403 body and the UI already handles the error event, so this is behavior-equivalent for the user — but the HTTP status is now 200 even on that authz failure. Auth and client selection themselves are untouched; the reorder sits entirely after `getUserNamespaces` + `getClientForRequest`.

Known gap (tracked in RAD-399, not a blocker): there is still no stream-open timeout or heartbeat, so a backend that accepts the follow but never sends bytes shows as "connected but empty," indistinguishable from a quiet pod, and the streaming goroutine stays until the client disconnects. This PR strictly improves on the prior pend-forever behavior; the timeout/heartbeat is the follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow reorder of the pod-log SSE handler and clearer error delivery on an already-open stream; no auth or data-model changes.
> 
> **Overview**
> Fixes pod-log **EventSource** hanging at “Loading logs…” (0 bytes) when the follow stream to the apiserver stalls or is buffered by an OIDC/ALB proxy.
> 
> **`handlePodLogsStream`** now sends and flushes the **`connected`** SSE frame (and thus HTTP 200 + SSE headers) **before** calling **`GetContainerLogs`** with **`Follow: true`**, so the browser opens the stream immediately instead of waiting on the blocking upstream call. If opening the follow stream fails after the connection is already open, the handler continues to report that via an SSE **`error`** event rather than an HTTP error the client would not see.
> 
> Adds **`TestPodLogsStream_FlushesConnectedBeforeFollow`**, which uses a fake apiserver that blocks on **`/log`** without sending headers and asserts the client still gets 200 and **`event: connected`** within 3s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddba1bfe741c0b84a860fb8152ba246871ee0392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
