### PR TITLE
Name each failed Gateway in a policy's mixed-failure status

### DIFF
--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -205,6 +205,41 @@ describe('condition vocabulary beyond Accepted', () => {
     })
   })
 
+  // GEP-713 keys ancestor status on ancestorRef + controllerName: the same
+  // Gateway appears once per controller, and a bare ns/name label would
+  // attribute both verdicts to one indistinguishable thing.
+  it('tells colliding labels apart by controller', () => {
+    const p = policy(
+      { ancestorRef: { namespace: 'team-a', name: 'gw' }, controllerName: 'ctrl-a.example', conditions: [cond('Accepted', 'False', 'NotAllowed')] },
+      { ancestorRef: { namespace: 'team-a', name: 'gw' }, controllerName: 'ctrl-b.example', conditions: [cond('Accepted', 'False', 'ResourceNotFound')] },
+    )
+    expect(getGatewayPolicyStatus(p)?.reason)
+      .toBe('team-a/gw (ctrl-a.example): NotAllowed; team-a/gw (ctrl-b.example): ResourceNotFound')
+  })
+
+  // sectionName and a non-Gateway kind are part of the identity and short
+  // enough to always carry.
+  it('carries section and kind in the label', () => {
+    const p = policy(
+      { ancestorRef: { namespace: 'team-a', name: 'gw', sectionName: 'tls' }, conditions: [cond('Accepted', 'False', 'NotAllowed')] },
+      { ancestorRef: { kind: 'Service', namespace: 'team-a', name: 'svc' }, conditions: [cond('Accepted', 'False', 'ResourceNotFound')] },
+    )
+    expect(getGatewayPolicyStatus(p)?.reason)
+      .toBe('team-a/gw:tls: NotAllowed; Service team-a/svc: ResourceNotFound')
+  })
+
+  // Reasons may be 1024 chars and foreign CRDs need not honor the 16-ancestor
+  // cap, so the list is bounded rather than trusted.
+  it('caps the tooltip detail list', () => {
+    const p = policy(
+      ...[1, 2, 3, 4, 5, 6].map(i => ({
+        ancestorRef: { name: `gw-${i}` },
+        conditions: [cond('Accepted', 'False', `R${i}`)],
+      })),
+    )
+    expect(getGatewayPolicyStatus(p)?.reason).toBe('gw-1: R1; gw-2: R2; gw-3: R3; gw-4: R4; +2 more')
+  })
+
   it('keeps the reason when every failure agrees', () => {
     const p = policy(anc(cond('Accepted', 'False', 'NotAllowed')), anc(cond('Accepted', 'False', 'NotAllowed')))
     expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'NotAllowed (2/2)', tone: 'unhealthy' })

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -190,6 +190,21 @@ describe('condition vocabulary beyond Accepted', () => {
     expect(getGatewayPolicyStatus(p)).toMatchObject({ text: '2/3 failed', tone: 'unhealthy' })
   })
 
+  // The badge says "2/3 failed"; the tooltip must say which Gateway failed
+  // how, or the operator digs through raw status for the names.
+  it('names each failed ancestor and its reason in the tooltip', () => {
+    const p = policy(
+      { ancestorRef: { kind: 'Gateway', namespace: 'team-a', name: 'gw-a' }, conditions: [cond('Accepted', 'False', 'NotAllowed')] },
+      { ancestorRef: { kind: 'Gateway', name: 'gw-b' }, conditions: [cond('Accepted', 'False', 'ResourceNotFound')] },
+      anc(cond('Accepted', 'True')),
+    )
+    expect(getGatewayPolicyStatus(p)).toMatchObject({
+      text: '2/3 failed',
+      tone: 'unhealthy',
+      reason: 'team-a/gw-a: NotAllowed; gw-b: ResourceNotFound',
+    })
+  })
+
   it('keeps the reason when every failure agrees', () => {
     const p = policy(anc(cond('Accepted', 'False', 'NotAllowed')), anc(cond('Accepted', 'False', 'NotAllowed')))
     expect(getGatewayPolicyStatus(p)).toMatchObject({ text: 'NotAllowed (2/2)', tone: 'unhealthy' })

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.test.ts
@@ -228,6 +228,30 @@ describe('condition vocabulary beyond Accepted', () => {
       .toBe('team-a/gw:tls: NotAllowed; Service team-a/svc: ResourceNotFound')
   })
 
+  // The collision that qualifies a controller may be with an ancestor that
+  // SUCCEEDED: two controllers on one Gateway, one failing, must still say
+  // which one failed.
+  it('names the controller when the collision is with a successful ancestor', () => {
+    const p = policy(
+      { ancestorRef: { namespace: 'team-a', name: 'gw' }, controllerName: 'ctrl-a.example', conditions: [cond('Accepted', 'False', 'NotAllowed')] },
+      { ancestorRef: { namespace: 'team-a', name: 'gw' }, controllerName: 'ctrl-b.example', conditions: [cond('Accepted', 'True')] },
+      { ancestorRef: { name: 'gw-b' }, conditions: [cond('Accepted', 'False', 'ResourceNotFound')] },
+    )
+    expect(getGatewayPolicyStatus(p)?.reason)
+      .toBe('team-a/gw (ctrl-a.example): NotAllowed; gw-b: ResourceNotFound')
+  })
+
+  // group and port are part of the composite key too: entries differing only
+  // by them must not render identically.
+  it('carries group and port in the label', () => {
+    const p = policy(
+      { ancestorRef: { group: 'multicluster.x-k8s.io', kind: 'ServiceImport', namespace: 'team-a', name: 'svc' }, conditions: [cond('Accepted', 'False', 'NotAllowed')] },
+      { ancestorRef: { namespace: 'team-a', name: 'gw', port: 443 }, conditions: [cond('Accepted', 'False', 'ResourceNotFound')] },
+    )
+    expect(getGatewayPolicyStatus(p)?.reason)
+      .toBe('ServiceImport.multicluster.x-k8s.io team-a/svc: NotAllowed; team-a/gw:443: ResourceNotFound')
+  })
+
   // Reasons may be 1024 chars and foreign CRDs need not honor the 16-ancestor
   // cap, so the list is bounded rather than trusted.
   it('caps the tooltip detail list', () => {

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -51,12 +51,43 @@ const QUALIFIED_SUCCESS_REASONS = new Set(['PartiallyProgrammed'])
 /** Conditions that mean trouble when True, mirroring the generic ladder's set. */
 const NEGATIVE_CONDITIONS = new Set(['Degraded', 'Warning'])
 
-function ancestorName(ancestor: any): string {
+/**
+ * GEP-713 keys an ancestor's status on the full ancestorRef plus the
+ * controllerName — the same Gateway can appear once per controller, section,
+ * or kind. The label carries the short parts outright; the controllerName is
+ * long, so it is appended only when two labels would otherwise collide.
+ */
+function ancestorLabel(ancestor: any): string {
   const ref = ancestor?.ancestorRef
   const name = typeof ref?.name === 'string' ? ref.name : ''
   if (!name) return ''
   const ns = typeof ref?.namespace === 'string' ? ref.namespace : ''
-  return ns ? `${ns}/${name}` : name
+  const kind = typeof ref?.kind === 'string' ? ref.kind : ''
+  const section = typeof ref?.sectionName === 'string' ? ref.sectionName : ''
+  let label = ns ? `${ns}/${name}` : name
+  if (kind && kind !== 'Gateway') label = `${kind} ${label}`
+  if (section) label += `:${section}`
+  return label
+}
+
+/**
+ * Reasons are usually short CamelCase tokens, but the API allows 1024 chars
+ * and this reader accepts any CRD with an ancestors array, so the list is
+ * capped rather than trusted to stay small.
+ */
+const MAX_FAILURE_DETAILS = 4
+
+function renderFailureDetails(failures: { label: string; controller: string; problem: string }[]): string {
+  const labelCounts = new Map<string, number>()
+  for (const f of failures) labelCounts.set(f.label, (labelCounts.get(f.label) ?? 0) + 1)
+  const entries = failures.map(f => {
+    let label = f.label
+    if (label && (labelCounts.get(label) ?? 0) > 1 && f.controller) label += ` (${f.controller})`
+    return label ? `${label}: ${f.problem}` : f.problem
+  })
+  const shown = entries.slice(0, MAX_FAILURE_DETAILS)
+  const hidden = entries.length - shown.length
+  return hidden > 0 ? `${shown.join('; ')}; +${hidden} more` : shown.join('; ')
 }
 
 function conditionsOf(ancestor: any): any[] {
@@ -116,7 +147,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   const failureReasons = new Set<string>()
   // Which Gateway failed with what, for the tooltip: "2/3 failed" without it
   // sends the operator digging through raw status for the names.
-  const failureDetails: string[] = []
+  const failureDetails: { label: string; controller: string; problem: string }[] = []
   let acceptedAs: string | null = null
 
   for (const ancestor of ancestors) {
@@ -136,8 +167,11 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       failed++
       failure ??= { text: problemText(broken), reason: broken?.message }
       failureReasons.add(problemText(broken))
-      const name = ancestorName(ancestor)
-      failureDetails.push(name ? `${name}: ${problemText(broken)}` : problemText(broken))
+      failureDetails.push({
+        label: ancestorLabel(ancestor),
+        controller: typeof ancestor?.controllerName === 'string' ? ancestor.controllerName : '',
+        problem: problemText(broken),
+      })
       continue
     }
 
@@ -176,7 +210,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
 
   if (failed > 0 && failure) {
     if (failureReasons.size > 1) {
-      return { text: `${failed}/${total} failed`, tone: 'unhealthy', reason: failureDetails.join('; ') }
+      return { text: `${failed}/${total} failed`, tone: 'unhealthy', reason: renderFailureDetails(failureDetails) }
     }
     return { text: `${failure.text}${scope(failed)}`, tone: 'unhealthy', reason: failure.reason }
   }

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -63,10 +63,15 @@ function ancestorLabel(ancestor: any): string {
   if (!name) return ''
   const ns = typeof ref?.namespace === 'string' ? ref.namespace : ''
   const kind = typeof ref?.kind === 'string' ? ref.kind : ''
+  const group = typeof ref?.group === 'string' ? ref.group : ''
   const section = typeof ref?.sectionName === 'string' ? ref.sectionName : ''
+  const port = typeof ref?.port === 'number' ? ref.port : null
   let label = ns ? `${ns}/${name}` : name
-  if (kind && kind !== 'Gateway') label = `${kind} ${label}`
+  let prefix = kind && kind !== 'Gateway' ? kind : ''
+  if (group && group !== 'gateway.networking.k8s.io') prefix = prefix ? `${prefix}.${group}` : group
+  if (prefix) label = `${prefix} ${label}`
   if (section) label += `:${section}`
+  if (port !== null) label += `:${port}`
   return label
 }
 
@@ -77,9 +82,13 @@ function ancestorLabel(ancestor: any): string {
  */
 const MAX_FAILURE_DETAILS = 4
 
-function renderFailureDetails(failures: { label: string; controller: string; problem: string }[]): string {
-  const labelCounts = new Map<string, number>()
-  for (const f of failures) labelCounts.set(f.label, (labelCounts.get(f.label) ?? 0) + 1)
+function renderFailureDetails(
+  failures: { label: string; controller: string; problem: string }[],
+  // Collisions are counted across every ancestor, not just the failed ones: a
+  // failure and a success for the same Gateway under different controllers
+  // must still say which controller failed.
+  labelCounts: Map<string, number>,
+): string {
   const entries = failures.map(f => {
     let label = f.label
     if (label && (labelCounts.get(label) ?? 0) > 1 && f.controller) label += ` (${f.controller})`
@@ -148,9 +157,12 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   // Which Gateway failed with what, for the tooltip: "2/3 failed" without it
   // sends the operator digging through raw status for the names.
   const failureDetails: { label: string; controller: string; problem: string }[] = []
+  const ancestorLabelCounts = new Map<string, number>()
   let acceptedAs: string | null = null
 
   for (const ancestor of ancestors) {
+    const label = ancestorLabel(ancestor)
+    if (label) ancestorLabelCounts.set(label, (ancestorLabelCounts.get(label) ?? 0) + 1)
     const conditions = conditionsOf(ancestor)
 
     const broken = conditions.find(
@@ -168,7 +180,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       failure ??= { text: problemText(broken), reason: broken?.message }
       failureReasons.add(problemText(broken))
       failureDetails.push({
-        label: ancestorLabel(ancestor),
+        label,
         controller: typeof ancestor?.controllerName === 'string' ? ancestor.controllerName : '',
         problem: problemText(broken),
       })
@@ -210,7 +222,7 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
 
   if (failed > 0 && failure) {
     if (failureReasons.size > 1) {
-      return { text: `${failed}/${total} failed`, tone: 'unhealthy', reason: renderFailureDetails(failureDetails) }
+      return { text: `${failed}/${total} failed`, tone: 'unhealthy', reason: renderFailureDetails(failureDetails, ancestorLabelCounts) }
     }
     return { text: `${failure.text}${scope(failed)}`, tone: 'unhealthy', reason: failure.reason }
   }

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -51,6 +51,14 @@ const QUALIFIED_SUCCESS_REASONS = new Set(['PartiallyProgrammed'])
 /** Conditions that mean trouble when True, mirroring the generic ladder's set. */
 const NEGATIVE_CONDITIONS = new Set(['Degraded', 'Warning'])
 
+function ancestorName(ancestor: any): string {
+  const ref = ancestor?.ancestorRef
+  const name = typeof ref?.name === 'string' ? ref.name : ''
+  if (!name) return ''
+  const ns = typeof ref?.namespace === 'string' ? ref.namespace : ''
+  return ns ? `${ns}/${name}` : name
+}
+
 function conditionsOf(ancestor: any): any[] {
   return Array.isArray(ancestor?.conditions) ? ancestor.conditions : []
 }
@@ -104,6 +112,9 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   // Ancestors can fail for different reasons. Reporting the first one with a
   // count claims they all failed that way.
   const failureReasons = new Set<string>()
+  // Which Gateway failed with what, for the tooltip: "2/3 failed" without it
+  // sends the operator digging through raw status for the names.
+  const failureDetails: string[] = []
   let acceptedAs: string | null = null
 
   for (const ancestor of ancestors) {
@@ -123,6 +134,8 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
       failed++
       failure ??= { text: problemText(broken), reason: broken?.message }
       failureReasons.add(problemText(broken))
+      const name = ancestorName(ancestor)
+      failureDetails.push(name ? `${name}: ${problemText(broken)}` : problemText(broken))
       continue
     }
 
@@ -160,8 +173,10 @@ export function getGatewayPolicyStatus(resource: any): GenericStatus | null {
   const scope = (n: number) => (total > 1 ? ` (${n}/${total})` : '')
 
   if (failed > 0 && failure) {
-    const text = failureReasons.size > 1 ? `${failed}/${total} failed` : `${failure.text}${scope(failed)}`
-    return { text, tone: 'unhealthy', reason: failure.reason }
+    if (failureReasons.size > 1) {
+      return { text: `${failed}/${total} failed`, tone: 'unhealthy', reason: failureDetails.join('; ') }
+    }
+    return { text: `${failure.text}${scope(failed)}`, tone: 'unhealthy', reason: failure.reason }
   }
   if (degraded > 0 && warning) {
     return { text: `${warning.text}${scope(degraded)}`, tone: 'degraded', reason: warning.reason }

--- a/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
+++ b/packages/k8s-ui/src/components/resources/gateway-policy-status.ts
@@ -72,8 +72,10 @@ function conditionsOf(ancestor: any): any[] {
  * construction would render "Not Warning" and inverts the meaning.
  *
  * Spelled with a space where the Go reader behind MCP writes "NotAccepted",
- * matching each side's existing convention. Only the reason-less case differs;
- * whenever a controller supplies a reason the two are identical.
+ * matching each side's existing convention. Whenever a controller supplies a
+ * reason the two sides are identical; they part ways only here and on mixed
+ * failures, where the per-ancestor detail goes to the tooltip while MCP,
+ * having no tooltip, carries it in the text.
  */
 function problemText(cond: any, trueMeansTrouble = false): string {
   const reason = typeof cond?.reason === 'string' ? cond.reason.trim() : ''

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -483,6 +483,20 @@ func summarizeGenericCRD(obj *unstructured.Unstructured) *ResourceSummary {
 // Programmed=False — the controller took ownership and then could not apply it
 // — and reading acceptance first calls that healthy. Mirrors
 // getGatewayPolicyStatus in packages/k8s-ui.
+// policyAncestorName identifies the ancestor a failure belongs to, namespace-
+// qualified when the ref carries one.
+func policyAncestorName(ancestor map[string]any) string {
+	ref, _ := ancestor["ancestorRef"].(map[string]any)
+	name, _ := ref["name"].(string)
+	if name == "" {
+		return ""
+	}
+	if ns, _ := ref["namespace"].(string); ns != "" {
+		return ns + "/" + name
+	}
+	return name
+}
+
 func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// NoCopy rather than NestedSlice: this is a read-only summary on a request
 	// path, and NestedSlice deep-copies every ancestor — and panics outright on
@@ -509,6 +523,10 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// Ancestors can fail for different reasons; reporting the first with a count
 	// would claim they all failed that way.
 	failureReasons := map[string]struct{}{}
+	// Which Gateway failed with what. MCP has no tooltip channel, so on mixed
+	// reasons this rides in the text itself — bounded, since valid PolicyStatus
+	// carries at most 16 ancestors.
+	var failureDetails []string
 	verdict := ""
 
 	for _, a := range ancestors {
@@ -568,6 +586,11 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 				failure = broke
 			}
 			failureReasons[broke] = struct{}{}
+			if name := policyAncestorName(aMap); name != "" {
+				failureDetails = append(failureDetails, name+": "+broke)
+			} else {
+				failureDetails = append(failureDetails, broke)
+			}
 		case warned != "":
 			degraded++
 			if warning == "" {
@@ -589,7 +612,7 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	switch {
 	case failed > 0:
 		if len(failureReasons) > 1 {
-			return fmt.Sprintf("%d/%d failed", failed, total), true
+			return fmt.Sprintf("%d/%d failed (%s)", failed, total, strings.Join(failureDetails, "; ")), true
 		}
 		return failure + scope(failed), true
 	case degraded > 0:

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -483,18 +483,63 @@ func summarizeGenericCRD(obj *unstructured.Unstructured) *ResourceSummary {
 // Programmed=False — the controller took ownership and then could not apply it
 // — and reading acceptance first calls that healthy. Mirrors
 // getGatewayPolicyStatus in packages/k8s-ui.
-// policyAncestorName identifies the ancestor a failure belongs to, namespace-
-// qualified when the ref carries one.
-func policyAncestorName(ancestor map[string]any) string {
+// policyAncestorLabel identifies the ancestor a failure belongs to. GEP-713
+// keys an ancestor's status on the full ancestorRef plus the controllerName —
+// the same Gateway can appear once per controller, section, or kind — so the
+// label carries the short parts outright; the long controllerName is appended
+// by the caller only when two labels would otherwise collide.
+func policyAncestorLabel(ancestor map[string]any) string {
 	ref, _ := ancestor["ancestorRef"].(map[string]any)
 	name, _ := ref["name"].(string)
 	if name == "" {
 		return ""
 	}
+	label := name
 	if ns, _ := ref["namespace"].(string); ns != "" {
-		return ns + "/" + name
+		label = ns + "/" + name
 	}
-	return name
+	if kind, _ := ref["kind"].(string); kind != "" && kind != "Gateway" {
+		label = kind + " " + label
+	}
+	if section, _ := ref["sectionName"].(string); section != "" {
+		label += ":" + section
+	}
+	return label
+}
+
+type policyFailureDetail struct {
+	label      string
+	controller string
+	problem    string
+}
+
+// Reasons are usually short CamelCase tokens, but the API allows 1024 chars
+// and this reader accepts any CRD with an ancestors array, so the in-text list
+// is capped rather than trusted to stay small.
+const maxPolicyFailureDetails = 4
+
+func renderPolicyFailureDetails(failures []policyFailureDetail) string {
+	labelCounts := map[string]int{}
+	for _, f := range failures {
+		labelCounts[f.label]++
+	}
+	entries := make([]string, 0, len(failures))
+	for _, f := range failures {
+		label := f.label
+		if label != "" && labelCounts[f.label] > 1 && f.controller != "" {
+			label += " (" + f.controller + ")"
+		}
+		if label != "" {
+			entries = append(entries, label+": "+f.problem)
+		} else {
+			entries = append(entries, f.problem)
+		}
+	}
+	if len(entries) > maxPolicyFailureDetails {
+		hidden := len(entries) - maxPolicyFailureDetails
+		return strings.Join(entries[:maxPolicyFailureDetails], "; ") + fmt.Sprintf("; +%d more", hidden)
+	}
+	return strings.Join(entries, "; ")
 }
 
 func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
@@ -524,9 +569,8 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// would claim they all failed that way.
 	failureReasons := map[string]struct{}{}
 	// Which Gateway failed with what. MCP has no tooltip channel, so on mixed
-	// reasons this rides in the text itself — bounded, since valid PolicyStatus
-	// carries at most 16 ancestors.
-	var failureDetails []string
+	// reasons this rides in the text itself.
+	var failureDetails []policyFailureDetail
 	verdict := ""
 
 	for _, a := range ancestors {
@@ -586,11 +630,12 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 				failure = broke
 			}
 			failureReasons[broke] = struct{}{}
-			if name := policyAncestorName(aMap); name != "" {
-				failureDetails = append(failureDetails, name+": "+broke)
-			} else {
-				failureDetails = append(failureDetails, broke)
-			}
+			controller, _ := aMap["controllerName"].(string)
+			failureDetails = append(failureDetails, policyFailureDetail{
+				label:      policyAncestorLabel(aMap),
+				controller: controller,
+				problem:    broke,
+			})
 		case warned != "":
 			degraded++
 			if warning == "" {
@@ -612,7 +657,7 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	switch {
 	case failed > 0:
 		if len(failureReasons) > 1 {
-			return fmt.Sprintf("%d/%d failed (%s)", failed, total, strings.Join(failureDetails, "; ")), true
+			return fmt.Sprintf("%d/%d failed (%s)", failed, total, renderPolicyFailureDetails(failureDetails)), true
 		}
 		return failure + scope(failed), true
 	case degraded > 0:

--- a/pkg/ai/context/summary_crd.go
+++ b/pkg/ai/context/summary_crd.go
@@ -498,11 +498,28 @@ func policyAncestorLabel(ancestor map[string]any) string {
 	if ns, _ := ref["namespace"].(string); ns != "" {
 		label = ns + "/" + name
 	}
+	prefix := ""
 	if kind, _ := ref["kind"].(string); kind != "" && kind != "Gateway" {
-		label = kind + " " + label
+		prefix = kind
+	}
+	if group, _ := ref["group"].(string); group != "" && group != "gateway.networking.k8s.io" {
+		if prefix != "" {
+			prefix += "." + group
+		} else {
+			prefix = group
+		}
+	}
+	if prefix != "" {
+		label = prefix + " " + label
 	}
 	if section, _ := ref["sectionName"].(string); section != "" {
 		label += ":" + section
+	}
+	switch port := ref["port"].(type) {
+	case int64:
+		label += fmt.Sprintf(":%d", port)
+	case float64:
+		label += fmt.Sprintf(":%d", int64(port))
 	}
 	return label
 }
@@ -518,11 +535,10 @@ type policyFailureDetail struct {
 // is capped rather than trusted to stay small.
 const maxPolicyFailureDetails = 4
 
-func renderPolicyFailureDetails(failures []policyFailureDetail) string {
-	labelCounts := map[string]int{}
-	for _, f := range failures {
-		labelCounts[f.label]++
-	}
+// Collisions are counted across every ancestor, not just the failed ones: a
+// failure and a success for the same Gateway under different controllers must
+// still say which controller failed.
+func renderPolicyFailureDetails(failures []policyFailureDetail, labelCounts map[string]int) string {
 	entries := make([]string, 0, len(failures))
 	for _, f := range failures {
 		label := f.label
@@ -571,12 +587,16 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	// Which Gateway failed with what. MCP has no tooltip channel, so on mixed
 	// reasons this rides in the text itself.
 	var failureDetails []policyFailureDetail
+	ancestorLabelCounts := map[string]int{}
 	verdict := ""
 
 	for _, a := range ancestors {
 		aMap, ok := a.(map[string]any)
 		if !ok {
 			continue
+		}
+		if label := policyAncestorLabel(aMap); label != "" {
+			ancestorLabelCounts[label]++
 		}
 		rawConds, _, _ := unstructured.NestedFieldNoCopy(aMap, "conditions")
 		conds, _ := rawConds.([]any)
@@ -657,7 +677,7 @@ func gatewayPolicyStatus(obj *unstructured.Unstructured) (string, bool) {
 	switch {
 	case failed > 0:
 		if len(failureReasons) > 1 {
-			return fmt.Sprintf("%d/%d failed (%s)", failed, total, renderPolicyFailureDetails(failureDetails)), true
+			return fmt.Sprintf("%d/%d failed (%s)", failed, total, renderPolicyFailureDetails(failureDetails, ancestorLabelCounts)), true
 		}
 		return failure + scope(failed), true
 	case degraded > 0:

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -219,6 +219,14 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		}
 		return map[string]any{"conditions": out}
 	}
+	named := func(ns, name string, a map[string]any) map[string]any {
+		ref := map[string]any{"name": name}
+		if ns != "" {
+			ref["namespace"] = ns
+		}
+		a["ancestorRef"] = ref
+		return a
+	}
 	policy := func(ancestors ...map[string]any) *unstructured.Unstructured {
 		out := make([]any, 0, len(ancestors))
 		for _, a := range ancestors {
@@ -280,11 +288,18 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		{"ResolvedRefs alone is not a verdict", policy(anc(cond("ResolvedRefs", "True", ""))), "Pending", true},
 		{"partially applied is not success", policy(anc(cond("Accepted", "True", ""), cond("Programmed", "True", "PartiallyProgrammed"))), "PartiallyProgrammed", true},
 		// Reporting the first reason with a count claims they all failed that way.
-		{"mixed failure reasons report a count", policy(
+		{"mixed failure reasons report a count and each ancestor's reason", policy(
 			anc(cond("Accepted", "False", "NotAllowed")),
 			anc(cond("Accepted", "False", "ResourceNotFound")),
 			anc(cond("Accepted", "True", "")),
-		), "2/3 failed", true},
+		), "2/3 failed (NotAllowed; ResourceNotFound)", true},
+		// "2/3 failed" without naming the Gateways sends the reader digging
+		// through raw status for which ancestor failed how.
+		{"mixed failures name the Gateway that failed each way", policy(
+			named("team-a", "gw-a", anc(cond("Accepted", "False", "NotAllowed"))),
+			named("", "gw-b", anc(cond("Accepted", "False", "ResourceNotFound"))),
+			anc(cond("Accepted", "True", "")),
+		), "2/3 failed (team-a/gw-a: NotAllowed; gw-b: ResourceNotFound)", true},
 		{"matching failure reasons keep the reason", policy(
 			anc(cond("Accepted", "False", "NotAllowed")),
 			anc(cond("Accepted", "False", "NotAllowed")),

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -228,6 +228,18 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		a["ancestorRef"] = ref
 		return a
 	}
+	withController := func(controller string, a map[string]any) map[string]any {
+		a["controllerName"] = controller
+		return a
+	}
+	withSection := func(section string, a map[string]any) map[string]any {
+		a["ancestorRef"].(map[string]any)["sectionName"] = section
+		return a
+	}
+	withKind := func(kind string, a map[string]any) map[string]any {
+		a["ancestorRef"].(map[string]any)["kind"] = kind
+		return a
+	}
 	policy := func(ancestors ...map[string]any) *unstructured.Unstructured {
 		out := make([]any, 0, len(ancestors))
 		for _, a := range ancestors {
@@ -301,6 +313,29 @@ func TestGatewayPolicyStatus(t *testing.T) {
 			named("", "gw-b", anc(cond("Accepted", "False", "ResourceNotFound"))),
 			anc(cond("Accepted", "True", "")),
 		), "2/3 failed (team-a/gw-a: NotAllowed; gw-b: ResourceNotFound)", true},
+		// GEP-713 keys ancestor status on ancestorRef + controllerName: the same
+		// Gateway appears once per controller, and a bare ns/name label would
+		// attribute both verdicts to one indistinguishable thing.
+		{"colliding labels are told apart by controller", policy(
+			withController("ctrl-a.example", named("team-a", "gw", anc(cond("Accepted", "False", "NotAllowed")))),
+			withController("ctrl-b.example", named("team-a", "gw", anc(cond("Accepted", "False", "ResourceNotFound")))),
+		), "2/2 failed (team-a/gw (ctrl-a.example): NotAllowed; team-a/gw (ctrl-b.example): ResourceNotFound)", true},
+		// sectionName and a non-Gateway kind are part of the identity and short
+		// enough to always carry.
+		{"section and kind ride in the label", policy(
+			withSection("tls", named("team-a", "gw", anc(cond("Accepted", "False", "NotAllowed")))),
+			withKind("Service", named("team-a", "svc", anc(cond("Accepted", "False", "ResourceNotFound")))),
+		), "2/2 failed (team-a/gw:tls: NotAllowed; Service team-a/svc: ResourceNotFound)", true},
+		// Reasons may be 1024 chars and foreign CRDs need not honor the
+		// 16-ancestor cap, so the list is bounded rather than trusted.
+		{"the detail list is capped", policy(
+			named("", "gw-1", anc(cond("Accepted", "False", "R1"))),
+			named("", "gw-2", anc(cond("Accepted", "False", "R2"))),
+			named("", "gw-3", anc(cond("Accepted", "False", "R3"))),
+			named("", "gw-4", anc(cond("Accepted", "False", "R4"))),
+			named("", "gw-5", anc(cond("Accepted", "False", "R5"))),
+			named("", "gw-6", anc(cond("Accepted", "False", "R6"))),
+		), "6/6 failed (gw-1: R1; gw-2: R2; gw-3: R3; gw-4: R4; +2 more)", true},
 		{"matching failure reasons keep the reason", policy(
 			anc(cond("Accepted", "False", "NotAllowed")),
 			anc(cond("Accepted", "False", "NotAllowed")),

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -240,6 +240,14 @@ func TestGatewayPolicyStatus(t *testing.T) {
 		a["ancestorRef"].(map[string]any)["kind"] = kind
 		return a
 	}
+	withGroup := func(group string, a map[string]any) map[string]any {
+		a["ancestorRef"].(map[string]any)["group"] = group
+		return a
+	}
+	withPort := func(port int64, a map[string]any) map[string]any {
+		a["ancestorRef"].(map[string]any)["port"] = port
+		return a
+	}
 	policy := func(ancestors ...map[string]any) *unstructured.Unstructured {
 		out := make([]any, 0, len(ancestors))
 		for _, a := range ancestors {
@@ -326,6 +334,20 @@ func TestGatewayPolicyStatus(t *testing.T) {
 			withSection("tls", named("team-a", "gw", anc(cond("Accepted", "False", "NotAllowed")))),
 			withKind("Service", named("team-a", "svc", anc(cond("Accepted", "False", "ResourceNotFound")))),
 		), "2/2 failed (team-a/gw:tls: NotAllowed; Service team-a/svc: ResourceNotFound)", true},
+		// The collision that qualifies a controller may be with an ancestor that
+		// SUCCEEDED: two controllers on one Gateway, one failing, must still say
+		// which one failed.
+		{"a collision with a successful ancestor still names the controller", policy(
+			withController("ctrl-a.example", named("team-a", "gw", anc(cond("Accepted", "False", "NotAllowed")))),
+			withController("ctrl-b.example", named("team-a", "gw", anc(cond("Accepted", "True", "")))),
+			named("", "gw-b", anc(cond("Accepted", "False", "ResourceNotFound"))),
+		), "2/3 failed (team-a/gw (ctrl-a.example): NotAllowed; gw-b: ResourceNotFound)", true},
+		// group and port are part of the composite key too: entries differing
+		// only by them must not render identically.
+		{"group and port ride in the label", policy(
+			withGroup("multicluster.x-k8s.io", withKind("ServiceImport", named("team-a", "svc", anc(cond("Accepted", "False", "NotAllowed"))))),
+			withPort(443, named("team-a", "gw", anc(cond("Accepted", "False", "ResourceNotFound")))),
+		), "2/2 failed (ServiceImport.multicluster.x-k8s.io team-a/svc: NotAllowed; team-a/gw:443: ResourceNotFound)", true},
 		// Reasons may be 1024 chars and foreign CRDs need not honor the
 		// 16-ancestor cap, so the list is bounded rather than trusted.
 		{"the detail list is capped", policy(

--- a/pkg/ai/context/summary_crd_test.go
+++ b/pkg/ai/context/summary_crd_test.go
@@ -201,9 +201,10 @@ func TestSummary_FluxHelmRelease(t *testing.T) {
 
 // Mirrors gateway-policy-status.test.ts. The two implementations feed the UI
 // and the MCP answers respectively, so they have to agree about every case a
-// controller actually produces. The one deliberate difference is the
-// reason-less fallback spelling ("NotAccepted" here, "Not Accepted" there) —
-// see policyProblem.
+// controller actually produces. Two deliberate differences: the reason-less
+// fallback spelling ("NotAccepted" here, "Not Accepted" there — see
+// policyProblem), and where per-ancestor failure detail goes on mixed reasons
+// (the UI has a tooltip; MCP only has the text, so here it rides in-text).
 func TestGatewayPolicyStatus(t *testing.T) {
 	cond := func(t, s, reason string) map[string]any {
 		c := map[string]any{"type": t, "status": s}


### PR DESCRIPTION
## Summary

A Gateway API policy failing on several ancestors for different reasons renders `2/3 failed` — accurate, but the operator then has to dig through the raw status tree to learn *which* Gateway failed with *what*.

The UI tooltip now carries the per-ancestor breakdown (`team-a/gw-a: NotAllowed; gw-b: ResourceNotFound`), and the MCP summary — which has no tooltip channel — appends the same list to its text: `2/3 failed (team-a/gw-a: NotAllowed; gw-b: ResourceNotFound)`.

Ancestor identity follows GEP-713's composite key (`ancestorRef` + `controllerName`): the label is namespace-qualified and always carries the short components — `sectionName`, `port`, and a non-default `kind`/`group`. The long `controllerName` is appended only when two labels would otherwise collide, and collisions are counted across **all** ancestors, so a failure colliding with a *success* on the same Gateway still says which controller failed. The list is capped at four entries plus `+N more` — condition reasons may be 1024 chars and foreign CRDs with an `ancestors` array need not honor Gateway API's 16-ancestor cap, so the output is bounded rather than trusted.

Single-reason failures are unchanged (`NotAllowed (2/2)` with the controller message as tooltip — the message is more informative than repeating the reason per ancestor).

## Testing

Mirrored TS/Go tests pin the exact strings: mixed reasons with and without names, colliding labels disambiguated by controller (including failure-vs-success collisions), section/kind/group/port in the label, and the cap. `make tsc`, all 38 gateway-policy-status Vitest cases, full `pkg/ai/context` suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only status formatting in UI and AI summaries; no control-plane or auth changes. Wrong labels could mislead debugging but behavior for single-reason failures is unchanged.
> 
> **Overview**
> When a Gateway API policy fails on several ancestors for **different reasons**, the badge still shows **`N/M failed`**, but operators now get a **per-ancestor breakdown** instead of digging through raw `status.ancestors`.
> 
> In **k8s-ui**, mixed failures populate the status **`reason`** (tooltip) with entries like `team-a/gw-a: NotAllowed; gw-b: ResourceNotFound`. Labels follow **GEP-713** identity (namespace, non-Gateway kind/group, `sectionName`, `port`); **`controllerName`** is added only when two ancestors would share the same label. The list is **capped at four** entries, then `+N more`. **Uniform** failures stay as before (e.g. `NotAllowed (2/2)` with the controller message as tooltip).
> 
> **MCP / `gatewayPolicyStatus`** mirrors the same labeling and cap, but embeds the list in the status string (no tooltip): `2/3 failed (team-a/gw-a: NotAllowed; gw-b: ResourceNotFound)`.
> 
> Vitest and Go tests pin the exact strings for collisions, section/kind/group/port, and the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36aad831d9515c4944719b00502325ac98efb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->