### PR TITLE
Show real columns and status for CRDs Radar hasn't curated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ After `make <name>-demo`, run `kubectl config use-context kind-radar-<name>-demo
 
 **You MUST read `internal/server/server.go` before adding or modifying any endpoint** — it is the single source of truth for all routes. CLI flags live in `cmd/explorer/main.go`. Key URL patterns:
 - REST resources: `/api/resources/{kind}`, `/api/resources/{kind}/{ns}/{name}`, `/api/resources/apply` (POST), `/api/resources/preview` (POST, server-dry-run review), `/api/resources/schemas` (POST, connected-cluster OpenAPI schemas)
+  - `/api/resources/{kind}` returns a **bare array**; `?table=1` switches to the printer-column envelope `{items, kind, group, columns, cells}`, returned for every **200** with null `columns`/`cells` when there is no table (errors stay `{"error"}`). Don't combine with `?include=summary` — the strip runs first and mutates in place, so a column reading a stripped subtree resolves to null.
 - SSE streaming: `/api/events/stream`, `/api/traffic/flows/stream`
 - WebSocket: `/api/pods/{ns}/{name}/exec`
 - MCP: `/mcp` (Streamable HTTP — POST for JSON-RPC, GET for SSE)
@@ -269,6 +270,18 @@ Centralized `@layer components` classes in `theme/components.css` (Tailwind util
 - Buttons: `.btn-brand` — not hand-rolled `bg-blue-*`
 - Badges: `<Badge severity="...">` or `<Badge kind="...">` — never hand-write color strings
 - Shadows: `shadow-theme-sm/md/lg` — not raw Tailwind shadows
+
+### Printer columns (uncurated CRDs)
+
+CRDs Radar hasn't curated fill their table from the kind's own
+`spec.versions[].additionalPrinterColumns` — the columns `kubectl get` shows.
+Engine in `internal/server/printer_columns.go`, frontend helpers in
+`packages/k8s-ui/src/components/resources/printer-columns.ts`; both carry the
+detail at the point of use. Three things that are easy to get wrong:
+
+- **Exclusive, never merged.** A kind gets the curated set *or* the printer set, and curated always wins — several curated sets encode why the vendor-obvious field is the wrong one to show. `hasCuratedColumns` is the single definition of curated.
+- **Never hand-roll the JSONPath.** Evaluation goes through `apiextensions-apiserver`'s `tableconvertor`: real CRDs use filter expressions, wildcards and escaped keys, and it also owns first-match semantics and type coercion.
+- **Use the served version, not the storage version.** Printer columns are per-version and the API server converts objects into the version being listed.
 
 ### Resource Renderers
 

--- a/go.mod
+++ b/go.mod
@@ -156,6 +156,8 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.55.0 // indirect

--- a/internal/server/printer_columns.go
+++ b/internal/server/printer_columns.go
@@ -1,0 +1,362 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// printerColumn is one vendor-declared column from a CRD's
+// spec.versions[].additionalPrinterColumns.
+type printerColumn struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Format      string `json:"format,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Priority > 0 is kubectl's `-o wide` tier: declared, but not shown by
+	// default. Forwarded so the client can honour the same distinction.
+	Priority int32 `json:"priority,omitempty"`
+}
+
+// resourceTableResponse is the `?table=1` envelope. Its shape does not vary
+// across the outcomes that answer 200: a preflight RBAC denial, a CRD Radar
+// cannot read, and a kind that simply declares no columns all return the same
+// three fields with Columns/Cells nil, so a consumer never has to switch on the
+// top-level type. Outcomes that answer 4xx/5xx are unchanged — they return
+// {"error": ...} as every other handler does.
+type resourceTableResponse struct {
+	Items any `json:"items"`
+	// The resource these columns describe — the lowercased plural from the
+	// request path, not a Kubernetes Kind. The client changes its selection
+	// before the new list resolves, so without this it could pair the previous
+	// selection's columns with the new one's rows.
+	Kind  string `json:"kind,omitempty"`
+	Group string `json:"group,omitempty"`
+	// Nil when this kind has no usable printer columns, for any reason.
+	Columns []printerColumn `json:"columns"`
+	// metadata.uid -> one value per entry in Columns, same order. Nil whenever
+	// Columns is nil. A column that does not resolve for a given object yields
+	// a null in that slot rather than being omitted.
+	Cells map[string][]any `json:"cells"`
+}
+
+// minSubstantivePrinterColumns is the eligibility gate. Radar already renders
+// Name, Namespace and Age, so a CRD declaring only those (or one lone column
+// beside them) would replace the generic Status column with less than it took
+// away. Such kinds keep the generic columns instead.
+const minSubstantivePrinterColumns = 2
+
+// redundantPrinterColumns are columns Radar renders itself. Most CRDs declare
+// Age, so without this the table would carry it twice.
+var redundantPrinterColumns = map[string]bool{"name": true, "namespace": true, "age": true}
+
+// buildResourceTable resolves the printer columns for a CRD kind and evaluates
+// them over items. Returns nil columns (never an error) whenever the kind has
+// no usable table: the caller renders its generic columns and the user sees a
+// working list either way.
+func buildResourceTable(ctx context.Context, listCache *k8s.ResourceCache, kind, group string, items []*unstructured.Unstructured) ([]printerColumn, map[string][]any) {
+	if group == "" {
+		return nil, nil
+	}
+	// The rows were read from listCache; the columns are resolved from whatever
+	// the globals point at now. A context switch in between would pair one
+	// cluster's objects with another cluster's column definitions, which the
+	// kind/group identity cannot detect — both clusters call it the same kind.
+	// Same identity check finalizePostContextSwitch's consumers use elsewhere.
+	if listCache != nil && listCache != k8s.GetResourceCache() {
+		return nil, nil
+	}
+	discovery := k8s.GetResourceDiscovery()
+	if discovery == nil {
+		return nil, nil
+	}
+	gvr, ok := discovery.GetGVRWithGroup(kind, group)
+	if !ok || gvr.Resource == "" {
+		return nil, nil
+	}
+
+	crd := crdForResource(ctx, gvr)
+	if crd == nil {
+		return nil, nil
+	}
+	// Re-checked after the lookup, not only before it: the entry check leaves
+	// discovery and the CRD read inside the window, so a switch starting right
+	// after it would still pair cluster B's definitions with cluster A's rows.
+	if listCache != nil && listCache != k8s.GetResourceCache() {
+		return nil, nil
+	}
+
+	return tableFromCRD(ctx, crd, gvr.Version, items)
+}
+
+var crdGVR = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+
+// crdForResource returns the CRD that defines gvr, preferring the informer.
+//
+// GetDynamicWithGroup deliberately routes CRDs to a live GET so the YAML tab
+// and MCP get_resource see spec.versions[].schema and spec.conversion, which
+// the cache strips. Printer columns need neither — and transform.go preserves
+// additionalPrinterColumns in the cache precisely so they can be read from it.
+// Going through the direct path added a full apiserver round-trip (~150ms) to
+// every table-mode list, repeated on each SSE-driven refetch.
+//
+// The dynamic cache starts a CRD informer if one isn't already up and can
+// block briefly waiting for it to sync; CRDs are in its preload set, so in
+// practice it is warm. The direct path remains as the fallback for when that
+// read fails, so a restricted cache still resolves columns rather than
+// silently dropping them.
+//
+// A failure here stays silent either way: reading CRDs is a separate grant
+// from reading the custom resources themselves. The converse is deliberate
+// too — a caller who can list the CRs sees the column definitions even
+// without that grant, since those describe objects they can already read.
+func crdForResource(ctx context.Context, gvr schema.GroupVersionResource) *unstructured.Unstructured {
+	name := gvr.Resource + "." + gvr.Group
+	if dyn := k8s.GetDynamicResourceCache(); dyn != nil {
+		if crd, err := dyn.Get(crdGVR, "", name); err == nil && crd != nil {
+			return crd
+		}
+	}
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+	crd, err := cache.GetDynamicWithGroup(ctx, "CustomResourceDefinition", "", name, "apiextensions.k8s.io")
+	if err != nil {
+		return nil
+	}
+	return crd
+}
+
+// convertorForDefs compiles the table convertor for a version's declared
+// columns, or nil when the kind has no usable ones.
+//
+// Not cached: the compiled jsonpath.JSONPath objects carry mutable walk state
+// (beginRange/inRange/lastEndNode), so a shared convertor races across
+// concurrent list requests. Compiling costs noise next to evaluating the paths
+// over every row.
+func convertorForDefs(defs []apiextensionsv1.CustomResourceColumnDefinition) rest.TableConvertor {
+	if len(defs) == 0 {
+		return nil
+	}
+	convertor, err := tableconvertor.New(defs)
+	if err != nil {
+		// New returns a usable default convertor alongside the error, but that
+		// default carries only the synthetic Name column — nothing worth
+		// replacing the generic columns with.
+		return nil
+	}
+	return convertor
+}
+
+// tableFromCRD is the whole derivation with the cluster lookups already done,
+// so it can be exercised without a cache or discovery.
+func tableFromCRD(ctx context.Context, crd *unstructured.Unstructured, version string, items []*unstructured.Unstructured) ([]printerColumn, map[string][]any) {
+	defs := printerColumnDefsForVersion(crd, version)
+	convertor := convertorForDefs(defs)
+	if convertor == nil {
+		return nil, nil
+	}
+
+	list := &unstructured.UnstructuredList{}
+	for _, item := range items {
+		if item != nil {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	table, err := convertor.ConvertToTable(ctx, list, &metav1.TableOptions{})
+	if err != nil || table == nil {
+		return nil, nil
+	}
+
+	// ConvertToTable prepends a synthetic Name column that Radar already
+	// renders; drop it and the vendor's own duplicates alongside it. keptIdx
+	// maps a surviving column back to its cell offset in every row.
+	columns := make([]printerColumn, 0, len(table.ColumnDefinitions))
+	keptIdx := make([]int, 0, len(table.ColumnDefinitions))
+	for i, def := range table.ColumnDefinitions {
+		if i == 0 || redundantPrinterColumns[strings.ToLower(strings.TrimSpace(def.Name))] {
+			continue
+		}
+		columns = append(columns, printerColumn{
+			Name: def.Name, Type: def.Type, Format: def.Format,
+			Description: vendorDescription(defs, i), Priority: def.Priority,
+		})
+		keptIdx = append(keptIdx, i)
+	}
+	if countSubstantive(columns) < minSubstantivePrinterColumns {
+		return nil, nil
+	}
+
+	// Rows come back in list order from meta.EachListItem, so index alignment
+	// with list.Items holds. Keyed by uid regardless, because the client joins
+	// against a separately-rendered row set.
+	cells := make(map[string][]any, len(table.Rows))
+	for i, row := range table.Rows {
+		if i >= len(list.Items) {
+			break
+		}
+		uid := string(list.Items[i].GetUID())
+		if uid == "" {
+			continue
+		}
+		values := make([]any, len(keptIdx))
+		for j, idx := range keptIdx {
+			if idx < len(row.Cells) {
+				values[j] = row.Cells[idx]
+			}
+		}
+		cells[uid] = values
+	}
+	return columns, cells
+}
+
+// vendorDescription returns the description the CRD itself declared for the
+// column at table-header index i, or "" when it declared none.
+//
+// The convertor's headers can't supply this: for a column with no description
+// it substitutes "Custom resource definition column (in JSONPath format): <the
+// path>", which is machinery, not something to show an operator — and most
+// CRDs omit the field. Header 0 is the convertor's own synthetic Name column
+// and every later header comes from one def in order, so header i is defs[i-1].
+func vendorDescription(defs []apiextensionsv1.CustomResourceColumnDefinition, i int) string {
+	if i-1 < 0 || i-1 >= len(defs) {
+		return ""
+	}
+	return defs[i-1].Description
+}
+
+// countSubstantive counts the columns a reader would actually gain. Columns in
+// kubectl's `-o wide` tier don't count toward the gate: a kind whose only
+// columns are hidden by default has nothing to show.
+func countSubstantive(columns []printerColumn) int {
+	// Mirrors the client exactly, in its order: it deduplicates by trimmed name
+	// first-wins across ALL priorities, drops blanks, and only then hides the
+	// `-o wide` tier. Counting per-priority instead let a wide-tier duplicate
+	// shadow a substantive one — `Phase`(wide), `Phase`, `Ready` counted two
+	// here and rendered one on screen, which is exactly what the gate exists
+	// to prevent. CRD validation requires neither unique nor trimmed names.
+	seen := make(map[string]bool, len(columns))
+	n := 0
+	for _, c := range columns {
+		name := strings.TrimSpace(c.Name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		if c.Priority == 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// printerColumnDefsForVersion returns the columns declared by the exact version
+// being listed. Printer columns are per-version and the API server converts
+// objects into the requested version, so the storage version's JSONPaths can
+// address a schema these objects do not have.
+func printerColumnDefsForVersion(crd *unstructured.Unstructured, version string) []apiextensionsv1.CustomResourceColumnDefinition {
+	versions, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if !found || err != nil {
+		return nil
+	}
+	for _, v := range versions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := vm["name"].(string); name != version {
+			continue
+		}
+		raw, ok := vm["additionalPrinterColumns"]
+		if !ok {
+			return nil
+		}
+		encoded, err := json.Marshal(raw)
+		if err != nil {
+			return nil
+		}
+		var defs []apiextensionsv1.CustomResourceColumnDefinition
+		if err := json.Unmarshal(encoded, &defs); err != nil {
+			return nil
+		}
+		return defs
+	}
+	return nil
+}
+
+// parseTableMode reports whether the caller asked for the printer-column
+// envelope. Unknown values are rejected rather than silently ignored, matching
+// parseResourcesInclude's posture.
+func parseTableMode(v string) (bool, error) {
+	switch v {
+	case "":
+		return false, nil
+	case "1", "true":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown table=%q (want: 1, true)", v)
+	}
+}
+
+// coerceUnstructured collects the unstructured objects out of a list result.
+// The dynamic path returns []*unstructured.Unstructured for a single namespace
+// but []any once listPerNs merges across several, so both shapes reach here.
+func coerceUnstructured(result any) []*unstructured.Unstructured {
+	switch typed := result.(type) {
+	case []*unstructured.Unstructured:
+		return typed
+	case []any:
+		items := make([]*unstructured.Unstructured, 0, len(typed))
+		for _, entry := range typed {
+			if u, ok := entry.(*unstructured.Unstructured); ok {
+				items = append(items, u)
+			}
+		}
+		return items
+	default:
+		return nil
+	}
+}
+
+// writeEmptyResourceTable answers a request that resolved to nothing for a
+// reason that must not leak schema — today, an RBAC denial. Same envelope, no
+// table, so the shape still doesn't vary with the caller's permissions.
+func (s *Server) writeEmptyResourceTable(w http.ResponseWriter, tableMode bool, kind, group string) {
+	if !tableMode {
+		s.writeJSON(w, []any{})
+		return
+	}
+	s.writeJSON(w, resourceTableResponse{Items: []any{}, Kind: kind, Group: group})
+}
+
+// writeResourceList writes a list response in whichever representation the
+// caller asked for. In table mode the envelope is written for every outcome —
+// including the ones that produce no columns — so the response shape never
+// depends on the caller's permissions or on whether the kind is a CRD.
+func (s *Server) writeResourceList(w http.ResponseWriter, r *http.Request, listCache *k8s.ResourceCache, tableMode bool, kind, group string, result any) {
+	if !tableMode {
+		s.writeJSON(w, result)
+		return
+	}
+	// Items sits a level down from writeJSON's own nil-slice check, so it has to
+	// be normalized here or an empty list serializes as `null` in table mode
+	// while the bare-array path returns `[]` for the same request.
+	resp := resourceTableResponse{Items: normalizeNilSlice(result), Kind: kind, Group: group}
+	// Resolved even for an empty list: the columns belong to the CRD, not to
+	// the rows, so an eligible kind keeps its headers when it holds nothing —
+	// and the set doesn't flip as the last object comes and goes.
+	resp.Columns, resp.Cells = buildResourceTable(r.Context(), listCache, kind, group, coerceUnstructured(result))
+	s.writeJSON(w, resp)
+}

--- a/internal/server/printer_columns_test.go
+++ b/internal/server/printer_columns_test.go
@@ -1,0 +1,442 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func crdWith(version string, cols []map[string]any) *unstructured.Unstructured {
+	entry := map[string]any{"name": version, "served": true, "storage": true}
+	if cols != nil {
+		raw := make([]any, 0, len(cols))
+		for _, c := range cols {
+			raw = append(raw, c)
+		}
+		entry["additionalPrinterColumns"] = raw
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": "widgets.example.com"},
+		"spec":       map[string]any{"versions": []any{entry}},
+	}}
+}
+
+func pcObj(uid string, content map[string]any) *unstructured.Unstructured {
+	o := map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w-" + uid, "uid": uid},
+	}
+	for k, v := range content {
+		o[k] = v
+	}
+	return &unstructured.Unstructured{Object: o}
+}
+
+func pcCol(name, jsonPath, colType string, priority int64) map[string]any {
+	c := map[string]any{"name": name, "jsonPath": jsonPath, "type": colType}
+	if priority != 0 {
+		c["priority"] = priority
+	}
+	return c
+}
+
+func TestTableFromCRD_EvaluatesAndTypesCells(t *testing.T) {
+	crd := crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol("Replicas", ".status.replicas", "integer", 0),
+		pcCol("Ready", ".status.ready", "boolean", 0),
+	})
+	items := []*unstructured.Unstructured{
+		pcObj("a", map[string]any{"status": map[string]any{"phase": "Running", "replicas": int64(3), "ready": true}}),
+		pcObj("b", map[string]any{"status": map[string]any{"phase": "Pending"}}),
+	}
+
+	columns, cells := tableFromCRD(context.Background(), crd, "v1", items)
+	if len(columns) != 3 {
+		t.Fatalf("want 3 columns, got %d (%+v)", len(columns), columns)
+	}
+	if columns[0].Name != "Phase" || columns[1].Type != "integer" {
+		t.Errorf("column metadata not forwarded: %+v", columns)
+	}
+	if got := cells["a"]; len(got) != 3 || got[0] != "Running" || got[1] != int64(3) || got[2] != true {
+		t.Errorf("row a: values must keep their declared types, got %#v", got)
+	}
+	// A path that resolves for one object and not another must leave a hole,
+	// not shift the remaining values into the wrong columns.
+	if got := cells["b"]; len(got) != 3 || got[0] != "Pending" || got[1] != nil || got[2] != nil {
+		t.Errorf("row b: unresolved paths must be nil in place, got %#v", got)
+	}
+}
+
+func TestTableFromCRD_DropsColumnsRadarAlreadyRenders(t *testing.T) {
+	crd := crdWith("v1", []map[string]any{
+		pcCol("Age", ".metadata.creationTimestamp", "date", 0),
+		pcCol("Namespace", ".metadata.namespace", "string", 0),
+		pcCol("Host", ".spec.host", "string", 0),
+		pcCol("Port", ".spec.port", "integer", 0),
+	})
+	items := []*unstructured.Unstructured{pcObj("a", map[string]any{"spec": map[string]any{"host": "h", "port": int64(80)}})}
+
+	columns, cells := tableFromCRD(context.Background(), crd, "v1", items)
+	if len(columns) != 2 || columns[0].Name != "Host" || columns[1].Name != "Port" {
+		t.Fatalf("Age/Namespace must be dropped, got %+v", columns)
+	}
+	if got := cells["a"]; len(got) != 2 || got[0] != "h" || got[1] != int64(80) {
+		t.Errorf("cells must realign to the kept columns, got %#v", got)
+	}
+}
+
+func TestTableFromCRD_EligibilityGate(t *testing.T) {
+	tests := []struct {
+		name string
+		cols []map[string]any
+		want bool
+	}{
+		// The regression this gate exists to stop: exclusive mode would replace
+		// the generic Status column with a table narrower than it took away.
+		{"only Age", []map[string]any{pcCol("Age", ".metadata.creationTimestamp", "date", 0)}, false},
+		{"one substantive column", []map[string]any{
+			pcCol("Age", ".metadata.creationTimestamp", "date", 0),
+			pcCol("Status", ".status.phase", "string", 0),
+		}, false},
+		{"two substantive columns", []map[string]any{
+			pcCol("Status", ".status.phase", "string", 0),
+			pcCol("Host", ".spec.host", "string", 0),
+		}, true},
+		// Columns kubectl hides behind -o wide cannot carry the gate on their own.
+		{"substantive only at wide priority", []map[string]any{
+			pcCol("Status", ".status.phase", "string", 0),
+			pcCol("UID", ".metadata.uid", "string", 1),
+			pcCol("Hash", ".metadata.labels.hash", "string", 1),
+		}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			columns, _ := tableFromCRD(context.Background(), crdWith("v1", tc.cols), "v1",
+				[]*unstructured.Unstructured{pcObj("a", nil)})
+			if got := columns != nil; got != tc.want {
+				t.Errorf("eligible = %v, want %v (columns %+v)", got, tc.want, columns)
+			}
+		})
+	}
+}
+
+func TestTableFromCRD_WideColumnsAreForwardedNotDropped(t *testing.T) {
+	// The gate ignores them; the response still carries them so the client can
+	// offer them in the column picker the way `kubectl -o wide` does.
+	columns, _ := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Status", ".status.phase", "string", 0),
+		pcCol("Host", ".spec.host", "string", 0),
+		pcCol("UID", ".metadata.uid", "string", 1),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+
+	if len(columns) != 3 || columns[2].Name != "UID" || columns[2].Priority != 1 {
+		t.Fatalf("wide-tier column must survive with its priority, got %+v", columns)
+	}
+}
+
+func TestPrinterColumnDefsForVersion_MatchesTheServedVersion(t *testing.T) {
+	// Printer columns are per-version and the API server converts objects into
+	// the requested version, so reading another version's paths would address a
+	// schema these objects do not have.
+	crd := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"versions": []any{
+		map[string]any{"name": "v1alpha1", "additionalPrinterColumns": []any{pcCol("Old", ".status.old", "string", 0)}},
+		map[string]any{"name": "v1", "storage": true, "additionalPrinterColumns": []any{pcCol("New", ".status.new", "string", 0)}},
+	}}}}
+
+	if defs := printerColumnDefsForVersion(crd, "v1"); len(defs) != 1 || defs[0].Name != "New" {
+		t.Errorf("v1 must resolve its own columns, got %+v", defs)
+	}
+	if defs := printerColumnDefsForVersion(crd, "v1alpha1"); len(defs) != 1 || defs[0].Name != "Old" {
+		t.Errorf("v1alpha1 must resolve its own columns, got %+v", defs)
+	}
+	if defs := printerColumnDefsForVersion(crd, "v2"); defs != nil {
+		t.Errorf("an absent version must resolve nothing, got %+v", defs)
+	}
+}
+
+func TestPrinterColumnDefsForVersion_Malformed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		crd  *unstructured.Unstructured
+	}{
+		{"no versions", &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}},
+		{"no columns", crdWith("v1", nil)},
+		{"columns of the wrong shape", &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"versions": []any{
+			map[string]any{"name": "v1", "additionalPrinterColumns": "not-a-list"},
+		}}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if defs := printerColumnDefsForVersion(tc.crd, "v1"); defs != nil {
+				t.Errorf("want nil, got %+v", defs)
+			}
+		})
+	}
+}
+
+func TestTableFromCRD_UnparseableJSONPathYieldsNoTable(t *testing.T) {
+	// A single bad path makes tableconvertor.New return a Name-only convertor,
+	// which is not worth replacing the generic columns with.
+	columns, cells := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Good", ".status.phase", "string", 0),
+		pcCol("Bad", ".status[", "string", 0),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+	if columns != nil || cells != nil {
+		t.Errorf("want no table, got columns %+v cells %+v", columns, cells)
+	}
+}
+
+func TestTableFromCRD_SkipsObjectsWithoutUID(t *testing.T) {
+	// Cells are keyed by uid because the client joins them against a separately
+	// rendered row set; an object with no uid has nothing to join on.
+	noUID := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "anon"},
+		"status":   map[string]any{"phase": "Running", "host": "h"},
+	}}
+	_, cells := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol("Host", ".status.host", "string", 0),
+	}), "v1", []*unstructured.Unstructured{noUID, pcObj("a", map[string]any{"status": map[string]any{"phase": "P", "host": "x"}})})
+
+	if len(cells) != 1 {
+		t.Fatalf("want only the identifiable object, got %#v", cells)
+	}
+	if got := cells["a"]; len(got) != 2 || got[0] != "P" {
+		t.Errorf("the surviving row must keep its own values, got %#v", got)
+	}
+}
+
+func TestParseTableMode(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    bool
+		wantErr bool
+	}{
+		{"", false, false},
+		{"1", true, false},
+		{"true", true, false},
+		{"0", false, true},
+		{"yes", false, true},
+	} {
+		got, err := parseTableMode(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("parseTableMode(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("parseTableMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCoerceUnstructured(t *testing.T) {
+	a, b := pcObj("a", nil), pcObj("b", nil)
+	// Single-namespace lists arrive typed; listPerNs merges arrive as []any.
+	if got := coerceUnstructured([]*unstructured.Unstructured{a, b}); len(got) != 2 {
+		t.Errorf("typed slice: want 2, got %d", len(got))
+	}
+	if got := coerceUnstructured([]any{a, b}); len(got) != 2 {
+		t.Errorf("merged slice: want 2, got %d", len(got))
+	}
+	if got := coerceUnstructured([]any{a, "junk", nil, b}); len(got) != 2 {
+		t.Errorf("mixed slice must keep only unstructured entries, got %d", len(got))
+	}
+	if got := coerceUnstructured("not a list"); got != nil {
+		t.Errorf("want nil for a non-list, got %#v", got)
+	}
+}
+
+func TestTableFromCRD_EmptyListStillResolvesColumns(t *testing.T) {
+	// Columns belong to the CRD, not to the rows. An eligible kind holding
+	// nothing must still show its headers, and the set must not appear and
+	// disappear as the last object is created and deleted.
+	columns, cells := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Status", ".status.phase", "string", 0),
+		pcCol("Host", ".spec.host", "string", 0),
+	}), "v1", nil)
+
+	if len(columns) != 2 {
+		t.Fatalf("want 2 columns for an empty list, got %+v", columns)
+	}
+	if len(cells) != 0 {
+		t.Errorf("want no cells for an empty list, got %#v", cells)
+	}
+}
+
+func TestNormalizeNilSlice(t *testing.T) {
+	// A nil slice serializes as `null`. In table mode the items slice sits
+	// inside the envelope, below the depth writeJSON's own check reaches, so an
+	// empty list came back as `null` there while the bare-array path for the
+	// same request returned `[]`.
+	var typedNil []*unstructured.Unstructured
+	for _, tc := range []struct {
+		name string
+		in   any
+	}{
+		{"untyped nil", nil},
+		{"typed nil slice", typedNil},
+		{"nil any slice", []any(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(normalizeNilSlice(tc.in))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(encoded) != "[]" {
+				t.Errorf("got %s, want []", encoded)
+			}
+		})
+	}
+
+	// A populated slice must pass through untouched.
+	items := []*unstructured.Unstructured{pcObj("a", nil)}
+	if got := normalizeNilSlice(items); got == nil {
+		t.Error("a populated slice must survive normalization")
+	}
+}
+
+func TestWriteEmptyResourceTable_DeniedRequestCarriesNoSchema(t *testing.T) {
+	// An RBAC denial and an authorized-but-empty list both produce zero items,
+	// but only the second may carry columns: resolving them reads the CRD as
+	// Radar's own identity, so answering a denial with them would hand schema
+	// to a caller who cannot list the kind. The envelope shape stays identical
+	// either way.
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.writeEmptyResourceTable(rec, true, "widgets", "example.com")
+
+	var got resourceTableResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Columns != nil || got.Cells != nil {
+		t.Errorf("a denial must carry no table, got columns %+v cells %+v", got.Columns, got.Cells)
+	}
+	if got.Kind != "widgets" || got.Group != "example.com" {
+		t.Errorf("identity must still be echoed, got %q/%q", got.Kind, got.Group)
+	}
+	// items must be [] and not null, same as every other table-mode response.
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"items":[]`)) {
+		t.Errorf("items must serialize as [], got %s", rec.Body.String())
+	}
+}
+
+func TestWriteEmptyResourceTable_BareArrayWhenNotTableMode(t *testing.T) {
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.writeEmptyResourceTable(rec, false, "widgets", "example.com")
+	if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
+		t.Errorf("want a bare array without table mode, got %s", body)
+	}
+}
+
+func TestCRDGVRAddressesV1(t *testing.T) {
+	// crdForResource looks the CRD up by this GVR against the informer rather
+	// than through GetDynamicWithGroup, which routes CRDs to a live GET for the
+	// YAML tab's benefit. A wrong version here would miss the informer on every
+	// request and silently fall back to that ~150ms round-trip.
+	if crdGVR.Group != "apiextensions.k8s.io" || crdGVR.Version != "v1" || crdGVR.Resource != "customresourcedefinitions" {
+		t.Errorf("crdGVR must match the registered dynamic cache entry, got %v", crdGVR)
+	}
+}
+
+func TestTableFromCRD_GateIgnoresBlankNames(t *testing.T) {
+	// The client drops a blank name outright, so counting one here lets a kind
+	// through a gate it does not actually clear: " " plus "Phase" would be two
+	// columns to the server and one on screen.
+	columns, _ := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol("   ", ".status.other", "string", 0),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+	if columns != nil {
+		t.Errorf("a blank name must not satisfy the gate, got %+v", columns)
+	}
+}
+
+func TestTableFromCRD_GateCountsNamesTheClientWillMerge(t *testing.T) {
+	// The client trims before deduplicating, so untrimmed variants of one name
+	// would pass a two-column gate here and then collapse into a single column
+	// there — replacing the generic Status with less than the gate promised.
+	// Kubernetes requires a non-empty column name, not a trimmed one.
+	columns, _ := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol(" Phase ", ".status.phase", "string", 0),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+	if columns != nil {
+		t.Errorf("padded duplicates must not satisfy the gate, got %+v", columns)
+	}
+}
+
+func TestBuildResourceTable_RejectsACacheThatChangedUnderIt(t *testing.T) {
+	// The rows come from the cache the handler captured; the columns are
+	// resolved from the globals afterwards. If a context switch replaced the
+	// cache in between, the two belong to different clusters — and kind/group
+	// identity cannot tell, because both clusters call it the same kind.
+	stale := &k8s.ResourceCache{}
+	columns, cells := buildResourceTable(context.Background(), stale, "widgets", "example.com", nil)
+	if columns != nil || cells != nil {
+		t.Errorf("a stale list cache must produce no table, got columns %+v cells %+v", columns, cells)
+	}
+}
+
+func TestTableFromCRD_GateHonoursFirstWinsDedupeAcrossPriorities(t *testing.T) {
+	// The client deduplicates by name first-wins across all priorities, then
+	// hides the wide tier. A wide-tier name appearing before its substantive
+	// twin therefore shadows it on screen, and counting per-priority missed
+	// that: two columns to the gate, one rendered.
+	columns, _ := tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 1),
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol("Ready", ".status.ready", "string", 0),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+	if columns != nil {
+		t.Errorf("a shadowed duplicate must not satisfy the gate, got %+v", columns)
+	}
+
+	// The same three names without the shadowing still clear it.
+	columns, _ = tableFromCRD(context.Background(), crdWith("v1", []map[string]any{
+		pcCol("Phase", ".status.phase", "string", 0),
+		pcCol("Ready", ".status.ready", "string", 0),
+	}), "v1", []*unstructured.Unstructured{pcObj("a", nil)})
+	if len(columns) != 2 {
+		t.Errorf("two distinct substantive columns must clear the gate, got %+v", columns)
+	}
+}
+
+func TestTableFromCRD_DescriptionComesFromTheCRDNotTheConvertor(t *testing.T) {
+	// tableconvertor substitutes "Custom resource definition column (in JSONPath
+	// format): <path>" for a column the CRD gave no description. Most CRDs give
+	// none, so forwarding the convertor's headers would put the raw JSONPath in
+	// a user-facing tooltip on nearly every uncurated kind.
+	described := pcCol("Phase", ".status.phase", "string", 0)
+	described["description"] = "Current lifecycle phase"
+	crd := crdWith("v1", []map[string]any{
+		described,
+		pcCol("Replicas", ".status.replicas", "integer", 0),
+	})
+
+	columns, _ := tableFromCRD(context.Background(), crd, "v1", nil)
+	if len(columns) != 2 {
+		t.Fatalf("want 2 columns, got %d (%+v)", len(columns), columns)
+	}
+	if columns[0].Description != "Current lifecycle phase" {
+		t.Errorf("a declared description must survive, got %q", columns[0].Description)
+	}
+	if columns[1].Description != "" {
+		t.Errorf("an undeclared description must stay empty, got %q", columns[1].Description)
+	}
+	for _, c := range columns {
+		if strings.Contains(c.Description, "JSONPath format") {
+			t.Errorf("column %q leaked the convertor's synthetic description: %q", c.Name, c.Description)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1963,6 +1963,13 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// table=1 switches to the printer-column envelope. See resourceTableResponse
+	// for why that envelope is written even when there are no columns to report.
+	tableMode, err := parseTableMode(r.URL.Query().Get("table"))
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// parseNamespacesForUser primes the per-user perm cache (triggers
 	// DiscoverNamespaces if needed). canRead below relies on it.
@@ -1973,7 +1980,11 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	// returns the explicit status.
 	finalNamespaces, _, _, ok := s.preflightResourceList(r, kind, group, namespaces)
 	if !ok {
-		s.writeJSON(w, []any{})
+		// Denied, not empty. writeResourceList resolves columns for an empty
+		// list, and that lookup runs as Radar's own identity — so routing a
+		// denial through it would answer a caller who cannot list the kind with
+		// its column metadata. Emit the envelope without a table.
+		s.writeEmptyResourceTable(w, tableMode, kind, group)
 		return
 	}
 	namespaces = finalNamespaces
@@ -2072,7 +2083,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		if includeSummary {
 			result = applySummaryStrip(result)
 		}
-		s.writeJSON(w, result)
+		s.writeResourceList(w, r, cache, tableMode, kind, group, result)
 		return
 	}
 
@@ -2377,7 +2388,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		result = summarizeTypedList(kind, result)
 		result = applySummaryStrip(result)
 	}
-	s.writeJSON(w, result)
+	s.writeResourceList(w, r, cache, tableMode, kind, group, result)
 }
 
 // normalizeKind converts K8s kind names to lowercase for case-insensitive matching
@@ -4589,13 +4600,20 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 
 // Helper methods
 
+// normalizeNilSlice turns a nil slice into an empty one. Nil slices serialize
+// as "null", which breaks callers that expect an array. Shared with the
+// printer-column envelope, where the slice is nested a level down and so never
+// reaches writeJSON's own top-level check.
+func normalizeNilSlice(data any) any {
+	if data == nil || (reflect.TypeOf(data) != nil && reflect.TypeOf(data).Kind() == reflect.Slice && reflect.ValueOf(data).IsNil()) {
+		return []any{}
+	}
+	return data
+}
+
 func (s *Server) writeJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
-	// Nil slices serialize as "null" in JSON — normalize to empty array "[]"
-	// to avoid frontend errors when the response is expected to be an array.
-	if data == nil || (reflect.TypeOf(data) != nil && reflect.TypeOf(data).Kind() == reflect.Slice && reflect.ValueOf(data).IsNil()) {
-		data = []any{}
-	}
+	data = normalizeNilSlice(data)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		// Can't change HTTP status at this point, but log for debugging
 		log.Printf("Failed to encode JSON response: %v", err)

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -137,7 +137,13 @@ import {
   parseColumnFilterExcludes,
   podMatchesProblemCategory,
   SEVERITY_DOT_COLOR,
+  healthColors,
 } from './resource-utils'
+import { getGenericResourceStatus } from './generic-status'
+import {
+  type PrinterColumnDef, type PrinterTable, PRINTER_COLUMN_PREFIX, formatPrinterCell, printerCellSortValue,
+  printerCellTone, printerColumnKey, printerColumnWidth, printerTableKey, printerTableMatchesKind, readPrinterCell,
+} from './printer-columns'
 import { SEVERITY_BADGE, EVENT_TYPE_COLORS } from '../../utils/badge-colors'
 import { pluralize } from '../../utils/pluralize'
 import { getPodGpuCount, getNodeGpuCount } from '../../utils/extended-resources'
@@ -2245,9 +2251,128 @@ function getColumnsForKind(kind: string, group?: string): Column[] {
   return DEFAULT_COLUMNS
 }
 
+/**
+ * Whether Radar hand-curates this kind's columns. The single definition of
+ * "curated": the printer-column XOR, the storage-key qualifier, and the host's
+ * decision whether to request table mode at all must all agree, or the server
+ * does work the client throws away — or worse, they disagree about which set a
+ * kind is on.
+ */
+export function hasCuratedColumns(kind: string, group?: string): boolean {
+  return getColumnsForKind(kind, group) !== DEFAULT_COLUMNS
+}
+
 // Get the default visible columns for a kind
 function getDefaultVisibleColumns(columns: Column[]): Set<string> {
   return new Set(columns.filter(c => c.defaultVisible !== false).map(c => c.key))
+}
+
+// Materializes one vendor-declared printer column into a self-contained
+// ExtraColumn, so it rides the same render/sort/filter rails as a user's custom
+// column. Values were evaluated server-side and arrive keyed by uid.
+function buildPrinterColumn(def: PrinterColumnDef, index: number, table: PrinterTable): ExtraColumn {
+  const read = (resource: any) => readPrinterCell(table, resource?.metadata?.uid, index)
+  return {
+    key: printerColumnKey(def),
+    label: def.name,
+    width: printerColumnWidth(def),
+    // Columns in kubectl's `-o wide` tier are declared but not shown by
+    // default; the column picker still offers them.
+    defaultVisible: (def.priority ?? 0) === 0,
+    tooltip: def.description || undefined,
+    render: (resource: any) => {
+      const value = read(resource)
+      // `date` cells arrive already humanized ("5m") — the API server's table
+      // converter does that, so re-formatting here would parse "5m" as a date.
+      const text = formatPrinterCell(value)
+      if (!text) return <span className="text-sm text-theme-text-tertiary">-</span>
+      // A column the vendor named Ready/Healthy/Established carries the only
+      // scannable signal these kinds have — they have no curated Status column.
+      // Rendering it as grey text would leave a screen of uniform "True".
+      const tone = printerCellTone(def, value)
+      if (tone) {
+        return (
+          // The value, not the column's description — the header tooltip
+          // carries that. A cell tooltip exists to reveal a truncated value.
+          <Tooltip content={text}>
+            <span className={clsx('badge', healthColors[tone])}>{text}</span>
+          </Tooltip>
+        )
+      }
+      return (
+        <Tooltip content={text}>
+          <span className="text-sm text-theme-text-secondary truncate block">{text}</span>
+        </Tooltip>
+      )
+    },
+    getSortValue: (resource: any) => printerCellSortValue(read(resource), def),
+    getFilterValue: (resource: any) => formatPrinterCell(read(resource)),
+  }
+}
+
+// Printer columns fill in only where Radar has no curated set for the kind —
+// the two are exclusive, never merged. A curated set is hand-tuned and often
+// encodes why a vendor-obvious field is the wrong one to show, so it wins.
+function buildPrinterColumns(
+  kind: string,
+  group: string | undefined,
+  table: PrinterTable | null | undefined,
+): ExtraColumn[] {
+  if (!table?.columns?.length) return []
+  if (!printerTableMatchesKind(table, kind, group)) return []
+  if (hasCuratedColumns(kind, group)) return []
+  return table.columns.map((def, i) => buildPrinterColumn(def, i, table))
+}
+
+// The kind's effective column set. Printer columns replace the generic
+// Name/Namespace/Status/Age set rather than joining it: the vendor's columns
+// are the answer to the same question the generic Status column was guessing
+// at, and showing both would ask the reader which one to believe. Name,
+// Namespace and Age stay because Radar renders those itself (the server drops
+// the CRD's own duplicates of them before sending).
+function columnsForKindWithPrinter(
+  kind: string,
+  group: string | undefined,
+  printerColumns: ExtraColumn[],
+): Column[] {
+  const curated = getColumnsForKind(kind, group)
+  if (!printerColumns.length || hasCuratedColumns(kind, group)) return curated
+  return [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-48' },
+    ...printerColumns,
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ]
+}
+
+/**
+ * The visible-column set for a kind the user has saved settings for.
+ *
+ * Saved choices win, with two seeded exceptions for columns the blob predates —
+ * a user cannot have decided to hide something they were never shown:
+ *   - host extras, which are injected by the embedding app;
+ *   - printer columns, but only when the blob names none at all. Once it names
+ *     one, the user has seen the set and an absent key is a deliberate hide.
+ */
+export function mergeSavedVisibleColumns(
+  savedVisible: string[],
+  extraKeys: string[],
+  printerColumns: ExtraColumn[],
+): Set<string> {
+  const merged = new Set(savedVisible)
+  for (const k of extraKeys) merged.add(k)
+  if (!savedVisible.some(k => k.startsWith(PRINTER_COLUMN_PREFIX))) {
+    for (const c of printerColumns) {
+      if (c.defaultVisible !== false) merged.add(c.key)
+    }
+  }
+  return merged
+}
+
+/** Storage/reset identity for a selection. Two CRDs can share a plural across
+ * API groups, and their columns are unrelated. */
+export function selectedKindIdentityOf(kind: { name: string; group?: string }): string {
+  return `${kind.name} ${kind.group ?? ''}`
 }
 
 // Host-injected leading columns minus any whose key collides with a built-in.
@@ -2276,6 +2401,22 @@ function filterHostExtras(
 // localStorage helpers for column settings
 const COLUMN_SETTINGS_PREFIX = 'radar-columns-'
 
+// Storage identity for a kind's column settings. normalizeKindToPlural falls
+// through to the bare plural for anything outside the curated collision
+// catalog, so two uncurated CRDs sharing a plural in different API groups —
+// Crossplane ships two `Usage` kinds — would share one blob and leak column
+// visibility, widths and custom columns between them. Harmless while both got
+// identical generic columns; not harmless once each has its own printer
+// columns. Only the fallthrough kinds are qualified, so curated and core kinds
+// keep the key their saved preferences are already under.
+export function columnSettingsKey(kind: string, group?: string): string {
+  const normalized = normalizeKindToPlural(kind, group)
+  if (group && !hasCuratedColumns(kind, group)) {
+    return `${normalized}.${group}`
+  }
+  return normalized
+}
+
 interface ColumnSettings {
   visible: string[]
   widths: Record<string, number>
@@ -2284,7 +2425,7 @@ interface ColumnSettings {
 
 function loadColumnSettings(kind: string, group?: string): ColumnSettings | null {
   try {
-    const key = COLUMN_SETTINGS_PREFIX + normalizeKindToPlural(kind, group)
+    const key = COLUMN_SETTINGS_PREFIX + columnSettingsKey(kind, group)
     const raw = localStorage.getItem(key)
     if (raw) return JSON.parse(raw)
   } catch { /* ignore */ }
@@ -2293,14 +2434,14 @@ function loadColumnSettings(kind: string, group?: string): ColumnSettings | null
 
 function saveColumnSettings(kind: string, group: string | undefined, settings: ColumnSettings) {
   try {
-    const key = COLUMN_SETTINGS_PREFIX + normalizeKindToPlural(kind, group)
+    const key = COLUMN_SETTINGS_PREFIX + columnSettingsKey(kind, group)
     localStorage.setItem(key, JSON.stringify(settings))
   } catch { /* ignore */ }
 }
 
 function clearColumnSettings(kind: string, group?: string) {
   try {
-    const key = COLUMN_SETTINGS_PREFIX + normalizeKindToPlural(kind, group)
+    const key = COLUMN_SETTINGS_PREFIX + columnSettingsKey(kind, group)
     localStorage.removeItem(key)
   } catch { /* ignore */ }
 }
@@ -2408,6 +2549,11 @@ interface ResourcesViewProps {
    *  doesn't need to extend KNOWN_COLUMNS or per-kind cell renderers.
    *  When undefined, behavior is byte-identical to single-cluster mode. */
   extraLeadingColumns?: ExtraColumn[]
+  /** Vendor-declared columns from the kind's CRD (additionalPrinterColumns),
+   *  evaluated server-side. Used ONLY for kinds Radar has no curated column
+   *  set for — the two are exclusive. Hosts that don't fetch them get the
+   *  generic columns and nothing changes. */
+  printerTable?: PrinterTable | null
   /** Escape hatch for full-page-nav row selection: receive the FULL
    *  resource object on row click / Enter / `d` / search-Enter, instead
    *  of the stripped {kind, namespace, name, group} shape onResourceClick
@@ -2637,6 +2783,7 @@ export function ResourcesView({
   onCreateResource,
   defaultKind = DEFAULT_KIND_INFO,
   extraLeadingColumns,
+  printerTable,
   onRowSelect,
   rowHrefFor,
   onCompareSubmit,
@@ -2834,22 +2981,32 @@ export function ResourcesView({
   // collision: a colliding extra is filtered out (with a dev-mode warn)
   // so we don't render two columns sharing one key — that would yield
   // duplicate React keys and corrupt visibleColumns / columnWidths state.
+  const builtPrinterColumns = useMemo(
+    () => buildPrinterColumns(selectedKind.name, selectedKind.group, printerTable),
+    [selectedKind.name, selectedKind.group, printerTable],
+  )
+  const printerColumnsKey = useMemo(
+    () => printerTableKey(builtPrinterColumns.length ? printerTable : null),
+    [printerTable, builtPrinterColumns],
+  )
+
   const allColumns = useMemo(() => {
-    const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
+    const kindColumns = columnsForKindWithPrinter(selectedKind.name, selectedKind.group, builtPrinterColumns)
     if (!extraLeadingColumns?.length && !builtCustomColumns.length) return kindColumns
     const builtinKeys = new Set(kindColumns.map(c => c.key))
     const filteredExtras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)
     return [...filteredExtras, ...kindColumns, ...builtCustomColumns]
-  }, [selectedKind.name, selectedKind.group, extraLeadingColumns, builtCustomColumns])
+  }, [selectedKind.name, selectedKind.group, extraLeadingColumns, builtCustomColumns, builtPrinterColumns])
 
   // Map of extra column keys for fast O(1) lookup on each render path
   // (cell render, sort, column-filter unique-values).
   const extraColumnsByKey = useMemo(() => {
     const m = new Map<string, ExtraColumn>()
     extraLeadingColumns?.forEach(c => m.set(c.key, c))
+    builtPrinterColumns.forEach(c => m.set(c.key, c))
     builtCustomColumns.forEach(c => m.set(c.key, c))
     return m
-  }, [extraLeadingColumns, builtCustomColumns])
+  }, [extraLeadingColumns, builtCustomColumns, builtPrinterColumns])
 
   // Guards the save effect from persisting on the initial load of each kind
   // (set false by the load effect, flipped true on its first skipped save).
@@ -2879,7 +3036,7 @@ export function ResourcesView({
     // (non-array, blank path, bad source) must not crash the later .map or add dead columns.
     const savedCustom = sanitizeCustomColumnDefs(saved?.custom)
     setCustomColumns(savedCustom)
-    const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
+    const kindColumns = columnsForKindWithPrinter(selectedKind.name, selectedKind.group, builtPrinterColumns)
     const builtinKeys = new Set(kindColumns.map(c => c.key))
     const extras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)
     const effective = [...extras, ...kindColumns, ...savedCustom.map(buildCustomColumn)]
@@ -2906,16 +3063,18 @@ export function ResourcesView({
         setVisibleColumns(getDefaultVisibleColumns(effective))
         setColumnWidths({})
       } else {
-        const merged = new Set(saved.visible)
-        for (const k of extraKeys) merged.add(k)
-        setVisibleColumns(merged)
+        setVisibleColumns(mergeSavedVisibleColumns(saved.visible, extraKeys, builtPrinterColumns))
         setColumnWidths(saved.widths || {})
       }
     } else {
       setVisibleColumns(getDefaultVisibleColumns(effective))
       setColumnWidths({})
     }
-  }, [selectedKind.name, selectedKind.group, extraLeadingColumns])
+    // printerColumnsKey, not builtPrinterColumns: the built array is a new
+    // identity on every refetch, and re-running this effect would reset the
+    // user's in-session column choices each time the list polls. The key only
+    // changes when the kind changes or an operator upgrade changes the CRD.
+  }, [selectedKind.name, selectedKind.group, extraLeadingColumns, printerColumnsKey])
 
   // Save column settings when they change (skip the initial load of each kind)
   useEffect(() => {
@@ -3969,12 +4128,17 @@ export function ResourcesView({
 
   // Reset sort and filters when kind changes (but not when syncing from URL navigation)
   // Track previous kind to skip on mount (where the effect fires but kind hasn't actually changed)
-  const prevKindRef = useRef(selectedKind.name)
+  // Keyed on group as well as plural: two CRDs can share a plural across API
+  // groups, and their printer columns are unrelated. Resetting on the plural
+  // alone would carry a `printer:*` sort or filter onto a table with no such
+  // column, where every row fails the filter and the list looks empty.
+  const selectedKindIdentity = selectedKindIdentityOf(selectedKind)
+  const prevKindRef = useRef(selectedKindIdentity)
   useEffect(() => {
-    if (prevKindRef.current === selectedKind.name) {
+    if (prevKindRef.current === selectedKindIdentity) {
       return
     }
-    prevKindRef.current = selectedKind.name
+    prevKindRef.current = selectedKindIdentity
     setSortColumn(null)
     setSortDirection(null)
     setOpenColumnFilter(null)
@@ -3983,7 +4147,7 @@ export function ResourcesView({
       setColumnFilterExcludes({})
     }
     setProblemFilters([])
-  }, [selectedKind.name])
+  }, [selectedKindIdentity])
 
   // Toggle sort for a column
   const handleSort = useCallback((column: string) => {
@@ -4017,7 +4181,17 @@ export function ResourcesView({
       case 'age':
         return meta.creationTimestamp ? new Date(meta.creationTimestamp).getTime() : 0
       case 'status':
-        return status.phase || ''
+        // Uncurated kinds sort on the text their badge shows: they have no
+        // phase to sort on when the status came from a condition or a replica
+        // count, so phase ordered them all as equal.
+        //
+        // Curated kinds sort on phase. Their cell already shows something
+        // richer, but routing the sort through the per-kind readers would
+        // reorder the most-used lists — Pods, Deployments, Nodes — and cost a
+        // status derivation per comparison.
+        return hasCuratedColumns(selectedKind.name, selectedKind.group)
+          ? (status.phase || '')
+          : (getGenericResourceStatus(resource)?.text ?? '')
       case 'containers':
         // Pod containers column — sort by readiness ratio
         if (status.containerStatuses) {
@@ -4096,7 +4270,7 @@ export function ResourcesView({
       default:
         return ''
     }
-  }, [metricsLookup])
+  }, [metricsLookup, selectedKind.name, selectedKind.group])
 
   // Helper to check if a pod matches problem filters
   const podMatchesProblemFilter = useCallback((pod: any, filters: string[]): boolean => {
@@ -6436,53 +6610,13 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
 function GenericCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status': {
-      // Try to extract status from common patterns
-      const status = resource.status
-      if (!status) return <span className="text-sm text-theme-text-tertiary">-</span>
-
-      // Check for phase (common in many CRDs)
-      if (status.phase) {
-        const phase = status.phase as string
-        const isHealthy = ['Running', 'Active', 'Succeeded', 'Ready', 'Healthy', 'Available'].includes(phase)
-        const isWarning = ['Pending', 'Progressing', 'Unknown'].includes(phase)
-        return (
-          <span className={clsx(
-            'badge',
-            isHealthy ? 'status-healthy' :
-            isWarning ? 'status-degraded' :
-            'status-unhealthy'
-          )}>
-            {phase}
-          </span>
-        )
-      }
-
-      // Check for conditions (common pattern)
-      if (status.conditions && Array.isArray(status.conditions)) {
-        const readyCondition = status.conditions.find((c: any) => c.type === 'Ready' || c.type === 'Available')
-        if (readyCondition) {
-          const isReady = readyCondition.status === 'True'
-          return (
-            <span className={clsx(
-              'badge',
-              isReady ? 'status-healthy' : 'status-degraded'
-            )}>
-              {isReady ? 'Ready' : 'Not Ready'}
-            </span>
-          )
-        }
-      }
-
-      // Check for state field
-      if (status.state) {
-        return (
-          <span className="text-sm text-theme-text-secondary truncate">
-            {String(status.state)}
-          </span>
-        )
-      }
-
-      return <span className="text-sm text-theme-text-tertiary">-</span>
+      const derived = getGenericResourceStatus(resource)
+      if (!derived) return <span className="text-sm text-theme-text-tertiary">-</span>
+      return (
+        <Tooltip content={derived.reason ?? derived.text}>
+          <span className={clsx('badge', healthColors[derived.tone])}>{derived.text}</span>
+        </Tooltip>
+      )
     }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>

--- a/packages/k8s-ui/src/components/resources/column-settings-key.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-settings-key.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { columnSettingsKey, hasCuratedColumns } from './ResourcesView'
+import { getCellFilterValue } from './resource-utils'
+import { getGenericResourceStatus } from './generic-status'
+
+describe('columnSettingsKey', () => {
+  // Two uncurated CRDs sharing a plural across API groups — Crossplane ships
+  // two `Usage` kinds — shared one blob and leaked column visibility, widths
+  // and custom columns between them.
+  it('qualifies uncurated CRDs by their API group', () => {
+    expect(columnSettingsKey('usages', 'apiextensions.crossplane.io'))
+      .not.toBe(columnSettingsKey('usages', 'protection.crossplane.io'))
+    expect(columnSettingsKey('usages', 'apiextensions.crossplane.io'))
+      .toBe('usages.apiextensions.crossplane.io')
+  })
+
+  // Curated and core kinds keep the key their saved preferences are already
+  // under, so nobody's columns reset on upgrade.
+  it('leaves core kinds alone', () => {
+    expect(columnSettingsKey('pods')).toBe('pods')
+    expect(columnSettingsKey('deployments', 'apps')).toBe('deployments')
+  })
+
+  it('leaves curated CRDs alone', () => {
+    expect(columnSettingsKey('rollouts', 'argoproj.io')).toBe('rollouts')
+  })
+
+  // Crossplane managed resources are curated through a group heuristic, not a
+  // KNOWN_COLUMNS entry — curation has to be read from getColumnsForKind, not
+  // from key membership.
+  it('leaves Crossplane managed resources alone', () => {
+    const key = columnSettingsKey('buckets', 's3.aws.upbound.io')
+    expect(key).toBe('buckets')
+  })
+})
+
+describe('hasCuratedColumns', () => {
+  // One definition shared by the XOR, the storage key, and the host's decision
+  // whether to request a table. If they disagreed, the server would resolve a
+  // table the client discards — or two of them would put a kind on different
+  // column sets.
+  it('recognizes curated kinds, including group-routed and heuristic ones', () => {
+    expect(hasCuratedColumns('pods')).toBe(true)
+    expect(hasCuratedColumns('rollouts', 'argoproj.io')).toBe(true)
+    expect(hasCuratedColumns('clusters', 'postgresql.cnpg.io')).toBe(true)
+    // Crossplane managed resources are curated by group heuristic, not plural.
+    expect(hasCuratedColumns('buckets', 's3.aws.upbound.io')).toBe(true)
+  })
+
+  it('reports uncurated CRDs as uncurated', () => {
+    expect(hasCuratedColumns('usages', 'protection.crossplane.io')).toBe(false)
+    expect(hasCuratedColumns('widgets', 'example.com')).toBe(false)
+  })
+
+  it('agrees with columnSettingsKey about which kinds get group-qualified', () => {
+    for (const [kind, group] of [['usages', 'protection.crossplane.io'], ['widgets', 'example.com']] as const) {
+      expect(hasCuratedColumns(kind, group)).toBe(false)
+      expect(columnSettingsKey(kind, group)).toContain(group)
+    }
+    for (const [kind, group] of [['rollouts', 'argoproj.io'], ['buckets', 's3.aws.upbound.io']] as const) {
+      expect(hasCuratedColumns(kind, group)).toBe(true)
+      expect(columnSettingsKey(kind, group)).not.toContain(group)
+    }
+  })
+})
+
+describe('status sort scope', () => {
+  const pod = {
+    status: {
+      phase: 'Running',
+      conditions: [{ type: 'Ready', status: 'False' }],
+      containerStatuses: [{ name: 'app', ready: false, restartCount: 3, state: { running: {} } }],
+    },
+    spec: { containers: [{ name: 'app' }] },
+  }
+  const uncuratedCR = { status: { conditions: [{ type: 'Ready', status: 'False', reason: 'QuorumLost' }] } }
+
+  // Curated kinds keep phase-based ordering: routing them through the per-kind
+  // readers would reorder the most-used lists for a divergence that predates
+  // this work.
+  it('leaves a curated kind sorting on its phase', () => {
+    expect(hasCuratedColumns('pods')).toBe(true)
+    expect(pod.status.phase).toBe('Running')
+    // The displayed text differs from the phase — that gap is intentional here.
+    expect(getCellFilterValue(pod, 'status', 'pods')).not.toBe('Running')
+  })
+
+  // An uncurated CR has no phase at all, so phase sorted every row as equal.
+  it('sorts an uncurated kind on the text its badge shows', () => {
+    expect(hasCuratedColumns('widgets', 'example.com')).toBe(false)
+    expect((uncuratedCR.status as any).phase).toBeUndefined()
+    const shown = getGenericResourceStatus(uncuratedCR)?.text
+    expect(shown).toBe('QuorumLost')
+    // Sort and the filter dropdown must offer the same string, or the dropdown
+    // lists values that appear on no row.
+    expect(getCellFilterValue(uncuratedCR, 'status', 'widgets')).toBe(shown)
+  })
+})

--- a/packages/k8s-ui/src/components/resources/column-visibility-merge.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-visibility-merge.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { mergeSavedVisibleColumns, selectedKindIdentityOf } from './ResourcesView'
+
+const printer = (key: string, defaultVisible = true) => ({ key, label: key, defaultVisible }) as any
+
+describe('mergeSavedVisibleColumns', () => {
+  it('keeps the saved set when it already knows the printer columns', () => {
+    const merged = mergeSavedVisibleColumns(
+      ['name', 'printer:Phase'],
+      [],
+      [printer('printer:Phase'), printer('printer:Host')],
+    )
+    // Host is absent from a blob that names another printer column, so the user
+    // hid it on purpose — seeding it back would make it un-hideable.
+    expect(merged.has('printer:Host')).toBe(false)
+    expect(merged.has('printer:Phase')).toBe(true)
+  })
+
+  it('seeds printer defaults into a blob that predates them', () => {
+    const merged = mergeSavedVisibleColumns(
+      ['name', 'namespace', 'age'],
+      [],
+      [printer('printer:Phase'), printer('printer:Host')],
+    )
+    // Without this the table would render Name + Namespace + Age and nothing
+    // else for every user who had ever touched this kind's columns.
+    expect(merged.has('printer:Phase')).toBe(true)
+    expect(merged.has('printer:Host')).toBe(true)
+    expect(merged.has('name')).toBe(true)
+  })
+
+  it('does not seed a wide-tier column, which is hidden by default', () => {
+    const merged = mergeSavedVisibleColumns(['name'], [], [printer('printer:Wide', false)])
+    expect(merged.has('printer:Wide')).toBe(false)
+  })
+
+  it('always seeds host extras, which the embedding app injects', () => {
+    const merged = mergeSavedVisibleColumns(['name'], ['cluster'], [])
+    expect(merged.has('cluster')).toBe(true)
+  })
+
+  it('is a no-op for a kind with no printer columns', () => {
+    expect([...mergeSavedVisibleColumns(['name', 'status'], [], [])].sort()).toEqual(['name', 'status'])
+  })
+})
+
+describe('selectedKindIdentityOf', () => {
+  // Two CRDs can ship the same plural in different API groups. Keyed on the
+  // plural alone, a `printer:*` sort or filter survives the switch onto a table
+  // with no such column, and every row silently fails the filter.
+  it('separates the same plural in different groups', () => {
+    expect(selectedKindIdentityOf({ name: 'widgets', group: 'a.io' }))
+      .not.toBe(selectedKindIdentityOf({ name: 'widgets', group: 'b.io' }))
+  })
+
+  it('is stable for the same selection', () => {
+    expect(selectedKindIdentityOf({ name: 'widgets', group: 'a.io' }))
+      .toBe(selectedKindIdentityOf({ name: 'widgets', group: 'a.io' }))
+  })
+
+  it('treats an absent group and an empty group alike', () => {
+    expect(selectedKindIdentityOf({ name: 'pods' })).toBe(selectedKindIdentityOf({ name: 'pods', group: '' }))
+  })
+})

--- a/packages/k8s-ui/src/components/resources/generic-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/generic-status.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import { getGenericResourceStatus } from './generic-status'
+
+const withStatus = (status: any) => ({ status })
+
+describe('getGenericResourceStatus', () => {
+  describe('phase', () => {
+    it('reports a known-healthy phase as healthy', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Running' })))
+        .toEqual({ text: 'Running', tone: 'healthy' })
+    })
+
+    it('reports a known-degraded phase as degraded and carries the message', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Pending', message: 'waiting for quota' })))
+        .toEqual({ text: 'Pending', tone: 'degraded', reason: 'waiting for quota' })
+    })
+
+    it('reports a known-failure phase as unhealthy', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Failed' })))
+        .toMatchObject({ text: 'Failed', tone: 'unhealthy' })
+    })
+
+    // The cell and drawer ladders both painted any unrecognized phase red,
+    // so every operator-specific phase name read as an outage.
+    it('prefers a known phase over conditions', () => {
+      const s = getGenericResourceStatus(withStatus({
+        phase: 'Running',
+        conditions: [{ type: 'Ready', status: 'False' }],
+      }))
+      expect(s).toEqual({ text: 'Running', tone: 'healthy' })
+    })
+
+    // An unrecognized phase says nothing about health, so a condition or a
+    // replica count that does must win. Short-circuiting on it would hide a
+    // real failure behind an operator's private vocabulary.
+    it('lets a failing condition outrank an unrecognized phase', () => {
+      expect(getGenericResourceStatus(withStatus({
+        phase: 'Rebalancing',
+        conditions: [{ type: 'Ready', status: 'False', reason: 'QuorumLost' }],
+      }))).toMatchObject({ text: 'QuorumLost', tone: 'unhealthy' })
+    })
+
+    it('lets a failing replica count outrank an unrecognized phase', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Rebalancing', replicas: 3 })))
+        .toEqual({ text: '0/3 Ready', tone: 'unhealthy' })
+    })
+
+    it('keeps an unrecognized phase as the last resort', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Rebalancing' })))
+        .toMatchObject({ text: 'Rebalancing', tone: 'unknown' })
+    })
+
+    it('prefers a bare state string to an unrecognized phase', () => {
+      expect(getGenericResourceStatus(withStatus({ phase: 'Rebalancing', state: 'Draining' })))
+        .toEqual({ text: 'Draining', tone: 'unknown' })
+    })
+  })
+
+  describe('conditions with known polarity', () => {
+    it('reads Ready=True as healthy', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Ready', status: 'True' }] })))
+        .toEqual({ text: 'Ready', tone: 'healthy' })
+    })
+
+    it('prefers the condition reason over a synthesized negative label', () => {
+      expect(getGenericResourceStatus(withStatus({
+        conditions: [{ type: 'Ready', status: 'False', reason: 'BackoffLimitExceeded', message: 'too many retries' }],
+      }))).toEqual({ text: 'BackoffLimitExceeded', tone: 'unhealthy', reason: 'too many retries' })
+    })
+
+    it('synthesizes a negative label when there is no reason', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Available', status: 'False' }] })))
+        .toMatchObject({ text: 'Not Available', tone: 'unhealthy' })
+    })
+
+    // A controller that cannot evaluate a condition has not reported a failure.
+    it('does not treat Unknown as False', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Ready', status: 'Unknown' }] })))
+        .toMatchObject({ text: 'Ready', tone: 'unknown' })
+    })
+
+    it('resolves Ready ahead of Available regardless of array order', () => {
+      expect(getGenericResourceStatus(withStatus({
+        conditions: [{ type: 'Available', status: 'False' }, { type: 'Ready', status: 'True' }],
+      }))).toEqual({ text: 'Ready', tone: 'healthy' })
+    })
+
+    // Progressing=False is the resting state of a settled resource; the drawer
+    // ladder treated it like a failed Ready and mislabeled healthy objects.
+    it('does not infer health from Progressing', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Progressing', status: 'False' }] })))
+        .toMatchObject({ tone: 'unknown' })
+    })
+  })
+
+  describe('conditions with unknown polarity', () => {
+    // gmp PodMonitoring publishes only this; every TS ladder rendered a dash.
+    it('surfaces an unrecognized condition type as text without a health claim', () => {
+      expect(getGenericResourceStatus(withStatus({
+        conditions: [{ type: 'ConfigurationCreateSuccess', status: 'True' }],
+      }))).toEqual({ text: 'ConfigurationCreateSuccess', tone: 'unknown' })
+    })
+
+    it('reads GKE ComputeClass Health as a known positive condition', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Health', status: 'True' }] })))
+        .toEqual({ text: 'Health', tone: 'healthy' })
+    })
+
+    it('skips condition entries with no type', () => {
+      expect(getGenericResourceStatus(withStatus({
+        conditions: [{ status: 'True' }, { type: 'Settled', status: 'True' }],
+      }))).toEqual({ text: 'Settled', tone: 'unknown' })
+    })
+  })
+
+  describe('bare string status fields', () => {
+    // kubefledged ImageCache publishes status.status; the ladders checked
+    // status.state only, so it rendered a dash.
+    it('falls back to status.status', () => {
+      expect(getGenericResourceStatus(withStatus({ status: 'Succeeded', reason: 'ok' })))
+        .toEqual({ text: 'Succeeded', tone: 'unknown' })
+    })
+
+    it('prefers status.state over status.status', () => {
+      expect(getGenericResourceStatus(withStatus({ state: 'Bound', status: 'other' })))
+        .toEqual({ text: 'Bound', tone: 'unknown' })
+    })
+
+    it('ignores state/status when they are not strings', () => {
+      expect(getGenericResourceStatus(withStatus({ state: { phase: 'x' } }))).toBeNull()
+    })
+  })
+
+
+  describe('known-negative conditions and replicas', () => {
+    it('reads a Degraded=True condition as degraded', () => {
+      expect(getGenericResourceStatus(withStatus({
+        conditions: [{ type: 'Degraded', status: 'True', message: 'one shard offline' }],
+      }))).toEqual({ text: 'Degraded', tone: 'degraded', reason: 'one shard offline' })
+    })
+
+    it('ignores a known-negative condition that is False', () => {
+      expect(getGenericResourceStatus(withStatus({ conditions: [{ type: 'Degraded', status: 'False' }] })))
+        .toMatchObject({ tone: 'unknown' })
+    })
+
+    it('reports full replica coverage as healthy', () => {
+      expect(getGenericResourceStatus(withStatus({ replicas: 3, readyReplicas: 3 })))
+        .toEqual({ text: '3/3 Ready', tone: 'healthy' })
+    })
+
+    it('grades partial replica coverage degraded and none unhealthy', () => {
+      expect(getGenericResourceStatus(withStatus({ replicas: 3, readyReplicas: 1 })))
+        .toEqual({ text: '1/3 Ready', tone: 'degraded' })
+      expect(getGenericResourceStatus(withStatus({ replicas: 3 })))
+        .toEqual({ text: '0/3 Ready', tone: 'unhealthy' })
+    })
+
+    it('falls back to availableReplicas when readyReplicas is absent', () => {
+      expect(getGenericResourceStatus(withStatus({ replicas: 2, availableReplicas: 2 })))
+        .toEqual({ text: '2/2 Ready', tone: 'healthy' })
+    })
+
+    // Replicas say more than a vendor condition name, and both only rank below
+    // the condition types whose polarity is actually known.
+    it('ranks replicas above an unknown-polarity condition but below Ready', () => {
+      expect(getGenericResourceStatus(withStatus({
+        replicas: 2, readyReplicas: 2,
+        conditions: [{ type: 'ConfigurationCreateSuccess', status: 'True' }],
+      }))).toEqual({ text: '2/2 Ready', tone: 'healthy' })
+
+      expect(getGenericResourceStatus(withStatus({
+        replicas: 2, readyReplicas: 2,
+        conditions: [{ type: 'Ready', status: 'False', reason: 'Stalled' }],
+      }))).toMatchObject({ text: 'Stalled', tone: 'unhealthy' })
+    })
+
+    it('ignores a zero or non-numeric replica count', () => {
+      expect(getGenericResourceStatus(withStatus({ replicas: 0 }))).toBeNull()
+      expect(getGenericResourceStatus(withStatus({ replicas: '3' }))).toBeNull()
+    })
+  })
+
+  describe('nothing to report', () => {
+    it.each([
+      ['no resource', undefined],
+      ['no status', {}],
+      // A resource whose status IS a string, not a status object — guarded, or
+      // reading .phase off a string would silently yield undefined forever.
+      ['non-object status', { status: 'ok' }],
+      ['empty status', { status: {} }],
+      ['empty conditions', { status: { conditions: [] } }],
+      ['blank phase', { status: { phase: '   ' } }],
+      ['conditions that are not an array', { status: { conditions: 'Ready' } }],
+    ])('returns null for %s', (_label, resource) => {
+      expect(getGenericResourceStatus(resource as any)).toBeNull()
+    })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/generic-status.ts
+++ b/packages/k8s-ui/src/components/resources/generic-status.ts
@@ -1,0 +1,158 @@
+import type { HealthLevel } from './resource-utils'
+
+/**
+ * Derives a status for a resource with no dedicated renderer — a CRD Radar
+ * hasn't curated. Shared by the table cell, the column filter and sort, the
+ * drawer dispatch and the generic renderer, so a row cannot show one status
+ * and its filter dropdown offer another.
+ *
+ * Two rules it enforces:
+ *   - Polarity is only claimed for a fixed set of condition types. Any other
+ *     type is reported as text with an `unknown` tone —
+ *     `ConfigurationCreateSuccess=True` is informative, but reading health out
+ *     of an arbitrary condition name is a guess.
+ *   - `Unknown` is not `False`. A condition the controller can't evaluate is
+ *     not a failure.
+ *
+ * The Go summarizer behind MCP (pkg/ai/context/summary_crd.go) derives this
+ * separately and does not agree: it is conditions-first where this is
+ * phase-first, and reads `Unknown` as false. They differ on, for example,
+ * {phase: Running, Ready: False}.
+ */
+export interface GenericStatus {
+  /** Display text. Never empty when a GenericStatus is returned. */
+  text: string
+  tone: HealthLevel
+  /** Condition message, when one explains a non-healthy tone. */
+  reason?: string
+}
+
+// Union of the phase vocabularies the five call sites had accumulated.
+const HEALTHY_PHASES = new Set([
+  'Running', 'Active', 'Succeeded', 'Ready', 'Healthy', 'Available', 'Bound', 'Complete', 'Completed',
+])
+const DEGRADED_PHASES = new Set([
+  'Pending', 'Progressing', 'Unknown', 'Terminating', 'Waiting', 'Provisioning', 'Reconciling',
+])
+const UNHEALTHY_PHASES = new Set([
+  'Failed', 'Error', 'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'Lost', 'Rejected',
+])
+
+/**
+ * Condition types whose polarity is a convention rather than a guess, most
+ * specific first. NOT the Go summarizer's order — it resolves Ready >
+ * Available > Synced and knows neither Healthy nor Health; see the note above
+ * on why the two are not yet aligned. `Progressing` is deliberately absent:
+ * `Progressing=False` on a settled resource is normal, so treating it like a
+ * failed `Ready` mislabels healthy objects.
+ */
+export const KNOWN_POSITIVE_CONDITIONS = ['Ready', 'Available', 'Healthy', 'Health', 'Synced'] as const
+
+/** Condition types that mean trouble when True — the mirror of the set above. */
+export const KNOWN_NEGATIVE_CONDITIONS = ['Degraded', 'Warning', 'ScalingLimited'] as const
+
+function conditionReason(cond: any): string | undefined {
+  const reason = typeof cond?.reason === 'string' ? cond.reason.trim() : ''
+  return reason || undefined
+}
+
+function conditionMessage(cond: any): string | undefined {
+  const message = typeof cond?.message === 'string' ? cond.message.trim() : ''
+  return message || undefined
+}
+
+function fromCondition(cond: any, polarityKnown: boolean): GenericStatus | null {
+  const type = typeof cond?.type === 'string' ? cond.type.trim() : ''
+  if (!type) return null
+  const state = cond?.status
+
+  if (state === 'True') {
+    return { text: type, tone: polarityKnown ? 'healthy' : 'unknown' }
+  }
+  if (state === 'False') {
+    return {
+      text: conditionReason(cond) || `Not ${type}`,
+      tone: polarityKnown ? 'unhealthy' : 'unknown',
+      reason: conditionMessage(cond),
+    }
+  }
+  // "Unknown" (or anything else): the controller could not determine this.
+  // Not a failure — report it without a health claim.
+  return { text: conditionReason(cond) || type, tone: 'unknown', reason: conditionMessage(cond) }
+}
+
+/**
+ * Derives a status for a resource with no kind-specific handling.
+ * Returns null when the object carries nothing that reads as a status —
+ * callers render their own placeholder rather than inventing one.
+ */
+export function getGenericResourceStatus(resource: any): GenericStatus | null {
+  const status = resource?.status
+  if (!status || typeof status !== 'object') return null
+
+  const phase = typeof status.phase === 'string' ? status.phase.trim() : ''
+  if (phase) {
+    const reason = typeof status.message === 'string' && status.message.trim()
+      ? status.message.trim()
+      : typeof status.reason === 'string' && status.reason.trim()
+        ? status.reason.trim()
+        : undefined
+    if (HEALTHY_PHASES.has(phase)) return { text: phase, tone: 'healthy' }
+    if (DEGRADED_PHASES.has(phase)) return { text: phase, tone: 'degraded', reason }
+    if (UNHEALTHY_PHASES.has(phase)) return { text: phase, tone: 'unhealthy', reason }
+    // An unrecognized phase does NOT short-circuit. Its health is unknown to
+    // us, so a Ready=False condition or a failed replica count below is the
+    // better answer; the phase text is kept as the last resort. Returning here
+    // would hide a real failure behind an operator's private vocabulary.
+  }
+
+  const conditions = Array.isArray(status.conditions) ? status.conditions : []
+  for (const type of KNOWN_POSITIVE_CONDITIONS) {
+    const match = conditions.find((c: any) => c?.type === type)
+    if (match) {
+      const derived = fromCondition(match, true)
+      if (derived) return derived
+    }
+  }
+  for (const type of KNOWN_NEGATIVE_CONDITIONS) {
+    const match = conditions.find((c: any) => c?.type === type && c?.status === 'True')
+    if (match) {
+      return { text: match.type, tone: 'degraded', reason: conditionMessage(match) ?? conditionReason(match) }
+    }
+  }
+
+  // Replica counts read as a status on their own, and say more than a vendor
+  // condition name would. Ranked above the unknown-polarity fallback for that
+  // reason.
+  if (typeof status.replicas === 'number' && status.replicas > 0) {
+    const desired = status.replicas
+    const ready = typeof status.readyReplicas === 'number' ? status.readyReplicas
+      : typeof status.availableReplicas === 'number' ? status.availableReplicas
+        : 0
+    const text = `${ready}/${desired} Ready`
+    if (ready >= desired) return { text, tone: 'healthy' }
+    return { text, tone: ready > 0 ? 'degraded' : 'unhealthy' }
+  }
+
+  // No condition whose polarity we know. Report the first one as text so a CRD
+  // that only publishes its own vocabulary still says something, but without a
+  // health claim.
+  for (const cond of conditions) {
+    const derived = fromCondition(cond, false)
+    if (derived) return derived
+  }
+
+  // `state` and `status` are both used as a bare string status by CRDs that
+  // publish neither a phase nor conditions. Guarded on string because both
+  // names are also used for nested objects.
+  for (const key of ['state', 'status'] as const) {
+    const value = status[key]
+    if (typeof value === 'string' && value.trim()) {
+      return { text: value.trim(), tone: 'unknown' }
+    }
+  }
+
+  if (phase) return { text: phase, tone: 'unknown' }
+
+  return null
+}

--- a/packages/k8s-ui/src/components/resources/index.ts
+++ b/packages/k8s-ui/src/components/resources/index.ts
@@ -44,7 +44,15 @@ export * from './resource-utils-prometheus'
 export * from './resource-utils-trivy'
 export * from './resource-utils-traefik'
 export * from './resource-utils-velero'
-export { ResourcesView, ResourcesViewDataContext } from './ResourcesView'
+export { ResourcesView, ResourcesViewDataContext, hasCuratedColumns } from './ResourcesView'
 export type { ResourceQueryResult, ExtraColumn, LargeListGuardState } from './ResourcesView'
 export { ResourcesSidebar } from './ResourcesSidebar'
 export type { ResourcesSidebarProps, SelectedKindInfo, PinnedItem } from './ResourcesSidebar'
+export {
+  sanitizePrinterTable,
+  printerTableKey,
+  printerColumnKey,
+} from './printer-columns'
+export type { PrinterColumnDef, PrinterTable } from './printer-columns'
+export { getGenericResourceStatus } from './generic-status'
+export type { GenericStatus } from './generic-status'

--- a/packages/k8s-ui/src/components/resources/printer-columns.test.ts
+++ b/packages/k8s-ui/src/components/resources/printer-columns.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatPrinterCell,
+  printerTableMatchesKind,
+  parseHumanDuration,
+  printerCellSortValue,
+  printerCellTone,
+  printerColumnKey,
+  printerTableKey,
+  readPrinterCell,
+  sanitizePrinterTable,
+} from './printer-columns'
+
+describe('sanitizePrinterTable', () => {
+  it('keeps a well-formed table and defaults priority to 0', () => {
+    const t = sanitizePrinterTable({
+      columns: [{ name: 'Phase', type: 'string' }, { name: 'Replicas', type: 'integer', priority: 1 }],
+      cells: { a: ['Running', 3] },
+    })
+    expect(t?.columns).toEqual([
+      { name: 'Phase', type: 'string', format: undefined, description: undefined, priority: 0 },
+      { name: 'Replicas', type: 'integer', format: undefined, description: undefined, priority: 1 },
+    ])
+    expect(t?.cells.a).toEqual(['Running', 3])
+  })
+
+  it.each([
+    ['null', null],
+    ['no columns key', { cells: {} }],
+    ['empty columns', { columns: [], cells: {} }],
+    ['columns that are not an array', { columns: 'Phase' }],
+    ['every column malformed', { columns: [{ type: 'string' }, null, { name: '  ' }] }],
+  ])('returns null for %s', (_label, raw) => {
+    expect(sanitizePrinterTable(raw)).toBeNull()
+  })
+
+  // A dropped duplicate must take its cell with it, or every later value
+  // renders one column to the left.
+  it('realigns cells when a column is dropped', () => {
+    const t = sanitizePrinterTable({
+      columns: [{ name: 'Phase' }, { name: 'Phase' }, { name: 'Host' }],
+      cells: { a: ['Running', 'dup', 'example.com'] },
+    })
+    expect(t?.columns.map(c => c.name)).toEqual(['Phase', 'Host'])
+    expect(t?.cells.a).toEqual(['Running', 'example.com'])
+  })
+
+  it('ignores rows that are not arrays', () => {
+    const t = sanitizePrinterTable({ columns: [{ name: 'A' }, { name: 'B' }], cells: { a: 'nope', b: ['1', '2'] } })
+    expect(t?.cells).toEqual({ b: ['1', '2'] })
+  })
+
+  it('tolerates a missing cells map', () => {
+    expect(sanitizePrinterTable({ columns: [{ name: 'A' }] })?.cells).toEqual({})
+  })
+})
+
+describe('printerTableKey', () => {
+  it('is stable across refetches and changes with the column set', () => {
+    const a = { columns: [{ name: 'Phase' }, { name: 'Host' }], cells: {} }
+    const b = { columns: [{ name: 'Phase' }, { name: 'Host' }], cells: { x: ['1'] } }
+    expect(printerTableKey(a)).toBe(printerTableKey(b))
+    expect(printerTableKey(a)).not.toBe(printerTableKey({ columns: [{ name: 'Phase' }], cells: {} }))
+  })
+
+  it('is empty when there is no table', () => {
+    expect(printerTableKey(null)).toBe('')
+    expect(printerTableKey({ columns: [], cells: {} })).toBe('')
+  })
+})
+
+describe('printerColumnKey', () => {
+  // Built-in keys never carry a prefix and custom columns use label:/annotation:,
+  // so this namespace cannot collide with either.
+  it('namespaces the key', () => {
+    expect(printerColumnKey({ name: 'Status' })).toBe('printer:Status')
+    expect(printerColumnKey({ name: 'Status' })).not.toBe('status')
+  })
+})
+
+describe('readPrinterCell', () => {
+  const table = { columns: [{ name: 'A' }, { name: 'B' }], cells: { u1: ['x', 2] } }
+  it('reads by uid and index', () => {
+    expect(readPrinterCell(table, 'u1', 0)).toBe('x')
+    expect(readPrinterCell(table, 'u1', 1)).toBe(2)
+  })
+  it('is undefined for an unknown uid, a missing uid, or an out-of-range index', () => {
+    expect(readPrinterCell(table, 'nope', 0)).toBeUndefined()
+    expect(readPrinterCell(table, undefined, 0)).toBeUndefined()
+    expect(readPrinterCell(table, 'u1', 9)).toBeUndefined()
+  })
+})
+
+describe('formatPrinterCell', () => {
+  it.each([
+    ['string', 'Running', 'Running'],
+    ['zero', 0, '0'],
+    ['number', 3, '3'],
+    ['true', true, 'True'],
+    ['false', false, 'False'],
+    ['null', null, ''],
+    ['undefined', undefined, ''],
+    // The apiserver leaves an unresolvable path null, but a `type` mismatch can
+    // still hand back a structure. Rendering "[object Object]" would be worse
+    // than rendering nothing.
+    ['object', { a: 1 }, ''],
+    ['array', [1, 2], ''],
+  ])('renders %s', (_label, value, want) => {
+    expect(formatPrinterCell(value)).toBe(want)
+  })
+})
+
+describe('printerCellSortValue', () => {
+  // Sorting must use the value, not its rendered text, or 10 sorts before 9.
+  it('sorts numbers numerically', () => {
+    expect([10, 9, 100].map(printerCellSortValue).sort((a, b) => (a as number) - (b as number)))
+      .toEqual([9, 10, 100])
+  })
+  it('sorts booleans by truth and falls back to empty for anything else', () => {
+    expect(printerCellSortValue(true)).toBe(1)
+    expect(printerCellSortValue(false)).toBe(0)
+    expect(printerCellSortValue({ a: 1 })).toBe('')
+    expect(printerCellSortValue(null)).toBe('')
+  })
+})
+
+describe('printerTableMatchesKind', () => {
+  const table = { kind: 'widgets', group: 'example.com', columns: [{ name: 'A' }], cells: {} }
+
+  it('matches its own kind and group', () => {
+    expect(printerTableMatchesKind(table, 'widgets', 'example.com')).toBe(true)
+  })
+
+  // The selected kind changes before the new list resolves, so an unchecked
+  // table can briefly be the PREVIOUS kind's — which the visibility effect
+  // would then persist under the new kind's storage key.
+  it('rejects a table belonging to another kind or another group', () => {
+    expect(printerTableMatchesKind(table, 'gadgets', 'example.com')).toBe(false)
+    expect(printerTableMatchesKind(table, 'widgets', 'other.io')).toBe(false)
+    expect(printerTableMatchesKind(table, 'widgets', undefined)).toBe(false)
+  })
+
+  it('rejects a table with no identity rather than pairing it blindly', () => {
+    expect(printerTableMatchesKind({ columns: [{ name: 'A' }], cells: {} }, 'widgets', 'example.com')).toBe(false)
+    expect(printerTableMatchesKind(null, 'widgets', 'example.com')).toBe(false)
+  })
+
+  it('treats an absent group and an empty group as the same', () => {
+    const noGroup = { kind: 'widgets', columns: [{ name: 'A' }], cells: {} }
+    expect(printerTableMatchesKind(noGroup, 'widgets', '')).toBe(true)
+    expect(printerTableMatchesKind(noGroup, 'widgets', undefined)).toBe(true)
+  })
+})
+
+describe('sanitizePrinterTable identity', () => {
+  it('carries kind and group through', () => {
+    const t = sanitizePrinterTable({ kind: 'widgets', group: 'example.com', columns: [{ name: 'A' }], cells: {} })
+    expect(t).toMatchObject({ kind: 'widgets', group: 'example.com' })
+  })
+
+  it('leaves them undefined when the server sent none', () => {
+    const t = sanitizePrinterTable({ columns: [{ name: 'A' }], cells: {} })
+    expect(t?.kind).toBeUndefined()
+    expect(t?.group).toBeUndefined()
+  })
+})
+
+describe('date sorting', () => {
+  // The table converter hands back humanized ages, so sorting them as text puts
+  // "10m" before "2m".
+  it.each([['5s', 5], ['2m', 120], ['3h', 10800], ['4d', 345600], ['1y', 31536000], ['2d3h', 183600], ['1y64d', 37065600]])(
+    'parses %s', (text, want) => expect(parseHumanDuration(text)).toBe(want))
+
+  it.each([['', null], ['   ', null], ['abc', null], ['5', null], ['5x', null], ['-3m', null], ['<invalid>', null]])(
+    'rejects %s', (text, want) => expect(parseHumanDuration(text)).toBe(want))
+
+  it('orders date cells oldest-first ascending, like the Age column', () => {
+    const def = { name: 'Last Refresh', type: 'date' }
+    const sorted = ['10m', '2m', '1h', '30s']
+      .map(v => ({ v, k: printerCellSortValue(v, def) as number }))
+      .sort((a, b) => a.k - b.k)
+      .map(x => x.v)
+    expect(sorted).toEqual(['1h', '10m', '2m', '30s'])
+  })
+
+  it('leaves a date column that is not a duration sorting as text', () => {
+    expect(printerCellSortValue('<invalid>', { name: 'D', type: 'date' })).toBe('<invalid>')
+  })
+
+  it('does not reinterpret duration-looking values in non-date columns', () => {
+    expect(printerCellSortValue('10m', { name: 'Size', type: 'string' })).toBe('10m')
+    expect(printerCellSortValue('10m')).toBe('10m')
+  })
+})
+
+describe('printerTableKey priority', () => {
+  // Default visibility is derived from priority, so promoting a column out of
+  // the -o wide tier has to re-run the visibility defaults.
+  it('changes when a column priority changes', () => {
+    const wide = { columns: [{ name: 'A' }, { name: 'B', priority: 1 }], cells: {} }
+    const promoted = { columns: [{ name: 'A' }, { name: 'B', priority: 0 }], cells: {} }
+    expect(printerTableKey(wide)).not.toBe(printerTableKey(promoted))
+  })
+})
+
+describe('printerCellTone', () => {
+  // The one place Radar interprets vendor data rather than passing it through.
+  // Deliberately narrow: the vendor NAMED the column, which is a far stronger
+  // signal than inferring health from a value.
+  it.each([
+    ['Ready', true, 'healthy'],
+    ['Ready', false, 'unhealthy'],
+    ['Healthy', 'True', 'healthy'],
+    ['Healthy', 'False', 'unhealthy'],
+    ['Established', 'true', 'healthy'],
+    ['Installed', 'True', 'healthy'],
+    ['Provided', 'True', 'healthy'],
+    ['ReadyToUse', 'False', 'unhealthy'],
+    ['Synced', 'True', 'healthy'],
+  ])('%s=%s tones as %s', (name, value, want) => {
+    expect(printerCellTone({ name }, value)).toBe(want)
+  })
+
+  // Names whose polarity is inverted must not be read as positive.
+  it.each([
+    ['Degraded', 'False', 'healthy'],
+    ['Denied', 'False', 'healthy'],
+  ])('%s=%s tones as %s', (name, value, want) => {
+    expect(printerCellTone({ name }, value)).toBe(want)
+  })
+
+  // A controller that could not evaluate a field it owns has not reported a
+  // failure — but only for a column we have a claim to speak about.
+  it('reports Unknown without calling it a failure, on named columns', () => {
+    expect(printerCellTone({ name: 'Ready' }, 'Unknown')).toBe('unknown')
+    expect(printerCellTone({ name: 'Degraded' }, 'Unknown')).toBe('unknown')
+  })
+
+  // The name decides whether we speak at all. Checking the value first badged
+  // `Mode: Unknown` on a column whose polarity we have no claim to.
+  it('stays silent on an unnamed column even when the value is Unknown', () => {
+    expect(printerCellTone({ name: 'Mode' }, 'Unknown')).toBeNull()
+    expect(printerCellTone({ name: 'Strategy' }, 'Unknown')).toBeNull()
+    expect(printerCellTone({ name: 'Whatever' }, 'Unknown')).toBeNull()
+  })
+
+  // The same condition must not change severity depending on whether it
+  // arrived through the generic Status column or a printer column.
+  it('tones a degraded name amber, matching the generic ladder', () => {
+    expect(printerCellTone({ name: 'Degraded' }, 'True')).toBe('degraded')
+    expect(printerCellTone({ name: 'Warning' }, 'True')).toBe('degraded')
+    expect(printerCellTone({ name: 'ScalingLimited' }, 'True')).toBe('degraded')
+  })
+
+  it('reserves red for genuinely terminal names', () => {
+    expect(printerCellTone({ name: 'Denied' }, 'True')).toBe('unhealthy')
+    expect(printerCellTone({ name: 'Failed' }, 'True')).toBe('unhealthy')
+  })
+
+  it('renders plain text for a column whose polarity we do not know', () => {
+    expect(printerCellTone({ name: 'Mode' }, 'True')).toBeNull()
+    expect(printerCellTone({ name: 'Strategy' }, false)).toBeNull()
+  })
+
+  // A named column holding something other than a truth value is not a badge —
+  // "Ready: 3/5" is a count, not a state.
+  it.each([
+    ['Ready', '3/5'],
+    ['Ready', 'Active'],
+    ['Healthy', 5],
+    ['Ready', null],
+    ['Ready', { a: 1 }],
+  ])('renders %s=%s as plain text', (name, value) => {
+    expect(printerCellTone({ name }, value)).toBeNull()
+  })
+
+  it('matches the column name case-insensitively and ignores padding', () => {
+    expect(printerCellTone({ name: '  READY  ' }, 'true')).toBe('healthy')
+  })
+})
+
+describe('printerTableKey collision safety', () => {
+  // Column names are vendor text and really do contain spaces ("VERIFY IMAGES",
+  // "FAILURE POLICY"). A separator-joined key let two different column sets
+  // produce one string, so the visibility effect would miss a real change.
+  it('distinguishes sets that a separator-joined key would merge', () => {
+    const a = printerTableKey({ columns: [{ name: 'A' }, { name: 'B' }, { name: 'C' }], cells: {} })
+    const b = printerTableKey({ columns: [{ name: 'A:0 B' }, { name: 'C' }], cells: {} })
+    expect(a).not.toBe(b)
+  })
+
+  it('still changes when only a priority changes', () => {
+    const before = printerTableKey({ columns: [{ name: 'Phase', priority: 1 }], cells: {} })
+    const after = printerTableKey({ columns: [{ name: 'Phase', priority: 0 }], cells: {} })
+    expect(before).not.toBe(after)
+  })
+})
+

--- a/packages/k8s-ui/src/components/resources/printer-columns.ts
+++ b/packages/k8s-ui/src/components/resources/printer-columns.ts
@@ -1,0 +1,249 @@
+import type { HealthLevel } from './resource-utils'
+import { KNOWN_NEGATIVE_CONDITIONS, KNOWN_POSITIVE_CONDITIONS } from './generic-status'
+
+// Vendor-declared table columns from a CRD's additionalPrinterColumns,
+// evaluated server-side (see internal/server/printer_columns.go) and shipped
+// with the list response. The pure parts live here so they're unit-tested;
+// the JSX render is materialized in ResourcesView.
+
+/** One column definition, as the CRD declared it. */
+export interface PrinterColumnDef {
+  name: string
+  type?: string
+  format?: string
+  /** The vendor's own text. Absent for most CRDs, which declare none. */
+  description?: string
+  /** kubectl's `-o wide` tier. Declared, but not shown by default. */
+  priority?: number
+}
+
+export interface PrinterTable {
+  /** The kind these columns describe, echoed by the server. */
+  kind?: string
+  group?: string
+  columns: PrinterColumnDef[]
+  /** metadata.uid -> one value per entry in `columns`, same order. */
+  cells: Record<string, unknown[]>
+}
+
+/**
+ * Stable identity for a column set. Printer columns are fixed per CRD version,
+ * so this string only changes when the kind changes or an operator is upgraded
+ * mid-session — which is exactly when the visibility defaults should be
+ * recomputed, and never on an ordinary refetch.
+ */
+export function printerTableKey(table: PrinterTable | null | undefined): string {
+  if (!table?.columns?.length) return ''
+  // Priority is part of the identity, not just the name: default visibility is
+  // derived from it, so an operator upgrade that promotes a column out of the
+  // `-o wide` tier has to re-run the visibility defaults. Serialized rather
+  // than concatenated because column names are vendor text that can contain
+  // the separators — real ones already carry spaces ("VERIFY IMAGES").
+  return JSON.stringify(table.columns.map(c => [c.name, c.priority ?? 0]))
+}
+
+/**
+ * Column key. Prefixed so it can never collide with a built-in column key or
+ * with a user-defined `label:`/`annotation:` custom column. Build-only — never
+ * parsed back into a name.
+ */
+export const PRINTER_COLUMN_PREFIX = 'printer:'
+
+export function printerColumnKey(def: PrinterColumnDef): string {
+  return `${PRINTER_COLUMN_PREFIX}${def.name}`
+}
+
+/**
+ * Drops anything malformed. The server owns this shape, but it crosses the
+ * wire, and a bad entry would otherwise produce a dead column or crash a map.
+ */
+export function sanitizePrinterTable(raw: any): PrinterTable | null {
+  if (!raw || !Array.isArray(raw.columns) || raw.columns.length === 0) return null
+  const seen = new Set<string>()
+  const columns: PrinterColumnDef[] = []
+  const keptIdx: number[] = []
+  raw.columns.forEach((c: any, i: number) => {
+    if (!c || typeof c.name !== 'string') return
+    const name = c.name.trim()
+    if (!name || seen.has(name)) return
+    seen.add(name)
+    columns.push({
+      name,
+      type: typeof c.type === 'string' ? c.type : undefined,
+      format: typeof c.format === 'string' ? c.format : undefined,
+      description: typeof c.description === 'string' ? c.description : undefined,
+      priority: typeof c.priority === 'number' ? c.priority : 0,
+    })
+    keptIdx.push(i)
+  })
+  if (!columns.length) return null
+
+  const cells: Record<string, unknown[]> = {}
+  const rawCells = raw.cells && typeof raw.cells === 'object' ? raw.cells : {}
+  for (const uid of Object.keys(rawCells)) {
+    const row = rawCells[uid]
+    if (!Array.isArray(row)) continue
+    // Realign to the surviving columns, or a dropped duplicate would shift
+    // every later value into the wrong column.
+    cells[uid] = keptIdx.map(i => row[i])
+  }
+  return {
+    kind: typeof raw.kind === 'string' ? raw.kind : undefined,
+    group: typeof raw.group === 'string' ? raw.group : undefined,
+    columns,
+    cells,
+  }
+}
+
+/**
+ * Whether a table describes the kind currently selected. The selected kind
+ * changes before the new list resolves, so an unchecked table can briefly be
+ * the PREVIOUS kind's — which the column-visibility effect would then persist
+ * under the new kind's storage key.
+ */
+export function printerTableMatchesKind(
+  table: PrinterTable | null | undefined,
+  kind: string,
+  group: string | undefined,
+): boolean {
+  if (!table) return false
+  // A server that sent no identity cannot be paired safely.
+  if (!table.kind) return false
+  // The server echoes the lowercased request path segment, so compare
+  // case-insensitively rather than relying on the caller's plural already
+  // being lowercase — a deep link that discovery could not resolve isn't.
+  return table.kind.toLowerCase() === kind.toLowerCase() && (table.group ?? '') === (group ?? '')
+}
+
+export function readPrinterCell(table: PrinterTable, uid: string | undefined, index: number): unknown {
+  if (!uid) return undefined
+  const row = table.cells[uid]
+  return Array.isArray(row) ? row[index] : undefined
+}
+
+/**
+ * Display text for one cell. Every value is a scalar by the time it gets here:
+ * the table converter humanizes `date` cells to "5m", coerces the numeric
+ * types, and JSON-encodes a `string` column whose path lands on an object or
+ * array — so a badly-aimed JSONPath arrives as a blob like `{"foo":"bar"}`
+ * rather than as structure. Non-scalars can therefore only come from a
+ * malformed response, and those read as absent.
+ */
+export function formatPrinterCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'boolean') return value ? 'True' : 'False'
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'string') return value
+  return ''
+}
+
+/**
+ * Seconds represented by a Kubernetes human-readable duration ("5m", "2d3h",
+ * "1y64d"), or null if it isn't one. The table converter emits these for `date`
+ * columns, and sorting them as text puts "10m" before "2m".
+ */
+const DURATION_UNIT_SECONDS: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400, y: 31536000 }
+
+export function parseHumanDuration(text: string): number | null {
+  const trimmed = text.trim()
+  if (!trimmed || !/^(\d+[smhdy])+$/.test(trimmed)) return null
+  let total = 0
+  for (const [, amount, unit] of trimmed.matchAll(/(\d+)([smhdy])/g)) {
+    total += Number(amount) * DURATION_UNIT_SECONDS[unit]
+  }
+  return total
+}
+
+/** Sort key. Numbers and booleans sort by value, not by their rendered text. */
+export function printerCellSortValue(value: unknown, def?: PrinterColumnDef): string | number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'boolean') return value ? 1 : 0
+  if (typeof value === 'string') {
+    if (def?.type === 'date') {
+      const seconds = parseHumanDuration(value)
+      // A date cell holds an age, so a bigger number is an OLDER object —
+      // the reverse of the Age column's timestamp. Negating restores the
+      // shared meaning: ascending puts the oldest first in both.
+      if (seconds !== null) return -seconds
+    }
+    return value
+  }
+  return ''
+}
+
+/**
+ * Width class for a column. Printer columns carry no width hint, so this is
+ * derived from the declared type: scalars are narrow, strings need room.
+ */
+export function printerColumnWidth(def: PrinterColumnDef): string {
+  switch (def.type) {
+    case 'integer':
+    case 'number':
+    case 'boolean':
+      return 'w-24'
+    case 'date':
+      return 'w-28'
+    default:
+      return 'w-40'
+  }
+}
+
+/**
+ * Column names whose polarity is a convention rather than a guess. Shared with
+ * the condition sets in generic-status.ts so the two can't drift, plus the
+ * names CRDs actually use for the same idea in a printer column.
+ *
+ * This is the one place Radar interprets vendor data rather than passing it
+ * through. It is deliberately narrow: the vendor NAMED the column, which is a
+ * much stronger signal than inferring health from a value. Anything not on
+ * these lists renders as plain text with no health claim.
+ */
+const POSITIVE_COLUMN_NAMES = new Set(
+  [...KNOWN_POSITIVE_CONDITIONS, 'ReadyToUse', 'Established', 'Installed', 'Provided']
+    .map(n => n.toLowerCase()),
+)
+// Split by severity, not just polarity. generic-status.ts tones a true
+// KNOWN_NEGATIVE_CONDITION as `degraded` (amber); collapsing these to red here
+// would make the same `Degraded=True` amber in the generic Status column and
+// red in a printer column.
+const DEGRADED_COLUMN_NAMES = new Set(KNOWN_NEGATIVE_CONDITIONS.map(n => n.toLowerCase()))
+const TERMINAL_COLUMN_NAMES = new Set(['denied', 'failed'])
+
+/** The three states a boolean-ish printer cell can hold, however it is typed. */
+function truthiness(value: unknown): 'true' | 'false' | 'unknown' | null {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value !== 'string') return null
+  switch (value.trim().toLowerCase()) {
+    case 'true': return 'true'
+    case 'false': return 'false'
+    case 'unknown': return 'unknown'
+    default: return null
+  }
+}
+
+/**
+ * Health tone for a printer cell, or null to render it as plain text.
+ *
+ * Only fires when the column's NAME carries a known polarity and its VALUE is
+ * True/False/Unknown — the shape a condition-derived printer column has. A
+ * column named `Healthy` holding `True` is the vendor telling us this row is
+ * fine; rendering that as grey text throws away the only scannable signal on
+ * the kinds that have no curated Status column.
+ */
+export function printerCellTone(def: PrinterColumnDef, value: unknown): HealthLevel | null {
+  const state = truthiness(value)
+  if (!state) return null
+  // The NAME decides whether we say anything at all — including for Unknown.
+  // Checking the value first would badge `Mode: Unknown` on a column whose
+  // polarity we have no claim to.
+  const name = def.name.trim().toLowerCase()
+  const positive = POSITIVE_COLUMN_NAMES.has(name)
+  const degraded = DEGRADED_COLUMN_NAMES.has(name)
+  const terminal = TERMINAL_COLUMN_NAMES.has(name)
+  if (!positive && !degraded && !terminal) return null
+  // Unknown is not a failure — the controller could not evaluate it.
+  if (state === 'unknown') return 'unknown'
+  if (positive) return state === 'true' ? 'healthy' : 'unhealthy'
+  if (degraded) return state === 'true' ? 'degraded' : 'healthy'
+  return state === 'true' ? 'unhealthy' : 'healthy'
+}

--- a/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Info, CheckCircle, XCircle, AlertCircle, ChevronRight, ChevronDown, FileCode, AlertTriangle, Layers } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { getGenericResourceStatus } from '../generic-status'
+import type { HealthLevel } from '../resource-utils'
 
 interface GenericRendererProps {
   data: any
@@ -13,7 +15,7 @@ export function GenericRenderer({ data }: GenericRendererProps) {
   const conditions = status.conditions
 
   // Determine health status from conditions or status fields
-  const healthStatus = getHealthStatus(status, conditions)
+  const healthStatus = getHealthStatus(data)
 
   // Extract important fields from spec and status
   const statusFields = getImportantFields(status, 'status')
@@ -138,89 +140,22 @@ interface HealthStatusResult {
   message?: string
 }
 
-function getHealthStatus(status: any, conditions?: any[]): HealthStatusResult | null {
-  if (!status) return null
+// This renderer's banner has four tones, while the shared derivation speaks the
+// full HealthLevel vocabulary. `alert` folds into unhealthy and `neutral` into
+// unknown — the banner has no distinct treatment for either.
+const BANNER_TYPE: Record<HealthLevel, HealthType> = {
+  healthy: 'healthy',
+  degraded: 'degraded',
+  alert: 'unhealthy',
+  unhealthy: 'unhealthy',
+  neutral: 'unknown',
+  unknown: 'unknown',
+}
 
-  // Check phase first (common pattern)
-  if (status.phase) {
-    const phase = String(status.phase)
-    const healthyPhases = ['Running', 'Active', 'Succeeded', 'Ready', 'Healthy', 'Available', 'Bound', 'Complete']
-    const degradedPhases = ['Pending', 'Progressing', 'Unknown', 'Terminating', 'Waiting']
-    const unhealthyPhases = ['Failed', 'Error', 'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull']
-
-    if (healthyPhases.includes(phase)) {
-      return { type: 'healthy', label: phase }
-    }
-    if (degradedPhases.includes(phase)) {
-      return { type: 'degraded', label: phase, message: status.message || status.reason }
-    }
-    if (unhealthyPhases.includes(phase)) {
-      return { type: 'unhealthy', label: phase, message: status.message || status.reason }
-    }
-  }
-
-  // Check conditions
-  if (conditions && Array.isArray(conditions) && conditions.length > 0) {
-    // Look for Ready or Available condition
-    const readyCondition = conditions.find((c: any) =>
-      c.type === 'Ready' || c.type === 'Available' || c.type === 'Healthy'
-    )
-    if (readyCondition) {
-      if (readyCondition.status === 'True') {
-        return { type: 'healthy', label: 'Ready' }
-      }
-      if (readyCondition.status === 'False') {
-        return {
-          type: 'unhealthy',
-          label: 'Not Ready',
-          message: readyCondition.message || readyCondition.reason
-        }
-      }
-    }
-
-    // Check for any False conditions that indicate problems
-    const problemConditions = conditions.filter((c: any) =>
-      c.status === 'False' && ['Ready', 'Available', 'Healthy', 'Initialized'].includes(c.type)
-    )
-    if (problemConditions.length > 0) {
-      const problem = problemConditions[0]
-      return {
-        type: 'unhealthy',
-        label: `${problem.type}: False`,
-        message: problem.message || problem.reason
-      }
-    }
-
-    // Check for warning conditions
-    const warningConditions = conditions.filter((c: any) =>
-      c.status === 'True' && ['Degraded', 'Warning', 'ScalingLimited'].includes(c.type)
-    )
-    if (warningConditions.length > 0) {
-      const warning = warningConditions[0]
-      return {
-        type: 'degraded',
-        label: warning.type,
-        message: warning.message || warning.reason
-      }
-    }
-  }
-
-  // Check replica-based status
-  if (status.replicas !== undefined) {
-    const desired = status.replicas
-    const ready = status.readyReplicas || status.availableReplicas || 0
-    if (desired > 0 && ready >= desired) {
-      return { type: 'healthy', label: `${ready}/${desired} Ready` }
-    }
-    if (desired > 0 && ready > 0) {
-      return { type: 'degraded', label: `${ready}/${desired} Ready` }
-    }
-    if (desired > 0 && ready === 0) {
-      return { type: 'unhealthy', label: `0/${desired} Ready` }
-    }
-  }
-
-  return null
+function getHealthStatus(resource: any): HealthStatusResult | null {
+  const derived = getGenericResourceStatus(resource)
+  if (!derived) return null
+  return { type: BANNER_TYPE[derived.tone], label: derived.text, message: derived.reason }
 }
 
 // ============================================================================

--- a/packages/k8s-ui/src/components/resources/resource-utils-velero.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-velero.test.ts
@@ -94,6 +94,36 @@ describe('getCellFilterValue — Velero status column', () => {
     const bsl = { apiVersion: 'velero.io/v1', kind: 'BackupStorageLocation', status: { phase: 'Unavailable' } }
     expect(getCellFilterValue(bsl, 'status', 'backupstoragelocations')).toBe('Unavailable')
   })
+
+  // The cell dispatch sends a non-Velero BackupStorageLocation/BackupRepository
+  // to GenericCell. The filter dropdown and the sort key have to follow it
+  // there, or the column offers and orders values that appear on no row.
+  it('leaves a foreign BackupStorageLocation on the generic reader', () => {
+    // Conditions, not a phase: Velero's reader keys on phase and has nothing to
+    // say here, so this only passes if the generic derivation ran.
+    const foreign = {
+      apiVersion: 'other.io/v1',
+      kind: 'BackupStorageLocation',
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    }
+    expect(getCellFilterValue(foreign, 'status', 'backupstoragelocations')).toBe('Ready')
+  })
+
+  it('leaves a foreign BackupRepository on the generic reader', () => {
+    const foreign = {
+      apiVersion: 'other.io/v1',
+      kind: 'BackupRepository',
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    }
+    expect(getCellFilterValue(foreign, 'status', 'backuprepositories')).toBe('Ready')
+  })
+
+  // Velero's own readers speak a phase vocabulary a foreign CRD does not share,
+  // so the two must not produce the same string for the same object.
+  it('does not label a foreign resource with Velero vocabulary', () => {
+    const foreign = { apiVersion: 'other.io/v1', kind: 'BackupRepository', status: { phase: 'NotReady' } }
+    expect(getCellFilterValue(foreign, 'status', 'backuprepositories')).not.toBe('Not ready')
+  })
 })
 
 describe('Velero Backup phase vocabulary', () => {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -18,6 +18,7 @@ import { getBackupStatus as _getBackupStatus, getRestoreStatus as _getRestoreSta
 import { getExternalSecretStatus as _getExternalSecretStatus, getClusterExternalSecretStatus as _getClusterExternalSecretStatus, getSecretStoreStatus as _getSecretStoreStatus, getClusterSecretStoreStatus as _getClusterSecretStoreStatus, getSecretStoreProviderType as _getSecretStoreProviderType } from './resource-utils-eso'
 import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
 import { getCNPGClusterStatus as _getCNPGClusterStatus, getCNPGBackupStatus as _getCNPGBackupStatus, getCNPGScheduledBackupStatus as _getCNPGScheduledBackupStatus, getCNPGPoolerStatus as _getCNPGPoolerStatus, isApiGroup as _isApiGroup, CNPG_GROUP as _CNPG_GROUP } from './resource-utils-cnpg'
+import { getGenericResourceStatus } from './generic-status'
 import { getCalicoIPPoolAllowedUses, getCalicoIPPoolBlockSize, getCalicoIPPoolEncapsulation, getCalicoPolicyNamespaceSelector, getCalicoPolicyServiceAccountSelector, getCalicoPolicyTypes, isCalicoApiVersion, isCalicoPolicyResource } from './resource-utils-calico'
 
 // ============================================================================
@@ -2216,7 +2217,16 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       if (kindLower === 'nvidiaclusterpolicies') return _getNvidiaClusterPolicyStatus(resource).text
       if (kindLower === 'nvidiadrivers') return _getNvidiaDriverStatus(resource).text
       if (kindLower === 'resourceclaims') return _getResourceClaimStatus(resource).text
-      if (kindLower === 'backups') return _getBackupStatus(resource).text
+      // Positively gated, matching the cell dispatch: `backups` is reached here
+      // only when the group is unknown to normalizeKindToPlural, and a third
+      // vendor's Backup renders through the generic path — so the sort key has
+      // to come from there too, or the column sorts on a Velero-derived string
+      // the row never displayed.
+      if (kindLower === 'backups') {
+        if (_isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGBackupStatus(resource).text
+        if (_isApiGroup(resource.apiVersion, 'velero.io')) return _getBackupStatus(resource).text
+        return getGenericResourceStatus(resource)?.text ?? ''
+      }
       // Velero's Restore/Schedule keys are group-qualified (see
       // GROUP_QUALIFIED_COLUMN_KEYS) because those plurals are shared with
       // rancher/backup-restore-operator and others. The unqualified plural
@@ -2224,8 +2234,17 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       // reader below rather than being filtered as though it were Velero.
       if (kindLower === 'velerorestores') return _getRestoreStatus(resource).text
       if (kindLower === 'veleroschedules') return _getScheduleStatus(resource).text
-      if (kindLower === 'backupstoragelocations') return _getBSLStatus(resource).text
-      if (kindLower === 'backuprepositories') return _getBackupRepositoryStatus(resource).text
+      // Same positive gate as `backups` above, for the same reason: the cell
+      // dispatch sends a non-Velero resource to GenericCell, so the sort and
+      // filter keys have to come from there too.
+      if (kindLower === 'backupstoragelocations') {
+        if (_isApiGroup(resource.apiVersion, 'velero.io')) return _getBSLStatus(resource).text
+        return getGenericResourceStatus(resource)?.text ?? ''
+      }
+      if (kindLower === 'backuprepositories') {
+        if (_isApiGroup(resource.apiVersion, 'velero.io')) return _getBackupRepositoryStatus(resource).text
+        return getGenericResourceStatus(resource)?.text ?? ''
+      }
       if (kindLower === 'externalsecrets') return _getExternalSecretStatus(resource).text
       if (kindLower === 'clusterexternalsecrets') return _getClusterExternalSecretStatus(resource).text
       if (kindLower === 'secretstores') return _getSecretStoreStatus(resource).text
@@ -2242,15 +2261,9 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       if (kindLower === 'cnpgbackups') return _getCNPGBackupStatus(resource).text
       if (kindLower === 'scheduledbackups' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGScheduledBackupStatus(resource).text
       if (kindLower === 'poolers' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGPoolerStatus(resource).text
-      // Generic CRDs: try status.phase, then Ready condition
-      if (resource.status?.phase) return resource.status.phase
-      {
-        const conditions = resource.status?.conditions || []
-        const ready = conditions.find((c: any) => c.type === 'Ready')
-        if (ready?.status === 'True') return 'Ready'
-        if (ready?.status === 'False') return 'Not Ready'
-      }
-      return ''
+      // Generic CRDs. Must read the same text the cell renders or the dropdown
+      // offers strings that appear on no row — hence the shared derivation.
+      return getGenericResourceStatus(resource)?.text ?? ''
     case 'state':
       if (kindLower === 'orders') return getOrderState(resource).text
       if (kindLower === 'challenges') return getChallengeState(resource).text

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -655,12 +655,25 @@ describe('shared plurals — the status path collides too', () => {
   // The renderer and the status badge are two separate switches over the same
   // plural, and fixing one leaves the other reading a foreign CRD's conditions
   // as if they were Knative's.
+  // Phase-only on purpose. Knative reports a bare "Unknown" for a resource with
+  // no conditions, while the generic path reports the phase — so this fixture
+  // tells the two apart. A Ready=False condition would not: both paths surface
+  // the same text for it, and pinning which of phase/conditions wins is a
+  // separate concern that generic-status.test.ts owns.
   it('does not give a foreign subscriptions CRD a Knative status', () => {
     const s = getResourceStatus('subscriptions', {
       apiVersion: 'operators.coreos.com/v1alpha1',
-      status: { conditions: [{ type: 'Ready', status: 'False' }], phase: 'AtLatestKnown' },
+      status: { phase: 'AtLatestKnown' },
     })
     expect(s?.text).toBe('AtLatestKnown')
+  })
+
+  it('still routes a Knative subscription to the Knative status', () => {
+    const s = getResourceStatus('subscriptions', {
+      apiVersion: 'messaging.knative.dev/v1',
+      status: { phase: 'AtLatestKnown' },
+    })
+    expect(s?.text).toBe('Unknown')
   })
 
   it('still gives Knative its own status', () => {

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx'
-import { SEVERITY_BADGE } from '../../utils/badge-colors'
+import { SEVERITY_BADGE, HEALTH_BADGE_COLORS } from '../../utils/badge-colors'
 import { isArgoRolloutResource } from '../../utils/workload-rollout'
+import { getGenericResourceStatus } from '../resources/generic-status'
 import {
   getPodStatus,
   getWorkloadDisplayStatus,
@@ -1201,36 +1202,8 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
     return { text: status.text, color: status.color }
   }
 
-  // Generic status extraction
-  const status = data.status
-  if (status) {
-    if (status.phase) {
-      const phase = String(status.phase)
-      const healthyPhases = ['Running', 'Active', 'Succeeded', 'Ready', 'Healthy', 'Available', 'Bound']
-      const warningPhases = ['Pending', 'Progressing', 'Unknown', 'Terminating']
-      const isHealthy = healthyPhases.includes(phase)
-      const isWarning = warningPhases.includes(phase)
-      return {
-        text: phase,
-        color: isHealthy ? SEVERITY_BADGE.success :
-               isWarning ? SEVERITY_BADGE.warning :
-               SEVERITY_BADGE.error
-      }
-    }
-
-    if (status.conditions && Array.isArray(status.conditions)) {
-      const readyCondition = status.conditions.find((c: any) =>
-        c.type === 'Ready' || c.type === 'Available' || c.type === 'Progressing'
-      )
-      if (readyCondition) {
-        const isReady = readyCondition.status === 'True'
-        return {
-          text: isReady ? 'Ready' : 'Not Ready',
-          color: isReady ? SEVERITY_BADGE.success : SEVERITY_BADGE.warning
-        }
-      }
-    }
-  }
+  const derived = getGenericResourceStatus(data)
+  if (derived) return { text: derived.text, color: HEALTH_BADGE_COLORS[derived.tone] }
 
   return null
 }

--- a/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
+++ b/packages/k8s-ui/src/components/trace/ReachabilityView.tsx
@@ -535,7 +535,7 @@ export function problemRows(
     // entry can carry several findings, and one origin several failed routes.
     // `k` is what `seen` just proved unique, so pairing them is what makes the
     // React key safe rather than each caller having to get it right.
-    rows.push({ ...r, key: `${r.key} ${k}` })
+    rows.push({ ...r, key: `${r.key}\x00${k}` })
   }
   const refNode = (r?: ResourceRef) => (r ? `n:${r.kind}/${r.namespace ?? ''}/${r.name || 'pods'}` : '')
 

--- a/packages/k8s-ui/src/source-hygiene.test.ts
+++ b/packages/k8s-ui/src/source-hygiene.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+// A stray NUL in a source file compiles fine and passes every type and unit
+// check, so nothing else here would catch one. What it does break is the
+// tooling around the file: grep treats the file as binary and silently reports
+// no matches, which is a genuinely confusing way to lose an afternoon. This
+// package is also published as source, so the byte would ship to consumers.
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full))
+    else if (/\.(ts|tsx|css)$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+describe('source hygiene', () => {
+  it('has no NUL bytes in any source file', () => {
+    const offenders = sourceFiles(join(__dirname))
+      .filter(f => readFileSync(f).includes(0x00))
+      .map(f => f.slice(f.indexOf('/src/')))
+    expect(offenders).toEqual([])
+  })
+})

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -16,8 +16,10 @@ import {
   ResourcesView as BaseResourcesView,
   CORE_RESOURCES,
   intersectWorkloadWrites,
+  hasCuratedColumns,
+  sanitizePrinterTable,
 } from '@skyhook-io/k8s-ui'
-import type { Capabilities, ResourceQueryResult, WorkloadWritePermissions } from '@skyhook-io/k8s-ui'
+import type { Capabilities, PrinterTable, ResourceQueryResult, WorkloadWritePermissions } from '@skyhook-io/k8s-ui'
 import type { SelectedResource } from '../../types'
 import { kindToPlural, type NavigateToResource } from '../../utils/navigation'
 import { CreateResourceDialog } from '../shared/CreateResourceDialog'
@@ -229,12 +231,19 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // Fetch full data only for the selected kind
   const selectedKindQuery = useQuery({
     queryKey: ['resources', selectedKind?.name, isSelectedCrd ? selectedKind?.group : '', namespaces],
-    queryFn: async () => {
-      if (!selectedKind) return []
+    queryFn: async (): Promise<{ items: any[]; printerTable: PrinterTable | null }> => {
+      if (!selectedKind) return { items: [], printerTable: null }
       const params = new URLSearchParams()
       if (namespaces.length > 0) params.set('namespaces', namespacesParam)
       if (isSelectedCrd && selectedKind.group) params.set('group', selectedKind.group)
       if (selectedKindSummaryServed) params.set('include', 'summary')
+      // Only CRDs can declare printer columns, and a curated kind discards the
+      // result — so table mode is requested from exactly the kinds that can use
+      // it. Resolving a table costs the server a CRD read per request; doing
+      // that for a kind whose columns are hand-curated is pure waste.
+      const wantsTable = isSelectedCrd && !!selectedKind.group &&
+        !hasCuratedColumns(selectedKind.name, selectedKind.group)
+      if (wantsTable) params.set('table', '1')
       const startedAt = performance.now()
       debugNamespaceLog('resources:selected-kind-fetch-start', {
         kind: selectedKind.name,
@@ -258,7 +267,19 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
         const errorData = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
         throw new ApiError(errorData.error || `Failed to fetch ${selectedKind.name}`, res.status, errorData)
       }
-      return res.json()
+      const body = await res.json()
+      // Both branches are current shapes, not a guess at a legacy one: a Radar
+      // backend that predates `table` ignores the parameter and answers with
+      // the bare array. @skyhook-io/radar-app is versioned independently of the
+      // backend it points at, so a consumer can pair a new frontend with an
+      // older Radar — and reading that array as a missing envelope would render
+      // every CRD list empty. Items and columns still come from one response,
+      // so a row can never render against another fetch's cells.
+      if (!wantsTable || Array.isArray(body)) return { items: body as any[], printerTable: null }
+      return {
+        items: Array.isArray(body?.items) ? body.items as any[] : [],
+        printerTable: sanitizePrinterTable(body),
+      }
     },
     enabled: !!selectedKind && !selectedKindQueryBlocked,
     staleTime: 30000,
@@ -275,13 +296,13 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     return {
       resourceName: selectedKind.name,
       group: selectedKind.group,
-      data: selectedKindQueryBlocked ? [] : selectedKindQuery.data as any[] | undefined,
+      data: selectedKindQueryBlocked ? [] : selectedKindQuery.data?.items,
       isLoading: waitingForGuardCount || selectedKindQuery.isLoading,
       error: selectedKindQueryBlocked ? undefined : selectedKindQuery.error,
       refetch: selectedKindQuery.refetch,
       dataUpdatedAt: selectedKindQuery.dataUpdatedAt,
     }
-  }, [selectedKind, selectedKindQueryBlocked, waitingForGuardCount, selectedKindQuery.data, selectedKindQuery.isLoading, selectedKindQuery.error, selectedKindQuery.refetch, selectedKindQuery.dataUpdatedAt])
+  }, [selectedKind, selectedKindQueryBlocked, waitingForGuardCount, selectedKindQuery.data?.items, selectedKindQuery.isLoading, selectedKindQuery.error, selectedKindQuery.refetch, selectedKindQuery.dataUpdatedAt])
 
   // Metrics
   const { data: topPodMetrics } = useTopPodMetrics({ enabled: topPodMetricsEnabled, namespaces })
@@ -352,6 +373,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       resourceReasons={countsData?.reasons}
       resourceUnavailable={countsData?.unavailable}
       selectedKindQuery={selectedKindQueryResult}
+      printerTable={selectedKindQueryBlocked ? null : selectedKindQuery.data?.printerTable ?? null}
       connectionState={connection.state}
       largeListGuard={largeListGuard}
       onSelectedKindChange={setSelectedKind}


### PR DESCRIPTION
Radar hand-curates ~198 column sets. Every other CRD fell to Name/Namespace/Status/Age, with a Status that was frequently a dash — so on an operator-heavy cluster a large share of kinds rendered a table that said nothing. Those kinds already publish what matters about themselves: `additionalPrinterColumns` is what `kubectl get` renders, and most CRDs declare it.

This makes uncurated kinds show real columns and a real status, without touching any kind Radar has curated.

Surveying 12 clusters: curated coverage runs 35–41% of CRD kinds on our GKE clusters but only 7–27% on the ones shaped like customers'. What's in the gap there is not obscure — `RayCluster`, `RayJob`, Kueue's `ClusterQueue`/`Workload`, `JobSet`, `LeaderWorkerSet`, Volcano's `PodGroup`, Crossplane v2's `Operation`/`FunctionRevision`, `TargetGroupBinding`.

## What changed

### One generic status derivation

Four copies of "what is this uncurated CRD's status" had drifted apart — the table cell, the column filter/sort value, the drawer dispatch, and the generic renderer — each knowing a different set of phases and condition types. The table could disagree with its own filter dropdown. They now share `getGenericResourceStatus` (`packages/k8s-ui/src/components/resources/generic-status.ts`), which nets out ~134 lines smaller than the copies it replaces.

Behaviour that falls out of unifying them:

- An unrecognized phase is neither painted red nor allowed to short-circuit. Operator-specific names like `Rebalancing` are a vocabulary we don't know, not an outage — and an ungradeable phase must not suppress a gradeable `Ready=False` below it. The phase text remains the last resort.
- Polarity is only claimed for a fixed set of condition types. Anything else is reported as text with no health claim, which is what makes gmp `PodMonitoring` (`ConfigurationCreateSuccess`) and GKE `ComputeClass` (`Health`) stop rendering a dash.
- `Unknown` is not `False` — a condition the controller couldn't evaluate isn't a failure.
- `status.status` is read alongside `status.state`, which is what kubefledged `ImageCache` publishes.

Sorting the Status column follows the same boundary: uncurated kinds sort on the text their badge shows, since they often have no phase to sort on at all and phase ordered every row as equal. Curated kinds keep sorting on phase — their cell and sort have always differed, and reordering the most-used lists is not this change's business.

### Printer columns, evaluated server-side

`?table=1` on the list endpoint returns `{items, kind, group, columns, cells}`. Columns are evaluated by the API server's own CRD table code (`apiextensions-apiserver`'s `tableconvertor`) rather than hand-rolled JSONPath — real CRDs use filter expressions, wildcards and escaped keys, and the convertor also owns first-match semantics and type coercion.

Load-bearing decisions a reviewer should look at:

- **Curated XOR printer, never merged.** Curated always wins; several curated sets encode why the vendor-obvious field is the wrong one to show. `hasCuratedColumns` is the single definition of "curated", shared by the XOR, the storage-key qualifier, and the client's decision whether to request a table at all.
- **Eligibility gate.** A kind needs ≥2 substantive columns after dropping Name/Namespace/Age and the `-o wide` tier. Without it, kinds declaring only `Age` would trade the generic Status column for nothing — 21 of 36 otherwise-eligible kinds on one surveyed cluster are that thin. The gate counts columns exactly as the client will render them: trimmed, blanks dropped, deduplicated first-wins across priorities, then the wide tier hidden.
- **The served version, not the storage version.** The API server converts objects into the version being listed and printer columns are per-version, so storage-version paths can address a schema these objects don't have.
- **A stable envelope.** Table mode returns the same fields for every outcome that answers 200 — eligible, ineligible, empty, unreadable CRD, preflight RBAC-denied — with `columns`/`cells` null when there's no table (errors keep their status and `{"error"}` body). A response whose top-level type depended on the caller's permissions would force dual-shape handling on every consumer. An authorized empty list still carries its columns, since they belong to the CRD rather than the rows; a denial deliberately doesn't, because resolving them uses Radar's own identity. Without the parameter the response is the bare array it always was, so `useResources` and library consumers are untouched. The client accepts either shape when it asks for a table: `@skyhook-io/radar-app` is versioned independently of the backend it points at, so a frontend that sends `table=1` can meet one that ignores it, and that pairing falls back to the generic columns rather than an empty list.
- **The CRD is read from the informer.** `GetDynamicWithGroup` routes CRDs to a live GET so the YAML tab and MCP see `spec.versions[].schema`, which printer columns don't need and the cache strips anyway while preserving the columns. Going direct cost a full apiserver round-trip per list. The client also skips table mode entirely for curated kinds, whose result it would discard.
- **Convertors are built per request, deliberately not cached.** The compiled `jsonpath.JSONPath` objects carry mutable walk state, so a shared instance would race across concurrent lists. The compile is noise next to the per-item evaluation.
- Rows and columns are checked to come from the same cluster: a context switch between listing and resolving would otherwise pair one cluster's objects with another's definitions, which kind/group identity can't detect because both clusters call it the same kind.

### Rendering

Printer columns materialize into `ExtraColumn`s, so sort, column filters, the picker and per-kind persistence all come free. Values keep their declared types — integers sort numerically, and `date` cells sort on parsed duration since the converter humanizes them to `5m`.

A column whose **name** carries a known polarity (`Ready`, `Healthy`, `Established`, `Installed`, … or `Degraded`, `Denied`, `Failed`) and whose **value** is True/False/Unknown renders as a health badge rather than plain text. These kinds have no curated Status column, so this is their only scannable signal; a screen of uniform grey `True` is exactly what a status column exists not to be. The polarity sets and their severities are shared with `generic-status.ts`, so the same condition can't be amber in one column and red in another. This is the only place vendor data is interpreted, and it's narrow on purpose: the vendor *naming* the column is the signal, never the value alone.

Column-settings storage keys are group-qualified for kinds that previously fell through to a bare plural. Two uncurated CRDs sharing a plural across API groups — Crossplane ships two `Usage` kinds — shared one blob and leaked visibility, widths and custom columns between them. Curated and core kinds keep their existing key, so no saved preference resets.

## Testing

`make tsc` · `make test` · race-enabled server tests · 2759 k8s-ui · 507 web. ~140 new unit tests across the Go engine, the status derivation, the printer-column helpers and the storage-key predicate.

Visual-tested against three clusters (GKE, EKS, a Crossplane management cluster) at 1280 and 1920, light and dark. Covered: a kind rendering its vendor columns (`VerticalPodAutoscaler` → Mode/CPU/Mem/Provided, matching `kubectl get vpa`); a thin kind correctly keeping the generic columns; an empty eligible kind; the `-o wide` tier present in the picker but unchecked; vendor SHOUTING-CASE headers (which read normally, since Radar uppercases all headers); health badges on `HEALTHY`/`INSTALLED`/`ESTABLISHED` with adjacent non-polarity columns left as plain text; and a curated Crossplane managed resource correctly keeping its curated set. No console errors.

## Limitations and follow-ups

- MCP's generic CRD summary (`summarizeGenericCRD`) doesn't use printer columns, and its status ladder is conditions-first where the TypeScript one is phase-first — so MCP and the UI still disagree on e.g. `{phase: Running, Ready: False}`. Both are scoped with the MCP work.
- The resource drawer doesn't use printer columns; table only.
- A foreign CRD whose plural collides with a bare curated key (`backups.third-party.io` → Velero's set) inherits the wrong columns and is denied its own. Pre-existing in the curated dispatch; fixing it needs group-aware lookup across all 198 sets.
- Radar's empty state replaces the table entirely, so an eligible kind holding nothing shows no headers. The columns are still resolved, which keeps the set stable as the first object appears or the last is deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an optional list response shape and CRD reads on every table-mode list for uncurated kinds; RBAC and cluster-switch guards are explicit but the resources list path is heavily used.
> 
> **Overview**
> **Uncurated CRDs** now get **kubectl-style table columns** and a **consistent status** instead of the generic Name/Namespace/Status/Age layout with a often-empty Status. **Curated kinds are unchanged** — printer columns and hand-tuned sets are **exclusive** (`hasCuratedColumns` gates both client and server).
> 
> The list API adds **`?table=1`**, which returns `{items, kind, group, columns, cells}` with cells evaluated via the apiserver’s **CRD table convertor** (served API version, ≥2 substantive columns after dropping Name/Namespace/Age, stable envelope even when empty or denied so RBAC denials don’t leak column schema). Without the flag, responses stay a **bare array**.
> 
> The UI wires **`printerTable`** into `ResourcesView`, materializes columns as `ExtraColumn`s (sort/filter/picker, `-o wide` tier), **group-qualifies** column localStorage for colliding plurals, and only requests table mode for **uncurated CRDs**.
> 
> **`getGenericResourceStatus`** replaces four divergent “generic CRD status” paths (table, filter/sort, drawer dispatch, `GenericRenderer`) so badges, filters, and sorting agree; uncurated Status sort uses displayed text, curated kinds still sort on phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae25b15f6fc49c5925475cf2e5b0dd04a9c3662a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


