### PR TITLE
Prepare CRD creation history for kind collisions

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -1044,7 +1044,9 @@ func extractTimelineHistoricalEvents(clusterContext, kind, apiVersion, namespace
 			}
 		}
 
-	default:
+	}
+
+	if len(events) == 0 {
 		if u, ok := obj.(*unstructured.Unstructured); ok {
 			ct := u.GetCreationTimestamp()
 			if !ct.IsZero() {

--- a/internal/k8s/timeline_historical_collision_test.go
+++ b/internal/k8s/timeline_historical_collision_test.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractTimelineHistoricalEvents_UnstructuredKindCollisionsKeepCreatedEvent(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+	}{
+		{name: "Volcano Job", apiVersion: "batch.volcano.sh/v1alpha1", kind: "Job"},
+		{name: "Knative Service", apiVersion: "serving.knative.dev/v1", kind: "Service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := historicalUnstructured(tt.apiVersion, tt.kind, createdAt)
+			events := extractTimelineHistoricalEvents("cluster-a", tt.kind, tt.apiVersion, "gpu-demo", "collision", obj, nil, nil)
+
+			assertSingleCreatedHistoricalEvent(t, events, tt.apiVersion, createdAt)
+		})
+	}
+}
+
+func TestExtractTimelineHistoricalEvents_GenericUnstructuredKeepsCreatedEvent(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
+	obj := historicalUnstructured("example.io/v1", "Widget", createdAt)
+
+	events := extractTimelineHistoricalEvents("cluster-a", "Widget", "example.io/v1", "gpu-demo", "generic", obj, nil, nil)
+
+	assertSingleCreatedHistoricalEvent(t, events, "example.io/v1", createdAt)
+}
+
+func TestExtractTimelineHistoricalEvents_UnstructuredWithoutCreationTimestampEmitsNothing(t *testing.T) {
+	obj := historicalUnstructured("batch.volcano.sh/v1alpha1", "Job", time.Time{})
+
+	events := extractTimelineHistoricalEvents("cluster-a", "Job", "batch.volcano.sh/v1alpha1", "gpu-demo", "collision", obj, nil, nil)
+
+	if len(events) != 0 {
+		t.Fatalf("historical events = %+v, want none", events)
+	}
+}
+
+func TestExtractTimelineHistoricalEvents_TypedCoreJobDoesNotDuplicateCreatedEvent(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 31, 13, 0, 0, 0, time.UTC)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:              "core-job",
+		Namespace:         "gpu-demo",
+		CreationTimestamp: metav1.NewTime(createdAt),
+	}}
+
+	events := extractTimelineHistoricalEvents("cluster-a", "Job", "", "gpu-demo", "core-job", job, nil, nil)
+
+	assertSingleCreatedHistoricalEvent(t, events, "", createdAt)
+}
+
+func historicalUnstructured(apiVersion, kind string, createdAt time.Time) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	obj.SetNamespace("gpu-demo")
+	obj.SetName("collision")
+	obj.SetCreationTimestamp(metav1.NewTime(createdAt))
+	return obj
+}
+
+func assertSingleCreatedHistoricalEvent(t *testing.T, events []timeline.TimelineEvent, apiVersion string, createdAt time.Time) {
+	t.Helper()
+	if len(events) != 1 {
+		t.Fatalf("historical events = %d, want exactly one: %+v", len(events), events)
+	}
+	event := events[0]
+	if event.Source != timeline.SourceHistorical || event.Reason != "created" {
+		t.Fatalf("historical event = %+v, want one created event", event)
+	}
+	if event.APIVersion != apiVersion {
+		t.Fatalf("apiVersion = %q, want %q", event.APIVersion, apiVersion)
+	}
+	if !event.Timestamp.Equal(createdAt) {
+		t.Fatalf("timestamp = %s, want %s", event.Timestamp, createdAt)
+	}
+}

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -108,6 +108,32 @@ func TestSQLiteStore_AppendBatch(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_HistoricalBuiltinKindCollisionsPersistSeparately(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	ts := time.Unix(1700000000, 0)
+	events := []TimelineEvent{
+		NewHistoricalEvent("cluster-a", "Job", "batch/v1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil),
+		NewHistoricalEvent("cluster-a", "Job", "batch.volcano.sh/v1alpha1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil),
+	}
+	for i := range events {
+		events[i].ClusterContext = "cluster-a"
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch failed: %v", err)
+	}
+
+	got, err := store.Query(ctx, QueryOptions{ClusterContext: "cluster-a", Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("historical collision events = %d, want 2: %+v", len(got), got)
+	}
+}
+
 func TestSQLiteStore_Query_Names(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()

--- a/pkg/timeline/converter.go
+++ b/pkg/timeline/converter.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // informerEventID derives a deterministic id from the resource's observable
@@ -99,8 +101,11 @@ func NewK8sEventTimelineEvent(event *corev1.Event, owner *OwnerInfo) TimelineEve
 // clusters with a same-named resource created at the same instant would collide
 // in one persistent store without it.
 func NewHistoricalEvent(clusterContext, kind, apiVersion, namespace, name string, ts time.Time, reason, message string, healthState HealthState, owner *OwnerInfo, labels map[string]string) TimelineEvent {
-	// Create deterministic ID from event attributes to avoid duplicates
-	hashInput := fmt.Sprintf("historical:%s:%s/%s/%s:%d:%s", clusterContext, kind, namespace, name, ts.UnixNano(), reason)
+	identityKind := kind
+	if group := historicalCollisionGroup(kind, apiVersion); group != "" {
+		identityKind = group + "/" + kind
+	}
+	hashInput := fmt.Sprintf("historical:%s:%s/%s/%s:%d:%s", clusterContext, identityKind, namespace, name, ts.UnixNano(), reason)
 	hash := sha256.Sum256([]byte(hashInput))
 	id := fmt.Sprintf("hist-%x", hash[:8]) // Use first 8 bytes for shorter ID
 
@@ -119,6 +124,23 @@ func NewHistoricalEvent(clusterContext, kind, apiVersion, namespace, name string
 		Owner:       owner,
 		Labels:      labels,
 	}
+}
+
+// Generic unstructured Kinds already shipped group-less historical IDs. Only
+// the typed-extractor collision path can be qualified without duplicating that
+// persisted history when an upgrade re-extracts resources.
+func historicalCollisionGroup(kind, apiVersion string) string {
+	switch kind {
+	case "Pod", "Deployment", "ReplicaSet", "StatefulSet", "DaemonSet",
+		"Service", "Ingress", "CronJob", "HorizontalPodAutoscaler", "Job":
+	default:
+		return ""
+	}
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil || gv.Group == "" || gv.Group == resourceid.GroupForBuiltinKind(kind) {
+		return ""
+	}
+	return gv.Group
 }
 
 // ExtractOwner gets the controller owner reference from an object

--- a/pkg/timeline/converter_id_test.go
+++ b/pkg/timeline/converter_id_test.go
@@ -67,6 +67,39 @@ func TestHistoricalEventID_ClusterQualified(t *testing.T) {
 	}
 }
 
+func TestHistoricalEventID_BuiltinKindCollisionUsesAPIGroup(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+	core := NewHistoricalEvent("cluster-a", "Job", "batch/v1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	volcano := NewHistoricalEvent("cluster-a", "Job", "batch.volcano.sh/v1alpha1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	if core.ID == volcano.ID {
+		t.Fatalf("historical ids collide across core and Volcano Jobs: %q", core.ID)
+	}
+}
+
+func TestHistoricalEventID_BuiltinCompatibilityAndCustomVersionTolerance(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+	legacyCore := NewHistoricalEvent("cluster-a", "Job", "", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	if legacyCore.ID != "hist-4c4cfecb256e14b8" {
+		t.Fatalf("legacy built-in historical id changed: %q", legacyCore.ID)
+	}
+	canonicalCore := NewHistoricalEvent("cluster-a", "Job", "batch/v1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	if legacyCore.ID != canonicalCore.ID {
+		t.Fatalf("canonical built-in apiVersion changed the legacy historical id: %q vs %q", legacyCore.ID, canonicalCore.ID)
+	}
+
+	v1alpha1 := NewHistoricalEvent("cluster-a", "Job", "batch.volcano.sh/v1alpha1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	v1beta1 := NewHistoricalEvent("cluster-a", "Job", "batch.volcano.sh/v1beta1", "team-a", "train", ts, "created", "", HealthUnknown, nil, nil)
+	if v1alpha1.ID != v1beta1.ID {
+		t.Fatalf("served versions in one API group must share a historical id: %q vs %q", v1alpha1.ID, v1beta1.ID)
+	}
+
+	legacyGeneric := NewHistoricalEvent("cluster-a", "NetworkPolicy", "", "team-a", "guard", ts, "created", "", HealthUnknown, nil, nil)
+	calico := NewHistoricalEvent("cluster-a", "NetworkPolicy", "projectcalico.org/v3", "team-a", "guard", ts, "created", "", HealthUnknown, nil, nil)
+	if legacyGeneric.ID != calico.ID {
+		t.Fatalf("existing generic CRD history changed id during upgrade: %q vs %q", legacyGeneric.ID, calico.ID)
+	}
+}
+
 // The GitOps identity labels must survive the grouping filter — the server's
 // argo:/helm: app matchKeys join deleted members' events by exactly these.
 func TestExtractLabels_KeepsGitOpsIdentityLabels(t *testing.T) {


### PR DESCRIPTION
## Why this matters

Radar's GPU, batch, and AI/ML expansion exposed a general CRD observation gap: a dynamic resource whose Kind matches a typed Kubernetes resource could enter the typed history switch, emit nothing, and lose its startup creation event. Volcano Job and Knative Service are concrete examples.

This PR prepares the extraction and durable-ID portions of that fix. On this branch alone, the earlier Kind/namespace/name seen guard can still suppress a same-named CRD before extraction; #1553’s group-aware seen identity is required for the end-to-end behavior.

## Where this fits

This is an independent Timeline history slice in the broader API-group identity foundation. That foundation makes shared Timeline, Topology, Applications, and AI/MCP surfaces truthful before deeper ecosystem verticals; it does not claim deep semantics for all 37 curated kinds.

- #1545 scopes live diff dispatch by API group.
- #1549 → #1553 make recreate and persisted seen identity group-aware.
- #1560 carries identity through grouping, Topology, Applications, navigation, REST, and MCP.

This slice is reviewable independently, but it is not a complete shippable fix until #1553 is underneath it and the combined production path is retested.

## What changed

- Fall back to generic unstructured creation extraction only when Kind-specific extraction emitted no events.
- Preserve the typed path and avoid duplicate creation events for core resources.
- Group-qualify historical IDs only for the 10 Kinds whose typed extractors previously swallowed colliding unstructured resources: Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, Service, Ingress, CronJob, HorizontalPodAutoscaler, and Job.
- Preserve legacy IDs for canonical built-ins and generic CRDs that already emitted history, including Calico NetworkPolicy.
- Keep alternate served versions within one custom API group on the same deterministic ID.

## Review focus

- Generic fallback runs only when specialized extraction emitted nothing.
- Canonical built-in IDs remain byte-for-byte compatible with persisted history.
- Existing generic-CRD IDs do not change during upgrade.
- Foreign-group collisions among the 10 eligible Kinds separate by API group but not served version.
- Direct memory and SQLite store tests retain both same-second core Job and Volcano Job events; the current startup path does not yet deliver both events to those stores without #1553.

## Boundaries

This fixes collisions introduced by the typed historical extractor. Custom-vs-custom historical collisions for non-eligible Kinds, such as CAPI Cluster versus CloudNativePG Cluster, remain outside this slice. Seen/recreate identity, Timeline grouping, Topology, and Applications are handled by the related PRs above. There is no UI change.

## Verification

- `cd pkg && go test -count=1 ./resourceid ./timeline`
- `go test -count=1 ./internal/timeline ./internal/k8s`
- `cd pkg && go test -race -count=1 ./timeline -run 'TestHistoricalEventID_'`
- `go test -race -count=1 ./internal/timeline -run 'TestSQLiteStore_HistoricalBuiltinKindCollisionsPersistSeparately'`
- `make test`
- `make build`
- Golden assertion pins the pre-change built-in historical ID.
- Fresh SQLite regression proves same-second core Job and Volcano Job creation events persist separately.
- Extraction coverage includes Volcano Job, Knative Service, ordinary unstructured resources, typed core Job deduplication, and missing timestamps.
- Exact-head live smoke against same-named core and Volcano Jobs: both resources were received, but the Volcano add was dropped as `already_seen`; only core history remained. This is the known #1553 dependency, not a passing end-to-end result.
- Visual test skipped: no rendered UI change.

## Ship status

Draft. Unit, race, and SQLite coverage for this slice pass, but the advertised end-to-end fix does not work on this branch alone. Restack or rebase on #1553, add a production-path regression for the same-name core and Volcano Job pair, and repeat the live smoke before marking ready.
