### PR TITLE
Sort and filter group-qualified kinds through their own readers

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -4410,22 +4410,21 @@ export function ResourcesView({
       case 'age':
         return meta.creationTimestamp ? new Date(meta.creationTimestamp).getTime() : 0
       case 'status':
-        // Uncurated kinds sort on the text their badge shows: they have no
-        // phase to sort on when the status came from a condition or a replica
-        // count, so phase ordered them all as equal. It also has to stay the
-        // derived text rather than the raw phase — the ladder deliberately does
-        // not short-circuit on a phase it doesn't recognise.
+        // Phase first for a curated kind: it keeps the most-used lists — Pods,
+        // Deployments, Nodes — ordering as they always have.
         //
-        // Curated kinds sort on phase, which keeps the most-used lists — Pods,
-        // Deployments, Nodes — ordering as they always have without a status
-        // derivation per comparison. Where a curated kind publishes no phase at
-        // all, fall back rather than compare every row as equal: Kyverno Policy
-        // and Istio Gateway keep their state in conditions, so the column
-        // simply did not sort.
-        if (!hasCuratedColumns(selectedKind.name, selectedKind.group)) {
-          return getGenericResourceStatus(resource)?.text ?? ''
+        // Everything else routes through getCellFilterValue, the same reader
+        // the cell and the filter dropdown use, so all three agree on one
+        // string. Deriving it here instead ordered rows on a status the row
+        // never displayed: a Gateway shows `Programmed` while the generic
+        // ladder, which knows neither Programmed nor Accepted, called it
+        // `Accepted` — so a healthy Gateway and a pending one sorted equal.
+        // getCellFilterValue ends in that same generic derivation, so an
+        // uncurated kind still sorts on the text its badge shows.
+        if (hasCuratedColumns(selectedKind.name, selectedKind.group) && status.phase) {
+          return status.phase
         }
-        return status.phase || (getGenericResourceStatus(resource)?.text ?? '')
+        return getCellFilterValue(resource, 'status', kindLower)
       case 'servers':
         // Numeric so 10 does not sort before 9.
         if (kindLower === 'istiogateways') return getIstioGatewayServerCount(resource)
@@ -4634,17 +4633,20 @@ export function ResourcesView({
       // (istiogateways, cnpgclusters) otherwise arrives here as its bare plural
       // and misses its own sort readers. Hoisted out of the comparator.
       const sortKind = normalizeKindToPlural(selectedKind.name, selectedKind.group)
-      result = [...result].sort((a: any, b: any) => {
-        const aVal = extra?.getSortValue ? extra.getSortValue(a) : getSortValue(a, sortColumn, sortKind)
-        const bVal = extra?.getSortValue ? extra.getSortValue(b) : getSortValue(b, sortColumn, sortKind)
+      const keyOf = extra?.getSortValue ?? ((r: any) => getSortValue(r, sortColumn, sortKind))
+      // Derived once per row, not once per comparison: a sort visits O(n log n)
+      // pairs, and the status key now runs a per-kind status derivation.
+      const decorated = result.map((r: any) => ({ r, k: keyOf(r) }))
+      decorated.sort((a, b) => {
         let comparison = 0
-        if (typeof aVal === 'number' && typeof bVal === 'number') {
-          comparison = aVal - bVal
+        if (typeof a.k === 'number' && typeof b.k === 'number') {
+          comparison = a.k - b.k
         } else {
-          comparison = String(aVal).localeCompare(String(bVal))
+          comparison = String(a.k).localeCompare(String(b.k))
         }
         return sortDirection === 'desc' ? -comparison : comparison
       })
+      result = decorated.map(d => d.r)
     } else {
       // Default sort by kind
       const kindLower = normalizeKindToPlural(selectedKind.name, selectedKind.group)

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -140,6 +140,7 @@ import {
   healthColors,
 } from './resource-utils'
 import { getGenericResourceStatus } from './generic-status'
+import { getIstioGatewayServerCount, getIstioGatewaySelectorString } from './resource-utils-istio'
 import {
   type PrinterColumnDef, type PrinterTable, PRINTER_COLUMN_PREFIX, formatPrinterCell, printerCellSortValue,
   printerCellTone, printerColumnKey, printerColumnWidth, printerTableKey, printerTableMatchesKind, readPrinterCell,
@@ -4411,15 +4412,27 @@ export function ResourcesView({
       case 'status':
         // Uncurated kinds sort on the text their badge shows: they have no
         // phase to sort on when the status came from a condition or a replica
-        // count, so phase ordered them all as equal.
+        // count, so phase ordered them all as equal. It also has to stay the
+        // derived text rather than the raw phase — the ladder deliberately does
+        // not short-circuit on a phase it doesn't recognise.
         //
-        // Curated kinds sort on phase. Their cell already shows something
-        // richer, but routing the sort through the per-kind readers would
-        // reorder the most-used lists — Pods, Deployments, Nodes — and cost a
-        // status derivation per comparison.
-        return hasCuratedColumns(selectedKind.name, selectedKind.group)
-          ? (status.phase || '')
-          : (getGenericResourceStatus(resource)?.text ?? '')
+        // Curated kinds sort on phase, which keeps the most-used lists — Pods,
+        // Deployments, Nodes — ordering as they always have without a status
+        // derivation per comparison. Where a curated kind publishes no phase at
+        // all, fall back rather than compare every row as equal: Kyverno Policy
+        // and Istio Gateway keep their state in conditions, so the column
+        // simply did not sort.
+        if (!hasCuratedColumns(selectedKind.name, selectedKind.group)) {
+          return getGenericResourceStatus(resource)?.text ?? ''
+        }
+        return status.phase || (getGenericResourceStatus(resource)?.text ?? '')
+      case 'servers':
+        // Numeric so 10 does not sort before 9.
+        if (kindLower === 'istiogateways') return getIstioGatewayServerCount(resource)
+        return ''
+      case 'selector':
+        if (kindLower === 'istiogateways') return getIstioGatewaySelectorString(resource)
+        return ''
       case 'containers':
         // Pod containers column — sort by readiness ratio
         if (status.containerStatuses) {
@@ -4617,9 +4630,13 @@ export function ResourcesView({
     // the built-in getSortValue for their key.
     if (sortColumn && sortDirection) {
       const extra = extraColumnsByKey.get(sortColumn)
+      // Normalized, matching the filter call sites: a group-qualified kind
+      // (istiogateways, cnpgclusters) otherwise arrives here as its bare plural
+      // and misses its own sort readers. Hoisted out of the comparator.
+      const sortKind = normalizeKindToPlural(selectedKind.name, selectedKind.group)
       result = [...result].sort((a: any, b: any) => {
-        const aVal = extra?.getSortValue ? extra.getSortValue(a) : getSortValue(a, sortColumn, selectedKind.name)
-        const bVal = extra?.getSortValue ? extra.getSortValue(b) : getSortValue(b, sortColumn, selectedKind.name)
+        const aVal = extra?.getSortValue ? extra.getSortValue(a) : getSortValue(a, sortColumn, sortKind)
+        const bVal = extra?.getSortValue ? extra.getSortValue(b) : getSortValue(b, sortColumn, sortKind)
         let comparison = 0
         if (typeof aVal === 'number' && typeof bVal === 'number') {
           comparison = aVal - bVal

--- a/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { getCellFilterValue } from './resource-utils'
+
+// The table renders Istio Gateway through IstioGatewayCell, which reads the
+// spec. The filter dropdown and the sort key have to read the same thing, or
+// the dropdown offers values that appear on no row and the column sorts on a
+// string the user never saw — the failure this file exists to pin.
+const gateway = (spec: any) => ({ apiVersion: 'networking.istio.io/v1', kind: 'Gateway', spec })
+
+describe('Istio Gateway filter values', () => {
+  it('reads status from the spec, not the generic derivation', () => {
+    const tls = gateway({ servers: [{ port: { number: 443 }, tls: { mode: 'SIMPLE' } }] })
+    const plain = gateway({ servers: [{ port: { number: 80 } }] })
+    const none = gateway({ servers: [] })
+    expect(getCellFilterValue(tls, 'status', 'istiogateways')).toBe('TLS')
+    expect(getCellFilterValue(plain, 'status', 'istiogateways')).toBe('Active')
+    expect(getCellFilterValue(none, 'status', 'istiogateways')).toBe('No Servers')
+  })
+
+  // Read as a Gateway API Gateway instead, the same object filters as
+  // "Unknown" — a value that appears on no row, since the cell shows Active.
+  // That divergence is what routing the normalized key fixes.
+  it('diverges from the row when read under the Gateway API key', () => {
+    const g = gateway({ servers: [{ port: { number: 80 } }] })
+    expect(getCellFilterValue(g, 'status', 'gateways')).not.toBe(
+      getCellFilterValue(g, 'status', 'istiogateways'),
+    )
+  })
+
+  it('reads the server count and selector its columns display', () => {
+    const g = gateway({ servers: [{ port: { number: 80 } }, { port: { number: 443 } }], selector: { istio: 'ingressgateway' } })
+    expect(getCellFilterValue(g, 'servers', 'istiogateways')).toBe('2')
+    expect(getCellFilterValue(g, 'selector', 'istiogateways')).toBe('istio=ingressgateway')
+  })
+
+  it('renders an absent selector the way the cell does', () => {
+    expect(getCellFilterValue(gateway({ servers: [] }), 'selector', 'istiogateways')).toBe('-')
+  })
+
+  // Those column keys are Istio's. A kind that happens to share them gets
+  // nothing rather than a value read off the wrong shape.
+  it('claims servers and selector only for Istio Gateways', () => {
+    const other = { apiVersion: 'other.io/v1', kind: 'Thing', spec: { servers: [{ port: { number: 1 } }] } }
+    expect(getCellFilterValue(other, 'servers', 'things')).toBe('')
+    expect(getCellFilterValue(other, 'selector', 'things')).toBe('')
+  })
+})
+
+describe('Kyverno Policy filter values', () => {
+  // Reachable only once `policies` normalizes to `kyvernopolicies`; the filter
+  // call sites pass the normalized key, so this is the string they see.
+  it('reads the Kyverno status rather than the generic derivation', () => {
+    const policy = {
+      apiVersion: 'kyverno.io/v1',
+      kind: 'Policy',
+      spec: { rules: [{ name: 'r' }] },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    }
+    expect(getCellFilterValue(policy, 'status', 'kyvernopolicies')).not.toBe('')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { getCellFilterValue } from './resource-utils'
+import { getCellFilterValue, getGatewayStatus } from './resource-utils'
+import { getGenericResourceStatus } from './generic-status'
 
 // The table renders Istio Gateway through IstioGatewayCell, which reads the
 // spec. The filter dropdown and the sort key have to read the same thing, or
@@ -59,3 +60,38 @@ describe('Kyverno Policy filter values', () => {
     expect(getCellFilterValue(policy, 'status', 'kyvernopolicies')).not.toBe('')
   })
 })
+
+describe('curated kinds that publish no phase', () => {
+  // Sorting used to derive its own status here rather than reuse the reader the
+  // cell uses. A Gateway has no status.phase, so the sort key came from the
+  // generic ladder — which knows neither Programmed nor Accepted and called
+  // every Gateway "Accepted". A healthy Gateway and a pending one therefore
+  // sorted equal, and neither matched the text on screen.
+  const gateway = (accepted: string, programmed: string) => ({
+    apiVersion: 'gateway.networking.k8s.io/v1',
+    kind: 'Gateway',
+    status: { conditions: [{ type: 'Accepted', status: accepted }, { type: 'Programmed', status: programmed }] },
+  })
+
+  it.each([
+    ['True', 'True', 'Programmed'],
+    ['True', 'False', 'Accepted'],
+    ['False', 'False', 'Not Accepted'],
+  ])('Accepted=%s Programmed=%s sorts and filters on the text the cell shows', (a, p, expected) => {
+    const gw = gateway(a, p)
+    expect(getGatewayStatus(gw).text).toBe(expected)
+    expect(getCellFilterValue(gw, 'status', 'gateways')).toBe(expected)
+  })
+
+  // The reason the shared reader is load-bearing rather than incidental.
+  it('distinguishes a programmed Gateway from a pending one', () => {
+    const ok = getCellFilterValue(gateway('True', 'True'), 'status', 'gateways')
+    const pending = getCellFilterValue(gateway('True', 'False'), 'status', 'gateways')
+    expect(ok).not.toBe(pending)
+    // Both collapse to one value under the generic ladder, which is what made
+    // the column stop sorting.
+    expect(getGenericResourceStatus(gateway('True', 'True'))?.text)
+      .toBe(getGenericResourceStatus(gateway('True', 'False'))?.text)
+  })
+})
+

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -19,6 +19,7 @@ import { getExternalSecretStatus as _getExternalSecretStatus, getClusterExternal
 import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
 import { getCNPGClusterStatus as _getCNPGClusterStatus, getCNPGBackupStatus as _getCNPGBackupStatus, getCNPGScheduledBackupStatus as _getCNPGScheduledBackupStatus, getCNPGPoolerStatus as _getCNPGPoolerStatus, isApiGroup as _isApiGroup, CNPG_GROUP as _CNPG_GROUP } from './resource-utils-cnpg'
 import { getGenericResourceStatus } from './generic-status'
+import { getIstioGatewayStatus as _getIstioGatewayStatus, getIstioGatewayServerCount as _getIstioGatewayServerCount, getIstioGatewaySelectorString as _getIstioGatewaySelectorString } from './resource-utils-istio'
 import { getCalicoIPPoolAllowedUses, getCalicoIPPoolBlockSize, getCalicoIPPoolEncapsulation, getCalicoPolicyNamespaceSelector, getCalicoPolicyServiceAccountSelector, getCalicoPolicyTypes, isCalicoApiVersion, isCalicoPolicyResource } from './resource-utils-calico'
 
 // ============================================================================
@@ -2261,9 +2262,18 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       if (kindLower === 'cnpgbackups') return _getCNPGBackupStatus(resource).text
       if (kindLower === 'scheduledbackups' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGScheduledBackupStatus(resource).text
       if (kindLower === 'poolers' && _isApiGroup(resource.apiVersion, _CNPG_GROUP)) return _getCNPGPoolerStatus(resource).text
+      if (kindLower === 'istiogateways') return _getIstioGatewayStatus(resource).text
       // Generic CRDs. Must read the same text the cell renders or the dropdown
       // offers strings that appear on no row — hence the shared derivation.
       return getGenericResourceStatus(resource)?.text ?? ''
+    // Istio Gateway's own columns. Without these the filter dropdown is empty
+    // for a column the table is visibly populating.
+    case 'servers':
+      if (kindLower === 'istiogateways') return String(_getIstioGatewayServerCount(resource))
+      return ''
+    case 'selector':
+      if (kindLower === 'istiogateways') return _getIstioGatewaySelectorString(resource)
+      return ''
     case 'state':
       if (kindLower === 'orders') return getOrderState(resource).text
       if (kindLower === 'challenges') return getChallengeState(resource).text


### PR DESCRIPTION
## Summary

Sorting passed the raw plural where filtering passed the normalized key, so a kind resolving through `GROUP_QUALIFIED_COLUMN_KEYS` never reached its own sort readers. Two visible consequences, both on kinds that only recently became reachable:

| | Before | Now |
|---|---|---|
| Kyverno Policy — Status sort | every row compares equal; column does not sort | sorts on the derived status |
| Istio Gateway — Status sort | same | same |
| Istio Gateway — Status filter | derived generically for a resource with neither phase nor conditions | reads the spec the cell renders |
| Istio Gateway — Servers / Selector | table populates them; dropdown empty, sort compares `''` | both read the same spec as the cell |
| Gateway API Gateway — Status sort | a programmed Gateway and a pending one compare **equal**, and neither matches the text on screen | sorts on the same string the cell shows |

The Kyverno case is a regression from #1533: it sorted correctly as an uncurated kind, and making it curated routed it to a `status.phase` it does not have.

## What changed

- **The sort key is normalized**, matching the filter call sites.
- **The status key routes through `getCellFilterValue`** — the reader the cell and the filter dropdown already use — so all three agree on one string. Deriving it separately was the root cause: for a curated kind with no `status.phase`, sorting fell to the generic ladder, which knows neither `Programmed` nor `Accepted` and labels every Gateway `Accepted`. Phase still short-circuits for curated kinds that publish one, so Pods, Deployments and Nodes are untouched.
- **Sort keys are derived once per row**, not once per comparison. A sort visits O(n log n) pairs and the status key now runs a per-kind derivation, so the previous shape re-derived the same value tens of thousands of times on a large list.
- **Istio Gateway's own columns get extractors** for status, servers and selector, reading the same spec `IstioGatewayCell` renders.

## Testing

`make tsc` clean · k8s-ui **3146 tests** pass.

Six new tests pin the filter values against the spec the cell reads, including that the same object filters differently under the Gateway API key than under Istio's — the divergence the normalized key removes — and that `servers`/`selector` are claimed only for Istio Gateways.

`getSortValue` lives inside the component and is not exported, so the sort path is covered by type-checking and by the shared readers the filter tests exercise, not by a direct unit test.

## Notes

Found by an adversarial review of #1533 after it merged. Two other findings from that review were checked and not carried here:

- **Kyverno status filtering was reported broken; it is not.** `getCellFilterValue` has a `kyvernopolicies` case and both filter call sites already normalize.
- **Migrating the changed column-settings keys was suggested; it would be wrong.** Istio Gateway's column set itself changed, so restoring preferences saved under the old key would reapply choices about columns that no longer exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared sort/filter logic for many resource kinds in the main resources table; behavior is well-tested but affects list ordering and filters broadly.
> 
> **Overview**
> Fixes resource list **sort** and **filter** disagreeing with what rows show, especially for group-qualified kinds (Istio Gateway, Kyverno Policy, Gateway API Gateway).
> 
> **Sort** now uses the same normalized kind key as filtering (`normalizeKindToPlural`), so Istio/Kyverno readers run instead of bare plurals. **Status** sorting reuses `getCellFilterValue` (same as the cell and filter dropdown) instead of `status.phase` or a separate generic derivation—so programmed vs pending Gateways order correctly and Istio status matches the spec-based badge. Curated kinds that still expose `status.phase` (Pods, Deployments, Nodes) keep phase-based sort.
> 
> Sorting **precomputes keys once per row** (decorate-sort) because status derivation is heavier. **Istio Gateway** gets `getCellFilterValue` cases for **status**, **servers**, and **selector**, wired through sort in `ResourcesView`.
> 
> New **Vitest** coverage locks filter values to cell semantics and documents Gateway API vs Istio key divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa42ce07c108b38ca883c02a6cf01c84d8624911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

