### PR TITLE
Gofmt the tree and gate formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt -w needed on:"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: Run tests
         run: go test ./...
 

--- a/internal/cloud/conn.go
+++ b/internal/cloud/conn.go
@@ -57,9 +57,9 @@ func (c *wsConn) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (c *wsConn) Close() error          { return c.ws.Close() }
-func (c *wsConn) LocalAddr() net.Addr   { return c.ws.LocalAddr() }
-func (c *wsConn) RemoteAddr() net.Addr  { return c.ws.RemoteAddr() }
+func (c *wsConn) Close() error                       { return c.ws.Close() }
+func (c *wsConn) LocalAddr() net.Addr                { return c.ws.LocalAddr() }
+func (c *wsConn) RemoteAddr() net.Addr               { return c.ws.RemoteAddr() }
 func (c *wsConn) SetReadDeadline(t time.Time) error  { return c.ws.SetReadDeadline(t) }
 func (c *wsConn) SetWriteDeadline(t time.Time) error { return c.ws.SetWriteDeadline(t) }
 func (c *wsConn) SetDeadline(t time.Time) error {

--- a/internal/images/types.go
+++ b/internal/images/types.go
@@ -42,12 +42,12 @@ type InspectRequest struct {
 
 // ImageMetadata contains lightweight metadata about an image (without downloading layers)
 type ImageMetadata struct {
-	Image        string      `json:"image"`
-	Digest       string      `json:"digest"`
-	Platform     string      `json:"platform"`
-	TotalSize    int64       `json:"totalSize"`    // Total compressed size of all layers
-	LayerCount   int         `json:"layerCount"`
-	Cached       bool        `json:"cached"`       // Whether filesystem is already cached
-	Filesystem   *ImageFilesystem `json:"filesystem,omitempty"` // Included if cached
-	AuthMethod   string      `json:"authMethod"`   // "anonymous", "credentials", etc.
+	Image      string           `json:"image"`
+	Digest     string           `json:"digest"`
+	Platform   string           `json:"platform"`
+	TotalSize  int64            `json:"totalSize"` // Total compressed size of all layers
+	LayerCount int              `json:"layerCount"`
+	Cached     bool             `json:"cached"`               // Whether filesystem is already cached
+	Filesystem *ImageFilesystem `json:"filesystem,omitempty"` // Included if cached
+	AuthMethod string           `json:"authMethod"`           // "anonymous", "credentials", etc.
 }

--- a/internal/k8s/reasons.go
+++ b/internal/k8s/reasons.go
@@ -6,9 +6,9 @@ package k8s
 // rather than in pkg/health because they are detector vocabulary, not part of the
 // shared health classifier.
 const (
-	crashLoopReason            = "CrashLoopBackOff"
-	highRestartReason          = "HighRestartCount"
-	readinessProbeFailedReason = "ReadinessProbeFailed"
+	crashLoopReason             = "CrashLoopBackOff"
+	highRestartReason           = "HighRestartCount"
+	readinessProbeFailedReason  = "ReadinessProbeFailed"
 	readinessProbeInvalidReason = "ReadinessProbeInvalid"
 	livenessProbeInvalidReason  = "LivenessProbeInvalid"
 	initContainerStalledReason  = "InitContainerStalled"

--- a/internal/loadtest/generator.go
+++ b/internal/loadtest/generator.go
@@ -150,14 +150,16 @@ func podsInApp(app, pods, perApp int) int {
 	return perApp
 }
 
-func (g *Generator) appIndex(pod int) int   { return pod / g.cfg.PodsPerApp }
-func (g *Generator) nsName(app int) string  { return fmt.Sprintf("loadtest-%02d", app%g.cfg.Namespaces) }
+func (g *Generator) appIndex(pod int) int      { return pod / g.cfg.PodsPerApp }
+func (g *Generator) nsName(app int) string     { return fmt.Sprintf("loadtest-%02d", app%g.cfg.Namespaces) }
 func (g *Generator) appName(app int) string    { return fmt.Sprintf("app-%04d", app) }
 func (g *Generator) rsName(app int) string     { return fmt.Sprintf("app-%04d-rs", app) }
 func (g *Generator) cmName(app int) string     { return fmt.Sprintf("app-%04d-config", app) }
 func (g *Generator) secretName(app int) string { return fmt.Sprintf("app-%04d-secret", app) }
-func (g *Generator) nodeName(i int) string  { return fmt.Sprintf("loadtest-node-%03d", i%g.cfg.Nodes) }
-func (g *Generator) podName(pod int) string { return fmt.Sprintf("app-%04d-%06d", g.appIndex(pod), pod) }
+func (g *Generator) nodeName(i int) string     { return fmt.Sprintf("loadtest-node-%03d", i%g.cfg.Nodes) }
+func (g *Generator) podName(pod int) string {
+	return fmt.Sprintf("app-%04d-%06d", g.appIndex(pod), pod)
+}
 func (g *Generator) deployUID(app int) types.UID {
 	return types.UID(fmt.Sprintf("loadtest-deploy-%04d", app))
 }

--- a/internal/mcp/tools_rbac.go
+++ b/internal/mcp/tools_rbac.go
@@ -32,9 +32,9 @@ import (
 //     specific Role/ClusterRole to inspect)
 
 type subjectPermissionsInput struct {
-	Kind      string `json:"kind" jsonschema:"subject kind: ServiceAccount, User, or Group; access checks support ServiceAccount only. A serviceAccountName read off a pod spec can be passed directly as service_account instead of kind+name"`
-	Namespace string `json:"namespace,omitempty" jsonschema:"subject namespace (required for ServiceAccount, omit for User/Group)"`
-	Name      string `json:"name" jsonschema:"subject name"`
+	Kind              string  `json:"kind" jsonschema:"subject kind: ServiceAccount, User, or Group; access checks support ServiceAccount only. A serviceAccountName read off a pod spec can be passed directly as service_account instead of kind+name"`
+	Namespace         string  `json:"namespace,omitempty" jsonschema:"subject namespace (required for ServiceAccount, omit for User/Group)"`
+	Name              string  `json:"name" jsonschema:"subject name"`
 	Verb              string  `json:"verb,omitempty" jsonschema:"access check only: Kubernetes API verb; must be supplied together with resource"`
 	Resource          string  `json:"resource,omitempty" jsonschema:"access check only: plural Kubernetes API resource, e.g. configmaps; must be supplied together with verb"`
 	Group             string  `json:"group,omitempty" jsonschema:"access check only: resource API group; omit for core/v1"`

--- a/internal/prometheus/handlers.go
+++ b/internal/prometheus/handlers.go
@@ -137,15 +137,15 @@ func parseTimeRange(rangeStr string) (start, end time.Time, step time.Duration) 
 
 // ResourceMetricsResponse is the response shape for resource metrics.
 type ResourceMetricsResponse struct {
-	Kind      string         `json:"kind"`
-	Namespace string         `json:"namespace,omitempty"`
-	Name      string         `json:"name"`
+	Kind      string              `json:"kind"`
+	Namespace string              `json:"namespace,omitempty"`
+	Name      string              `json:"name"`
 	Category  prom.MetricCategory `json:"category"`
-	Unit      string         `json:"unit"`
-	Range     string         `json:"range"`
+	Unit      string              `json:"unit"`
+	Range     string              `json:"range"`
 	Result    *prom.QueryResult   `json:"result"`
-	Query     string         `json:"query,omitempty"` // PromQL query used (included when result is empty for diagnostics)
-	Hint      string         `json:"hint,omitempty"`  // Contextual hint when results are empty (e.g. cri-docker label issues)
+	Query     string              `json:"query,omitempty"` // PromQL query used (included when result is empty for diagnostics)
+	Hint      string              `json:"hint,omitempty"`  // Contextual hint when results are empty (e.g. cri-docker label issues)
 }
 
 // handleResourceMetrics returns Prometheus metrics for a specific resource.
@@ -306,10 +306,10 @@ func handleClusterScopedResourceMetrics(w http.ResponseWriter, r *http.Request) 
 
 // NamespaceMetricsResponse is the response shape for namespace-level metrics.
 type NamespaceMetricsResponse struct {
-	Namespace string         `json:"namespace"`
+	Namespace string              `json:"namespace"`
 	Category  prom.MetricCategory `json:"category"`
-	Unit      string         `json:"unit"`
-	Range     string         `json:"range"`
+	Unit      string              `json:"unit"`
+	Range     string              `json:"range"`
 	Result    *prom.QueryResult   `json:"result"`
 }
 
@@ -360,8 +360,8 @@ func handleNamespaceMetrics(w http.ResponseWriter, r *http.Request) {
 // ClusterMetricsResponse is the response shape for cluster-level metrics.
 type ClusterMetricsResponse struct {
 	Category prom.MetricCategory `json:"category"`
-	Unit     string         `json:"unit"`
-	Range    string         `json:"range"`
+	Unit     string              `json:"unit"`
+	Range    string              `json:"range"`
 	Result   *prom.QueryResult   `json:"result"`
 }
 
@@ -449,7 +449,7 @@ func handleRawQuery(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-// retryWithoutContainerFilter re-runs the query without the container!='' filter
+// retryWithoutContainerFilter re-runs the query without the container!=” filter
 // when the primary result is empty and the category uses that filter. This handles
 // cri-docker and other setups where cAdvisor metrics lack the container label.
 // Returns the updated result (original or fallback) and the query that produced it.

--- a/internal/prometheus/rightsizing.go
+++ b/internal/prometheus/rightsizing.go
@@ -64,35 +64,35 @@ type ObservedStatistic struct {
 }
 
 type RightsizingRow struct {
-	Container               string               `json:"container"`
-	Resource                string               `json:"resource"`
+	Container               string                `json:"container"`
+	Resource                string                `json:"resource"`
 	Fit                     RightsizingFit        `json:"fit"`
 	Confidence              RightsizingConfidence `json:"confidence"`
-	CurrentRequest          *string              `json:"currentRequest,omitempty"`
-	CurrentRequestValue     *float64             `json:"currentRequestValue,omitempty"`
-	CurrentLimit            *string              `json:"currentLimit,omitempty"`
-	CurrentLimitValue       *float64             `json:"currentLimitValue,omitempty"`
-	Observed                *ObservedStatistic   `json:"observed,omitempty"`
-	Peak                    *ObservedStatistic   `json:"peak,omitempty"`
-	CalculatedReq           *string              `json:"calculatedRequest,omitempty"`
-	CalculatedRequestValue  *float64             `json:"calculatedRequestValue,omitempty"`
-	RecommendedReq          *string              `json:"recommendedRequest,omitempty"`
-	RecommendedRequestValue *float64             `json:"recommendedRequestValue,omitempty"`
-	ReductionLimited        bool                 `json:"reductionLimited,omitempty"`
-	Bursty                  bool                 `json:"bursty,omitempty"`
-	RecommendationReason    string               `json:"recommendationReason,omitempty"`
-	SampleCount             int                  `json:"sampleCount"`
-	ExpectedSamples         int                  `json:"expectedSamples"`
-	Coverage                float64              `json:"coverage"`
-	HPAManaged              bool                 `json:"hpaManaged"`
-	HPAEvidenceAvailable    bool                 `json:"hpaEvidenceAvailable"`
-	ThrottleAvailable       bool                 `json:"throttleAvailable,omitempty"`
-	ThrottleRatio           *float64             `json:"throttleRatio,omitempty"`
-	CurrentPodOOM           bool                 `json:"currentPodOOM,omitempty"`
-	WindowOOMEvidence       bool                 `json:"windowOomEvidence,omitempty"`
-	OOMEvidenceAvailable    bool                 `json:"oomEvidenceAvailable"`
-	LimitConflict           bool                 `json:"limitConflict,omitempty"`
-	QueryError              string               `json:"queryError,omitempty"`
+	CurrentRequest          *string               `json:"currentRequest,omitempty"`
+	CurrentRequestValue     *float64              `json:"currentRequestValue,omitempty"`
+	CurrentLimit            *string               `json:"currentLimit,omitempty"`
+	CurrentLimitValue       *float64              `json:"currentLimitValue,omitempty"`
+	Observed                *ObservedStatistic    `json:"observed,omitempty"`
+	Peak                    *ObservedStatistic    `json:"peak,omitempty"`
+	CalculatedReq           *string               `json:"calculatedRequest,omitempty"`
+	CalculatedRequestValue  *float64              `json:"calculatedRequestValue,omitempty"`
+	RecommendedReq          *string               `json:"recommendedRequest,omitempty"`
+	RecommendedRequestValue *float64              `json:"recommendedRequestValue,omitempty"`
+	ReductionLimited        bool                  `json:"reductionLimited,omitempty"`
+	Bursty                  bool                  `json:"bursty,omitempty"`
+	RecommendationReason    string                `json:"recommendationReason,omitempty"`
+	SampleCount             int                   `json:"sampleCount"`
+	ExpectedSamples         int                   `json:"expectedSamples"`
+	Coverage                float64               `json:"coverage"`
+	HPAManaged              bool                  `json:"hpaManaged"`
+	HPAEvidenceAvailable    bool                  `json:"hpaEvidenceAvailable"`
+	ThrottleAvailable       bool                  `json:"throttleAvailable,omitempty"`
+	ThrottleRatio           *float64              `json:"throttleRatio,omitempty"`
+	CurrentPodOOM           bool                  `json:"currentPodOOM,omitempty"`
+	WindowOOMEvidence       bool                  `json:"windowOomEvidence,omitempty"`
+	OOMEvidenceAvailable    bool                  `json:"oomEvidenceAvailable"`
+	LimitConflict           bool                  `json:"limitConflict,omitempty"`
+	QueryError              string                `json:"queryError,omitempty"`
 }
 
 type RightsizingResponse struct {

--- a/internal/server/ai_diagnose_managedby_test.go
+++ b/internal/server/ai_diagnose_managedby_test.go
@@ -19,9 +19,9 @@ func obj(labels, ann map[string]string) *unstructured.Unstructured {
 
 func TestManagedByFromMeta(t *testing.T) {
 	cases := []struct {
-		name   string
-		obj    *unstructured.Unstructured
-		want   string
+		name string
+		obj  *unstructured.Unstructured
+		want string
 	}{
 		{"argo label", obj(map[string]string{"argocd.argoproj.io/instance": "app"}, nil), "Argo CD"},
 		{"argo annotation", obj(nil, map[string]string{"argocd.argoproj.io/tracking-id": "app:apps/Deployment"}), "Argo CD"},

--- a/internal/server/sse_authorizer_test.go
+++ b/internal/server/sse_authorizer_test.go
@@ -168,7 +168,7 @@ func TestSweepExpiredAuthMemo(t *testing.T) {
 	base := time.Now()
 	memo := map[string]authMemoEntry{
 		"expired-a": {allowed: true, expires: base.Add(-time.Second)},
-		"expired-b": {allowed: false, expires: base},                // expires == now → expired
+		"expired-b": {allowed: false, expires: base}, // expires == now → expired
 		"live":      {allowed: true, expires: base.Add(time.Minute)},
 	}
 	removed := sweepExpiredAuthMemo(memo, base)

--- a/internal/summarycontext/attach.go
+++ b/internal/summarycontext/attach.go
@@ -4,8 +4,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 	"github.com/skyhook-io/radar/internal/k8s"
+	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
 )
 
 // AttachToTypedList fills in SummaryContext for each *aicontext.ResourceSummary

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -374,11 +374,11 @@ type EntryProblem struct {
 	Summary string `json:"summary"`
 	// Detail is the underlying cause (a controller condition, usually), shown on
 	// hover. Empty when it would just repeat Summary.
-	Detail string `json:"detail,omitempty"`
-	Severity string      `json:"severity"`
-	Code     string      `json:"code,omitempty"`
-	Action   string      `json:"action,omitempty"`
-	Command  string      `json:"command,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+	Severity string `json:"severity"`
+	Code     string `json:"code,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Command  string `json:"command,omitempty"`
 }
 
 // UnknownClass enumerates the two distinct flavors of an unknown verdict.

--- a/pkg/ai/context/summary.go
+++ b/pkg/ai/context/summary.go
@@ -37,7 +37,7 @@ type ResourceSummary struct {
 	// worth a look", never as "currently broken" — the health level
 	// (summaryContext.health, from pkg/health) is the authority on that.
 	Issue string `json:"issue,omitempty"`
-	Age       string `json:"age,omitempty"`
+	Age   string `json:"age,omitempty"`
 	// Terminating signals that metadata.deletionTimestamp is set on the
 	// resource. AI agents need this signal to avoid suggesting
 	// mutating actions that will fail (e.g. "run kubectl rollout restart"
@@ -52,14 +52,14 @@ type ResourceSummary struct {
 	Finalizers []string `json:"finalizers,omitempty"`
 
 	// Type-specific fields (only populated when relevant)
-	Image         string   `json:"image,omitempty"`
-	Ports         string   `json:"ports,omitempty"`
-	Schedule      string   `json:"schedule,omitempty"`
-	Type          string   `json:"type,omitempty"` // Service type, Secret type
-	Selector      string   `json:"selector,omitempty"`
-	ClusterIP     string   `json:"clusterIP,omitempty"`
-	Hosts         []string `json:"hosts,omitempty"`
-	Restarts      int32    `json:"restarts,omitempty"`
+	Image     string   `json:"image,omitempty"`
+	Ports     string   `json:"ports,omitempty"`
+	Schedule  string   `json:"schedule,omitempty"`
+	Type      string   `json:"type,omitempty"` // Service type, Secret type
+	Selector  string   `json:"selector,omitempty"`
+	ClusterIP string   `json:"clusterIP,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
+	Restarts  int32    `json:"restarts,omitempty"`
 	// LastTerminatedReason is why the most recently terminated container
 	// exited (OOMKilled, Error, ...). It is HISTORY, not an active fault: a
 	// pod OOMKilled an hour ago that has been Ready since is healthy, and
@@ -69,27 +69,27 @@ type ResourceSummary struct {
 	LastTerminatedReason string `json:"lastTerminatedReason,omitempty"`
 	// LastRestartedAge is how long ago that termination happened, mirroring
 	// kubectl's "2 (5m ago)" RESTARTS column. Empty when nothing restarted.
-	LastRestartedAge string `json:"lastRestartedAge,omitempty"`
-	Node             string `json:"node,omitempty"`
-	Strategy      string   `json:"strategy,omitempty"`
-	Completions   string   `json:"completions,omitempty"`
-	Duration      string   `json:"duration,omitempty"`
-	Suspended     *bool    `json:"suspended,omitempty"`
-	Unschedulable *bool    `json:"unschedulable,omitempty"`
-	Active        int      `json:"active,omitempty"`
-	Target        string   `json:"target,omitempty"`
-	MinReplicas   *int32   `json:"minReplicas,omitempty"`
-	MaxReplicas   int32    `json:"maxReplicas,omitempty"`
-	Current       int32    `json:"current,omitempty"`
-	Desired       int32    `json:"desired,omitempty"`
-	Roles         []string `json:"roles,omitempty"`
-	Version       string   `json:"version,omitempty"`
-	Pressures     []string `json:"pressures,omitempty"`
-	Keys          []string `json:"keys,omitempty"`
-	StorageClass  string   `json:"storageClass,omitempty"`
-	Capacity      string   `json:"capacity,omitempty"`
-	AccessModes   []string `json:"accessModes,omitempty"`
-	Owner         string   `json:"owner,omitempty"`
+	LastRestartedAge string   `json:"lastRestartedAge,omitempty"`
+	Node             string   `json:"node,omitempty"`
+	Strategy         string   `json:"strategy,omitempty"`
+	Completions      string   `json:"completions,omitempty"`
+	Duration         string   `json:"duration,omitempty"`
+	Suspended        *bool    `json:"suspended,omitempty"`
+	Unschedulable    *bool    `json:"unschedulable,omitempty"`
+	Active           int      `json:"active,omitempty"`
+	Target           string   `json:"target,omitempty"`
+	MinReplicas      *int32   `json:"minReplicas,omitempty"`
+	MaxReplicas      int32    `json:"maxReplicas,omitempty"`
+	Current          int32    `json:"current,omitempty"`
+	Desired          int32    `json:"desired,omitempty"`
+	Roles            []string `json:"roles,omitempty"`
+	Version          string   `json:"version,omitempty"`
+	Pressures        []string `json:"pressures,omitempty"`
+	Keys             []string `json:"keys,omitempty"`
+	StorageClass     string   `json:"storageClass,omitempty"`
+	Capacity         string   `json:"capacity,omitempty"`
+	AccessModes      []string `json:"accessModes,omitempty"`
+	Owner            string   `json:"owner,omitempty"`
 
 	// SummaryContext is the per-row enrichment attached by AI-facing list
 	// surfaces (REST /api/ai/resources/{kind}, MCP list_resources, search

--- a/pkg/capacityapi/common.go
+++ b/pkg/capacityapi/common.go
@@ -72,7 +72,6 @@ func NewUsageObservation(asOf time.Time) UsageObservation {
 	}
 }
 
-
 type Confidence string
 
 const (

--- a/pkg/cronsched/cronsched_test.go
+++ b/pkg/cronsched/cronsched_test.go
@@ -20,8 +20,8 @@ func TestMinInterval(t *testing.T) {
 		{"0 0 1 */4 *", true, 100 * day}, // quarterly (every 4th month) — gap ~4 months
 		{"0 0 1 1 *", true, 365 * day},   // yearly via numeric month (Jan 1)
 		{"0 0 1 1,7 *", true, 180 * day}, // semi-annual (Jan + Jul) — 6-month gap
-		{"0 0 ? * *", true, day},          // daily via Quartz '?' for day-of-month
-		{"0 0 * * ?", true, day},          // daily via Quartz '?' for day-of-week
+		{"0 0 ? * *", true, day},         // daily via Quartz '?' for day-of-month
+		{"0 0 * * ?", true, day},         // daily via Quartz '?' for day-of-week
 		{"@daily", true, day},            //
 		{"@weekly", true, 7 * day},       //
 		{"@yearly", true, 365 * day},     //
@@ -87,11 +87,11 @@ func TestStaleThreshold(t *testing.T) {
 		schedule string
 		want     time.Duration
 	}{
-		{"*/5 * * * *", day},               // intra-day → floored at 24h
-		{"0 * * * *", day},                 // hourly → floored at 24h
-		{"0 0 * * *", 36 * time.Hour},      // daily → 24h + 50% grace
+		{"*/5 * * * *", day},                // intra-day → floored at 24h
+		{"0 * * * *", day},                  // hourly → floored at 24h
+		{"0 0 * * *", 36 * time.Hour},       // daily → 24h + 50% grace
 		{"0 0 * * 1", 7*day + 84*time.Hour}, // weekly → 7d + 50% grace
-		{"unparseable", day},               // fallback → flat 24h
+		{"unparseable", day},                // fallback → flat 24h
 	}
 	for _, c := range cases {
 		if got := StaleThreshold(c.schedule); got != c.want {

--- a/pkg/gitops/insights/insights_test.go
+++ b/pkg/gitops/insights/insights_test.go
@@ -1412,10 +1412,10 @@ func TestEnrichChangeHealthFromTree_BackfillsEmptyHealth(t *testing.T) {
 		{Ref: gitopstree.ResourceRef{Kind: "ConfigMap", Namespace: "staging", Name: "vars"}, Health: ""},
 	}}
 	changes := []Change{
-		{Ref: Ref{Group: "apps", Kind: "Deployment", Namespace: "staging", Name: "radar-hub"}, Health: ""},        // backfilled → Degraded
-		{Ref: Ref{Kind: "Service", Namespace: "staging", Name: "radar-hub"}, Health: "Progressing"},              // already set → unchanged
-		{Ref: Ref{Kind: "ConfigMap", Namespace: "staging", Name: "vars"}, Health: ""},                            // tree node empty → stays empty
-		{Ref: Ref{Kind: "SealedSecret", Namespace: "staging", Name: "x"}, Health: ""},                            // not in tree → stays empty
+		{Ref: Ref{Group: "apps", Kind: "Deployment", Namespace: "staging", Name: "radar-hub"}, Health: ""}, // backfilled → Degraded
+		{Ref: Ref{Kind: "Service", Namespace: "staging", Name: "radar-hub"}, Health: "Progressing"},        // already set → unchanged
+		{Ref: Ref{Kind: "ConfigMap", Namespace: "staging", Name: "vars"}, Health: ""},                      // tree node empty → stays empty
+		{Ref: Ref{Kind: "SealedSecret", Namespace: "staging", Name: "x"}, Health: ""},                      // not in tree → stays empty
 	}
 	enrichChangeHealthFromTree(changes, tree)
 	if changes[0].Health != "Degraded" {

--- a/pkg/gitops/tree/managed.go
+++ b/pkg/gitops/tree/managed.go
@@ -12,7 +12,7 @@ import (
 // Modern Argo (default since Argo CD 2.x) stamps every managed resource with
 // the tracking-id annotation. The value format is:
 //
-//   <app-name>:<group>/<kind>:<namespace>/<name>
+//	<app-name>:<group>/<kind>:<namespace>/<name>
 //
 // Legacy Argo configurations (operator opt-in via the
 // `--application-instance-name` controller flag, or older deployments) use a

--- a/pkg/health/level_test.go
+++ b/pkg/health/level_test.go
@@ -49,8 +49,8 @@ func TestLegacyString(t *testing.T) {
 		want  string
 	}{
 		{LevelHealthy, "healthy"},
-		{LevelNeutral, "healthy"},   // Succeeded etc. read healthy in legacy vocab
-		{LevelUnknown, "healthy"},   // legacy classifier never produced unknown
+		{LevelNeutral, "healthy"}, // Succeeded etc. read healthy in legacy vocab
+		{LevelUnknown, "healthy"}, // legacy classifier never produced unknown
 		{LevelDegraded, "warning"},
 		{LevelUnhealthy, "error"},
 	}

--- a/pkg/packages/crd_groups.go
+++ b/pkg/packages/crd_groups.go
@@ -14,7 +14,7 @@ package packages
 // Helm release secrets) — that's how rows merge.
 var crdGroupToChart = map[string]string{
 	// Cert-manager
-	"cert-manager.io":   "cert-manager",
+	"cert-manager.io":      "cert-manager",
 	"acme.cert-manager.io": "cert-manager",
 
 	// Argo CD + Argo Workflows + Argo Rollouts.
@@ -36,24 +36,24 @@ var crdGroupToChart = map[string]string{
 	"karpenter.k8s.aws": "karpenter",
 
 	// External Secrets Operator
-	"external-secrets.io":          "external-secrets",
+	"external-secrets.io": "external-secrets",
 
 	// Velero
 	"velero.io": "velero",
 
 	// Kyverno
-	"kyverno.io":                "kyverno",
-	"wgpolicyk8s.io":            "kyverno", // PolicyReport CRDs
+	"kyverno.io":     "kyverno",
+	"wgpolicyk8s.io": "kyverno", // PolicyReport CRDs
 
 	// Prometheus stack (kube-prometheus-stack)
 	"monitoring.coreos.com": "kube-prometheus-stack",
 
 	// Istio
-	"networking.istio.io":  "istio",
-	"security.istio.io":    "istio",
-	"telemetry.istio.io":   "istio",
-	"install.istio.io":     "istio",
-	"extensions.istio.io":  "istio",
+	"networking.istio.io": "istio",
+	"security.istio.io":   "istio",
+	"telemetry.istio.io":  "istio",
+	"install.istio.io":    "istio",
+	"extensions.istio.io": "istio",
 
 	// Traefik
 	"traefik.io":          "traefik",
@@ -66,7 +66,7 @@ var crdGroupToChart = map[string]string{
 	"opentelemetry.io": "opentelemetry-operator",
 
 	// KEDA
-	"keda.sh": "keda",
+	"keda.sh":          "keda",
 	"eventing.keda.sh": "keda",
 
 	// Knative
@@ -76,17 +76,17 @@ var crdGroupToChart = map[string]string{
 	"sources.knative.dev":  "knative-eventing",
 
 	// Cluster API
-	"cluster.x-k8s.io":           "cluster-api",
-	"controlplane.cluster.x-k8s.io": "cluster-api",
-	"bootstrap.cluster.x-k8s.io":  "cluster-api",
+	"cluster.x-k8s.io":                "cluster-api",
+	"controlplane.cluster.x-k8s.io":   "cluster-api",
+	"bootstrap.cluster.x-k8s.io":      "cluster-api",
 	"infrastructure.cluster.x-k8s.io": "cluster-api",
-	"addons.cluster.x-k8s.io":     "cluster-api",
+	"addons.cluster.x-k8s.io":         "cluster-api",
 
 	// Trivy operator
 	"aquasecurity.github.io": "trivy-operator",
 
 	// Cilium
-	"cilium.io":          "cilium",
+	"cilium.io": "cilium",
 }
 
 // chartFromCRDGroup returns (chartName, true) if the group is in our

--- a/pkg/packages/gitops_test.go
+++ b/pkg/packages/gitops_test.go
@@ -87,8 +87,8 @@ func TestMapArgoHealth(t *testing.T) {
 		// real signal (degraded), not as the same bucket as Unknown.
 		"Missing": HealthDegraded,
 		"Unknown": HealthUnknown,
-		"":       HealthUnknown,
-		"Bogus":  HealthUnknown,
+		"":        HealthUnknown,
+		"Bogus":   HealthUnknown,
 	}
 	for in, want := range cases {
 		if got := mapArgoHealth(in); got != want {

--- a/pkg/prom/client_test.go
+++ b/pkg/prom/client_test.go
@@ -353,7 +353,6 @@ func TestClient_Query_MissingOrNullResultIsEmptyNotError(t *testing.T) {
 	}
 }
 
-
 func TestClient_Query_RejectsStringResult(t *testing.T) {
 	tr := fakeProm(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"string","result":[1700000000,"hello world"]}}`))

--- a/pkg/prom/queries.go
+++ b/pkg/prom/queries.go
@@ -121,7 +121,7 @@ func BuildQuery(kind, namespace, name string, category MetricCategory) string {
 }
 
 // BuildQueryNoContainerFilter builds the same query as BuildQuery but without
-// the container!='' filter. This is used as a fallback for clusters where cAdvisor
+// the container!=” filter. This is used as a fallback for clusters where cAdvisor
 // metrics lack the container label (e.g. cri-docker setups).
 func BuildQueryNoContainerFilter(kind, namespace, name string, category MetricCategory) string {
 	return buildQueryInner(kind, namespace, name, category, false)
@@ -145,7 +145,7 @@ func BuildNamespaceQuery(namespace string, category MetricCategory) string {
 	return buildNamespaceQueryInner(namespace, category, true)
 }
 
-// BuildNamespaceQueryNoContainerFilter is the fallback variant without container!='' filter.
+// BuildNamespaceQueryNoContainerFilter is the fallback variant without container!=” filter.
 func BuildNamespaceQueryNoContainerFilter(namespace string, category MetricCategory) string {
 	return buildNamespaceQueryInner(namespace, category, false)
 }
@@ -175,7 +175,7 @@ func BuildClusterQuery(category MetricCategory) string {
 	return buildClusterQueryInner(category, true)
 }
 
-// BuildClusterQueryNoContainerFilter is the fallback variant without container!='' filter.
+// BuildClusterQueryNoContainerFilter is the fallback variant without container!=” filter.
 func BuildClusterQueryNoContainerFilter(category MetricCategory) string {
 	return buildClusterQueryInner(category, false)
 }
@@ -200,7 +200,7 @@ func buildClusterQueryInner(category MetricCategory, filterContainer bool) strin
 }
 
 // CategoryUsesContainerFilter returns true if the category's queries include
-// the container!='' filter that may need a fallback on cri-docker clusters.
+// the container!=” filter that may need a fallback on cri-docker clusters.
 func CategoryUsesContainerFilter(category MetricCategory) bool {
 	return category == CategoryCPU || category == CategoryMemory
 }

--- a/pkg/rbac/index_test.go
+++ b/pkg/rbac/index_test.go
@@ -480,4 +480,3 @@ func TestMemoizer_ZeroTTLDisablesCaching(t *testing.T) {
 		t.Errorf("expected 2 build calls with TTL=0, got %d", calls)
 	}
 }
-

--- a/pkg/timeline/types.go
+++ b/pkg/timeline/types.go
@@ -180,10 +180,10 @@ type TimelineResponse struct {
 
 // TimelineMeta contains metadata about the timeline query result
 type TimelineMeta struct {
-	TotalEvents int    `json:"totalEvents"`
-	GroupCount  int    `json:"groupCount"`
-	QueryTimeMs int64  `json:"queryTimeMs"`
-	HasMore bool `json:"hasMore"` // For pagination
+	TotalEvents int   `json:"totalEvents"`
+	GroupCount  int   `json:"groupCount"`
+	QueryTimeMs int64 `json:"queryTimeMs"`
+	HasMore     bool  `json:"hasMore"` // For pagination
 }
 
 // FilterPreset defines a named filter configuration

--- a/pkg/topology/certificates.go
+++ b/pkg/topology/certificates.go
@@ -187,4 +187,3 @@ func GetSecretCertificateInfo(provider ResourceProvider, namespace, name string)
 
 	return nil, fmt.Errorf("secret %s/%s not found", namespace, name)
 }
-

--- a/pkg/topology/memo.go
+++ b/pkg/topology/memo.go
@@ -29,7 +29,7 @@ type Memoizer struct {
 type memoEntry struct {
 	topo      *Topology
 	builtAt   time.Time
-	indexOnce sync.Once          // guards lazy build of index
+	indexOnce sync.Once           // guards lazy build of index
 	index     *RelationshipsIndex // populated by Memoizer.GetIndex on first call
 }
 


### PR DESCRIPTION
## Summary

25 Go files had drifted from `gofmt` (misaligned struct tags and similar) because nothing in CI checked formatting. This formats them and adds a `gofmt -l` gate to the Backend job — it runs from the repo root, so it covers both the main module and `pkg/`.

## Testing

`gofmt -l` clean across `internal/ pkg/ cmd/`; both modules build. Formatting-only changes otherwise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and CI enforcement only; no runtime behavior changes except possible Unicode in comments.
> 
> **Overview**
> **Applies `gofmt` across ~25 Go files** where struct tags, const blocks, and one-liner methods had drifted (alignment and spacing only—no intended logic changes).
> 
> **Adds a CI gate** on the Backend job: `gofmt -l .` from the repo root fails the build if any file needs formatting, so `internal/`, `pkg/`, and `cmd/` stay consistent going forward.
> 
> A few incidental cleanups ride along with formatting (import order in `summarycontext/attach`, blank lines removed in tests/maps). Comment text in Prometheus helpers now uses curly quotes when referring to the `container!=''` filter; **PromQL strings in code are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a148dd296f0dd5ef50f204323ec26b6672b97e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->