### PR TITLE
Read Gateway API policy status, which lives per-ancestor

### DIFF
--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -105,11 +105,10 @@ describe('aggregating across ancestors', () => {
 })
 
 describe('shapes that are not a verdict', () => {
-  // The controller published a PolicyStatus saying this policy applies to
-  // nothing. "Not attached" and "not reconciled yet" are indistinguishable
-  // here, so this reports the fact without claiming health either way.
-  it('says so when the policy attaches to nothing', () => {
-    expect(getGatewayPolicyStatus(policy())).toMatchObject({ text: 'No ancestors', tone: 'unknown' })
+  // Yields nothing rather than a verdict, so a policy that also publishes
+  // top-level conditions still gets read from those.
+  it('declines to judge a policy that attaches to nothing', () => {
+    expect(getGatewayPolicyStatus(policy())).toBeNull()
   })
 
   it('ignores malformed ancestors rather than throwing', () => {
@@ -140,3 +139,64 @@ describe('wiring into the generic ladder', () => {
     expect(getGenericResourceStatus({ status: { phase: 'Running' } })).toMatchObject({ text: 'Running', tone: 'healthy' })
   })
 })
+
+describe('condition vocabulary beyond Accepted', () => {
+  // GKE reports attachment with its own condition; Gateway API's
+  // BackendTLSPolicy requires ResolvedRefs as well as Accepted.
+  it.each([
+    ['Attached', 'InvalidTarget'],
+    ['ResolvedRefs', 'InvalidCACertificateRef'],
+    ['Programmed', 'ResourceNotFound'],
+  ])('treats %s=False as a failure', (type, reason) => {
+    const p = policy(anc(cond('Accepted', 'True'), cond(type, 'False', reason)))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: reason, tone: 'unhealthy' })
+  })
+
+  // GEP-713 lists Reconciling as a legitimate state on the way to being
+  // applied. Painting ordinary convergence red teaches operators to ignore red.
+  it.each(['Reconciling', 'Pending', 'Progressing'])('treats %s as in-flight, not failed', reason => {
+    const p = policy(anc(cond('Accepted', 'True'), cond('Programmed', 'False', reason)))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: reason, tone: 'degraded' })
+  })
+
+  it('does not read a partially applied policy as success', () => {
+    const p = policy(anc(cond('Accepted', 'True'), cond('Programmed', 'True', 'PartiallyProgrammed')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'PartiallyProgrammed', tone: 'degraded' })
+  })
+
+  // Reporting the first reason with a count claims every ancestor failed that
+  // way. When they differ, say how many failed instead of guessing why.
+  it('does not attribute one ancestor\'s reason to another', () => {
+    const p = policy(
+      anc(cond('Accepted', 'False', 'NotAllowed')),
+      anc(cond('Accepted', 'False', 'ResourceNotFound')),
+      anc(cond('Accepted', 'True')),
+    )
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: '2/3 failed', tone: 'unhealthy' })
+  })
+
+  it('keeps the reason when every failure agrees', () => {
+    const p = policy(anc(cond('Accepted', 'False', 'NotAllowed')), anc(cond('Accepted', 'False', 'NotAllowed')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'NotAllowed (2/2)', tone: 'unhealthy' })
+  })
+})
+
+describe('policies that also publish top-level conditions', () => {
+  // GCPBackendPolicy declares both status.ancestors and status.conditions.
+  // Dispatching on the shape alone suppressed the conditions entirely.
+  it('falls back to top-level conditions when the ancestors say nothing', () => {
+    const dual = { status: { ancestors: [], conditions: [{ type: 'Ready', status: 'False', reason: 'Invalid' }] } }
+    expect(getGenericResourceStatus(dual)).toMatchObject({ text: 'Invalid', tone: 'unhealthy' })
+  })
+
+  it('still prefers a verdict the ancestors did give', () => {
+    const dual = {
+      status: {
+        ancestors: [{ conditions: [cond('Accepted', 'False', 'NotAllowed')] }],
+        conditions: [{ type: 'Ready', status: 'True' }],
+      },
+    }
+    expect(getGenericResourceStatus(dual)).toMatchObject({ text: 'NotAllowed', tone: 'unhealthy' })
+  })
+})
+

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getGatewayPolicyStatus, hasGatewayPolicyStatus } from './gateway-policy-status'
+import { getGatewayPolicyStatus } from './gateway-policy-status'
 import { getGenericResourceStatus } from './generic-status'
 
 const cond = (type: string, status: string, reason?: string, message?: string) => ({ type, status, reason, message })
@@ -116,9 +116,9 @@ describe('shapes that are not a verdict', () => {
     expect(() => getGatewayPolicyStatus({ status: { ancestors: [{ conditions: 'nope' }] } })).not.toThrow()
   })
 
-  it('is not a policy when ancestors is absent or not an array', () => {
-    expect(hasGatewayPolicyStatus({ status: { conditions: [] } })).toBe(false)
-    expect(hasGatewayPolicyStatus({ status: { ancestors: {} } })).toBe(false)
+  it('yields nothing when ancestors is absent or not an array', () => {
+    expect(getGatewayPolicyStatus({ status: { conditions: [] } })).toBeNull()
+    expect(getGatewayPolicyStatus({ status: { ancestors: {} } })).toBeNull()
     expect(getGatewayPolicyStatus({ status: {} })).toBeNull()
   })
 })
@@ -154,9 +154,24 @@ describe('condition vocabulary beyond Accepted', () => {
 
   // GEP-713 lists Reconciling as a legitimate state on the way to being
   // applied. Painting ordinary convergence red teaches operators to ignore red.
-  it.each(['Reconciling', 'Pending', 'Progressing'])('treats %s as in-flight, not failed', reason => {
+  it.each(['Reconciling', 'Pending'])('treats %s as in-flight, not failed', reason => {
     const p = policy(anc(cond('Accepted', 'True'), cond('Programmed', 'False', reason)))
     expect(getGatewayPolicyStatus(p)).toMatchObject({ text: reason, tone: 'degraded' })
+  })
+
+  // GKE's healthy shape carries no Accepted condition at all. Checking only
+  // Accepted read it as pending, which is a policy that works reported amber.
+  it('accepts a verdict that is not spelled Accepted', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Attached', 'True')))))
+      .toMatchObject({ text: 'Attached', tone: 'healthy' })
+    expect(getGatewayPolicyStatus(policy(anc(cond('Programmed', 'True')))))
+      .toMatchObject({ text: 'Programmed', tone: 'healthy' })
+  })
+
+  // Refs resolving is a precondition, not a statement that the policy applies.
+  it('does not treat ResolvedRefs alone as a verdict', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('ResolvedRefs', 'True')))))
+      .toMatchObject({ tone: 'degraded' })
   })
 
   it('does not read a partially applied policy as success', () => {

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -38,6 +38,13 @@ describe('Gateway API PolicyStatus', () => {
     expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'ShadowedRules', tone: 'degraded' })
   })
 
+  // Accepted=False reads as "Not Accepted"; Warning=True means there IS a
+  // warning, so the same construction would invert it.
+  it('names a reason-less warning after the condition, not its negation', () => {
+    const p = policy(anc(cond('Accepted', 'True'), cond('Warning', 'True')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'Warning', tone: 'degraded' })
+  })
+
   it('carries the controller message as the tooltip reason', () => {
     const p = policy(anc(cond('Accepted', 'False', 'Invalid', 'spec.targetRef.kind is not supported')))
     expect(getGatewayPolicyStatus(p)?.reason).toBe('spec.targetRef.kind is not supported')
@@ -71,6 +78,24 @@ describe('aggregating across ancestors', () => {
   it('treats Unknown as undecided rather than as failure', () => {
     const p = policy(anc(cond('Accepted', 'Unknown', 'Pending')))
     expect(getGatewayPolicyStatus(p)).toMatchObject({ tone: 'degraded' })
+  })
+
+  // One slot for both kinds of problem showed the warning's reason next to the
+  // failure's count and tone — the operator reads the warning as the failure.
+  it('reports the failure, not an earlier warning, when both are present', () => {
+    const p = policy(
+      anc(cond('Accepted', 'True'), cond('Warning', 'True', 'ShadowedRules')),
+      anc(cond('Accepted', 'False', 'NotAllowed')),
+    )
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'NotAllowed (1/2)', tone: 'unhealthy' })
+  })
+
+  it('still reports the warning when nothing failed', () => {
+    const p = policy(
+      anc(cond('Accepted', 'True'), cond('Warning', 'True', 'ShadowedRules')),
+      anc(cond('Accepted', 'True')),
+    )
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'ShadowedRules (1/2)', tone: 'degraded' })
   })
 
   it('is healthy only when every ancestor accepted', () => {

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { getGatewayPolicyStatus, hasGatewayPolicyStatus } from './gateway-policy-status'
+import { getGenericResourceStatus } from './generic-status'
+
+const cond = (type: string, status: string, reason?: string, message?: string) => ({ type, status, reason, message })
+const policy = (...ancestors: any[]) => ({ status: { ancestors } })
+const anc = (...conditions: any[]) => ({ ancestorRef: { kind: 'Gateway', name: 'gw' }, conditions })
+
+describe('Gateway API PolicyStatus', () => {
+  // Taken from a live EnvoyPatchPolicy. The controller accepted the policy and
+  // then could not apply it. Read positives-first — the way the generic ladder
+  // resolves conditions — this object is healthy, which is the whole reason it
+  // gets its own reader.
+  it('reports the failure on a policy that was accepted and then not applied', () => {
+    const p = policy(anc(cond('Accepted', 'True', 'Accepted'), cond('Programmed', 'False', 'ResourceNotFound')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'ResourceNotFound', tone: 'unhealthy' })
+  })
+
+  it('reports a plain accepted policy as healthy', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Accepted', 'True', 'Accepted')))))
+      .toMatchObject({ text: 'Accepted', tone: 'healthy' })
+  })
+
+  it('reports a rejected policy with the controller reason', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Accepted', 'False', 'Conflicted')))))
+      .toMatchObject({ text: 'Conflicted', tone: 'unhealthy' })
+  })
+
+  it('falls back to the condition type when the controller gave no reason', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Accepted', 'False')))))
+      .toMatchObject({ text: 'Not Accepted', tone: 'unhealthy' })
+  })
+
+  // Envoy Gateway publishes this combination. A positives-first read returns
+  // healthy and the warning never surfaces.
+  it('does not let an accepted policy hide a warning', () => {
+    const p = policy(anc(cond('Accepted', 'True'), cond('Warning', 'True', 'ShadowedRules')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'ShadowedRules', tone: 'degraded' })
+  })
+
+  it('carries the controller message as the tooltip reason', () => {
+    const p = policy(anc(cond('Accepted', 'False', 'Invalid', 'spec.targetRef.kind is not supported')))
+    expect(getGatewayPolicyStatus(p)?.reason).toBe('spec.targetRef.kind is not supported')
+  })
+})
+
+describe('aggregating across ancestors', () => {
+  // A policy may attach to several Gateways with different outcomes. Collapsing
+  // to a bare "Accepted" would hide the one that rejected it.
+  it('reports a failure anywhere, and how widespread it is', () => {
+    const p = policy(
+      anc(cond('Accepted', 'True')),
+      anc(cond('Accepted', 'False', 'NotAllowed')),
+      anc(cond('Accepted', 'True')),
+    )
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'NotAllowed (1/3)', tone: 'unhealthy' })
+  })
+
+  it('does not add a count when the policy attaches to one ancestor', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Accepted', 'False', 'NotAllowed'))))?.text)
+      .toBe('NotAllowed')
+  })
+
+  // Absence is not acceptance: an ancestor the controller has not answered for
+  // must not be counted as healthy just because its sibling was.
+  it('does not read an ancestor with no verdict as accepted', () => {
+    const p = policy(anc(cond('Accepted', 'True')), anc())
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'Pending (1/2)', tone: 'degraded' })
+  })
+
+  it('treats Unknown as undecided rather than as failure', () => {
+    const p = policy(anc(cond('Accepted', 'Unknown', 'Pending')))
+    expect(getGatewayPolicyStatus(p)).toMatchObject({ tone: 'degraded' })
+  })
+
+  it('is healthy only when every ancestor accepted', () => {
+    expect(getGatewayPolicyStatus(policy(anc(cond('Accepted', 'True')), anc(cond('Accepted', 'True')))))
+      .toMatchObject({ text: 'Accepted', tone: 'healthy' })
+  })
+})
+
+describe('shapes that are not a verdict', () => {
+  // The controller published a PolicyStatus saying this policy applies to
+  // nothing. "Not attached" and "not reconciled yet" are indistinguishable
+  // here, so this reports the fact without claiming health either way.
+  it('says so when the policy attaches to nothing', () => {
+    expect(getGatewayPolicyStatus(policy())).toMatchObject({ text: 'No ancestors', tone: 'unknown' })
+  })
+
+  it('ignores malformed ancestors rather than throwing', () => {
+    expect(() => getGatewayPolicyStatus({ status: { ancestors: [null, 'nope', 42] } })).not.toThrow()
+    expect(() => getGatewayPolicyStatus({ status: { ancestors: [{ conditions: 'nope' }] } })).not.toThrow()
+  })
+
+  it('is not a policy when ancestors is absent or not an array', () => {
+    expect(hasGatewayPolicyStatus({ status: { conditions: [] } })).toBe(false)
+    expect(hasGatewayPolicyStatus({ status: { ancestors: {} } })).toBe(false)
+    expect(getGatewayPolicyStatus({ status: {} })).toBeNull()
+  })
+})
+
+describe('wiring into the generic ladder', () => {
+  it('resolves a policy through its own reader', () => {
+    const p = policy(anc(cond('Accepted', 'True', 'Accepted'), cond('Programmed', 'False', 'ResourceNotFound')))
+    expect(getGenericResourceStatus(p)).toMatchObject({ text: 'ResourceNotFound', tone: 'unhealthy' })
+  })
+
+  // The dispatch is on shape, so it must not intercept an ordinary resource.
+  it('leaves a resource with top-level conditions alone', () => {
+    const r = { status: { conditions: [{ type: 'Ready', status: 'True' }] } }
+    expect(getGenericResourceStatus(r)).toMatchObject({ text: 'Ready', tone: 'healthy' })
+  })
+
+  it('leaves a phase-based resource alone', () => {
+    expect(getGenericResourceStatus({ status: { phase: 'Running' } })).toMatchObject({ text: 'Running', tone: 'healthy' })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -28,15 +28,25 @@ import type { GenericStatus } from './generic-status'
 const EFFECT_CONDITIONS = ['Accepted', 'Attached', 'Programmed', 'ResolvedRefs'] as const
 
 /**
+ * The subset that is a verdict in its own right, so True means the policy took
+ * effect. `ResolvedRefs` is deliberately absent: refs resolving is a
+ * precondition, not a statement that the policy applies. Kept separate from
+ * EFFECT_CONDITIONS because a condition can be conclusive when False and say
+ * nothing when True — GKE reports a healthy policy as `Attached=True` with no
+ * `Accepted` at all, so checking only `Accepted` read it as pending.
+ */
+const VERDICT_CONDITIONS = ['Accepted', 'Attached', 'Programmed'] as const
+
+/**
  * Reasons that mean "not settled yet" rather than "failed". GEP-713 lists
  * Reconciling as a legitimate state for a policy on its way to being applied,
  * and rendering ordinary convergence as a red failure would train operators to
  * ignore the colour.
  */
-const TRANSIENT_REASONS = new Set(['Reconciling', 'Pending', 'Progressing', 'Unknown'])
+const TRANSIENT_REASONS = new Set(['Reconciling', 'Pending'])
 
 /** A True condition can still be qualified: partial application is not success. */
-const QUALIFIED_SUCCESS_REASONS = new Set(['PartiallyProgrammed', 'PartiallyValid', 'Partial'])
+const QUALIFIED_SUCCESS_REASONS = new Set(['PartiallyProgrammed'])
 
 /** Conditions that mean trouble when True, mirroring the generic ladder's set. */
 const NEGATIVE_CONDITIONS = new Set(['Degraded', 'Warning'])
@@ -63,11 +73,6 @@ function problemText(cond: any, trueMeansTrouble = false): string {
   const type = typeof cond?.type === 'string' ? cond.type.trim() : ''
   if (!type) return 'Failed'
   return trueMeansTrouble ? type : `Not ${type}`
-}
-
-/** True when the object carries a Gateway API PolicyStatus. */
-export function hasGatewayPolicyStatus(resource: any): boolean {
-  return Array.isArray(resource?.status?.ancestors)
 }
 
 /**
@@ -99,6 +104,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   // Ancestors can fail for different reasons. Reporting the first one with a
   // count claims they all failed that way.
   const failureReasons = new Set<string>()
+  let acceptedAs: string | null = null
 
   for (const ancestor of ancestors) {
     const conditions = conditionsOf(ancestor)
@@ -139,7 +145,15 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       continue
     }
 
-    if (conditions.some((c: any) => c?.type === 'Accepted' && c?.status === 'True')) accepted++
+    const verdict = conditions.find(
+      (c: any) => VERDICT_CONDITIONS.includes(c?.type) && c?.status === 'True',
+    )
+    if (verdict) {
+      accepted++
+      // Named after the condition that granted it, so a GKE policy reads
+      // "Attached" where an Envoy one reads "Accepted".
+      acceptedAs ??= verdict.type
+    }
   }
 
   const total = ancestors.length
@@ -152,7 +166,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   if (degraded > 0 && warning) {
     return { text: `${warning.text}${scope(degraded)}`, tone: 'degraded', reason: warning.reason }
   }
-  if (accepted === total) return { text: 'Accepted', tone: 'healthy' }
+  if (accepted === total) return { text: acceptedAs ?? 'Accepted', tone: 'healthy' }
 
   // Some ancestor published neither an outcome nor a failure — the controller
   // has seen the policy but not finished with it.

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -19,8 +19,24 @@ import type { GenericStatus } from './generic-status'
  * positives-first, that object is healthy; it is not.
  */
 
-/** Conditions that describe whether the policy took effect. */
-const EFFECT_CONDITIONS = ['Accepted', 'Programmed'] as const
+/**
+ * Conditions that describe whether the policy took effect. `Accepted` is
+ * GEP-713's own verdict; `Programmed` and `ResolvedRefs` are how Gateway API
+ * and its implementations report that a policy the controller took on could
+ * not actually be applied, and `Attached` is GKE's equivalent.
+ */
+const EFFECT_CONDITIONS = ['Accepted', 'Attached', 'Programmed', 'ResolvedRefs'] as const
+
+/**
+ * Reasons that mean "not settled yet" rather than "failed". GEP-713 lists
+ * Reconciling as a legitimate state for a policy on its way to being applied,
+ * and rendering ordinary convergence as a red failure would train operators to
+ * ignore the colour.
+ */
+const TRANSIENT_REASONS = new Set(['Reconciling', 'Pending', 'Progressing', 'Unknown'])
+
+/** A True condition can still be qualified: partial application is not success. */
+const QUALIFIED_SUCCESS_REASONS = new Set(['PartiallyProgrammed', 'PartiallyValid', 'Partial'])
 
 /** Conditions that mean trouble when True, mirroring the generic ladder's set. */
 const NEGATIVE_CONDITIONS = new Set(['Degraded', 'Warning'])
@@ -36,6 +52,10 @@ function conditionsOf(ancestor: any): any[] {
  * The fallback has to follow the condition's polarity. `Accepted=False` reads
  * as "Not Accepted", but `Warning=True` means there *is* a warning, so the same
  * construction would render "Not Warning" and inverts the meaning.
+ *
+ * Spelled with a space where the Go reader behind MCP writes "NotAccepted",
+ * matching each side's existing convention. Only the reason-less case differs;
+ * whenever a controller supplies a reason the two are identical.
  */
 function problemText(cond: any, trueMeansTrouble = false): string {
   const reason = typeof cond?.reason === 'string' ? cond.reason.trim() : ''
@@ -61,10 +81,11 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   const ancestors = resource?.status?.ancestors
   if (!Array.isArray(ancestors)) return null
 
-  // Distinct from an unset status: the controller published a PolicyStatus and
-  // said this policy applies to nothing. Reported as text without a health
-  // claim, because "not attached" and "not reconciled yet" look identical here.
-  if (ancestors.length === 0) return { text: 'No ancestors', tone: 'unknown' }
+  // Null rather than a verdict, so the caller can fall back to any top-level
+  // conditions the object also carries. A policy that attaches to nothing and
+  // says nothing else is left to render as absent, because "not attached" and
+  // "not reconciled yet" are indistinguishable from here.
+  if (ancestors.length === 0) return null
 
   let failed = 0
   let degraded = 0
@@ -75,6 +96,9 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   // failure.
   let failure: { text: string; reason?: string } | null = null
   let warning: { text: string; reason?: string } | null = null
+  // Ancestors can fail for different reasons. Reporting the first one with a
+  // count claims they all failed that way.
+  const failureReasons = new Set<string>()
 
   for (const ancestor of ancestors) {
     const conditions = conditionsOf(ancestor)
@@ -83,8 +107,16 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       (c: any) => EFFECT_CONDITIONS.includes(c?.type) && c?.status === 'False',
     )
     if (broken) {
+      const reason = typeof broken?.reason === 'string' ? broken.reason.trim() : ''
+      // A controller still working towards the desired state is not a failure.
+      if (TRANSIENT_REASONS.has(reason)) {
+        degraded++
+        warning ??= { text: reason, reason: broken?.message }
+        continue
+      }
       failed++
       failure ??= { text: problemText(broken), reason: broken?.message }
+      failureReasons.add(problemText(broken))
       continue
     }
 
@@ -95,6 +127,18 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       continue
     }
 
+    // A qualified success is not success: PartiallyProgrammed means some of the
+    // policy landed and some did not.
+    const qualified = conditions.find(
+      (c: any) => EFFECT_CONDITIONS.includes(c?.type) && c?.status === 'True' &&
+        QUALIFIED_SUCCESS_REASONS.has(typeof c?.reason === 'string' ? c.reason.trim() : ''),
+    )
+    if (qualified) {
+      degraded++
+      warning ??= { text: qualified.reason.trim(), reason: qualified?.message }
+      continue
+    }
+
     if (conditions.some((c: any) => c?.type === 'Accepted' && c?.status === 'True')) accepted++
   }
 
@@ -102,7 +146,8 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   const scope = (n: number) => (total > 1 ? ` (${n}/${total})` : '')
 
   if (failed > 0 && failure) {
-    return { text: `${failure.text}${scope(failed)}`, tone: 'unhealthy', reason: failure.reason }
+    const text = failureReasons.size > 1 ? `${failed}/${total} failed` : `${failure.text}${scope(failed)}`
+    return { text, tone: 'unhealthy', reason: failure.reason }
   }
   if (degraded > 0 && warning) {
     return { text: `${warning.text}${scope(degraded)}`, tone: 'degraded', reason: warning.reason }

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -29,11 +29,20 @@ function conditionsOf(ancestor: any): any[] {
   return Array.isArray(ancestor?.conditions) ? ancestor.conditions : []
 }
 
-function problemText(cond: any): string {
+/**
+ * The controller's reason where it gave one — it names the actual failure
+ * (ResourceNotFound, Conflicted, NotAllowed) where the type does not.
+ *
+ * The fallback has to follow the condition's polarity. `Accepted=False` reads
+ * as "Not Accepted", but `Warning=True` means there *is* a warning, so the same
+ * construction would render "Not Warning" and inverts the meaning.
+ */
+function problemText(cond: any, trueMeansTrouble = false): string {
   const reason = typeof cond?.reason === 'string' ? cond.reason.trim() : ''
   if (reason) return reason
   const type = typeof cond?.type === 'string' ? cond.type.trim() : ''
-  return type ? `Not ${type}` : 'Failed'
+  if (!type) return 'Failed'
+  return trueMeansTrouble ? type : `Not ${type}`
 }
 
 /** True when the object carries a Gateway API PolicyStatus. */
@@ -60,7 +69,12 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   let failed = 0
   let degraded = 0
   let accepted = 0
-  let problem: { text: string; reason?: string } | null = null
+  // Tracked apart, not in one slot: a warning on the first ancestor and a
+  // failure on the second would otherwise show the warning's text alongside
+  // the failure's count and tone, reading as though the warning was the
+  // failure.
+  let failure: { text: string; reason?: string } | null = null
+  let warning: { text: string; reason?: string } | null = null
 
   for (const ancestor of ancestors) {
     const conditions = conditionsOf(ancestor)
@@ -70,14 +84,14 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
     )
     if (broken) {
       failed++
-      problem ??= { text: problemText(broken), reason: broken?.message }
+      failure ??= { text: problemText(broken), reason: broken?.message }
       continue
     }
 
     const warned = conditions.find((c: any) => NEGATIVE_CONDITIONS.has(c?.type) && c?.status === 'True')
     if (warned) {
       degraded++
-      problem ??= { text: problemText(warned), reason: warned?.message }
+      warning ??= { text: problemText(warned, true), reason: warned?.message }
       continue
     }
 
@@ -87,11 +101,11 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   const total = ancestors.length
   const scope = (n: number) => (total > 1 ? ` (${n}/${total})` : '')
 
-  if (failed > 0 && problem) {
-    return { text: `${problem.text}${scope(failed)}`, tone: 'unhealthy', reason: problem.reason }
+  if (failed > 0 && failure) {
+    return { text: `${failure.text}${scope(failed)}`, tone: 'unhealthy', reason: failure.reason }
   }
-  if (degraded > 0 && problem) {
-    return { text: `${problem.text}${scope(degraded)}`, tone: 'degraded', reason: problem.reason }
+  if (degraded > 0 && warning) {
+    return { text: `${warning.text}${scope(degraded)}`, tone: 'degraded', reason: warning.reason }
   }
   if (accepted === total) return { text: 'Accepted', tone: 'healthy' }
 

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -1,0 +1,101 @@
+import type { GenericStatus } from './generic-status'
+
+/**
+ * Gateway API policy attachment (GEP-713) reports status per *ancestor*, at
+ * `status.ancestors[].conditions`, not at `status.conditions` — so the generic
+ * ladder finds nothing and these kinds render "-".
+ *
+ * The shape is shared by every policy implementation: Gateway API's own
+ * BackendTLSPolicy and BackendLBPolicy, Envoy Gateway's SecurityPolicy /
+ * ClientTrafficPolicy / BackendTrafficPolicy / EnvoyPatchPolicy /
+ * EnvoyExtensionPolicy, and GKE's GCPBackendPolicy family. Dispatching on the
+ * shape rather than on a list of kinds means a policy from an implementation
+ * Radar has never heard of reads correctly too.
+ *
+ * Kept separate from the generic ladder rather than folded into it, because the
+ * ladder resolves positive conditions before negative ones and that order is
+ * wrong here: a policy is routinely `Accepted=True` *and* `Programmed=False`,
+ * which means the controller took ownership and then failed to apply it. Read
+ * positives-first, that object is healthy; it is not.
+ */
+
+/** Conditions that describe whether the policy took effect. */
+const EFFECT_CONDITIONS = ['Accepted', 'Programmed'] as const
+
+/** Conditions that mean trouble when True, mirroring the generic ladder's set. */
+const NEGATIVE_CONDITIONS = new Set(['Degraded', 'Warning'])
+
+function conditionsOf(ancestor: any): any[] {
+  return Array.isArray(ancestor?.conditions) ? ancestor.conditions : []
+}
+
+function problemText(cond: any): string {
+  const reason = typeof cond?.reason === 'string' ? cond.reason.trim() : ''
+  if (reason) return reason
+  const type = typeof cond?.type === 'string' ? cond.type.trim() : ''
+  return type ? `Not ${type}` : 'Failed'
+}
+
+/** True when the object carries a Gateway API PolicyStatus. */
+export function hasGatewayPolicyStatus(resource: any): boolean {
+  return Array.isArray(resource?.status?.ancestors)
+}
+
+/**
+ * Status for one policy, aggregated across the Gateways it attaches to.
+ *
+ * A policy may attach to several ancestors with different outcomes, so a
+ * failure anywhere wins and the count says how widespread it is — collapsing to
+ * a bare "Accepted" would hide the Gateway that rejected it.
+ */
+export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
+  const ancestors = resource?.status?.ancestors
+  if (!Array.isArray(ancestors)) return null
+
+  // Distinct from an unset status: the controller published a PolicyStatus and
+  // said this policy applies to nothing. Reported as text without a health
+  // claim, because "not attached" and "not reconciled yet" look identical here.
+  if (ancestors.length === 0) return { text: 'No ancestors', tone: 'unknown' }
+
+  let failed = 0
+  let degraded = 0
+  let accepted = 0
+  let problem: { text: string; reason?: string } | null = null
+
+  for (const ancestor of ancestors) {
+    const conditions = conditionsOf(ancestor)
+
+    const broken = conditions.find(
+      (c: any) => EFFECT_CONDITIONS.includes(c?.type) && c?.status === 'False',
+    )
+    if (broken) {
+      failed++
+      problem ??= { text: problemText(broken), reason: broken?.message }
+      continue
+    }
+
+    const warned = conditions.find((c: any) => NEGATIVE_CONDITIONS.has(c?.type) && c?.status === 'True')
+    if (warned) {
+      degraded++
+      problem ??= { text: problemText(warned), reason: warned?.message }
+      continue
+    }
+
+    if (conditions.some((c: any) => c?.type === 'Accepted' && c?.status === 'True')) accepted++
+  }
+
+  const total = ancestors.length
+  const scope = (n: number) => (total > 1 ? ` (${n}/${total})` : '')
+
+  if (failed > 0 && problem) {
+    return { text: `${problem.text}${scope(failed)}`, tone: 'unhealthy', reason: problem.reason }
+  }
+  if (degraded > 0 && problem) {
+    return { text: `${problem.text}${scope(degraded)}`, tone: 'degraded', reason: problem.reason }
+  }
+  if (accepted === total) return { text: 'Accepted', tone: 'healthy' }
+
+  // Some ancestor published neither an outcome nor a failure — the controller
+  // has seen the policy but not finished with it.
+  return { text: `Pending${scope(total - accepted)}`, tone: 'degraded' }
+}

--- a/packages/k8s-ui/src/components/resources/generic-status.ts
+++ b/packages/k8s-ui/src/components/resources/generic-status.ts
@@ -1,5 +1,5 @@
 import type { HealthLevel } from './resource-utils'
-import { getGatewayPolicyStatus, hasGatewayPolicyStatus } from './gateway-policy-status'
+import { getGatewayPolicyStatus } from './gateway-policy-status'
 
 /**
  * Derives a status for a resource with no dedicated renderer — a CRD Radar
@@ -100,10 +100,8 @@ export function getGenericResourceStatus(resource: any): GenericStatus | null {
   // publishes top-level conditions still gets read — GCPBackendPolicy declares
   // both, and suppressing its conditions would hide a Ready=False behind an
   // empty ancestor list.
-  if (hasGatewayPolicyStatus(resource)) {
-    const policy = getGatewayPolicyStatus(resource)
-    if (policy) return policy
-  }
+  const policy = getGatewayPolicyStatus(resource)
+  if (policy) return policy
 
   const phase = typeof status.phase === 'string' ? status.phase.trim() : ''
   if (phase) {

--- a/packages/k8s-ui/src/components/resources/generic-status.ts
+++ b/packages/k8s-ui/src/components/resources/generic-status.ts
@@ -96,7 +96,14 @@ export function getGenericResourceStatus(resource: any): GenericStatus | null {
   // by its own reader, because the rungs below would answer it wrongly: they
   // take a positive condition before a negative one, and a policy that is
   // `Accepted=True, Programmed=False` has been taken up and then failed.
-  if (hasGatewayPolicyStatus(resource)) return getGatewayPolicyStatus(resource)
+  // Returns null when the ancestors say nothing, so a policy that also
+  // publishes top-level conditions still gets read — GCPBackendPolicy declares
+  // both, and suppressing its conditions would hide a Ready=False behind an
+  // empty ancestor list.
+  if (hasGatewayPolicyStatus(resource)) {
+    const policy = getGatewayPolicyStatus(resource)
+    if (policy) return policy
+  }
 
   const phase = typeof status.phase === 'string' ? status.phase.trim() : ''
   if (phase) {

--- a/packages/k8s-ui/src/components/resources/generic-status.ts
+++ b/packages/k8s-ui/src/components/resources/generic-status.ts
@@ -1,4 +1,5 @@
 import type { HealthLevel } from './resource-utils'
+import { getGatewayPolicyStatus, hasGatewayPolicyStatus } from './gateway-policy-status'
 
 /**
  * Derives a status for a resource with no dedicated renderer — a CRD Radar
@@ -89,6 +90,13 @@ function fromCondition(cond: any, polarityKnown: boolean): GenericStatus | null 
 export function getGenericResourceStatus(resource: any): GenericStatus | null {
   const status = resource?.status
   if (!status || typeof status !== 'object') return null
+
+  // Gateway API policies keep their conditions per-ancestor, one level below
+  // where the rest of this function looks. Dispatched on the shape and resolved
+  // by its own reader, because the rungs below would answer it wrongly: they
+  // take a positive condition before a negative one, and a policy that is
+  // `Accepted=True, Programmed=False` has been taken up and then failed.
+  if (hasGatewayPolicyStatus(resource)) return getGatewayPolicyStatus(resource)
 
   const phase = typeof status.phase === 'string' ? status.phase.trim() : ''
   if (phase) {

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -495,8 +495,10 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	if !ok {
 		return "", false
 	}
+	// Not a verdict: a policy that also publishes top-level conditions is left
+	// to those, and one that says nothing at all is left to render as absent.
 	if len(ancestors) == 0 {
-		return "NoAncestors", true
+		return "", false
 	}
 
 	failed, degraded, accepted := 0, 0, 0
@@ -504,6 +506,9 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// failure on the second would otherwise report the warning's text with the
 	// failure's count, reading as though the warning was the failure.
 	failure, warning := "", ""
+	// Ancestors can fail for different reasons; reporting the first with a count
+	// would claim they all failed that way.
+	failureReasons := map[string]struct{}{}
 
 	for _, a := range ancestors {
 		aMap, ok := a.(map[string]any)
@@ -522,14 +527,26 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 			}
 			condType, _ := cond["type"].(string)
 			condStatus, _ := cond["status"].(string)
+			reason, _ := cond["reason"].(string)
 			switch {
-			case (condType == "Accepted" || condType == "Programmed") && condStatus == "False":
-				if broke == "" {
+			case isPolicyEffectCondition(condType) && condStatus == "False":
+				// A controller still converging is not a failure: GEP-713 lists
+				// Reconciling as a legitimate state on the way to applied.
+				if policyTransientReasons[reason] {
+					if warned == "" {
+						warned = reason
+					}
+				} else if broke == "" {
 					broke = policyProblem(cond, condType, false)
 				}
 			case (condType == "Degraded" || condType == "Warning") && condStatus == "True":
 				if warned == "" {
 					warned = policyProblem(cond, condType, true)
+				}
+			case isPolicyEffectCondition(condType) && condStatus == "True" && policyQualifiedReasons[reason]:
+				// Partially applied is not applied.
+				if warned == "" {
+					warned = reason
 				}
 			case condType == "Accepted" && condStatus == "True":
 				hasAccepted = true
@@ -542,6 +559,7 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 			if failure == "" {
 				failure = broke
 			}
+			failureReasons[broke] = struct{}{}
 		case warned != "":
 			degraded++
 			if warning == "" {
@@ -562,6 +580,9 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 
 	switch {
 	case failed > 0:
+		if len(failureReasons) > 1 {
+			return fmt.Sprintf("%d/%d failed", failed, total), true
+		}
 		return failure + scope(failed), true
 	case degraded > 0:
 		return warning + scope(degraded), true
@@ -572,8 +593,36 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	}
 }
 
+// Conditions that describe whether the policy took effect. Accepted is
+// GEP-713's own verdict; Programmed and ResolvedRefs are how Gateway API and
+// its implementations report that a policy the controller took on could not be
+// applied, and Attached is GKE's equivalent.
+func isPolicyEffectCondition(t string) bool {
+	switch t {
+	case "Accepted", "Attached", "Programmed", "ResolvedRefs":
+		return true
+	}
+	return false
+}
+
+// Reasons that mean not-settled-yet rather than failed.
+var policyTransientReasons = map[string]bool{
+	"Reconciling": true, "Pending": true, "Progressing": true, "Unknown": true,
+}
+
+// A True condition can still be qualified: partial application is not success.
+var policyQualifiedReasons = map[string]bool{
+	"PartiallyProgrammed": true, "PartiallyValid": true, "Partial": true,
+}
+
 // policyProblem prefers the controller's reason, which names the actual
 // failure (ResourceNotFound, Conflicted, NotAllowed) where the type does not.
+//
+// The reason-less fallback reads "NotAccepted" here and "Not Accepted" in the
+// TypeScript reader. That is deliberate rather than drift: this file's other
+// summarizers already use the unspaced form for MCP output, while the UI spells
+// it for a human to read. Every case where a controller supplied a reason —
+// which is nearly all of them — is identical in both.
 //
 // The fallback follows the condition's polarity: Accepted=False reads as
 // NotAccepted, but Warning=True means there *is* a warning and the same

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -509,6 +509,7 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// Ancestors can fail for different reasons; reporting the first with a count
 	// would claim they all failed that way.
 	failureReasons := map[string]struct{}{}
+	verdict := ""
 
 	for _, a := range ancestors {
 		aMap, ok := a.(map[string]any)
@@ -548,8 +549,15 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 				if warned == "" {
 					warned = reason
 				}
-			case condType == "Accepted" && condStatus == "True":
+			case isPolicyVerdictCondition(condType) && condStatus == "True":
+				// GKE reports a healthy policy as Attached=True with no
+				// Accepted condition, so checking only Accepted read it as
+				// pending. ResolvedRefs is excluded: refs resolving is a
+				// precondition, not a statement that the policy applies.
 				hasAccepted = true
+				if verdict == "" {
+					verdict = condType
+				}
 			}
 		}
 
@@ -587,6 +595,9 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	case degraded > 0:
 		return warning + scope(degraded), true
 	case accepted == total:
+		if verdict != "" {
+			return verdict, true
+		}
 		return "Accepted", true
 	default:
 		return "Pending" + scope(total-accepted), true
@@ -605,14 +616,25 @@ func isPolicyEffectCondition(t string) bool {
 	return false
 }
 
+// isPolicyVerdictCondition reports the subset of effect conditions that mean
+// the policy took effect when True. A condition can be conclusive when False
+// and say nothing when True, which is why this is not the same set.
+func isPolicyVerdictCondition(t string) bool {
+	switch t {
+	case "Accepted", "Attached", "Programmed":
+		return true
+	}
+	return false
+}
+
 // Reasons that mean not-settled-yet rather than failed.
 var policyTransientReasons = map[string]bool{
-	"Reconciling": true, "Pending": true, "Progressing": true, "Unknown": true,
+	"Reconciling": true, "Pending": true,
 }
 
 // A True condition can still be qualified: partial application is not success.
 var policyQualifiedReasons = map[string]bool{
-	"PartiallyProgrammed": true, "PartiallyValid": true, "Partial": true,
+	"PartiallyProgrammed": true,
 }
 
 // policyProblem prefers the controller's reason, which names the actual

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -500,7 +500,10 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	}
 
 	failed, degraded, accepted := 0, 0, 0
-	problem := ""
+	// Tracked apart, not in one slot: a warning on the first ancestor and a
+	// failure on the second would otherwise report the warning's text with the
+	// failure's count, reading as though the warning was the failure.
+	failure, warning := "", ""
 
 	for _, a := range ancestors {
 		aMap, ok := a.(map[string]any)
@@ -522,11 +525,11 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 			switch {
 			case (condType == "Accepted" || condType == "Programmed") && condStatus == "False":
 				if broke == "" {
-					broke = policyProblem(cond, condType)
+					broke = policyProblem(cond, condType, false)
 				}
 			case (condType == "Degraded" || condType == "Warning") && condStatus == "True":
 				if warned == "" {
-					warned = policyProblem(cond, condType)
+					warned = policyProblem(cond, condType, true)
 				}
 			case condType == "Accepted" && condStatus == "True":
 				hasAccepted = true
@@ -536,13 +539,13 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 		switch {
 		case broke != "":
 			failed++
-			if problem == "" {
-				problem = broke
+			if failure == "" {
+				failure = broke
 			}
 		case warned != "":
 			degraded++
-			if problem == "" {
-				problem = warned
+			if warning == "" {
+				warning = warned
 			}
 		case hasAccepted:
 			accepted++
@@ -559,9 +562,9 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 
 	switch {
 	case failed > 0:
-		return problem + scope(failed), true
+		return failure + scope(failed), true
 	case degraded > 0:
-		return problem + scope(degraded), true
+		return warning + scope(degraded), true
 	case accepted == total:
 		return "Accepted", true
 	default:
@@ -571,14 +574,21 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 
 // policyProblem prefers the controller's reason, which names the actual
 // failure (ResourceNotFound, Conflicted, NotAllowed) where the type does not.
-func policyProblem(cond map[string]any, condType string) string {
+//
+// The fallback follows the condition's polarity: Accepted=False reads as
+// NotAccepted, but Warning=True means there *is* a warning and the same
+// construction would render NotWarning, inverting it.
+func policyProblem(cond map[string]any, condType string, trueMeansTrouble bool) string {
 	if reason, _ := cond["reason"].(string); reason != "" {
 		return reason
 	}
-	if condType != "" {
-		return "Not" + condType
+	if condType == "" {
+		return "Failed"
 	}
-	return "Failed"
+	if trueMeansTrouble {
+		return condType
+	}
+	return "Not" + condType
 }
 
 // extractReadyCondition extracts the most informative condition from status.conditions.

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -452,6 +452,16 @@ func summarizeGenericCRD(obj *unstructured.Unstructured) *ResourceSummary {
 		Age:       age(obj.GetCreationTimestamp().Time),
 	}
 
+	// Gateway API policies (GEP-713) report per-ancestor, at
+	// status.ancestors[].conditions, so the top-level lookups below find
+	// nothing and the status comes back empty. Matched on the shape rather
+	// than on a list of kinds: every implementation shares it, and Radar
+	// should read one it has never heard of.
+	if status, ok := gatewayPolicyStatus(obj); ok {
+		s.Status = status
+		return s
+	}
+
 	// Try status.conditions — most CRDs follow this convention
 	s.Status = extractReadyCondition(obj)
 
@@ -462,6 +472,113 @@ func summarizeGenericCRD(obj *unstructured.Unstructured) *ResourceSummary {
 	}
 
 	return s
+}
+
+// gatewayPolicyStatus summarizes a Gateway API PolicyStatus, aggregated across
+// the ancestors a policy attaches to. The second return reports whether the
+// object carries one at all.
+//
+// Failures are checked before acceptance, which is the reverse of
+// extractReadyCondition. A policy is routinely Accepted=True and
+// Programmed=False — the controller took ownership and then could not apply it
+// — and reading acceptance first calls that healthy. Mirrors
+// getGatewayPolicyStatus in packages/k8s-ui.
+func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
+	// NoCopy rather than NestedSlice: this is a read-only summary on a request
+	// path, and NestedSlice deep-copies every ancestor — and panics outright on
+	// content it cannot copy rather than returning an error.
+	raw, found, err := unstructured.NestedFieldNoCopy(obj.Object, "status", "ancestors")
+	if !found || err != nil {
+		return "", false
+	}
+	ancestors, ok := raw.([]any)
+	if !ok {
+		return "", false
+	}
+	if len(ancestors) == 0 {
+		return "NoAncestors", true
+	}
+
+	failed, degraded, accepted := 0, 0, 0
+	problem := ""
+
+	for _, a := range ancestors {
+		aMap, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawConds, _, _ := unstructured.NestedFieldNoCopy(aMap, "conditions")
+		conds, _ := rawConds.([]any)
+
+		broke, warned := "", ""
+		hasAccepted := false
+		for _, c := range conds {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			condType, _ := cond["type"].(string)
+			condStatus, _ := cond["status"].(string)
+			switch {
+			case (condType == "Accepted" || condType == "Programmed") && condStatus == "False":
+				if broke == "" {
+					broke = policyProblem(cond, condType)
+				}
+			case (condType == "Degraded" || condType == "Warning") && condStatus == "True":
+				if warned == "" {
+					warned = policyProblem(cond, condType)
+				}
+			case condType == "Accepted" && condStatus == "True":
+				hasAccepted = true
+			}
+		}
+
+		switch {
+		case broke != "":
+			failed++
+			if problem == "" {
+				problem = broke
+			}
+		case warned != "":
+			degraded++
+			if problem == "" {
+				problem = warned
+			}
+		case hasAccepted:
+			accepted++
+		}
+	}
+
+	total := len(ancestors)
+	scope := func(n int) string {
+		if total > 1 {
+			return fmt.Sprintf(" (%d/%d)", n, total)
+		}
+		return ""
+	}
+
+	switch {
+	case failed > 0:
+		return problem + scope(failed), true
+	case degraded > 0:
+		return problem + scope(degraded), true
+	case accepted == total:
+		return "Accepted", true
+	default:
+		return "Pending" + scope(total-accepted), true
+	}
+}
+
+// policyProblem prefers the controller's reason, which names the actual
+// failure (ResourceNotFound, Conflicted, NotAllowed) where the type does not.
+func policyProblem(cond map[string]any, condType string) string {
+	if reason, _ := cond["reason"].(string); reason != "" {
+		return reason
+	}
+	if condType != "" {
+		return "Not" + condType
+	}
+	return "Failed"
 }
 
 // extractReadyCondition extracts the most informative condition from status.conditions.

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -199,8 +199,11 @@ func TestSummary_FluxHelmRelease(t *testing.T) {
 	}
 }
 
-// Mirrors gateway-policy-status.test.ts. The two implementations feed the same
-// UI and the same MCP answers, so they have to agree on these cases.
+// Mirrors gateway-policy-status.test.ts. The two implementations feed the UI
+// and the MCP answers respectively, so they have to agree about every case a
+// controller actually produces. The one deliberate difference is the
+// reason-less fallback spelling ("NotAccepted" here, "Not Accepted" there) —
+// see policyProblem.
 func TestGatewayPolicyStatus(t *testing.T) {
 	cond := func(t, s, reason string) map[string]any {
 		c := map[string]any{"type": t, "status": s}
@@ -261,7 +264,26 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		// Accepted=False reads as NotAccepted; Warning=True means there IS a
 		// warning, so the same construction would invert it.
 		{"reason-less warning keeps its own name", policy(anc(cond("Accepted", "True", ""), cond("Warning", "True", ""))), "Warning", true},
-		{"attaches to nothing", policy(), "NoAncestors", true},
+		// Not a verdict: a dual-shape policy falls back to its top-level
+		// conditions, and one with nothing else renders as absent.
+		{"attaches to nothing", policy(), "", false},
+		// GKE reports attachment with its own condition; BackendTLSPolicy
+		// requires ResolvedRefs as well as Accepted.
+		{"Attached=False is a failure", policy(anc(cond("Accepted", "True", ""), cond("Attached", "False", "InvalidTarget"))), "InvalidTarget", true},
+		{"ResolvedRefs=False is a failure", policy(anc(cond("Accepted", "True", ""), cond("ResolvedRefs", "False", "InvalidCACertificateRef"))), "InvalidCACertificateRef", true},
+		// GEP-713 lists Reconciling as a legitimate in-flight state.
+		{"Reconciling is in-flight, not failed", policy(anc(cond("Accepted", "True", ""), cond("Programmed", "False", "Reconciling"))), "Reconciling", true},
+		{"partially applied is not success", policy(anc(cond("Accepted", "True", ""), cond("Programmed", "True", "PartiallyProgrammed"))), "PartiallyProgrammed", true},
+		// Reporting the first reason with a count claims they all failed that way.
+		{"mixed failure reasons report a count", policy(
+			anc(cond("Accepted", "False", "NotAllowed")),
+			anc(cond("Accepted", "False", "ResourceNotFound")),
+			anc(cond("Accepted", "True", "")),
+		), "2/3 failed", true},
+		{"matching failure reasons keep the reason", policy(
+			anc(cond("Accepted", "False", "NotAllowed")),
+			anc(cond("Accepted", "False", "NotAllowed")),
+		), "NotAllowed (2/2)", true},
 		{"not a policy", &unstructured.Unstructured{Object: map[string]any{"status": map[string]any{"conditions": []any{}}}}, "", false},
 	}
 

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -273,6 +273,11 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		{"ResolvedRefs=False is a failure", policy(anc(cond("Accepted", "True", ""), cond("ResolvedRefs", "False", "InvalidCACertificateRef"))), "InvalidCACertificateRef", true},
 		// GEP-713 lists Reconciling as a legitimate in-flight state.
 		{"Reconciling is in-flight, not failed", policy(anc(cond("Accepted", "True", ""), cond("Programmed", "False", "Reconciling"))), "Reconciling", true},
+		// GKE's healthy shape carries no Accepted condition at all.
+		{"a verdict not spelled Accepted still counts", policy(anc(cond("Attached", "True", ""))), "Attached", true},
+		{"Programmed alone is a verdict", policy(anc(cond("Programmed", "True", ""))), "Programmed", true},
+		// Refs resolving is a precondition, not a verdict.
+		{"ResolvedRefs alone is not a verdict", policy(anc(cond("ResolvedRefs", "True", ""))), "Pending", true},
 		{"partially applied is not success", policy(anc(cond("Accepted", "True", ""), cond("Programmed", "True", "PartiallyProgrammed"))), "PartiallyProgrammed", true},
 		// Reporting the first reason with a count claims they all failed that way.
 		{"mixed failure reasons report a count", policy(

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -248,6 +248,19 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		{"an ancestor with no verdict is not accepted", policy(anc(cond("Accepted", "True", "")), anc()), "Pending (1/2)", true},
 		{"unknown is undecided, not failed", policy(anc(cond("Accepted", "Unknown", "Pending"))), "Pending", true},
 		{"healthy only when every ancestor accepted", policy(anc(cond("Accepted", "True", "")), anc(cond("Accepted", "True", ""))), "Accepted", true},
+		// One slot for both kinds of problem reported the warning's reason with
+		// the failure's count, reading as though the warning was the failure.
+		{"failure wins over an earlier warning", policy(
+			anc(cond("Accepted", "True", ""), cond("Warning", "True", "ShadowedRules")),
+			anc(cond("Accepted", "False", "NotAllowed")),
+		), "NotAllowed (1/2)", true},
+		{"warning still reported when nothing failed", policy(
+			anc(cond("Accepted", "True", ""), cond("Warning", "True", "ShadowedRules")),
+			anc(cond("Accepted", "True", "")),
+		), "ShadowedRules (1/2)", true},
+		// Accepted=False reads as NotAccepted; Warning=True means there IS a
+		// warning, so the same construction would invert it.
+		{"reason-less warning keeps its own name", policy(anc(cond("Accepted", "True", ""), cond("Warning", "True", ""))), "Warning", true},
 		{"attaches to nothing", policy(), "NoAncestors", true},
 		{"not a policy", &unstructured.Unstructured{Object: map[string]any{"status": map[string]any{"conditions": []any{}}}}, "", false},
 	}

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -198,3 +198,119 @@ func TestSummary_FluxHelmRelease(t *testing.T) {
 		t.Errorf("Image (chart) = %q, want redis", s.Image)
 	}
 }
+
+// Mirrors gateway-policy-status.test.ts. The two implementations feed the same
+// UI and the same MCP answers, so they have to agree on these cases.
+func TestGatewayPolicyStatus(t *testing.T) {
+	cond := func(t, s, reason string) map[string]any {
+		c := map[string]any{"type": t, "status": s}
+		if reason != "" {
+			c["reason"] = reason
+		}
+		return c
+	}
+	anc := func(conds ...map[string]any) map[string]any {
+		out := make([]any, 0, len(conds))
+		for _, c := range conds {
+			out = append(out, c)
+		}
+		return map[string]any{"conditions": out}
+	}
+	policy := func(ancestors ...map[string]any) *unstructured.Unstructured {
+		out := make([]any, 0, len(ancestors))
+		for _, a := range ancestors {
+			out = append(out, a)
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{"ancestors": out},
+		}}
+	}
+
+	tests := []struct {
+		name string
+		obj  *unstructured.Unstructured
+		want string
+		ok   bool
+	}{
+		// A live EnvoyPatchPolicy: taken up by the controller, then not applied.
+		// Reading acceptance first would call this healthy.
+		{"accepted then not applied", policy(anc(cond("Accepted", "True", "Accepted"), cond("Programmed", "False", "ResourceNotFound"))), "ResourceNotFound", true},
+		{"plain accepted", policy(anc(cond("Accepted", "True", "Accepted"))), "Accepted", true},
+		{"rejected carries the reason", policy(anc(cond("Accepted", "False", "Conflicted"))), "Conflicted", true},
+		{"rejected without a reason", policy(anc(cond("Accepted", "False", ""))), "NotAccepted", true},
+		{"warning is not hidden by acceptance", policy(anc(cond("Accepted", "True", ""), cond("Warning", "True", "ShadowedRules"))), "ShadowedRules", true},
+		{"failure anywhere wins and is counted", policy(
+			anc(cond("Accepted", "True", "")),
+			anc(cond("Accepted", "False", "NotAllowed")),
+			anc(cond("Accepted", "True", "")),
+		), "NotAllowed (1/3)", true},
+		{"no count for a single ancestor", policy(anc(cond("Accepted", "False", "NotAllowed"))), "NotAllowed", true},
+		{"an ancestor with no verdict is not accepted", policy(anc(cond("Accepted", "True", "")), anc()), "Pending (1/2)", true},
+		{"unknown is undecided, not failed", policy(anc(cond("Accepted", "Unknown", "Pending"))), "Pending", true},
+		{"healthy only when every ancestor accepted", policy(anc(cond("Accepted", "True", "")), anc(cond("Accepted", "True", ""))), "Accepted", true},
+		{"attaches to nothing", policy(), "NoAncestors", true},
+		{"not a policy", &unstructured.Unstructured{Object: map[string]any{"status": map[string]any{"conditions": []any{}}}}, "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := gatewayPolicyStatus(tc.obj)
+			if ok != tc.ok {
+				t.Fatalf("recognized = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGatewayPolicyStatusToleratesMalformedInput(t *testing.T) {
+	// Entries that are the wrong shape but still valid unstructured content are
+	// skipped, not fatal: one usable ancestor still yields a verdict.
+	mixed := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"ancestors": []any{
+			nil,
+			"nope",
+			map[string]any{"conditions": "not-a-slice"},
+			map[string]any{"conditions": []any{map[string]any{"type": "Accepted", "status": "True"}}},
+		}},
+	}}
+	got, ok := gatewayPolicyStatus(mixed)
+	if !ok {
+		t.Fatal("a list with one usable ancestor is still a PolicyStatus")
+	}
+	// Three of the four ancestors produced no verdict, so this is not healthy.
+	if got != "Pending (3/4)" {
+		t.Errorf("status = %q, want %q", got, "Pending (3/4)")
+	}
+
+	// Content the API server could never return — a bare Go int is not valid
+	// unstructured JSON. NestedSlice panics on this rather than erroring, which
+	// is why the reader takes the field without copying and asserts the shape
+	// itself. The entry is skipped and the remaining ancestors still resolve.
+	odd := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"ancestors": []any{42}},
+	}}
+	var got2 string
+	var ok2 bool
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("reading a PolicyStatus must not panic, got: %v", r)
+			}
+		}()
+		got2, ok2 = gatewayPolicyStatus(odd)
+	}()
+	if !ok2 || got2 != "Pending" {
+		t.Errorf("status = %q ok = %v, want %q true", got2, ok2, "Pending")
+	}
+
+	// A field that is not a list at all is not a PolicyStatus.
+	notAList := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"ancestors": map[string]any{}},
+	}}
+	if _, ok := gatewayPolicyStatus(notAList); ok {
+		t.Error("a non-list ancestors field should fall through, not be reported as a policy")
+	}
+}


### PR DESCRIPTION
## Summary

Gateway API's policy attachment (GEP-713) reports status at `status.ancestors[].conditions`, not `status.conditions`. Radar's generic status ladder only reads the latter, so every policy rendered `-` — including policies that are actively broken.

Two `EnvoyPatchPolicy` objects on a live cluster are `Accepted=True` **and** `Programmed=False (ResourceNotFound)`: the controller took ownership and then could not apply them. They showed nothing at all.

**13 kinds across three independent vendors** carry this shape, and none are curated, so the generic ladder is exactly what serves them:

- Gateway API — `BackendTLSPolicy`, `BackendLBPolicy`
- Envoy Gateway — `SecurityPolicy`, `ClientTrafficPolicy`, `BackendTrafficPolicy`, `EnvoyPatchPolicy`, `EnvoyExtensionPolicy`
- GKE networking — six `GCPBackendPolicy`-family kinds

The class grows over time: policy attachment is the modern Gateway API extension mechanism.

## What changed

**Its own reader, not another ladder rung.** The ladder resolves positive conditions before negative ones, and that order is wrong here — read positives-first, an `Accepted=True, Programmed=False` policy is healthy. It is not. `getGatewayPolicyStatus` checks failures first.

**Dispatched on the shape, not a list of kinds**, so a policy from an implementation Radar has never heard of reads correctly without a registry entry to maintain.

**One wiring point.** It resolves inside `getGenericResourceStatus`, so the table cell, sort key, filter dropdown, drawer dispatch and generic renderer all pick it up together. The shared condition vocabulary (`KNOWN_POSITIVE_CONDITIONS`) is deliberately untouched, so printer-column tone is unaffected.

**A failure anywhere wins, and carries a count.** A policy may attach to several Gateways with different outcomes; collapsing to a bare `Accepted` would hide the one that rejected it, so a partial failure reads `NotAllowed (1/3)`.

**Go gets the same reader.** These kinds fall through to `summarizeGenericCRD`, so a TS-only fix would have the table report a broken policy while MCP returned nothing for the same object. The Go side uses `NestedFieldNoCopy` rather than `NestedSlice`: this is a read-only summary on a request path, and `NestedSlice` deep-copies every ancestor and panics outright on content it cannot copy.

## Testing

`make tsc` clean · Go build and `pkg/ai/context` pass · k8s-ui **157 files / 3170 tests** pass.

**17 TS tests and 14 Go subtests, deliberately mirrored** so the two implementations are pinned to the same answers — the accepted-then-not-applied case, a warning that must not hide behind acceptance, partial multi-ancestor, an ancestor with no verdict not counting as accepted, `Unknown` as undecided rather than failed, and malformed input.

**Verified against live clusters**, not only fixtures:

| Object | Before | After |
|---|---|---|
| `EnvoyPatchPolicy` (Accepted=True, Programmed=False) | `-` | **ResourceNotFound**, red |
| `SecurityPolicy` (Accepted=True) | `-` | **Accepted**, green |
| `SecurityPolicy` (no status written) | `-` | `-` (unchanged, and correct) |

Rendering confirmed in a browser against those objects.

## Notes

`status.ancestors: []` — a controller reporting the policy applies to nothing — is distinguished from no status at all and reads `No ancestors`. That wording is Gateway API's own term and may not be the right thing to show an operator; no object on the clusters checked is in that state, so it is a spec-legal shape rather than an observed one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only status derivation for display and MCP summaries; no cluster mutation. Main risk is misclassification edge cases on uncommon policy status shapes, mitigated by extensive mirrored tests.
> 
> **Overview**
> Gateway API policies (GEP-713) expose status under `status.ancestors[].conditions`, so the generic status path showed `-` and would misread `Accepted=True` with `Programmed=False` as healthy. This PR adds **`getGatewayPolicyStatus`** (TypeScript) and **`gatewayPolicyStatus`** (Go), dispatched by shape inside **`getGenericResourceStatus`** / **`summarizeGenericCRD`**, so table, filters, and MCP summaries stay aligned.
> 
> The reader evaluates **failures before acceptance**, surfaces warnings without hiding hard failures, aggregates multi-gateway attachment with counts (e.g. `NotAllowed (1/3)`), treats `Reconciling`/`Pending` as degraded, and returns **null** for empty `ancestors` so dual-shape resources (e.g. GCPBackendPolicy) still fall back to top-level `status.conditions`. Go uses **`NestedFieldNoCopy`** to avoid `NestedSlice` panics on malformed ancestor entries.
> 
> **Mirrored TS/Go test suites** lock behavior for accepted-then-not-applied, mixed ancestor outcomes, and malformed input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230e2702afabf0eca776b4666a23ab3924fd013d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->