### PR TITLE
feat(audit): per-resource check opt-out via radarhq.io/ignore-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Proactive best-practices scanner with 31 checks across security, reliability, an
 - Check-grouped remediation queue with search and category, severity, and framework filters; expand a check to see affected resources
 - Each finding includes description and remediation guidance, with inline hide actions for a check or category
 - Configurable: ignored namespaces (with wildcard patterns), disabled checks, persisted across sessions
+- Per-resource opt-out via the `radarhq.io/ignore-checks` annotation (comma-separated check IDs) — set on the resource a finding is attributed to, so the exclusion travels with the manifest instead of living in one operator's local settings
 - Framework labels: NSA/CISA, CIS benchmarks
 - MCP tool (`get_cluster_audit`) for AI-assisted cluster analysis
 

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -160,6 +160,12 @@ func RunChecks(input *CheckInput) *ScanResults {
 	// reporting a missing input.
 	findings = append(findings, checkCNPGDeclarativeBackup(tr, input)...)
 
+	// --- Per-resource opt-outs (radarhq.io/ignore-checks) ---
+	// One central seam instead of a per-check concern: every check emits
+	// normally, then a subject's annotation withdraws its own findings and its
+	// own evaluated tally before results are built.
+	findings = applyIgnoreAnnotations(findings, tr, buildIgnoreIndex(input))
+
 	return buildResults(findings, tr, missingInputs)
 }
 
@@ -198,6 +204,32 @@ func (t *evalTracker) record(checkID, namespace string) {
 func (t *evalTracker) recordAll(ids []string, namespace string) {
 	for _, id := range ids {
 		t.record(id, namespace)
+	}
+}
+
+// unrecord removes one evaluated subject from checkID's tally — used when a
+// subject opts out of that check via annotation, so the denominator counts
+// only subjects the check actually spoke about.
+//
+// A check may emit a finding for a subject it never recorded (a ref-grain
+// finding under a subject-grain eligibility gate), so an absent tally means
+// "this subject was never in the denominator" and must be left alone rather
+// than driven negative.
+func (t *evalTracker) unrecord(checkID, namespace string) {
+	byNS := t.counts[checkID]
+	if byNS == nil {
+		return
+	}
+	if byNS[namespace] == 0 {
+		return
+	}
+	if byNS[namespace] == 1 {
+		delete(byNS, namespace)
+	} else {
+		byNS[namespace]--
+	}
+	if len(byNS) == 0 {
+		delete(t.counts, checkID)
 	}
 }
 

--- a/pkg/audit/ignore.go
+++ b/pkg/audit/ignore.go
@@ -1,0 +1,165 @@
+package audit
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/skyhook-io/radar/pkg/resourceid"
+)
+
+// IgnoreChecksAnnotation opts a single resource out of named checks:
+//
+//	radarhq.io/ignore-checks: singleReplica
+//	radarhq.io/ignore-checks: hostNetwork,livenessProbeMissing
+//
+// The value is a comma-separated list of check IDs (see CheckRegistry).
+// Names that match no check are inert. The annotation must sit on the
+// resource a finding is ATTRIBUTED to — for the pod-spec family that is the
+// workload (Deployment/StatefulSet/...), not the Pod it generates.
+//
+// Annotations, not Radar-side settings: the opt-out then travels with the
+// manifest, so every operator's Radar reports the same posture.
+const IgnoreChecksAnnotation = "radarhq.io/ignore-checks"
+
+// ignoreIndex maps ResourceKey → set of checkIDs that resource opts out of.
+type ignoreIndex map[string]map[string]bool
+
+func parseIgnoredChecks(value string) map[string]bool {
+	if value == "" {
+		return nil
+	}
+	ids := make(map[string]bool)
+	for _, part := range strings.Split(value, ",") {
+		if id := strings.TrimSpace(part); id != "" {
+			ids[id] = true
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+func (idx ignoreIndex) add(kind string, obj metav1.Object) {
+	ids := parseIgnoredChecks(obj.GetAnnotations()[IgnoreChecksAnnotation])
+	if ids == nil {
+		return
+	}
+	// Emission sites leave Finding.Group empty and buildResults backfills it
+	// from the same table, so both sides of the lookup normalize identically.
+	// CRD kinds aren't in the table and resolve to "" on both sides — matching
+	// the group audit findings actually carry, not the object's real API group.
+	key := resourceid.ResourceKey(resourceid.GroupForBuiltinKind(kind), kind, obj.GetNamespace(), obj.GetName())
+	existing := idx[key]
+	if existing == nil {
+		idx[key] = ids
+		return
+	}
+	for id := range ids {
+		existing[id] = true
+	}
+}
+
+func (idx ignoreIndex) addUnstructured(objs []*unstructured.Unstructured) {
+	for _, o := range objs {
+		if o == nil {
+			continue
+		}
+		idx.add(o.GetKind(), o)
+	}
+}
+
+// buildIgnoreIndex collects the per-resource check opt-outs from every subject
+// inventory in the input. Subjects with no annotation cost one map lookup.
+func buildIgnoreIndex(input *CheckInput) ignoreIndex {
+	idx := ignoreIndex{}
+	if input == nil {
+		return idx
+	}
+	for _, o := range input.Pods {
+		idx.add("Pod", o)
+	}
+	for _, o := range input.Deployments {
+		idx.add("Deployment", o)
+	}
+	for _, o := range input.StatefulSets {
+		idx.add("StatefulSet", o)
+	}
+	for _, o := range input.DaemonSets {
+		idx.add("DaemonSet", o)
+	}
+	for _, o := range input.Jobs {
+		idx.add("Job", o)
+	}
+	for _, o := range input.CronJobs {
+		idx.add("CronJob", o)
+	}
+	for _, o := range input.Services {
+		idx.add("Service", o)
+	}
+	for _, o := range input.Ingresses {
+		idx.add("Ingress", o)
+	}
+	for _, o := range input.HorizontalPodAutoscalers {
+		idx.add("HorizontalPodAutoscaler", o)
+	}
+	for _, o := range input.PodDisruptionBudgets {
+		idx.add("PodDisruptionBudget", o)
+	}
+	for _, o := range input.ConfigMaps {
+		idx.add("ConfigMap", o)
+	}
+	for _, o := range input.Secrets {
+		idx.add("Secret", o)
+	}
+	for _, o := range input.ServiceAccounts {
+		idx.add("ServiceAccount", o)
+	}
+	idx.addUnstructured(input.ManagedResources)
+	idx.addUnstructured(input.CompositeResources)
+	idx.addUnstructured(input.IngressRoutes)
+	idx.addUnstructured(input.MiddlewareSubjects)
+	idx.addUnstructured(input.CNPGClusters)
+	return idx
+}
+
+// applyIgnoreAnnotations drops findings the subject opted out of and takes the
+// same subject out of that check's evaluated denominator, so a suppressed
+// failure doesn't silently inflate the pass rate.
+//
+// Only a subject that actually FAILED leaves the denominator — the opt-out is
+// applied to findings, and a passing subject produces none. An annotated
+// resource that passes therefore still counts as evaluated+passed, and fixing
+// an annotated resource moves it back into the denominator.
+//
+// Findings arrive pre-merge, so one (resource, checkID) pair can appear several
+// times (one per container). The denominator is decremented once per distinct
+// pair — the same grain the tracker counts in.
+func applyIgnoreAnnotations(findings []Finding, tr *evalTracker, idx ignoreIndex) []Finding {
+	if len(idx) == 0 {
+		return findings
+	}
+	type checkKey struct{ resource, checkID string }
+	dropped := make(map[checkKey]bool)
+
+	kept := findings[:0]
+	for _, f := range findings {
+		group := f.Group
+		if group == "" {
+			group = resourceid.GroupForBuiltinKind(f.Kind)
+		}
+		resource := resourceid.ResourceKey(group, f.Kind, f.Namespace, f.Name)
+		if !idx[resource][f.CheckID] {
+			kept = append(kept, f)
+			continue
+		}
+		key := checkKey{resource, f.CheckID}
+		if !dropped[key] {
+			dropped[key] = true
+			tr.unrecord(f.CheckID, f.Namespace)
+		}
+	}
+	return kept
+}

--- a/pkg/audit/ignore_test.go
+++ b/pkg/audit/ignore_test.go
@@ -1,0 +1,224 @@
+package audit
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func annotated(d *appsv1.Deployment, value string) *appsv1.Deployment {
+	d.Annotations = map[string]string{IgnoreChecksAnnotation: value}
+	return d
+}
+
+func TestIgnoreAnnotation_SuppressesNamedCheckOnlyForThatResource(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments: []*appsv1.Deployment{
+			annotated(deploymentInNS("solo-ignored", "prod", 1, secureContainer("app", false)), "singleReplica"),
+			deploymentInNS("solo-flagged", "prod", 1, secureContainer("app", false)),
+		},
+	}
+	results := RunChecks(input)
+
+	single := findingNames(results.Findings, "singleReplica")
+	if single["solo-ignored"] {
+		t.Error("singleReplica finding should be suppressed on annotated deployment")
+	}
+	if !single["solo-flagged"] {
+		t.Error("singleReplica finding missing on unannotated deployment")
+	}
+	// Other checks on the annotated resource are unaffected.
+	if !findingNames(results.Findings, "readinessProbeMissing")["solo-ignored"] {
+		t.Error("readinessProbeMissing should still fire on the annotated deployment")
+	}
+}
+
+func TestIgnoreAnnotation_MultipleChecksCommaSeparated(t *testing.T) {
+	d := deploymentInNS("hostnet", "prod", 1, secureContainer("app", false))
+	d.Spec.Template.Spec.HostNetwork = true
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments:              []*appsv1.Deployment{annotated(d, "singleReplica, hostNetwork")},
+	}
+	results := RunChecks(input)
+
+	for _, id := range []string{"singleReplica", "hostNetwork"} {
+		if findingNames(results.Findings, id)["hostnet"] {
+			t.Errorf("%s finding should be suppressed by comma-separated annotation", id)
+		}
+	}
+	if !findingNames(results.Findings, "readinessProbeMissing")["hostnet"] {
+		t.Error("readinessProbeMissing should still fire on the annotated deployment")
+	}
+}
+
+func TestIgnoreAnnotation_UnknownCheckNameIsHarmless(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments: []*appsv1.Deployment{
+			annotated(deploymentInNS("solo", "prod", 1, secureContainer("app", true)), "notARealCheck"),
+		},
+	}
+	results := RunChecks(input)
+
+	if !findingNames(results.Findings, "singleReplica")["solo"] {
+		t.Error("unknown check name in annotation must not suppress anything")
+	}
+}
+
+func TestIgnoreAnnotation_ExcludedFromCounts(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments: []*appsv1.Deployment{
+			annotated(deploymentInNS("solo-ignored", "prod", 1, secureContainer("a", true)), "singleReplica"),
+			deploymentInNS("solo-flagged", "prod", 1, secureContainer("a", true)),
+			deploymentInNS("scaled", "prod", 2, secureContainer("a", true)),
+		},
+	}
+	results := RunChecks(input)
+
+	// solo-ignored is excluded from the denominator: 2 evaluated (solo-flagged
+	// failing, scaled passing), not 3.
+	if got := results.CheckCounts["singleReplica"]; got != (CheckCount{Evaluated: 2, Passed: 1}) {
+		t.Errorf("singleReplica counts = %+v, want {Evaluated:2 Passed:1}", got)
+	}
+	if got := results.EvaluatedByNamespace["singleReplica"]["prod"]; got != 2 {
+		t.Errorf("EvaluatedByNamespace[singleReplica][prod] = %d, want 2", got)
+	}
+}
+
+func TestIgnoreAnnotation_MultiContainerDecrementsEvaluatedOnce(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments: []*appsv1.Deployment{
+			// Two containers both missing the readiness probe → two raw
+			// findings for one (resource, check) pair pre-merge.
+			annotated(deploymentInNS("multi", "prod", 2, secureContainer("a", false), secureContainer("b", false)), "readinessProbeMissing"),
+			deploymentInNS("ok", "prod", 2, secureContainer("a", true)),
+		},
+	}
+	results := RunChecks(input)
+
+	if findingNames(results.Findings, "readinessProbeMissing")["multi"] {
+		t.Error("readinessProbeMissing should be suppressed on annotated multi-container deployment")
+	}
+	if got := results.CheckCounts["readinessProbeMissing"]; got != (CheckCount{Evaluated: 1, Passed: 1}) {
+		t.Errorf("readinessProbeMissing counts = %+v, want {Evaluated:1 Passed:1}", got)
+	}
+}
+
+func annotatedUnstructured(u *unstructured.Unstructured, value string) *unstructured.Unstructured {
+	u.SetAnnotations(map[string]string{IgnoreChecksAnnotation: value})
+	return u
+}
+
+// CRD subjects are keyed by the group audit findings actually carry ("" — CRD
+// kinds are absent from the builtin table), not by the object's real API group.
+func TestIgnoreAnnotation_CRDSubject(t *testing.T) {
+	const g = "traefik.io"
+	route := annotatedUnstructured(
+		traefikRoute(g, "IngressRoute", "app", "r1", []map[string]any{{"name": "missing-svc"}}, nil),
+		"traefikRouteMissingService",
+	)
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		AllServices:              []*corev1.Service{},
+		IngressRoutes:            []*unstructured.Unstructured{route},
+	}
+	results := RunChecks(input)
+
+	if findingNames(results.Findings, "traefikRouteMissingService")["r1"] {
+		t.Error("traefikRouteMissingService should be suppressed on the annotated IngressRoute")
+	}
+	if got := results.CheckCounts["traefikRouteMissingService"].Evaluated; got != 0 {
+		t.Errorf("Evaluated = %d, want 0 — the ignored route must leave the denominator", got)
+	}
+}
+
+// The opt-out is per-resource: annotating one CRD subject must not silence the
+// same check on its unannotated siblings, nor steal their evaluated tally.
+func TestIgnoreAnnotation_CRDSubjectScopedToResource(t *testing.T) {
+	const g = "traefik.io"
+	input := &CheckInput{
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		AllServices:              []*corev1.Service{},
+		IngressRoutes: []*unstructured.Unstructured{
+			annotatedUnstructured(
+				traefikRoute(g, "IngressRoute", "app", "ignored", []map[string]any{{"name": "missing-a"}}, nil),
+				"traefikRouteMissingService",
+			),
+			traefikRoute(g, "IngressRoute", "app", "flagged", []map[string]any{{"name": "missing-b"}}, nil),
+		},
+	}
+	results := RunChecks(input)
+
+	names := findingNames(results.Findings, "traefikRouteMissingService")
+	if names["ignored"] {
+		t.Error("annotated route should be suppressed")
+	}
+	if !names["flagged"] {
+		t.Error("unannotated sibling route must still be flagged")
+	}
+	if got := results.CheckCounts["traefikRouteMissingService"]; got != (CheckCount{Evaluated: 1, Passed: 0}) {
+		t.Errorf("counts = %+v, want {Evaluated:1 Passed:0}", got)
+	}
+	if got := results.EvaluatedByNamespace["traefikRouteMissingService"]["app"]; got != 1 {
+		t.Errorf("EvaluatedByNamespace[app] = %d, want 1 — the sibling's tally must survive", got)
+	}
+}
+
+// A CRD kind whose name collides with a builtin (CNPG Cluster) must still be
+// keyed under "" like every other CRD subject.
+func TestIgnoreAnnotation_CRDSubjectCollidingKind(t *testing.T) {
+	cluster := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Cluster",
+		"metadata": map[string]any{
+			"name": "db", "namespace": "prod",
+			"annotations": map[string]any{IgnoreChecksAnnotation: "cnpgNoDeclarativeBackup"},
+		},
+	}}
+	input := &CheckInput{
+		ServiceAccounts:                   []*corev1.ServiceAccount{},
+		HorizontalPodAutoscalers:          []*autoscalingv2.HorizontalPodAutoscaler{},
+		CNPGClusters:                      []*unstructured.Unstructured{cluster},
+		CNPGScheduledBackupsAuthoritative: true,
+	}
+	results := RunChecks(input)
+
+	if findingNames(results.Findings, "cnpgNoDeclarativeBackup")["db"] {
+		t.Error("cnpgNoDeclarativeBackup should be suppressed on the annotated CNPG Cluster")
+	}
+}
+
+func TestIgnoreAnnotation_NonWorkloadSubject(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts: []*corev1.ServiceAccount{},
+		Pods:            []*corev1.Pod{},
+		Services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "headless-tool",
+				Namespace:   "prod",
+				Annotations: map[string]string{IgnoreChecksAnnotation: "serviceNoMatchingPods"},
+			},
+			Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "nothing"}},
+		}},
+	}
+	results := RunChecks(input)
+
+	if findingNames(results.Findings, "serviceNoMatchingPods")["headless-tool"] {
+		t.Error("serviceNoMatchingPods should be suppressed on annotated Service")
+	}
+}


### PR DESCRIPTION
## Description

Cluster Audit had no way to say "this check doesn't apply to *this* resource". A team running a deliberately single-replica batch shim, or a Deployment that genuinely wants `hostNetwork`, could only silence the check globally via audit settings — which turns it off for every other resource too.

This adds a per-resource opt-out annotation:

```yaml
metadata:
  annotations:
    radarhq.io/ignore-checks: singleReplica,hostNetwork
```

The value is a comma-separated list of check IDs from `CheckRegistry`; names matching no check are inert. The annotation must sit on the resource a finding is **attributed to** — for the pod-spec family that's the workload (Deployment/StatefulSet/…), not the Pod it generates.

**Annotations rather than Radar-side settings** is the load-bearing choice: the opt-out travels with the manifest, so every operator's Radar reports the same posture instead of each one carrying its own local mute list.

**Implementation** — one central seam instead of a per-check concern (`pkg/audit/ignore.go`):

- `buildIgnoreIndex` walks every subject inventory in `CheckInput` once and builds `ResourceKey → set of opted-out checkIDs`. A subject with no annotation costs one map lookup.
- Every check emits normally. `applyIgnoreAnnotations` then runs at the end of `RunChecks`, drops the findings a subject opted out of, and withdraws that subject from the check's evaluated denominator so a suppressed failure doesn't silently inflate the pass rate.
- Findings arrive pre-merge, so one `(resource, checkID)` pair can appear several times (one per container). The denominator is decremented once per distinct pair — the same grain `evalTracker` counts in.

**Subjects are keyed by the group audit findings actually carry.** Built-in kinds resolve through `resourceid.GroupForBuiltinKind`; CRD kinds aren't in that table and resolve to `""`. Both sides of the lookup — the index and the finding — derive the group the same way, so they always agree.

That follows the convention the audit suite already establishes: `buildResults` backfills `Finding.Group` from the same table, no emission site sets it for a CRD subject (`traefik.go`: *"Group is intentionally left empty — the audit backfills group from the builtin table"*), and three consumers outside `pkg/audit` are written against it — `pkg/topology/auditkey.go`'s `auditKey` join, the `/api/audit/resource/...` drill-down handler, and `internal/auditcontext`.

Also hardens the denominator decrement in `evalTracker.unrecord`: a check can emit a **ref-grain** finding for a subject its **subject-grain** eligibility gate never recorded, so an absent tally now means "never in the denominator" and is left alone rather than driven negative.

**Out of scope (noted, not changed):**

- `unrecord` is keyed by `(checkID, namespace)`, so it still can't tell one subject's tally from a sibling's. Where a check emits without recording — only `traefikRouteMissingService`, and only for a route carrying *both* a core-Service and a `TraefikService` ref while the TraefikService inventory isn't authoritative (`traefik.go` gates `record` on `svcRefsCheckable`, but `checkServiceRef` still emits for the core ref) — annotating that route consumes a sibling route's tally. Closing it means either gating the emit loop on `svcRefsCheckable`, which suppresses a sound finding under partial visibility, or making `evalTracker` subject-aware, which changes the counting contract for all ~24 `record` call sites. Worth its own issue.
- An annotated subject that *passes* stays in both `Evaluated` and `Passed` — the opt-out is applied to findings, and a passing subject produces none. So the same annotation reads differently depending on whether the resource currently fails, and fixing an annotated resource moves it back into the denominator. Intentional, and stated in the `applyIgnoreAnnotations` doc comment.
- `pkg/topology/auditkey.go` asserts *"None of these collision kinds are audited today"* — stale, since `cnpg.go` emits findings with `Kind: "Cluster"`, which collides with CAPI's `Cluster` under the groupless CRD convention. Pre-existing, unrelated to this PR, deserves its own issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Nine unit tests in `pkg/audit/ignore_test.go`, covering both the typed and the CRD subject paths.

Typed subjects: single check suppressed on one resource only (siblings still flagged, other checks on the same resource unaffected), comma-separated lists, unknown check names inert, exclusion from `CheckCounts` / `EvaluatedByNamespace`, multi-container workloads decrementing the denominator exactly once, and a non-workload subject (`serviceNoMatchingPods` on a Service).

CRD subjects: `TestIgnoreAnnotation_CRDSubject` (Traefik `IngressRoute`), `TestIgnoreAnnotation_CRDSubjectScopedToResource` (annotating one route must not silence its sibling *or* steal its evaluated tally), and `TestIgnoreAnnotation_CRDSubjectCollidingKind` (CNPG `Cluster` — a CRD kind whose name collides with a built-in).

Each CRD test asserts both halves of the contract — the finding is suppressed *and* the subject leaves the evaluated denominator — so a key that silently fails to match is caught rather than passing as a no-op.

`pkg/` is its own Go module, so the audit suite runs from there:

- `go test -race -run TestIgnoreAnnotation -count=2 ./audit` — ok (1.0s)
- `go test -race ./audit` — ok, full package including the pre-existing count/registry/traefik/cnpg suites
- `go test ./...` from `pkg/` — all packages ok
- Consumers of the audit keying convention: `go test ./internal/server ./internal/auditcontext` (root module) and `go test ./topology` (pkg module) — all ok
- `gofmt -l pkg/audit`, `go vet ./audit`, and `go build ./...` in both modules — clean

Not exercised against a live cluster: the change is pure `pkg/audit` logic with no client-go, informer, or handler surface, and the annotation is read off objects the existing inventories already carry.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #1367

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds post-processing in `RunChecks` only; no API or auth changes. Mis-keyed annotations would fail to suppress findings but would not hide unrelated checks.
> 
> **Overview**
> Cluster Audit gains **manifest-level opt-outs** so teams can silence specific checks on individual resources without disabling them cluster-wide.
> 
> Resources can set `radarhq.io/ignore-checks` to a comma-separated list of check IDs (on the resource findings are attributed to—e.g. the Deployment, not its Pods). After all checks run, a single post-pass drops matching findings and adjusts **evaluated** counts via new `evalTracker.unrecord`, so suppressed failures do not inflate pass rates. Built-in and CRD subjects share the same resource-key convention as existing audit results.
> 
> README documents the annotation. Nine unit tests cover scoped suppression, comma lists, unknown IDs, counts, multi-container workloads, CRDs (Traefik, CNPG), and Services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6125d6fbc11679a7783292aeb7d9746f17d6c599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->