### PR TITLE
fix(copy): stream pod file downloads and save them natively on desktop

### DIFF
--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -127,12 +127,19 @@ func (a *DesktopApp) saveStream(defaultFilename string, src io.Reader) (string, 
 	if err != nil {
 		return "", err
 	}
-	if _, err := io.Copy(f, src); err != nil {
-		f.Close()
-		os.Remove(path)
-		return "", err
+	// Buffered writes commonly report failure at close (ENOSPC, EIO on a
+	// network mount), so the close error matters as much as the copy error —
+	// either one has to take the partial file with it.
+	_, copyErr := io.Copy(f, src)
+	closeErr := f.Close()
+	if copyErr == nil {
+		copyErr = closeErr
 	}
-	return path, f.Close()
+	if copyErr != nil {
+		os.Remove(path)
+		return "", copyErr
+	}
+	return path, nil
 }
 
 // domReady is called when the webview DOM is ready.

--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -61,6 +62,7 @@ func (a *DesktopApp) startup(ctx context.Context) {
 	a.ctx = ctx
 	startNativeMouseMonitor(ctx)
 	a.srv.SetSaveFileFunc(a.saveFile)
+	a.srv.SetSaveStreamFunc(a.saveStream)
 
 	// The OS titlebar must track the active kubeconfig context for the same
 	// reason the in-page selector does: a fleet UI showing the wrong cluster
@@ -70,10 +72,10 @@ func (a *DesktopApp) startup(ctx context.Context) {
 	})
 }
 
-// saveFile writes a file to the user's Downloads folder.
+// downloadPath resolves a collision-free path in the user's Downloads folder.
 // We write directly to ~/Downloads instead of showing a native save dialog
 // because Wails' SaveFileDialog is immediately dismissed by the webview on macOS.
-func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, error) {
+func downloadPath(defaultFilename string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -98,11 +100,39 @@ func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, erro
 		}
 		path = filepath.Join(dir, fmt.Sprintf("%s (%d)%s", name, i, ext))
 	}
+	return path, nil
+}
 
+// saveFile writes a file to the user's Downloads folder.
+func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, error) {
+	path, err := downloadPath(defaultFilename)
+	if err != nil {
+		return "", err
+	}
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+// saveStream writes src to the user's Downloads folder without buffering it in
+// memory, so downloads are bounded by disk rather than by webview or process
+// memory. A failed copy leaves no partial file behind.
+func (a *DesktopApp) saveStream(defaultFilename string, src io.Reader) (string, error) {
+	path, err := downloadPath(defaultFilename)
+	if err != nil {
+		return "", err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(f, src); err != nil {
+		f.Close()
+		os.Remove(path)
+		return "", err
+	}
+	return path, f.Close()
 }
 
 // domReady is called when the webview DOM is ready.

--- a/cmd/desktop/save_stream_test.go
+++ b/cmd/desktop/save_stream_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// errReader yields prefix, then fails — standing in for a download that dies
+// partway through.
+type errReader struct {
+	prefix string
+	pos    int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.pos < len(r.prefix) {
+		n := copy(p, r.prefix[r.pos:])
+		r.pos += n
+		return n, nil
+	}
+	return 0, errors.New("transport died")
+}
+
+func TestSaveStreamWritesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a := &DesktopApp{}
+
+	path, err := a.saveStream("app.log", strings.NewReader("hello world"))
+	if err != nil {
+		t.Fatalf("saveStream: %v", err)
+	}
+	if want := filepath.Join(home, "Downloads", "app.log"); path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != "hello world" {
+		t.Errorf("content = %q, want %q", data, "hello world")
+	}
+}
+
+func TestSaveStreamAvoidsCollisions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a := &DesktopApp{}
+
+	if _, err := a.saveStream("app.log", strings.NewReader("first")); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	path, err := a.saveStream("app.log", strings.NewReader("second"))
+	if err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	if want := filepath.Join(home, "Downloads", "app (1).log"); path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	data, _ := os.ReadFile(filepath.Join(home, "Downloads", "app.log"))
+	if string(data) != "first" {
+		t.Errorf("original file was overwritten: %q", data)
+	}
+}
+
+// A download that dies mid-copy must not leave a truncated file sitting in
+// Downloads looking like a successful save.
+func TestSaveStreamRemovesPartialFileOnError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a := &DesktopApp{}
+
+	_, err := a.saveStream("big.bin", &errReader{prefix: strings.Repeat("x", 4096)})
+	if err == nil {
+		t.Fatal("saveStream succeeded, want the underlying read error")
+	}
+	entries, readErr := os.ReadDir(filepath.Join(home, "Downloads"))
+	if readErr != nil {
+		t.Fatalf("read Downloads: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Downloads contains %d file(s), want none", len(entries))
+	}
+}
+
+func TestSaveStreamAndSaveFileAgreeOnPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a := &DesktopApp{}
+
+	first, err := a.saveFile("notes.txt", []byte("a"))
+	if err != nil {
+		t.Fatalf("saveFile: %v", err)
+	}
+	second, err := a.saveStream("notes.txt", io.LimitReader(strings.NewReader("bb"), 2))
+	if err != nil {
+		t.Fatalf("saveStream: %v", err)
+	}
+	if first == second {
+		t.Fatalf("both saves resolved to %q; collision handling is not shared", first)
+	}
+	if want := filepath.Join(home, "Downloads", "notes (1).txt"); second != want {
+		t.Errorf("second path = %q, want %q", second, want)
+	}
+}

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -186,7 +186,7 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 	runAttempt := func(ctx context.Context, offset uint64, stdout io.Writer) error {
 		var cmd []string
 		if offset == 0 {
-			cmd = []string{"tar", "cf", "-", "-C", dir, base}
+			cmd = []string{"tar", "cf", "-", "-C", dir, "--", base}
 		} else {
 			// tail -c+N is 1-based: resume at the first byte not yet delivered.
 			// The header block stays 512 bytes however large the size field
@@ -196,7 +196,7 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 			// the trick kubectl cp --retries relies on. A file rotated or
 			// rewritten mid-transfer splices two different archives, which
 			// nothing downstream can detect.
-			cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar cf - -C %s %s | tail -c+%d", shellQuote(dir), shellQuote(base), offset+1)}
+			cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar cf - -C %s -- %s | tail -c+%d", shellQuote(dir), shellQuote(base), offset+1)}
 		}
 
 		req := client.CoreV1().RESTClient().Post().
@@ -286,6 +286,13 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 // the desktop app, so `save=native` does nothing in server or browser mode.
 func (s *Server) deliverPodFile(w http.ResponseWriter, r *http.Request, src io.Reader, fileName string, size int64, namespace, podName, filePath string) {
 	if s.saveStreamFunc != nil && r.URL.Query().Get("save") == "native" {
+		// Writing to the user's disk is a side effect, and a GET reaches the
+		// loopback listener cross-origin with no preflight — an <img> tag is
+		// enough. The streaming path below is an ordinary read and stays open.
+		if !localOriginOK(r) {
+			s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
+			return
+		}
 		name := sanitizeFilename(fileName)
 		if name == "" {
 			s.writeError(w, http.StatusBadRequest, "invalid filename")

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -268,17 +269,50 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if header.Typeflag == tar.TypeReg {
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
-			w.Header().Set("Content-Length", strconv.FormatInt(header.Size, 10))
-			if n, err := io.CopyN(w, tr, header.Size); err != nil {
-				// Headers are already sent; ending the body short of
-				// Content-Length makes the client fail the download visibly.
-				log.Printf("[copy] streaming %s from %s/%s aborted after %d of %d bytes: %v", filePath, namespace, podName, n, header.Size, err)
-				errorlog.Record("copy", "error", "file download for %s/%s path=%s aborted after %d of %d bytes: %v", namespace, podName, filePath, n, header.Size, err)
-			}
+			s.deliverPodFile(w, r, tr, fileName, header.Size, namespace, podName, filePath)
 			return
 		}
+	}
+}
+
+// deliverPodFile hands an extracted file to the caller: written straight to
+// disk in the desktop app, streamed to the HTTP response otherwise. src must
+// yield at least size bytes; reads stop there.
+//
+// The desktop app saves natively because blob URL downloads are swallowed by
+// its webview. Routing the bytes back through /desktop/save-file would make
+// the webview buffer and base64 the whole file, so the server writes it here
+// instead — constant memory, no size ceiling. saveStreamFunc is set only by
+// the desktop app, so `save=native` does nothing in server or browser mode.
+func (s *Server) deliverPodFile(w http.ResponseWriter, r *http.Request, src io.Reader, fileName string, size int64, namespace, podName, filePath string) {
+	if s.saveStreamFunc != nil && r.URL.Query().Get("save") == "native" {
+		name := sanitizeFilename(fileName)
+		if name == "" {
+			s.writeError(w, http.StatusBadRequest, "invalid filename")
+			return
+		}
+		savedPath, err := s.saveStreamFunc(name, io.LimitReader(src, size))
+		if err != nil {
+			log.Printf("[copy] native save of %s from %s/%s failed: %v", filePath, namespace, podName, err)
+			errorlog.Record("copy", "error", "native save failed for %s/%s path=%s: %v", namespace, podName, filePath, err)
+			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to save file: %v", err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{"path": savedPath}); err != nil {
+			log.Printf("[copy] failed to write native save response: %v", err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	if n, err := io.CopyN(w, src, size); err != nil {
+		// Headers are already sent; ending the body short of
+		// Content-Length makes the client fail the download visibly.
+		log.Printf("[copy] streaming %s from %s/%s aborted after %d of %d bytes: %v", filePath, namespace, podName, n, size, err)
+		errorlog.Record("copy", "error", "file download for %s/%s path=%s aborted after %d of %d bytes: %v", namespace, podName, filePath, n, size, err)
 	}
 }
 

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -3,6 +3,7 @@ package server
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -174,69 +175,61 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// First try: tar cf - to stream the file (handles binary files correctly)
+	// First try: tar cf - to stream the file (handles binary files correctly).
+	// The stream is extracted and written to the response as it arrives —
+	// buffering a whole file would put arbitrarily large files in memory, and
+	// exec transports drop long transfers anyway (see resumingTarStream).
 	dir := path.Dir(filePath)
 	base := path.Base(filePath)
 
-	cmd := []string{"tar", "cf", "-", "-C", dir, base}
+	runAttempt := func(ctx context.Context, offset uint64, stdout io.Writer) error {
+		var cmd []string
+		if offset == 0 {
+			cmd = []string{"tar", "cf", "-", "-C", dir, base}
+		} else {
+			// tail -c+N is 1-based: resume at the first byte not yet delivered.
+			// The header block stays 512 bytes however large the size field
+			// says the file is, so a re-exec emits an identical byte stream
+			// from 512 onward for as long as the file's existing bytes are
+			// unchanged — an appended-to log still splices correctly. This is
+			// the trick kubectl cp --retries relies on. A file rotated or
+			// rewritten mid-transfer splices two different archives, which
+			// nothing downstream can detect.
+			cmd = []string{"/bin/sh", "-c", fmt.Sprintf("tar cf - -C %s %s | tail -c+%d", shellQuote(dir), shellQuote(base), offset+1)}
+		}
 
-	req := client.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec").
-		VersionedParams(&corev1.PodExecOptions{
-			Container: container,
-			Command:   cmd,
-			Stdout:    true,
-			Stderr:    true,
-		}, scheme.ParameterCodec)
+		req := client.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(podName).
+			Namespace(namespace).
+			SubResource("exec").
+			VersionedParams(&corev1.PodExecOptions{
+				Container: container,
+				Command:   cmd,
+				Stdout:    true,
+				Stderr:    true,
+			}, scheme.ParameterCodec)
 
-	exec, err := rcpkg.NewExecutor(config, req.URL())
-	if err != nil {
-		log.Printf("[copy] Failed to create executor for download %s/%s: %v", namespace, podName, err)
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create executor: %v", err))
-		return
+		exec, err := rcpkg.NewExecutor(config, req.URL())
+		if err != nil {
+			return fmt.Errorf("failed to create executor: %w", err)
+		}
+
+		var stderr bytes.Buffer
+		if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdout: stdout,
+			Stderr: &stderr,
+		}); err != nil {
+			return fmt.Errorf("%w %s", err, stderr.String())
+		}
+		return nil
 	}
 
-	var stdout, stderr bytes.Buffer
-	err = exec.StreamWithContext(r.Context(), remotecommand.StreamOptions{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	})
-	if err != nil {
-		errMsg := err.Error() + " " + stderr.String()
-		if isCommandNotFound(errMsg) {
-			// tar not available — fallback to cat
-			catContent, catErr := s.downloadWithCat(r, namespace, podName, container, filePath)
-			if catErr != nil {
-				if isCommandNotFound(catErr.Error()) {
-					s.writeError(w, http.StatusInternalServerError, "Container lacks 'tar' and 'cat' commands. Cannot download files from distroless containers.")
-				} else {
-					log.Printf("[copy] cat fallback failed for %s/%s path=%s: %v", namespace, podName, filePath, catErr)
-					errorlog.Record("copy", "error", "file download failed for %s/%s: %v", namespace, podName, catErr)
-					s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", catErr))
-				}
-				return
-			}
-			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
-			w.Header().Set("Content-Length", strconv.Itoa(len(catContent)))
-			w.Write(catContent)
-			return
-		}
-		if strings.Contains(errMsg, "No such file") || strings.Contains(errMsg, "not found") {
-			s.writeError(w, http.StatusNotFound, fmt.Sprintf("File not found: %s", filePath))
-			return
-		}
-		log.Printf("[copy] exec tar failed for %s/%s path=%s: %v, stderr: %s", namespace, podName, filePath, err, stderr.String())
-		errorlog.Record("copy", "error", "file download failed for %s/%s path=%s: %v", namespace, podName, filePath, err)
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", err))
-		return
-	}
+	stream := newResumingTarStream(r.Context(), runAttempt, tarStreamMaxRetries)
+	defer stream.Close()
 
 	// Extract the file from the tar stream
-	tr := tar.NewReader(&stdout)
+	tr := tar.NewReader(stream)
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
@@ -244,26 +237,125 @@ func (s *Server) handlePodFileDownload(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err != nil {
-			log.Printf("[copy] tar extract error for %s/%s: %v", namespace, podName, err)
-			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to extract file: %v", err))
+			errMsg := err.Error()
+			if isCommandNotFound(errMsg) {
+				// tar not available — fallback to cat
+				catContent, catErr := s.downloadWithCat(r, namespace, podName, container, filePath)
+				if catErr != nil {
+					if isCommandNotFound(catErr.Error()) {
+						s.writeError(w, http.StatusInternalServerError, "Container lacks 'tar' and 'cat' commands. Cannot download files from distroless containers.")
+					} else {
+						log.Printf("[copy] cat fallback failed for %s/%s path=%s: %v", namespace, podName, filePath, catErr)
+						errorlog.Record("copy", "error", "file download failed for %s/%s: %v", namespace, podName, catErr)
+						s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", catErr))
+					}
+					return
+				}
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
+				w.Header().Set("Content-Length", strconv.Itoa(len(catContent)))
+				w.Write(catContent)
+				return
+			}
+			if strings.Contains(errMsg, "No such file") || strings.Contains(errMsg, "not found") {
+				s.writeError(w, http.StatusNotFound, fmt.Sprintf("File not found: %s", filePath))
+				return
+			}
+			log.Printf("[copy] exec tar failed for %s/%s path=%s: %v", namespace, podName, filePath, err)
+			errorlog.Record("copy", "error", "file download failed for %s/%s path=%s: %v", namespace, podName, filePath, err)
+			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to download file: %v", err))
 			return
 		}
 
 		if header.Typeflag == tar.TypeReg {
-			content, err := io.ReadAll(tr)
-			if err != nil {
-				log.Printf("[copy] Failed to read file from tar %s/%s: %v", namespace, podName, err)
-				s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to read file: %v", err))
-				return
-			}
-
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
-			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
-			w.Write(content)
+			w.Header().Set("Content-Length", strconv.FormatInt(header.Size, 10))
+			if n, err := io.CopyN(w, tr, header.Size); err != nil {
+				// Headers are already sent; ending the body short of
+				// Content-Length makes the client fail the download visibly.
+				log.Printf("[copy] streaming %s from %s/%s aborted after %d of %d bytes: %v", filePath, namespace, podName, n, header.Size, err)
+				errorlog.Record("copy", "error", "file download for %s/%s path=%s aborted after %d of %d bytes: %v", namespace, podName, filePath, n, header.Size, err)
+			}
 			return
 		}
 	}
+}
+
+// tarStreamMaxRetries bounds how many times a dropped tar stream is resumed.
+const tarStreamMaxRetries = 10
+
+// execTarAttempt runs one tar exec attempt, writing the tar byte stream
+// starting at the given offset (bytes already delivered) to stdout, and
+// returns once the exec finishes.
+type execTarAttempt func(ctx context.Context, offset uint64, stdout io.Writer) error
+
+// resumingTarStream reads a pod's tar output across exec attempts,
+// transparently resuming after mid-stream drops. Exec transports routinely
+// kill long transfers (LBs, tunnels, apiserver proxies) — sometimes as a
+// normal close, which client-go surfaces as a successful exec with truncated
+// output. This is the failure kubectl cp works around with --retries, and the
+// resume mechanism here is modeled on its TarPipe.
+//
+// A premature clean EOF is indistinguishable from real completion at this
+// layer, so EOF also triggers a resume. Consumers must therefore stop reading
+// once they have what they need — the download handler stops after the file
+// entry and never reads the archive trailer.
+type resumingTarStream struct {
+	ctx        context.Context
+	run        execTarAttempt
+	maxRetries int
+	reader     *io.PipeReader
+	bytesRead  uint64
+	retries    int
+}
+
+func newResumingTarStream(ctx context.Context, run execTarAttempt, maxRetries int) *resumingTarStream {
+	t := &resumingTarStream{ctx: ctx, run: run, maxRetries: maxRetries}
+	t.startFrom(0)
+	return t
+}
+
+func (t *resumingTarStream) startFrom(offset uint64) {
+	pr, pw := io.Pipe()
+	t.reader = pr
+	go func() {
+		pw.CloseWithError(t.run(t.ctx, offset, pw))
+	}()
+}
+
+func (t *resumingTarStream) Read(p []byte) (int, error) {
+	for {
+		n, err := t.reader.Read(p)
+		if n > 0 {
+			t.bytesRead += uint64(n)
+			return n, nil
+		}
+		if err == nil {
+			continue
+		}
+		if t.ctx.Err() != nil {
+			return 0, err
+		}
+		// A first-attempt failure before any data propagates unchanged: the
+		// caller needs the raw error to classify it (cat fallback, 404), and
+		// nothing has been delivered, so a client retry is free.
+		if t.bytesRead == 0 && t.retries == 0 {
+			return 0, err
+		}
+		if t.retries >= t.maxRetries {
+			return 0, err
+		}
+		t.retries++
+		log.Printf("[copy] tar stream interrupted, resuming at %d bytes (retry %d/%d): %v", t.bytesRead, t.retries, t.maxRetries, err)
+		t.startFrom(t.bytesRead)
+	}
+}
+
+// Close unblocks the current attempt's writer; the exec attempt itself is
+// stopped by the request context.
+func (t *resumingTarStream) Close() error {
+	return t.reader.CloseWithError(context.Canceled)
 }
 
 // downloadWithCat is a fallback when tar is not available

--- a/internal/server/copy_native_save_test.go
+++ b/internal/server/copy_native_save_test.go
@@ -129,6 +129,78 @@ func TestDeliverPodFileNativeSaveReportsFailure(t *testing.T) {
 	}
 }
 
+// save=native writes to the user's disk from a GET, which a page on another
+// origin can fire without a preflight. Only the native branch is gated; the
+// streaming path is an ordinary read.
+func TestDeliverPodFileNativeSaveRejectsCrossOrigin(t *testing.T) {
+	called := false
+	s := &Server{saveStreamFunc: func(string, io.Reader) (string, error) {
+		called = true
+		return "/home/u/Downloads/a.txt", nil
+	}}
+	w := httptest.NewRecorder()
+
+	req := newDeliverRequest("path=/tmp/a.txt&save=native")
+	req.Header.Set("Origin", "https://evil.example.com")
+	s.deliverPodFile(w, req, strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	if called {
+		t.Fatal("saveStreamFunc was called for a cross-origin request")
+	}
+	if res := w.Result(); res.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", res.StatusCode)
+	}
+}
+
+// The desktop webview runs on the loopback server itself, and the Vite dev
+// proxy forwards its own loopback origin.
+func TestDeliverPodFileNativeSaveAllowsLoopbackOrigin(t *testing.T) {
+	called := false
+	s := &Server{saveStreamFunc: func(name string, src io.Reader) (string, error) {
+		called = true
+		_, err := io.ReadAll(src)
+		return "/home/u/Downloads/" + name, err
+	}}
+	w := httptest.NewRecorder()
+
+	req := newDeliverRequest("path=/tmp/a.txt&save=native")
+	req.Header.Set("Origin", "http://localhost:9273")
+	s.deliverPodFile(w, req, strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	if !called {
+		t.Fatal("a loopback origin must still be able to save")
+	}
+	if res := w.Result(); res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+}
+
+// Reading a file cross-origin is not a side effect — the origin check must not
+// leak onto the streaming path.
+func TestDeliverPodFileCrossOriginStreamsWithoutNativeSave(t *testing.T) {
+	s := &Server{saveStreamFunc: func(string, io.Reader) (string, error) {
+		t.Fatal("saveStreamFunc must not be reached without save=native")
+		return "", nil
+	}}
+	w := httptest.NewRecorder()
+
+	req := newDeliverRequest("path=/tmp/a.txt")
+	req.Header.Set("Origin", "https://evil.example.com")
+	s.deliverPodFile(w, req, strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want application/octet-stream", got)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", body, "hello world")
+	}
+}
+
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/server/copy_native_save_test.go
+++ b/internal/server/copy_native_save_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newDeliverRequest builds a request for deliverPodFile with the given query.
+func newDeliverRequest(query string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/api/pods/ns/pod/files/download?"+query, nil)
+}
+
+func TestDeliverPodFileStreamsToClientByDefault(t *testing.T) {
+	s := &Server{}
+	w := httptest.NewRecorder()
+
+	s.deliverPodFile(w, newDeliverRequest("path=/tmp/a.txt"), strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want application/octet-stream", got)
+	}
+	if got := res.Header.Get("Content-Length"); got != "11" {
+		t.Errorf("Content-Length = %q, want 11", got)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", body, "hello world")
+	}
+}
+
+// save=native must be inert unless the desktop app installed a stream func —
+// a server or in-cluster deployment must never write downloads to local disk.
+func TestDeliverPodFileIgnoresNativeSaveWithoutStreamFunc(t *testing.T) {
+	s := &Server{}
+	w := httptest.NewRecorder()
+
+	s.deliverPodFile(w, newDeliverRequest("path=/tmp/a.txt&save=native"), strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	res := w.Result()
+	if got := res.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("Content-Type = %q, want the file to be streamed to the client", got)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", body, "hello world")
+	}
+}
+
+func TestDeliverPodFileNativeSaveWritesToDisk(t *testing.T) {
+	var gotName string
+	var gotData []byte
+	s := &Server{saveStreamFunc: func(name string, src io.Reader) (string, error) {
+		gotName = name
+		var err error
+		gotData, err = io.ReadAll(src)
+		return "/home/u/Downloads/" + name, err
+	}}
+	w := httptest.NewRecorder()
+
+	// Trailing bytes stand in for the tar block padding that follows the file.
+	s.deliverPodFile(w, newDeliverRequest("path=/tmp/a.txt&save=native"), strings.NewReader("hello world\x00\x00\x00"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	var body struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Path != "/home/u/Downloads/a.txt" {
+		t.Errorf("path = %q, want /home/u/Downloads/a.txt", body.Path)
+	}
+	if gotName != "a.txt" {
+		t.Errorf("saved name = %q, want a.txt", gotName)
+	}
+	if string(gotData) != "hello world" {
+		t.Errorf("saved data = %q, want %q (padding must not be written)", gotData, "hello world")
+	}
+}
+
+func TestDeliverPodFileNativeSaveRejectsTraversalFilename(t *testing.T) {
+	called := false
+	s := &Server{saveStreamFunc: func(string, io.Reader) (string, error) {
+		called = true
+		return "", nil
+	}}
+	w := httptest.NewRecorder()
+
+	s.deliverPodFile(w, newDeliverRequest("path=/tmp/..&save=native"), strings.NewReader("x"), "..", 1, "ns", "pod", "/tmp/..")
+
+	if called {
+		t.Fatal("saveStreamFunc was called with an unusable filename")
+	}
+	if res := w.Result(); res.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", res.StatusCode)
+	}
+}
+
+func TestDeliverPodFileNativeSaveReportsFailure(t *testing.T) {
+	s := &Server{saveStreamFunc: func(string, io.Reader) (string, error) {
+		return "", errors.New("disk full")
+	}}
+	w := httptest.NewRecorder()
+
+	s.deliverPodFile(w, newDeliverRequest("path=/tmp/a.txt&save=native"), strings.NewReader("hello world"), "a.txt", 11, "ns", "pod", "/tmp/a.txt")
+
+	res := w.Result()
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", res.StatusCode)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if !strings.Contains(string(body), "disk full") {
+		t.Errorf("body = %q, want it to name the underlying error", body)
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"a.txt", "a.txt"},
+		{"/etc/passwd", "passwd"},
+		{"../../etc/passwd", "passwd"},
+		{"dir/sub/file.log", "file.log"},
+		{"ev\x00il.txt", "evil.txt"},
+		{"..", ""},
+		{".", ""},
+		{"", ""},
+		{"/", ""},
+	}
+	for _, tt := range tests {
+		if got := sanitizeFilename(tt.in); got != tt.want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/server/copy_stream_test.go
+++ b/internal/server/copy_stream_test.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// buildTarArchive returns a tar archive containing a single regular file.
+func buildTarArchive(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write tar content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// fakeTarExec simulates the pod-exec tar attempts. Each attempt serves the
+// archive from the requested offset, optionally stopping early with an
+// injected outcome.
+type fakeTarExec struct {
+	archive []byte
+	// stopAfter[i] truncates attempt i after that many bytes (relative to the
+	// attempt's offset); -1 means serve to the end.
+	stopAfter []int
+	// errs[i] is returned by attempt i when it stops (nil simulates the
+	// "exec reported success but the stream was truncated" mode).
+	errs    []error
+	offsets []uint64
+}
+
+func (f *fakeTarExec) run(_ context.Context, offset uint64, stdout io.Writer) error {
+	attempt := len(f.offsets)
+	f.offsets = append(f.offsets, offset)
+
+	if offset > uint64(len(f.archive)) {
+		return fmt.Errorf("offset %d beyond archive", offset)
+	}
+	data := f.archive[offset:]
+	stop := -1
+	var err error
+	if attempt < len(f.stopAfter) {
+		stop = f.stopAfter[attempt]
+	}
+	if attempt < len(f.errs) {
+		err = f.errs[attempt]
+	}
+	if stop >= 0 && stop < len(data) {
+		data = data[:stop]
+	}
+	// Write in small chunks like a real stream would arrive.
+	for len(data) > 0 {
+		n := 1024
+		if n > len(data) {
+			n = len(data)
+		}
+		if _, werr := stdout.Write(data[:n]); werr != nil {
+			return werr
+		}
+		data = data[n:]
+	}
+	return err
+}
+
+func randomContent(t *testing.T, size int) []byte {
+	t.Helper()
+	content := make([]byte, size)
+	rng := rand.New(rand.NewSource(1511))
+	if _, err := rng.Read(content); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return content
+}
+
+// extractSingleFile reads the archive from the stream the way the download
+// handler does: header, then the entry body only (never the tar trailer).
+func extractSingleFile(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	tr := tar.NewReader(r)
+	header, err := tr.Next()
+	if err != nil {
+		t.Fatalf("tar.Next: %v", err)
+	}
+	if header.Typeflag != tar.TypeReg {
+		t.Fatalf("unexpected typeflag %v", header.Typeflag)
+	}
+	var out bytes.Buffer
+	if _, err := io.CopyN(&out, tr, header.Size); err != nil {
+		t.Fatalf("copy entry: %v", err)
+	}
+	return out.Bytes()
+}
+
+func TestResumingTarStreamCleanTransfer(t *testing.T) {
+	content := randomContent(t, 64*1024)
+	fake := &fakeTarExec{archive: buildTarArchive(t, "data.csv", content)}
+
+	stream := newResumingTarStream(context.Background(), fake.run, 3)
+	defer stream.Close()
+
+	got := extractSingleFile(t, stream)
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content mismatch: got %d bytes, want %d", len(got), len(content))
+	}
+	if len(fake.offsets) != 1 {
+		t.Fatalf("expected a single attempt, got offsets %v", fake.offsets)
+	}
+}
+
+func TestResumingTarStreamResumesAfterTransportError(t *testing.T) {
+	content := randomContent(t, 256*1024)
+	archive := buildTarArchive(t, "data.csv", content)
+	fake := &fakeTarExec{
+		archive:   archive,
+		stopAfter: []int{100 * 1024, -1},
+		errs:      []error{errors.New("next reader: unexpected EOF")},
+	}
+
+	stream := newResumingTarStream(context.Background(), fake.run, 3)
+	defer stream.Close()
+
+	got := extractSingleFile(t, stream)
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content mismatch after resume: got %d bytes, want %d", len(got), len(content))
+	}
+	if len(fake.offsets) != 2 {
+		t.Fatalf("expected 2 attempts, got offsets %v", fake.offsets)
+	}
+	if fake.offsets[0] != 0 {
+		t.Fatalf("first attempt should start at 0, got %d", fake.offsets[0])
+	}
+	if fake.offsets[1] != 100*1024 {
+		t.Fatalf("resume should start at the truncation point %d, got %d", 100*1024, fake.offsets[1])
+	}
+}
+
+// The failure mode from issue #1511: the exec completes without error (the
+// transport surfaced a normal close) but the tar stream is truncated.
+func TestResumingTarStreamResumesAfterSilentTruncation(t *testing.T) {
+	content := randomContent(t, 256*1024)
+	archive := buildTarArchive(t, "data.csv", content)
+	fake := &fakeTarExec{
+		archive:   archive,
+		stopAfter: []int{64 * 1024, -1},
+		errs:      []error{nil},
+	}
+
+	stream := newResumingTarStream(context.Background(), fake.run, 3)
+	defer stream.Close()
+
+	got := extractSingleFile(t, stream)
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content mismatch after silent truncation: got %d bytes, want %d", len(got), len(content))
+	}
+	if len(fake.offsets) != 2 {
+		t.Fatalf("expected 2 attempts, got offsets %v", fake.offsets)
+	}
+	if fake.offsets[1] != 64*1024 {
+		t.Fatalf("resume should start at %d, got %d", 64*1024, fake.offsets[1])
+	}
+}
+
+func TestResumingTarStreamFirstAttemptErrorPropagates(t *testing.T) {
+	execErr := errors.New(`exec: "tar": executable file not found in $PATH`)
+	fake := &fakeTarExec{
+		archive:   buildTarArchive(t, "data.csv", []byte("hello")),
+		stopAfter: []int{0},
+		errs:      []error{execErr},
+	}
+
+	stream := newResumingTarStream(context.Background(), fake.run, 3)
+	defer stream.Close()
+
+	_, err := io.ReadAll(stream)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "executable file not found") {
+		t.Fatalf("expected original exec error, got: %v", err)
+	}
+	if len(fake.offsets) != 1 {
+		t.Fatalf("a zero-byte first-attempt failure must not retry, got offsets %v", fake.offsets)
+	}
+}
+
+func TestResumingTarStreamGivesUpAfterMaxRetries(t *testing.T) {
+	content := randomContent(t, 64*1024)
+	archive := buildTarArchive(t, "data.csv", content)
+	transportErr := errors.New("next reader: unexpected EOF")
+	fake := &fakeTarExec{
+		archive:   archive,
+		stopAfter: []int{1024, 0, 0, 0},
+		errs:      []error{transportErr, transportErr, transportErr, transportErr},
+	}
+
+	stream := newResumingTarStream(context.Background(), fake.run, 2)
+	defer stream.Close()
+
+	_, err := io.ReadAll(stream)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// initial attempt + 2 retries
+	if len(fake.offsets) != 3 {
+		t.Fatalf("expected 3 attempts, got offsets %v", fake.offsets)
+	}
+}
+
+func TestResumingTarStreamNoRetryAfterContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	content := randomContent(t, 64*1024)
+	archive := buildTarArchive(t, "data.csv", content)
+	fake := &fakeTarExec{
+		archive:   archive,
+		stopAfter: []int{1024},
+		errs:      []error{errors.New("context canceled")},
+	}
+
+	stream := newResumingTarStream(ctx, fake.run, 5)
+	defer stream.Close()
+
+	buf := make([]byte, 2048)
+	if _, err := io.ReadFull(stream, buf[:1024]); err != nil {
+		t.Fatalf("initial read: %v", err)
+	}
+	cancel()
+
+	_, err := io.ReadAll(stream)
+	if err == nil {
+		t.Fatal("expected error after cancel, got nil")
+	}
+	if len(fake.offsets) != 1 {
+		t.Fatalf("must not retry after context cancel, got offsets %v", fake.offsets)
+	}
+}

--- a/internal/server/desktop_save_file.go
+++ b/internal/server/desktop_save_file.go
@@ -38,10 +38,8 @@ func (s *Server) handleDesktopSaveFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Sanitize filename: strip path components, reject empty
-	req.Filename = filepath.Base(req.Filename)
-	req.Filename = strings.ReplaceAll(req.Filename, "\x00", "")
-	if req.Filename == "" || req.Filename == "." || req.Filename == ".." {
+	req.Filename = sanitizeFilename(req.Filename)
+	if req.Filename == "" {
 		s.writeError(w, http.StatusBadRequest, "invalid filename")
 		return
 	}
@@ -81,4 +79,15 @@ func (s *Server) handleDesktopSaveFile(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(map[string]string{"path": path}); err != nil {
 		log.Printf("[desktop] Failed to write save-file response: %v", err)
 	}
+}
+
+// sanitizeFilename strips path components and NUL bytes from a client-supplied
+// filename so it can only ever name a file inside the save directory. Returns
+// "" when nothing usable remains.
+func sanitizeFilename(name string) string {
+	name = filepath.Base(strings.ReplaceAll(name, "\x00", ""))
+	if name == "" || name == "." || name == ".." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,7 @@ type Server struct {
 	permCache          *auth.PermissionCache
 	oidcHandler        *auth.OIDCHandler
 	saveFileFunc       func(defaultFilename string, data []byte) (string, error)
+	saveStreamFunc     func(defaultFilename string, src io.Reader) (string, error)
 	cloudConnectCfg    CloudConnectConfig
 	cloudInstall       *cloudInstallManager
 
@@ -1132,6 +1133,14 @@ func (s *Server) SetUpdater(u *updater.Updater) {
 // Only used by the desktop app.
 func (s *Server) SetSaveFileFunc(fn func(defaultFilename string, data []byte) (string, error)) {
 	s.saveFileFunc = fn
+}
+
+// SetSaveStreamFunc attaches a native streaming-save callback, enabling the
+// server to write a download straight to disk instead of returning it to the
+// webview. Unlike SetSaveFileFunc it never holds the payload in memory, so it
+// carries downloads of any size. Only used by the desktop app.
+func (s *Server) SetSaveStreamFunc(fn func(defaultFilename string, src io.Reader) (string, error)) {
+	s.saveStreamFunc = fn
 }
 
 // Handler returns the full application handler for the authenticated Cloud

--- a/packages/k8s-ui/src/components/ui/Toast.tsx
+++ b/packages/k8s-ui/src/components/ui/Toast.tsx
@@ -154,6 +154,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   )
 }
 
+const TOAST_Z_INDEX = 200
+
 function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
   // Calculate position - either near button or default to bottom-right
   const style: React.CSSProperties = toast.position
@@ -161,13 +163,13 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
         position: 'fixed',
         left: Math.min(toast.position.x, window.innerWidth - 520),
         top: toast.position.y,
-        zIndex: 50,
+        zIndex: TOAST_Z_INDEX,
       }
     : {
         position: 'fixed',
         bottom: 16,
         right: 16,
-        zIndex: 50,
+        zIndex: TOAST_Z_INDEX,
       }
 
   const isError = toast.type === 'error'

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -7,7 +7,8 @@ import { clsx } from 'clsx'
 import { useImageMetadata, ApiError } from '../../api/client'
 import type { FileNode, ImageFilesystem } from '../../types'
 import { formatBytes } from '../../utils/format'
-import { downloadBlob, filterTree } from './file-browser-utils'
+import { filterTree } from './file-browser-utils'
+import { useFileDownload } from '../../hooks/useFileDownload'
 import { Tooltip } from '../ui/Tooltip'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { Input } from '@skyhook-io/k8s-ui'
@@ -628,39 +629,22 @@ interface FileTreeNodeProps {
 
 function FileTreeNode({ node, depth, defaultExpanded = true, image, namespace, podName, pullSecrets }: FileTreeNodeProps) {
   const [expanded, setExpanded] = useState(defaultExpanded && depth < 2)
-  const [downloading, setDownloading] = useState(false)
+  const { downloading, download } = useFileDownload()
   const isDir = node.type === 'dir'
   const isSymlink = node.type === 'symlink'
   const isFile = node.type === 'file'
 
-  const handleDownload = async (e: React.MouseEvent) => {
+  const handleDownload = (e: React.MouseEvent) => {
     e.stopPropagation()
     if (downloading) return
 
-    setDownloading(true)
-    try {
-      const params = new URLSearchParams()
-      params.set('image', image)
-      params.set('path', node.path)
-      if (namespace) params.set('namespace', namespace)
-      if (podName) params.set('pod', podName)
-      if (pullSecrets.length > 0) params.set('pullSecrets', pullSecrets.join(','))
-
-      const response = await fetch(apiUrl(`/images/file?${params.toString()}`), {
-        credentials: getCredentialsMode(),
-        headers: getAuthHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error('Failed to download file')
-      }
-
-      const blob = await response.blob()
-      await downloadBlob(blob, node.name)
-    } catch (err) {
-      console.error('Download failed:', err)
-    } finally {
-      setDownloading(false)
-    }
+    const params = new URLSearchParams()
+    params.set('image', image)
+    params.set('path', node.path)
+    if (namespace) params.set('namespace', namespace)
+    if (podName) params.set('pod', podName)
+    if (pullSecrets.length > 0) params.set('pullSecrets', pullSecrets.join(','))
+    void download(apiUrl(`/images/file?${params.toString()}`), node.name)
   }
 
   const handleClick = () => {

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -5,7 +5,8 @@ import { PaneLoader, Input } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import type { FileNode } from '../../types'
 import { formatBytes } from '../../utils/format'
-import { downloadBlob, filterTree } from './file-browser-utils'
+import { filterTree } from './file-browser-utils'
+import { useFileDownload } from '../../hooks/useFileDownload'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { Tooltip } from '../ui/Tooltip'
 
@@ -308,37 +309,19 @@ interface PodFileTreeNodeProps {
 }
 
 function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: PodFileTreeNodeProps) {
-  const [downloading, setDownloading] = useState(false)
+  const { downloading, download } = useFileDownload()
   const isDir = node.type === 'dir'
   const isSymlink = node.type === 'symlink'
   const isDownloadable = !isDir // files and symlinks can be downloaded
 
-  const handleDownload = async (e: React.MouseEvent) => {
+  const handleDownload = (e: React.MouseEvent) => {
     e.stopPropagation()
     if (downloading) return
 
-    setDownloading(true)
-    try {
-      const params = new URLSearchParams()
-      params.set('container', container)
-      params.set('path', node.path)
-
-      const response = await fetch(apiUrl(`/pods/${namespace}/${podName}/files/download?${params.toString()}`), {
-        credentials: getCredentialsMode(),
-        headers: getAuthHeaders(),
-      })
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({ error: 'Download failed' }))
-        throw new Error(err.error || `HTTP ${response.status}`)
-      }
-
-      const blob = await response.blob()
-      await downloadBlob(blob, node.name)
-    } catch (err) {
-      console.error('Download failed:', err)
-    } finally {
-      setDownloading(false)
-    }
+    const params = new URLSearchParams()
+    params.set('container', container)
+    params.set('path', node.path)
+    void download(apiUrl(`/pods/${namespace}/${podName}/files/download?${params.toString()}`), node.name)
   }
 
   const handleClick = () => {

--- a/web/src/components/resources/file-browser-utils.ts
+++ b/web/src/components/resources/file-browser-utils.ts
@@ -1,19 +1,4 @@
 import type { FileNode } from '../../types'
-import { isDesktopApp, desktopSaveBlob } from '../../utils/desktop-download'
-
-/** Trigger a file download from a Blob. Uses native save dialog on desktop. */
-export async function downloadBlob(blob: Blob, filename: string): Promise<void> {
-  if (await isDesktopApp()) {
-    await desktopSaveBlob(blob, filename)
-    return
-  }
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 /** Recursively filter a FileNode tree by name substring match. */
 export function filterTree(node: FileNode, query: string): FileNode | null {

--- a/web/src/hooks/useFileDownload.ts
+++ b/web/src/hooks/useFileDownload.ts
@@ -1,0 +1,49 @@
+import { createElement, useCallback, useState } from 'react'
+import { FolderOpen } from 'lucide-react'
+import { useToast } from '../components/ui/Toast'
+import { downloadFromUrl } from '../utils/desktop-download'
+import { openFile, openFolder } from '../utils/desktop-open-folder'
+
+/**
+ * Downloads a file from an API URL and reports the outcome through a toast.
+ *
+ * In the desktop app the server saves straight to ~/Downloads and the success
+ * toast offers to reveal it; in the browser the file downloads normally and
+ * only failures are surfaced. Without this, a failed download left nothing on
+ * screen but a console message.
+ */
+export function useFileDownload(): {
+  downloading: boolean
+  download: (url: string, filename: string) => Promise<void>
+} {
+  const [downloading, setDownloading] = useState(false)
+  const { showSuccess, showError } = useToast()
+
+  const download = useCallback(
+    async (url: string, filename: string) => {
+      setDownloading(true)
+      try {
+        const path = await downloadFromUrl(url, filename)
+        if (path) {
+          showSuccess(
+            'File saved',
+            path,
+            {
+              label: 'Show in Finder',
+              icon: createElement(FolderOpen, { className: 'w-3.5 h-3.5' }),
+              onClick: () => openFolder(path),
+            },
+            () => openFile(path),
+          )
+        }
+      } catch (err) {
+        showError('Download failed', err instanceof Error ? err.message : String(err))
+      } finally {
+        setDownloading(false)
+      }
+    },
+    [showSuccess, showError],
+  )
+
+  return { downloading, download }
+}

--- a/web/src/utils/desktop-download.ts
+++ b/web/src/utils/desktop-download.ts
@@ -64,3 +64,47 @@ export async function desktopSaveBlob(blob: Blob, filename: string): Promise<str
   const body = await res.json()
   return body.path
 }
+
+/**
+ * Downloads a file from an API URL.
+ *
+ * In the desktop app the server writes the file straight to ~/Downloads and
+ * returns its path — the bytes never enter the webview, so downloads are
+ * bounded by disk rather than by memory. In the browser the response is
+ * turned into a blob URL and clicked as usual.
+ *
+ * Returns the saved path on desktop, or null in the browser.
+ */
+export async function downloadFromUrl(url: string, filename: string): Promise<string | null> {
+  const desktop = await isDesktopApp()
+  const sep = url.includes('?') ? '&' : '?'
+  const res = await fetch(desktop ? `${url}${sep}save=native` : url, {
+    credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: 'Download failed' }))
+    throw new Error(body.error ?? `HTTP ${res.status}`)
+  }
+
+  if (desktop) {
+    // Endpoints that support native save reply with JSON {path}. Others stream
+    // the file back, and the webview cannot save it from a blob URL, so fall
+    // back to the base64 upload path — which is memory-bound, but it is what
+    // those endpoints have always used.
+    if (res.headers.get('Content-Type')?.includes('application/json')) {
+      const body = await res.json()
+      return body.path
+    }
+    return await desktopSaveBlob(await res.blob(), filename)
+  }
+
+  const blob = await res.blob()
+  const objectUrl = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = objectUrl
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(objectUrl)
+  return null
+}


### PR DESCRIPTION
Fixes #1511

Downloading a large file from a pod failed with `unexpected EOF` and a 500 after ~32s. Fixing that surfaced a second, independent failure in the desktop app, and a third in how failures were reported at all.

## 1. The stream was buffered, and drops were not survivable

`handlePodFileDownload` read the entire tar stream into a `bytes.Buffer` before extracting it. Exec transports routinely kill long transfers (LBs, tunnels, apiserver proxies), and a drop can arrive as a *clean* close — client-go's WebSocket demux treats `CloseNormalClosure` as plain `io.EOF`, so `StreamWithContext` returns nil while stdout is truncated. That is exactly what the reported log shows: the error came from tar extraction, not from the exec.

This is the long-standing Kubernetes problem that broke `kubectl cp` for large files (kubernetes/kubernetes#60140). kubectl's answer is the `--retries` resume: re-exec `tar cf - <src> | tail -c+<offset>` and continue from the byte where the stream died.

`resumingTarStream` does the same here, and the response is now streamed to the client instead of held in memory twice. A premature clean EOF also triggers a resume, since it is indistinguishable from real completion at that layer.

The resume execs via `/bin/sh` rather than a bare `sh`, matching the file listing paths — direct exec through the container runtime can fail to resolve binaries that are reachable through the shell.

## 2. The desktop app capped downloads at ~75MB

Independent of the above, and the reason this still looked broken after the server fix.

The webview cannot save from a blob URL, so downloads were routed back to the server through `/desktop/save-file`: read the whole file into a blob, base64-encode it (+33%), POST it as JSON — against a 100MB body cap. A 250MB file needed over a gigabyte of webview memory and was rejected regardless. There is a second ceiling too: V8's max string length puts a hard stop around 384MB.

The desktop app does not show a save dialog; it writes to `~/Downloads`. The bytes were already on the server, so they now go straight there:

- `SetSaveStreamFunc` installs a streaming save hook. The desktop app copies the reader to `~/Downloads` and removes the partial file if the copy fails.
- `deliverPodFile` serves `save=native` by handing the extracted file to that hook and replying with the saved path — constant memory, no size ceiling.
- The hook is installed **only** by the desktop app, so `save=native` does nothing in server or in-cluster mode. There is a test pinning that.
- `downloadFromUrl` replaces the blob-level helper, falling back to the old upload path for endpoints that do not support native save.

## 3. Failures were invisible

Both file browsers reported download errors with `console.error` only — the spinner stopped and nothing appeared on screen. They now raise a toast.

That exposed a further problem: toasts sat at z-index 50 while the file browser modals cover the viewport at z-100 with a 60%-black blurred backdrop, so the toast arrived behind frosted glass. Toasts moved to 200 — above modals and the omnibar/search popovers (121, 130), below tooltips (9999).

## Testing

10 new unit tests across `deliverPodFile` (default streaming, `save=native` inert without the hook, correct bytes excluding tar padding, traversal filename rejected, save failure surfaced) and `saveStream` (writes, collisions, partial-file cleanup on error).

Verified against a live EKS cluster:

| Case | Result |
|---|---|
| 250MB, browser | byte-identical (sha256), 7s |
| 1GB, desktop native save | byte-identical, 27s, 75-byte response |
| `save=native` in server mode | inert — streams the file as normal |
| Error toast | legible above the modal backdrop |
| Success toast | shows the saved path and "Show in Finder" |

## Not included

`/api/images/file` (the image filesystem browser) still routes desktop downloads through the base64 path and keeps the ~75MB ceiling. It lives in `internal/images`, which has no access to the server's save hook — threading it through is a separate change. That browser does gain the error toast here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pod exec download/resume behavior and adds a GET side effect that writes to local disk when `save=native` is used, though it is gated to loopback origins and only when the desktop hook is installed.
> 
> **Overview**
> Fixes large pod file downloads that failed with truncated tar streams and desktop size limits.
> 
> **Server:** Pod file download no longer buffers the full `tar` exec output. A **`resumingTarStream`** re-runs `tar … | tail -c+<offset>` (kubectl `cp --retries` style) when the exec transport drops or silently truncates, then streams the extracted file with **`io.CopyN`** instead of `ReadAll`. **`deliverPodFile`** adds optional **`save=native`**: when the desktop app registers **`SetSaveStreamFunc`**, bytes go straight to disk and the handler returns JSON `{path}`; cross-origin requests to that branch are rejected via **`localOriginOK`**, and filenames go through shared **`sanitizeFilename`**.
> 
> **Desktop:** **`saveStream`** copies an `io.Reader` into `~/Downloads` (shared collision logic with **`saveFile`**), deleting partial files on failure; wired at startup with **`SetSaveStreamFunc`**.
> 
> **UI:** Pod/image file browsers use **`useFileDownload`** / **`downloadFromUrl`** (`save=native` on desktop) with success/error toasts; toast **z-index** raised so messages appear above file modals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3de7e5cdfb116030186b62afbc4b81e2c51357f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->