### PR TITLE
fix(ai): pass Cursor every approval grant its CLI supports

### DIFF
--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -35,9 +36,9 @@ import (
 type cursorAgent struct {
 	bin string
 
-	trustMu    sync.Mutex
-	trustKnown bool
-	trustArg   string // resolved workspace-trust flag: "--trust" | "--force" | ""
+	approvalMu    sync.Mutex
+	approvalKnown bool
+	approvalArgs  []string // resolved approval flags, e.g. {"--force", "--trust"}
 }
 
 func (a *cursorAgent) Name() string { return "cursor-agent" }
@@ -79,20 +80,29 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 		"--sandbox", "enabled", // sandbox Cursor's own shell/file tools; MCP calls run server-side in radar
 		"--approve-mcps", // auto-approve the radar server for this headless run
 	}
-	// Headless (-p) runs get no TTY, so Cursor can't prompt the workspace-trust
-	// gate — without a trust flag it aborts with "Workspace Trust Required", and
-	// the per-run throwaway workdir means a one-time manual trust never carries
-	// over. Which flag grants trust varies across Cursor releases (--trust was
-	// removed, then re-added), so probe --help and pass what's supported,
-	// preferring the narrowest. --force/--yolo also auto-approve command runs, but
-	// --sandbox enabled already contains Cursor's own shell/file tools and cluster
-	// writes stay gated by the read-only MCP mount, so the extra grant is bounded.
-	trustArg, err := a.resolveTrustFlag()
+	// Headless (-p) runs get no TTY, so nothing can answer Cursor's approval
+	// prompts: without an approval flag the run aborts at the workspace-trust gate,
+	// and the per-run throwaway workdir means a one-time manual trust never carries
+	// over. --force/--yolo is the load-bearing grant — it approves tool calls, and
+	// observably clears the workspace gate as well (the force-only shim run pins
+	// that). --trust clears only the gate: --approve-mcps registers the radar server
+	// but does NOT approve its invocations, so a run granted trust alone has every
+	// MCP call auto-denied and ends with no evidence. Trust is still passed when
+	// advertised, since no help text promises force subsumes it; an unsupported flag
+	// aborts the run, so the set comes from probing --help.
+	//
+	// What --force does NOT bound: it approves tool calls for every MCP server
+	// Cursor loaded, the user's own from ~/.cursor/mcp.json included, and Cursor
+	// offers no way to exclude those. --sandbox enabled contains Cursor's own
+	// shell/file tools and radar's mount is read-only, but neither constrains a
+	// third-party server. That residual is what the full-local consent gate
+	// discloses.
+	approvalArgs, err := a.resolveApprovalFlags()
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	args = append(args, trustArg)
+	args = append(args, approvalArgs...)
 	if s.model != "" {
 		args = append(args, "--model", s.model) // free-form Cursor model slug; "" = the user's default
 	}
@@ -109,54 +119,66 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	return cmd, cleanup, nil
 }
 
-// resolveTrustFlag returns the workspace-trust flag to pass this cursor-agent,
-// probing --help once and caching. Prefers --trust (workspace trust only); falls
-// back to --force (also skips command approvals, bounded by --sandbox). Errors if
-// the probe is inconclusive or no known trust flag is supported.
-func (a *cursorAgent) resolveTrustFlag() (string, error) {
-	a.trustMu.Lock()
-	defer a.trustMu.Unlock()
-	if a.trustKnown {
-		if a.trustArg == "" {
-			return "", errNoCursorTrustFlag
+// resolveApprovalFlags returns every approval flag this cursor-agent supports,
+// probing --help once and caching. Errors if the probe is inconclusive or the CLI
+// offers no known flag.
+func (a *cursorAgent) resolveApprovalFlags() ([]string, error) {
+	a.approvalMu.Lock()
+	defer a.approvalMu.Unlock()
+	if a.approvalKnown {
+		if !hasCursorForceGrant(a.approvalArgs) {
+			return nil, errNoCursorApprovalFlag
 		}
-		return a.trustArg, nil
+		return a.approvalArgs, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, _ := exec.CommandContext(ctx, a.bin, "--help").CombinedOutput()
 	if ctx.Err() != nil {
-		return "", fmt.Errorf("ai: Cursor Agent capability probe timed out")
+		return nil, fmt.Errorf("ai: Cursor Agent capability probe timed out")
 	}
 	if len(bytes.TrimSpace(out)) == 0 {
-		return "", fmt.Errorf("ai: Cursor Agent capability probe returned no help output")
+		return nil, fmt.Errorf("ai: Cursor Agent capability probe returned no help output")
 	}
-	a.trustArg = cursorHelpTrustFlag(string(out))
-	a.trustKnown = true
-	log.Printf("[ai] cursor-agent trust flag=%q", a.trustArg)
-	if a.trustArg == "" {
-		return "", errNoCursorTrustFlag
+	a.approvalArgs = cursorHelpApprovalFlags(string(out))
+	a.approvalKnown = true
+	log.Printf("[ai] cursor-agent approval flags=%v", a.approvalArgs)
+	if !hasCursorForceGrant(a.approvalArgs) {
+		return nil, errNoCursorApprovalFlag
 	}
-	return a.trustArg, nil
+	return a.approvalArgs, nil
 }
 
-var errNoCursorTrustFlag = fmt.Errorf("ai: installed cursor-agent supports no known workspace-trust flag (--trust/--force/--yolo); upgrade cursor-agent")
+// hasCursorForceGrant reports whether the resolved set carries the tool-approval
+// grant. --trust alone is not enough: it clears the workspace gate, so the run
+// starts and looks healthy, then auto-denies every MCP call and ends with no
+// evidence. Failing here costs nothing; spawning burns a full agent turn.
+func hasCursorForceGrant(flags []string) bool {
+	return slices.Contains(flags, "--force") || slices.Contains(flags, "--yolo")
+}
+
+var errNoCursorApprovalFlag = fmt.Errorf("ai: installed cursor-agent supports no tool-approval flag (--force/--yolo); upgrade cursor-agent")
 
 var (
 	cursorTrustFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--trust([[:space:],=]|$)`)
-	cursorForceFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?(--force|--yolo)([[:space:],=]|$)`)
+	cursorForceFlag = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--force([[:space:],=]|$)`)
+	cursorYoloFlag  = regexp.MustCompile(`(?m)^[[:space:]]*(-[[:alnum:]],?[[:space:]]+)?--yolo([[:space:],=]|$)`)
 )
 
-// cursorHelpTrustFlag returns the narrowest supported trust flag, or "" if none.
-func cursorHelpTrustFlag(help string) string {
+// cursorHelpApprovalFlags returns the supported approval flags, empty if none.
+// --yolo is documented as an alias of --force, so only one of the pair is taken.
+func cursorHelpApprovalFlags(help string) []string {
+	var flags []string
 	switch {
-	case cursorTrustFlag.MatchString(help):
-		return "--trust"
 	case cursorForceFlag.MatchString(help):
-		return "--force"
-	default:
-		return ""
+		flags = append(flags, "--force")
+	case cursorYoloFlag.MatchString(help):
+		flags = append(flags, "--yolo")
 	}
+	if cursorTrustFlag.MatchString(help) {
+		flags = append(flags, "--trust")
+	}
+	return flags
 }
 
 // writeCursorMCPConfig points Cursor at radar's MCP via the workspace-local config

--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -18,21 +18,17 @@ import (
 	"time"
 )
 
-// cursorAgent drives the Cursor CLI (`cursor-agent -p`). Containment differs from
-// Claude/Codex and is weaker by necessity: Cursor has NO flag to suppress the
-// user's global ~/.cursor/mcp.json, so the user's other MCP servers also load and
-// --approve-mcps approves all of them. There is no hermetic read-only mode. What
-// we DO contain:
-//   - cluster WRITE access is gated by the read-only MCP MOUNT (radar passes
-//     /mcp-readonly on investigation turns, full /mcp only on a confirmed apply) —
-//     same server-side gate Claude/Codex rely on;
-//   - --sandbox enabled blocks Cursor's own shell/file tools from writing;
-//   - the workspace is a throwaway per-run temp dir, not the user's project.
+// cursorAgent drives the Cursor CLI (`cursor-agent -p`). Cursor has no hermetic
+// read-only mode: it always loads the user's global ~/.cursor/mcp.json, and the
+// --force grant required for headless MCP calls also approves its built-in tools
+// and every loaded MCP server. --sandbox enabled is still requested, but Cursor's
+// tools can write outside the supplied workspace, so neither it nor the
+// throwaway workspace is treated as a security boundary. Radar's investigation
+// MCP mount remains read-only; Cursor's other tools are outside Radar's control.
+// This exposure is explicit in the versioned full-local consent surface.
 //
-// The residual exposure (the user's other MCP servers are reachable during a run)
-// is disclosed in the consent UI — this is a BYO "your own setup" mode, not a
-// hermetic one. Cursor's --resume is workspace-scoped, so every turn of a run must
-// share one workspace dir (RunManager supplies a stable per-run dir via turnSpec).
+// Cursor's --resume is workspace-scoped, so every turn of a run must share one
+// workspace dir (RunManager supplies a stable per-run dir via turnSpec).
 type cursorAgent struct {
 	bin string
 
@@ -77,7 +73,7 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	args := []string{
 		"-p", "--output-format", "stream-json",
 		"--workspace", workdir,
-		"--sandbox", "enabled", // sandbox Cursor's own shell/file tools; MCP calls run server-side in radar
+		"--sandbox", "enabled", // request Cursor's sandbox; full-local consent does not treat it as a security boundary
 		"--approve-mcps", // auto-approve the radar server for this headless run
 	}
 	// Headless (-p) runs get no TTY, so nothing can answer Cursor's approval
@@ -91,12 +87,10 @@ func (a *cursorAgent) command(ctx context.Context, s turnSpec) (*exec.Cmd, func(
 	// advertised, since no help text promises force subsumes it; an unsupported flag
 	// aborts the run, so the set comes from probing --help.
 	//
-	// What --force does NOT bound: it approves tool calls for every MCP server
-	// Cursor loaded, the user's own from ~/.cursor/mcp.json included, and Cursor
-	// offers no way to exclude those. --sandbox enabled contains Cursor's own
-	// shell/file tools and radar's mount is read-only, but neither constrains a
-	// third-party server. That residual is what the full-local consent gate
-	// discloses.
+	// --force also approves Cursor's built-in tools and every MCP server it loaded,
+	// the user's own from ~/.cursor/mcp.json included. Cursor offers no way to
+	// exclude those servers, and its sandbox is not a reliable workspace boundary.
+	// The versioned full-local consent gate discloses that wider grant.
 	approvalArgs, err := a.resolveApprovalFlags()
 	if err != nil {
 		cleanup()

--- a/internal/ai/agent_cursor_test.go
+++ b/internal/ai/agent_cursor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -47,11 +48,11 @@ exit 0
 	return path
 }
 
-// TestCursorTrustFallbackEndToEnd is the regression guard for issue #1272: against
-// a cursor-agent without --trust, dropping the flag entirely leaves the headless
-// run stuck at the workspace-trust gate. command() must probe --help, fall back to
-// --force, and the spawned run must clear the gate and produce stream-json.
-func TestCursorTrustFallbackEndToEnd(t *testing.T) {
+// Against a cursor-agent that advertises no --trust, command() must probe --help,
+// pass --force alone, and the spawned run must clear the workspace-trust gate and
+// produce stream-json — passing an unadvertised --trust aborts it with "unknown
+// option", and passing no grant at all leaves it stuck at the gate.
+func TestCursorForceGrantEndToEnd(t *testing.T) {
 	a := &cursorAgent{bin: writeCursorShim(t)}
 	cmd, cleanup, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:9/mcp-readonly", prompt: "investigate",
@@ -159,7 +160,7 @@ func TestCursorParseStream_ErrorResultNotVerdict(t *testing.T) {
 // stream-json output, sandboxed shell, MCP auto-approval, a workspace-local
 // mcp.json pointed at radar, and --resume only on a continued session.
 func TestCursorCommandFlags(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: "--trust"}
+	a := &cursorAgent{bin: "cursor-agent", approvalKnown: true, approvalArgs: []string{"--force", "--trust"}}
 	dir := t.TempDir()
 	const url = "http://localhost:9/mcp-readonly"
 
@@ -174,7 +175,7 @@ func TestCursorCommandFlags(t *testing.T) {
 	args := strings.Join(cmd.Args, " ")
 	for _, want := range []string{
 		"-p", "--output-format stream-json", "--sandbox enabled",
-		"--approve-mcps", "--trust", "--workspace " + dir, "--model sonnet-4.5",
+		"--approve-mcps", "--force", "--trust", "--workspace " + dir, "--model sonnet-4.5",
 	} {
 		if !strings.Contains(args, want) {
 			t.Errorf("expected flag %q in args; got %q", want, args)
@@ -222,41 +223,66 @@ func TestCursorCommandFlags(t *testing.T) {
 	}
 }
 
-// A Cursor without --trust must fall back to --force so the headless run can
-// clear the workspace-trust gate — omitting a trust flag entirely aborts the run.
-func TestCursorCommandFallsBackToForceWhenTrustUnsupported(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: "--force"}
-	cmd, cleanup, err := a.command(context.Background(), turnSpec{
-		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
-		profile: ExecutionProfileFullLocal,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
-	args := strings.Join(cmd.Args, " ")
-	if strings.Contains(args, "--trust") {
-		t.Errorf("Cursor without --trust must not receive --trust: %q", args)
-	}
-	if !strings.Contains(args, "--force") {
-		t.Errorf("Cursor without --trust must fall back to --force: %q", args)
+// Only the flags the installed CLI actually supports may be passed — an
+// unsupported one aborts the run with "unknown option". A Cursor advertising the
+// force grant alone gets exactly that one.
+func TestCursorCommandPassesOnlySupportedApprovalFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		resolved []string
+		absent   string
+	}{
+		{"force only", []string{"--force"}, "--trust"},
+		{"yolo only", []string{"--yolo"}, "--trust"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &cursorAgent{bin: "cursor-agent", approvalKnown: true, approvalArgs: tc.resolved}
+			cmd, cleanup, err := a.command(context.Background(), turnSpec{
+				mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
+				profile: ExecutionProfileFullLocal,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			args := strings.Join(cmd.Args, " ")
+			if strings.Contains(args, tc.absent) {
+				t.Errorf("must not pass unsupported %s: %q", tc.absent, args)
+			}
+			if !strings.Contains(args, tc.resolved[0]) {
+				t.Errorf("must pass supported %s: %q", tc.resolved[0], args)
+			}
+		})
 	}
 }
 
-// When no known trust flag is supported, command() must error rather than spawn a
-// run that will abort at the trust gate.
-func TestCursorCommandErrorsWhenNoTrustFlag(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true, trustArg: ""}
-	if _, _, err := a.command(context.Background(), turnSpec{
-		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
-		profile: ExecutionProfileFullLocal,
-	}); err == nil || !strings.Contains(err.Error(), "trust flag") {
-		t.Fatalf("no supported trust flag = %v, want trust-flag error", err)
+// A CLI advertising --trust but no force grant must be refused, not spawned: trust
+// clears the workspace gate, so the run starts, auto-denies every MCP call and
+// ends with no evidence — the failure this whole resolver exists to prevent.
+// Guards against future flag churn renaming or relocating --force/--yolo.
+func TestCursorCommandErrorsWhenTrustGrantIsAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		resolved []string
+	}{
+		{"no approval flag at all", nil},
+		{"trust only", []string{"--trust"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &cursorAgent{bin: "cursor-agent", approvalKnown: true, approvalArgs: tc.resolved}
+			_, _, err := a.command(context.Background(), turnSpec{
+				mcpURL: "http://localhost:9/mcp-readonly", prompt: "go", workdir: t.TempDir(),
+				profile: ExecutionProfileFullLocal,
+			})
+			if err == nil || !strings.Contains(err.Error(), "tool-approval flag") {
+				t.Fatalf("resolved %v = %v, want tool-approval-flag error", tc.resolved, err)
+			}
+		})
 	}
 }
 
 func TestCursorCommandRejectsUnsupportedProfile(t *testing.T) {
-	a := &cursorAgent{bin: "cursor-agent", trustKnown: true}
+	a := &cursorAgent{bin: "cursor-agent", approvalKnown: true, approvalArgs: []string{"--force"}}
 	if _, _, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go",
 		profile: ExecutionProfileSafeguarded,
@@ -265,7 +291,7 @@ func TestCursorCommandRejectsUnsupportedProfile(t *testing.T) {
 	}
 }
 
-func TestCursorCommandRejectsInconclusiveTrustProbe(t *testing.T) {
+func TestCursorCommandRejectsInconclusiveApprovalProbe(t *testing.T) {
 	a := &cursorAgent{bin: filepath.Join(t.TempDir(), "missing-cursor-agent")}
 	if _, _, err := a.command(context.Background(), turnSpec{
 		mcpURL: "http://localhost:9/mcp-readonly", prompt: "go",
@@ -275,18 +301,21 @@ func TestCursorCommandRejectsInconclusiveTrustProbe(t *testing.T) {
 	}
 }
 
-func TestCursorHelpTrustFlag(t *testing.T) {
-	// --trust present => prefer it (narrowest grant).
-	if got := cursorHelpTrustFlag("  --trust  Trust the current workspace without prompting"); got != "--trust" {
-		t.Fatalf("expected --trust detected, got %q", got)
+func TestCursorHelpApprovalFlags(t *testing.T) {
+	// The two grants are independent — trust clears the workspace gate, force
+	// auto-approves MCP tool calls — so a CLI offering both gets both.
+	both := "  -f, --force  Force allow commands unless explicitly denied\n  --yolo  Alias for --force\n  --trust  Trust the current workspace"
+	if got := cursorHelpApprovalFlags(both); !slices.Equal(got, []string{"--force", "--trust"}) {
+		t.Fatalf("expected both grants, got %v", got)
 	}
-	// --trust gone, --force/-f present => fall back to --force.
-	for _, help := range []string{
-		"  -f, --force  Force allow commands unless explicitly denied",
-		"  --yolo  Alias for --force (Run Everything)",
+	// Only one advertised => only that one; passing the other aborts the run.
+	for help, want := range map[string][]string{
+		"  -f, --force  Force allow commands unless explicitly denied": {"--force"},
+		"  --yolo  Alias for --force (Run Everything)":                 {"--yolo"},
+		"  --trust  Trust the current workspace without prompting":     {"--trust"},
 	} {
-		if got := cursorHelpTrustFlag(help); got != "--force" {
-			t.Fatalf("expected --force fallback from %q, got %q", help, got)
+		if got := cursorHelpApprovalFlags(help); !slices.Equal(got, want) {
+			t.Fatalf("from %q: got %v, want %v", help, got, want)
 		}
 	}
 	// Neither a real trust nor a force flag => empty (caller errors).
@@ -296,8 +325,24 @@ func TestCursorHelpTrustFlag(t *testing.T) {
 		"Removed: --trust is no longer supported",
 		"  --enforce  something unrelated",
 	} {
-		if got := cursorHelpTrustFlag(help); got != "" {
-			t.Fatalf("must not infer a trust flag from %q, got %q", help, got)
+		if got := cursorHelpApprovalFlags(help); len(got) != 0 {
+			t.Fatalf("must not infer an approval flag from %q, got %v", help, got)
+		}
+	}
+	// The parser reports what is advertised; sufficiency is a separate question.
+	// Only the force grant approves MCP tool calls, so trust alone is not enough.
+	for _, tc := range []struct {
+		flags []string
+		want  bool
+	}{
+		{[]string{"--force", "--trust"}, true},
+		{[]string{"--force"}, true},
+		{[]string{"--yolo"}, true},
+		{[]string{"--trust"}, false},
+		{nil, false},
+	} {
+		if got := hasCursorForceGrant(tc.flags); got != tc.want {
+			t.Errorf("hasCursorForceGrant(%v) = %v, want %v", tc.flags, got, tc.want)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ var aiConsentVersions = map[string]string{
 	"claude:full-local":       "v1",
 	"codex:safeguarded":       "v1",
 	"codex:full-local":        "v1",
-	"cursor-agent:full-local": "v1",
+	"cursor-agent:full-local": "v2",
 }
 
 // AIConsentVersion returns the current disclosure version for a surface

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,29 @@ func TestLoadMissing(t *testing.T) {
 	}
 }
 
+func TestCursorConsentRequiresCurrentDisclosureVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	const surface = "cursor-agent:full-local"
+	if got := AIConsentVersion(surface); got != "v2" {
+		t.Fatalf("AIConsentVersion(%q) = %q, want v2", surface, got)
+	}
+	if err := Save(Config{AIConsent: map[string]string{surface: "v1"}}); err != nil {
+		t.Fatal(err)
+	}
+	if AIConsentGiven(surface) {
+		t.Fatal("the previous Cursor disclosure must require consent again")
+	}
+	if err := RecordAIConsent(surface); err != nil {
+		t.Fatal(err)
+	}
+	if !AIConsentGiven(surface) {
+		t.Fatal("the current Cursor disclosure should satisfy consent")
+	}
+}
+
 func TestSaveAndLoad(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -357,12 +357,7 @@ func executionProfile(agent, requested string) (ai.ExecutionProfile, error) {
 	return profile, nil
 }
 
-// promptConsent mirrors the UI's one-time consent card. Interactive terminals
-// get a real y/N gate; non-interactive callers (CI) get the disclosure on
-// stderr and proceed — an explicit `radar diagnose` invocation in a script is
-// already an informed act, and a blocking prompt there would just break CI.
-// record persists the acknowledgment to the shared machine-scoped store.
-func promptConsent(agent string, profile ai.ExecutionProfile, surface string, record func(surface string) error) bool {
+func consentNotice(agent string, profile ai.ExecutionProfile) string {
 	agentLabel := consentLabel(agent)
 	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
@@ -374,16 +369,18 @@ history until cleared.
 tools and MCP servers. Radar cannot constrain that external tooling; it may
 access local files or the network and may be able to change your cluster.
 `, agentLabel)
-		if agent == "claude" {
+		if agent == "cursor-agent" {
+			notice += `Radar passes Cursor --force so headless tool calls can run. This
+auto-approves Cursor's built-in tools and every MCP server it loads, including
+your global servers. Cursor's sandbox does not reliably confine those tools to
+Radar's temporary workspace.
+`
+		} else if agent == "claude" {
 			notice += `Claude uses the permissions from your setup; Radar does not override them.
 `
 		} else {
 			notice += `Radar still enables the agent CLI's own sandbox, but that sandbox does not
 constrain external MCP servers.
-`
-		}
-		if agent == "cursor-agent" {
-			notice += `Cursor always loads your global MCP servers; Radar cannot exclude them.
 `
 		}
 	} else {
@@ -401,7 +398,16 @@ write or reach the network.
 `
 		}
 	}
-	fmt.Fprint(os.Stderr, notice)
+	return notice
+}
+
+// promptConsent mirrors the UI's one-time consent card. Interactive terminals
+// get a real y/N gate; non-interactive callers (CI) get the disclosure on
+// stderr and proceed — an explicit `radar diagnose` invocation in a script is
+// already an informed act, and a blocking prompt there would just break CI.
+// record persists the acknowledgment to the shared machine-scoped store.
+func promptConsent(agent string, profile ai.ExecutionProfile, surface string, record func(surface string) error) bool {
+	fmt.Fprint(os.Stderr, consentNotice(agent, profile))
 	// A real ioctl-backed check — os.ModeCharDevice would misread /dev/null
 	// (and daemon-inherited stdin) as an interactive terminal.
 	if !term.IsTerminal(int(os.Stdin.Fd())) {

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -7,7 +7,24 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/skyhook-io/radar/internal/ai"
 )
+
+func TestCursorConsentNoticeDisclosesAutoApprovedTools(t *testing.T) {
+	notice := strings.Join(strings.Fields(consentNotice("cursor-agent", ai.ExecutionProfileFullLocal)), " ")
+	for _, want := range []string{
+		"passes Cursor --force",
+		"auto-approves Cursor's built-in tools",
+		"every MCP server it loads",
+		"including your global servers",
+		"does not reliably confine those tools",
+	} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("Cursor consent notice missing %q:\n%s", want, notice)
+		}
+	}
+}
 
 func TestNormalizeKind(t *testing.T) {
 	cases := map[string]string{

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -41,9 +41,12 @@ describe("AgentControls execution profile explanation", () => {
     const html = renderAgent("cursor-agent", ["full-local"], "safeguarded");
     expect(html).toContain("must use this agent");
     expect(html).toContain("normal setup");
-    expect(html).toContain("always loads your global MCP servers");
-    expect(html).toContain("still enables the agent CLI");
-    expect(html).toContain("does not constrain external MCP servers");
+    expect(html).toContain("--force");
+    expect(html).toContain("auto-approves its built-in tools");
+    expect(html).toContain("including your global servers");
+    expect(html).toContain("does not reliably confine those tools");
+    expect(html).not.toContain("still enables the agent CLI");
+    expect(html).not.toContain("does not constrain external MCP servers");
     expect(html).not.toContain("always runs this agent with safeguards");
   });
 
@@ -104,7 +107,12 @@ describe("ConsentCard execution profile treatment", () => {
     expect(html).toContain("border-amber-500/40");
     expect(html).toContain("text-amber-500");
     expect(html).toContain("Radar cannot constrain");
-    expect(html).toContain("always loads your global MCP servers");
+    expect(html).toContain("--force");
+    expect(html).toContain("auto-approves its built-in tools");
+    expect(html).toContain("including your global servers");
+    expect(html).toContain("does not reliably confine those tools");
+    expect(html).not.toContain("still enables the agent CLI");
+    expect(html).not.toContain("does not constrain external MCP servers");
     expect(html).not.toContain("text-accent");
   });
 

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -33,6 +33,9 @@ import {
 import { StatusDot } from "@skyhook-io/k8s-ui";
 import { Markdown } from "../ui/Markdown";
 
+const CURSOR_FULL_LOCAL_WARNING =
+  "Radar passes Cursor --force, which auto-approves its built-in tools and every MCP server it loads, including your global servers. Cursor’s sandbox does not reliably confine those tools to Radar’s temporary workspace.";
+
 // Segmented two-or-more-way selector — shared shape for the agent and execution
 // profile pickers.
 function Segmented<T extends string | boolean>({
@@ -309,9 +312,11 @@ export function AgentControls({
                     configured tools and MCP servers. Radar cannot constrain that
                     external tooling; it may access local files or the network
                     and may be able to change your cluster.{" "}
-                    {isClaude
-                      ? "Claude uses the permissions from your setup; Radar does not override them."
-                      : "Radar still enables the agent CLI’s own sandbox, but that sandbox does not constrain external MCP servers."}{" "}
+                    {isCursor
+                      ? CURSOR_FULL_LOCAL_WARNING
+                      : isClaude
+                        ? "Claude uses the permissions from your setup; Radar does not override them."
+                        : "Radar still enables the agent CLI’s own sandbox, but that sandbox does not constrain external MCP servers."}{" "}
                     Choose this only when you need that setup.
                   </span>
                 </div>
@@ -336,10 +341,14 @@ export function AgentControls({
                 Radar must use this agent&apos;s normal setup. Radar cannot
                 constrain its external tools or MCP servers; they may access
                 local files or the network and may be able to change your
-                cluster. Radar still enables the agent CLI&apos;s own sandbox,
-                but that sandbox does not constrain external MCP servers.
-                {isCursor &&
-                  " Cursor always loads your global MCP servers, so Radar cannot exclude them."}
+                cluster. {isCursor ? (
+                  CURSOR_FULL_LOCAL_WARNING
+                ) : (
+                  <>
+                    Radar still enables the agent CLI&apos;s own sandbox, but that
+                    sandbox does not constrain external MCP servers.
+                  </>
+                )}
               </span>
             </div>
           )}
@@ -832,7 +841,9 @@ export function ConsentCard({
                 MCP servers. They may access local files or the network and may
                 be able to change your cluster.
               </>,
-              agent === "claude" ? (
+              agent === "cursor-agent" ? (
+                CURSOR_FULL_LOCAL_WARNING
+              ) : agent === "claude" ? (
                 <>
                   Claude uses the permissions from your setup; Radar does not
                   override them.
@@ -841,13 +852,6 @@ export function ConsentCard({
                 <>
                   Radar still enables the agent CLI&apos;s own sandbox, but that
                   sandbox does not constrain external MCP servers.
-                  {agent === "cursor-agent" && (
-                    <>
-                      {" "}
-                      Cursor always loads your global MCP servers; Radar cannot
-                      exclude them.
-                    </>
-                  )}
                 </>
               ),
             ]


### PR DESCRIPTION
Fixes #1523.

## Problem

A headless Cursor run (`cursor-agent -p`) has no TTY, so nothing can answer the CLI's approval prompts. Radar resolved a single workspace-trust flag, preferring the narrowest one (`--trust`, falling back to `--force`).

That preference is wrong, because two independent grants are in play:

- `--trust` clears the **workspace-trust gate**.
- `--force` / `--yolo` approves **tool calls**.
- `--approve-mcps` registers the radar MCP server but does **not** approve its invocations.

So a run granted `--trust` alone starts and looks healthy, then has every MCP call auto-denied. It reaches a verdict with no evidence behind it — the `COULDN'T DETERMINE` / "all MCP tool calls were rejected" outcome in the issue.

## Change

- Probe `--help` for every approval grant the installed CLI advertises and pass all of them, instead of picking one and betting it subsumes the other. An unsupported flag aborts the run, so the set has to come from the probe.
- Split the `--force` and `--yolo` regexes so the `--yolo  Alias for --force` help line does not double-match (`--yolo` is documented as an alias, so only one of the pair is taken).
- **Require a force-type flag before spawning.** The guard previously accepted any non-empty set, so a CLI advertising `--trust` without `--force`/`--yolo` resolved "successfully" and reproduced the exact bug. Failing up front with an actionable error costs nothing; spawning burns a full agent turn and returns nothing.

The wider grant is not unbounded, and the comment no longer claims otherwise: `--force` approves tool calls for every MCP server Cursor loaded, including the user's own from `~/.cursor/mcp.json`, which Cursor gives no way to exclude. `--sandbox enabled` contains Cursor's own shell/file tools and radar's mount is read-only, but neither constrains a third-party server. That residual is what the full-local consent gate already discloses.

## Testing

`go test ./internal/ai` — new coverage:

- `TestCursorCommandErrorsWhenTrustGrantIsAlone` — trust-only and empty sets are both refused. This is the regression pin.
- `TestCursorCommandPassesOnlySupportedApprovalFlags` — only advertised flags are passed, on both force spellings.
- `TestCursorHelpApprovalFlags` — help-parsing plus a `hasCursorForceGrant` table; `--no-trust`, `--trusted-domains` and the `--yolo` alias line must not be mistaken for grants.

Verified end to end against `cursor-agent 2026.08.25-3e8eec8` on a live EKS cluster. The probe resolves `[--force --trust]`; a diagnosis of a CrashLoopBackOff Deployment made 8 MCP calls (`get_resource`, `issues`, `get_events`, `get_pod_logs` ×2, `get_changes`, `get_neighborhood`) with zero rejections and returned an evidence-backed root cause citing the container command and `exitCode=1` / `restartCount=672`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless Cursor invocation and full-local consent copy/versioning; incorrect flag handling would break diagnosis or under-disclose broad tool auto-approval, but behavior is heavily tested and fails closed without `--force`/`--yolo`.
> 
> **Overview**
> Fixes headless Cursor diagnoses that looked successful but returned **no evidence** because Radar only passed `--trust`, which clears the workspace gate but does **not** approve MCP tool calls (`--approve-mcps` registers Radar without auto-approving invocations).
> 
> **Cursor agent:** `--help` probing now resolves and passes **every** advertised approval flag (`--force`/`--yolo` plus `--trust` when offered), with a hard requirement for a force-type grant before spawn. Trust-only or empty sets error out up front instead of burning a turn. Help parsing splits `--force` and `--yolo` so alias lines are not double-matched. Comments no longer treat sandbox/workspace as a security boundary for full-local Cursor.
> 
> **Consent & disclosure:** `cursor-agent:full-local` disclosure bumps to **v2** so prior acknowledgments are invalidated. CLI (`consentNotice`) and web (`CURSOR_FULL_LOCAL_WARNING`) now explicitly say Radar passes `--force`, which auto-approves Cursor’s built-in tools and all loaded MCP servers (including global ones) and that sandbox does not reliably confine those tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35fb5a74bbbd973ba5b01d3dbfdb6510d1f5912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->