### PR TITLE
fix(timeline): preserve updates for colliding CRD kinds

### DIFF
--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -33,53 +33,72 @@ type FieldChange = k8score.FieldChange
 // kindDiffFunc is the per-kind diff dispatcher signature used by diffFunctions.
 type kindDiffFunc func(oldObj, newObj any) ([]FieldChange, []string)
 
+type kindDiffRegistration struct {
+	group string
+	diff  kindDiffFunc
+}
+
 // diffFunctions is the single source of truth for kinds with audited diff
 // coverage. ComputeDiff dispatches via this map, KindHasDiffer reads its
 // keys — no separate "kinds we know about" list to drift out of sync.
 //
-// Adding a kind here is a CONTRACT: the diff function MUST surface every
+// Adding a registration here is a CONTRACT: the diff function MUST surface every
 // status field a user would care about, because for kinds in this map,
 // recordToTimelineStore drops update events when the diff is empty.
-var diffFunctions = map[string]kindDiffFunc{
-	"Deployment":                     diffDeployment,
-	"Pod":                            diffPod,
-	"Service":                        diffService,
-	"ConfigMap":                      diffConfigMap,
-	"Secret":                         diffSecret,
-	"SealedSecret":                   diffSealedSecret,
-	"Ingress":                        diffIngress,
-	"ReplicaSet":                     diffReplicaSet,
-	"DaemonSet":                      diffDaemonSet,
-	"StatefulSet":                    diffStatefulSet,
-	"HorizontalPodAutoscaler":        diffHPA,
-	"Job":                            diffJob,
-	"Node":                           diffNode,
-	"PersistentVolumeClaim":          diffPVC,
-	"Application":                    diffApplication,
-	"Kustomization":                  diffKustomization,
-	"HelmRelease":                    diffFluxHelmRelease,
-	"GitRepository":                  func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "GitRepository") },
-	"OCIRepository":                  func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") },
-	"HelmRepository":                 func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") },
-	"Gateway":                        diffGateway,
-	"GatewayClass":                   diffGatewayClass,
-	"HTTPRoute":                      diffGatewayRoute,
-	"GRPCRoute":                      diffGatewayRoute,
-	"TCPRoute":                       diffGatewayRoute,
-	"TLSRoute":                       diffGatewayRoute,
-	"ReferenceGrant":                 diffReferenceGrant,
-	"ResourceQuota":                  diffResourceQuota,
-	"LimitRange":                     diffLimitRange,
-	"MutatingWebhookConfiguration":   diffAdmissionWebhookConfiguration,
-	"ValidatingWebhookConfiguration": diffAdmissionWebhookConfiguration,
-	"Rollout":                        diffRollout,
+// Versions within a group intentionally share a differ; a same-kind object
+// from any other group uses the generic unstructured differ instead.
+var diffFunctions = map[string]kindDiffRegistration{
+	"Deployment":                     {group: "apps", diff: diffDeployment},
+	"Pod":                            {group: "", diff: diffPod},
+	"Service":                        {group: "", diff: diffService},
+	"ConfigMap":                      {group: "", diff: diffConfigMap},
+	"Secret":                         {group: "", diff: diffSecret},
+	"SealedSecret":                   {group: "bitnami.com", diff: diffSealedSecret},
+	"Ingress":                        {group: "networking.k8s.io", diff: diffIngress},
+	"ReplicaSet":                     {group: "apps", diff: diffReplicaSet},
+	"DaemonSet":                      {group: "apps", diff: diffDaemonSet},
+	"StatefulSet":                    {group: "apps", diff: diffStatefulSet},
+	"HorizontalPodAutoscaler":        {group: "autoscaling", diff: diffHPA},
+	"Job":                            {group: "batch", diff: diffJob},
+	"Node":                           {group: "", diff: diffNode},
+	"PersistentVolumeClaim":          {group: "", diff: diffPVC},
+	"Application":                    {group: "argoproj.io", diff: diffApplication},
+	"Kustomization":                  {group: "kustomize.toolkit.fluxcd.io", diff: diffKustomization},
+	"HelmRelease":                    {group: "helm.toolkit.fluxcd.io", diff: diffFluxHelmRelease},
+	"GitRepository":                  {group: "source.toolkit.fluxcd.io", diff: func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "GitRepository") }},
+	"OCIRepository":                  {group: "source.toolkit.fluxcd.io", diff: func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") }},
+	"HelmRepository":                 {group: "source.toolkit.fluxcd.io", diff: func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") }},
+	"Gateway":                        {group: "gateway.networking.k8s.io", diff: diffGateway},
+	"GatewayClass":                   {group: "gateway.networking.k8s.io", diff: diffGatewayClass},
+	"HTTPRoute":                      {group: "gateway.networking.k8s.io", diff: diffGatewayRoute},
+	"GRPCRoute":                      {group: "gateway.networking.k8s.io", diff: diffGatewayRoute},
+	"TCPRoute":                       {group: "gateway.networking.k8s.io", diff: diffGatewayRoute},
+	"TLSRoute":                       {group: "gateway.networking.k8s.io", diff: diffGatewayRoute},
+	"ReferenceGrant":                 {group: "gateway.networking.k8s.io", diff: diffReferenceGrant},
+	"ResourceQuota":                  {group: "", diff: diffResourceQuota},
+	"LimitRange":                     {group: "", diff: diffLimitRange},
+	"MutatingWebhookConfiguration":   {group: "admissionregistration.k8s.io", diff: diffAdmissionWebhookConfiguration},
+	"ValidatingWebhookConfiguration": {group: "admissionregistration.k8s.io", diff: diffAdmissionWebhookConfiguration},
+	"Rollout":                        {group: "argoproj.io", diff: diffRollout},
 }
 
-// ComputeDiff computes the diff between old and new objects based on kind.
-// Returns nil if the kind has no audited diff function or if no meaningful
+// ComputeDiff computes the diff between old and new objects based on kind and
+// API group. Returns nil when the inputs cannot be diffed or no meaningful
 // changes were detected.
 func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
-	fn, ok := diffFunctions[kind]
+	registration, ok := diffFunctions[kind]
+	oldAPIVersion := extractAPIVersion(oldObj)
+	newAPIVersion := extractAPIVersion(newObj)
+	if oldAPIVersion != "" && newAPIVersion != "" && GroupFromAPIVersion(oldAPIVersion) != GroupFromAPIVersion(newAPIVersion) {
+		return nil
+	}
+	apiVersion := newAPIVersion
+	if apiVersion == "" {
+		apiVersion = oldAPIVersion
+	}
+	if ok && apiVersion != "" && GroupFromAPIVersion(apiVersion) != registration.group {
+		ok = false
+	}
 	if !ok {
 		oldU, newU, ok := unstructuredPair(oldObj, newObj)
 		if !ok {
@@ -91,7 +110,11 @@ func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 		}
 		return buildDiff(changes, summaryParts)
 	}
-	changes, summaryParts := fn(oldObj, newObj)
+	if oldU, newU, unstructured := unstructuredPair(oldObj, newObj); unstructured {
+		oldObj = diffInputForUnstructured(kind, oldU)
+		newObj = diffInputForUnstructured(kind, newU)
+	}
+	changes, summaryParts := registration.diff(oldObj, newObj)
 	if len(changes) == 0 {
 		return nil
 	}
@@ -103,7 +126,7 @@ func ComputeDiffFromUnstructured(kind string, oldU, newU *unstructured.Unstructu
 	if oldU == nil || newU == nil {
 		return nil
 	}
-	return ComputeDiff(kind, diffInputForUnstructured(kind, oldU), diffInputForUnstructured(kind, newU))
+	return ComputeDiff(kind, oldU, newU)
 }
 
 func diffInputForUnstructured(kind string, u *unstructured.Unstructured) any {

--- a/internal/k8s/history_group_dispatch_test.go
+++ b/internal/k8s/history_group_dispatch_test.go
@@ -1,0 +1,183 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestComputeDiff_CoreJobKeepsAuditedDiffer(t *testing.T) {
+	oldJob := &batchv1.Job{Status: batchv1.JobStatus{Active: 1}}
+	newJob := oldJob.DeepCopy()
+	newJob.Status.Active = 2
+
+	for _, test := range []struct {
+		name string
+		old  any
+		new  any
+	}{
+		{name: "typed", old: oldJob, new: newJob},
+		{name: "matching unstructured", old: jobAsUnstructured(t, oldJob), new: jobAsUnstructured(t, newJob)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			diff := ComputeDiff("Job", test.old, test.new)
+			if diff == nil || !containsPath(diff, "status.active") {
+				t.Fatalf("core batch Job lost its audited diff: %+v", diff)
+			}
+		})
+	}
+
+	diff := ComputeDiffFromUnstructured("Job", jobAsUnstructured(t, oldJob), jobAsUnstructured(t, newJob))
+	if diff == nil || !containsPath(diff, "status.active") {
+		t.Fatalf("unstructured entry point lost the core Job audited diff: %+v", diff)
+	}
+}
+
+func TestComputeDiff_CollidingCRDsUseGenericDiffer(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		oldObject  map[string]any
+		newObject  map[string]any
+	}{
+		{
+			name:       "Volcano Job",
+			apiVersion: "batch.volcano.sh/v1alpha1",
+			kind:       "Job",
+			oldObject:  map[string]any{"status": map[string]any{"state": map[string]any{"phase": "Pending"}}},
+			newObject:  map[string]any{"status": map[string]any{"state": map[string]any{"phase": "Running"}}},
+		},
+		{
+			name:       "Istio Gateway",
+			apiVersion: "networking.istio.io/v1",
+			kind:       "Gateway",
+			oldObject:  map[string]any{"spec": map[string]any{"servers": []any{}}},
+			newObject:  map[string]any{"spec": map[string]any{"servers": []any{map[string]any{"port": map[string]any{"number": int64(443)}}}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldObject := collisionObject(test.apiVersion, test.kind, test.oldObject)
+			newObject := collisionObject(test.apiVersion, test.kind, test.newObject)
+			diff := ComputeDiff(test.kind, oldObject, newObject)
+			if diff == nil || !containsPath(diff, "resource") {
+				t.Fatalf("colliding CRD update did not use the generic differ: %+v", diff)
+			}
+			fromUnstructured := ComputeDiffFromUnstructured(test.kind, oldObject, newObject)
+			if fromUnstructured == nil || !containsPath(fromUnstructured, "resource") {
+				t.Fatalf("unstructured entry point did not use the generic differ: %+v", fromUnstructured)
+			}
+		})
+	}
+}
+
+func TestComputeDiff_MatchingAuditedCRDKeepsCuratedDiffer(t *testing.T) {
+	oldApplication := collisionObject("argoproj.io/v1alpha1", "Application", map[string]any{
+		"status": map[string]any{"sync": map[string]any{"status": "Synced"}},
+	})
+	newApplication := collisionObject("argoproj.io/v1alpha1", "Application", map[string]any{
+		"status": map[string]any{"sync": map[string]any{"status": "OutOfSync"}},
+	})
+
+	diff := ComputeDiff("Application", oldApplication, newApplication)
+	if diff == nil || !containsPath(diff, "status.sync.status") {
+		t.Fatalf("Argo Application lost its curated diff: %+v", diff)
+	}
+}
+
+func TestComputeDiff_CollidingCRDReconcileChurnStillDrops(t *testing.T) {
+	oldJob := collisionObject("batch.volcano.sh/v1alpha1", "Job", map[string]any{
+		"status": map[string]any{"state": map[string]any{"phase": "Running", "lastTransitionTime": "2026-08-31T10:00:00Z"}},
+	})
+	newJob := oldJob.DeepCopy()
+	newJob.SetResourceVersion("2")
+	if err := unstructured.SetNestedField(newJob.Object, "2026-08-31T10:01:00Z", "status", "state", "lastTransitionTime"); err != nil {
+		t.Fatalf("set transition time: %v", err)
+	}
+
+	if diff := ComputeDiff("Job", oldJob, newJob); diff != nil {
+		t.Fatalf("reconcile-only metadata churn produced a diff: %+v", diff)
+	}
+}
+
+func TestComputeDiff_DifferentAPIGroupsAreNotDiffed(t *testing.T) {
+	oldApplication := collisionObject("example.com/v1", "Application", map[string]any{
+		"status": map[string]any{"phase": "Ready"},
+	})
+	newApplication := collisionObject("argoproj.io/v1alpha1", "Application", map[string]any{
+		"status": map[string]any{"sync": map[string]any{"status": "Synced"}},
+	})
+
+	if diff := ComputeDiff("Application", oldApplication, newApplication); diff != nil {
+		t.Fatalf("different API-group identities were diffed as one resource: %+v", diff)
+	}
+}
+
+func TestRecordToTimelineStore_CollidingCRDUpdateSurvives(t *testing.T) {
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(timeline.ResetStore)
+
+	oldJob := collisionObject("batch.volcano.sh/v1alpha1", "Job", map[string]any{
+		"status": map[string]any{"state": map[string]any{"phase": "Pending"}},
+	})
+	newJob := collisionObject("batch.volcano.sh/v1alpha1", "Job", map[string]any{
+		"status": map[string]any{"state": map[string]any{"phase": "Running"}},
+	})
+	newJob.SetResourceVersion("2")
+
+	diff := ComputeDiff("Job", oldJob, newJob)
+	recordToTimelineStore(ActiveClusterContext(), "Job", "gpu-demo", "collision-demo", "volcano-job-uid", "update", oldJob, newJob, diff, true)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Job"}, Namespaces: []string{"gpu-demo"},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 1 || events[0].Diff == nil {
+		t.Fatalf("Volcano Job update disappeared from the timeline: %+v", events)
+	}
+	if events[0].APIVersion != "batch.volcano.sh/v1alpha1" {
+		t.Fatalf("timeline apiVersion = %q", events[0].APIVersion)
+	}
+}
+
+func collisionObject(apiVersion, kind string, body map[string]any) *unstructured.Unstructured {
+	object := map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":            "collision-demo",
+			"namespace":       "gpu-demo",
+			"uid":             "volcano-job-uid",
+			"resourceVersion": "1",
+		},
+	}
+	for key, value := range body {
+		object[key] = value
+	}
+	return &unstructured.Unstructured{Object: object}
+}
+
+func jobAsUnstructured(t *testing.T, job *batchv1.Job) *unstructured.Unstructured {
+	t.Helper()
+	job = job.DeepCopy()
+	job.TypeMeta = metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"}
+	job.UID = types.UID("core-job-uid")
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(job)
+	if err != nil {
+		t.Fatalf("convert Job: %v", err)
+	}
+	return &unstructured.Unstructured{Object: object}
+}


### PR DESCRIPTION
## Why this matters

Radar's GPU, batch, and AI/ML expansion added many CRDs and exposed a general Kubernetes identity gap: Kind alone is not unique across API groups. Timeline diff dispatch was Kind-only, so a colliding CRD could be sent to an unrelated typed differ and its updates could disappear.

This change keeps updates truthful for examples such as core Job versus Volcano Job and Gateway API Gateway versus Istio Gateway.

## Where this fits

This is an independent Timeline identity foundation. It makes shared observation surfaces reliable before deeper Kueue, Volcano, Ray, training, and inference workflows; it does not claim deep semantics for all 37 curated ecosystem kinds.

Related slices:

- #1548 restores generic creation extraction for colliding CRDs, with a separate event-ID gate documented there.
- #1549 → #1553 make recreate and persisted seen identity API-group-aware.
- #1560 carries the same identity invariant through Timeline grouping, Topology, Applications, navigation, REST, and MCP.

This PR has no dependency on those slices.

## What changed

- Associate each audited Timeline differ with its canonical API group while remaining version-tolerant within that group.
- Preserve `apiVersion` through unstructured dispatch and convert to typed objects only after the group matches.
- Route same-Kind resources from another group through the generic unstructured differ.
- Refuse to diff old and new objects from different API groups.
- Keep Timeline event and persistence schemas unchanged.

## Review focus

- An audited typed differ runs only for its registered API group.
- Served-version changes within that group remain supported.
- Foreign-group collisions take the generic path instead of disappearing.
- Cross-group old/new pairs never fabricate a change.
- Existing no-diff reconcile filtering remains intact.

## Boundaries

This does not change historical-event IDs, recreate-stash keys, persisted seen keys, Timeline grouping, Topology, Applications, or UI layout.

## Verification

- `make tsc`
- `make test`
- `make build`
- Focused `internal/k8s` coverage for typed and unstructured core Jobs, Volcano Job, Istio Gateway, Argo Application, no-diff reconcile churn, cross-group identity, and Timeline recording
- `internal/helm` coverage for the unstructured Helm diff caller
- Visual test skipped: no rendered UI change

## Ship status

Ready as an independent foundation slice.
