### PR TITLE
fix(k8s): fence stale permission probes behind a generation counter

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -343,6 +343,10 @@ func InitResourceCache(ctx context.Context) error {
 			initErr = ctx.Err()
 			return
 		}
+		if permResult == nil {
+			initErr = fmt.Errorf("resource permission probe superseded during initialization")
+			return
+		}
 
 		// scopes drives which informers are created and at what scope.
 		// k8score routes each kind through the matching factory (cluster-wide

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -711,6 +711,12 @@ var (
 	resourcePermsExpiry   time.Time
 	resourcePermsTTL      = 60 * time.Second
 	resourcePermsErrorTTL = 5 * time.Second // Short TTL when API errors caused fail-closed results
+	// resourcePermsGeneration (guarded by resourcePermsMu) fences in-flight
+	// probes against invalidation: probes run without the lock, so a context
+	// switch can invalidate mid-probe and the old cluster's result would
+	// otherwise republish with a fresh TTL. Probes capture the generation
+	// before starting and publish only if it is unchanged.
+	resourcePermsGeneration uint64
 )
 
 // resourceProbe describes one typed-resource probe target. The probe issues
@@ -940,6 +946,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 		resourcePermsMu.RUnlock()
 		return result
 	}
+	observedGeneration := resourcePermsGeneration
 	resourcePermsMu.RUnlock()
 
 	// Compute probes WITHOUT holding the write lock — concurrent callers
@@ -964,15 +971,21 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 
 	result, hadErrors := probeResourceAccess(ctx, GetDynamicClient(), scopeNamespaces, forceNamespace)
 
-	resourcePermsMu.Lock()
-	cachedPermResult = result
 	ttl := resourcePermsTTL
 	if hadErrors {
 		ttl = resourcePermsErrorTTL
 		log.Printf("Warning: resource access probes had API errors, using short cache TTL (%v)", ttl)
 	}
-	resourcePermsExpiry = time.Now().Add(ttl)
-	resourcePermsMu.Unlock()
+	resourcePermsMu.Lock()
+	if resourcePermsGeneration == observedGeneration {
+		cachedPermResult = result
+		resourcePermsExpiry = time.Now().Add(ttl)
+		resourcePermsMu.Unlock()
+	} else {
+		resourcePermsMu.Unlock()
+		log.Printf("RBAC: dropping resource permission probe result — cache invalidated while the probe was in flight")
+		return nil
+	}
 
 	return result
 }
@@ -1364,9 +1377,13 @@ func GetCachedPermissionResult() *PermissionCheckResult {
 	}
 }
 
-// InvalidateResourcePermissionsCache forces the next CheckResourcePermissions call to refresh
+// InvalidateResourcePermissionsCache forces the next CheckResourcePermissions
+// call to refresh. Bumping the generation also fences out any probe already
+// in flight — its result belongs to the pre-invalidation cluster/scope and
+// must not be republished.
 func InvalidateResourcePermissionsCache() {
 	resourcePermsMu.Lock()
 	defer resourcePermsMu.Unlock()
 	cachedPermResult = nil
+	resourcePermsGeneration++
 }

--- a/internal/k8s/capabilities_generation_test.go
+++ b/internal/k8s/capabilities_generation_test.go
@@ -1,0 +1,120 @@
+package k8s
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// gatedFakeDyn builds a dynamic.Interface that allows every list call, but
+// runs gate() before answering. Lets a test hold probe goroutines mid-flight
+// to model an old cluster's probe still running while a context switch
+// invalidates the permission cache.
+func gatedFakeDyn(t *testing.T, gate func()) dynamic.Interface {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{}
+	perms := &ResourcePermissions{}
+	for _, p := range resourceProbeTargets(perms) {
+		gvrToListKind[p.gvr] = p.gvr.Resource + "List"
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+	client.PrependReactor("list", "*", func(clienttesting.Action) (bool, runtime.Object, error) {
+		gate()
+		return false, nil, nil // fall through to the default reactor (empty list => allowed)
+	})
+	return client
+}
+
+// TestStaleProbeResultDroppedAfterInvalidation models the context-switch
+// race: a probe pass starts against the old cluster, the switch invalidates
+// the permission cache, and only then does the old probe finish. Its publish
+// must be dropped — otherwise the previous cluster's scopes sit in the cache
+// with a fresh TTL and informer wiring reads them for the new cluster. A
+// probe started after the invalidation must still publish normally.
+func TestStaleProbeResultDroppedAfterInvalidation(t *testing.T) {
+	// CheckResourcePermissions bails when the typed client is nil; point it
+	// at a non-existent server — only buildScopeCandidates touches it, and
+	// that fails fast.
+	dummyClient, err := kubernetes.NewForConfig(&rest.Config{Host: "http://localhost:1"})
+	if err != nil {
+		t.Fatalf("creating dummy client: %v", err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
+	oldClusterDyn := gatedFakeDyn(t, func() {
+		startOnce.Do(func() { close(started) })
+		<-release
+	})
+
+	clientMu.Lock()
+	k8sClient = dummyClient
+	dynamicClient = oldClusterDyn
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		k8sClient = nil
+		dynamicClient = nil
+		clientMu.Unlock()
+		InvalidateResourcePermissionsCache()
+	})
+	InvalidateResourcePermissionsCache()
+
+	oldProbeDone := make(chan *PermissionCheckResult, 1)
+	go func() {
+		oldProbeDone <- CheckResourcePermissions(context.Background())
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("old cluster probe never started")
+	}
+
+	// The context switch: invalidate while the old probe is still in flight.
+	InvalidateResourcePermissionsCache()
+	close(release)
+
+	select {
+	case <-oldProbeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("old probe did not finish")
+	}
+
+	if got := GetCachedPermissionResult(); got != nil {
+		t.Fatalf("stale in-flight probe republished the previous cluster's result after invalidation (Pods=%v)", got.Perms.Pods)
+	}
+
+	// New cluster: everything denied — the opposite of the old cluster's
+	// all-allowed shape, so a stale cache hit is unmistakable.
+	clientMu.Lock()
+	dynamicClient = fakeDyn(t, func(schema.GroupVersionResource, string) bool { return false })
+	clientMu.Unlock()
+
+	fresh := CheckResourcePermissions(context.Background())
+	if fresh == nil {
+		t.Fatal("fresh probe returned nil")
+	}
+	if fresh.Perms.Pods {
+		t.Fatal("fresh probe served the previous cluster's cached result (Pods=true on an all-denied cluster)")
+	}
+	cached := GetCachedPermissionResult()
+	if cached == nil {
+		t.Fatal("fresh probe after invalidation must publish its result")
+	}
+	if cached.Perms.Pods {
+		t.Fatal("cache holds the previous cluster's result (Pods=true on an all-denied cluster)")
+	}
+}

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -302,10 +302,8 @@ func ResetTestState() {
 	cachedCapabilities = nil
 	capabilitiesMu.Unlock()
 
-	// Reset resource permissions cache
-	resourcePermsMu.Lock()
-	cachedPermResult = nil
-	resourcePermsMu.Unlock()
+	// Reset resource permissions cache (generation bump fences in-flight probes)
+	InvalidateResourcePermissionsCache()
 	ForceNamespaceScope = false
 	SetFallbackNamespace("")
 	ClearNamespaceScopeOverride()


### PR DESCRIPTION
## Description

`CheckResourcePermissions` deliberately runs its probe pass **without** holding `resourcePermsMu`, so a context switch is never blocked behind network calls. But the publish at the end was unconditional, and `InvalidateResourcePermissionsCache` only cleared the cached pointer — nothing recorded that an invalidation had happened.

So a probe still in flight when the cluster changed would finish and republish the **previous** cluster's per-kind scopes with a fresh 60s TTL. Anything reading the cache in that window could be wired against the old cluster's namespaces: typed informer wiring via `Scopes` (`internal/k8s/cache.go`), the dynamic CRD cache's `ScopeCandidates`/`Namespace` snapshot (`internal/k8s/dynamic_cache.go`), and every `GetCachedPermissionResult()` consumer in `internal/server`, `internal/mcp` and audit. Existing mitigations (switch-scoped contexts failing the old probe's remaining calls fast, short TTL on error results) shrink the window but don't close it.

**Fix** — a generation counter guarded by the existing mutex, as proposed in the issue:

- `resourcePermsGeneration uint64` alongside `cachedPermResult`, under `resourcePermsMu`. No new locks.
- `InvalidateResourcePermissionsCache` increments it while clearing the pointer, so an invalidation is now observable by in-flight probes.
- `CheckResourcePermissions` captures the generation under the same `RLock` as its cache-miss check (strictly before probing starts) and, at publish time, stores the result only if the generation is unchanged. A superseded probe is dropped with a log line and returns `nil`.
- Both non-test callers already handle a `nil` result; `InitResourceCache` now fails initialization explicitly instead of dereferencing it.
- `ResetTestState` routes through `InvalidateResourcePermissionsCache` so tests get the generation bump too.

Non-race paths behave exactly as before. No API changes.

**Out of scope (noted, not changed):** `CheckCapabilities` / `CheckNamespaceCapabilities` and the per-user caches have the same unconditional-publish shape. A stale publish there survives at most the 60s TTL and only affects UI control gating — the apiserver still enforces real RBAC on writes — so the same fence pattern applies if it ever bites, but the issue scopes this PR to the resource-permission probe cache.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

New regression test `internal/k8s/capabilities_generation_test.go` — `TestStaleProbeResultDroppedAfterInvalidation`. A gated fake dynamic client holds the probe goroutines mid-flight (the old cluster's probe), the test invalidates the cache (the context switch), releases the probe, and asserts the stale publish is dropped. It then swaps in an all-denied "new cluster" fake and asserts the fresh probe's publish still lands — the fence must not wedge the cache shut.

- Reproduces the race before the fix: `capabilities_generation_test.go:97: stale in-flight probe republished the previous cluster's result after invalidation (Pods=true)`
- After the fix: `go test -race -run TestStaleProbeResultDroppedAfterInvalidation -count=5 ./internal/k8s/` passes
- Full package: `go test -race ./internal/k8s/` — ok (31.4s), including the pre-existing `TestConcurrentInvalidateDuringPermissionCheck` deadlock guard
- `go vet ./internal/k8s/` and `go build ./...` clean

- [x] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #1169

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster-switch informer wiring and permission cache publishing; incorrect behavior could mis-scope watches, but the change closes a known stale-cache race with a targeted generation fence and regression test.
> 
> **Overview**
> Fixes a **kubeconfig context-switch race** where an in-flight `CheckResourcePermissions` probe could still **publish the previous cluster’s scopes** into the 60s cache after `InvalidateResourcePermissionsCache`, wiring informers and dynamic CRD fallbacks against the wrong cluster.
> 
> A **`resourcePermsGeneration`** counter (under the existing `resourcePermsMu`) is captured before probes run and checked at publish time; **`InvalidateResourcePermissionsCache`** clears the cache and bumps the generation so superseded probes are **dropped** (`nil` + log) instead of cached. **`InitResourceCache`** now fails init explicitly when the probe is superseded, and **`ResetTestState`** invalidates via the same path so tests fence in-flight probes too.
> 
> Adds **`TestStaleProbeResultDroppedAfterInvalidation`** with a gated fake dynamic client to assert stale publishes are dropped while a post-invalidation probe still caches normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a04ad7a5d9a60fae9e3542e3509bd8fdd82bf7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->