### PR TITLE
Isolate Timeline recreate joins by API group

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -23,9 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	toolscache "k8s.io/client-go/tools/cache"
 
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/k8score"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -702,6 +704,14 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	if obj == nil {
 		obj = oldObj
 	}
+	if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	apiVersion := extractAPIVersion(obj)
+	apiGroup := resourceid.GroupForBuiltinKind(kind)
+	if apiVersion != "" {
+		apiGroup = GroupFromAPIVersion(apiVersion)
+	}
 
 	resourceVersion := ""
 	if obj != nil {
@@ -711,18 +721,16 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	}
 
 	if op == "delete" {
-		stashDeletedForRecreate(kind, namespace, name, uid, obj)
+		stashDeletedForRecreate(apiGroup, kind, namespace, name, uid, obj)
 	}
 
 	// One extraction of owner/labels/createdAt, reused for both the event and
-	// the tombstone. ExtractTombstoneEntry unwraps DeletedFinalStateUnknown, so
-	// a delete whose payload is that wrapper still yields the final object.
+	// the tombstone.
 	entry, extracted := timeline.ExtractTombstoneEntry(obj)
 	owner := entry.Owner
 	labels := entry.Labels
 	createdAt := entry.CreatedAt
 	healthState := classifyTimelineHealth(kind, obj, time.Now())
-	apiVersion := extractAPIVersion(obj)
 
 	// Feed the tombstone on every add/update/delete. While the object is live
 	// this mirrors its enrichment; once it is gone (delete, or a late K8s event
@@ -779,10 +787,11 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	}
 
 	// Recreate-join: an add that replaces a just-deleted object of the same
-	// name but a different UID carries the diff against its predecessor, so
-	// the change feed can show what the recreate changed instead of a
-	// contentless delete+add pair. Guarded to young objects post-sync — the
-	// same conditions under which the add below is recorded at all.
+	// group, kind, namespace, and name but a different UID carries the diff
+	// against its predecessor, so the change feed can show what the recreate
+	// changed instead of a contentless delete+add pair. Guarded to young
+	// objects post-sync — the same conditions under which the add below is
+	// recorded at all.
 	//
 	// Status is stripped from BOTH sides before diffing: every recreate
 	// resets status, so cross-recreate status deltas (ready 1→0, condition
@@ -792,7 +801,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	recreated := false
 	if op == "add" && newObj != nil && initialSyncComplete {
 		if meta, ok := newObj.(metav1.Object); ok && time.Since(meta.GetCreationTimestamp().Time) <= 30*time.Second {
-			if stashed, ok := takeRecreateMatch(kind, namespace, name, uid); ok {
+			if stashed, ok := takeRecreateMatch(apiGroup, kind, namespace, name, uid); ok {
 				if localDiff := ComputeDiff(kind, stripStatusForRecreateDiff(stashed), stripStatusForRecreateDiff(newObj)); localDiff != nil && len(localDiff.Fields) > 0 {
 					diff = &timeline.DiffInfo{
 						Fields:  make([]timeline.FieldChange, len(localDiff.Fields)),
@@ -894,9 +903,8 @@ func isUnstructuredUpdate(oldObj, newObj any) bool {
 }
 
 // extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")
-// for unstructured/CRD objects. Typed informer objects strip kind/apiVersion, so they
-// fall through to "" — the navigation layer treats an empty group as "core/typed kind",
-// which is correct since core kinds don't collide.
+// for unstructured objects. Typed informer objects have empty TypeMeta after decoding;
+// identity call sites recover their group from resourceid.GroupForBuiltinKind.
 func extractAPIVersion(obj any) string {
 	if u, ok := obj.(*unstructured.Unstructured); ok {
 		return u.GetAPIVersion()

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -12,8 +13,9 @@ import (
 // apply, Argo Replace=true, immutable-field edits) reaches the timeline as a
 // contentless delete + add pair: the old object is gone by the time the add
 // arrives, so there is nothing to diff against. The stash keeps the last-seen
-// object of recently deleted resources so the next add under the same name —
-// with a different UID — can be diffed against what it replaced.
+// object of recently deleted resources so the next add under the same API
+// group, kind, namespace, and name — with a different UID — can be diffed
+// against what it replaced.
 //
 // In-memory only: entries expire after recreateJoinTTL, the store is capped,
 // and a cluster-context switch clears it. The timeline itself still records
@@ -69,13 +71,13 @@ var (
 	recreateStash   = map[string]recreateEntry{}
 )
 
-func recreateKey(kind, namespace, name string) string {
-	return kind + "/" + namespace + "/" + name
+func recreateKey(group, kind, namespace, name string) string {
+	return resourceid.ResourceKey(group, kind, namespace, name)
 }
 
 // stashDeletedForRecreate records a deleted object for a potential
 // recreate-join. No-op for kinds outside the allowlist.
-func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
+func stashDeletedForRecreate(group, kind, namespace, name, uid string, obj any) {
 	if obj == nil || !recreateStashKinds[kind] {
 		return
 	}
@@ -84,23 +86,23 @@ func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
 	if len(recreateStash) >= recreateStashCap {
 		evictRecreateStashLocked()
 	}
-	recreateStash[recreateKey(kind, namespace, name)] = recreateEntry{
+	recreateStash[recreateKey(group, kind, namespace, name)] = recreateEntry{
 		obj:       obj,
 		uid:       uid,
 		deletedAt: time.Now(),
 	}
 }
 
-// takeRecreateMatch returns the stashed predecessor of kind/ns/name when the
-// new UID differs and the delete is within the join TTL. The entry is
+// takeRecreateMatch returns the stashed predecessor of group/kind/ns/name when
+// the new UID differs and the delete is within the join TTL. The entry is
 // consumed (or discarded, if stale or same-UID) either way.
-func takeRecreateMatch(kind, namespace, name, newUID string) (any, bool) {
+func takeRecreateMatch(group, kind, namespace, name, newUID string) (any, bool) {
 	if !recreateStashKinds[kind] {
 		return nil, false
 	}
 	recreateStashMu.Lock()
 	defer recreateStashMu.Unlock()
-	key := recreateKey(kind, namespace, name)
+	key := recreateKey(group, kind, namespace, name)
 	entry, ok := recreateStash[key]
 	if !ok {
 		return nil, false

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	toolscache "k8s.io/client-go/tools/cache"
 
 	"github.com/skyhook-io/radar/internal/timeline"
 )
@@ -127,18 +128,149 @@ func TestRecreateJoin_SameUIDReAdd_NoJoin(t *testing.T) {
 	}
 }
 
+func TestRecreateJoin_CrossGroupAddDoesNotConsumeDeletedService(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	deletedCore := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:              "api",
+		Namespace:         "shop",
+		UID:               types.UID("core-uid-1"),
+		CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+	}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "core-uid-1", "delete", nil, deletedCore, nil, false)
+
+	knative := &unstructured.Unstructured{}
+	knative.SetAPIVersion("serving.knative.dev/v1")
+	knative.SetKind("Service")
+	knative.SetNamespace("shop")
+	knative.SetName("api")
+	knative.SetUID(types.UID("knative-uid-1"))
+	knative.SetCreationTimestamp(metav1.Now())
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "knative-uid-1", "add", nil, knative, nil, false)
+
+	store := timeline.GetStore()
+	// Seen identity is a separate contract; clear it so this test isolates the recreate stash.
+	store.ClearResourceSeen(ActiveClusterContext(), "Service", "shop", "api")
+	recreatedCore := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:              "api",
+		Namespace:         "shop",
+		UID:               types.UID("core-uid-2"),
+		CreationTimestamp: metav1.Now(),
+	}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080}}}}
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "core-uid-2", "add", nil, recreatedCore, nil, false)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Service"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("add events = %d, want 2: %+v", len(events), events)
+	}
+	var knativeAdd, coreRecreate *timeline.TimelineEvent
+	for i := range events {
+		switch events[i].UID {
+		case "knative-uid-1":
+			knativeAdd = &events[i]
+		case "core-uid-2":
+			coreRecreate = &events[i]
+		}
+	}
+	if knativeAdd == nil || knativeAdd.APIVersion != "serving.knative.dev/v1" || knativeAdd.Reason == timeline.ReasonRecreated {
+		t.Fatalf("cross-group add was treated as a recreate: %+v", knativeAdd)
+	}
+	if coreRecreate == nil || coreRecreate.Reason != timeline.ReasonRecreated || coreRecreate.Diff == nil || len(coreRecreate.Diff.Fields) == 0 {
+		t.Fatalf("same-group core Service did not consume its recreate stash: %+v", coreRecreate)
+	}
+}
+
+func TestRecreateJoin_KnativeDeleteTombstonePreservesGroupAndObject(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	deletedKnative := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "serving.knative.dev/v1",
+		"kind":       "Service",
+		"metadata": map[string]any{
+			"name":              "api",
+			"namespace":         "shop",
+			"uid":               "knative-uid-1",
+			"creationTimestamp": time.Now().Add(-time.Hour).Format(time.RFC3339),
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{map[string]any{"image": "example/api:v1"}},
+				},
+			},
+		},
+	}}
+	recordToTimelineStore(
+		ActiveClusterContext(),
+		"Service",
+		"shop",
+		"api",
+		"knative-uid-1",
+		"delete",
+		nil,
+		toolscache.DeletedFinalStateUnknown{Key: "shop/api", Obj: deletedKnative},
+		nil,
+		false,
+	)
+
+	core := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:              "api",
+		Namespace:         "shop",
+		UID:               types.UID("core-uid-1"),
+		CreationTimestamp: metav1.Now(),
+	}}
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "core-uid-1", "add", nil, core, nil, false)
+
+	stashed, ok := takeRecreateMatch("serving.knative.dev", "Service", "shop", "api", "knative-uid-2")
+	if !ok {
+		t.Fatal("cross-group core Service add consumed the wrapped Knative Service stash")
+	}
+	stashedKnative, ok := stashed.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("stashed predecessor = %T, want *unstructured.Unstructured", stashed)
+	}
+	if stashedKnative != deletedKnative {
+		t.Fatal("recreate stash did not preserve the original unstructured tombstone object")
+	}
+}
+
 func TestTakeRecreateMatch_TTLExpiry(t *testing.T) {
 	resetRecreateStash()
 	defer resetRecreateStash()
 
 	recreateStashMu.Lock()
-	recreateStash[recreateKey("Deployment", "shop", "web")] = recreateEntry{
+	recreateStash[recreateKey("apps", "Deployment", "shop", "web")] = recreateEntry{
 		obj: testDeployment("uid-1", "nginx:1.0", time.Now()), uid: "uid-1",
 		deletedAt: time.Now().Add(-recreateJoinTTL - time.Minute),
 	}
 	recreateStashMu.Unlock()
 
-	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+	if _, ok := takeRecreateMatch("apps", "Deployment", "shop", "web", "uid-2"); ok {
 		t.Fatal("expired stash entry must not join")
 	}
 	recreateStashMu.Lock()
@@ -153,14 +285,14 @@ func TestRecreateStash_KindGateAndReset(t *testing.T) {
 	resetRecreateStash()
 	defer resetRecreateStash()
 
-	stashDeletedForRecreate("Pod", "shop", "p", "uid-1", &corev1.Pod{})
-	if _, ok := takeRecreateMatch("Pod", "shop", "p", "uid-2"); ok {
+	stashDeletedForRecreate("", "Pod", "shop", "p", "uid-1", &corev1.Pod{})
+	if _, ok := takeRecreateMatch("", "Pod", "shop", "p", "uid-2"); ok {
 		t.Fatal("Pod is outside the stash allowlist")
 	}
 
-	stashDeletedForRecreate("Deployment", "shop", "web", "uid-1", testDeployment("uid-1", "nginx:1.0", time.Now()))
+	stashDeletedForRecreate("apps", "Deployment", "shop", "web", "uid-1", testDeployment("uid-1", "nginx:1.0", time.Now()))
 	resetRecreateStash()
-	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+	if _, ok := takeRecreateMatch("apps", "Deployment", "shop", "web", "uid-2"); ok {
 		t.Fatal("reset must clear the stash")
 	}
 }
@@ -170,7 +302,7 @@ func TestRecreateStash_CapEviction(t *testing.T) {
 	defer resetRecreateStash()
 
 	for i := 0; i < recreateStashCap+100; i++ {
-		stashDeletedForRecreate("ConfigMap", "shop", fmt.Sprintf("cm-%d", i), fmt.Sprintf("uid-%d", i), &corev1.ConfigMap{})
+		stashDeletedForRecreate("", "ConfigMap", "shop", fmt.Sprintf("cm-%d", i), fmt.Sprintf("uid-%d", i), &corev1.ConfigMap{})
 	}
 	recreateStashMu.Lock()
 	size := len(recreateStash)
@@ -180,7 +312,7 @@ func TestRecreateStash_CapEviction(t *testing.T) {
 	}
 	// The newest entries must have survived eviction — recreates that matter
 	// happen seconds after the delete.
-	if _, ok := takeRecreateMatch("ConfigMap", "shop", fmt.Sprintf("cm-%d", recreateStashCap+99), "other-uid"); !ok {
+	if _, ok := takeRecreateMatch("", "ConfigMap", "shop", fmt.Sprintf("cm-%d", recreateStashCap+99), "other-uid"); !ok {
 		t.Fatal("newest entry was evicted; eviction must drop oldest first")
 	}
 }


### PR DESCRIPTION
## Why this matters

Radar's GPU, batch, and AI/ML expansion made same-Kind collisions common enough to expose a general identity bug. Timeline could associate a deleted built-in resource with a newly added CRD that reused the same Kind, namespace, and name, fabricating a recreate diff between unrelated objects.

This makes delete/recreate history truthful for examples such as core Service versus Knative Service.

## Where this fits

This is a foundational Timeline identity slice. It supports truthful shared Timeline, Topology, Applications, and AI/MCP behavior before deeper ecosystem verticals; it does not claim deep semantics for all 37 curated kinds.

- No upstream PR is required.
- #1553 is explicitly stacked on this PR and makes memory/SQLite seen identity group-aware.
- #1545 and #1548 are adjacent independent Timeline slices.
- #1560 carries the same identity invariant across Timeline grouping, Topology, Applications, navigation, REST, and MCP and should be reconciled after the Timeline stack.

## What changed

- Key recreate-stash entries by canonical API group, Kind, namespace, and name.
- Derive groups from dynamic object API versions and the built-in Kind mapping while excluding served version from the key.
- Unwrap Kubernetes `DeletedFinalStateUnknown` before group derivation and stashing, preserving the original unstructured predecessor.
- Preserve existing TTL, UID, capacity, reset, kind-gate, and same-group recreation behavior without changing EventStore APIs.
- Cover core Service versus Knative Service, including a tombstoned Knative delete followed by cross-group and same-group adds.

## Review focus

- Cross-group adds never consume a deleted object's stash entry.
- Same-group served-version changes remain joinable.
- Tombstones retain both group identity and the original object used for the later diff.
- UID, TTL, capacity eviction, reset, and kind gating remain unchanged.
- Concurrent stash access remains safe.

## Boundaries

This fixes only the ephemeral recreate bridge. Persisted seen identity is handled by downstream #1553; historical-event IDs are a separate #1548 ship gate; grouping and cross-surface identity remain in #1560. There is no UI change.

## Verification

- `go test ./internal/k8s -run 'Test(RecreateJoin|TakeRecreateMatch|RecreateStash|StripStatusForRecreateDiff)' -count=1`
- `go test ./internal/k8s -count=1`
- `go test -race ./internal/k8s -run 'Test(RecreateJoin|TakeRecreateMatch|RecreateStash|StripStatusForRecreateDiff)' -count=1`
- `make test`
- `make build` (includes frontend type-checking)
- Live cluster deletion/recreation was not run because it would destructively replace a fixture resource; the production-path unit and race tests exercise the delete/add/tombstone bridge directly
- Visual test skipped: internal Timeline identity correction with no UI change

## Ship status

Ready; merge before stacked #1553.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path Timeline identity for delete/recreate enrichment; wrong group derivation could miss valid joins or still mis-associate events, though behavior is bounded to in-memory stash with extensive new tests.
> 
> **Overview**
> Fixes Timeline **recreate-join** falsely linking unrelated resources that share Kind, namespace, and name (e.g. core `Service` vs Knative `Service`).
> 
> The ephemeral recreate stash now keys entries with **canonical API group + kind + namespace + name** via `resourceid.ResourceKey`, deriving group from unstructured `apiVersion` or `resourceid.GroupForBuiltinKind` for typed informer objects. **`recordToTimelineStore`** unwraps `DeletedFinalStateUnknown` before group derivation and stashing so tombstoned deletes keep the real predecessor object. Stash/take call sites (`stashDeletedForRecreate`, `takeRecreateMatch`) take an explicit `apiGroup`; TTL, UID checks, cap eviction, kind gating, and same-group recreate diffs are unchanged.
> 
> New tests cover cross-group adds not consuming another group’s stash, Knative tombstone deletes preserving group/object, and updated stash keys for built-ins (`apps`, empty core group).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ba08fa3fdd160c32da28c6a7f6608a60fce75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->