### PR TITLE
fix(auth): key the permission cache by username + groups

### DIFF
--- a/internal/mcp/changes_rbac_test.go
+++ b/internal/mcp/changes_rbac_test.go
@@ -36,7 +36,7 @@ func TestFilterRecentChangesRBAC(t *testing.T) {
 	// User can list deployments in shop, but NOT secrets there and NOT webhooks
 	// cluster-wide (unseeded → SAR against a nil client → fail closed).
 	ctx := withClusterAdmin(t, "scoped")
-	perms := getPermCache().Get("scoped")
+	perms := getPermCache().Get("scoped", nil)
 	perms.SetCanI("list", "apps", "deployments", "shop", true)
 
 	got := filterRecentChangesRBAC(ctx, clone())
@@ -65,7 +65,7 @@ func TestApplyCorrelationVisibilityFilters_RBACHiddenIsNotNoChanges(t *testing.T
 	}
 
 	ctx := withClusterAdmin(t, "corr-scoped")
-	getPermCache().Get("corr-scoped").SetCanI("list", "apps", "deployments", "shop", true)
+	getPermCache().Get("corr-scoped", nil).SetCanI("list", "apps", "deployments", "shop", true)
 
 	// The only relevant change is an unreadable ConfigMap → empty AND hidden.
 	visible, hidden := applyCorrelationVisibilityFilters(ctx, []issuesapi.RecentChange{

--- a/internal/mcp/permission_cache_group_key_test.go
+++ b/internal/mcp/permission_cache_group_key_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	pkgauth "github.com/skyhook-io/radar/pkg/auth"
+)
+
+// TestResolveUserPerms_GroupChangeNotServedStaleCeiling pins the caller-layer
+// behavior of the permission-cache group-key fix at the MCP namespace-
+// resolution path (resolveUserPerms). The cached UserPermissions entry is
+// produced by SubjectAccessReviews run with username AND groups, so the same
+// username arriving with a DIFFERENT group set must never be served the other
+// identity's cached ceiling — it must recompute.
+//
+// In this unit env there is no live apiserver (k8s.GetClient() == nil), so a
+// recompute fail-closes to no-access (AllowedNamespaces == []). That is the
+// load-bearing signal: a different group set is a cache MISS (recompute), not a
+// hit on the other identity's entry. Both directions are covered so a stale
+// entry from either the stronger or the weaker identity can never leak.
+//
+// If the cache regressed to username-only keying, the uncached group set would
+// hit the seeded entry and inherit its ceiling — the assertions below fail.
+func TestResolveUserPerms_GroupChangeNotServedStaleCeiling(t *testing.T) {
+	strong := []string{"platform-admins"}
+	weak := []string{"viewers"}
+
+	userCtx := func(username string, groups []string) context.Context {
+		return pkgauth.ContextWithUser(context.Background(), &pkgauth.User{Username: username, Groups: groups})
+	}
+
+	t.Run("stronger cached, weaker must not inherit", func(t *testing.T) {
+		getPermCache().Invalidate()
+		t.Cleanup(func() { getPermCache().Invalidate() })
+
+		// alice/[platform-admins]: cluster-admin ceiling (nil = all namespaces).
+		getPermCache().Set("alice", strong, &pkgauth.UserPermissions{AllowedNamespaces: nil})
+
+		// Sanity: the cached identity resolves to its own (cluster-admin) ceiling.
+		if _, p := resolveUserPerms(userCtx("alice", strong)); p == nil || p.AllowedNamespaces != nil {
+			t.Fatalf("cached strong identity perms = %+v, want cluster-admin (AllowedNamespaces == nil)", p)
+		}
+
+		// alice/[viewers] is a different identity: it must recompute (miss →
+		// fail-closed here), NOT inherit the cluster-admin ceiling.
+		_, p := resolveUserPerms(userCtx("alice", weak))
+		if p == nil {
+			t.Fatal("resolveUserPerms returned nil perms for an authenticated user")
+		}
+		if p.AllowedNamespaces == nil {
+			t.Fatal("weaker identity inherited the cluster-admin ceiling (nil = all namespaces) from a different group set")
+		}
+	})
+
+	t.Run("weaker cached, stronger must not inherit", func(t *testing.T) {
+		getPermCache().Invalidate()
+		t.Cleanup(func() { getPermCache().Invalidate() })
+
+		// bob/[viewers]: namespace-restricted ceiling.
+		getPermCache().Set("bob", weak, &pkgauth.UserPermissions{AllowedNamespaces: []string{"team-a"}})
+
+		// Sanity: the cached identity resolves to its own restricted ceiling.
+		if _, p := resolveUserPerms(userCtx("bob", weak)); p == nil || !equalSlice(p.AllowedNamespaces, []string{"team-a"}) {
+			t.Fatalf("cached weak identity perms = %+v, want AllowedNamespaces [team-a]", p)
+		}
+
+		// bob/[platform-admins] is a different identity: it must recompute
+		// (miss → fail-closed), NOT be served the restricted [team-a] entry.
+		_, p := resolveUserPerms(userCtx("bob", strong))
+		if p == nil {
+			t.Fatal("resolveUserPerms returned nil perms for an authenticated user")
+		}
+		if equalSlice(p.AllowedNamespaces, []string{"team-a"}) {
+			t.Fatal("stronger identity was served the weaker identity's cached ceiling [team-a] from a different group set")
+		}
+	})
+}

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -103,7 +103,7 @@ func resolveUserPerms(ctx context.Context) (*pkgauth.User, *pkgauth.UserPermissi
 		return nil, nil
 	}
 	cache := getPermCache()
-	if perms := cache.Get(user.Username); perms != nil {
+	if perms := cache.Get(user.Username, user.Groups); perms != nil {
 		return user, perms
 	}
 
@@ -122,7 +122,7 @@ func resolveUserPerms(ctx context.Context) (*pkgauth.User, *pkgauth.UserPermissi
 	}
 
 	perms := &pkgauth.UserPermissions{AllowedNamespaces: allowed}
-	cache.Set(user.Username, perms)
+	cache.Set(user.Username, user.Groups, perms)
 	return user, perms
 }
 

--- a/internal/mcp/permissions_test.go
+++ b/internal/mcp/permissions_test.go
@@ -16,7 +16,7 @@ import (
 func withTestUserPerms(t *testing.T, username string, groups []string, allowed []string) context.Context {
 	t.Helper()
 	ctx := pkgauth.ContextWithUser(context.Background(), &pkgauth.User{Username: username, Groups: groups})
-	getPermCache().Set(username, &pkgauth.UserPermissions{AllowedNamespaces: allowed})
+	getPermCache().Set(username, groups, &pkgauth.UserPermissions{AllowedNamespaces: allowed})
 	t.Cleanup(func() {
 		getPermCache().Invalidate()
 	})
@@ -161,7 +161,7 @@ func TestCanReadClusterScopedKind_SARError_FailsClosed(t *testing.T) {
 
 	// And the deny must NOT be cached — the next call should also flow
 	// through the fail-closed path, not a stale cached false.
-	perms := getPermCache().Get("alice")
+	perms := getPermCache().Get("alice", nil)
 	if perms == nil {
 		t.Fatal("user perms unexpectedly evicted")
 	}
@@ -181,7 +181,7 @@ func TestCanReadClusterScopedKind_AllowedCachesResult(t *testing.T) {
 	})
 	// First call — without a real K8s client this still hits the fail-closed
 	// path (no client). To exercise the cache hit, seed it directly:
-	perms := getPermCache().Get("alice")
+	perms := getPermCache().Get("alice", nil)
 	perms.SetCanI("list", "", "nodes", "", true)
 
 	if !canReadClusterScopedKind(ctx, "nodes", "", "list") {

--- a/internal/mcp/policy_context_rbac_test.go
+++ b/internal/mcp/policy_context_rbac_test.go
@@ -42,7 +42,7 @@ func withIndex(t *testing.T, reports ...*unstructured.Unstructured) {
 func mcpFindings(t *testing.T, user, namespace, pod string, seed func(p *pkgauth.UserPermissions)) ([]resourcecontext.KyvernoFinding, resourcecontext.OmittedReason, bool) {
 	t.Helper()
 	ctx := withClusterAdmin(t, user)
-	seed(getPermCache().Get(user))
+	seed(getPermCache().Get(user, nil))
 	families := k8s.ReadablePolicyReportFamilies(namespace, func(group, resource, ns string) bool {
 		return canReadInNamespace(ctx, group, resource, ns, "list")
 	})

--- a/internal/mcp/related_issues_auth_test.go
+++ b/internal/mcp/related_issues_auth_test.go
@@ -20,7 +20,7 @@ func TestMCPRelatedIssuesAuthorizeNodeClassSubject(t *testing.T) {
 	perms := &pkgauth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", karpenter.Group, "nodepools", "", true)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
-	getPermCache().Set("alice", perms)
+	getPermCache().Set("alice", nil, perms)
 	t.Cleanup(func() { getPermCache().Invalidate() })
 	access := issueRelatedResourceAccess(ctx)
 
@@ -52,7 +52,7 @@ func TestMCPRelatedIssuesAuthorizeMissingNodeClassEvidence(t *testing.T) {
 	perms := &pkgauth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", karpenter.Group, "nodepools", "", true)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
-	getPermCache().Set("alice", perms)
+	getPermCache().Set("alice", nil, perms)
 	t.Cleanup(func() { getPermCache().Invalidate() })
 	access := issueRelatedResourceAccess(ctx)
 	pool := issues.Ref{Group: karpenter.Group, Kind: karpenter.NodePoolKind, Name: "compute"}

--- a/internal/mcp/tools_diagnose_test.go
+++ b/internal/mcp/tools_diagnose_test.go
@@ -156,7 +156,7 @@ func TestHandleDiagnose_GitOpsKindDispatch(t *testing.T) {
 	ctx := withClusterAdmin(t, "admin")
 	// The GitOps read is gated on a per-kind get SAR; grant it so the test
 	// exercises the dispatch fork (not the RBAC gate, covered separately).
-	getPermCache().Get("admin").SetCanI("get", "argoproj.io", "applications", "alpha", true)
+	getPermCache().Get("admin", nil).SetCanI("get", "argoproj.io", "applications", "alpha", true)
 
 	_, _, err := handleDiagnose(ctx, nil, diagnoseInput{Kind: "application", Namespace: "alpha", Name: "whatever"})
 	if err == nil {
@@ -183,7 +183,7 @@ func TestHandleGitOpsDiagnose_PerKindRBAC(t *testing.T) {
 
 	// Granting the per-kind get lets the read through (then fails for not-found,
 	// not forbidden) — proving the gate is the only thing blocking it.
-	getPermCache().Get("limited").SetCanI("get", "argoproj.io", "applications", "argocd", true)
+	getPermCache().Get("limited", nil).SetCanI("get", "argoproj.io", "applications", "argocd", true)
 	if _, _, err := handleDiagnose(ctx, nil, diagnoseInput{Kind: "application", Namespace: "argocd", Name: "guestbook"}); err == nil || strings.Contains(err.Error(), "forbidden") {
 		t.Errorf("with get granted, expected a non-forbidden (not-found) error, got %v", err)
 	}
@@ -196,7 +196,7 @@ func TestHandleGitOpsDiagnose_NamespaceGate(t *testing.T) {
 	setupFakeCacheForFilterTests(t)
 	// User scoped to team-a; cluster RBAC grants get on applications in argocd.
 	ctx := withRestrictedUser(t, "scoped", []string{"team-a"})
-	getPermCache().Get("scoped").SetCanI("get", "argoproj.io", "applications", "argocd", true)
+	getPermCache().Get("scoped", nil).SetCanI("get", "argoproj.io", "applications", "argocd", true)
 
 	_, _, err := handleDiagnose(ctx, nil, diagnoseInput{Kind: "application", Namespace: "argocd", Name: "guestbook"})
 	if err == nil || !strings.Contains(err.Error(), "forbidden") {

--- a/internal/mcp/tools_filter_test.go
+++ b/internal/mcp/tools_filter_test.go
@@ -73,7 +73,7 @@ func setupFakeCacheForFilterTests(t *testing.T) {
 func withRestrictedUser(t *testing.T, username string, allowed []string) context.Context {
 	t.Helper()
 	ctx := pkgauth.ContextWithUser(context.Background(), &pkgauth.User{Username: username, Groups: nil})
-	getPermCache().Set(username, &pkgauth.UserPermissions{AllowedNamespaces: allowed})
+	getPermCache().Set(username, nil, &pkgauth.UserPermissions{AllowedNamespaces: allowed})
 	return ctx
 }
 
@@ -84,7 +84,7 @@ func withRestrictedUser(t *testing.T, username string, allowed []string) context
 func withClusterAdmin(t *testing.T, username string) context.Context {
 	t.Helper()
 	ctx := pkgauth.ContextWithUser(context.Background(), &pkgauth.User{Username: username, Groups: nil})
-	getPermCache().Set(username, &pkgauth.UserPermissions{AllowedNamespaces: nil})
+	getPermCache().Set(username, nil, &pkgauth.UserPermissions{AllowedNamespaces: nil})
 	return ctx
 }
 
@@ -94,7 +94,7 @@ func withClusterAdmin(t *testing.T, username string) context.Context {
 // Sets both list and get verbs.
 func grantClusterRead(t *testing.T, username string, gvrs ...string) {
 	t.Helper()
-	perms := getPermCache().Get(username)
+	perms := getPermCache().Get(username, nil)
 	if perms == nil {
 		t.Fatalf("user %q not in perm cache; call withRestrictedUser/withClusterAdmin first", username)
 	}
@@ -112,7 +112,7 @@ func grantClusterRead(t *testing.T, username string, gvrs ...string) {
 // scoped reads are gated even when the cache contains the resource.
 func denyClusterRead(t *testing.T, username string, gvrs ...string) {
 	t.Helper()
-	perms := getPermCache().Get(username)
+	perms := getPermCache().Get(username, nil)
 	if perms == nil {
 		t.Fatalf("user %q not in perm cache", username)
 	}
@@ -490,7 +490,7 @@ func seedSecretGetCanI(t *testing.T, username string, allowedNamespaces []string
 
 func seedSecretCanIVerb(t *testing.T, username, verb string, allowedNamespaces []string, deniedNamespaces []string) {
 	t.Helper()
-	perms := getPermCache().Get(username)
+	perms := getPermCache().Get(username, nil)
 	if perms == nil {
 		t.Fatalf("user %q not in perm cache", username)
 	}
@@ -547,7 +547,7 @@ func TestHandleListResources_Secrets_ClusterWideShape_NoSecretRBAC(t *testing.T)
 	// can't return.
 	setupFakeCacheForFilterTests(t)
 	ctx := withClusterAdmin(t, "broad-reader")
-	perms := getPermCache().Get("broad-reader")
+	perms := getPermCache().Get("broad-reader", nil)
 	if perms == nil {
 		t.Fatalf("broad-reader not in cache")
 	}
@@ -570,7 +570,7 @@ func TestHandleListResources_Secrets_ClusterWideShape_WithSecretRBAC(t *testing.
 	// allowed — user sees every secret in the cache.
 	setupFakeCacheForFilterTests(t)
 	ctx := withClusterAdmin(t, "broad-reader")
-	perms := getPermCache().Get("broad-reader")
+	perms := getPermCache().Get("broad-reader", nil)
 	if perms == nil {
 		t.Fatalf("broad-reader not in cache")
 	}
@@ -727,7 +727,7 @@ func TestHandleSearch_Secrets_ClusterWideShape_NsFilter(t *testing.T) {
 	// `list secrets` SAR.
 	setupFakeCacheForFilterTests(t)
 	ctx := withClusterAdmin(t, "broad-reader")
-	perms := getPermCache().Get("broad-reader")
+	perms := getPermCache().Get("broad-reader", nil)
 	if perms == nil {
 		t.Fatalf("broad-reader not in cache")
 	}

--- a/internal/mcp/tools_neighborhood_test.go
+++ b/internal/mcp/tools_neighborhood_test.go
@@ -54,7 +54,7 @@ func makeConfigMapNode(ns, name string) *topology.Node {
 func TestCanReadNeighborhoodNodeMCP_SecretRequiresPerKindRBAC(t *testing.T) {
 	ctx := withTestUserPerms(t, "alice", nil, []string{"default"})
 	// alice has namespace access to default but explicit deny on secrets-get.
-	perms := getPermCache().Get("alice")
+	perms := getPermCache().Get("alice", nil)
 	perms.SetCanI("get", "", "secrets", "default", false)
 
 	secret := makeSecretNode("default", "nginx-tls")
@@ -67,7 +67,7 @@ func TestCanReadNeighborhoodNodeMCP_SecretRequiresPerKindRBAC(t *testing.T) {
 // must be allowed. Locks down the positive path so the gate isn't blanket-deny.
 func TestCanReadNeighborhoodNodeMCP_SecretAllowedWithPerKindRBAC(t *testing.T) {
 	ctx := withTestUserPerms(t, "bob", nil, []string{"default"})
-	perms := getPermCache().Get("bob")
+	perms := getPermCache().Get("bob", nil)
 	perms.SetCanI("get", "", "secrets", "default", true)
 
 	secret := makeSecretNode("default", "nginx-tls")
@@ -135,7 +135,7 @@ func makeKnativeServiceNode(ns, name string) *topology.Node {
 // and surface to users without provider-specific RBAC.
 func TestCanReadNeighborhoodNodeMCP_NodeClassDeniedWithoutSAR(t *testing.T) {
 	ctx := withTestUserPerms(t, "alice", nil, nil)
-	perms := getPermCache().Get("alice")
+	perms := getPermCache().Get("alice", nil)
 	// Deny all NodeClass variants. The helper iterates the table; without
 	// discovery only ec2 enters the SAR loop (group != "" check is harmless
 	// — the discovery filter is skip-when-missing).
@@ -154,7 +154,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassDeniedWithoutSAR(t *testing.T) {
 // providers to fail.
 func TestCanReadNeighborhoodNodeMCP_NodeClassAllowedWithProviderSAR(t *testing.T) {
 	ctx := withTestUserPerms(t, "bob", nil, nil)
-	perms := getPermCache().Get("bob")
+	perms := getPermCache().Get("bob", nil)
 	// Bob has EC2 access only — should still pass for NodeClass.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
@@ -171,7 +171,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassAllowedWithProviderSAR(t *testing.T
 // EC2 RBAC must not see AKS NodeClass nodes. Mirrors the REST test.
 func TestCanReadNeighborhoodNodeMCP_NodeClassPerVariantDeniesWrongProvider(t *testing.T) {
 	ctx := withTestUserPerms(t, "bob", nil, nil)
-	perms := getPermCache().Get("bob")
+	perms := getPermCache().Get("bob", nil)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
@@ -207,7 +207,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassPerVariantDeniesWrongProvider(t *te
 
 func TestApplyClusterScopedTopologyRBACMCPFiltersExactNodeClassProvider(t *testing.T) {
 	ctx := withTestUserPerms(t, "topology-reader", nil, nil)
-	perms := getPermCache().Get("topology-reader")
+	perms := getPermCache().Get("topology-reader", nil)
 	perms.SetCanI("list", "eks.amazonaws.com", "nodeclasses", "", true)
 	perms.SetCanI("list", "infra.example.io", "customnodeclasses", "", false)
 
@@ -228,7 +228,7 @@ func TestApplyClusterScopedTopologyRBACMCPFiltersExactNodeClassProvider(t *testi
 
 func TestApplyClusterScopedTopologyRBACMCPFiltersCalicoByExactGroup(t *testing.T) {
 	ctx := withTestUserPerms(t, "topology-reader", nil, nil)
-	perms := getPermCache().Get("topology-reader")
+	perms := getPermCache().Get("topology-reader", nil)
 	perms.SetCanI("list", "projectcalico.org", "globalnetworkpolicies", "", true)
 	perms.SetCanI("list", "crd.projectcalico.org", "globalnetworkpolicies", "", false)
 
@@ -282,7 +282,7 @@ func pseudoKindTuplesForTestMCP(kind, group string) (tuples []topology.SARTuple,
 // provider API is open-ended and cannot be represented by a static table.
 func TestAllowPseudoKindTuplesMCP_NodeClass_DefersToExactNode(t *testing.T) {
 	ctx := withTestUserPerms(t, "alice", nil, nil)
-	perms := getPermCache().Get("alice")
+	perms := getPermCache().Get("alice", nil)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
@@ -298,7 +298,7 @@ func TestAllowPseudoKindTuplesMCP_NodeClass_DefersToExactNode(t *testing.T) {
 
 func TestAllowPseudoKindTuplesMCP_NodeClass_AllowedWithProviderSAR(t *testing.T) {
 	ctx := withTestUserPerms(t, "bob", nil, nil)
-	perms := getPermCache().Get("bob")
+	perms := getPermCache().Get("bob", nil)
 	// EC2 only — single-provider grant must be enough for the kind-level gate.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
@@ -317,7 +317,7 @@ func TestHandleGetNeighborhoodMCP_NodeClassRootNotNamespaceRequired(t *testing.T
 
 	// Unauthorized
 	ctxDeny := withTestUserPerms(t, "alice", nil, nil)
-	denyPerms := getPermCache().Get("alice")
+	denyPerms := getPermCache().Get("alice", nil)
 	denyPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
@@ -337,7 +337,7 @@ func TestHandleGetNeighborhoodMCP_NodeClassRootNotNamespaceRequired(t *testing.T
 
 	// Authorized
 	ctxAllow := withTestUserPerms(t, "bob", nil, nil)
-	allowPerms := getPermCache().Get("bob")
+	allowPerms := getPermCache().Get("bob", nil)
 	allowPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	allowPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
@@ -361,7 +361,7 @@ func TestHandleGetNeighborhoodMCP_NodePoolRootNotNamespaceRequired(t *testing.T)
 	setupSecretRefCacheMCP(t)
 
 	ctxDeny := withTestUserPerms(t, "alice", nil, nil)
-	denyPerms := getPermCache().Get("alice")
+	denyPerms := getPermCache().Get("alice", nil)
 	denyPerms.SetCanI("get", "karpenter.sh", "nodepools", "", false)
 	_, _, err := handleGetNeighborhood(ctxDeny, nil, getNeighborhoodInput{
 		Kind: "nodepool",
@@ -378,7 +378,7 @@ func TestHandleGetNeighborhoodMCP_NodePoolRootNotNamespaceRequired(t *testing.T)
 	}
 
 	ctxAllow := withTestUserPerms(t, "bob", nil, nil)
-	allowPerms := getPermCache().Get("bob")
+	allowPerms := getPermCache().Get("bob", nil)
 	allowPerms.SetCanI("get", "karpenter.sh", "nodepools", "", true)
 	_, _, err2 := handleGetNeighborhood(ctxAllow, nil, getNeighborhoodInput{
 		Kind: "nodepool",
@@ -456,7 +456,7 @@ func TestNeighborhoodMCP_SecretRootIncluded(t *testing.T) {
 	// `get secrets`. Both Allow checks must pass; root resolves; result
 	// includes the Secret node.
 	ctx := withTestUserPerms(t, "bob", nil, []string{"default"})
-	bobPerms := getPermCache().Get("bob")
+	bobPerms := getPermCache().Get("bob", nil)
 	bobPerms.SetCanI("get", "", "secrets", "default", true)
 
 	call, _, err := handleGetNeighborhood(ctx, nil, getNeighborhoodInput{
@@ -494,7 +494,7 @@ func TestNeighborhoodMCP_SecretRootIncluded(t *testing.T) {
 	// Existence-hiding preserved: same 404-shape result the
 	// IncludeSecrets=false path produced, but driven by RBAC.
 	ctxDenied := withTestUserPerms(t, "alice", nil, []string{"default"})
-	alicePerms := getPermCache().Get("alice")
+	alicePerms := getPermCache().Get("alice", nil)
 	alicePerms.SetCanI("get", "", "secrets", "default", false)
 
 	_, _, err2 := handleGetNeighborhood(ctxDenied, nil, getNeighborhoodInput{

--- a/internal/mcp/tools_upgrade_auth_test.go
+++ b/internal/mcp/tools_upgrade_auth_test.go
@@ -15,7 +15,7 @@ import (
 // internal/server). Change both tables together.
 func TestMCPUpgradeAuthorizerDecisionMatrix(t *testing.T) {
 	ctx := withClusterAdmin(t, "upgrade-matrix")
-	perms := getPermCache().Get("upgrade-matrix")
+	perms := getPermCache().Get("upgrade-matrix", nil)
 	perms.SetCanI("list", "", "nodes", "", true)
 	perms.SetCanI("list", "", "persistentvolumes", "", false)
 	perms.SetCanI("list", "storage.k8s.io", "csidrivers", "", true)
@@ -66,7 +66,7 @@ func TestMCPUpgradeAuthorizerNamespacesMirrorsHTTPScope(t *testing.T) {
 	}
 
 	restricted := pkgauth.ContextWithUser(context.Background(), &pkgauth.User{Username: "upgrade-scope-user"})
-	getPermCache().Set("upgrade-scope-user", &pkgauth.UserPermissions{AllowedNamespaces: []string{"tenant-b"}})
+	getPermCache().Set("upgrade-scope-user", nil, &pkgauth.UserPermissions{AllowedNamespaces: []string{"tenant-b"}})
 	if got := (mcpUpgradeAuthorizer{ctx: restricted}).Namespaces(); len(got) != 1 || got[0] != "tenant-b" {
 		t.Fatalf("restricted scope = %v, want [tenant-b]", got)
 	}

--- a/internal/server/ai_handlers_rbac_test.go
+++ b/internal/server/ai_handlers_rbac_test.go
@@ -26,7 +26,7 @@ func TestProxyAuth_AIGetSecret_PerNamespaceRBAC_Denied(t *testing.T) {
 	// nginx-tls (seeded as the SA which has cluster-wide secrets RBAC),
 	// so without the preflight a 200 would leak secret bytes.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretGetCanI(t, env, "alice", nil, []string{"default"})
@@ -47,7 +47,7 @@ func TestProxyAuth_AIGetNode_ClusterScopedRBAC_Denied(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", "", "nodes", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/ai/resources/node/_/worker-1", "broad-reader", "")
 	defer resp.Body.Close()
@@ -62,7 +62,7 @@ func TestProxyAuth_AIGetPod_NamespaceDenied(t *testing.T) {
 	// A regression that fetched first and then filtered would let timing
 	// signal whether the pod exists (oracle).
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 
@@ -79,7 +79,7 @@ func TestProxyAuth_AIGetPod_NamespaceAllowed(t *testing.T) {
 	// Pins that the preflight isn't accidentally over-gating happy-path
 	// requests (e.g., a misordered check that always denies).
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 
@@ -118,7 +118,7 @@ func TestAI_SecretsList_PerNamespaceDenied_Returns403(t *testing.T) {
 	// `list secrets` is denied. preflightResourceList must intercept
 	// before reaching the cache.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretListCanI(t, env, "alice", nil, []string{"default"})
@@ -137,7 +137,7 @@ func TestAI_NodesList_NoClusterRBAC_Returns403(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/ai/resources/nodes", "broad-reader", "")
 	defer resp.Body.Close()
@@ -152,7 +152,7 @@ func TestAI_NamespacesList_NoListNamespacesSAR_Returns403(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "namespaces", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/ai/resources/namespaces", "broad-reader", "")
 	defer resp.Body.Close()
@@ -176,7 +176,7 @@ func TestAI_NamespacesList_NoListNamespacesSAR_Returns403(t *testing.T) {
 // wrong-kind result), which is the bug.
 func TestAI_ListServices_WithGroup_RoutesToDynamicCache(t *testing.T) {
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 
@@ -230,7 +230,7 @@ func TestAI_DeploymentsList_HappyPath_AttachesSummaryContext(t *testing.T) {
 	// adds — pin it so a refactor that skipped attachment surfaces
 	// here).
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 

--- a/internal/server/ai_policy_rbac_test.go
+++ b/internal/server/ai_policy_rbac_test.go
@@ -37,7 +37,7 @@ func TestAIResourceContext_WithholdsTheFamilyTheCallerCannotRead(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("half", perms)
+	env.srv.permCache.Set("half", nil, perms)
 
 	got := aiPolicyAdapter(t, env, "half", "app").FindingsFor("", "Pod", "app", "web")
 	if len(got) != 1 {
@@ -55,7 +55,7 @@ func TestAIResourceContext_SaysDeniedRatherThanClean(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", false)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("none", perms)
+	env.srv.permCache.Set("none", nil, perms)
 
 	a := aiPolicyAdapter(t, env, "none", "app")
 	if got := a.FindingsFor("", "Pod", "app", "web"); len(got) != 0 {
@@ -80,7 +80,7 @@ func TestAIResourceContext_AuthorizesClusterScopedSubjectsAgainstTheClusterKind(
 	allow(perms, "wgpolicyk8s.io", "policyreports", "", true)
 	allow(perms, "wgpolicyk8s.io", "clusterpolicyreports", "", false)
 	allow(perms, "openreports.io", "clusterreports", "", false)
-	env.srv.permCache.Set("cluster", perms)
+	env.srv.permCache.Set("cluster", nil, perms)
 
 	a := aiPolicyAdapter(t, env, "cluster", "")
 	if got := a.FindingsFor("", "Namespace", "", "shop"); len(got) != 0 {
@@ -97,7 +97,7 @@ func TestAIResourceContext_KeepsEverythingForAFullyAuthorizedCaller(t *testing.T
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", true)
-	env.srv.permCache.Set("full", perms)
+	env.srv.permCache.Set("full", nil, perms)
 
 	a := aiPolicyAdapter(t, env, "full", "app")
 	if got := a.FindingsFor("", "Pod", "app", "web"); len(got) != 2 {
@@ -119,7 +119,7 @@ func TestAIResourceContext_SaysSoWhenThisResourcesFindingsWereWithheld(t *testin
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("half", perms)
+	env.srv.permCache.Set("half", nil, perms)
 
 	a := aiPolicyAdapter(t, env, "half", "app")
 	if got := a.FindingsFor("", "Pod", "app", "web"); len(got) != 0 {
@@ -142,7 +142,7 @@ func TestAIResourceContext_ReportsNoWithholdingForAGenuinelyCleanResource(t *tes
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("half", perms)
+	env.srv.permCache.Set("half", nil, perms)
 
 	if aiPolicyAdapter(t, env, "half", "app").WithheldFor("", "Pod", "app", "web") {
 		t.Error("nothing about this resource was withheld; a note here is a false alarm on every clean resource")

--- a/internal/server/argo_diff_test.go
+++ b/internal/server/argo_diff_test.go
@@ -413,7 +413,7 @@ func TestArgoResourceDiff_RBACDeniesBeforeArgoCall(t *testing.T) {
 	env := newAuthTestServer(t)
 	// alice can see both the app namespace (argocd) and the target namespace
 	// (default), but per-namespace `get secrets` in default is denied.
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"argocd", "default"},
 	})
 	seedServerSecretGetCanI(t, env, "alice", nil, []string{"default"})

--- a/internal/server/capacity_auth_test.go
+++ b/internal/server/capacity_auth_test.go
@@ -17,7 +17,7 @@ func TestCapacityNamespacesBypassSavedViewPreference(t *testing.T) {
 	t.Cleanup(func() { k8s.SetTestContextName(previousContext) })
 
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"alpha", "beta"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"alpha", "beta"}})
 	r := requestWithUser(http.MethodGet, "/api/capacity", &auth.User{Username: "alice"})
 	s.setActiveNamespaceForUser(r, []string{"alpha"})
 	if got := s.getActiveNamespaceForUser(r); !slices.Equal(got, []string{"alpha"}) {
@@ -57,7 +57,7 @@ func TestCapacityOwnerResolutionRequiresImmediateOwnerVisibility(t *testing.T) {
 
 func TestCapacityNamespacesHonorExplicitAndForcedScope(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"alpha", "beta"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"alpha", "beta"}})
 
 	r := requestWithUser(http.MethodGet, "/api/capacity?namespaces=beta,other", &auth.User{Username: "alice"})
 	if got := s.capacityNamespacesForUser(r); !slices.Equal(got, []string{"beta"}) {

--- a/internal/server/capacity_capability_test.go
+++ b/internal/server/capacity_capability_test.go
@@ -34,7 +34,7 @@ func TestKarpenterCapabilityReportsAbsenceBeforeRBACDenial(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", karpenterGroup, karpenterNodePoolResource, "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	r := requestWithUser(http.MethodGet, "/api/capabilities", &auth.User{Username: "alice"})
 	got := s.karpenterCapability(r)
@@ -89,7 +89,7 @@ func TestKarpenterCapabilityShortCircuitsWithoutUsableConnection(t *testing.T) {
 			if tt.seedDenied {
 				perms.SetCanI("list", karpenterGroup, karpenterNodePoolResource, "", false)
 			}
-			s.permCache.Set("alice", perms)
+			s.permCache.Set("alice", nil, perms)
 			r := requestWithUser(http.MethodGet, "/api/capabilities", &auth.User{Username: "alice"})
 
 			got := s.karpenterCapability(r)

--- a/internal/server/capacity_contract_test.go
+++ b/internal/server/capacity_contract_test.go
@@ -76,7 +76,7 @@ func TestCapacityNotDetectedPrecedesRBACDenial(t *testing.T) {
 	permissions.SetCanI("get", "", "configmaps", "kube-system", false)
 	permissions.SetCanI("list", "", "pods", "default", false)
 	permissions.SetCanI("list", "", "pods", "broken", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	var body capacityapi.OverviewResponse
 	assertOK(t, env.authGet(t, "/api/capacity", "alice", ""), &body)
@@ -94,7 +94,7 @@ func TestCapacityNodeVisibilityGateDeniesEveryRoute(t *testing.T) {
 	permissions := &auth.UserPermissions{AllowedNamespaces: nil}
 	permissions.SetCanI("list", karpenter.Group, "nodepools", "", true)
 	permissions.SetCanI("list", "", "nodes", "", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	for _, path := range []string{"/api/capacity", "/api/capacity/pools", "/api/capacity/demand", "/api/capacity/activity"} {
 		resp := env.authGet(t, path, "alice", "")
@@ -128,7 +128,7 @@ func TestCapacityOverviewNodePoolsDeniedRendersClusterShape(t *testing.T) {
 	permissions.SetCanI("list", "", "pods", "default", false)
 	permissions.SetCanI("list", "", "pods", "broken", false)
 	permissions.SetCanI("get", "", "configmaps", "kube-system", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	resp := env.authGet(t, "/api/capacity", "alice", "")
 	defer resp.Body.Close()
@@ -181,7 +181,7 @@ func TestCapacityAuthorizedStateEnvelopes(t *testing.T) {
 		permissions.SetCanI("get", "", "configmaps", "kube-system", false)
 		permissions.SetCanI("list", "", "pods", "default", false)
 		permissions.SetCanI("list", "", "pods", "broken", false)
-		env.srv.permCache.Set("alice", permissions)
+		env.srv.permCache.Set("alice", nil, permissions)
 
 		var body capacityapi.OverviewResponse
 		assertOK(t, env.authGet(t, "/api/capacity", "alice", ""), &body)
@@ -199,7 +199,7 @@ func TestCapacityAuthorizedStateEnvelopes(t *testing.T) {
 		permissions := &auth.UserPermissions{AllowedNamespaces: nil}
 		permissions.SetCanI("list", karpenter.Group, "nodepools", "", true)
 		permissions.SetCanI("list", "", "nodes", "", true)
-		env.srv.permCache.Set("alice", permissions)
+		env.srv.permCache.Set("alice", nil, permissions)
 
 		var body capacityapi.OverviewResponse
 		assertOK(t, env.authGet(t, "/api/capacity", "alice", ""), &body)
@@ -383,7 +383,7 @@ func TestCapacityDemandSummaryOmittedWithoutPodObservations(t *testing.T) {
 	permissions.SetCanI("list", "", "nodes", "", true)
 	permissions.SetCanI("list", "", "pods", "", false)
 	permissions.SetCanI("list", "metrics.k8s.io", "nodes", "", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	resp := env.authGet(t, "/api/capacity/demand", "alice", "")
 	defer resp.Body.Close()
@@ -440,7 +440,7 @@ func TestCapacityDemandPoolFilterDoesNotRevealNodePoolExistenceUnderDenial(t *te
 	// Node-visible but NodePool-denied: the demand route must fail closed on the
 	// NodePool denial (not the node gate), identically for every pool name.
 	permissions.SetCanI("list", "", "nodes", "", true)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	var errorMessage string
 	for _, pool := range []string{"general", "missing"} {
@@ -480,7 +480,7 @@ func TestCapacityOptionalSourceDenialOmitsCounts(t *testing.T) {
 	permissions.SetCanI("list", "apps", "replicasets", "default", false)
 	permissions.SetCanI("list", "batch", "jobs", "default", false)
 	permissions.SetCanI("get", "", "configmaps", "kube-system", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	resp := env.authGet(t, "/api/capacity", "alice", "")
 	defer resp.Body.Close()
@@ -982,7 +982,7 @@ func TestCapacityActivityRBACMetadataUsesOnlyAuthorizedRelevantEvents(t *testing
 	permissions.SetCanI("list", "", "nodes", "", true)
 	permissions.SetCanI("list", "", "events", "", false)
 	permissions.SetCanI("list", "", "events", "private", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	var body capacityapi.ActivityResponse
 	assertOK(t, env.authGet(t, "/api/capacity/activity", "alice", ""), &body)
@@ -1418,7 +1418,7 @@ func TestCapacityOverviewOmitsPodDerivedCountsUnderPodDenial(t *testing.T) {
 	permissions.SetCanI("list", "", "pods", "", false)
 	permissions.SetCanI("list", "metrics.k8s.io", "nodes", "", false)
 	permissions.SetCanI("get", "", "configmaps", "kube-system", false)
-	env.srv.permCache.Set("alice", permissions)
+	env.srv.permCache.Set("alice", nil, permissions)
 
 	resp := env.authGet(t, "/api/capacity", "alice", "")
 	defer resp.Body.Close()

--- a/internal/server/capacity_groups_test.go
+++ b/internal/server/capacity_groups_test.go
@@ -195,7 +195,7 @@ func TestCapacityResponsesFailClosedOnMidRequestContextSwitch(t *testing.T) {
 		permissions.SetCanI("list", "", "pods", "default", false)
 		permissions.SetCanI("list", "", "pods", "broken", false)
 		permissions.SetCanI("get", "", "configmaps", "kube-system", false)
-		env.srv.permCache.Set("alice", permissions)
+		env.srv.permCache.Set("alice", nil, permissions)
 
 		// Baseline: this path serves 200 when the cluster holds still.
 		resp := env.authGet(t, "/api/capacity", "alice", "")

--- a/internal/server/cnpg_handlers_test.go
+++ b/internal/server/cnpg_handlers_test.go
@@ -54,7 +54,7 @@ func TestCNPGCatalogUsers_DeniesRatherThanReportingNoUsers(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"pg"}}
 	allow(perms, cnpgGroup, "clusters", "", false)
-	env.srv.permCache.Set("nobody", perms)
+	env.srv.permCache.Set("nobody", nil, perms)
 
 	resp := env.authGet(t, "/api/cnpg/clusterimagecatalogs/postgres-fleet/clusters", "nobody", "")
 	defer resp.Body.Close()
@@ -68,7 +68,7 @@ func TestCNPGCatalogUsers_NamespacedRouteAuthorizesInItsNamespace(t *testing.T) 
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"pg"}}
 	allow(perms, cnpgGroup, "clusters", "pg", false)
-	env.srv.permCache.Set("scoped", perms)
+	env.srv.permCache.Set("scoped", nil, perms)
 
 	resp := env.authGet(t, "/api/cnpg/imagecatalogs/pg/postgres-pinned/clusters", "scoped", "")
 	defer resp.Body.Close()

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -206,7 +206,7 @@ func TestDashboardCalicoCoverageUsesNamespaceAwareReadsAndCalicoFallback(t *test
 		perms.SetCanI("list", tuple.group, tuple.resource, tuple.namespace, true)
 	}
 	perms.SetCanI("list", legacyNetworkPolicy.Group, legacyNetworkPolicy.Resource, "ns-c", false)
-	server.permCache.Set("alice", perms)
+	server.permCache.Set("alice", nil, perms)
 	authenticated := requestWithUser("GET", "/", &auth.User{Username: "alice"})
 	filtered := server.getDashboardNetworkPolicyCoverage(authenticated, cache, []string{"ns-a", "ns-b", "ns-c"})
 	if filtered == nil {

--- a/internal/server/gitops_handlers_test.go
+++ b/internal/server/gitops_handlers_test.go
@@ -230,7 +230,7 @@ func TestGitopsRequestHasNamespaceAccess(t *testing.T) {
 
 func TestFilterGitOpsTreeForUserAppliesNamespaceAndClusterScope(t *testing.T) {
 	s := &Server{permCache: auth.NewPermissionCache()}
-	s.permCache.Set("gitops-tree-user", &auth.UserPermissions{AllowedNamespaces: []string{"team-a"}})
+	s.permCache.Set("gitops-tree-user", nil, &auth.UserPermissions{AllowedNamespaces: []string{"team-a"}})
 	req := &gitopsRequest{AllowedNamespaces: []string{"team-a"}}
 	tree := &gitopstree.ResourceTree{
 		Root: gitopstree.Node{ID: "root", Role: gitopstree.RoleRoot, Ref: gitopstree.ResourceRef{Kind: "Application", Namespace: "argocd", Name: "app"}},

--- a/internal/server/issues_related_auth_test.go
+++ b/internal/server/issues_related_auth_test.go
@@ -20,7 +20,7 @@ func TestRESTRelatedIssuesAuthorizeNodeClassSubject(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", karpenter.Group, "nodepools", "", true)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 	r := requestWithUser(http.MethodGet, "/api/issues/resource/nodepool/_/compute", &auth.User{Username: "alice"})
 	access := s.issueRelatedResourceAccess(r)
 
@@ -47,7 +47,7 @@ func TestRESTRelatedIssuesAuthorizeMissingNodeClassEvidence(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", karpenter.Group, "nodepools", "", true)
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 	r := requestWithUser(http.MethodGet, "/api/issues/resource/nodepool/_/compute", &auth.User{Username: "alice"})
 	access := s.issueRelatedResourceAccess(r)
 	pool := issues.Ref{Group: karpenter.Group, Kind: karpenter.NodePoolKind, Name: "compute"}

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -209,14 +209,14 @@ func TestFinalizePostContextSwitch_ClearsBothCaches(t *testing.T) {
 	// that drops either side leaves stale state attached to the new cluster.
 	s := newTestServer(t)
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
+	s.permCache.Set("alice", nil, &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
 	s.setActiveNamespaceForUser(reqAs("alice"), []string{"alpha"})
 	s.setActiveNamespaceForUser(reqAs("bob"), []string{"beta", "gamma"})
 
 	s.finalizePostContextSwitch()
 
-	if got := s.permCache.Get("alice"); got != nil {
-		t.Errorf("permCache.Get(alice) = %+v after finalize, want nil", got)
+	if got := s.permCache.Get("alice", nil); got != nil {
+		t.Errorf("permCache.Get(alice, nil) = %+v after finalize, want nil", got)
 	}
 	if got := s.getActiveNamespaceForUser(reqAs("alice")); len(got) != 0 {
 		t.Errorf("alice ns pick survived: %v", got)
@@ -331,7 +331,7 @@ func TestResolveHelmNamespaces_AuthenticatedClusterWideUserDoesNotUseBackendFall
 	restoreHelmNamespaceFallbackState(t)
 
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: nil})
+	s.permCache.Set("alice", nil, &pkgauth.UserPermissions{AllowedNamespaces: nil})
 
 	got, ok := s.resolveHelmNamespaces(reqAs("alice"))
 	if !ok {
@@ -349,7 +349,7 @@ func TestResolveHelmNamespacesForScope_ClusterWideWorkloadReaderUsesPerNamespace
 	perms.SetCanI("list", "", "secrets", "default", true)
 	perms.SetCanI("list", "", "secrets", "broken", false)
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	got, ok := s.resolveHelmNamespacesForScope(reqAs("alice"), nil)
 	if !ok {

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -155,14 +155,14 @@ func TestFinalizePostContextSwitch_ClearsBothCaches(t *testing.T) {
 	// that drops either side leaves stale state attached to the new cluster.
 	s := newTestServer(t)
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
+	s.permCache.Set("alice", nil, &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
 	s.setActiveNamespaceForUser(reqAs("alice"), []string{"alpha"})
 	s.setActiveNamespaceForUser(reqAs("bob"), []string{"beta", "gamma"})
 
 	s.finalizePostContextSwitch()
 
-	if got := s.permCache.Get("alice"); got != nil {
-		t.Errorf("permCache.Get(alice) = %+v after finalize, want nil", got)
+	if got := s.permCache.Get("alice", nil); got != nil {
+		t.Errorf("permCache.Get(alice, nil) = %+v after finalize, want nil", got)
 	}
 	if got := s.getActiveNamespaceForUser(reqAs("alice")); len(got) != 0 {
 		t.Errorf("alice ns pick survived: %v", got)
@@ -277,7 +277,7 @@ func TestResolveHelmNamespaces_AuthenticatedClusterWideUserDoesNotUseBackendFall
 	restoreHelmNamespaceFallbackState(t)
 
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: nil})
+	s.permCache.Set("alice", nil, &pkgauth.UserPermissions{AllowedNamespaces: nil})
 
 	got, ok := s.resolveHelmNamespaces(reqAs("alice"))
 	if !ok {
@@ -295,7 +295,7 @@ func TestResolveHelmNamespacesForScope_ClusterWideWorkloadReaderUsesPerNamespace
 	perms.SetCanI("list", "", "secrets", "default", true)
 	perms.SetCanI("list", "", "secrets", "broken", false)
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	got, ok := s.resolveHelmNamespacesForScope(reqAs("alice"), nil)
 	if !ok {

--- a/internal/server/neighborhood_rbac_test.go
+++ b/internal/server/neighborhood_rbac_test.go
@@ -46,11 +46,11 @@ func makeConfigMapNode(ns, name string) *topology.Node {
 // denied. Same setup as the existing handleGetResource secrets RBAC tests.
 func TestCanReadNeighborhoodNode_SecretRequiresPerKindRBAC(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("alice", &auth.UserPermissions{
+	s.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	// alice has namespace access to default but NOT per-namespace secrets-get.
-	perms := s.permCache.Get("alice")
+	perms := s.permCache.Get("alice", nil)
 	perms.SetCanI("get", "", "secrets", "default", false)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/pod/default/anything", &auth.User{
@@ -67,10 +67,10 @@ func TestCanReadNeighborhoodNode_SecretRequiresPerKindRBAC(t *testing.T) {
 // must be allowed. Locks down the positive path so the gate isn't blanket-deny.
 func TestCanReadNeighborhoodNode_SecretAllowedWithPerKindRBAC(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("bob", &auth.UserPermissions{
+	s.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
-	perms := s.permCache.Get("bob")
+	perms := s.permCache.Get("bob", nil)
 	perms.SetCanI("get", "", "secrets", "default", true)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/pod/default/anything", &auth.User{
@@ -87,7 +87,7 @@ func TestCanReadNeighborhoodNode_SecretAllowedWithPerKindRBAC(t *testing.T) {
 // gate alone — adding the Secret-specific tightening must not regress that.
 func TestCanReadNeighborhoodNode_ConfigMapStaysOnNamespaceGate(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("alice", &auth.UserPermissions{
+	s.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	// alice has no configmap-specific SAR seeded — namespace access alone
@@ -147,7 +147,7 @@ func TestCanReadNeighborhoodNode_NodeClassDeniedWithoutSAR(t *testing.T) {
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "alice"})
 	n := makeNodeClassNode("default-class")
@@ -166,7 +166,7 @@ func TestCanReadNeighborhoodNode_NodeClassAllowedWithProviderSAR(t *testing.T) {
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	s.permCache.Set("bob", perms)
+	s.permCache.Set("bob", nil, perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
 	n := makeNodeClassNode("default-class")
@@ -192,7 +192,7 @@ func TestCanReadNeighborhoodNode_NodeClassPerVariantDeniesWrongProvider(t *testi
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	s.permCache.Set("bob", perms)
+	s.permCache.Set("bob", nil, perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
 
@@ -233,7 +233,7 @@ func TestCanReadNeighborhoodNode_NodeClassPerVariantDeniesWrongProvider(t *testi
 // and ride on namespace access alone (no per-kind tightening for Knative).
 func TestCanReadNeighborhoodNode_KnativeServiceUsesNamespaceGate(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"prod"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"prod"}})
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/service/prod/api", &auth.User{Username: "alice"})
 	n := makeKnativeServiceNode("prod", "api")
@@ -242,7 +242,7 @@ func TestCanReadNeighborhoodNode_KnativeServiceUsesNamespaceGate(t *testing.T) {
 	}
 
 	// Sanity: user without namespace access → denied.
-	s.permCache.Set("carol", &auth.UserPermissions{AllowedNamespaces: []string{"staging"}})
+	s.permCache.Set("carol", nil, &auth.UserPermissions{AllowedNamespaces: []string{"staging"}})
 	r2 := requestWithUser("GET", "/api/ai/neighborhood/service/prod/api", &auth.User{Username: "carol"})
 	if s.canReadNeighborhoodNode(r2, n) {
 		t.Error("KnativeService allowed for user without namespace access — namespace gate must apply")
@@ -267,7 +267,7 @@ func TestAllowPseudoKindTuples_NodeClass_DefersToExactNode(t *testing.T) {
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "alice"})
 	tuples, fallthroughAllow := pseudoKindTuplesForTest("nodeclass", "")
@@ -289,7 +289,7 @@ func TestAllowPseudoKindTuples_NodeClass_AllowedWithProviderSAR(t *testing.T) {
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	s.permCache.Set("bob", perms)
+	s.permCache.Set("bob", nil, perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
 	tuples, fallthroughAllow := pseudoKindTuplesForTest("nodeclass", "")
@@ -304,11 +304,11 @@ func TestAllowPseudoKindTuples_NodePool(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	denyPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	denyPerms.SetCanI("get", "karpenter.sh", "nodepools", "", false)
-	s.permCache.Set("alice", denyPerms)
+	s.permCache.Set("alice", nil, denyPerms)
 
 	allowPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	allowPerms.SetCanI("get", "karpenter.sh", "nodepools", "", true)
-	s.permCache.Set("bob", allowPerms)
+	s.permCache.Set("bob", nil, allowPerms)
 
 	tuples, fallthroughAllow := pseudoKindTuplesForTest("nodepool", "")
 	if len(tuples) != 1 {
@@ -334,7 +334,7 @@ func TestNeighborhood_NodeClassRootPreflightNotBadRequest(t *testing.T) {
 	denyPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	env.srv.permCache.Set("alice", denyPerms)
+	env.srv.permCache.Set("alice", nil, denyPerms)
 
 	resp := env.authGet(t, "/api/ai/neighborhood/nodeclass/_/foo", "alice", "")
 	resp.Body.Close()
@@ -351,7 +351,7 @@ func TestNeighborhood_NodeClassRootPreflightNotBadRequest(t *testing.T) {
 	allowPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	allowPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
 	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
-	env.srv.permCache.Set("bob", allowPerms)
+	env.srv.permCache.Set("bob", nil, allowPerms)
 
 	resp2 := env.authGet(t, "/api/ai/neighborhood/nodeclass/_/foo", "bob", "")
 	resp2.Body.Close()
@@ -369,7 +369,7 @@ func TestNeighborhood_NodePoolRootPreflightNotBadRequest(t *testing.T) {
 
 	denyPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	denyPerms.SetCanI("get", "karpenter.sh", "nodepools", "", false)
-	env.srv.permCache.Set("alice", denyPerms)
+	env.srv.permCache.Set("alice", nil, denyPerms)
 	resp := env.authGet(t, "/api/ai/neighborhood/nodepool/_/foo", "alice", "")
 	resp.Body.Close()
 	if resp.StatusCode == http.StatusBadRequest {
@@ -381,7 +381,7 @@ func TestNeighborhood_NodePoolRootPreflightNotBadRequest(t *testing.T) {
 
 	allowPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	allowPerms.SetCanI("get", "karpenter.sh", "nodepools", "", true)
-	env.srv.permCache.Set("bob", allowPerms)
+	env.srv.permCache.Set("bob", nil, allowPerms)
 	resp2 := env.authGet(t, "/api/ai/neighborhood/nodepool/_/foo", "bob", "")
 	resp2.Body.Close()
 	if resp2.StatusCode == http.StatusBadRequest {
@@ -409,10 +409,10 @@ func TestNeighborhood_SecretRootIncluded(t *testing.T) {
 	// Authorized user: namespace access to default + per-namespace
 	// `get secrets` SAR. Both Allow checks (namespace + per-kind Secret)
 	// must pass.
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
-	bobPerms := env.srv.permCache.Get("bob")
+	bobPerms := env.srv.permCache.Get("bob", nil)
 	bobPerms.SetCanI("get", "", "secrets", "default", true)
 
 	resp := env.authGet(t, "/api/ai/neighborhood/secret/default/nginx-tls", "bob", "")
@@ -425,10 +425,10 @@ func TestNeighborhood_SecretRootIncluded(t *testing.T) {
 	// `get secrets` SAR. Allow rejects the root → empty subgraph → 404.
 	// Existence-hiding preserved: same 404 the IncludeSecrets=false path
 	// produced, but now driven by RBAC instead of topology elision.
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
-	alicePerms := env.srv.permCache.Get("alice")
+	alicePerms := env.srv.permCache.Get("alice", nil)
 	alicePerms.SetCanI("get", "", "secrets", "default", false)
 
 	resp2 := env.authGet(t, "/api/ai/neighborhood/secret/default/nginx-tls", "alice", "")

--- a/internal/server/permission_cache_group_key_test.go
+++ b/internal/server/permission_cache_group_key_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+// reqAsGroups builds a request whose context carries an authenticated user with
+// the given username AND group set — the two inputs getUserNamespaces keys the
+// permission cache on.
+func reqAsGroups(username string, groups []string) *http.Request {
+	r := httptest.NewRequest("GET", "/api/resources/pods", nil)
+	ctx := auth.ContextWithUser(r.Context(), &auth.User{Username: username, Groups: groups})
+	return r.WithContext(ctx)
+}
+
+// TestGetUserNamespaces_GroupChangeNotServedStaleCeiling pins the caller-layer
+// behavior of the permission-cache group-key fix at the real namespace-
+// resolution path (getUserNamespaces). The cached UserPermissions entry is
+// produced by SubjectAccessReviews run with username AND groups, so the same
+// username arriving with a DIFFERENT group set must never be served the other
+// identity's cached namespace ceiling — it must recompute.
+//
+// In this unit env there is no live apiserver (k8s.GetClient() == nil), so a
+// recompute fail-closes to no-access ([]). That is exactly the load-bearing
+// signal: a different group set is a cache MISS (recompute), not a hit on the
+// other identity's entry. Both directions are covered so a stale entry from
+// either the stronger or the weaker identity can never leak to the other.
+//
+// If the cache regressed to username-only keying, the uncached group set would
+// hit the seeded entry and inherit its ceiling — the assertions below flip to
+// failures.
+func TestGetUserNamespaces_GroupChangeNotServedStaleCeiling(t *testing.T) {
+	strong := []string{"platform-admins"}
+	weak := []string{"viewers"}
+	requested := []string{"default", "kube-system"}
+
+	t.Run("stronger cached, weaker must not inherit", func(t *testing.T) {
+		s := newAuthServer(auth.Config{Mode: "proxy"})
+		// alice/[platform-admins]: cluster-admin ceiling (nil = all namespaces).
+		s.permCache.Set("alice", strong, &auth.UserPermissions{AllowedNamespaces: nil})
+
+		// Sanity: the cached identity resolves to its own (cluster-admin) ceiling.
+		if got := s.getUserNamespaces(reqAsGroups("alice", strong), requested); !slices.Equal(got, requested) {
+			t.Fatalf("cached strong identity ceiling = %v, want %v (cluster-admin sees all requested)", got, requested)
+		}
+
+		// alice/[viewers] is a different identity: it must recompute (miss →
+		// fail-closed here), NOT be served the admin ceiling.
+		got := s.getUserNamespaces(reqAsGroups("alice", weak), requested)
+		if len(got) != 0 {
+			t.Fatalf("weaker identity inherited the admin ceiling from a different group set: got %v, want [] (recompute)", got)
+		}
+	})
+
+	t.Run("weaker cached, stronger must not inherit", func(t *testing.T) {
+		s := newAuthServer(auth.Config{Mode: "proxy"})
+		// bob/[viewers]: namespace-restricted ceiling.
+		s.permCache.Set("bob", weak, &auth.UserPermissions{AllowedNamespaces: []string{"default"}})
+
+		// Sanity: the cached identity resolves to its own restricted ceiling.
+		if got := s.getUserNamespaces(reqAsGroups("bob", weak), requested); !slices.Equal(got, []string{"default"}) {
+			t.Fatalf("cached weak identity ceiling = %v, want [default]", got)
+		}
+
+		// bob/[platform-admins] is a different identity: it must recompute
+		// (miss → fail-closed), NOT be served the restricted ["default"] entry.
+		got := s.getUserNamespaces(reqAsGroups("bob", strong), []string{"default"})
+		if len(got) != 0 {
+			t.Fatalf("stronger identity was served the weaker identity's cached ceiling: got %v, want [] (recompute)", got)
+		}
+	})
+}

--- a/internal/server/policy_coverage_rbac_test.go
+++ b/internal/server/policy_coverage_rbac_test.go
@@ -102,7 +102,7 @@ func TestPolicyCoverage_WithholdsTheFamilyTheCallerCannotRead(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "require-limits")
 
@@ -142,7 +142,7 @@ func TestPolicyCoverage_WithholdsANamespaceItCannotReadAtAll(t *testing.T) {
 	allow(perms, "openreports.io", "reports", "app", false)
 	allow(perms, "wgpolicyk8s.io", "policyreports", "other", false)
 	allow(perms, "openreports.io", "reports", "other", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "require-limits")
 
@@ -184,7 +184,7 @@ func TestPolicyCoverage_AuthorizesClusterScopedSubjectsAgainstTheClusterScopedKi
 	// Denied on the namespaced names, which must not be what this is gated on.
 	allow(perms, "wgpolicyk8s.io", "policyreports", "", false)
 	allow(perms, "openreports.io", "reports", "", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "require-limits")
 
@@ -209,7 +209,7 @@ func TestPolicyCoverage_WithholdsClusterScopedSubjectsWhenDenied(t *testing.T) {
 	allow(perms, "wgpolicyk8s.io", "clusterpolicyreports", "", false)
 	allow(perms, "openreports.io", "clusterreports", "", false)
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "require-limits")
 
@@ -240,7 +240,7 @@ func TestPolicyCoverage_AuthorizesPerSubjectNamespaceNotPerPolicy(t *testing.T) 
 	// Cluster-scoped denied, which must not remove the namespace they can read.
 	allow(perms, "wgpolicyk8s.io", "clusterpolicyreports", "", false)
 	allow(perms, "openreports.io", "clusterreports", "", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "require-limits")
 
@@ -277,7 +277,7 @@ func TestPolicyCoverage_CountsResourcesApartFromChecks(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "two-rules")
 
@@ -309,7 +309,7 @@ func TestPolicyCoverage_FailingResourceCountExcludesPassingOnes(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "mixed")
 
@@ -339,7 +339,7 @@ func TestPolicyCoverage_OnlyRealFailuresCountAsFailingResources(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "wgpolicyk8s.io", "policyreports", "app", true)
 	allow(perms, "openreports.io", "reports", "app", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	got := coverageFor(t, env, "alice", "no-verdict")
 

--- a/internal/server/policy_queued_test.go
+++ b/internal/server/policy_queued_test.go
@@ -49,7 +49,7 @@ func TestPolicyQueued_DeniesRatherThanReportingAnEmptyQueue(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "kyverno.io", "updaterequests", "", false)
-	env.srv.permCache.Set("nobody", perms)
+	env.srv.permCache.Set("nobody", nil, perms)
 
 	resp := env.authGet(t, "/api/policy/policies/require-labels/queued", "nobody", "")
 	defer resp.Body.Close()
@@ -64,7 +64,7 @@ func TestPolicyQueued_RejectsAMissingPolicyName(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"app"}}
 	allow(perms, "kyverno.io", "updaterequests", "", true)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	// chi will not route an empty {policy}, so the trailing-slash form is the
 	// reachable shape of "no name given".

--- a/internal/server/rbac_handlers_test.go
+++ b/internal/server/rbac_handlers_test.go
@@ -245,7 +245,7 @@ func assertForbiddenWhenDeniedRBACList(t *testing.T, path, deniedResource string
 		allowed := resource != deniedResource
 		perms.SetCanI("list", "rbac.authorization.k8s.io", resource, "", allowed)
 	}
-	testServerSrv.permCache.Set(username, perms)
+	testServerSrv.permCache.Set(username, nil, perms)
 	// Entry is keyed by the unique "denied-user" name and TTL'd by the
 	// cache; no cleanup needed — other tests don't use this username.
 

--- a/internal/server/reachability_run_test.go
+++ b/internal/server/reachability_run_test.go
@@ -164,7 +164,7 @@ func TestTraceInClusterRequiresCloudMember(t *testing.T) {
 func TestTraceInClusterDoesNotLeakExistenceAcrossNamespaces(t *testing.T) {
 	s := newTestServer(t)
 	s.permCache = auth.NewPermissionCache()
-	s.permCache.Set("u@example.com", &auth.UserPermissions{AllowedNamespaces: []string{"ns-a"}})
+	s.permCache.Set("u@example.com", nil, &auth.UserPermissions{AllowedNamespaces: []string{"ns-a"}})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/trace/Service/ns-b/secret-svc/in-cluster", strings.NewReader(`{}`))
 	rctx := chi.NewRouteContext()

--- a/internal/server/reachability_run_test.go
+++ b/internal/server/reachability_run_test.go
@@ -164,7 +164,7 @@ func TestTraceInClusterRequiresCloudMember(t *testing.T) {
 func TestTraceInClusterDoesNotLeakExistenceAcrossNamespaces(t *testing.T) {
 	s := newTestServer(t)
 	s.permCache = auth.NewPermissionCache()
-	s.permCache.Set("u@example.com", nil, &auth.UserPermissions{AllowedNamespaces: []string{"ns-a"}})
+	s.permCache.Set("u@example.com", []string{"radar:member"}, &auth.UserPermissions{AllowedNamespaces: []string{"ns-a"}})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/trace/Service/ns-b/secret-svc/in-cluster", strings.NewReader(`{}`))
 	rctx := chi.NewRouteContext()

--- a/internal/server/read_rbac_leaks_test.go
+++ b/internal/server/read_rbac_leaks_test.go
@@ -63,8 +63,8 @@ func TestSecretReadableNamespaces(t *testing.T) {
 
 	t.Run("cluster-wide namespaces, cluster-scope secrets denied -> none", func(t *testing.T) {
 		env := newAuthTestServer(t)
-		env.srv.permCache.Set("broad", &auth.UserPermissions{AllowedNamespaces: nil})
-		env.srv.permCache.Get("broad").SetCanI("list", "", "secrets", "", false)
+		env.srv.permCache.Set("broad", nil, &auth.UserPermissions{AllowedNamespaces: nil})
+		env.srv.permCache.Get("broad", nil).SetCanI("list", "", "secrets", "", false)
 
 		got := env.srv.secretReadableNamespaces(clusterWideReq("broad"), nil)
 		if len(got) != 0 || got == nil {
@@ -74,8 +74,8 @@ func TestSecretReadableNamespaces(t *testing.T) {
 
 	t.Run("cluster-wide namespaces, cluster-scope secrets allowed -> all (nil)", func(t *testing.T) {
 		env := newAuthTestServer(t)
-		env.srv.permCache.Set("admin", &auth.UserPermissions{AllowedNamespaces: nil})
-		env.srv.permCache.Get("admin").SetCanI("list", "", "secrets", "", true)
+		env.srv.permCache.Set("admin", nil, &auth.UserPermissions{AllowedNamespaces: nil})
+		env.srv.permCache.Get("admin", nil).SetCanI("list", "", "secrets", "", true)
 
 		if got := env.srv.secretReadableNamespaces(clusterWideReq("admin"), nil); got != nil {
 			t.Errorf("allowed cluster-scope secrets must yield nil (all), got %#v", got)
@@ -84,8 +84,8 @@ func TestSecretReadableNamespaces(t *testing.T) {
 
 	t.Run("namespace-restricted -> per-namespace subset", func(t *testing.T) {
 		env := newAuthTestServer(t)
-		env.srv.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"default", "kube-system"}})
-		perms := env.srv.permCache.Get("alice")
+		env.srv.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"default", "kube-system"}})
+		perms := env.srv.permCache.Get("alice", nil)
 		perms.SetCanI("list", "", "secrets", "default", true)
 		perms.SetCanI("list", "", "secrets", "kube-system", false)
 
@@ -109,7 +109,7 @@ func TestProxyAuth_NamespaceGatedReadPaths(t *testing.T) {
 			env := newAuthTestServer(t)
 			// carol can see "other", never "default" — getUserNamespaces
 			// intersects requested(default) with allowed(other) -> empty.
-			env.srv.permCache.Set("carol", &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
+			env.srv.permCache.Set("carol", nil, &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
 
 			resp := env.authGet(t, p, "carol", "")
 			defer resp.Body.Close()

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -196,7 +196,7 @@ func TestResourceCountsMarksDeniedClusterTrustBundleForbidden(t *testing.T) {
 	user := &auth.User{Username: "alice"}
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "certificates.k8s.io", "clustertrustbundles", "", false)
-	s.permCache.Set(user.Username, perms)
+	s.permCache.Set(user.Username, user.Groups, perms)
 	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
 
 	rec := httptest.NewRecorder()

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -343,7 +343,7 @@ func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	user := &auth.User{Username: "alice"}
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "karpenter.sh", "nodepools", "", false)
-	s.permCache.Set(user.Username, perms)
+	s.permCache.Set(user.Username, nil, perms)
 	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
 
 	rec := httptest.NewRecorder()
@@ -371,7 +371,7 @@ func TestResourceCountsSurfacesDeniedCoreClusterScopedKindAsForbidden(t *testing
 	user := &auth.User{Username: "alice"}
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
-	s.permCache.Set(user.Username, perms)
+	s.permCache.Set(user.Username, nil, perms)
 	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
 
 	rec := httptest.NewRecorder()

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -204,7 +204,7 @@ func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	user := &auth.User{Username: "alice"}
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "karpenter.sh", "nodepools", "", false)
-	s.permCache.Set(user.Username, perms)
+	s.permCache.Set(user.Username, nil, perms)
 	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
 
 	rec := httptest.NewRecorder()
@@ -232,7 +232,7 @@ func TestResourceCountsSurfacesDeniedCoreClusterScopedKindAsForbidden(t *testing
 	user := &auth.User{Username: "alice"}
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
-	s.permCache.Set(user.Username, perms)
+	s.permCache.Set(user.Username, nil, perms)
 	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
 
 	rec := httptest.NewRecorder()

--- a/internal/server/rightsizing_scan_test.go
+++ b/internal/server/rightsizing_scan_test.go
@@ -16,7 +16,7 @@ func TestResolveRightsizingScanScopeUnrestrictedRequiresClusterListPerKind(t *te
 	perms.SetCanI("list", "apps", "deployments", "", true)
 	perms.SetCanI("list", "apps", "statefulsets", "", false)
 	perms.SetCanI("list", "apps", "daemonsets", "", true)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	scope := s.resolveRightsizingScanScope(reqAs("alice"), nil)
 	if namespaces, ok := scope.NamespacesByKind["Deployment"]; !ok || namespaces != nil {
@@ -56,7 +56,7 @@ func TestResolveRightsizingScanScopeFiltersEachKindAcrossNamespaces(t *testing.T
 	perms.SetCanI("list", "apps", "statefulsets", "beta", true)
 	perms.SetCanI("list", "apps", "daemonsets", "alpha", false)
 	perms.SetCanI("list", "apps", "daemonsets", "beta", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 
 	scope := s.resolveRightsizingScanScope(reqAs("alice"), []string{"beta", "alpha"})
 	if got := scope.NamespacesByKind["Deployment"]; !slices.Equal(got, []string{"alpha"}) {
@@ -87,7 +87,7 @@ func TestResolveRightsizingScanScopeNoNamespaceAccessExcludesAllKinds(t *testing
 func TestHandleRightsizingScanExplicitDeniedNamespaceReturnsForbidden(t *testing.T) {
 	s := newTestServer(t)
 	s.permCache = pkgauth.NewPermissionCache()
-	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
+	s.permCache.Set("alice", nil, &pkgauth.UserPermissions{AllowedNamespaces: []string{"alpha"}})
 	req := httptest.NewRequest(http.MethodPost, "/api/prometheus/rightsizing/scan?namespace=beta", nil)
 	req = req.WithContext(pkgauth.ContextWithUser(req.Context(), &pkgauth.User{Username: "alice"}))
 	rec := httptest.NewRecorder()

--- a/internal/server/rollouts_handlers_test.go
+++ b/internal/server/rollouts_handlers_test.go
@@ -250,7 +250,7 @@ func TestCanReadWorkloadRefSourceFollowsTheDeniedRead(t *testing.T) {
 			srv := &Server{permCache: auth.NewPermissionCache()}
 			perms := &auth.UserPermissions{AllowedNamespaces: []string{"prod"}}
 			perms.SetCanI("get", "apps", "deployments", "prod", tc.allowed)
-			srv.permCache.Set("alice", perms)
+			srv.permCache.Set("alice", nil, perms)
 
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{Username: "alice"}))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1518,7 +1518,7 @@ func (s *Server) canReadDecision(r *http.Request, group, resource, namespace, ve
 	if user == nil || s.permCache == nil {
 		return true, true
 	}
-	if s.permCache.Get(user.Username) == nil {
+	if s.permCache.Get(user.Username, user.Groups) == nil {
 		// Trigger namespace discovery so SAR cache has a parent UserPermissions
 		// entry. parseNamespacesForUser is the canonical path that populates
 		// this; if it hasn't run yet, canReadUser falls through to a fresh SAR.
@@ -1547,7 +1547,7 @@ func (s *Server) canReadUserDecision(ctx context.Context, user *auth.User, group
 	if user == nil || s.permCache == nil {
 		return true, true
 	}
-	perms := s.permCache.Get(user.Username)
+	perms := s.permCache.Get(user.Username, user.Groups)
 	if perms != nil {
 		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
 			return v, true
@@ -3636,7 +3636,7 @@ func (s *Server) filterEventsByRBAC(r *http.Request, events []timeline.TimelineE
 
 	// Prime the parent UserPermissions entry once so the parallel canReadUser
 	// calls below share its SAR memo instead of racing to populate it.
-	if s.permCache.Get(user.Username) == nil {
+	if s.permCache.Get(user.Username, user.Groups) == nil {
 		_ = s.getUserNamespaces(r, []string{})
 	}
 
@@ -4869,7 +4869,7 @@ func (s *Server) getUserNamespaces(r *http.Request, requested []string) []string
 		return requested
 	}
 
-	perms := s.permCache.Get(user.Username)
+	perms := s.permCache.Get(user.Username, user.Groups)
 	if perms != nil {
 		log.Printf("[auth] Using cached permissions for %s: allowed=%v", user.Username, perms.AllowedNamespaces == nil)
 	}
@@ -4912,7 +4912,7 @@ func (s *Server) getUserNamespaces(r *http.Request, requested []string) []string
 
 		log.Printf("[auth] DiscoverNamespaces result for %s: allowed=%v (nil=all, []=none)", user.Username, allowed)
 		perms = &auth.UserPermissions{AllowedNamespaces: allowed}
-		s.permCache.Set(user.Username, perms)
+		s.permCache.Set(user.Username, user.Groups, perms)
 	}
 
 	return auth.FilterNamespacesForUser(requested, user, perms)
@@ -4966,7 +4966,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// available) so the closure's canReadUser calls hit the memo. When auth is
 	// off, UserFromContext is nil and canReadUser short-circuits to allow.
 	user := auth.UserFromContext(r.Context())
-	if user != nil && s.permCache != nil && s.permCache.Get(user.Username) == nil {
+	if user != nil && s.permCache != nil && s.permCache.Get(user.Username, user.Groups) == nil {
 		_ = s.getUserNamespaces(r, []string{})
 	}
 	s.broadcaster.HandleSSE(w, r, deny, s.newSSEChangeAuthorizer(r.Context(), user))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1513,7 +1513,7 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 	if user == nil || s.permCache == nil {
 		return true
 	}
-	if s.permCache.Get(user.Username) == nil {
+	if s.permCache.Get(user.Username, user.Groups) == nil {
 		// Trigger namespace discovery so SAR cache has a parent UserPermissions
 		// entry. parseNamespacesForUser is the canonical path that populates
 		// this; if it hasn't run yet, canReadUser falls through to a fresh SAR.
@@ -1537,7 +1537,7 @@ func (s *Server) canReadUser(ctx context.Context, user *auth.User, group, resour
 	if user == nil || s.permCache == nil {
 		return true
 	}
-	perms := s.permCache.Get(user.Username)
+	perms := s.permCache.Get(user.Username, user.Groups)
 	if perms != nil {
 		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
 			return v
@@ -3564,7 +3564,7 @@ func (s *Server) filterEventsByRBAC(r *http.Request, events []timeline.TimelineE
 
 	// Prime the parent UserPermissions entry once so the parallel canReadUser
 	// calls below share its SAR memo instead of racing to populate it.
-	if s.permCache.Get(user.Username) == nil {
+	if s.permCache.Get(user.Username, user.Groups) == nil {
 		_ = s.getUserNamespaces(r, []string{})
 	}
 
@@ -4790,7 +4790,7 @@ func (s *Server) getUserNamespaces(r *http.Request, requested []string) []string
 		return requested
 	}
 
-	perms := s.permCache.Get(user.Username)
+	perms := s.permCache.Get(user.Username, user.Groups)
 	if perms != nil {
 		log.Printf("[auth] Using cached permissions for %s: allowed=%v", user.Username, perms.AllowedNamespaces == nil)
 	}
@@ -4833,7 +4833,7 @@ func (s *Server) getUserNamespaces(r *http.Request, requested []string) []string
 
 		log.Printf("[auth] DiscoverNamespaces result for %s: allowed=%v (nil=all, []=none)", user.Username, allowed)
 		perms = &auth.UserPermissions{AllowedNamespaces: allowed}
-		s.permCache.Set(user.Username, perms)
+		s.permCache.Set(user.Username, user.Groups, perms)
 	}
 
 	return auth.FilterNamespacesForUser(requested, user, perms)
@@ -4887,7 +4887,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// available) so the closure's canReadUser calls hit the memo. When auth is
 	// off, UserFromContext is nil and canReadUser short-circuits to allow.
 	user := auth.UserFromContext(r.Context())
-	if user != nil && s.permCache != nil && s.permCache.Get(user.Username) == nil {
+	if user != nil && s.permCache != nil && s.permCache.Get(user.Username, user.Groups) == nil {
 		_ = s.getUserNamespaces(r, []string{})
 	}
 	s.broadcaster.HandleSSE(w, r, deny, s.newSSEChangeAuthorizer(r.Context(), user))

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -201,7 +201,7 @@ func TestGetUserNamespaces_CachedClusterAdmin(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "admin"}
 	// nil AllowedNamespaces = cluster admin (all namespaces)
-	s.permCache.Set("admin", &auth.UserPermissions{AllowedNamespaces: nil})
+	s.permCache.Set("admin", nil, &auth.UserPermissions{AllowedNamespaces: nil})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev", "prod"})
@@ -214,7 +214,7 @@ func TestGetUserNamespaces_CachedClusterAdmin(t *testing.T) {
 func TestGetUserNamespaces_CachedRestricted(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "alice"}
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev", "prod", "staging"})
@@ -236,7 +236,7 @@ func TestGetUserNamespaces_CachedNoAccess(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "nobody"}
 	// empty (not nil) = no access
-	s.permCache.Set("nobody", &auth.UserPermissions{AllowedNamespaces: []string{}})
+	s.permCache.Set("nobody", nil, &auth.UserPermissions{AllowedNamespaces: []string{}})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev"})
@@ -249,7 +249,7 @@ func TestGetUserNamespaces_CachedNoAccess(t *testing.T) {
 func TestGetUserNamespaces_CachedRestricted_AllNamespacesRequested(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "alice"}
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
 
 	r := requestWithUser("GET", "/", user)
 	// nil requested = "all namespaces" → should return user's allowed list
@@ -314,7 +314,7 @@ func TestProxyAuth_PodMetricsNamespaceGated(t *testing.T) {
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
 			env := newAuthTestServer(t)
-			env.srv.permCache.Set("carol", &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
+			env.srv.permCache.Set("carol", nil, &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
 
 			resp := env.authGet(t, path, "carol", "")
 			defer resp.Body.Close()
@@ -508,7 +508,7 @@ func TestProxyAuth_NamespaceFiltering_Restricted(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: alice can only see "staging" (not "default" where resources live)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", []string{"devs"}, &auth.UserPermissions{
 		AllowedNamespaces: []string{"staging"},
 	})
 
@@ -531,7 +531,7 @@ func TestProxyAuth_NamespaceFiltering_Allowed(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: bob can see "default" (where test resources live)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", []string{"ops"}, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 
@@ -553,7 +553,7 @@ func TestProxyAuth_NamespaceFiltering_Topology(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: restricted to a namespace with no resources
-	env.srv.permCache.Set("viewer", &auth.UserPermissions{
+	env.srv.permCache.Set("viewer", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"empty-ns"},
 	})
 
@@ -573,7 +573,7 @@ func TestProxyAuth_NamespaceFiltering_ClusterAdmin(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: nil AllowedNamespaces = cluster admin
-	env.srv.permCache.Set("admin", &auth.UserPermissions{
+	env.srv.permCache.Set("admin", []string{"system:masters"}, &auth.UserPermissions{
 		AllowedNamespaces: nil,
 	})
 
@@ -593,7 +593,7 @@ func TestProxyAuth_DashboardClusterScopedCountsRequireClusterScopedRBAC(t *testi
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
 	perms.SetCanI("list", "", "namespaces", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/dashboard", "broad-reader", "")
 	defer resp.Body.Close()
@@ -626,7 +626,7 @@ func TestProxyAuth_ClusterScopedReadsRequireClusterScopedRBAC(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
 	perms.SetCanI("list", "rbac.authorization.k8s.io", "clusterroles", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	for _, kind := range []string{"nodes", "clusterroles"} {
 		resp := env.authGet(t, "/api/resources/"+kind, "broad-reader", "")
@@ -666,7 +666,7 @@ func TestProxyAuth_NamespacesResource_RequiresListNamespacesSAR(t *testing.T) {
 
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "namespaces", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/resources/namespaces", "broad-reader", "")
 	defer resp.Body.Close()
@@ -690,7 +690,7 @@ func TestProxyAuth_NamespacesResource_GetRequiresGetNamespacesSAR(t *testing.T) 
 
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"alpha"}}
 	perms.SetCanI("get", "", "namespaces", "", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	resp := env.authGet(t, "/api/resources/namespaces/_/alpha", "alice", "")
 	defer resp.Body.Close()
@@ -708,13 +708,13 @@ func TestProxyAuth_CanI_CacheIsPerUser(t *testing.T) {
 
 	alicePerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	alicePerms.SetCanI("list", "", "nodes", "", true)
-	env.srv.permCache.Set("alice", alicePerms)
+	env.srv.permCache.Set("alice", nil, alicePerms)
 
 	// Bob has the same namespace ceiling but no cached node allow. He must
 	// not inherit alice's grant from the canI cache.
 	bobPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	bobPerms.SetCanI("list", "", "nodes", "", false)
-	env.srv.permCache.Set("bob", bobPerms)
+	env.srv.permCache.Set("bob", nil, bobPerms)
 
 	// Sanity: alice's grant works (she can see nodes — the SA has them).
 	aliceResp := env.authGet(t, "/api/resources/nodes", "alice", "")
@@ -739,7 +739,7 @@ func TestHandleSetActiveNamespace_RejectsDeniedNamespace(t *testing.T) {
 	// otherwise a restricted user could probe namespace existence by
 	// observing 200 vs 403. Pin the info-leak guard.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -771,7 +771,7 @@ func TestHandleSetActiveNamespace_RejectsLegacyShape(t *testing.T) {
 	t.Cleanup(func() { k8s.SetTestContextName(prev) })
 
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -809,7 +809,7 @@ func TestHandleGetNamespaceScope_NoPick_EmitsEmptySliceNotNull(t *testing.T) {
 	// — caught by /visual-test. The defensive code is small and easy to
 	// regress in a refactor, so pin the byte-level wire shape here.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -844,7 +844,7 @@ func TestProxyAuth_NamespaceFiltering_NoAccess(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: empty slice = no access
-	env.srv.permCache.Set("nobody", &auth.UserPermissions{
+	env.srv.permCache.Set("nobody", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{},
 	})
 

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -201,7 +201,7 @@ func TestGetUserNamespaces_CachedClusterAdmin(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "admin"}
 	// nil AllowedNamespaces = cluster admin (all namespaces)
-	s.permCache.Set("admin", &auth.UserPermissions{AllowedNamespaces: nil})
+	s.permCache.Set("admin", nil, &auth.UserPermissions{AllowedNamespaces: nil})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev", "prod"})
@@ -214,7 +214,7 @@ func TestGetUserNamespaces_CachedClusterAdmin(t *testing.T) {
 func TestGetUserNamespaces_CachedRestricted(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "alice"}
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev", "prod", "staging"})
@@ -236,7 +236,7 @@ func TestGetUserNamespaces_CachedNoAccess(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "nobody"}
 	// empty (not nil) = no access
-	s.permCache.Set("nobody", &auth.UserPermissions{AllowedNamespaces: []string{}})
+	s.permCache.Set("nobody", nil, &auth.UserPermissions{AllowedNamespaces: []string{}})
 
 	r := requestWithUser("GET", "/", user)
 	got := s.getUserNamespaces(r, []string{"dev"})
@@ -249,7 +249,7 @@ func TestGetUserNamespaces_CachedNoAccess(t *testing.T) {
 func TestGetUserNamespaces_CachedRestricted_AllNamespacesRequested(t *testing.T) {
 	s := newAuthServer(auth.Config{Mode: "proxy"})
 	user := &auth.User{Username: "alice"}
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"dev", "staging"}})
 
 	r := requestWithUser("GET", "/", user)
 	// nil requested = "all namespaces" → should return user's allowed list
@@ -314,7 +314,7 @@ func TestProxyAuth_PodMetricsNamespaceGated(t *testing.T) {
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
 			env := newAuthTestServer(t)
-			env.srv.permCache.Set("carol", &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
+			env.srv.permCache.Set("carol", nil, &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
 
 			resp := env.authGet(t, path, "carol", "")
 			defer resp.Body.Close()
@@ -508,7 +508,7 @@ func TestProxyAuth_NamespaceFiltering_Restricted(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: alice can only see "staging" (not "default" where resources live)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", []string{"devs"}, &auth.UserPermissions{
 		AllowedNamespaces: []string{"staging"},
 	})
 
@@ -531,7 +531,7 @@ func TestProxyAuth_NamespaceFiltering_Allowed(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: bob can see "default" (where test resources live)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", []string{"ops"}, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 
@@ -553,7 +553,7 @@ func TestProxyAuth_NamespaceFiltering_Topology(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: restricted to a namespace with no resources
-	env.srv.permCache.Set("viewer", &auth.UserPermissions{
+	env.srv.permCache.Set("viewer", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"empty-ns"},
 	})
 
@@ -573,7 +573,7 @@ func TestProxyAuth_NamespaceFiltering_ClusterAdmin(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: nil AllowedNamespaces = cluster admin
-	env.srv.permCache.Set("admin", &auth.UserPermissions{
+	env.srv.permCache.Set("admin", []string{"system:masters"}, &auth.UserPermissions{
 		AllowedNamespaces: nil,
 	})
 
@@ -593,7 +593,7 @@ func TestProxyAuth_DashboardClusterScopedCountsRequireClusterScopedRBAC(t *testi
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
 	perms.SetCanI("list", "", "namespaces", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/dashboard", "broad-reader", "")
 	defer resp.Body.Close()
@@ -626,7 +626,7 @@ func TestProxyAuth_ClusterScopedReadsRequireClusterScopedRBAC(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "nodes", "", false)
 	perms.SetCanI("list", "rbac.authorization.k8s.io", "clusterroles", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	for _, kind := range []string{"nodes", "clusterroles"} {
 		resp := env.authGet(t, "/api/resources/"+kind, "broad-reader", "")
@@ -666,7 +666,7 @@ func TestProxyAuth_NamespacesResource_RequiresListNamespacesSAR(t *testing.T) {
 
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "", "namespaces", "", false)
-	env.srv.permCache.Set("broad-reader", perms)
+	env.srv.permCache.Set("broad-reader", nil, perms)
 
 	resp := env.authGet(t, "/api/resources/namespaces", "broad-reader", "")
 	defer resp.Body.Close()
@@ -690,7 +690,7 @@ func TestProxyAuth_NamespacesResource_GetRequiresGetNamespacesSAR(t *testing.T) 
 
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"alpha"}}
 	perms.SetCanI("get", "", "namespaces", "", false)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	resp := env.authGet(t, "/api/resources/namespaces/_/alpha", "alice", "")
 	defer resp.Body.Close()
@@ -708,13 +708,13 @@ func TestProxyAuth_CanI_CacheIsPerUser(t *testing.T) {
 
 	alicePerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	alicePerms.SetCanI("list", "", "nodes", "", true)
-	env.srv.permCache.Set("alice", alicePerms)
+	env.srv.permCache.Set("alice", nil, alicePerms)
 
 	// Bob has the same namespace ceiling but no cached node allow. He must
 	// not inherit alice's grant from the canI cache.
 	bobPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	bobPerms.SetCanI("list", "", "nodes", "", false)
-	env.srv.permCache.Set("bob", bobPerms)
+	env.srv.permCache.Set("bob", nil, bobPerms)
 
 	// Sanity: alice's grant works (she can see nodes — the SA has them).
 	aliceResp := env.authGet(t, "/api/resources/nodes", "alice", "")
@@ -739,7 +739,7 @@ func TestHandleSetActiveNamespace_RejectsDeniedNamespace(t *testing.T) {
 	// otherwise a restricted user could probe namespace existence by
 	// observing 200 vs 403. Pin the info-leak guard.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -771,7 +771,7 @@ func TestHandleSetActiveNamespace_RejectsLegacyShape(t *testing.T) {
 	t.Cleanup(func() { k8s.SetTestContextName(prev) })
 
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -809,7 +809,7 @@ func TestHandleGetNamespaceScope_NoPick_EmitsEmptySliceNotNull(t *testing.T) {
 	// — caught by /visual-test. The defensive code is small and easy to
 	// regress in a refactor, so pin the byte-level wire shape here.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"alpha"},
 	})
 
@@ -838,7 +838,7 @@ func TestProxyAuth_NamespaceFiltering_NoAccess(t *testing.T) {
 	env := newAuthTestServer(t)
 
 	// Pre-populate cache: empty slice = no access
-	env.srv.permCache.Set("nobody", &auth.UserPermissions{
+	env.srv.permCache.Set("nobody", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{},
 	})
 

--- a/internal/server/server_secrets_rbac_test.go
+++ b/internal/server/server_secrets_rbac_test.go
@@ -35,7 +35,7 @@ func seedServerSecretGetCanI(t *testing.T, env *authTestEnv, username string, al
 
 func seedServerSecretCanIVerb(t *testing.T, env *authTestEnv, username, verb string, allowedNamespaces []string, deniedNamespaces []string) {
 	t.Helper()
-	perms := env.srv.permCache.Get(username)
+	perms := env.srv.permCache.Get(username, nil)
 	if perms == nil {
 		t.Fatalf("user %q not in perm cache; call permCache.Set first", username)
 	}
@@ -53,7 +53,7 @@ func TestProxyAuth_SecretsList_NamespaceRestricted_Denied(t *testing.T) {
 	// The cache reads as the SA and may carry secrets her ClusterRole
 	// excludes — the per-namespace SAR gate must intercept.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretListCanI(t, env, "alice", nil, []string{"default"})
@@ -75,7 +75,7 @@ func TestProxyAuth_SecretsList_NamespaceRestricted_Allowed(t *testing.T) {
 	// bob has both namespace access AND per-namespace secret RBAC for
 	// default. The gate must pass through.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretListCanI(t, env, "bob", []string{"default"}, nil)
@@ -100,10 +100,10 @@ func TestProxyAuth_SecretsList_ClusterWideShape_NoSecretRBAC(t *testing.T) {
 	// visibility and still lack secrets RBAC. Pin the cluster-scope SAR
 	// gate so this conflation doesn't return.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("broad-reader", &auth.UserPermissions{
+	env.srv.permCache.Set("broad-reader", nil, &auth.UserPermissions{
 		AllowedNamespaces: nil,
 	})
-	perms := env.srv.permCache.Get("broad-reader")
+	perms := env.srv.permCache.Get("broad-reader", nil)
 	perms.SetCanI("list", "", "secrets", "", false)
 
 	resp := env.authGet(t, "/api/resources/secrets", "broad-reader", "")
@@ -123,10 +123,10 @@ func TestProxyAuth_SecretsList_ClusterWideShape_WithSecretRBAC(t *testing.T) {
 	// Same cluster-wide-namespace shape, but with explicit cluster-scope
 	// `list secrets` RBAC seeded. Cache returns every secret.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("admin", &auth.UserPermissions{
+	env.srv.permCache.Set("admin", []string{"system:masters"}, &auth.UserPermissions{
 		AllowedNamespaces: nil,
 	})
-	perms := env.srv.permCache.Get("admin")
+	perms := env.srv.permCache.Get("admin", []string{"system:masters"})
 	perms.SetCanI("list", "", "secrets", "", true)
 
 	resp := env.authGet(t, "/api/resources/secrets", "admin", "system:masters")
@@ -147,7 +147,7 @@ func TestProxyAuth_SecretsGet_Denied(t *testing.T) {
 	// 404 would let the user probe secret existence by observing 200 vs 404;
 	// 403 is the explicit deny.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretGetCanI(t, env, "alice", nil, []string{"default"})
@@ -161,7 +161,7 @@ func TestProxyAuth_SecretsGet_Denied(t *testing.T) {
 
 func TestProxyAuth_SecretsGet_Allowed(t *testing.T) {
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("bob", &auth.UserPermissions{
+	env.srv.permCache.Set("bob", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretGetCanI(t, env, "bob", []string{"default"}, nil)
@@ -180,7 +180,7 @@ func TestProxyAuth_SecretsGet_Allowed(t *testing.T) {
 // namespace-bounded user.
 func TestProxyAuth_SearchSecrets_PerNamespaceFanout(t *testing.T) {
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretListCanI(t, env, "alice", []string{"default"}, nil)
@@ -214,7 +214,7 @@ func TestProxyAuth_SearchSecrets_NamespaceDenied(t *testing.T) {
 	// Same alice setup but per-namespace secret denied — search should drop
 	// Secret entirely (no hits) instead of leaking through.
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default"},
 	})
 	seedServerSecretListCanI(t, env, "alice", nil, []string{"default"})
@@ -280,7 +280,7 @@ func TestSmokeSecretsList_NoAuthPassthrough(t *testing.T) {
 // equivalent MCP test alone doesn't pin this code.
 func TestProxyAuth_SecretsList_PartialNamespaceAccess(t *testing.T) {
 	env := newAuthTestServer(t)
-	env.srv.permCache.Set("alice", &auth.UserPermissions{
+	env.srv.permCache.Set("alice", nil, &auth.UserPermissions{
 		AllowedNamespaces: []string{"default", "kube-system"},
 	})
 	seedServerSecretListCanI(t, env, "alice", []string{"default"}, []string{"kube-system"})

--- a/internal/server/topology_rbac_test.go
+++ b/internal/server/topology_rbac_test.go
@@ -12,7 +12,7 @@ func TestApplyClusterScopedTopologyRBACFiltersNodeClassesByExactProvider(t *test
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "eks.amazonaws.com", "nodeclasses", "", true)
 	perms.SetCanI("list", "infra.example.io", "customnodeclasses", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 	r := requestWithUser("GET", "/api/topology", &auth.User{Username: "alice"})
 
 	eksID := "nodeclass//shared/eks.amazonaws.com/nodeclass"
@@ -42,7 +42,7 @@ func TestApplyClusterScopedTopologyRBACFiltersCalicoByExactGroup(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("list", "projectcalico.org", "globalnetworkpolicies", "", true)
 	perms.SetCanI("list", "crd.projectcalico.org", "globalnetworkpolicies", "", false)
-	s.permCache.Set("alice", perms)
+	s.permCache.Set("alice", nil, perms)
 	r := requestWithUser("GET", "/api/topology", &auth.User{Username: "alice"})
 
 	projectID := "calicoglobalnetworkpolicy//shared/projectcalico.org"

--- a/internal/server/upgrade_readiness_authz_test.go
+++ b/internal/server/upgrade_readiness_authz_test.go
@@ -16,7 +16,7 @@ func TestHTTPUpgradeAuthorizerDecisionMatrix(t *testing.T) {
 	perms.SetCanI("list", "scheduling.k8s.io", "workloads", "team-a", true)
 	perms.SetCanI("list", "", "secrets", "team-a", true)
 	perms.SetCanI("list", "", "secrets", "team-b", false)
-	s.permCache.Set("upgrade-matrix", perms)
+	s.permCache.Set("upgrade-matrix", nil, perms)
 
 	r := requestWithUser("GET", "/api/upgrade-readiness", &auth.User{Username: "upgrade-matrix"})
 	authz := httpUpgradeAuthorizer{s: s, r: r}

--- a/internal/server/upgrade_readiness_handler_test.go
+++ b/internal/server/upgrade_readiness_handler_test.go
@@ -41,7 +41,7 @@ func TestUpgradeReadinessNamespacesIntersectsForcedScopeWithUserAccess(t *testin
 	})
 
 	s := &Server{permCache: auth.NewPermissionCache()}
-	s.permCache.Set("alice", &auth.UserPermissions{AllowedNamespaces: []string{"tenant-b"}})
+	s.permCache.Set("alice", nil, &auth.UserPermissions{AllowedNamespaces: []string{"tenant-b"}})
 	req := requestWithUser("GET", "/api/upgrade-readiness", &auth.User{Username: "alice"})
 	if got := s.upgradeReadinessNamespaces(req); !noNamespaceAccess(got) {
 		t.Fatalf("upgrade namespace scope = %v, want no access", got)

--- a/internal/server/velero_handlers_test.go
+++ b/internal/server/velero_handlers_test.go
@@ -84,7 +84,7 @@ func TestVeleroStoredBackups_DeniesRatherThanReportingAnEmptyLocation(t *testing
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	allow(perms, veleroGroup, "backups", "velero", false)
-	env.srv.permCache.Set("nobody", perms)
+	env.srv.permCache.Set("nobody", nil, perms)
 
 	resp := env.authGet(t, "/api/velero/backupstoragelocations/velero/default/backups", "nobody", "")
 	defer resp.Body.Close()
@@ -245,7 +245,7 @@ func TestVeleroStoredBackupsCountsWhatCanActuallyBeRestored(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	allow(perms, veleroGroup, "backups", "velero", true)
-	env.srv.permCache.Set("reader", perms)
+	env.srv.permCache.Set("reader", nil, perms)
 
 	resp := env.authGet(t, "/api/velero/backupstoragelocations/velero/primary/backups", "reader", "")
 	defer resp.Body.Close()
@@ -293,7 +293,7 @@ func TestVeleroStoredBackupsSeparatesNoVeleroFromAFailedRead(t *testing.T) {
 	env := newAuthTestServer(t)
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	allow(perms, veleroGroup, "backups", "velero", true)
-	env.srv.permCache.Set("reader", perms)
+	env.srv.permCache.Set("reader", nil, perms)
 
 	resp := env.authGet(t, "/api/velero/backupstoragelocations/velero/primary/backups", "reader", "")
 	defer resp.Body.Close()

--- a/internal/server/velero_results_rbac_test.go
+++ b/internal/server/velero_results_rbac_test.go
@@ -26,7 +26,7 @@ func TestVeleroRunMessages_RequiresAccessToTheRunItself(t *testing.T) {
 
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	perms.SetCanI("get", "velero.io", "backups", "velero", false)
-	env.srv.permCache.Set("mallory", perms)
+	env.srv.permCache.Set("mallory", nil, perms)
 
 	resp := env.authPost(t, "/api/velero/backups/velero/nightly/messages", "mallory", "", "")
 	defer resp.Body.Close()
@@ -47,7 +47,7 @@ func TestVeleroRunMessages_GatesRestoresSeparately(t *testing.T) {
 	// Allowed on backups, denied on restores: the two must not share a verdict.
 	perms.SetCanI("get", "velero.io", "backups", "velero", true)
 	perms.SetCanI("get", "velero.io", "restores", "velero", false)
-	env.srv.permCache.Set("bob", perms)
+	env.srv.permCache.Set("bob", nil, perms)
 
 	resp := env.authPost(t, "/api/velero/restores/velero/recovery/messages", "bob", "", "")
 	defer resp.Body.Close()
@@ -66,7 +66,7 @@ func TestVeleroRunMessages_LetsAnAuthorizedCallerThrough(t *testing.T) {
 
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	perms.SetCanI("get", "velero.io", "backups", "velero", true)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	resp := env.authPost(t, "/api/velero/backups/velero/nightly/messages", "alice", "", "")
 	defer resp.Body.Close()
@@ -84,7 +84,7 @@ func TestVeleroRunMessages_RejectsKindsWithNoResults(t *testing.T) {
 
 	perms := &auth.UserPermissions{AllowedNamespaces: []string{"velero"}}
 	perms.SetCanI("get", "velero.io", "schedules", "velero", true)
-	env.srv.permCache.Set("alice", perms)
+	env.srv.permCache.Set("alice", nil, perms)
 
 	resp := env.authPost(t, "/api/velero/schedules/velero/nightly/messages", "alice", "", "")
 	defer resp.Body.Close()

--- a/internal/server/vitals_test.go
+++ b/internal/server/vitals_test.go
@@ -47,7 +47,7 @@ func TestVitals_NodeRBACDeniedSurfacesRestricted(t *testing.T) {
 	const username = "vitals-node-denied"
 	perms := &pkgauth.UserPermissions{}
 	perms.SetCanI("list", "", "nodes", "", false)
-	testServerSrv.permCache.Set(username, perms)
+	testServerSrv.permCache.Set(username, nil, perms)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vitals", nil)
 	req = req.WithContext(pkgauth.ContextWithUser(req.Context(), &pkgauth.User{Username: username}))
@@ -91,7 +91,7 @@ func TestVitals_DeploymentsOnlyUserGetsNoPodData(t *testing.T) {
 	perms.SetCanI("list", "", "pods", "", false)
 	perms.SetCanI("list", "apps", "deployments", "", true)
 	perms.SetCanI("list", "", "nodes", "", true)
-	testServerSrv.permCache.Set(username, perms)
+	testServerSrv.permCache.Set(username, nil, perms)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vitals", nil)
 	req = req.WithContext(pkgauth.ContextWithUser(req.Context(), &pkgauth.User{Username: username}))
@@ -132,7 +132,7 @@ func TestVitals_MixedNamespacePodAccessMarksPartial(t *testing.T) {
 	perms.SetCanI("list", "apps", "deployments", "kube-system", true)
 	perms.SetCanI("list", "", "nodes", "", true)
 	perms.AllowedNamespaces = []string{"default", "kube-system"}
-	testServerSrv.permCache.Set(username, perms)
+	testServerSrv.permCache.Set(username, nil, perms)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vitals", nil)
 	req = req.WithContext(pkgauth.ContextWithUser(req.Context(), &pkgauth.User{Username: username}))

--- a/pkg/auth/permissions.go
+++ b/pkg/auth/permissions.go
@@ -103,7 +103,11 @@ func cacheKey(username string, groups []string) string {
 }
 
 // groupsFingerprint returns a deterministic fingerprint of a group set:
-// sorted, deduped, and joined. Empty/nil groups fingerprints to "".
+// sorted, deduped, and joined. Empty-string elements are dropped (an empty
+// group is not a real principal), so nil, [], [""], and ["", ""] all
+// fingerprint to "" — one identity. The proxy path already trims empties, but
+// the OIDC path (internal/auth/oidc.go) does not; dropping them here makes the
+// no-groups collision explicit rather than accidental.
 func groupsFingerprint(groups []string) string {
 	if len(groups) == 0 {
 		return ""
@@ -111,6 +115,9 @@ func groupsFingerprint(groups []string) string {
 	uniq := make([]string, 0, len(groups))
 	seen := make(map[string]struct{}, len(groups))
 	for _, g := range groups {
+		if g == "" {
+			continue // empty group is not a real principal
+		}
 		if _, ok := seen[g]; ok {
 			continue
 		}

--- a/pkg/auth/permissions.go
+++ b/pkg/auth/permissions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"slices"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,9 +81,44 @@ func (p *UserPermissions) SetCanI(verb, group, resource, namespace string, allow
 // PermissionCache caches per-user permission lookups (thread-safe)
 type PermissionCache struct {
 	mu          sync.RWMutex
-	cache       map[string]*UserPermissions // keyed by username
+	cache       map[string]*UserPermissions // keyed by cacheKey(username, groups)
 	ttl         time.Duration
 	contextName func() string // current K8s context; entries with a different stamp are invisible
+}
+
+// cacheKeySep separates the username from the groups fingerprint in a cache
+// key. It is a control byte that cannot appear in a Kubernetes username or
+// group name, so a username's entries remain enumerable by splitting on it.
+const cacheKeySep = "\x00"
+
+// cacheKey builds the composite cache key for an identity. The verdicts stored
+// in a UserPermissions entry are computed by SubjectAccessReviews that run with
+// the username AND its groups, so an entry is only valid for that exact
+// (username, groups) identity — keying by username alone lets a different group
+// set inherit another identity's RBAC ceiling for the cache TTL. Groups are
+// canonicalized (sorted + deduped) so order and duplicates don't fork the key;
+// empty/nil groups is a valid, distinct identity (not a wildcard).
+func cacheKey(username string, groups []string) string {
+	return username + cacheKeySep + groupsFingerprint(groups)
+}
+
+// groupsFingerprint returns a deterministic fingerprint of a group set:
+// sorted, deduped, and joined. Empty/nil groups fingerprints to "".
+func groupsFingerprint(groups []string) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	uniq := make([]string, 0, len(groups))
+	seen := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		if _, ok := seen[g]; ok {
+			continue
+		}
+		seen[g] = struct{}{}
+		uniq = append(uniq, g)
+	}
+	sort.Strings(uniq)
+	return strings.Join(uniq, cacheKeySep)
 }
 
 // NewPermissionCache creates a new permission cache with a 2-minute TTL.
@@ -111,11 +148,11 @@ func (pc *PermissionCache) WithContextName(provider func() string) *PermissionCa
 
 // Get returns cached permissions for a user, or nil if not cached / expired
 // / stamped with a different context than the current one.
-func (pc *PermissionCache) Get(username string) *UserPermissions {
+func (pc *PermissionCache) Get(username string, groups []string) *UserPermissions {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 
-	perms, ok := pc.cache[username]
+	perms, ok := pc.cache[cacheKey(username, groups)]
 	if !ok || time.Now().After(perms.ExpiresAt) {
 		return nil
 	}
@@ -132,7 +169,7 @@ func (pc *PermissionCache) Get(username string) *UserPermissions {
 // current context so cross-cluster requests can't see it. Opportunistically
 // evicts expired entries so a long-running deploy with churning users
 // doesn't accumulate.
-func (pc *PermissionCache) Set(username string, perms *UserPermissions) {
+func (pc *PermissionCache) Set(username string, groups []string, perms *UserPermissions) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
@@ -141,14 +178,15 @@ func (pc *PermissionCache) Set(username string, perms *UserPermissions) {
 	if pc.contextName != nil {
 		perms.ContextName = pc.contextName()
 	}
-	pc.cache[username] = perms
+	key := cacheKey(username, groups)
+	pc.cache[key] = perms
 
-	for u, p := range pc.cache {
-		if u == username {
+	for k, p := range pc.cache {
+		if k == key {
 			continue
 		}
 		if now.After(p.ExpiresAt) {
-			delete(pc.cache, u)
+			delete(pc.cache, k)
 		}
 	}
 }

--- a/pkg/auth/permissions_test.go
+++ b/pkg/auth/permissions_test.go
@@ -185,6 +185,21 @@ func TestPermissionCache_GroupScopedKey(t *testing.T) {
 	if got := pc.Get("carol", nil); got == nil {
 		t.Fatal("no-groups entry must hit for the no-groups identity, got nil")
 	}
+
+	// Empty-string group elements are dropped: [""] canonicalizes to [] and
+	// ["a", ""] to ["a"]. An empty group is not a real principal, and the OIDC
+	// path doesn't trim empties like the proxy path does — pin the collision so
+	// it's explicit, not accidental.
+	if cacheKey("u", nil) != cacheKey("u", []string{""}) {
+		t.Error(`cacheKey("u", nil) must equal cacheKey("u", [""]) — empty group is dropped`)
+	}
+	if cacheKey("u", []string{"a"}) != cacheKey("u", []string{"a", ""}) {
+		t.Error(`cacheKey("u", ["a"]) must equal cacheKey("u", ["a", ""]) — empty group is dropped`)
+	}
+	// Dropping empties must not collapse distinct real group sets.
+	if cacheKey("u", []string{"a", ""}) == cacheKey("u", []string{"a", "b"}) {
+		t.Error(`cacheKey("u", ["a", ""]) must differ from cacheKey("u", ["a", "b"]) — "b" is a real principal`)
+	}
 }
 
 func TestPermissionCache_Expiry(t *testing.T) {

--- a/pkg/auth/permissions_test.go
+++ b/pkg/auth/permissions_test.go
@@ -128,9 +128,9 @@ func TestPermissionCache_SetAndGet(t *testing.T) {
 	pc := NewPermissionCache()
 
 	perms := &UserPermissions{AllowedNamespaces: []string{"default"}}
-	pc.Set("alice", perms)
+	pc.Set("alice", nil, perms)
 
-	got := pc.Get("alice")
+	got := pc.Get("alice", nil)
 	if got == nil {
 		t.Fatal("expected cached perms, got nil")
 	}
@@ -142,9 +142,48 @@ func TestPermissionCache_SetAndGet(t *testing.T) {
 func TestPermissionCache_Miss(t *testing.T) {
 	pc := NewPermissionCache()
 
-	got := pc.Get("nonexistent")
+	got := pc.Get("nonexistent", nil)
 	if got != nil {
 		t.Error("expected nil for cache miss")
+	}
+}
+
+// TestPermissionCache_GroupScopedKey pins the group-identity fix: the cache
+// key must include the caller's groups, not just the username. The SARs that
+// produce a UserPermissions entry run with username AND groups, so the same
+// username arriving with a different group set (proxy header change, OIDC
+// role change mid-TTL) must NOT inherit the first request's RBAC verdicts.
+func TestPermissionCache_GroupScopedKey(t *testing.T) {
+	pc := NewPermissionCache()
+
+	// Entry produced by SARs run for alice WITH groups [platform-admins]:
+	// cluster-wide namespace access (AllowedNamespaces == nil).
+	pc.Set("alice", []string{"platform-admins"}, &UserPermissions{AllowedNamespaces: nil})
+
+	// A request arrives as alice but WITH groups [viewers]. It must be a
+	// MISS — the weaker identity must not read the admin entry.
+	if got := pc.Get("alice", []string{"viewers"}); got != nil {
+		t.Fatalf("cross-identity leak: alice/[viewers] inherited alice/[platform-admins] entry: %+v", got)
+	}
+
+	// Same username + SAME groups must still HIT.
+	if got := pc.Get("alice", []string{"platform-admins"}); got == nil {
+		t.Fatal("same username + same groups should hit, got nil")
+	}
+
+	// Group order and duplicates must not matter (canonical fingerprint).
+	pc.Set("bob", []string{"a", "b"}, &UserPermissions{AllowedNamespaces: []string{"default"}})
+	if got := pc.Get("bob", []string{"b", "a", "a"}); got == nil {
+		t.Fatal("reordered/duplicated groups should map to the same key, got nil")
+	}
+
+	// Empty/nil groups is a valid distinct identity, not a wildcard.
+	pc.Set("carol", nil, &UserPermissions{AllowedNamespaces: []string{"kube-system"}})
+	if got := pc.Get("carol", []string{"admins"}); got != nil {
+		t.Fatalf("no-groups entry must not be read by a grouped identity: %+v", got)
+	}
+	if got := pc.Get("carol", nil); got == nil {
+		t.Fatal("no-groups entry must hit for the no-groups identity, got nil")
 	}
 }
 
@@ -155,11 +194,11 @@ func TestPermissionCache_Expiry(t *testing.T) {
 	}
 
 	perms := &UserPermissions{AllowedNamespaces: []string{"default"}}
-	pc.Set("alice", perms)
+	pc.Set("alice", nil, perms)
 
 	time.Sleep(5 * time.Millisecond)
 
-	got := pc.Get("alice")
+	got := pc.Get("alice", nil)
 	if got != nil {
 		t.Error("expected nil for expired cache entry")
 	}
@@ -168,12 +207,12 @@ func TestPermissionCache_Expiry(t *testing.T) {
 func TestPermissionCache_Invalidate(t *testing.T) {
 	pc := NewPermissionCache()
 
-	pc.Set("alice", &UserPermissions{AllowedNamespaces: []string{"default"}})
-	pc.Set("bob", &UserPermissions{AllowedNamespaces: []string{"staging"}})
+	pc.Set("alice", nil, &UserPermissions{AllowedNamespaces: []string{"default"}})
+	pc.Set("bob", nil, &UserPermissions{AllowedNamespaces: []string{"staging"}})
 
 	pc.Invalidate()
 
-	if pc.Get("alice") != nil || pc.Get("bob") != nil {
+	if pc.Get("alice", nil) != nil || pc.Get("bob", nil) != nil {
 		t.Error("Invalidate should clear all entries")
 	}
 }


### PR DESCRIPTION
## What was wrong

`PermissionCache` keyed entries by username only, but the SubjectAccessReviews that fill an entry (`DiscoverNamespaces`, `SubjectCanI`, `ReviewSubjectAccess`) run with the username **and its groups**. So when the same username arrived with a different group set - a forwarded-identity proxy header change, or an OIDC token/role change within the 2-minute TTL - `Get(username)` served the first request's namespace ceiling and `canI` verdicts.

This is an authorization-**isolation correctness** bug, **not an exploitable escalation**: the groups are asserted by the operator's proxy/IdP and are not attacker-forgeable. It is real but low-severity, and it cuts both ways - an identity can be served a broader ceiling than its groups grant, or a narrower one (wrongful lockout), until the entry expires.

## The fix

Key the cache by username + a canonical fingerprint of the groups (sorted, deduped, empty strings dropped, joined deterministically). A different group set is a distinct entry; a reordered or duplicated one is the same entry.

- No-groups and empty-string groups collapse to one identity (an empty string is not a real principal, and not a wildcard).
- The separator is a control byte that cannot appear in a Kubernetes username or group, so a username's entries stay enumerable for eviction.
- Context-stamp behavior is unchanged - groups go in the key, not the stamp. `Invalidate` still wipes everything; opportunistic expired-entry eviction compares full keys.

`Get`/`Set` take the caller's groups; every production caller (HTTP `getUserNamespaces` / `canRead*` / SSE priming, MCP `resolveUserPerms`) passes `user.Groups` - the same value already used for that request's SARs. The diff touches ~40 files, but almost all of that is the mechanical `Get`/`Set` signature update in existing tests; the substantive change is `pkg/auth/permissions.go` plus the handful of call sites.

## Tests

- `pkg/auth` (`TestPermissionCache_GroupScopedKey`): fails against username-only keying (`alice/[platform-admins]` must not be served to `alice/[viewers]`), passes with the fix; plus same-groups hit, reorder/dedupe canonicalization, empty-string canonicalization (`nil` = `[]` = `[""]`), and distinct real groups still differ.
- Caller layer: server (`getUserNamespaces`) and MCP (`resolveUserPerms`) regression tests assert that a group change is a cache **miss** (recompute), not a stale ceiling, in both directions - the layer where a future caller passing `nil` would otherwise silently reopen this.

Fixes #1503

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S
