### PR TITLE
Pin Service/Job pairing complexity by operation count

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -26,6 +26,10 @@ import (
 type Builder struct {
 	provider ResourceProvider
 	dynamic  DynamicProvider
+	// Iterations of the Service/Job pairing loop, counted so a test can pin
+	// the loop's complexity class without timing anything: completed Jobs can
+	// never back a Service, so the count must not grow with them.
+	serviceJobComparisons int
 }
 
 // NewBuilder creates a new topology builder
@@ -3092,6 +3096,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		// Check Jobs
 		for _, job := range activeJobsByNS[svc.Namespace] {
+			b.serviceJobComparisons++
 			if matchesSelector(job.Spec.Template.ObjectMeta.Labels, svc.Spec.Selector) {
 				jobID := jobIDs[job.Namespace+"/"+job.Name]
 				if jobID != "" {

--- a/pkg/topology/service_job_pairing_test.go
+++ b/pkg/topology/service_job_pairing_test.go
@@ -270,3 +270,29 @@ func BenchmarkBuildTopologyServiceJobPairingTwiceLargeCluster(b *testing.B) {
 		}
 	}
 }
+
+// The complexity guard without a clock: the pairing loop's iteration count is
+// exact and machine-independent where its wall-clock time is not (see
+// requireTimingTestsEnabled). With one live Job per namespace, an indexed
+// pairing considers exactly one candidate per Service; the per-Service rescan
+// this pins against multiplies that by the completed runs.
+func TestServiceJobPairingConsidersOnlyActiveJobs(t *testing.T) {
+	const (
+		services      = 300
+		namespaces    = 30
+		completedJobs = 5000
+	)
+	b := NewBuilder(pairingProvider(services, namespaces, completedJobs))
+	opts := DefaultBuildOptions()
+	opts.ForRelationshipCache = true
+	if _, err := b.Build(opts); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if b.serviceJobComparisons == 0 {
+		t.Fatal("the pairing loop never ran — the counter is not wired to the code under test")
+	}
+	if b.serviceJobComparisons > services {
+		t.Fatalf("pairing considered %d candidates for %d Services with one live Job per namespace — completed Jobs are being scanned",
+			b.serviceJobComparisons, services)
+	}
+}


### PR DESCRIPTION
## Summary

The Service/Job pairing complexity tests assert wall-clock ratios, which made them flaky on shared CI runners — they are opt-in via `RADAR_TIMING_TESTS` since #1540, leaving CI with no automated guard against reintroducing the per-Service Job rescan.

This adds a deterministic guard: the pairing loop counts its iterations (one unexported int on `Builder`), and a test asserts the count cannot exceed one candidate per Service when each namespace holds one live Job. Completed Jobs entering the scan blow the count up by the completed-run multiplier (50,300 vs 300 in the fixture), so the signal is exact and machine-independent — no clock involved.

## Testing

Test fails with a 167x count blowup when the active-Job filter is removed (verified by mutation); full `pkg/topology` suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only instrumentation plus a small counter increment in pairing logic; no change to edge semantics or production behavior beyond counting loop iterations.
> 
> **Overview**
> Replaces flaky wall-clock pairing complexity checks with a **deterministic iteration guard** on the topology `Builder`.
> 
> The builder now tracks `serviceJobComparisons` on each pass through the Service→Job pairing loop. **`TestServiceJobPairingConsidersOnlyActiveJobs`** builds a large fixture (many Services plus thousands of completed Jobs) and asserts that count stays at most one comparison per Service—so completed Jobs are not rescanned per Service. The test also fails fast if the counter is not wired into the loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4688346bbc1a5f6f84c73dcb9ab6c85acb65eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->