### PR TITLE
Mark denied namespaces in the namespace picker

### DIFF
--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -44,6 +44,7 @@ type NamespaceScopeResponse struct {
 	KubeconfigNamespace  string             `json:"kubeconfigNamespace"`
 	Mode                 NamespaceScopeMode `json:"mode"`
 	AccessibleNamespaces []string           `json:"accessibleNamespaces"`
+	DeniedNamespaces     []string           `json:"deniedNamespaces"`
 	Authoritative        bool               `json:"authoritative"`
 	CanClearNamespace    bool               `json:"canClearNamespace"`
 	CacheScoped          bool               `json:"cacheScoped"`
@@ -409,6 +410,23 @@ func intersectPicksWithAllowed(picks, allowed []string) []string {
 	return out
 }
 
+func deniedNamespaces(namespaces []string, permissions *k8s.PermissionCheckResult, cacheScoped bool, cacheScopeNamespace string) []string {
+	denied := []string{}
+	if permissions == nil {
+		return denied
+	}
+	for _, namespace := range namespaces {
+		if cacheScoped && namespace != cacheScopeNamespace {
+			continue
+		}
+		visibility := k8s.BuildVisibilitySummary(permissions, namespace)
+		if visibility != nil && visibility.Core["pods"] == "unavailable" && visibility.Core["deployments"] == "unavailable" {
+			denied = append(denied, namespace)
+		}
+	}
+	return denied
+}
+
 func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -503,12 +521,14 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	if namespaces == nil {
 		namespaces = []string{}
 	}
+	denied := deniedNamespaces(namespaces, k8s.GetCachedPermissionResult(), k8s.ForceNamespaceScope, cacheScopeNs)
 
 	s.writeJSON(w, NamespaceScopeResponse{
 		Actives:              actives,
 		KubeconfigNamespace:  kubeNs,
 		Mode:                 mode,
 		AccessibleNamespaces: namespaces,
+		DeniedNamespaces:     denied,
 		Authoritative:        authoritative,
 		CanClearNamespace:    canClear,
 		CacheScoped:          k8s.ForceNamespaceScope,

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/settings"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -56,6 +57,59 @@ func TestNsPreferenceKey_PerUserIsolation(t *testing.T) {
 	// The \x00 separator makes this safe — verify by counterexample.
 	if nsPreferenceKey("alice", "foo") == nsPreferenceKey("ali", "cefoo") {
 		t.Error("nsPreferenceKey separator is ambiguous")
+	}
+}
+
+func TestDeniedNamespacesUsesCoreWorkloadVisibility(t *testing.T) {
+	permissions := &k8s.PermissionCheckResult{
+		Scopes: map[string]k8score.ResourceScope{
+			k8score.Pods:        {Enabled: true, Namespace: "team-a"},
+			k8score.Deployments: {Enabled: true, Namespace: "team-b"},
+			k8score.Nodes:       {Enabled: true},
+		},
+	}
+
+	got := deniedNamespaces([]string{"team-a", "team-b", "team-c"}, permissions, false, "")
+	if !slices.Equal(got, []string{"team-c"}) {
+		t.Fatalf("deniedNamespaces = %v, want [team-c]", got)
+	}
+}
+
+func TestDeniedNamespacesHandlesMultiNamespaceAndUnknownPermissions(t *testing.T) {
+	permissions := &k8s.PermissionCheckResult{
+		Scopes: map[string]k8score.ResourceScope{
+			k8score.Pods: {Enabled: true, Namespace: "team-a"},
+		},
+		ScopeNamespaces: map[string][]string{
+			k8score.Pods: {"team-a", "team-b"},
+		},
+	}
+
+	if got := deniedNamespaces([]string{"team-a", "team-b"}, permissions, false, ""); len(got) != 0 {
+		t.Fatalf("multi-namespace grants marked denied: %v", got)
+	}
+	if got := deniedNamespaces([]string{"team-a"}, nil, false, ""); len(got) != 0 {
+		t.Fatalf("unknown permissions marked denied: %v", got)
+	}
+	clusterWide := &k8s.PermissionCheckResult{
+		Scopes: map[string]k8score.ResourceScope{
+			k8score.Deployments: {Enabled: true},
+		},
+	}
+	if got := deniedNamespaces([]string{"team-a", "team-b"}, clusterWide, false, ""); len(got) != 0 {
+		t.Fatalf("cluster-wide workload access marked denied: %v", got)
+	}
+}
+
+func TestDeniedNamespacesOnlyMarksCurrentCacheScope(t *testing.T) {
+	permissions := &k8s.PermissionCheckResult{Scopes: map[string]k8score.ResourceScope{}}
+
+	got := deniedNamespaces([]string{"team-a", "team-b"}, permissions, true, "team-a")
+	if !slices.Equal(got, []string{"team-a"}) {
+		t.Fatalf("deniedNamespaces = %v, want [team-a]", got)
+	}
+	if got := deniedNamespaces([]string{"team-a", "team-b"}, permissions, true, ""); len(got) != 0 {
+		t.Fatalf("namespaces marked denied without an active cache scope: %v", got)
 	}
 }
 

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -803,7 +803,7 @@ func TestHandleSetActiveNamespace_RejectsLegacyShape(t *testing.T) {
 }
 
 func TestHandleGetNamespaceScope_NoPick_EmitsEmptySliceNotNull(t *testing.T) {
-	// Pin the wire contract: actives and accessibleNamespaces must serialize
+	// Pin the wire contract: actives, accessibleNamespaces, and deniedNamespaces must serialize
 	// as [] (non-nil empty), not null. Without the nil-coercion in
 	// handleGetNamespaceScope the frontend crashed on `scope.actives.slice()`
 	// — caught by /visual-test. The defensive code is small and easy to
@@ -831,6 +831,12 @@ func TestHandleGetNamespaceScope_NoPick_EmitsEmptySliceNotNull(t *testing.T) {
 	}
 	if !strings.Contains(string(body), `"accessibleNamespaces":[`) {
 		t.Errorf("expected accessibleNamespaces:[…] in body, got: %s", body)
+	}
+	if strings.Contains(string(body), `"deniedNamespaces":null`) {
+		t.Errorf("deniedNamespaces marshalled as null: %s", body)
+	}
+	if !strings.Contains(string(body), `"deniedNamespaces":[`) {
+		t.Errorf("expected deniedNamespaces:[…] in body, got: %s", body)
 	}
 }
 

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { ChevronDown, Globe, Search, AlertTriangle } from 'lucide-react'
+import { Badge } from '../ui/Badge'
 import { Tooltip } from '../ui/Tooltip'
 import { MultiSelectPicker } from '../ui/MultiSelectPicker'
 
@@ -14,6 +15,8 @@ export interface NamespaceScopeView {
   actives: string[]
   /** Namespaces the user may pick from. */
   accessibleNamespaces: string[]
+  /** Namespaces where Radar cannot list pods or deployments. */
+  deniedNamespaces?: string[]
   mode?: 'cluster-wide' | 'namespace' | 'restricted' | string
   /** Single-namespace cache-scope control instead of a multi-select filter. */
   cacheScoped?: boolean
@@ -115,6 +118,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
     if (!scope) return [] as string[]
     return [...(scope.accessibleNamespaces ?? [])].sort((a, b) => a.localeCompare(b))
   }, [scope])
+  const deniedNamespaces = useMemo(() => new Set(scope?.deniedNamespaces ?? []), [scope?.deniedNamespaces])
 
   const filteredItems = useMemo(() => {
     const q = search.trim().toLowerCase()
@@ -215,6 +219,21 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
           ? `View is filtered to namespace ${scopeActives[0]}. Click to switch or reset.`
           : `View is filtered to ${activeCount} namespaces. Click to adjust or reset.`
 
+  const renderNamespaceMeta = (ns: string) => (
+    <>
+      {deniedNamespaces.has(ns) && (
+        <Badge severity="error" size="sm" title="Radar cannot list pods or deployments in this namespace.">
+          No access
+        </Badge>
+      )}
+      {ns === scope.kubeconfigNamespace && ns !== '' && (
+        <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary shrink-0">
+          kubeconfig
+        </span>
+      )}
+    </>
+  )
+
   return (
     <>
       <Tooltip
@@ -286,7 +305,6 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
 
                   {filteredItems.map(ns => {
                     const isChecked = draft.has(ns)
-                    const isContextDefault = ns === scope.kubeconfigNamespace && ns !== ''
                     return (
                       <li key={ns}>
                         <label className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-theme-hover text-left text-theme-text-primary cursor-pointer">
@@ -299,11 +317,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
                               className="shrink-0 accent-current"
                             />
                             <span className="truncate">{ns}</span>
-                            {isContextDefault && (
-                              <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary shrink-0">
-                                kubeconfig
-                              </span>
-                            )}
+                            {renderNamespaceMeta(ns)}
                           </span>
                         </label>
                       </li>
@@ -335,13 +349,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
                 noItemsLabel="No namespaces available."
                 clearAllDisabled={!canClearAll || activeCount === 0}
                 clearAllAriaLabel="Clear namespace selection"
-                renderItemMeta={ns =>
-                  ns === scope.kubeconfigNamespace && ns !== '' ? (
-                    <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary shrink-0">
-                      kubeconfig
-                    </span>
-                  ) : null
-                }
+                renderItemMeta={renderNamespaceMeta}
               />
             )}
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6069,6 +6069,8 @@ export interface NamespaceScope {
    */
   mode: "cluster-wide" | "namespace" | "restricted";
   accessibleNamespaces: string[];
+  /** Namespaces where Radar cannot list pods or deployments. */
+  deniedNamespaces: string[];
   /** false when accessibleNamespaces is a best-effort short list (no list perm). */
   authoritative: boolean;
   /** false when clearing would leave no usable namespace fallback. */


### PR DESCRIPTION
## Summary

Configured namespaces can appear as ordinary picker options even when Radar cannot list its core workloads there, making an empty view look like a healthy empty namespace. This marks those entries with a **No access** badge and a brief explanation.

Closes #1171.

## What changed

- Extend the namespace-scope response with namespaces where the startup permission probes found neither Pod nor Deployment list access.
- Render a themed **No access** badge in both namespace-picker modes, with a tooltip explaining the exact Pod/Deployment criterion.
- Preserve existing behavior: denied entries remain selectable, and this does not change namespace filtering or which resources Radar can display. A user with Service-only access can still select the namespace and view Services.
- In rescopable single-namespace cache mode, annotate only the currently probed namespace; other picker options remain unmarked until selected and probed.
- Avoid claiming denial when permission-probe results are unavailable.

## Testing

- `make tsc`
- `npm test --workspace=@skyhook-io/k8s-ui` — 2,657 passed, 1 skipped
- `make test`
- `make build`
- Visual test at 1920×1080 and 1280×720 in light and dark themes; verified badge alignment, picker layout, tooltip accessibility text, and no console errors.