### PR TITLE
Keep quiet pod terminals alive through idle proxies

### DIFF
--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -30,6 +30,8 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+const podExecHeartbeatInterval = 30 * time.Second
+
 // defaultShellScript is the built-in fallback command used when no shell is
 // requested explicitly via ?shell= and no override is set via --pod-shell-default.
 // It exports TERM so colours and cursor movement work in container shells that
@@ -223,6 +225,24 @@ type TerminalMessage struct {
 	Cols uint16 `json:"cols,omitempty"`
 }
 
+func runPodExecHeartbeat(conn *websocket.Conn, interval time.Duration, done <-chan struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			// Active output already keeps intermediaries alive, so let the Ping
+			// wait behind it instead of timing out a healthy busy terminal.
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Time{}); err != nil {
+				return
+			}
+		}
+	}
+}
+
 // wsWriter wraps a websocket connection to satisfy io.Writer
 type wsWriter struct {
 	conn *websocket.Conn
@@ -294,6 +314,9 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 		conn.Close()
 		log.Printf("Exec session %s ended (%s/%s)", sessionID, namespace, podName)
 	}()
+	heartbeatDone := make(chan struct{})
+	defer close(heartbeatDone)
+	go runPodExecHeartbeat(conn, podExecHeartbeatInterval, heartbeatDone)
 
 	// Get K8s client and config (impersonated when auth is enabled)
 	client := s.getClientForRequest(r)

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -3,12 +3,79 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
 )
+
+func TestRunPodExecHeartbeat(t *testing.T) {
+	stop := make(chan struct{})
+	returned := make(chan struct{})
+	serverErr := make(chan error, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		runPodExecHeartbeat(conn, 10*time.Millisecond, stop)
+		close(returned)
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	pingReceived := make(chan struct{}, 1)
+	conn.SetPingHandler(func(data string) error {
+		select {
+		case pingReceived <- struct{}{}:
+		default:
+		}
+		return conn.WriteControl(websocket.PongMessage, []byte(data), time.Now().Add(time.Second))
+	})
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+	})
+
+	select {
+	case <-pingReceived:
+	case err := <-serverErr:
+		t.Fatalf("upgrade WebSocket: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat Ping")
+	}
+
+	close(stop)
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat loop did not stop")
+	}
+}
 
 // TestDefaultExecCommand pins the argv precedence: ?shell= override wins
 // over everything; Windows pods route to cmd.exe ahead of the POSIX-only


### PR DESCRIPTION
## Summary

Quiet pod terminal sessions can be disconnected by ingress and load-balancer idle timeouts even though Radar itself permits long-lived exec streams. This keeps those sessions active without requiring operators to tune proxy-specific timeout settings.

## What changed

- Emit a WebSocket protocol Ping from the pod-exec handler every 30 seconds for the lifetime of the session.
- Use Gorilla's concurrency-safe control-frame writer, leaving terminal input/output messages and the frontend protocol unchanged.
- Let Ping frames wait behind active terminal output instead of imposing a write deadline; active output already keeps intermediaries from considering the connection idle.
- Stop the heartbeat on handler teardown or a control-write failure, while leaving the existing WebSocket reader responsible for session cleanup.
- Cover Ping delivery and heartbeat shutdown with a real client/server WebSocket test.

## Testing

- `go test -race ./internal/server -run '^TestRunPodExecHeartbeat$' -count=10`
- `make test`
- `make build`
- Visual test skipped: no rendered UI changes.

## Notes

This deliberately applies only to pod exec. It does not add terminal lifetime limits, pong-based dead-peer detection, frontend reconnect behavior, or user-facing heartbeat configuration. Environment-level verification through an affected ingress remains the final proof that a specific intermediary counts WebSocket control frames as activity.
