### PR TITLE
Scope curated columns to the API group they were written for

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -623,6 +623,14 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'rules', label: 'Rules', width: 'w-16', hideOnMobile: true },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
+  istiogateways: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-48' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'servers', label: 'Servers', width: 'w-24' },
+    { key: 'selector', label: 'Selector', width: 'w-56' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
   gatewayclasses: [
     { key: 'name', label: 'Name' },
     { key: 'controller', label: 'Controller', width: 'w-64', tooltip: 'Gateway controller implementation (spec.controllerName)' },
@@ -2111,6 +2119,13 @@ const GROUP_QUALIFIED_COLUMN_KEYS: Record<string, Record<string, string>> = {
   // completely different shape (cluster + method, no storage location/expiry).
   backups: { 'postgresql.cnpg.io': 'cnpgbackups' },
   clusterpolicies: { 'nvidia.com': 'nvidiaclusterpolicies' },
+  // Kyverno's namespaced Policy. `policies` is a plural several projects use,
+  // so it is only Kyverno's when the group says so; the curated set and its
+  // cells already existed but nothing routed to them.
+  policies: { 'kyverno.io': 'kyvernopolicies' },
+  // Istio Gateway is not a Gateway API Gateway: it has servers and a workload
+  // selector, and none of Class/Listeners/Routes/Addresses.
+  gateways: { 'networking.istio.io': 'istiogateways' },
   services: { 'serving.knative.dev': 'knativeservices' },
   configurations: { 'serving.knative.dev': 'knativeconfigurations' },
   revisions: { 'serving.knative.dev': 'knativerevisions' },
@@ -2242,11 +2257,224 @@ function isLikelyCrossplaneMRGroup(kind: string, group: string): boolean {
   return false
 }
 
+/**
+ * API groups the Kubernetes API server reserves. A CRD cannot be created in
+ * one, so a curated set keyed on a core kind can never be claimed by a foreign
+ * resource and needs no ownership entry. Note the deliberate omissions:
+ * gateway.networking.k8s.io, snapshot.storage.k8s.io and cluster.x-k8s.io end
+ * in k8s.io but ARE CRD groups, so this is an explicit list, not a suffix test.
+ */
+const CORE_API_GROUPS = new Set([
+  '', 'apps', 'batch', 'autoscaling', 'policy', 'networking.k8s.io',
+  'rbac.authorization.k8s.io', 'storage.k8s.io', 'apiextensions.k8s.io',
+  'coordination.k8s.io', 'discovery.k8s.io', 'scheduling.k8s.io',
+  'admissionregistration.k8s.io', 'certificates.k8s.io', 'node.k8s.io',
+  'flowcontrol.apiserver.k8s.io', 'authentication.k8s.io', 'authorization.k8s.io',
+  'apiregistration.k8s.io', 'events.k8s.io', 'resource.k8s.io',
+  'internal.apiserver.k8s.io', 'storagemigration.k8s.io',
+])
+
+// ProviderConfig groups are unbounded — one per provider — so they are matched
+// by suffix. Managed resources take the isLikelyCrossplaneMRGroup branch above.
+function isCuratedUnboundedGroup(key: string, group: string): boolean {
+  if (key !== 'providerconfigs') return false
+  return group.endsWith('.crossplane.io') || group.endsWith('.upbound.io')
+}
+
+/**
+ * Which API group(s) each curated column set was written for.
+ *
+ * A CRD is not the kind Radar curated just because it reuses its plural:
+ * chaos-mesh ships workflows.chaos-mesh.org, Istio ships gateways, and Flux
+ * ships providers. Rendering Argo's or Gateway API's columns for those reads
+ * every field off a schema the object does not have. Anything not claimed here
+ * falls through to the generic set (and, for a CRD, to its own printer
+ * columns), which is the honest answer for a kind Radar has never seen.
+ *
+ * Core kinds need no entry: the API server reserves their groups, so a CRD
+ * cannot occupy one. See CORE_API_GROUPS.
+ */
+const CURATED_COLUMN_GROUPS: Record<string, readonly string[]> = {
+  challenges: ['acme.cert-manager.io'],
+  orders: ['acme.cert-manager.io'],
+  compositeresourcedefinitions: ['apiextensions.crossplane.io'],
+  compositions: ['apiextensions.crossplane.io'],
+  clustercompliancereports: ['aquasecurity.github.io'],
+  clusterinfraassessmentreports: ['aquasecurity.github.io'],
+  clusterrbacassessmentreports: ['aquasecurity.github.io'],
+  clustersbomreports: ['aquasecurity.github.io'],
+  configauditreports: ['aquasecurity.github.io'],
+  exposedsecretreports: ['aquasecurity.github.io'],
+  infraassessmentreports: ['aquasecurity.github.io'],
+  rbacassessmentreports: ['aquasecurity.github.io'],
+  sbomreports: ['aquasecurity.github.io'],
+  vulnerabilityreports: ['aquasecurity.github.io'],
+  analysisruns: ['argoproj.io'],
+  applications: ['argoproj.io'],
+  applicationsets: ['argoproj.io'],
+  appprojects: ['argoproj.io'],
+  clusterworkflowtemplates: ['argoproj.io'],
+  cronworkflows: ['argoproj.io'],
+  rollouts: ['argoproj.io'],
+  workflows: ['argoproj.io'],
+  workflowtemplates: ['argoproj.io'],
+  barmanobjectstores: ['barmancloud.cnpg.io'],
+  sealedsecrets: ['bitnami.com'],
+  certificaterequests: ['cert-manager.io'],
+  certificates: ['cert-manager.io'],
+  clusterissuers: ['cert-manager.io'],
+  issuers: ['cert-manager.io'],
+  capiclusters: ['cluster.x-k8s.io'],
+  clusterclasses: ['cluster.x-k8s.io'],
+  machinedeployments: ['cluster.x-k8s.io'],
+  machinehealthchecks: ['cluster.x-k8s.io'],
+  machinepools: ['cluster.x-k8s.io'],
+  machines: ['cluster.x-k8s.io'],
+  machinesets: ['cluster.x-k8s.io'],
+  kubeadmcontrolplanes: ['controlplane.cluster.x-k8s.io'],
+  brokers: ['eventing.knative.dev'],
+  eventtypes: ['eventing.knative.dev'],
+  triggers: ['eventing.knative.dev'],
+  clusterexternalsecrets: ['external-secrets.io'],
+  clustersecretstores: ['external-secrets.io'],
+  externalsecrets: ['external-secrets.io'],
+  secretstores: ['external-secrets.io'],
+  parallels: ['flows.knative.dev'],
+  sequences: ['flows.knative.dev'],
+  gatewayclasses: ['gateway.networking.k8s.io'],
+  gateways: ['gateway.networking.k8s.io'],
+  istiogateways: ['networking.istio.io'],
+  grpcroutes: ['gateway.networking.k8s.io'],
+  httproutes: ['gateway.networking.k8s.io'],
+  tcproutes: ['gateway.networking.k8s.io'],
+  tlsroutes: ['gateway.networking.k8s.io'],
+  helmreleases: ['helm.toolkit.fluxcd.io'],
+  awsmachines: ['infrastructure.cluster.x-k8s.io'],
+  awsmachinetemplates: ['infrastructure.cluster.x-k8s.io'],
+  awsmanagedclusters: ['infrastructure.cluster.x-k8s.io'],
+  awsmanagedcontrolplanes: ['controlplane.cluster.x-k8s.io'],
+  awsmanagedmachinepools: ['infrastructure.cluster.x-k8s.io'],
+  azuremachines: ['infrastructure.cluster.x-k8s.io'],
+  azuremachinetemplates: ['infrastructure.cluster.x-k8s.io'],
+  azuremanagedclusters: ['infrastructure.cluster.x-k8s.io'],
+  azuremanagedcontrolplanes: ['infrastructure.cluster.x-k8s.io'],
+  azuremanagedmachinepools: ['infrastructure.cluster.x-k8s.io'],
+  gcpmachines: ['infrastructure.cluster.x-k8s.io'],
+  gcpmachinetemplates: ['infrastructure.cluster.x-k8s.io'],
+  gcpmanagedclusters: ['infrastructure.cluster.x-k8s.io'],
+  gcpmanagedcontrolplanes: ['infrastructure.cluster.x-k8s.io'],
+  gcpmanagedmachinepools: ['infrastructure.cluster.x-k8s.io'],
+  ec2nodeclasses: ['karpenter.k8s.aws'],
+  nodeclaims: ['karpenter.sh'],
+  nodepools: ['karpenter.sh'],
+  clustertriggerauthentications: ['keda.sh'],
+  scaledjobs: ['keda.sh'],
+  scaledobjects: ['keda.sh'],
+  triggerauthentications: ['keda.sh'],
+  kustomizations: ['kustomize.toolkit.fluxcd.io'],
+  cleanuppolicies: ['kyverno.io'],
+  clustercleanuppolicies: ['kyverno.io'],
+  clusterpolicies: ['kyverno.io'],
+  kyvernopolicies: ['kyverno.io'],
+  updaterequests: ['kyverno.io'],
+  policyexceptions: ['kyverno.io', 'policies.kyverno.io'],
+  channels: ['messaging.knative.dev'],
+  inmemorychannels: ['messaging.knative.dev'],
+  knativesubscriptions: ['messaging.knative.dev'],
+  podmonitors: ['monitoring.coreos.com'],
+  prometheusrules: ['monitoring.coreos.com'],
+  servicemonitors: ['monitoring.coreos.com'],
+  knativecertificates: ['networking.internal.knative.dev'],
+  knativeingresses: ['networking.internal.knative.dev'],
+  serverlessservices: ['networking.internal.knative.dev'],
+  destinationrules: ['networking.istio.io'],
+  serviceentries: ['networking.istio.io'],
+  virtualservices: ['networking.istio.io'],
+  alerts: ['notification.toolkit.fluxcd.io'],
+  nvidiaclusterpolicies: ['nvidia.com'],
+  nvidiadrivers: ['nvidia.com'],
+  providers: ['pkg.crossplane.io'],
+  deletingpolicies: ['policies.kyverno.io'],
+  generatingpolicies: ['policies.kyverno.io'],
+  imagevalidatingpolicies: ['policies.kyverno.io'],
+  mutatingpolicies: ['policies.kyverno.io'],
+  namespaceddeletingpolicies: ['policies.kyverno.io'],
+  namespacedgeneratingpolicies: ['policies.kyverno.io'],
+  namespacedimagevalidatingpolicies: ['policies.kyverno.io'],
+  namespacedmutatingpolicies: ['policies.kyverno.io'],
+  namespacedvalidatingpolicies: ['policies.kyverno.io'],
+  validatingpolicies: ['policies.kyverno.io'],
+  cnpgbackups: ['postgresql.cnpg.io'],
+  cnpgclusterimagecatalogs: ['postgresql.cnpg.io'],
+  cnpgclusters: ['postgresql.cnpg.io'],
+  cnpgdatabases: ['postgresql.cnpg.io'],
+  cnpgimagecatalogs: ['postgresql.cnpg.io'],
+  cnpgpublications: ['postgresql.cnpg.io'],
+  cnpgsubscriptions: ['postgresql.cnpg.io'],
+  poolers: ['postgresql.cnpg.io'],
+  scheduledbackups: ['postgresql.cnpg.io'],
+  calicoglobalnetworkpolicies: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicohostendpoints: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicoippools: ['projectcalico.org', 'crd.projectcalico.org'],
+  caliconetworkpolicies: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicostagedglobalnetworkpolicies: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicostagedkubernetesnetworkpolicies: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicostagednetworkpolicies: ['projectcalico.org', 'crd.projectcalico.org'],
+  calicotiers: ['projectcalico.org', 'crd.projectcalico.org'],
+  httpproxies: ['projectcontour.io'],
+  clusterephemeralreports: ['reports.kyverno.io'],
+  ephemeralreports: ['reports.kyverno.io'],
+  authorizationpolicies: ['security.istio.io'],
+  peerauthentications: ['security.istio.io'],
+  domainmappings: ['serving.knative.dev'],
+  knativeconfigurations: ['serving.knative.dev'],
+  knativerevisions: ['serving.knative.dev'],
+  knativeroutes: ['serving.knative.dev'],
+  knativeservices: ['serving.knative.dev'],
+  gitrepositories: ['source.toolkit.fluxcd.io'],
+  helmrepositories: ['source.toolkit.fluxcd.io'],
+  ocirepositories: ['source.toolkit.fluxcd.io'],
+  apiserversources: ['sources.knative.dev'],
+  containersources: ['sources.knative.dev'],
+  pingsources: ['sources.knative.dev'],
+  sinkbindings: ['sources.knative.dev'],
+  ingressroutes: ['traefik.io', 'traefik.containo.us'],
+  ingressroutetcps: ['traefik.io', 'traefik.containo.us'],
+  ingressrouteudps: ['traefik.io', 'traefik.containo.us'],
+  middlewares: ['traefik.io', 'traefik.containo.us'],
+  middlewaretcps: ['traefik.io', 'traefik.containo.us'],
+  serverstransports: ['traefik.io', 'traefik.containo.us'],
+  serverstransporttcps: ['traefik.io', 'traefik.containo.us'],
+  tlsoptions: ['traefik.io', 'traefik.containo.us'],
+  tlsstores: ['traefik.io', 'traefik.containo.us'],
+  traefikservices: ['traefik.io', 'traefik.containo.us'],
+  backuprepositories: ['velero.io'],
+  backups: ['velero.io'],
+  backupstoragelocations: ['velero.io'],
+  velerorestores: ['velero.io'],
+  veleroschedules: ['velero.io'],
+  volumesnapshotlocations: ['velero.io'],
+  clusterpolicyreports: ['wgpolicyk8s.io'],
+  policyreports: ['wgpolicyk8s.io'],
+}
+
 function getColumnsForKind(kind: string, group?: string): Column[] {
-  const key = normalizeKindToPlural(kind, group)
-  if (KNOWN_COLUMNS[key]) return KNOWN_COLUMNS[key]
+  // Ahead of the curated lookup: a provider ships one CRD per service, so a
+  // managed resource routinely collides with a curated plural (acm's
+  // Certificate, s3's Service). Resolving the collision the other way would
+  // return DEFAULT_COLUMNS and never reach this branch at all.
   if (group && isLikelyCrossplaneMRGroup(kind, group)) {
     return KNOWN_COLUMNS.crossplanemanagedresources
+  }
+  const key = normalizeKindToPlural(kind, group)
+  const curated = KNOWN_COLUMNS[key]
+  if (curated) {
+    // A core kind cannot be shadowed by a CRD, so it keeps its columns without
+    // an ownership entry. Anything else has to be claimed for this exact group.
+    if (!group || CORE_API_GROUPS.has(group)) return curated
+    if (CURATED_COLUMN_GROUPS[key]?.includes(group)) return curated
+    if (isCuratedUnboundedGroup(key, group)) return curated
+    return DEFAULT_COLUMNS
   }
   return DEFAULT_COLUMNS
 }
@@ -6203,8 +6431,12 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       return <OrderCell resource={resource} column={column} />
     case 'challenges':
       return <ChallengeCell resource={resource} column={column} />
+    case 'istiogateways':
+      return <IstioGatewayCell resource={resource} column={column} />
     case 'gateways':
-      // Disambiguate Gateway API vs Istio Gateway by apiVersion
+      // Disambiguate Gateway API vs Istio Gateway by apiVersion. Retained
+      // alongside the case above because not every call site normalizes the
+      // kind through GROUP_QUALIFIED_COLUMN_KEYS before dispatching.
       if (resource.apiVersion?.includes('networking.istio.io')) {
         return <IstioGatewayCell resource={resource} column={column} />
       }

--- a/packages/k8s-ui/src/components/resources/curated-column-ownership.test.ts
+++ b/packages/k8s-ui/src/components/resources/curated-column-ownership.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { hasCuratedColumns } from './ResourcesView'
+
+// Parsed from the source rather than exported: this asserts a property of the
+// data as it is written, and an export would let the two drift.
+const SRC = readFileSync(join(__dirname, 'ResourcesView.tsx'), 'utf8')
+
+function objectBody(declName: string): string {
+  const start = SRC.indexOf(declName)
+  if (start < 0) throw new Error(`${declName} not found — the checks below would pass vacuously`)
+  const open = SRC.indexOf('{', start)
+  let depth = 1
+  let i = open + 1
+  while (depth > 0) {
+    if (SRC[i] === '{') depth++
+    else if (SRC[i] === '}') depth--
+    i++
+  }
+  return SRC.slice(open + 1, i)
+}
+
+function objectKeys(declName: string): string[] {
+  return [...objectBody(declName).matchAll(/^ {2}([a-z0-9_]+):/gm)].map(m => m[1])
+}
+
+const CURATED = objectKeys('const KNOWN_COLUMNS')
+const OWNED = new Set(objectKeys('const CURATED_COLUMN_GROUPS'))
+
+// Curated sets keyed on a kind the API server reserves. A CRD cannot be created
+// in a core group, so these can never be claimed by a foreign resource.
+const CORE_KEYS = new Set([
+  'pods', 'services', 'deployments', 'replicasets', 'statefulsets', 'daemonsets', 'jobs',
+  'cronjobs', 'configmaps', 'secrets', 'ingresses', 'ingressclasses', 'endpoints',
+  'endpointslices', 'persistentvolumeclaims', 'persistentvolumes', 'storageclasses', 'nodes',
+  'namespaces', 'serviceaccounts', 'roles', 'rolebindings', 'clusterroles', 'clusterrolebindings',
+  'horizontalpodautoscalers', 'hpas', 'poddisruptionbudgets', 'networkpolicies', 'events',
+  'leases', 'priorityclasses', 'runtimeclasses', 'resourcequotas', 'limitranges', 'csidrivers',
+  'csinodes', 'volumeattachments', 'mutatingwebhookconfigurations', 'validatingwebhookconfigurations',
+  'certificatesigningrequests', 'apiservices', 'customresourcedefinitions', 'replicationcontrollers',
+  'controllerrevisions', 'podtemplates', 'volumeattributesclasses', 'validatingadmissionpolicies',
+  'validatingadmissionpolicybindings', 'flowschemas', 'prioritylevelconfigurations',
+  'componentstatuses', 'resourceclaims', 'resourceclaimtemplates', 'resourceslices', 'deviceclasses',
+])
+
+// Groups are unbounded (one CRD per provider service), so these are gated by a
+// predicate instead of an enumerated list.
+const UNBOUNDED_KEYS = new Set(['providerconfigs', 'crossplanemanagedresources'])
+
+describe('curated column ownership', () => {
+  // The guard that matters: a curated set added without an owning group would
+  // silently claim every CRD that happens to share its plural.
+  it('declares an owning group for every non-core curated set', () => {
+    const undeclared = CURATED.filter(k => !CORE_KEYS.has(k) && !UNBOUNDED_KEYS.has(k) && !OWNED.has(k))
+    expect(undeclared).toEqual([])
+  })
+
+  it('does not declare ownership for a set that no longer exists', () => {
+    expect([...OWNED].filter(k => !CURATED.includes(k))).toEqual([])
+  })
+
+  // Brace-counting, not parsing: assert the extraction actually saw the whole
+  // table, or a silently-missed key would let the guard above pass vacuously.
+  it('extracted every curated key', () => {
+    expect(CURATED.length).toBe(199)
+    expect(OWNED.size).toBe(161)
+    expect(CURATED).toContain('pods')
+    expect(CURATED).toContain('crossplanemanagedresources')
+    expect([...OWNED]).toContain('awsmanagedcontrolplanes')
+  })
+})
+
+describe('curated sets are reachable', () => {
+  // Ownership answers "who may use this key". It does not answer "can anything
+  // reach this key at all" — and a curated set nothing routes to is invisible
+  // while every other check stays green. kyvernopolicies was exactly that: real
+  // columns, real cells, and no normalization entry to arrive through.
+  const QUALIFIED_TARGETS = new Set(
+    [...objectBody('const GROUP_QUALIFIED_COLUMN_KEYS').matchAll(/'[^']*':\s*'([a-z0-9_]+)'/g)].map(m => m[1]),
+  )
+
+  // Keys named after a vendor are Radar's own invention rather than a real API
+  // plural, so something has to route to them explicitly.
+  const VENDOR_PREFIXES = /^(cnpg|capi|knative|calico|velero|kyverno|nvidia|crossplane|istio)/
+
+  // Reached by predicate rather than by the qualified map.
+  const PREDICATE_REACHED = new Set(['crossplanemanagedresources'])
+  // Genuine upstream plurals that happen to start with a vendor name.
+  const REAL_PLURALS = new Set(['nvidiadrivers'])
+
+  it('routes something to every vendor-named curated set', () => {
+    const unreachable = CURATED.filter(
+      k => VENDOR_PREFIXES.test(k) &&
+        !QUALIFIED_TARGETS.has(k) &&
+        !PREDICATE_REACHED.has(k) &&
+        !REAL_PLURALS.has(k),
+    )
+    expect(unreachable).toEqual([])
+  })
+
+  it('resolves the real plural to the vendor key, not just the key to itself', () => {
+    // The inverse of the vacuity trap above: assert the plural a cluster would
+    // actually serve, not Radar's internal name for the column set.
+    expect(hasCuratedColumns('policies', 'kyverno.io')).toBe(true)
+    expect(hasCuratedColumns('gateways', 'networking.istio.io')).toBe(true)
+    expect(hasCuratedColumns('backups', 'postgresql.cnpg.io')).toBe(true)
+    expect(hasCuratedColumns('clusters', 'cluster.x-k8s.io')).toBe(true)
+    expect(hasCuratedColumns('services', 'serving.knative.dev')).toBe(true)
+    // ...and that an unrelated vendor still gets nothing.
+    expect(hasCuratedColumns('policies', 'someone-else.io')).toBe(false)
+  })
+})
+
+describe('every declaration resolves', () => {
+  // Size checks cannot catch a wrong group. Each declared pair has to actually
+  // return curated columns, and the same key under a group nobody claims has to
+  // not — run over all 160 rather than a hand-picked sample.
+  const DECLARED = [...objectBody('const CURATED_COLUMN_GROUPS')
+    .matchAll(/^ {2}([a-z0-9_]+): \[([^\]\n]+)\],$/gm)]
+    .map(m => [m[1], m[2].split(',').map(g => g.trim().replace(/'/g, ''))] as const)
+
+  it('covers the whole ownership table', () => {
+    expect(DECLARED.length).toBe(161)
+  })
+
+  it.each(DECLARED)('%s is curated under each group it claims', (key, groups) => {
+    for (const g of groups) expect(hasCuratedColumns(key, g)).toBe(true)
+  })
+
+  it.each(DECLARED)('%s is not curated under an unclaimed group', (key, _groups) => {
+    // Deliberately not a Crossplane/upbound suffix, which is matched by predicate.
+    expect(hasCuratedColumns(key, 'nobody-claims-this.invalid')).toBe(false)
+  })
+})
+
+describe('foreign CRDs do not inherit curated columns', () => {
+  // Each of these ships in the wild under a plural Radar curates for someone
+  // else. chaos-mesh Workflows are present on real clusters today.
+  it.each([
+    ['workflows', 'chaos-mesh.org', 'argoproj.io'],
+    ['providers', 'notification.toolkit.fluxcd.io', 'pkg.crossplane.io'],
+    ['services', 'example.com', ''],
+    ['backups', 'third-party.io', 'velero.io'],
+    ['clusters', 'kubeblocks.io', ''],
+    ['certificates', 'unrelated.io', 'cert-manager.io'],
+  ])('%s.%s is not treated as curated', (plural, foreignGroup) => {
+    expect(hasCuratedColumns(plural, foreignGroup)).toBe(false)
+  })
+
+  it.each([
+    ['workflows', 'argoproj.io'],
+    ['gateways', 'gateway.networking.k8s.io'],
+    ['providers', 'pkg.crossplane.io'],
+    ['scaledobjects', 'keda.sh'],
+    ['certificates', 'cert-manager.io'],
+    ['nodepools', 'karpenter.sh'],
+    ['externalsecrets', 'external-secrets.io'],
+    ['kustomizations', 'kustomize.toolkit.fluxcd.io'],
+    ['virtualservices', 'networking.istio.io'],
+    ['vulnerabilityreports', 'aquasecurity.github.io'],
+  ])('%s.%s keeps its curated columns', (plural, group) => {
+    expect(hasCuratedColumns(plural, group)).toBe(true)
+  })
+
+  // Core kinds carry no ownership entry and must not regress.
+  it.each([
+    ['pods', ''],
+    ['deployments', 'apps'],
+    ['jobs', 'batch'],
+    ['ingresses', 'networking.k8s.io'],
+    ['roles', 'rbac.authorization.k8s.io'],
+  ])('core %s.%s stays curated', (plural, group) => {
+    expect(hasCuratedColumns(plural, group)).toBe(true)
+  })
+
+  // Both are curated, but not by the same set: an Istio Gateway has servers and
+  // a workload selector, a Gateway API Gateway has a class, listeners, routes
+  // and addresses, and neither vocabulary describes the other.
+  it('gives Istio and Gateway API their own gateway column sets', () => {
+    expect(hasCuratedColumns('gateways', 'networking.istio.io')).toBe(true)
+    expect(hasCuratedColumns('gateways', 'gateway.networking.k8s.io')).toBe(true)
+
+    // objectBody slices to the first `{`, which inside an array is its first
+    // element — so take the array literal itself.
+    const columnKeys = (key: string) => {
+      const start = SRC.indexOf(`\n  ${key}: [`)
+      expect(start).toBeGreaterThan(-1)
+      const end = SRC.indexOf('\n  ],', start)
+      return [...SRC.slice(start, end).matchAll(/key: '([a-zA-Z]+)'/g)].map(m => m[1])
+    }
+    const istio = columnKeys('istiogateways')
+    const gwapi = columnKeys('gateways')
+    expect(istio).toContain('servers')
+    expect(istio).toContain('selector')
+    expect(gwapi).toContain('listeners')
+    expect(istio).not.toContain('listeners')
+    expect(gwapi).not.toContain('servers')
+  })
+
+  // CAPA serves AWSManagedControlPlane in the control-plane group; CAPZ and CAPG
+  // serve their equivalents in the infrastructure group. Declaring AWS as
+  // infrastructure silently dropped the curated columns on every CAPA cluster.
+  it('claims AWSManagedControlPlane in the control-plane group', () => {
+    expect(hasCuratedColumns('awsmanagedcontrolplanes', 'controlplane.cluster.x-k8s.io')).toBe(true)
+    expect(hasCuratedColumns('awsmanagedcontrolplanes', 'infrastructure.cluster.x-k8s.io')).toBe(false)
+    expect(hasCuratedColumns('azuremanagedcontrolplanes', 'infrastructure.cluster.x-k8s.io')).toBe(true)
+    expect(hasCuratedColumns('gcpmanagedcontrolplanes', 'infrastructure.cluster.x-k8s.io')).toBe(true)
+  })
+
+  // metrics.k8s.io is an aggregated API, not a group the API server reserves,
+  // and PodMetrics/NodeMetrics carry the plurals `pods`/`nodes`. Treating it as
+  // core handed them the Pod and Node column sets, which read fields they lack.
+  it('does not treat the aggregated metrics API as a core group', () => {
+    expect(hasCuratedColumns('pods', 'metrics.k8s.io')).toBe(false)
+    expect(hasCuratedColumns('nodes', 'metrics.k8s.io')).toBe(false)
+    expect(hasCuratedColumns('pods', '')).toBe(true)
+  })
+
+  // A provider ships one CRD per service, so managed resources collide with
+  // curated plurals constantly. The MR check has to run before the curated
+  // lookup or the collision resolves to generic columns and never reaches it.
+  it('keeps a managed resource whose plural collides with a curated kind', () => {
+    expect(hasCuratedColumns('certificates', 'acm.aws.upbound.io')).toBe(true)
+    expect(hasCuratedColumns('services', 's3.aws.upbound.io')).toBe(true)
+    expect(hasCuratedColumns('certificates', 'cert-manager.io')).toBe(true)
+  })
+
+  // Crossplane ProviderConfigs have one CRD per provider, so their groups
+  // cannot be enumerated and are matched by suffix instead.
+  it('keeps ProviderConfig curated across unbounded provider groups', () => {
+    expect(hasCuratedColumns('providerconfigs', 'aws.upbound.io')).toBe(true)
+    expect(hasCuratedColumns('providerconfigs', 'kubernetes.crossplane.io')).toBe(true)
+    expect(hasCuratedColumns('providerconfigs', 'not-crossplane.io')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

A CRD is not the kind Radar curated just because it reuses its plural. Column lookup resolved an unrecognized `(plural, group)` pair to the bare plural, so any vendor's CRD inherited the curated columns of whoever owned that name — rendering another project's schema against an object that has none of those fields. And because curated and printer columns are exclusive, the mis-claimed kind also lost the columns its own CRD declares. It got the wrong columns *and* was denied the right ones.

This is not hypothetical. On live clusters today:

| Kind | Renders | Actually is |
|---|---|---|
| `workflows.chaos-mesh.org` | Argo Workflow columns | a Chaos Mesh Workflow |
| `jobs.batch.volcano.sh` | core Batch Job columns | a Volcano Job |
| `cronjobs.batch.volcano.sh` | core Batch CronJob columns | a Volcano CronJob |

Making ownership explicit also surfaced the opposite failure — curated sets that *nothing* could reach — so two integrations that had quietly been rendering generic columns now get the ones written for them.

## What changed

**Curation is explicit.** `CURATED_COLUMN_GROUPS` records the API group(s) each curated set was written for. A non-core group gets those columns only if it is claimed; anything else falls through to the generic set and, for a CRD, to its own printer columns.

The map is keyed on **Radar's own column-set name**, not the Kubernetes plural, so two vendors sharing a plural take different keys and can never contend — `Backup` is `backups` for Velero and `cnpgbackups` for CNPG, with `GROUP_QUALIFIED_COLUMN_KEYS` resolving which.

Three things make the rule cheap to state:

- **Core kinds need no entry.** The API server reserves their groups, so a CRD cannot occupy one — a proof of non-collision, not a shortcut. `CORE_API_GROUPS` is an explicit list rather than a suffix test, because `gateway.networking.k8s.io`, `snapshot.storage.k8s.io` and `cluster.x-k8s.io` all end in `k8s.io` yet are CRD groups.
- **Crossplane managed resources are matched *before* the curated lookup.** A provider ships one CRD per service, so an MR routinely collides with a curated plural (`Certificate.acm.aws.upbound.io`, `Service.s3.aws.upbound.io`). Checking ownership first would resolve those to the generic set and never reach the MR branch at all. ProviderConfig groups are unbounded and matched by suffix.
- **Two guard tests keep it from rotting.** Every non-core curated set must declare an owning group, and every set Radar names for a vendor must have something that routes to it. Data alone would drift as integrations are added.

**Two curated sets are now reachable.** Both had real columns and real cells, wired to nothing — invisible while every other check stayed green:

- **Kyverno's namespaced `Policy`** — `kyvernopolicies` had columns and a `KyvernoPolicyCell`, but no `policies → kyvernopolicies` normalization. One entry connects both.
- **Istio `Gateway`** — it shared the Gateway API set, whose `Class`, `Listeners`, `Routes` and `Addresses` have no Istio counterpart and rendered empty. It now has its own set over the `servers` and `selector` cells `IstioGatewayRenderer` already implemented.

**Ambiguous plurals were resolved from the column sets, not the vendor's name.** `providers` carries `package`/`revision`, so it is Crossplane's rather than Flux's; `alerts` carries `provider`/`eventSources`, so it is Flux's. Two entries are worth a second look because they are counter-intuitive: `AWSManagedControlPlane` is claimed in `controlplane.cluster.x-k8s.io` where its Azure and GCP counterparts use the infrastructure group (CAPA is the outlier; `docs/integrations.md` is the reference), and `metrics.k8s.io` is deliberately *absent* from `CORE_API_GROUPS` because it is an aggregated API — `PodMetrics`/`NodeMetrics` carry the plurals `pods`/`nodes`, so treating it as core hands them the Pod and Node column sets.

## Testing

`make tsc` clean · k8s-ui **3140 tests** pass.

**354 tests cover this change.** Rather than sampling, every one of the 161 declarations is asserted in both directions — curated under each group it claims, not curated under a group nobody claims — because a size check cannot catch a wrong group. Plus the two guards, foreign-group rejection for known collisions, core-kind non-regression, the Crossplane collision cases, and the Gateway API/Istio column split.

**Regression was measured, not assumed.** Every `(plural, group)` pair observed across reachable clusters (308 unique) was classified before and after:

- curated **77 → 75**
- lost: exactly the three kinds in the table above
- gained: `policies.kyverno.io`, which had been falling to generic columns

Cluster data alone cannot prove a negative — it only covers integrations that happen to be installed. Every `(kind, group)` pair Radar names explicitly in its topology builder and cell dispatch was therefore classified the same way; that pass is what surfaced the Istio Gateway case, and it found no other.

Each declaration is either confirmed by a live cluster or corroborated by the group already appearing in the repo. Reviewers who run integrations absent from those clusters are the best check on the rest.

## Follow-ups not in this PR

- **The generic status ladder reports `{phase: Active, Degraded: True}` as healthy** — a phase outranks an explicit failure condition. A semantics change affecting every uncurated CRD, so it deserves its own decision.
- **The printer-column eligibility gate counts columns rather than weighing what they mean** — a kind with one authoritative `Ready` is rejected while one with `Host` and `Port` displaces the generic Status.
- **This table is a second hand-maintained integration registry**, parallel to renderer dispatch and discovery. A canonical `(kind, group) → column key` registry feeding normalization, rendering and ownership would remove the class of drift; the guard tests are the interim mitigation.
