### PR TITLE
fix(copy): hold the pod-file exec open until the whole file has arrived

### DIFF
--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -77,20 +79,7 @@ func (a *DesktopApp) startup(ctx context.Context) {
 // We write directly to ~/Downloads instead of showing a native save dialog
 // because Wails' SaveFileDialog is immediately dismissed by the webview on macOS.
 func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, error) {
-	f, err := claimDownloadFile(defaultFilename)
-	if err != nil {
-		return "", err
-	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		os.Remove(f.Name())
-		return "", err
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
-		return "", err
-	}
-	return f.Name(), nil
+	return a.saveFileStream(defaultFilename, bytes.NewReader(data))
 }
 
 // saveFileStream writes a streamed file to the user's Downloads folder. The
@@ -108,9 +97,10 @@ func (a *DesktopApp) saveFileStream(defaultFilename string, r io.Reader) (string
 	}
 	defer os.Remove(partial.Name()) // no-op once the rename below has moved it
 
-	if _, err := io.Copy(partial, r); err != nil {
-		partial.Close()
-		return "", err
+	if _, copyErr := io.Copy(partial, r); copyErr != nil {
+		// A close failure on a write handle can be the one that lost the data,
+		// so it is reported alongside the copy error rather than dropped.
+		return "", errors.Join(copyErr, partial.Close())
 	}
 	if err := partial.Close(); err != nil {
 		return "", err

--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/skyhook-io/radar/internal/app"
@@ -61,6 +63,7 @@ func (a *DesktopApp) startup(ctx context.Context) {
 	a.ctx = ctx
 	startNativeMouseMonitor(ctx)
 	a.srv.SetSaveFileFunc(a.saveFile)
+	a.srv.SetSaveFileStreamFunc(a.saveFileStream)
 
 	// The OS titlebar must track the active kubeconfig context for the same
 	// reason the in-page selector does: a fleet UI showing the wrong cluster
@@ -74,6 +77,91 @@ func (a *DesktopApp) startup(ctx context.Context) {
 // We write directly to ~/Downloads instead of showing a native save dialog
 // because Wails' SaveFileDialog is immediately dismissed by the webview on macOS.
 func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, error) {
+	f, err := claimDownloadFile(defaultFilename)
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// saveFileStream writes a streamed file to the user's Downloads folder. The
+// bytes land in a partial file first, so an interrupted transfer leaves nothing
+// that looks like a finished download and nothing that a second transfer of the
+// same name can collide with.
+func (a *DesktopApp) saveFileStream(defaultFilename string, r io.Reader) (string, error) {
+	dir, err := downloadsDir()
+	if err != nil {
+		return "", err
+	}
+	partial, err := os.CreateTemp(dir, sanitizeDownloadName(defaultFilename)+".*.part")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(partial.Name()) // no-op once the rename below has moved it
+
+	if _, err := io.Copy(partial, r); err != nil {
+		partial.Close()
+		return "", err
+	}
+	if err := partial.Close(); err != nil {
+		return "", err
+	}
+
+	claimed, err := claimDownloadFile(defaultFilename)
+	if err != nil {
+		return "", err
+	}
+	if err := claimed.Close(); err != nil {
+		os.Remove(claimed.Name())
+		return "", err
+	}
+	if err := os.Rename(partial.Name(), claimed.Name()); err != nil {
+		os.Remove(claimed.Name())
+		return "", err
+	}
+	return claimed.Name(), nil
+}
+
+// claimDownloadFile creates and returns an empty file in ~/Downloads named
+// after defaultFilename, working around collisions the way a browser does:
+// file.txt → file (1).txt. The name is claimed with O_EXCL rather than tested
+// with Stat first, so two downloads of the same name cannot pick it together
+// and a symlink planted at the path cannot be written through.
+func claimDownloadFile(defaultFilename string) (*os.File, error) {
+	dir, err := downloadsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	base := sanitizeDownloadName(defaultFilename)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	for i := 0; i <= 1000; i++ {
+		candidate := filepath.Join(dir, base)
+		if i > 0 {
+			candidate = filepath.Join(dir, fmt.Sprintf("%s (%d)%s", stem, i, ext))
+		}
+		f, err := os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err == nil {
+			return f, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("cannot create file %q: %w", candidate, err)
+		}
+	}
+	return nil, fmt.Errorf("could not find a free name for %q in %s", base, dir)
+}
+
+func downloadsDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -82,27 +170,55 @@ func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, erro
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("cannot access Downloads folder: %w", err)
 	}
+	return dir, nil
+}
 
-	// Collision handling: file.txt → file (1).txt → file (2).txt
-	base := defaultFilename
-	ext := filepath.Ext(base)
-	name := strings.TrimSuffix(base, ext)
-	path := filepath.Join(dir, base)
-	for i := 1; i <= 1000; i++ {
-		_, statErr := os.Stat(path)
-		if os.IsNotExist(statErr) {
-			break
-		}
-		if statErr != nil {
-			return "", fmt.Errorf("cannot check file %q: %w", path, statErr)
-		}
-		path = filepath.Join(dir, fmt.Sprintf("%s (%d)%s", name, i, ext))
+// sanitizeDownloadName reduces a name from inside a container to one this host
+// will accept, and keeps it from reaching outside the Downloads folder. Linux
+// file names are freer than Windows ones — the timestamped exports people pull
+// out of pods routinely carry colons — so the Windows rules are applied only
+// where they hold, leaving names untouched elsewhere.
+func sanitizeDownloadName(name string) string {
+	name = filepath.Base(strings.ReplaceAll(name, "\x00", ""))
+	if name == "." || name == ".." || name == string(filepath.Separator) {
+		return "download"
 	}
+	if runtime.GOOS == "windows" {
+		return windowsSafeName(name)
+	}
+	return name
+}
 
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return "", err
+// windowsReservedNames cannot be used as a file name on Windows whatever the
+// extension: CON.txt is still the console.
+var windowsReservedNames = map[string]bool{
+	"con": true, "prn": true, "aux": true, "nul": true,
+	"com1": true, "com2": true, "com3": true, "com4": true, "com5": true,
+	"com6": true, "com7": true, "com8": true, "com9": true,
+	"lpt1": true, "lpt2": true, "lpt3": true, "lpt4": true, "lpt5": true,
+	"lpt6": true, "lpt7": true, "lpt8": true, "lpt9": true,
+}
+
+func windowsSafeName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r < 0x20, r == '<', r == '>', r == ':', r == '"', r == '/', r == '\\', r == '|', r == '?', r == '*':
+			b.WriteByte('-')
+		default:
+			b.WriteRune(r)
+		}
 	}
-	return path, nil
+	// Windows silently drops a trailing dot or space, which would leave the
+	// name pointing at a file nobody asked for.
+	safe := strings.TrimRight(b.String(), " .")
+	if safe == "" {
+		return "download"
+	}
+	if windowsReservedNames[strings.ToLower(strings.TrimSuffix(safe, filepath.Ext(safe)))] {
+		safe = "_" + safe
+	}
+	return safe
 }
 
 // domReady is called when the webview DOM is ready.

--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -205,7 +205,9 @@ func windowsSafeName(name string) string {
 	if safe == "" {
 		return "download"
 	}
-	if windowsReservedNames[strings.ToLower(strings.TrimSuffix(safe, filepath.Ext(safe)))] {
+	// Windows reserves the name before the FIRST dot, so com1.x.y is still the
+	// serial port. Trimming only the last extension would let it through.
+	if windowsReservedNames[strings.ToLower(strings.SplitN(safe, ".", 2)[0])] {
 		safe = "_" + safe
 	}
 	return safe

--- a/cmd/desktop/save_file_stream_test.go
+++ b/cmd/desktop/save_file_stream_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSaveFileStreamWritesToDownloads(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	a := &DesktopApp{}
+	content := bytes.Repeat([]byte("radar"), 100000)
+	path, err := a.saveFileStream("export.csv", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("saveFileStream failed: %v", err)
+	}
+	if want := filepath.Join(home, "Downloads", "export.csv"); path != want {
+		t.Errorf("saved to %q, want %q", path, want)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("saved %d bytes, want %d identical bytes", len(got), len(content))
+	}
+}
+
+func TestSaveFileStreamNamesAroundCollisions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	a := &DesktopApp{}
+	first, err := a.saveFileStream("export.csv", strings.NewReader("one"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := a.saveFileStream("export.csv", strings.NewReader("two"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("a second save must not overwrite the first")
+	}
+	if want := filepath.Join(home, "Downloads", "export (1).csv"); second != want {
+		t.Errorf("second save landed on %q, want %q", second, want)
+	}
+}
+
+// A transfer that dies partway must not leave anything that looks like a
+// finished download — the whole point of the partial-file dance.
+func TestSaveFileStreamLeavesNothingBehindOnFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	a := &DesktopApp{}
+	failing := io.MultiReader(strings.NewReader("half a file"), errReader{errors.New("connection lost")})
+	if _, err := a.saveFileStream("export.csv", failing); err == nil {
+		t.Fatal("expected the failed transfer to be reported")
+	}
+
+	entries, err := os.ReadDir(filepath.Join(home, "Downloads"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		t.Errorf("leftover file after a failed transfer: %q", e.Name())
+	}
+}
+
+// Two downloads of the same name must both land, whole. The name is claimed
+// with O_EXCL rather than tested with Stat first for exactly this case.
+func TestSaveFileStreamConcurrentSavesOfTheSameName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const savers = 8
+	a := &DesktopApp{}
+	paths := make(chan string, savers)
+	var wg sync.WaitGroup
+	for i := 0; i < savers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body := strings.Repeat(fmt.Sprintf("%d", i), 4096)
+			path, err := a.saveFileStream("export.csv", strings.NewReader(body))
+			if err != nil {
+				t.Errorf("saver %d failed: %v", i, err)
+				return
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("saver %d cannot read back %q: %v", i, path, err)
+				return
+			}
+			if string(got) != body {
+				t.Errorf("saver %d got %d bytes of the wrong content", i, len(got))
+			}
+			paths <- path
+		}(i)
+	}
+	wg.Wait()
+	close(paths)
+
+	seen := map[string]bool{}
+	for path := range paths {
+		if seen[path] {
+			t.Errorf("two savers landed on the same path %q", path)
+		}
+		seen[path] = true
+	}
+	if len(seen) != savers {
+		t.Errorf("%d distinct files saved, want %d", len(seen), savers)
+	}
+
+	// Nothing partial may survive a run where every transfer succeeded.
+	entries, err := os.ReadDir(filepath.Join(home, "Downloads"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".part") {
+			t.Errorf("leftover partial file: %q", e.Name())
+		}
+	}
+}
+
+// A file name is never allowed to steer the write out of the Downloads folder.
+func TestSaveFileStreamKeepsHostileNamesInsideDownloads(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	a := &DesktopApp{}
+	path, err := a.saveFileStream("../../escaped.csv", strings.NewReader("x"))
+	if err != nil {
+		t.Fatalf("saveFileStream failed: %v", err)
+	}
+	if want := filepath.Join(home, "Downloads", "escaped.csv"); path != want {
+		t.Errorf("saved to %q, want %q", path, want)
+	}
+}
+
+// The exports people pull out of pods carry ISO timestamps, and a colon is a
+// legal Linux file name character that Windows refuses outright.
+func TestWindowsSafeName(t *testing.T) {
+	for name, want := range map[string]string{
+		"data_2026-08-27T10:02:03.511991310Z.csv": "data_2026-08-27T10-02-03.511991310Z.csv",
+		"report<1>|2?.log":                        "report-1--2-.log",
+		"trailing.  ":                             "trailing",
+		"CON":                                     "_CON",
+		"con.txt":                                 "_con.txt",
+		"lpt9.log":                                "_lpt9.log",
+		"ordinary.csv":                            "ordinary.csv",
+		":::":                                     "---",
+		"...":                                     "download",
+	} {
+		if got := windowsSafeName(name); got != want {
+			t.Errorf("windowsSafeName(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// A name is only rewritten where the host demands it; elsewhere the file keeps
+// the name it had in the container.
+func TestSanitizeDownloadNameKeepsPosixNamesIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows rewrites reserved characters by design")
+	}
+	if got := sanitizeDownloadName("data_2026-08-27T10:02:03Z.csv"); got != "data_2026-08-27T10:02:03Z.csv" {
+		t.Errorf("sanitizeDownloadName rewrote a name this host accepts: %q", got)
+	}
+}
+
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }

--- a/cmd/desktop/save_file_stream_test.go
+++ b/cmd/desktop/save_file_stream_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSaveFileStreamWritesToDownloads(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	a := &DesktopApp{}
 	content := bytes.Repeat([]byte("radar"), 100000)
@@ -38,7 +38,7 @@ func TestSaveFileStreamWritesToDownloads(t *testing.T) {
 
 func TestSaveFileStreamNamesAroundCollisions(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	a := &DesktopApp{}
 	first, err := a.saveFileStream("export.csv", strings.NewReader("one"))
@@ -61,7 +61,7 @@ func TestSaveFileStreamNamesAroundCollisions(t *testing.T) {
 // finished download — the whole point of the partial-file dance.
 func TestSaveFileStreamLeavesNothingBehindOnFailure(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	a := &DesktopApp{}
 	failing := io.MultiReader(strings.NewReader("half a file"), errReader{errors.New("connection lost")})
@@ -82,7 +82,7 @@ func TestSaveFileStreamLeavesNothingBehindOnFailure(t *testing.T) {
 // with O_EXCL rather than tested with Stat first for exactly this case.
 func TestSaveFileStreamConcurrentSavesOfTheSameName(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	const savers = 8
 	a := &DesktopApp{}
@@ -138,7 +138,7 @@ func TestSaveFileStreamConcurrentSavesOfTheSameName(t *testing.T) {
 // A file name is never allowed to steer the write out of the Downloads folder.
 func TestSaveFileStreamKeepsHostileNamesInsideDownloads(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 
 	a := &DesktopApp{}
 	path, err := a.saveFileStream("../../escaped.csv", strings.NewReader("x"))
@@ -160,9 +160,13 @@ func TestWindowsSafeName(t *testing.T) {
 		"CON":                                     "_CON",
 		"con.txt":                                 "_con.txt",
 		"lpt9.log":                                "_lpt9.log",
-		"ordinary.csv":                            "ordinary.csv",
-		":::":                                     "---",
-		"...":                                     "download",
+		// Windows reserves the name before the first dot, not the last.
+		"com1.x.y":     "_com1.x.y",
+		"CON.tar.gz":   "_CON.tar.gz",
+		"console.txt":  "console.txt",
+		"ordinary.csv": "ordinary.csv",
+		":::":          "---",
+		"...":          "download",
 	} {
 		if got := windowsSafeName(name); got != want {
 			t.Errorf("windowsSafeName(%q) = %q, want %q", name, got, want)
@@ -179,6 +183,15 @@ func TestSanitizeDownloadNameKeepsPosixNamesIntact(t *testing.T) {
 	if got := sanitizeDownloadName("data_2026-08-27T10:02:03Z.csv"); got != "data_2026-08-27T10:02:03Z.csv" {
 		t.Errorf("sanitizeDownloadName rewrote a name this host accepts: %q", got)
 	}
+}
+
+// setHome points os.UserHomeDir at dir on every platform: it reads HOME on unix
+// and USERPROFILE on Windows, and setting only one leaves the tests for the
+// Windows-specific naming running against the developer's real home directory.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 }
 
 type errReader struct{ err error }

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 // InitLoadTestResourceCache creates a resource cache from a fake client using
@@ -263,6 +264,22 @@ func SetTestClient(c *kubernetes.Clientset) *kubernetes.Clientset {
 // Returns the previous index so a test can restore it.
 //
 // This is intended for integration tests only.
+// SetTestConfig publishes a rest.Config directly, so a handler that resolves a
+// per-request config can run without a real cluster connection. SetTestClient
+// publishes the clientset but not the config, and a handler that needs both
+// bails out early with "cluster client not available" if only one is set.
+//
+// Returns the previous config so a test can restore it.
+//
+// This is intended for integration tests only.
+func SetTestConfig(c *rest.Config) *rest.Config {
+	clientMu.Lock()
+	prev := k8sConfig
+	k8sConfig = c
+	clientMu.Unlock()
+	return prev
+}
+
 func SetTestPolicyReportIndex(idx *policyreports.Index) *policyreports.Index {
 	prev := policyReportIndex.Load()
 	policyReportIndex.Store(idx)

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -82,15 +82,22 @@ func compressMiddleware() func(http.Handler) http.Handler {
 	}
 }
 
-// isStreamingRequest reports requests that open a long-lived response (SSE) or
-// switch protocols (WebSocket exec/terminal) and must not pass through the
-// compressor's per-request encoder acquisition.
+// isStreamingRequest reports requests that open a long-lived response (SSE), a
+// long-running transfer, or switch protocols (WebSocket exec/terminal), and must
+// not pass through the compressor's per-request encoder acquisition.
 func isStreamingRequest(r *http.Request) bool {
 	// Match by route, not just request headers: every SSE endpoint ends in
 	// "/stream" (events, pod/workload logs, traffic flows). This holds even if a
 	// future consumer reads the stream via fetch (Accept: */*) instead of
 	// EventSource, which the header check below would miss.
 	if strings.HasSuffix(r.URL.Path, "/stream") {
+		return true
+	}
+	// Pod file transfers are octet-stream, so the compressor would not compress
+	// them anyway, but it takes an encoder from the pool before the handler runs
+	// and holds it for the whole transfer — minutes, for the large files these
+	// routes exist to carry.
+	if strings.HasSuffix(r.URL.Path, "/files/download") || strings.HasSuffix(r.URL.Path, "/files/save") {
 		return true
 	}
 	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/event-stream") {

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -423,8 +424,9 @@ type podFileStream struct {
 	cancel   context.CancelFunc
 	complete bool
 
-	closeOnce sync.Once
-	closeErr  error
+	closeOnce    sync.Once
+	closeErr     error
+	graceExpired atomic.Bool
 }
 
 // podFileCloseGrace bounds the wait for the remote command to finish after the
@@ -579,12 +581,22 @@ func classifyPodFileOpenError(filePath string, readErr, streamErr error, stderr 
 		return &podFileOpenError{err: streamErr, stderr: stderr,
 			message: fmt.Sprintf("Permission denied: the container user cannot read %s", filePath)}
 	}
-	// Shells and tars disagree on the wording — "No such file or directory",
-	// "can't open ...: no such file" — so match on the shared shape, folded.
-	if strings.Contains(lowered, "no such file") || strings.Contains(lowered, "not found") ||
-		(streamErr == nil && readErr == io.EOF) {
+	// Every shell and tar in play words this the same way underneath — "No such
+	// file or directory", "Cannot stat: No such file...", "cannot open ...: No
+	// such file" — so the shared phrase is enough. A bare "not found" is not:
+	// the apiserver says `pods "web-0" not found` for a pod that is gone, and
+	// blaming the file for that sends the reader looking in the wrong place.
+	if strings.Contains(lowered, "no such file") {
 		return &podFileOpenError{err: streamErr, stderr: stderr, notFound: true,
 			message: fmt.Sprintf("File not found: %s", filePath)}
+	}
+	if streamErr == nil && readErr == io.EOF {
+		// The command reported success and sent nothing. tar exits non-zero for a
+		// file it cannot archive, so this is the stream being dropped rather than
+		// the file being absent — the very failure this transfer exists to catch,
+		// and it must not be filed away as a missing file.
+		return &podFileOpenError{err: readErr, stderr: stderr,
+			message: fmt.Sprintf("The transfer produced no data for %s", filePath)}
 	}
 	if streamErr == nil {
 		streamErr = readErr
@@ -626,7 +638,10 @@ func (p *podFileStream) Close() error {
 	p.closeOnce.Do(func() {
 		if p.complete {
 			_ = p.stdin.Close()
-			grace := time.AfterFunc(podFileCloseGrace, p.cancel)
+			grace := time.AfterFunc(podFileCloseGrace, func() {
+				p.graceExpired.Store(true)
+				p.cancel()
+			})
 			defer grace.Stop()
 			_, _ = io.Copy(io.Discard, p.stdout)
 		} else {
@@ -645,8 +660,14 @@ func (p *podFileStream) Close() error {
 		if p.complete && errors.Is(p.closeErr, context.Canceled) {
 			// A client that has its last byte disconnects, which cancels the
 			// request context while the exec is still winding down. The file
-			// arrived; that is not something to report.
-			p.closeErr = nil
+			// arrived; that is not something to report — unless we were the ones
+			// who cancelled, in which case the connection stopped answering and
+			// silently returning success would hide it.
+			if p.graceExpired.Load() {
+				p.closeErr = fmt.Errorf("the command did not finish within %s of the file arriving", podFileCloseGrace)
+			} else {
+				p.closeErr = nil
+			}
 		}
 	})
 	return p.closeErr
@@ -937,12 +958,21 @@ func shellQuote(s string) string {
 // isShellMissing detects a container without /bin/sh. Runtimes word it
 // differently — "executable file not found" from one, `exec: "/bin/sh": stat
 // /bin/sh: no such file or directory` from another — so both forms count.
+//
+// Only the runtime's own framing counts. A shell that started fine prefixes its
+// diagnostics with the same path, so bash reporting a missing file as
+// `/bin/sh: line 1: /data/x: No such file or directory` would otherwise read as
+// "this container has no shell".
 func isShellMissing(errMsg string) bool {
 	lower := strings.ToLower(errMsg)
 	if strings.Contains(lower, "executable file not found") && (strings.Contains(lower, "sh") || strings.Contains(lower, "shell")) {
 		return true
 	}
-	return strings.Contains(lower, "/bin/sh") && strings.Contains(lower, "no such file or directory")
+	if !strings.Contains(lower, "no such file or directory") {
+		return false
+	}
+	return strings.Contains(lower, `exec: "/bin/sh"`) ||
+		(strings.Contains(lower, "oci runtime") && strings.Contains(lower, "/bin/sh"))
 }
 
 // isCommandNotFound detects errors indicating a command is not available in the container

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -11,11 +14,16 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	k8sexec "k8s.io/client-go/util/exec"
 
 	"github.com/skyhook-io/radar/internal/errorlog"
 	"github.com/skyhook-io/radar/internal/images"
@@ -151,8 +159,106 @@ func (s *Server) listFilesWithLS(r *http.Request, namespace, podName, container,
 // handlePodFileDownload downloads a single file from a pod container.
 // GET /api/pods/{ns}/{name}/files/download?container=X&path=/some/file
 func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
-	if !s.requireConnected(w) {
+	src := s.openPodFileForRequest(w, r)
+	if src == nil {
 		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", src.name))
+	w.Header().Set("Content-Length", strconv.FormatInt(src.size, 10))
+
+	copied, copyErr := io.Copy(w, src)
+	closeErr := src.Close()
+
+	if copyErr != nil {
+		log.Printf("[copy] transfer of %s/%s path=%s stopped after %d of %d bytes: %v", src.namespace, src.podName, src.filePath, copied, src.size, copyErr)
+		errorlog.Record("copy", "error", "file download truncated for %s/%s path=%s after %d of %d bytes", src.namespace, src.podName, src.filePath, copied, src.size)
+		// The declared Content-Length is already on the wire, so breaking the
+		// connection is the only way left to stop the client from saving a
+		// short file as if it were whole.
+		panic(http.ErrAbortHandler)
+	}
+	if closeErr != nil {
+		// Every declared byte arrived, so the body stands; the command still
+		// reported trouble (an unreadable region, a file rewritten under it),
+		// which belongs in the error log rather than in a torn response.
+		log.Printf("[copy] reading %s/%s path=%s ended with an error after the file arrived in full: %v", src.namespace, src.podName, src.filePath, closeErr)
+		errorlog.Record("copy", "warning", "reading %s/%s path=%s ended with an error after the file arrived in full: %v", src.namespace, src.podName, src.filePath, closeErr)
+	}
+}
+
+// handlePodFileSave streams a file out of a pod straight onto the desktop app's
+// disk. The download route sends the bytes to the webview, which then has to
+// hand them back to be saved; for a large file that round trip is the part that
+// fails, so the desktop app asks the backend to do the whole thing.
+// POST /api/pods/{ns}/{name}/files/save?container=X&path=/some/file
+func (s *Server) handlePodFileSave(w http.ResponseWriter, r *http.Request) {
+	if s.saveFileStreamFunc == nil {
+		s.writeError(w, http.StatusNotFound, "not available")
+		return
+	}
+
+	src := s.openPodFileForRequest(w, r)
+	if src == nil {
+		return
+	}
+	defer src.Close()
+
+	savedPath, err := s.saveFileStreamFunc(src.name, src)
+	// Close before answering, so what the command reported is known — and
+	// logged — before the caller is told the file is on disk.
+	closeErr := src.Close()
+	if err != nil {
+		if errors.Is(err, ErrSaveCancelled) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		log.Printf("[copy] failed to save %s/%s path=%s: %v", src.namespace, src.podName, src.filePath, err)
+		errorlog.Record("copy", "error", "file save failed for %s/%s path=%s: %v", src.namespace, src.podName, src.filePath, err)
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to save file: %v", err))
+		return
+	}
+	if closeErr != nil {
+		// The declared bytes all arrived and are on disk, so the save stands;
+		// the command still reported trouble, which belongs in the error log.
+		log.Printf("[copy] reading %s/%s path=%s ended with an error after the file arrived in full: %v", src.namespace, src.podName, src.filePath, closeErr)
+		errorlog.Record("copy", "warning", "reading %s/%s path=%s ended with an error after the file arrived in full: %v", src.namespace, src.podName, src.filePath, closeErr)
+	}
+	s.writeJSON(w, map[string]string{"path": savedPath})
+}
+
+// podFileSource is one pod file ready to be read, however it was obtained.
+type podFileSource struct {
+	namespace string
+	podName   string
+	filePath  string
+	name      string
+	size      int64
+
+	stream *podFileStream // nil when the cat fallback produced the bytes
+	body   *bytes.Reader
+}
+
+func (p *podFileSource) Read(b []byte) (int, error) {
+	if p.stream != nil {
+		return p.stream.Read(b)
+	}
+	return p.body.Read(b)
+}
+
+func (p *podFileSource) Close() error {
+	if p.stream != nil {
+		return p.stream.Close()
+	}
+	return nil
+}
+
+// openPodFileForRequest validates the request and opens the named file, writing
+// the error response itself and returning nil when it cannot.
+func (s *Server) openPodFileForRequest(w http.ResponseWriter, r *http.Request) *podFileSource {
+	if !s.requireConnected(w) {
+		return nil
 	}
 
 	namespace := chi.URLParam(r, "namespace")
@@ -161,24 +267,160 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 	filePath := r.URL.Query().Get("path")
 	if filePath == "" {
 		s.writeError(w, http.StatusBadRequest, "path parameter is required")
-		return
+		return nil
 	}
 
 	filePath = path.Clean(filePath)
-	fileName := path.Base(filePath)
+	if !isDownloadablePath(filePath) {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("Not a file: %s", filePath))
+		return nil
+	}
 
 	client := s.getClientForRequest(r)
 	config := s.getConfigForRequest(r)
 	if client == nil || config == nil {
 		s.writeError(w, http.StatusServiceUnavailable, "cluster client not available — check cluster connection")
-		return
+		return nil
 	}
 
-	// First try: tar cf - to stream the file (handles binary files correctly)
-	dir := path.Dir(filePath)
-	base := path.Base(filePath)
+	src := &podFileSource{
+		namespace: namespace,
+		podName:   podName,
+		filePath:  filePath,
+		name:      path.Base(filePath),
+	}
 
-	cmd := []string{"tar", "cf", "-", "-C", dir, base}
+	stream, openErr := s.openPodFileWithTar(r.Context(), client, config, namespace, podName, container, filePath)
+	if openErr != nil && openErr.commandMissing && !openErr.shellMissing {
+		// The container has a shell but no tar; cat can still read the file.
+		stream, openErr = s.openPodFileWithCat(r.Context(), client, config, namespace, podName, container, filePath)
+	}
+	if openErr == nil {
+		src.stream = stream
+		src.size = stream.size
+		return src
+	}
+
+	switch {
+	case openErr.commandMissing:
+		// Nothing here can frame the file — read it as raw bytes and hope it is
+		// small, which is all a container this bare is likely to hold.
+		content, catErr := s.downloadWithCat(r, namespace, podName, container, filePath)
+		if catErr != nil {
+			if isCommandNotFound(catErr.Error()) {
+				s.writeError(w, http.StatusInternalServerError, "Container lacks 'tar' and 'cat' commands. Cannot download files from distroless containers.")
+				return nil
+			}
+			log.Printf("[copy] cat fallback failed for %s/%s path=%s: %v", namespace, podName, filePath, catErr)
+			errorlog.Record("copy", "error", "reading %s/%s path=%s failed: %v", namespace, podName, filePath, catErr)
+			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to read file: %v", catErr))
+			return nil
+		}
+		src.body = bytes.NewReader(content)
+		src.size = int64(len(content))
+		return src
+	case openErr.notFound:
+		s.writeError(w, http.StatusNotFound, openErr.message)
+	case openErr.notAFile:
+		s.writeError(w, http.StatusBadRequest, openErr.message)
+	default:
+		log.Printf("[copy] reading %s/%s path=%s failed: %v, stderr: %s", namespace, podName, filePath, openErr.err, openErr.stderr)
+		errorlog.Record("copy", "error", "reading %s/%s path=%s failed: %v", namespace, podName, filePath, openErr.err)
+		s.writeError(w, http.StatusInternalServerError, openErr.message)
+	}
+	return nil
+}
+
+// isDownloadablePath rejects the paths that cannot name a file inside the
+// container, so they fail with a clear message instead of an odd tar error.
+// Absolute is part of the contract: a relative name would reach `cat` as an
+// option, and every path the file browser produces is absolute anyway.
+func isDownloadablePath(cleaned string) bool {
+	if !path.IsAbs(cleaned) {
+		return false
+	}
+	base := path.Base(cleaned)
+	return base != "/" && base != "." && base != ".."
+}
+
+// podFileDrainGuard keeps the remote shell alive on a stdin read after the file
+// has been written out. Kubernetes tears the exec output stream down when the
+// process exits and drops whatever the client has not drained yet, while still
+// reporting success — over a slow link that silently costs the tail of a large
+// file. Radar closes stdin only once it holds every byte, so the process
+// outlives the transfer instead of racing it. The guard is armed only on
+// success: a command that failed has nothing worth waiting for, and waiting
+// would hang a caller that is still expecting the file.
+const podFileDrainGuard = "; rc=$?; [ $rc -eq 0 ] && read _; exit $rc"
+
+// podFileTarCommand archives a single file to stdout. "./" in front of the name
+// keeps a file called e.g. "-C" from being read as a tar option, and -h resolves
+// a symlink to the bytes it points at (the file browser offers Download on
+// symlinks, and a link entry carries no content).
+func podFileTarCommand(dir, base string) []string {
+	script := "tar cfh - -C " + shellQuote(dir) + " " + shellQuote("./"+base) + podFileDrainGuard
+	return []string{"/bin/sh", "-c", script}
+}
+
+// podFileNotRegularExit is how podFileCatCommand says the path exists but is
+// not a regular file. Nothing else in these commands uses it: tar exits 0, 1
+// or 2. A character device or a fifo has to be turned away before wc opens it,
+// because wc on /dev/zero never reaches an end.
+const podFileNotRegularExit = 3
+
+// podFileCatCommand reads a file out of a container that has no tar. It prints
+// the byte count on its own line first so the transfer can still tell a
+// complete read from a truncated one, which is what the tar header does on the
+// normal path. The type check is deliberately narrow — a path it cannot stat
+// falls through to wc, whose own error says more than a guess would.
+func podFileCatCommand(filePath string) []string {
+	quoted := shellQuote(filePath)
+	script := "if [ -e " + quoted + " ] && [ ! -f " + quoted + " ]; then echo 'not a regular file' >&2; exit " +
+		strconv.Itoa(podFileNotRegularExit) + "; fi; " +
+		"size=$(wc -c < " + quoted + ") || exit $?; printf '%s\n' \"$size\"; cat " + quoted + podFileDrainGuard
+	return []string{"/bin/sh", "-c", script}
+}
+
+// podFileOpenError distinguishes the outcomes the download handlers act on.
+type podFileOpenError struct {
+	err            error
+	stderr         string
+	message        string
+	commandMissing bool
+	shellMissing   bool
+	notFound       bool
+	notAFile       bool
+}
+
+func (e *podFileOpenError) Error() string { return e.message }
+
+// podFileStream carries one regular file's bytes out of a container. The exec
+// runs for as long as the stream is open; Close releases it.
+type podFileStream struct {
+	size     int64
+	written  int64
+	payload  io.Reader
+	stdout   *io.PipeReader
+	stdin    *io.PipeWriter
+	stderr   *bytes.Buffer
+	done     <-chan error
+	cancel   context.CancelFunc
+	complete bool
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// podFileCloseGrace bounds the wait for the remote command to finish after the
+// file has arrived. Nothing is left to receive by then, so cutting a wedged
+// connection loose costs nothing and keeps the handler from being pinned to it.
+const podFileCloseGrace = 30 * time.Second
+
+// startPodFileExec runs cmd in the container and hands back a stream whose
+// payload the caller frames. The command must keep stdin open per
+// podFileDrainGuard.
+func (s *Server) startPodFileExec(ctx context.Context, client kubernetes.Interface, config *rest.Config,
+	namespace, podName, container string, cmd []string) (*podFileStream, error) {
 
 	req := client.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -188,85 +430,211 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 		VersionedParams(&corev1.PodExecOptions{
 			Container: container,
 			Command:   cmd,
+			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
 		}, scheme.ParameterCodec)
 
-	exec, err := rcpkg.NewExecutor(config, req.URL())
+	executor, err := rcpkg.NewExecutor(config, req.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	execCtx, cancel := context.WithCancel(ctx)
+	stdoutR, stdoutW := io.Pipe()
+	stdinR, stdinW := io.Pipe()
+	stderr := &bytes.Buffer{}
+	done := make(chan error, 1)
+
+	go func() {
+		streamErr := executor.StreamWithContext(execCtx, remotecommand.StreamOptions{
+			Stdin:  stdinR,
+			Stdout: stdoutW,
+			Stderr: stderr,
+		})
+		_ = stdoutW.CloseWithError(streamErr)
+		_ = stdinR.Close()
+		done <- streamErr
+	}()
+
+	return &podFileStream{
+		size:   -1,
+		stdout: stdoutR,
+		stdin:  stdinW,
+		stderr: stderr,
+		done:   done,
+		cancel: cancel,
+	}, nil
+}
+
+// openPodFileWithTar starts the transfer and reads the tar header, so the
+// caller knows the file's size before it commits to a response.
+func (s *Server) openPodFileWithTar(ctx context.Context, client kubernetes.Interface, config *rest.Config,
+	namespace, podName, container, filePath string) (*podFileStream, *podFileOpenError) {
+
+	dir, base := path.Dir(filePath), path.Base(filePath)
+	stream, err := s.startPodFileExec(ctx, client, config, namespace, podName, container, podFileTarCommand(dir, base))
 	if err != nil {
 		log.Printf("[copy] Failed to create executor for download %s/%s: %v", namespace, podName, err)
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create executor: %v", err))
-		return
+		return nil, &podFileOpenError{err: err, message: fmt.Sprintf("Failed to create executor: %v", err)}
 	}
 
-	var stdout, stderr bytes.Buffer
-	err = exec.StreamWithContext(r.Context(), remotecommand.StreamOptions{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	})
+	tr := tar.NewReader(stream.stdout)
+	header, headerErr := tr.Next()
+	if headerErr != nil {
+		streamErr := stream.Close()
+		return nil, classifyPodFileOpenError(filePath, headerErr, streamErr, stream.stderr.String())
+	}
+	if header.Typeflag != tar.TypeReg {
+		_ = stream.Close()
+		return nil, &podFileOpenError{
+			err:      fmt.Errorf("tar entry %q is not a regular file (type %q)", header.Name, string(header.Typeflag)),
+			message:  fmt.Sprintf("Not a regular file: %s", filePath),
+			notAFile: true,
+		}
+	}
+
+	stream.size = header.Size
+	stream.payload = tr
+	return stream, nil
+}
+
+// openPodFileWithCat is the fallback for a container that has a shell but no
+// tar. It reads the size the command announced, then frames the rest of stdout
+// as the file.
+func (s *Server) openPodFileWithCat(ctx context.Context, client kubernetes.Interface, config *rest.Config,
+	namespace, podName, container, filePath string) (*podFileStream, *podFileOpenError) {
+
+	stream, err := s.startPodFileExec(ctx, client, config, namespace, podName, container, podFileCatCommand(filePath))
 	if err != nil {
-		errMsg := err.Error() + " " + stderr.String()
-		if isCommandNotFound(errMsg) {
-			// tar not available — fallback to cat
-			catContent, catErr := s.downloadWithCat(r, namespace, podName, container, filePath)
-			if catErr != nil {
-				if isCommandNotFound(catErr.Error()) {
-					s.writeError(w, http.StatusInternalServerError, "Container lacks 'tar' and 'cat' commands. Cannot download files from distroless containers.")
-				} else {
-					log.Printf("[copy] cat fallback failed for %s/%s path=%s: %v", namespace, podName, filePath, catErr)
-					errorlog.Record("copy", "error", "file download failed for %s/%s: %v", namespace, podName, catErr)
-					s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", catErr))
-				}
-				return
-			}
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
-			w.Header().Set("Content-Length", strconv.Itoa(len(catContent)))
-			w.Write(catContent)
-			return
-		}
-		if strings.Contains(errMsg, "No such file") || strings.Contains(errMsg, "not found") {
-			s.writeError(w, http.StatusNotFound, fmt.Sprintf("File not found: %s", filePath))
-			return
-		}
-		log.Printf("[copy] exec tar failed for %s/%s path=%s: %v, stderr: %s", namespace, podName, filePath, err, stderr.String())
-		errorlog.Record("copy", "error", "file download failed for %s/%s path=%s: %v", namespace, podName, filePath, err)
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", err))
-		return
+		log.Printf("[copy] Failed to create executor for download %s/%s: %v", namespace, podName, err)
+		return nil, &podFileOpenError{err: err, message: fmt.Sprintf("Failed to create executor: %v", err)}
 	}
 
-	// Extract the file from the tar stream
-	tr := tar.NewReader(&stdout)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			s.writeError(w, http.StatusNotFound, fmt.Sprintf("File not found in tar stream: %s", filePath))
-			return
+	buffered := bufio.NewReader(stream.stdout)
+	line, readErr := buffered.ReadString('\n')
+	if readErr != nil {
+		streamErr := stream.Close()
+		return nil, classifyPodFileOpenError(filePath, readErr, streamErr, stream.stderr.String())
+	}
+	size, parseErr := strconv.ParseInt(strings.TrimSpace(line), 10, 64)
+	if parseErr != nil || size < 0 {
+		_ = stream.Close()
+		return nil, &podFileOpenError{
+			err:     fmt.Errorf("unreadable size %q from wc: %v", strings.TrimSpace(line), parseErr),
+			message: fmt.Sprintf("Failed to read file: %s", filePath),
 		}
-		if err != nil {
-			log.Printf("[copy] tar extract error for %s/%s: %v", namespace, podName, err)
-			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to extract file: %v", err))
-			return
-		}
+	}
 
-		if header.Typeflag == tar.TypeReg {
-			content, err := io.ReadAll(tr)
-			if err != nil {
-				log.Printf("[copy] Failed to read file from tar %s/%s: %v", namespace, podName, err)
-				s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to read file: %v", err))
-				return
-			}
+	stream.size = size
+	stream.payload = io.LimitReader(buffered, size)
+	return stream, nil
+}
 
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
-			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
-			w.Write(content)
-			return
+// classifyPodFileOpenError turns "the file never arrived" into the reason the
+// caller needs: a missing command to fall back from, a missing file, or a
+// genuine failure.
+func classifyPodFileOpenError(filePath string, readErr, streamErr error, stderr string) *podFileOpenError {
+	combined := strings.TrimSpace(fmt.Sprintf("%v %s", streamErr, stderr))
+	if isCommandMissing(streamErr, stderr) {
+		return &podFileOpenError{
+			err:            streamErr,
+			stderr:         stderr,
+			commandMissing: true,
+			shellMissing:   isShellMissing(combined),
+			message:        combined,
 		}
+	}
+	var exitErr k8sexec.CodeExitError
+	if errors.As(streamErr, &exitErr) && exitErr.Code == podFileNotRegularExit {
+		return &podFileOpenError{err: streamErr, stderr: stderr, notAFile: true,
+			message: fmt.Sprintf("Not a regular file: %s", filePath)}
+	}
+	// Shells and tars disagree on the wording — "No such file or directory",
+	// "can't open ...: no such file" — so match on the shared shape, folded.
+	lowered := strings.ToLower(combined)
+	if strings.Contains(lowered, "no such file") || strings.Contains(lowered, "not found") ||
+		strings.Contains(lowered, "can't open") || (streamErr == nil && readErr == io.EOF) {
+		return &podFileOpenError{err: streamErr, stderr: stderr, notFound: true,
+			message: fmt.Sprintf("File not found: %s", filePath)}
+	}
+	if streamErr == nil {
+		streamErr = readErr
+	}
+	return &podFileOpenError{
+		err:     streamErr,
+		stderr:  stderr,
+		message: fmt.Sprintf("Failed to download file: %v", streamErr),
 	}
 }
 
-// downloadWithCat is a fallback when tar is not available
+// Read yields the file's bytes and refuses to end early. A stream that stops
+// short of the size the container announced is the truncation this transfer
+// exists to catch, so it surfaces as an error instead of a complete-looking
+// file.
+func (p *podFileStream) Read(b []byte) (int, error) {
+	n, err := p.payload.Read(b)
+	p.written += int64(n)
+	if err == io.EOF {
+		if p.written != p.size {
+			return n, fmt.Errorf("received %d of %d bytes: %w", p.written, p.size, io.ErrUnexpectedEOF)
+		}
+		p.complete = true
+	}
+	return n, err
+}
+
+// Close ends the exec and reports how the remote command finished. After a
+// complete read it releases the drain guard and drains what is left, which is
+// what lets the command finish writing and exit; otherwise it tears the
+// connection down without pulling the rest of the file across.
+func (p *podFileStream) Close() error {
+	p.closeOnce.Do(func() {
+		if p.complete {
+			_ = p.stdin.Close()
+			grace := time.AfterFunc(podFileCloseGrace, p.cancel)
+			defer grace.Stop()
+			_, _ = io.Copy(io.Discard, p.stdout)
+		} else {
+			p.cancel()
+			_ = p.stdin.CloseWithError(errPodFileAborted)
+			_ = p.stdout.CloseWithError(errPodFileAborted)
+		}
+		p.closeErr = <-p.done
+		p.cancel()
+		if p.complete && errors.Is(p.closeErr, context.Canceled) {
+			// A client that has its last byte disconnects, which cancels the
+			// request context while the exec is still winding down. The file
+			// arrived; that is not something to report.
+			p.closeErr = nil
+		}
+	})
+	return p.closeErr
+}
+
+var errPodFileAborted = errors.New("pod file transfer aborted")
+
+// isCommandMissing reports whether the container lacks the command we asked
+// for. Behind /bin/sh a missing binary is exit code 127 rather than the
+// runtime's "executable file not found", and shells word it differently
+// ("tar: not found" vs "command not found"), so the code is the reliable part.
+func isCommandMissing(streamErr error, stderr string) bool {
+	var exitErr k8sexec.CodeExitError
+	if errors.As(streamErr, &exitErr) && exitErr.Code == 127 {
+		return true
+	}
+	if streamErr == nil {
+		return false
+	}
+	combined := streamErr.Error() + " " + stderr
+	return isCommandNotFound(combined) || isShellMissing(combined)
+}
+
+// downloadWithCat is a fallback for containers without tar. It has no way to
+// learn the file's size up front, so it can neither hold the remote process
+// open until the last byte arrives nor tell a truncated read from a complete
+// one — treat it as best-effort for the small files these containers hold,
+// not as an equal path for large ones.
 func (s *Server) downloadWithCat(r *http.Request, namespace, podName, container, filePath string) ([]byte, error) {
 	client := s.getClientForRequest(r)
 	config := s.getConfigForRequest(r)
@@ -487,13 +855,7 @@ func classifyExecError(findErr, lsErr string) string {
 		return "Permission denied: the container user lacks access to this directory. Try a different path or container."
 	}
 
-	// Check for shell not found (distroless containers).
-	// Some runtimes report "executable file not found", others report
-	// "/bin/sh: no such file or directory" — catch both forms.
-	if strings.Contains(combined, "executable file not found") && (strings.Contains(combined, "sh") || strings.Contains(combined, "shell")) {
-		return "Container has no shell (/bin/sh). This is likely a distroless or scratch-based container that cannot be browsed."
-	}
-	if strings.Contains(combined, "/bin/sh") && strings.Contains(combined, "no such file or directory") {
+	if isShellMissing(combined) {
 		return "Container has no shell (/bin/sh). This is likely a distroless or scratch-based container that cannot be browsed."
 	}
 
@@ -530,6 +892,17 @@ func classifyExecError(findErr, lsErr string) string {
 // escaped single quote, and re-opening the quote.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// isShellMissing detects a container without /bin/sh. Runtimes word it
+// differently — "executable file not found" from one, `exec: "/bin/sh": stat
+// /bin/sh: no such file or directory` from another — so both forms count.
+func isShellMissing(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	if strings.Contains(lower, "executable file not found") && (strings.Contains(lower, "sh") || strings.Contains(lower, "shell")) {
+		return true
+	}
+	return strings.Contains(lower, "/bin/sh") && strings.Contains(lower, "no such file or directory")
 }
 
 // isCommandNotFound detects errors indicating a command is not available in the container

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -194,6 +194,13 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 // fails, so the desktop app asks the backend to do the whole thing.
 // POST /api/pods/{ns}/{name}/files/save?container=X&path=/some/file
 func (s *Server) handlePodFileSave(w http.ResponseWriter, r *http.Request) {
+	// Runs a command in a pod and writes a file to the user's disk, which is
+	// exactly what the local origin check exists to keep a page on another site
+	// from triggering.
+	if !localOriginOK(r) {
+		s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
+		return
+	}
 	if s.saveFileStreamFunc == nil {
 		s.writeError(w, http.StatusNotFound, "not available")
 		return
@@ -377,7 +384,16 @@ func podFileCatCommand(filePath string) []string {
 	quoted := shellQuote(filePath)
 	script := "if [ -e " + quoted + " ] && [ ! -f " + quoted + " ]; then echo 'not a regular file' >&2; exit " +
 		strconv.Itoa(podFileNotRegularExit) + "; fi; " +
-		"size=$(wc -c < " + quoted + ") || exit $?; printf '%s\n' \"$size\"; cat " + quoted + podFileDrainGuard
+		"size=$(wc -c < " + quoted + ") || exit $?; " +
+		"printf '%s\n' \"$size\"; " +
+		"cat " + quoted + "; rc=$?; " +
+		// The size and the bytes come from two separate reads, so a file that
+		// shrank in between leaves the reader waiting for bytes that will never
+		// come while the guard holds the stream open. Re-measuring before arming
+		// it turns that deadlock into an ordinary short read.
+		"after=$(wc -c < " + quoted + " 2>/dev/null) || after=-1; " +
+		"[ $rc -eq 0 ] && [ \"${after:--1}\" -ge \"$size\" ] && read _; " +
+		"exit $rc"
 	return []string{"/bin/sh", "-c", script}
 }
 

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"path"
 	"sort"
 	"strconv"
@@ -439,6 +440,15 @@ const podFileCloseGrace = 30 * time.Second
 // bound only covers a connection that has stopped answering.
 const podFileAbortGrace = 5 * time.Second
 
+// executorFor builds the exec client, through the Server so a test can stand in
+// for the cluster. Production leaves newExecutor nil and gets the real one.
+func (s *Server) executorFor(config *rest.Config, u *url.URL) (remotecommand.Executor, error) {
+	if s.newExecutor != nil {
+		return s.newExecutor(config, u)
+	}
+	return rcpkg.NewExecutor(config, u)
+}
+
 // startPodFileExec runs cmd in the container and hands back a stream whose
 // payload the caller frames. The command must keep stdin open per
 // podFileDrainGuard.
@@ -458,7 +468,7 @@ func (s *Server) startPodFileExec(ctx context.Context, client kubernetes.Interfa
 			Stderr:    true,
 		}, scheme.ParameterCodec)
 
-	executor, err := rcpkg.NewExecutor(config, req.URL())
+	executor, err := s.executorFor(config, req.URL())
 	if err != nil {
 		return nil, err
 	}
@@ -717,7 +727,7 @@ func (s *Server) downloadWithCat(r *http.Request, namespace, podName, container,
 			Stderr:    true,
 		}, scheme.ParameterCodec)
 
-	exec, err := rcpkg.NewExecutor(config, req.URL())
+	exec, err := s.executorFor(config, req.URL())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -550,11 +550,18 @@ func classifyPodFileOpenError(filePath string, readErr, streamErr error, stderr 
 		return &podFileOpenError{err: streamErr, stderr: stderr, notAFile: true,
 			message: fmt.Sprintf("Not a regular file: %s", filePath)}
 	}
+	lowered := strings.ToLower(combined)
+	// Checked before the missing-file shapes below: a shell says "can't open"
+	// for both, and answering "not found" for a file the container simply may
+	// not read sends the reader looking for the wrong thing.
+	if strings.Contains(lowered, "permission denied") || strings.Contains(lowered, "operation not permitted") {
+		return &podFileOpenError{err: streamErr, stderr: stderr,
+			message: fmt.Sprintf("Permission denied: the container user cannot read %s", filePath)}
+	}
 	// Shells and tars disagree on the wording — "No such file or directory",
 	// "can't open ...: no such file" — so match on the shared shape, folded.
-	lowered := strings.ToLower(combined)
 	if strings.Contains(lowered, "no such file") || strings.Contains(lowered, "not found") ||
-		strings.Contains(lowered, "can't open") || (streamErr == nil && readErr == io.EOF) {
+		(streamErr == nil && readErr == io.EOF) {
 		return &podFileOpenError{err: streamErr, stderr: stderr, notFound: true,
 			message: fmt.Sprintf("File not found: %s", filePath)}
 	}

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -416,6 +416,11 @@ type podFileStream struct {
 // connection loose costs nothing and keeps the handler from being pinned to it.
 const podFileCloseGrace = 30 * time.Second
 
+// podFileAbortGrace bounds the same wait when the file never arrived. A command
+// that failed has already exited, so its status is normally there at once; the
+// bound only covers a connection that has stopped answering.
+const podFileAbortGrace = 5 * time.Second
+
 // startPodFileExec runs cmd in the container and hands back a stream whose
 // payload the caller frames. The command must keep stdin open per
 // podFileDrainGuard.
@@ -568,6 +573,12 @@ func classifyPodFileOpenError(filePath string, readErr, streamErr error, stderr 
 	if streamErr == nil {
 		streamErr = readErr
 	}
+	if errors.Is(streamErr, context.Canceled) {
+		// Nothing came back to classify. Naming the cancellation would only
+		// hand the reader an internal detail they cannot act on.
+		return &podFileOpenError{err: streamErr, stderr: stderr,
+			message: fmt.Sprintf("The transfer stopped before %s could be read", filePath)}
+	}
 	return &podFileOpenError{
 		err:     streamErr,
 		stderr:  stderr,
@@ -603,9 +614,15 @@ func (p *podFileStream) Close() error {
 			defer grace.Stop()
 			_, _ = io.Copy(io.Discard, p.stdout)
 		} else {
-			p.cancel()
+			// Closing the pipes unblocks the exec goroutine so the command can
+			// still say why it failed. Cancelling ahead of it races that away
+			// and leaves only "context canceled", losing both the exit status
+			// and whatever the command wrote to stderr — which is the whole
+			// basis for telling a missing file from an unreadable one.
 			_ = p.stdin.CloseWithError(errPodFileAborted)
 			_ = p.stdout.CloseWithError(errPodFileAborted)
+			grace := time.AfterFunc(podFileAbortGrace, p.cancel)
+			defer grace.Stop()
 		}
 		p.closeErr = <-p.done
 		p.cancel()

--- a/internal/server/copy_handler_test.go
+++ b/internal/server/copy_handler_test.go
@@ -1,0 +1,403 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	k8sexec "k8s.io/client-go/util/exec"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// These tests drive the real routes and the real handlers. Only the exec client
+// is stood in for, because everything this change fixes lives between the tar
+// header and the response body: the size the archive declares, the bytes that
+// follow it, when stdin is released, and what the client is told when those
+// disagree. None of that is reachable from a test of the pieces.
+//
+// What they do NOT cover: the shell scripts, which no Go test can execute, and
+// the Kubernetes teardown behaviour that made the file arrive short in the first
+// place. Both are verified against a live cluster by hand. Green here means the
+// wiring is right, not that a download works.
+
+// fakeExecutor stands in for the cluster. respond receives the same streams
+// client-go would hand the real exec, so a test can write an archive, read the
+// stdin the drain guard depends on, and then report whatever status it likes.
+type fakeExecutor struct {
+	respond func(t *testing.T, opts remotecommand.StreamOptions) error
+	t       *testing.T
+}
+
+func (f *fakeExecutor) Stream(opts remotecommand.StreamOptions) error {
+	return f.StreamWithContext(context.Background(), opts)
+}
+
+func (f *fakeExecutor) StreamWithContext(ctx context.Context, opts remotecommand.StreamOptions) error {
+	return f.respond(f.t, opts)
+}
+
+// execRequest is what a test matches on to tell the transfer attempts apart:
+// the guarded tar first, then the framed cat, then the bare cat.
+type execRequest struct {
+	command []string
+}
+
+func (e execRequest) script() string {
+	if len(e.command) == 3 && e.command[0] == "/bin/sh" {
+		return e.command[2]
+	}
+	return strings.Join(e.command, " ")
+}
+
+func (e execRequest) isTar() bool  { return strings.Contains(e.script(), "tar cfh") }
+func (e execRequest) isCat() bool  { return strings.Contains(e.script(), "wc -c <") }
+func (e execRequest) isBare() bool { return len(e.command) > 0 && e.command[0] == "cat" }
+
+// downloadServer mounts the real routes with a fake exec client behind them.
+func downloadServer(t *testing.T, srv *Server, respond func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error) *httptest.Server {
+	t.Helper()
+
+	// The handlers refuse to start unless the cluster looks connected and both a
+	// client and a config resolve, so all three seams have to be published.
+	prevConn := k8s.GetConnectionStatus()
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{State: k8s.StateConnected})
+	t.Cleanup(func() { k8s.SetConnectionStatus(prevConn) })
+
+	apiserver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(apiserver.Close)
+
+	config := &rest.Config{Host: apiserver.URL}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("build clientset: %v", err)
+	}
+	prevClient := k8s.SetTestClient(client)
+	t.Cleanup(func() { k8s.SetTestClient(prevClient) })
+	prevConfig := k8s.SetTestConfig(config)
+	t.Cleanup(func() { k8s.SetTestConfig(prevConfig) })
+
+	srv.newExecutor = func(_ *rest.Config, u *url.URL) (remotecommand.Executor, error) {
+		return &fakeExecutor{t: t, respond: func(t *testing.T, opts remotecommand.StreamOptions) error {
+			return respond(t, execRequest{command: u.Query()["command"]}, opts)
+		}}, nil
+	}
+
+	router := chi.NewRouter()
+	router.Get("/api/pods/{namespace}/{name}/files/download", srv.handlePodFileDownload)
+	router.Post("/api/pods/{namespace}/{name}/files/save", srv.handlePodFileSave)
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func downloadURL(ts *httptest.Server, path string) string {
+	return ts.URL + "/api/pods/ns/pod/files/download?container=app&path=" + url.QueryEscape(path)
+}
+
+// writeArchive writes a one-file tar to w, keeping only the first keepBytes when
+// keepBytes is non-negative, which is how Kubernetes hands back a transfer whose
+// tail was dropped.
+func writeArchive(t *testing.T, w io.Writer, name string, payload []byte, keepBytes int) {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(payload)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.Bytes()
+	if keepBytes >= 0 && keepBytes < len(out) {
+		out = out[:keepBytes]
+	}
+	if _, err := w.Write(out); err != nil && err != io.ErrClosedPipe {
+		t.Logf("archive write ended: %v", err)
+	}
+}
+
+// get runs the request under a deadline, so a transfer that parks fails the test
+// instead of hanging the suite - which is exactly how the shrinking-file bug
+// behaved before it was fixed.
+func fetchRaw(t *testing.T, rawurl string, within time.Duration) (*http.Response, []byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), within)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request did not complete within %s: %v", within, err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	return resp, body, readErr
+}
+
+func fetchWithin(t *testing.T, rawurl string, within time.Duration) (*http.Response, []byte) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), within)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request did not complete within %s: %v", within, err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return resp, body // a torn response is a result, not a failure
+	}
+	return resp, body
+}
+
+func TestPodFileDownloadServesTheWholeFile(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 4096)
+	ts := downloadServer(t, &Server{}, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		if !req.isTar() {
+			t.Errorf("expected the tar attempt, got %q", req.script())
+		}
+		writeArchive(t, opts.Stdout, "app.log", payload, -1)
+		if opts.Stdin != nil {
+			_, _ = io.Copy(io.Discard, opts.Stdin) // the guard: wait to be released
+		}
+		return nil
+	})
+
+	resp, body := fetchWithin(t, downloadURL(ts, "/var/log/app.log"), 10*time.Second)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Length"); got != strconv.Itoa(len(payload)) {
+		t.Errorf("Content-Length = %q, want %d", got, len(payload))
+	}
+	if !strings.Contains(resp.Header.Get("Content-Disposition"), `filename="app.log"`) {
+		t.Errorf("Content-Disposition = %q", resp.Header.Get("Content-Disposition"))
+	}
+	if !bytes.Equal(body, payload) {
+		t.Errorf("served %d bytes, want %d identical bytes", len(body), len(payload))
+	}
+}
+
+// A short transfer must never reach the client as a complete response. The
+// declared Content-Length is what makes that true: without it the handler would
+// answer a cleanly terminated body that happens to be short, and the client
+// would store it believing the download succeeded.
+func TestPodFileDownloadTruncatedArchiveDoesNotLookComplete(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 4096)
+	var full bytes.Buffer
+	writeArchive(t, &full, "app.log", payload, -1)
+
+	ts := downloadServer(t, &Server{}, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		writeArchive(t, opts.Stdout, "app.log", payload, full.Len()-2048)
+		return nil // success, exactly as the real teardown reports it
+	})
+
+	resp, body, readErr := fetchRaw(t, downloadURL(ts, "/var/log/app.log"), 10*time.Second)
+	if int64(len(body)) == int64(len(payload)) {
+		t.Fatal("a truncated transfer was served as a complete file")
+	}
+	if resp.Header.Get("Content-Length") != strconv.Itoa(len(payload)) {
+		t.Errorf("Content-Length = %q, want the size the archive declared (%d)", resp.Header.Get("Content-Length"), len(payload))
+	}
+	// Reading the body must fail. A clean read of a short body is the corrupt
+	// download this endpoint must never produce.
+	if readErr == nil {
+		t.Errorf("client read %d bytes of a declared %d with no error, so it would save a corrupt file", len(body), len(payload))
+	}
+}
+
+// The desktop save is where a missed short read does real damage: the bytes are
+// already on the user's disk, and without the size check they are renamed into
+// place and reported as a finished download.
+func TestPodFileSaveRefusesToFinishATruncatedTransfer(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 4096)
+	var full bytes.Buffer
+	writeArchive(t, &full, "app.log", payload, -1)
+
+	var saved []byte
+	var savedName string
+	srv := &Server{saveFileStreamFunc: func(name string, r io.Reader) (string, error) {
+		savedName = name
+		var err error
+		saved, err = io.ReadAll(r) // the desktop app copies to a partial file exactly like this
+		if err != nil {
+			return "", err // and removes it, reporting the failure
+		}
+		return "/tmp/" + name, nil
+	}}
+
+	ts := downloadServer(t, srv, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		writeArchive(t, opts.Stdout, "app.log", payload, full.Len()-2048)
+		return nil
+	})
+
+	saveURL := ts.URL + "/api/pods/ns/pod/files/save?container=app&path=" + url.QueryEscape("/var/log/app.log")
+	req, err := http.NewRequest(http.MethodPost, saveURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("save request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("a truncated transfer was reported as saved (%q); the user has a corrupt file and no way to know", body)
+	}
+	if len(saved) == len(payload) {
+		t.Errorf("the callback received a complete file from a truncated transfer")
+	}
+	_ = savedName
+}
+
+// On the cat path there is no archive to notice the loss, only the byte count
+// the container announced, so the explicit size check is the whole defence. A
+// short read here must never be finished and reported as a saved file.
+func TestPodFileSaveRefusesToFinishAShortCatTransfer(t *testing.T) {
+	payload := []byte("the container announced more of this file than it sent")
+
+	var saved []byte
+	srv := &Server{saveFileStreamFunc: func(name string, r io.Reader) (string, error) {
+		var err error
+		saved, err = io.ReadAll(r)
+		if err != nil {
+			return "", err
+		}
+		return "/tmp/" + name, nil
+	}}
+
+	ts := downloadServer(t, srv, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		switch {
+		case req.isTar():
+			_, _ = io.WriteString(opts.Stderr, "sh: tar: not found")
+			return k8sexec.CodeExitError{Err: fmt.Errorf("command terminated with exit code 127"), Code: 127}
+		case req.isCat():
+			// Announce the whole file, then send part of it and exit clean - the
+			// shape a file that shrank mid-read produces. Deliberately does NOT
+			// wait on stdin: the script re-measures the file and declines to arm
+			// the drain guard when it came up short, which is what keeps a short
+			// transfer from parking instead of failing.
+			fmt.Fprintf(opts.Stdout, "%d\n", len(payload))
+			_, _ = opts.Stdout.Write(payload[:len(payload)-20])
+			return nil
+		default:
+			t.Errorf("unexpected attempt %q", req.script())
+			return fmt.Errorf("unexpected command")
+		}
+	})
+
+	saveURL := ts.URL + "/api/pods/ns/pod/files/save?container=app&path=" + url.QueryEscape("/var/log/app.log")
+	req, err := http.NewRequest(http.MethodPost, saveURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("save request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("a short transfer was reported as saved (%q); nothing else would have caught it", body)
+	}
+	if len(saved) == len(payload) {
+		t.Errorf("the callback was handed a complete file from a short transfer")
+	}
+}
+
+// The transfer must not release the remote process until it holds every byte.
+// Releasing early is what let Kubernetes drop the tail.
+func TestPodFileDownloadReleasesTheDrainGuardOnlyAfterTheFullRead(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 8192)
+	var full bytes.Buffer
+	writeArchive(t, &full, "app.log", payload, -1)
+	archive := full.Bytes()
+	held := archive[len(archive)-1024:]
+
+	ts := downloadServer(t, &Server{}, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		if opts.Stdin == nil {
+			t.Error("the transfer opened no stdin, so nothing can hold the process open")
+			return fmt.Errorf("no stdin stream")
+		}
+		if _, err := opts.Stdout.Write(archive[:len(archive)-1024]); err != nil {
+			return err
+		}
+		// Withhold the tail until stdin closes. If the server released the guard
+		// before reading everything, this never returns and the deadline fires.
+		_, _ = io.Copy(io.Discard, opts.Stdin)
+		_, _ = opts.Stdout.Write(held)
+		return nil
+	})
+
+	resp, body := fetchWithin(t, downloadURL(ts, "/var/log/app.log"), 10*time.Second)
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(body, payload) {
+		t.Fatalf("status %d, %d bytes: the guard was released before the file was whole", resp.StatusCode, len(body))
+	}
+}
+
+// A container without tar still has to deliver the file, through the framed cat
+// path, and that path has to be reached by the exit status rather than by
+// matching the wording of a message.
+func TestPodFileDownloadFallsBackToCatWhenTarIsMissing(t *testing.T) {
+	payload := []byte("no tar in this container, but the file still arrives")
+	var sawTar, sawCat bool
+
+	ts := downloadServer(t, &Server{}, func(t *testing.T, req execRequest, opts remotecommand.StreamOptions) error {
+		switch {
+		case req.isTar():
+			sawTar = true
+			_, _ = io.WriteString(opts.Stderr, "sh: tar: not found")
+			return k8sexec.CodeExitError{Err: fmt.Errorf("command terminated with exit code 127"), Code: 127}
+		case req.isCat():
+			sawCat = true
+			fmt.Fprintf(opts.Stdout, "%d\n", len(payload))
+			_, _ = opts.Stdout.Write(payload)
+			if opts.Stdin != nil {
+				_, _ = io.Copy(io.Discard, opts.Stdin)
+			}
+			return nil
+		default:
+			t.Errorf("unexpected attempt %q", req.script())
+			return fmt.Errorf("unexpected command")
+		}
+	})
+
+	resp, body := fetchWithin(t, downloadURL(ts, "/var/log/app.log"), 10*time.Second)
+	if !sawTar || !sawCat {
+		t.Fatalf("expected tar then cat; sawTar=%v sawCat=%v", sawTar, sawCat)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", resp.StatusCode, body)
+	}
+	if !bytes.Equal(body, payload) {
+		t.Errorf("served %q, want %q", body, payload)
+	}
+}

--- a/internal/server/copy_test.go
+++ b/internal/server/copy_test.go
@@ -66,10 +66,40 @@ func TestIsShellMissing(t *testing.T) {
 		`executable file not found in $PATH: "/bin/sh"`:            true,
 		"tar: /output/app.log: no such file or directory":          false,
 		"tar: /output: Permission denied":                          false,
+		// A shell that started fine reports a missing file under the same path
+		// it was invoked as. bash-as-/bin/sh is the common case, on the RHEL and
+		// UBI family among others, and reading this as "no shell here" drops the
+		// download to a fallback that cannot check what it received.
+		"/bin/sh: line 1: /output/nope.txt: No such file or directory": false,
+		"/bin/sh: 1: cannot open /output/nope.txt: No such file":       false,
 	} {
 		if got := isShellMissing(msg); got != want {
 			t.Errorf("isShellMissing(%q) = %v, want %v", msg, got, want)
 		}
+	}
+}
+
+// The apiserver says `pods "web-0" not found` for a pod that has gone away.
+// Answering "File not found: <path>" sends the reader hunting for a file that
+// was never the problem.
+func TestClassifyPodFileOpenErrorDoesNotBlameTheFileForAMissingPod(t *testing.T) {
+	err := classifyPodFileOpenError("/output/app.log", io.EOF,
+		errors.New(`pods "web-0" not found`), "")
+	if err.notFound {
+		t.Errorf("a missing pod was reported as a missing file: %+v", err)
+	}
+}
+
+// A command that reports success and sends nothing is the stream being dropped,
+// which is the failure this whole transfer exists to catch. Filing it as a
+// missing file would hide a recurrence behind a plausible answer.
+func TestClassifyPodFileOpenErrorDoesNotCallAnEmptyStreamAMissingFile(t *testing.T) {
+	err := classifyPodFileOpenError("/output/app.log", io.EOF, nil, "")
+	if err.notFound {
+		t.Errorf("an empty successful stream was reported as a missing file: %+v", err)
+	}
+	if !strings.Contains(err.message, "no data") {
+		t.Errorf("message = %q, want it to say the transfer produced nothing", err.message)
 	}
 }
 

--- a/internal/server/copy_test.go
+++ b/internal/server/copy_test.go
@@ -231,6 +231,36 @@ func TestClassifyPodFileOpenErrorNamesANonRegularFile(t *testing.T) {
 	}
 }
 
+// A shell says "can't open" for a file that is absent and for one it may not
+// read. Calling the second case not-found sends the reader looking for a file
+// that is sitting right there.
+func TestClassifyPodFileOpenErrorSeparatesPermissionFromMissing(t *testing.T) {
+	err := classifyPodFileOpenError("/output/secret.txt",
+		io.EOF,
+		k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 1"), Code: 1},
+		"sh: can't open /output/secret.txt: Permission denied")
+	if err.notFound {
+		t.Error("a file the container cannot read must not be reported as missing")
+	}
+	if !strings.Contains(err.message, "Permission denied") {
+		t.Errorf("message = %q, want it to name the permission problem", err.message)
+	}
+}
+
+// tar words the same problem differently, and it has to land the same way.
+func TestClassifyPodFileOpenErrorNamesAPermissionProblemFromTar(t *testing.T) {
+	err := classifyPodFileOpenError("/output/locked/secret.txt",
+		io.EOF,
+		k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 1"), Code: 1},
+		"tar: can't change directory to '/output/locked': Permission denied")
+	if err.notFound || err.notAFile || err.commandMissing {
+		t.Errorf("a permission problem was misrouted: %+v", err)
+	}
+	if !strings.Contains(err.message, "Permission denied") {
+		t.Errorf("message = %q, want it to name the permission problem", err.message)
+	}
+}
+
 func TestClassifyPodFileOpenErrorNamesAMissingFile(t *testing.T) {
 	// busybox ash words it without "or directory" and in lower case.
 	err := classifyPodFileOpenError("/output/nope",

--- a/internal/server/copy_test.go
+++ b/internal/server/copy_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -191,7 +193,7 @@ func TestPodFileCatCommand(t *testing.T) {
 	for _, want := range []string{
 		"wc -c < '/var/log/app.log'", // the size is announced so a short read is detectable
 		"cat '/var/log/app.log'",
-		podFileDrainGuard,
+		"read _", // the drain guard, without which a slow link loses the tail
 	} {
 		if !strings.Contains(script, want) {
 			t.Errorf("script %q is missing %q", script, want)
@@ -215,6 +217,26 @@ func TestPodFileCatCommandRefusesNonRegularFilesBeforeReading(t *testing.T) {
 	}
 	if !strings.Contains(script, "exit 3") {
 		t.Errorf("the guard must exit with %d so the handler can name the reason: %q", podFileNotRegularExit, script)
+	}
+}
+
+// The size and the bytes come from two separate reads of the file. If it shrank
+// in between, the reader is waiting for bytes that will never arrive, so arming
+// the guard would park the command and hang the request instead of failing it.
+func TestPodFileCatCommandArmsTheGuardOnlyWhenTheFileStillHoldsWhatWasPromised(t *testing.T) {
+	script := podFileCatCommand("/var/log/app.log")[2]
+
+	recheck := strings.Index(script, "after=$(wc -c <")
+	guard := strings.Index(script, "read _")
+	if recheck < 0 {
+		t.Fatalf("script never re-measures the file before arming the guard: %q", script)
+	}
+	if guard < recheck {
+		t.Errorf("the guard is armed before the re-measure, so a shrinking file still parks it: %q", script)
+	}
+	gate := strings.Index(script, "-ge ")
+	if gate < recheck || gate > guard {
+		t.Errorf("the re-measure must gate the guard on still having the promised bytes: %q", script)
 	}
 }
 
@@ -446,6 +468,36 @@ func closeWithin(t *testing.T, stream *podFileStream, limit time.Duration) error
 	case <-time.After(limit):
 		t.Fatal("Close() did not return")
 		return nil
+	}
+}
+
+// Running a command in a pod and writing a file to the user's disk is exactly
+// what a page on another site must not be able to trigger.
+func TestPodFileSaveRejectsCrossOriginRequests(t *testing.T) {
+	s := &Server{saveFileStreamFunc: func(string, io.Reader) (string, error) {
+		t.Error("a cross-origin request reached the save callback")
+		return "", nil
+	}}
+
+	for origin, wantStatus := range map[string]int{
+		"https://evil.example.com":  http.StatusForbidden,
+		"http://localhost.evil.com": http.StatusForbidden,
+		"http://localhost:9280":     0, // allowed through to the handler's own checks
+		"":                          0, // same-origin or a non-browser caller
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/api/pods/ns/pod/files/save?container=c&path=/f", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rec := httptest.NewRecorder()
+		s.handlePodFileSave(rec, req)
+
+		if wantStatus == http.StatusForbidden && rec.Code != http.StatusForbidden {
+			t.Errorf("Origin %q got %d, want %d", origin, rec.Code, http.StatusForbidden)
+		}
+		if wantStatus == 0 && rec.Code == http.StatusForbidden {
+			t.Errorf("Origin %q was rejected as cross-origin", origin)
+		}
 	}
 }
 

--- a/internal/server/copy_test.go
+++ b/internal/server/copy_test.go
@@ -362,14 +362,63 @@ func TestPodFileStreamCloseSurfacesACommandThatFailedLate(t *testing.T) {
 	}
 }
 
-// Abandoning the download must not wait for the rest of the file to come
-// across, and must not leave the exec running.
+// Abandoning the download must return at once rather than pulling the rest of
+// the file across first, and must not claim the file arrived.
 func TestPodFileStreamCloseWithoutReadingDoesNotHang(t *testing.T) {
 	payload := bytes.Repeat([]byte("x"), 1<<20)
 	stream := fakeExec(t, tarArchive(t, "app.log", payload, -1), nil)
 
-	if err := closeWithin(t, stream, 5*time.Second); err == nil {
-		t.Error("an abandoned transfer should not report success")
+	closeWithin(t, stream, 5*time.Second)
+	if stream.complete {
+		t.Error("an abandoned transfer must not be marked complete")
+	}
+	if stream.written >= int64(len(payload)) {
+		t.Errorf("Close drained %d bytes of an abandoned transfer, want it to stop early", stream.written)
+	}
+}
+
+// When no archive arrived, the command's own status is the only thing that can
+// tell a missing file from an unreadable one. Tearing the exec down before it
+// reports replaces that with "context canceled" and the reason is gone.
+func TestPodFileStreamClosePreservesWhyTheCommandFailed(t *testing.T) {
+	commandErr := errors.New("command terminated with exit code 2")
+	stream := failedExec(t, commandErr)
+
+	err := closeWithin(t, stream, 5*time.Second)
+	if errors.Is(err, context.Canceled) {
+		t.Fatal("cancellation raced away the command's status")
+	}
+	if !errors.Is(err, commandErr) {
+		t.Errorf("Close() = %v, want the command's own error", err)
+	}
+}
+
+// failedExec stands in for a command that wrote no archive and exited with a
+// status the handler needs in order to classify the failure.
+func failedExec(t *testing.T, commandErr error) *podFileStream {
+	t.Helper()
+	stdoutR, stdoutW := io.Pipe()
+	stdinR, stdinW := io.Pipe()
+	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// A real exec only reports once its streams are released, so the status
+		// lands after the reader has given up on the archive.
+		<-ctx.Done()
+		_ = stdoutW.CloseWithError(commandErr)
+		done <- commandErr
+	}()
+	// Releasing on pipe close is what the fixed Close relies on; the context
+	// here only models "the exec goroutine is still holding the streams".
+	go func() {
+		_, _ = io.Copy(io.Discard, stdinR)
+		cancel()
+	}()
+
+	return &podFileStream{
+		size: -1, payload: stdoutR, stdout: stdoutR, stdin: stdinW,
+		stderr: &bytes.Buffer{}, done: done, cancel: cancel,
 	}
 }
 

--- a/internal/server/copy_test.go
+++ b/internal/server/copy_test.go
@@ -1,0 +1,387 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	k8sexec "k8s.io/client-go/util/exec"
+)
+
+func TestPodFileTarCommand(t *testing.T) {
+	cmd := podFileTarCommand("/var/log", "app.log")
+	if len(cmd) != 3 || cmd[0] != "/bin/sh" || cmd[1] != "-c" {
+		t.Fatalf("expected an sh -c invocation, got %q", cmd)
+	}
+
+	script := cmd[2]
+	for _, want := range []string{
+		"tar cfh -",       // -h so a symlink yields the bytes it points at
+		"-C '/var/log'",   // the directory is quoted for the shell
+		"'./app.log'",     // "./" keeps a name starting with "-" from reading as an option
+		podFileDrainGuard, // the guard is what keeps the file whole over a slow link
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script %q is missing %q", script, want)
+		}
+	}
+}
+
+func TestPodFileTarCommandQuotesHostileNames(t *testing.T) {
+	script := podFileTarCommand("/tmp", "'; rm -rf / #")[2]
+	if strings.Contains(script, "rm -rf /;") || !strings.Contains(script, `'./'\''; rm -rf / #'`) {
+		t.Errorf("single quotes in the file name are not neutralised: %q", script)
+	}
+
+	script = podFileTarCommand("/tmp", "-C")[2]
+	if !strings.Contains(script, "'./-C'") {
+		t.Errorf("a file named -C must not reach tar as an option: %q", script)
+	}
+}
+
+func TestIsDownloadablePath(t *testing.T) {
+	for path, want := range map[string]bool{
+		"/var/log/app.log": true,
+		"/app.log":         true,
+		"/":                false,
+		".":                false,
+		"..":               false,
+	} {
+		if got := isDownloadablePath(path); got != want {
+			t.Errorf("isDownloadablePath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestIsShellMissing(t *testing.T) {
+	for msg, want := range map[string]bool{
+		`exec: "/bin/sh": stat /bin/sh: no such file or directory`: true,
+		`executable file not found in $PATH: "/bin/sh"`:            true,
+		"tar: /output/app.log: no such file or directory":          false,
+		"tar: /output: Permission denied":                          false,
+	} {
+		if got := isShellMissing(msg); got != want {
+			t.Errorf("isShellMissing(%q) = %v, want %v", msg, got, want)
+		}
+	}
+}
+
+func TestIsCommandMissing(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		stderr string
+		want   bool
+	}{
+		// Behind /bin/sh the runtime never reports the missing binary itself;
+		// the shell does, and only the exit code is worded consistently.
+		{"shell reports exit 127", k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 127"), Code: 127}, "sh: tar: not found", true},
+		{"wrapped exit 127", errors.Join(errors.New("exec failed"), k8sexec.CodeExitError{Err: errors.New("x"), Code: 127}), "", true},
+		{"runtime cannot find the shell", errors.New(`executable file not found in $PATH: "/bin/sh"`), "", true},
+		// containerd words a missing interpreter its own way, and a distroless
+		// container has to reach the cat fallback to get an honest answer.
+		{"containerd cannot stat the shell", errors.New(`OCI runtime exec failed: exec: "/bin/sh": stat /bin/sh: no such file or directory`), "", true},
+		{"tar failed for another reason", k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 1"), Code: 1}, "tar: /x: Permission denied", false},
+		{"no error at all", nil, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCommandMissing(tt.err, tt.stderr); got != tt.want {
+				t.Errorf("isCommandMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// tarArchive returns a single-file tar archive, optionally cut short to
+// reproduce the stream Kubernetes hands back when it drops the tail of a
+// large file.
+func tarArchive(t *testing.T, name string, payload []byte, keepBytes int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(payload)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.Bytes()
+	if keepBytes >= 0 && keepBytes < len(out) {
+		out = out[:keepBytes]
+	}
+	return out
+}
+
+// streamOver builds a podFileStream reading a ready-made archive, which is
+// enough to exercise everything the transfer does with the bytes.
+func streamOver(t *testing.T, archive []byte) *podFileStream {
+	t.Helper()
+	tr := tar.NewReader(bytes.NewReader(archive))
+	header, err := tr.Next()
+	if err != nil {
+		t.Fatalf("archive has no entry: %v", err)
+	}
+	return &podFileStream{size: header.Size, payload: tr}
+}
+
+func TestPodFileStreamDeliversWholeFile(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 5000)
+	stream := streamOver(t, tarArchive(t, "app.log", payload, -1))
+
+	var got bytes.Buffer
+	n, err := io.Copy(&got, stream)
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != int64(len(payload)) || !bytes.Equal(got.Bytes(), payload) {
+		t.Errorf("copied %d bytes, want %d identical bytes", n, len(payload))
+	}
+	if !stream.complete {
+		t.Error("a fully read stream must be marked complete so Close can release the guard")
+	}
+}
+
+func TestPodFileStreamRejectsTruncatedTransfer(t *testing.T) {
+	payload := bytes.Repeat([]byte("radar"), 5000)
+	full := tarArchive(t, "app.log", payload, -1)
+	stream := streamOver(t, tarArchive(t, "app.log", payload, len(full)-4096))
+
+	n, err := io.Copy(io.Discard, stream)
+	if err == nil {
+		t.Fatal("a truncated transfer must not read as a complete file")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("error = %v, want it to wrap io.ErrUnexpectedEOF", err)
+	}
+	if n >= int64(len(payload)) {
+		t.Errorf("copied %d bytes, expected fewer than the declared %d", n, len(payload))
+	}
+	if stream.complete {
+		t.Error("a truncated stream must not be marked complete")
+	}
+}
+
+func TestPodFileStreamAcceptsEmptyFile(t *testing.T) {
+	stream := streamOver(t, tarArchive(t, "empty.log", nil, -1))
+
+	n, err := io.Copy(io.Discard, stream)
+	if err != nil || n != 0 {
+		t.Fatalf("copy of an empty file = (%d, %v), want (0, nil)", n, err)
+	}
+	if !stream.complete {
+		t.Error("an empty file is still a complete transfer")
+	}
+}
+
+func TestPodFileCatCommand(t *testing.T) {
+	cmd := podFileCatCommand("/var/log/app.log")
+	if len(cmd) != 3 || cmd[0] != "/bin/sh" || cmd[1] != "-c" {
+		t.Fatalf("expected an sh -c invocation, got %q", cmd)
+	}
+	script := cmd[2]
+	for _, want := range []string{
+		"wc -c < '/var/log/app.log'", // the size is announced so a short read is detectable
+		"cat '/var/log/app.log'",
+		podFileDrainGuard,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script %q is missing %q", script, want)
+		}
+	}
+	if !strings.Contains(podFileCatCommand("/tmp/'; id #")[2], `'/tmp/'\''; id #'`) {
+		t.Error("single quotes in the file name are not neutralised")
+	}
+}
+
+// wc on a character device never reaches an end, so anything that exists but is
+// not a regular file has to be turned away before wc opens it.
+func TestPodFileCatCommandRefusesNonRegularFilesBeforeReading(t *testing.T) {
+	script := podFileCatCommand("/dev/zero")[2]
+	guard := strings.Index(script, "[ -e '/dev/zero' ] && [ ! -f '/dev/zero' ]")
+	if guard < 0 {
+		t.Fatalf("script has no type guard: %q", script)
+	}
+	if wc := strings.Index(script, "wc -c"); wc < guard {
+		t.Error("the type guard must run before wc opens the path")
+	}
+	if !strings.Contains(script, "exit 3") {
+		t.Errorf("the guard must exit with %d so the handler can name the reason: %q", podFileNotRegularExit, script)
+	}
+}
+
+func TestClassifyPodFileOpenErrorNamesANonRegularFile(t *testing.T) {
+	err := classifyPodFileOpenError("/dev/zero",
+		io.EOF,
+		k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 3"), Code: podFileNotRegularExit},
+		"not a regular file")
+	if !err.notAFile {
+		t.Errorf("exit %d should read as \"not a regular file\", got %+v", podFileNotRegularExit, err)
+	}
+	if err.commandMissing || err.notFound {
+		t.Errorf("exit %d must not be mistaken for a missing command or a missing file: %+v", podFileNotRegularExit, err)
+	}
+}
+
+func TestClassifyPodFileOpenErrorNamesAMissingFile(t *testing.T) {
+	// busybox ash words it without "or directory" and in lower case.
+	err := classifyPodFileOpenError("/output/nope",
+		io.EOF,
+		k8sexec.CodeExitError{Err: errors.New("command terminated with exit code 1"), Code: 1},
+		"/bin/sh: can't open /output/nope: no such file")
+	if !err.notFound {
+		t.Errorf("a shell that cannot open the path should read as not-found, got %+v", err)
+	}
+}
+
+// The cat fallback frames the file by the size the container announced, so a
+// stream cut short is caught the same way the tar path catches it.
+func TestPodFileStreamCatFramingRejectsShortRead(t *testing.T) {
+	full := "0123456789"
+	stream := &podFileStream{size: int64(len(full)), payload: io.LimitReader(strings.NewReader(full[:6]), int64(len(full)))}
+
+	n, err := io.Copy(io.Discard, stream)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("copy of a short cat stream = (%d, %v), want an unexpected-EOF error", n, err)
+	}
+	if stream.complete {
+		t.Error("a short cat stream must not be marked complete")
+	}
+}
+
+func TestPodFileStreamCatFramingAcceptsExactRead(t *testing.T) {
+	full := "0123456789"
+	stream := &podFileStream{size: int64(len(full)), payload: io.LimitReader(strings.NewReader(full), int64(len(full)))}
+
+	var got bytes.Buffer
+	if _, err := io.Copy(&got, stream); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if got.String() != full || !stream.complete {
+		t.Errorf("read %q (complete=%v), want %q complete", got.String(), stream.complete, full)
+	}
+}
+
+// fakeExec stands in for the exec goroutine: it writes an archive to stdout at
+// the pace a real transfer would, waits for the caller to release the drain
+// guard by closing stdin, and then reports how the remote command finished.
+func fakeExec(t *testing.T, archive []byte, commandErr error) *podFileStream {
+	t.Helper()
+	stdoutR, stdoutW := io.Pipe()
+	stdinR, stdinW := io.Pipe()
+	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		_, writeErr := stdoutW.Write(archive)
+		if writeErr == nil {
+			// The guard: the command stays alive until stdin closes.
+			_, _ = io.Copy(io.Discard, stdinR)
+		}
+		select {
+		case <-ctx.Done():
+			_ = stdoutW.CloseWithError(ctx.Err())
+			done <- ctx.Err()
+		default:
+			_ = stdoutW.CloseWithError(commandErr)
+			done <- commandErr
+		}
+	}()
+
+	tr := tar.NewReader(stdoutR)
+	header, err := tr.Next()
+	if err != nil {
+		t.Fatalf("archive has no entry: %v", err)
+	}
+	return &podFileStream{
+		size: header.Size, payload: tr, stdout: stdoutR, stdin: stdinW,
+		stderr: &bytes.Buffer{}, done: done, cancel: cancel,
+	}
+}
+
+func TestPodFileStreamCloseReleasesTheGuardAndReportsSuccess(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 4096)
+	stream := fakeExec(t, tarArchive(t, "app.log", payload, -1), nil)
+
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if err := closeWithin(t, stream, 5*time.Second); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
+	}
+}
+
+func TestPodFileStreamCloseSurfacesACommandThatFailedLate(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 4096)
+	commandErr := errors.New("command terminated with exit code 1")
+	stream := fakeExec(t, tarArchive(t, "app.log", payload, -1), commandErr)
+
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if err := closeWithin(t, stream, 5*time.Second); !errors.Is(err, commandErr) {
+		t.Errorf("Close() = %v, want the command's own error", err)
+	}
+}
+
+// Abandoning the download must not wait for the rest of the file to come
+// across, and must not leave the exec running.
+func TestPodFileStreamCloseWithoutReadingDoesNotHang(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 1<<20)
+	stream := fakeExec(t, tarArchive(t, "app.log", payload, -1), nil)
+
+	if err := closeWithin(t, stream, 5*time.Second); err == nil {
+		t.Error("an abandoned transfer should not report success")
+	}
+}
+
+func TestPodFileStreamCloseIsIdempotent(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 4096)
+	stream := fakeExec(t, tarArchive(t, "app.log", payload, -1), nil)
+
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	first := closeWithin(t, stream, 5*time.Second)
+	second := closeWithin(t, stream, 5*time.Second)
+	if first != second {
+		t.Errorf("second Close() = %v, want the first result %v", second, first)
+	}
+}
+
+func closeWithin(t *testing.T, stream *podFileStream, limit time.Duration) error {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() { result <- stream.Close() }()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(limit):
+		t.Fatal("Close() did not return")
+		return nil
+	}
+}
+
+func TestPodFileSourceServesCatFallbackBytes(t *testing.T) {
+	content := []byte("no tar in this container")
+	src := &podFileSource{name: "app.conf", size: int64(len(content)), body: bytes.NewReader(content)}
+
+	got, err := io.ReadAll(src)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("read %q, want %q", got, content)
+	}
+	if err := src.Close(); err != nil {
+		t.Errorf("closing a buffered source must not fail: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,7 @@ type Server struct {
 	permCache          *auth.PermissionCache
 	oidcHandler        *auth.OIDCHandler
 	saveFileFunc       func(defaultFilename string, data []byte) (string, error)
+	saveFileStreamFunc func(defaultFilename string, r io.Reader) (string, error)
 	cloudConnectCfg    CloudConnectConfig
 	cloudInstall       *cloudInstallManager
 
@@ -474,6 +475,10 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 		r.Get("/pods/{namespace}/{name}/exec", s.handlePodExec)
 		r.Get("/local-terminal", s.handleLocalTerminal)
 		r.Get("/pods/{namespace}/{name}/files/download", s.handlePodFileDownload)
+		// Desktop-only: streams a pod file to disk server-side. Sits outside the
+		// 60s timeout group for the same reason the download does — a large file
+		// over a slow cluster link legitimately takes longer than that.
+		r.Post("/pods/{namespace}/{name}/files/save", s.handlePodFileSave)
 		r.Get("/workloads/{kind}/{namespace}/{name}/logs/stream", s.handleWorkloadLogsStream)
 		// AI investigation event stream via SSE — long-lived; lives outside the
 		// 60s timeout group. The run keeps going server-side after disconnect.
@@ -1132,6 +1137,16 @@ func (s *Server) SetUpdater(u *updater.Updater) {
 // Only used by the desktop app.
 func (s *Server) SetSaveFileFunc(fn func(defaultFilename string, data []byte) (string, error)) {
 	s.saveFileFunc = fn
+}
+
+// SetSaveFileStreamFunc attaches a native save callback that consumes the file
+// as a stream, enabling the /api/pods/{ns}/{name}/files/save endpoint. It exists
+// so a large file can go from the cluster to disk without a copy of it passing
+// through the webview. The callback should write the stream to the chosen path
+// and return that path, leaving nothing behind if the write fails.
+// Only used by the desktop app.
+func (s *Server) SetSaveFileStreamFunc(fn func(defaultFilename string, r io.Reader) (string, error)) {
+	s.saveFileStreamFunc = fn
 }
 
 // Handler returns the full application handler for the authenticated Cloud

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/skyhook-io/radar/internal/ai"
 	"github.com/skyhook-io/radar/internal/argocd"
@@ -90,8 +91,12 @@ type Server struct {
 	oidcHandler        *auth.OIDCHandler
 	saveFileFunc       func(defaultFilename string, data []byte) (string, error)
 	saveFileStreamFunc func(defaultFilename string, r io.Reader) (string, error)
-	cloudConnectCfg    CloudConnectConfig
-	cloudInstall       *cloudInstallManager
+	// newExecutor builds the exec client for pod file transfers. Nil in
+	// production, where the package default is used; tests substitute a fake so
+	// the transfer can be driven end to end without a cluster.
+	newExecutor     func(*rest.Config, *url.URL) (remotecommand.Executor, error)
+	cloudConnectCfg CloudConnectConfig
+	cloudInstall    *cloudInstallManager
 
 	// nsPreferences holds each user's active-namespace pick from the in-app
 	// switcher. Key shape: "<username>\x00<contextName>" when auth is enabled,

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { createElement, useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, File, Link2, ChevronRight, AlertTriangle, Loader2, Search, Download, FolderOpen } from 'lucide-react'
 import { PaneLoader, Input } from '@skyhook-io/k8s-ui'
@@ -7,6 +7,9 @@ import type { FileNode } from '../../types'
 import { formatBytes } from '../../utils/format'
 import { downloadBlob, filterTree } from './file-browser-utils'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { isDesktopApp } from '../../utils/desktop-download'
+import { openFile, openFolder } from '../../utils/desktop-open-folder'
+import { useToast } from '../ui/Toast'
 import { Tooltip } from '../ui/Tooltip'
 
 interface PodFilesystem {
@@ -33,6 +36,36 @@ async function fetchPodFiles(
     throw new Error(error.error || `HTTP ${response.status}`)
   }
   return response.json()
+}
+
+/**
+ * Desktop only: has the backend write the pod file straight to disk. The browser
+ * route would hand the whole file to the webview only to have it hand every byte
+ * back to be saved, which is what puts a large file out of reach there.
+ * Returns the path it was saved to.
+ */
+async function savePodFileToDisk(
+  namespace: string,
+  podName: string,
+  container: string,
+  filePath: string,
+): Promise<string> {
+  const params = new URLSearchParams()
+  params.set('container', container)
+  params.set('path', filePath)
+
+  const response = await fetch(apiUrl(`/pods/${namespace}/${podName}/files/save?${params.toString()}`), {
+    method: 'POST',
+    credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
+  })
+  if (response.status === 204) throw new Error('cancelled')
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Save failed' }))
+    throw new Error(error.error || `HTTP ${response.status}`)
+  }
+  const body = await response.json()
+  return body.path
 }
 
 interface PodFilesystemModalProps {
@@ -309,6 +342,7 @@ interface PodFileTreeNodeProps {
 
 function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: PodFileTreeNodeProps) {
   const [downloading, setDownloading] = useState(false)
+  const { showSuccess, showError } = useToast()
   const isDir = node.type === 'dir'
   const isSymlink = node.type === 'symlink'
   const isDownloadable = !isDir // files and symlinks can be downloaded
@@ -319,6 +353,21 @@ function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: Po
 
     setDownloading(true)
     try {
+      if (await isDesktopApp()) {
+        const savedPath = await savePodFileToDisk(namespace, podName, container, node.path)
+        showSuccess(
+          'File saved',
+          savedPath,
+          {
+            label: 'Show in Finder',
+            icon: createElement(FolderOpen, { className: 'w-3.5 h-3.5' }),
+            onClick: () => openFolder(savedPath),
+          },
+          () => openFile(savedPath),
+        )
+        return
+      }
+
       const params = new URLSearchParams()
       params.set('container', container)
       params.set('path', node.path)
@@ -335,7 +384,10 @@ function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: Po
       const blob = await response.blob()
       await downloadBlob(blob, node.name)
     } catch (err) {
-      console.error('Download failed:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      if (message !== 'cancelled') {
+        showError(`Could not download ${node.name}`, message)
+      }
     } finally {
       setDownloading(false)
     }


### PR DESCRIPTION
## Problem

Fixes #1511. Downloading a ~250MB file from a pod fails; small files are fine.

```
[copy] Failed to read file from tar <ns>/<pod>: unexpected EOF
"GET /api/pods/<ns>/<pod>/files/download?..." - 500 73B in 32.211367041s
```

## Root cause

When the exec'd `tar` exits, the Kubernetes streaming path tears the stdout stream down and discards whatever the client has not drained yet, **and still reports success**: `StreamWithContext` returns nil, stderr is empty, the exit code is 0. `handlePodFileDownload` buffered the whole archive first, so the loss only surfaced as a short read from `io.ReadAll` and became a 500.

The faster the producer is relative to the consumer, the more of the tail is lost. On a fast local link nothing backs up and every size succeeds, which is why this only appears against a real remote cluster.

Reproduced on kind two independent ways, and the second rules the test harness out:

1. A rate-limited TCP proxy (8 MB/s) in front of the kind apiserver. The 250MB download took 31.9s (the report says 32.2s) and the 64MB one returned the reporter's log line verbatim.
2. No proxy at all, throttling only Radar's own consumption of the exec stdout stream. Truncation every time: `streamErr=<nil>`, empty stderr, ~62-65MB of a declared 67MB.

Discriminating runs, 64MB with the consumer throttled:

| variant | result |
|---|---|
| WebSocket executor (v5) | truncated |
| SPDY executor | truncated |
| stdin attached, nothing else | truncated |
| `sh -c 'tar ...; sleep 5'` | complete |
| unthrottled consumer | complete |

Not a client protocol bug and not Radar's buffering: it is the process-exit teardown. `kubectl exec -- tar cf -` over the same link truncates identically (58-61MB of 67MB), so no client can wait this out.

## Fix

Keep the remote process alive until Radar holds every byte, with a stdin drain guard:

```sh
tar cfh - -C <dir> './<base>'; rc=$?; [ $rc -eq 0 ] && read _; exit $rc
```

Radar closes stdin only after the whole payload has been read. `read` is a shell builtin, so the guard needs no extra binary in the container. It is armed only on success, so a `tar` that failed cannot hang a caller still waiting for an archive.

Measured, 64MB with the consumer throttled to 8 MB/s: 3/3 truncated without the guard, 3/3 complete with it, costing 0.4s.

The payload now streams to the sink instead of being buffered twice (peak memory was ~3x the file size, and nothing reached the client until the transfer finished). `Content-Length` comes from the tar header, and **that is what protects the client**: a body short of a declared length cannot terminate cleanly, so a truncated transfer is a failed download rather than a silently corrupt file. The byte count is also checked explicitly, which is what makes the desktop save refuse to finish, and what carries the `cat` path where there is no archive to notice the loss.

### The `cat` fallback

A container with a shell but no tar returned a **silently truncated file** (verified: 62.3MB of a 64MB file, HTTP 200). It now runs behind the same guard and announces the byte count from `wc -c` first, so the payload is framed and checked the way a tar header frames it.

Two hazards specific to that path, both reproduced before fixing:

- **A file that shrinks mid-transfer used to hang the request forever.** The size and the bytes come from two separate reads, so a file truncated in between leaves the reader waiting for bytes that will never arrive while the guard holds the stream open — on a route that deliberately has no timeout. Truncating a 64MB file 3s into a throttled transfer ran to the client's 45s timeout, answering 200 the whole way. The command now re-measures after `cat` and arms the guard only if the file still holds at least what was announced (`-ge`, not equality: a file that *grew* is fine, and demanding equality would drop the guard on a growing log file, which is the case the guard exists for). Same test after: ends in 7s, client sees a closed-short transfer.
- **`wc -c < /dev/zero` never reaches an end.** A device or fifo hung the request until the client gave up. A path that exists but is not a regular file is now refused before `wc` opens it.

### Errors that pointed at the wrong thing

Five wrong answers, each reproduced on a real container before being fixed. This is the most brittle layer in the change — it reads the wording of messages that differ per shell, per tar, and per runtime.

- **A file you may not read was reported as missing.** A shell says "can't open" for both. Verified with `DAC_OVERRIDE` dropped and a mode-000 file: `404 File not found`, indistinguishable from a file that is genuinely absent. Permission failures are now named.
- **A deleted pod was blamed on the file.** The apiserver says `pods "web-0" not found`; a bare `not found` match turned that into `File not found: /output/app.log`.
- **A working shell was mistaken for a missing one.** bash-as-`/bin/sh` reports a missing file as `/bin/sh: line 1: /x: No such file or directory`, which matched the test for a container with no shell — sending the download to the last-resort fallback and answering 500 instead of 404. Verified on bash-as-`/bin/sh` with no tar, the shape of the RHEL and UBI minimal images. The check now requires the runtime's own framing.
- **A failed command's reason was raced away.** `Close` cancelled the exec before reading the result, discarding both the exit status and stderr and leaving only `context canceled`. Invisible on busybox, which won the race; visible on GNU tar, which lost it.
- **An empty successful stream was filed as a missing file** — which is the failure this whole change exists to catch, disguised as a plausible answer.

### Also

- **Symlinks.** The browser offers Download on symlinks, but `tar cf -` archives a link entry, so the handler found no regular file and always answered 404. `-h` resolves the link.
- **Directories** used to return **200 with an arbitrary file from inside**. Only a regular first entry is accepted.
- **Distroless stays reachable.** Behind `/bin/sh` a missing binary is exit 127, not "executable file not found", and containerd words a missing interpreter its own way. Both count as a missing command, so a distroless container still gets "lacks tar and cat".
- **Paths must be absolute**, so a relative name cannot reach `cat` as an option.
- **A drain grace that expires is reported**, not resolved to silent success.
- **The two transfer routes bypass the compressor** (`compress.go`). These responses are octet-stream so nothing was being compressed, but the middleware takes a pooled encoder before the handler runs and holds it for the whole transfer — minutes, for the files these routes exist to carry.

## Desktop app

The report names the desktop app, and a backend-only fix leaves it broken. `desktopSaveBlob` base64-encodes the blob into a JSON body and `/api/desktop/save-file` caps that body at 100MB — about 74MB of file. Verified against the running app: an 80MB file returns `400 {"error":"invalid request body"}`, which the old UI turned into a console line.

`POST /api/pods/{ns}/{name}/files/save` streams the file from the cluster to `~/Downloads` server-side, so no copy passes through the webview. It runs a command in a pod and writes to the user's disk, so it is behind `localOriginOK` — the check this repo already applies to its other state-changing, process-spawning endpoints.

The name is claimed with `O_CREATE|O_EXCL` rather than tested with `Stat` first, so two saves of the same name cannot pick it together and a symlink planted at the path cannot be written through. Bytes land in a unique partial file and are renamed into place, so an interrupted transfer leaves nothing that looks finished. Windows-reserved characters and device names are folded only on Windows — and by the name before the *first* dot, since `com1.x.y` is still the serial port. This matters here because the file in the report is an ISO-timestamped CSV full of colons.

## Frontend

`handleDownload` caught every failure into `console.error`, so a failed download looked exactly like nothing happening — which is what the reporter saw. Failures now raise a toast, and a desktop save reports the path it landed on with the same "Show in Finder" affordance the existing desktop download hook uses. `downloadBlob` is left generic, since the image file browser shares it.

## Behaviour changes

User-visible, all deliberate:

| | before | after |
|---|---|---|
| Download a directory | 200 with an arbitrary nested file | 400 `Not a regular file` |
| Download a symlink | always 404 | 200, the target's bytes |
| Download a device or fifo | hung, or 200 with wrong content | 400 |
| Relative `path=` parameter | passed to the container | 400 |
| Unreadable file | 404 `File not found` | named as a permission problem |
| Truncated transfer | 200 with a short body | failed download |

New endpoint: `POST /api/pods/{ns}/{name}/files/save`, 404 unless the desktop app has registered a save callback, and same-origin only.

## Verification

kind cluster, throttled to 8 MB/s, every byte result checked by md5 against the file inside the pod. Run against **two base images**, because the error wording differs and one of them was hiding two of the bugs above:

- **alpine** (busybox `sh`, busybox `tar`/`wc`)
- **debian:12-slim** (`dash` as `/bin/sh`, GNU tar 1.34, GNU coreutils 9.1)

plus purpose-built containers for the awkward cases: no tar, no shell at all (distroless), bash as `/bin/sh`, non-root with `DAC_OVERRIDE` dropped.

| case | before | after |
|---|---|---|
| 250MB over tar | 500 `unexpected EOF` | 200, md5 matches, 31.5s |
| 64MB over tar, both images | 500 `unexpected EOF` | 200, md5 matches |
| 64MB without tar, both images | **200 with 62.3MB** | 200, md5 matches |
| file shrinks mid-transfer | **hung to the client's 45s timeout, answering 200** | fails in 7s, client sees a short transfer |
| symlink to a file | 404 | 200, md5 matches |
| directory / symlink to a directory | 200 with a nested file / 404 | 400 `Not a regular file` |
| `/dev/zero`, fifo | **hung until the client gave up** | 400 in 0.2s |
| unreadable file, both paths | 404 `File not found` | names the permission problem |
| missing file on bash-as-`/bin/sh` | 500 | 404 |
| pod does not exist | `File not found: <path>` | names the missing pod |
| file name starting with `-` | 500 `exit code 1` | 200, md5 matches |
| empty file, broken symlink, missing file | 200 / 404 / 404 | unchanged |
| distroless container | "lacks tar and cat" | unchanged |
| desktop save, 250MB | 400 at 80MB | 200, md5 matches |
| two concurrent desktop saves of one name | one clobbers the other | both land whole, distinct names |

Also driven through the real UI in a browser against the same throttled cluster: the 250MB download completes from the file browser modal, and clicking Download on a symlink-to-directory now shows a toast instead of a silent console error.

## Tests, and what they do and do not prove

`internal/server/copy_handler_test.go` drives the real routes and handlers through `httptest`, standing in only for the exec client. That needed a seam: a nil-able `newExecutor` on `Server` with a resolver falling back to today's exact call, plus `k8s.SetTestConfig` beside the existing `SetTestClient` (which publishes a client but not a config, so a handler needing both bails out early). Production behaviour is unchanged; the field is only ever set by a test.

Every case was checked by breaking the line it protects and confirming the test fails — remove the size check and the short-`cat` save test fails; drop `Content-Length` and the truncation test fails; take stdin away and the drain-guard test fails; break the exit-127 detection and the fallback test fails; remove the origin check and the cross-origin test fails.

That check was worth doing: the first version of the flagship test passed against deliberately broken code. Fixing it surfaced two things worth recording — on the tar path the explicit size check is redundant, because `tar.Reader` reports a truncated archive itself (it is load-bearing only on the `cat` path and on the desktop save), and a short body under a full `Content-Length` is already torn by net/http, so the declared length is what protects the client rather than the abort.

`internal/server/copy_test.go` covers command shapes and quoting, the type-guard ordering, error classification, and the stream lifecycle over real `io.Pipe`s. `cmd/desktop/save_file_stream_test.go` covers the save path, collisions, cleanup after a failed transfer, concurrent saves, hostile names, and the Windows folding; its concurrency test was checked against the previous `Stat`-based naming and fails there (2-3 distinct files out of 8).

**CI never executes the shell scripts.** No Go test can. A green run proves the Go wiring, not that a download works — that part is the manual cluster verification above, and it is why the script strings carry the comments they do. Anyone tidying them should re-run it by hand.

`go test ./...` green, `-race` green on `internal/server` and `cmd/desktop`, `make tsc` green, builds for linux/windows/darwin, gofmt clean. (`internal/k8s` has a pre-existing intermittent `-race` panic, present on the base commit and not run by CI.)

## Known limits

- **The browser path still holds the whole file in memory.** `handleDownload` does `await response.blob()`, so the server no longer buffers but the browser still does. Corruption is fixed everywhere; the memory ceiling is only lifted for the desktop app. Worth saying plainly so #1511 is not read as fully solved for every caller.
- No progress or cancel on a long download. Real progress means replacing `fetch` + `blob()` with a native browser download, which conflicts with header-based auth when Radar is embedded in Hub. Its own issue.
- The bare `cat` fallback, for a container with no shell at all, cannot learn a size, so it can neither hold the process open nor detect a short read. Documented in the code as best-effort; only reachable when the framed shell path also reports a missing command.
- The image file browser has the same silent `console.error` and the same desktop size ceiling. Different feature, no exec involved, left alone to keep this change to the reported bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pod exec, file I/O to the user's Downloads folder, and deliberate HTTP/API behavior changes (truncation, directories, symlinks); well-tested but high user impact for file transfers.
> 
> **Overview**
> Fixes large pod file downloads that truncated when Kubernetes tore down exec stdout on process exit while still reporting success.
> 
> **Streaming transfer with a stdin drain guard** keeps the remote `tar`/`cat` shell alive until every byte is read, then streams to the client with **`Content-Length` from the tar header** (or a framed `wc -c` line on the no-tar path). Short reads fail the transfer instead of returning HTTP 200 with a corrupt file; downloads abort the connection when copy stops early.
> 
> **New desktop path:** `POST /api/pods/.../files/save` (same-origin only) streams cluster → disk via `saveFileStream` (partial `.part` files, `O_EXCL` collision naming, Windows-safe filenames). The pod file browser uses this on desktop and shows toasts on failure.
> 
> Also tightens validation and errors (absolute paths only, symlinks via `tar -h`, permission vs missing-file vs missing pod), skips gzip middleware on long file routes, and adds handler/unit tests with injectable exec (`newExecutor`, `k8s.SetTestConfig`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6cf903683eabf9cc56dd26a7de3ce25686fc19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->