### PR TITLE
fix(topology): group chip/cardGrid hitbox extends outside the drawn box when zoomed in

### DIFF
--- a/packages/k8s-ui/src/components/topology/GroupNode.tsx
+++ b/packages/k8s-ui/src/components/topology/GroupNode.tsx
@@ -159,6 +159,10 @@ export const GroupNode = memo(function GroupNode({
     </div>
   )
 
+  // Chip and cardGrid roots must NOT counter-scale with zoom (group-header-scaled):
+  // the transform shrinks the visuals but the React Flow wrapper — the hitbox,
+  // drag target, and edge-attachment box — keeps the full ELK-computed size, so
+  // past zoom 0.7 the interactive area extends well outside the drawn box.
   // ── Level 1: Chip (compact collapsed card) ──
   if (displayLevel === 'chip') {
     // Size tier: 0-9 → 0, 10-99 → 1, 100-999 → 2, 1000+ → 3
@@ -178,7 +182,7 @@ export const GroupNode = memo(function GroupNode({
       <>
         {handles}
         <div
-          className="rounded-xl group-header-scaled overflow-hidden"
+          className="rounded-xl overflow-hidden"
           style={{ ...getBorderStyle(), ...getHeaderBgStyle(), padding: chipPadding, width: width || '100%', height: height || '100%' }}
         >
           {/* Header row: icon + name + count + status + controls */}
@@ -220,7 +224,7 @@ export const GroupNode = memo(function GroupNode({
       <>
         {handles}
         <div
-          className="rounded-xl overflow-hidden group-header-scaled"
+          className="rounded-xl overflow-hidden"
           style={{ ...getBorderStyle(), width: width || '100%', height: height || '100%' }}
         >
           {/* Header bar with level controls */}

--- a/packages/k8s-ui/src/components/topology/topology.css
+++ b/packages/k8s-ui/src/components/topology/topology.css
@@ -65,7 +65,10 @@
   box-shadow: none !important;
 }
 
-/* Group header scaling using CSS variable set by ViewportController */
+/* Group header scaling using CSS variable set by ViewportController.
+   Only safe on children INSIDE a group container (the expanded-group header row):
+   on a node's root content it desyncs the visible box from the React Flow
+   wrapper, whose full-size hitbox and edge anchors don't follow the transform. */
 .group-header-scaled {
   transform: scale(var(--group-header-scale, 1));
   transform-origin: top left;


### PR DESCRIPTION
## Problem

Zooming the topology past ~0.7 makes collapsed namespace **chips** (and card-grid groups) interactive well outside their visible border — hover, drag, and edge anchors all follow an invisible box that "stays as it was before zooming".

Root cause: the zoom-driven header scale (`--group-header-scale`, set by `ViewportController`) was applied to the *entire* chip/card-grid body. The `transform: scale()` shrinks the visuals toward the top-left corner, but the React Flow node wrapper — the actual hitbox, drag target, and edge-attachment box — keeps its full ELK-computed size. Measured live: at zoom 0.91 a chip draws at 280×73 px inside a 365×95 px interactive wrapper; at the 0.5 scale floor the drawn box is half the hitbox.

## Fix

Remove `group-header-scaled` from the chip and card-grid roots in `GroupNode.tsx`. The scale formula never exceeds 1 (it only shrinks past zoom 0.7), so zoomed-out rendering is unchanged — this only removes the zoomed-in shrink that desynced visuals from the wrapper. The class stays on the expanded-group header row, where it scales a child *inside* the container and hit-testing correctly follows the transform. Also documented the constraint on the CSS class.

## Verification

- DOM probes before/after: wrapper vs drawn-content rects now match exactly (Δ0 px) at every zoom; chip centers hit-test to themselves; points just outside the drawn border hit the pane.
- `make tsc` passes; all 23 topology unit tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/interaction fix in topology group rendering with no auth, data, or API changes; behavior change is limited to zoomed-in chip/card-grid hit targets.
> 
> **Overview**
> Fixes **misaligned interaction** for collapsed namespace **chips** and **card-grid** groups when the topology is zoomed in past ~0.7: hover, drag, and edge anchors no longer follow an invisible box larger than the drawn border.
> 
> **`group-header-scaled`** is removed from the **root** containers for chip and card-grid display levels in `GroupNode.tsx`. That class applies viewport-driven `transform: scale()`, which shrinks visuals but leaves the React Flow node wrapper at the full ELK size, so the hitbox stayed oversized. Scaling is **unchanged** on the expanded topology header row (inner child only), where hit-testing still matches.
> 
> Comments in `GroupNode.tsx` and `topology.css` document that **`group-header-scaled` must not** be applied to a node’s root content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03043f99168663885e8973cdec6a06a529e05900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->