### PR TITLE
fix(localterm): enforce --disable-local-terminal at endpoint

### DIFF
--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -213,7 +213,7 @@ var (
 	ForceDisableHelmWrite bool
 	// ForceDisableExec overrides the exec capability to false (for dev testing)
 	ForceDisableExec bool
-	// ForceDisableLocalTerminal overrides the localTerminal capability to false (for dev testing)
+	// ForceDisableLocalTerminal turns the local terminal off (--disable-local-terminal)
 	ForceDisableLocalTerminal bool
 )
 

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -177,6 +177,26 @@ func SetTestContextName(name string) string {
 	return prev
 }
 
+// SetTestLocalMode makes IsInCluster report local mode and returns a restore func.
+func SetTestLocalMode() func() {
+	clientMu.Lock()
+	previousInitializationStarted := initializationStarted
+	previousKubeconfigMode := kubeconfigMode
+	previousForceInCluster := ForceInCluster
+	initializationStarted = true
+	kubeconfigMode = "single"
+	ForceInCluster = false
+	clientMu.Unlock()
+
+	return func() {
+		clientMu.Lock()
+		initializationStarted = previousInitializationStarted
+		kubeconfigMode = previousKubeconfigMode
+		ForceInCluster = previousForceInCluster
+		clientMu.Unlock()
+	}
+}
+
 // SetTestRegistryEntry is a test-only helper that registers one context in the
 // isolated-load registry, so callers can exercise resolution against a
 // multi-kubeconfig layout. Returns a restore func.

--- a/internal/server/localterm.go
+++ b/internal/server/localterm.go
@@ -87,6 +87,12 @@ func setEnv(env []string, key, value string) []string {
 
 // handleLocalTerminal handles WebSocket connections for local terminal sessions
 func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
+	// Check the operator's opt-out first so it wins over runtime-mode detection,
+	// and before upgrading so the refusal remains a plain HTTP error.
+	if k8s.ForceDisableLocalTerminal {
+		s.writeError(w, http.StatusForbidden, "local terminal is disabled")
+		return
+	}
 	if k8s.IsInCluster() {
 		s.writeError(w, http.StatusBadRequest, "local terminal not available in-cluster mode")
 		return

--- a/internal/server/localterm_disable_test.go
+++ b/internal/server/localterm_disable_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// --disable-local-terminal must refuse the endpoint, not merely hide it from
+// the advertised capabilities: the handler runs a shell on the Radar host, so
+// an operator who turns it off must actually lose the route.
+func TestLocalTerminalDisabledRejectsRequest(t *testing.T) {
+	previousForceDisableLocalTerminal := k8s.ForceDisableLocalTerminal
+	t.Cleanup(func() {
+		k8s.ForceDisableLocalTerminal = previousForceDisableLocalTerminal
+	})
+	t.Cleanup(k8s.SetTestLocalMode())
+
+	k8s.ForceDisableLocalTerminal = true
+	if k8s.IsInCluster() {
+		t.Fatal("precondition: expected local mode")
+	}
+
+	w := httptest.NewRecorder()
+	(&Server{}).handleLocalTerminal(w, httptest.NewRequest(http.MethodGet, "/api/local-terminal", nil))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if got, want := w.Body.String(), "{\"error\":\"local terminal is disabled\"}\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestLocalTerminalInClusterRejectsRequest(t *testing.T) {
+	previousForceInCluster := k8s.ForceInCluster
+	previousForceDisableLocalTerminal := k8s.ForceDisableLocalTerminal
+	t.Cleanup(func() {
+		k8s.ForceInCluster = previousForceInCluster
+		k8s.ForceDisableLocalTerminal = previousForceDisableLocalTerminal
+	})
+
+	k8s.ForceInCluster = true
+	k8s.ForceDisableLocalTerminal = false
+
+	w := httptest.NewRecorder()
+	(&Server{}).handleLocalTerminal(w, httptest.NewRequest(http.MethodGet, "/api/local-terminal", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if got, want := w.Body.String(), "{\"error\":\"local terminal not available in-cluster mode\"}\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

`--disable-local-terminal` now closes the local-terminal endpoint as well as hiding its UI affordance. This prevents direct WebSocket clients from bypassing the operator opt-out and starting a shell on the Radar host.

## What changed

- Reject `/api/local-terminal` with HTTP 403 before the WebSocket upgrade when local terminal is disabled.
- Preserve the existing HTTP 400 response for in-cluster mode; an explicit operator opt-out takes precedence when both conditions apply.
- Cover the local-mode opt-out and in-cluster refusal paths with exact status and error-body assertions.

There is no behavior change when the flag is unset.

## Testing

- `make tsc`
- `make test`
- `make build`
- Visual test skipped: no UI delta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change gates host shell access on the server path that runs a local PTY; misconfiguration or bypass would be security-sensitive, but the fix tightens enforcement rather than expanding capability.
> 
> **Overview**
> **`--disable-local-terminal` now blocks `/api/local-terminal`**, not only hiding the feature in capabilities. The handler returns **HTTP 403** with `local terminal is disabled` **before** the WebSocket upgrade, so clients cannot bypass the operator opt-out and spawn a shell on the Radar host.
> 
> The **operator opt-out is checked first** and wins over in-cluster mode (which still returns **HTTP 400** when the flag is off). A test helper **`SetTestLocalMode`** was added so handler tests can assert local-mode behavior without a real kubeconfig.
> 
> Comment on `ForceDisableLocalTerminal` was updated to reference the CLI flag. **No change when the flag is unset.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca3f1a5fc5b07b1f428613ffff725223649b4a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->