### PR TITLE
fix(timeline): make seen identity API-group-aware

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/k8score"
-	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -688,18 +687,6 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 		return
 	}
 
-	if op == "add" {
-		if store.IsResourceSeen(clusterContext, kind, namespace, name) {
-			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonAlreadySeen, op, clusterContext)
-			if DebugEvents {
-				log.Printf("[DEBUG] Already seen, skipping: %s/%s/%s", kind, namespace, name)
-			}
-			return
-		}
-	} else if op == "delete" {
-		store.ClearResourceSeen(clusterContext, kind, namespace, name)
-	}
-
 	obj := newObj
 	if obj == nil {
 		obj = oldObj
@@ -708,9 +695,24 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 		obj = tombstone.Obj
 	}
 	apiVersion := extractAPIVersion(obj)
-	apiGroup := resourceid.GroupForBuiltinKind(kind)
+	apiGroup := ""
+	if gvr, ok := BuiltinGVRAnyGroup(kind); ok {
+		apiGroup = gvr.Group
+	}
 	if apiVersion != "" {
 		apiGroup = GroupFromAPIVersion(apiVersion)
+	}
+
+	if op == "add" {
+		if store.IsResourceSeen(clusterContext, apiGroup, kind, namespace, name) {
+			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonAlreadySeen, op, clusterContext)
+			if DebugEvents {
+				log.Printf("[DEBUG] Already seen, skipping: %s/%s/%s", kind, namespace, name)
+			}
+			return
+		}
+	} else if op == "delete" {
+		store.ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 	}
 
 	resourceVersion := ""
@@ -875,7 +877,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 					return
 				}
 			}
-			store.MarkResourceSeen(clusterContext, kind, namespace, name)
+			store.MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 			return
 		}
 	}
@@ -892,7 +894,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	timeline.IncrementRecorded(kind)
 
 	if op == "add" {
-		store.MarkResourceSeen(clusterContext, kind, namespace, name)
+		store.MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 	}
 }
 
@@ -904,7 +906,7 @@ func isUnstructuredUpdate(oldObj, newObj any) bool {
 
 // extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")
 // for unstructured objects. Typed informer objects have empty TypeMeta after decoding;
-// identity call sites recover their group from resourceid.GroupForBuiltinKind.
+// identity call sites recover their group from the canonical built-in GVR table.
 func extractAPIVersion(obj any) string {
 	if u, ok := obj.(*unstructured.Unstructured); ok {
 		return u.GetAPIVersion()

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -183,7 +183,7 @@ func TestRecordToTimelineStore_SyncAddMarksResourceSeen(t *testing.T) {
 	if store == nil {
 		t.Fatal("timeline store is nil")
 	}
-	if !store.IsResourceSeen(ActiveClusterContext(), "Pod", "default", "p") {
+	if !store.IsResourceSeen(ActiveClusterContext(), "", "Pod", "default", "p") {
 		t.Fatal("sync add should mark resource seen after historical event recording")
 	}
 }

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -158,9 +159,6 @@ func TestRecreateJoin_CrossGroupAddDoesNotConsumeDeletedService(t *testing.T) {
 	knative.SetCreationTimestamp(metav1.Now())
 	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "knative-uid-1", "add", nil, knative, nil, false)
 
-	store := timeline.GetStore()
-	// Seen identity is a separate contract; clear it so this test isolates the recreate stash.
-	store.ClearResourceSeen(ActiveClusterContext(), "Service", "shop", "api")
 	recreatedCore := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 		Name:              "api",
 		Namespace:         "shop",
@@ -192,6 +190,111 @@ func TestRecreateJoin_CrossGroupAddDoesNotConsumeDeletedService(t *testing.T) {
 	}
 	if coreRecreate == nil || coreRecreate.Reason != timeline.ReasonRecreated || coreRecreate.Diff == nil || len(coreRecreate.Diff.Fields) == 0 {
 		t.Fatalf("same-group core Service did not consume its recreate stash: %+v", coreRecreate)
+	}
+}
+
+func TestTimelineSeenIdentity_SameGroupSharesServedVersions(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	first := &unstructured.Unstructured{}
+	first.SetAPIVersion("serving.knative.dev/v1")
+	first.SetKind("Service")
+	first.SetNamespace("shop")
+	first.SetName("api")
+	first.SetUID(types.UID("knative-v1"))
+	first.SetCreationTimestamp(metav1.Now())
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "knative-v1", "add", nil, first, nil, false)
+
+	second := first.DeepCopy()
+	second.SetAPIVersion("serving.knative.dev/v1beta1")
+	second.SetUID(types.UID("knative-v1beta1"))
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "knative-v1beta1", "add", nil, second, nil, false)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Service"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 1 || events[0].UID != "knative-v1" {
+		t.Fatalf("same API group across served versions should produce one add, got %+v", events)
+	}
+	if !timeline.GetStore().IsResourceSeen(ActiveClusterContext(), "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("Knative Service group identity should be marked seen")
+	}
+}
+
+func TestTimelineSeenIdentity_CrossGroupAddsBothRecorded(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	coreService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "api", Namespace: "shop", UID: types.UID("core-uid"), CreationTimestamp: metav1.Now(),
+	}}
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "core-uid", "add", nil, coreService, nil, false)
+
+	knativeService := &unstructured.Unstructured{}
+	knativeService.SetAPIVersion("serving.knative.dev/v1")
+	knativeService.SetKind("Service")
+	knativeService.SetNamespace("shop")
+	knativeService.SetName("api")
+	knativeService.SetUID(types.UID("knative-uid"))
+	knativeService.SetCreationTimestamp(metav1.Now())
+	recordToTimelineStore(ActiveClusterContext(), "Service", "shop", "api", "knative-uid", "add", nil, knativeService, nil, false)
+
+	store := timeline.GetStore()
+	events, err := store.Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Service"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("cross-group adds = %d, want 2: %+v", len(events), events)
+	}
+	if !store.IsResourceSeen(ActiveClusterContext(), "", "Service", "shop", "api") ||
+		!store.IsResourceSeen(ActiveClusterContext(), "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("core and Knative Services should be independently seen")
+	}
+}
+
+func TestTimelineSeenIdentity_TypedBuiltinUsesCanonicalGroup(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{
+		Name: "reader", Namespace: "shop", UID: types.UID("role-uid"), CreationTimestamp: metav1.Now(),
+	}}
+	recordToTimelineStore(ActiveClusterContext(), "Role", "shop", "reader", "role-uid", "add", nil, role, nil, false)
+
+	store := timeline.GetStore()
+	if !store.IsResourceSeen(ActiveClusterContext(), "rbac.authorization.k8s.io", "Role", "shop", "reader") {
+		t.Fatal("typed Role should use its canonical API group")
+	}
+	if store.IsResourceSeen(ActiveClusterContext(), "", "Role", "shop", "reader") {
+		t.Fatal("typed Role must not be keyed as a core-group resource")
 	}
 }
 

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -95,8 +95,8 @@ func CompileFilter(preset *FilterPreset) (*CompiledFilter, error) {
 func ResourceKey(kind, namespace, name string) string {
 	return pkgtimeline.ResourceKey(kind, namespace, name)
 }
-func SeenResourceKey(clusterContext, kind, namespace, name string) string {
-	return pkgtimeline.SeenResourceKey(clusterContext, kind, namespace, name)
+func SeenResourceKey(clusterContext, group, kind, namespace, name string) string {
+	return pkgtimeline.SeenResourceKey(clusterContext, group, kind, namespace, name)
 }
 
 // Converter functions.

--- a/internal/timeline/postgres_store.go
+++ b/internal/timeline/postgres_store.go
@@ -502,8 +502,8 @@ func (s *PostgresStore) GetChangesForOwner(ctx context.Context, ownerKind, owner
 }
 
 // MarkResourceSeen records that a resource has been seen.
-func (s *PostgresStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *PostgresStore) MarkResourceSeen(clusterContext, group, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, group, kind, namespace, name)
 
 	s.seenMu.Lock()
 	s.seenResources[key] = true
@@ -513,16 +513,16 @@ func (s *PostgresStore) MarkResourceSeen(clusterContext, kind, namespace, name s
 }
 
 // IsResourceSeen checks if a resource has been seen before in the given cluster
-// context.
-func (s *PostgresStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+// context and API group.
+func (s *PostgresStore) IsResourceSeen(clusterContext, group, kind, namespace, name string) bool {
 	s.seenMu.RLock()
 	defer s.seenMu.RUnlock()
-	return s.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return s.seenResources[SeenResourceKey(clusterContext, group, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set.
-func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *PostgresStore) ClearResourceSeen(clusterContext, group, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, group, kind, namespace, name)
 
 	s.seenMu.Lock()
 	delete(s.seenResources, key)
@@ -1069,12 +1069,27 @@ func (s *PostgresStore) hydrateSeenResources(ctx context.Context) error {
 	}
 	defer rows.Close()
 
+	var loaded, obsolete int
 	for rows.Next() {
 		var key []byte
 		if err := rows.Scan(&key); err != nil {
 			return err
 		}
+		// Pre-group-identity rows lack the API-group qualifier and would
+		// wrongly suppress a same-named resource in another group if loaded;
+		// they're ignored here the same way SQLiteStore ignores them.
+		if !isGroupAwareSeenResourceKey(string(key)) {
+			obsolete++
+			continue
+		}
 		s.seenResources[string(key)] = true
+		loaded++
+	}
+	if obsolete > 0 {
+		log.Printf("[timeline] ignored %d obsolete seen_resources rows", obsolete)
+	}
+	if loaded > 0 {
+		log.Printf("[timeline] loaded %d seen resources from PostgreSQL", loaded)
 	}
 	return rows.Err()
 }

--- a/internal/timeline/postgres_store_test.go
+++ b/internal/timeline/postgres_store_test.go
@@ -226,7 +226,7 @@ func TestNewPostgresStoreHydratesNULSeenResourceKey(t *testing.T) {
 		t.Fatalf("first NewPostgresStore: %v", err)
 	}
 
-	key := SeenResourceKey("cluster-a", "Deployment", "default", "api")
+	key := SeenResourceKey("cluster-a", "", "Deployment", "default", "api")
 	if !strings.ContainsRune(key, '\x00') {
 		t.Fatalf("SeenResourceKey %q does not contain NUL", key)
 	}
@@ -915,7 +915,7 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first NewPostgresStore: %v", err)
 	}
-	store1.MarkResourceSeen("ctx1", "Deployment", "default", "web")
+	store1.MarkResourceSeen("ctx1", "", "Deployment", "default", "web")
 	if err := store1.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
@@ -926,12 +926,12 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 	}
 	defer store2.Close()
 
-	if !store2.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	if !store2.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("seen resource was not persisted")
 	}
 
-	store2.ClearResourceSeen("ctx1", "Deployment", "default", "web")
-	if store2.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	store2.ClearResourceSeen("ctx1", "", "Deployment", "default", "web")
+	if store2.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("seen resource was not cleared")
 	}
 
@@ -940,7 +940,7 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 		t.Fatalf("third NewPostgresStore: %v", err)
 	}
 	defer store3.Close()
-	if store3.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	if store3.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("cleared seen resource reappeared after restart")
 	}
 }
@@ -1205,11 +1205,11 @@ func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 
 	const n = 1200 // more than one batch
 	for i := 0; i < n; i++ {
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i))
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("app-%d", i))
 	}
 	// A mark immediately followed by a clear must not resurrect the row.
-	store.MarkResourceSeen("cluster-a", "Deployment", "default", "transient")
-	store.ClearResourceSeen("cluster-a", "Deployment", "default", "transient")
+	store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "transient")
+	store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "transient")
 
 	// Close drains the queue; nothing here should depend on the flush interval.
 	if err := store.Close(); err != nil {
@@ -1227,14 +1227,14 @@ func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 	})
 
 	for _, i := range []int{0, n / 2, n - 1} {
-		if !reopened.IsResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i)) {
+		if !reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("app-%d", i)) {
 			t.Errorf("app-%d not persisted across restart", i)
 		}
 	}
-	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "transient") {
+	if reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", "transient") {
 		t.Error("cleared resource came back after restart: the clear was applied before its mark")
 	}
-	if reopened.IsResourceSeen("cluster-b", "Deployment", "default", "app-0") {
+	if reopened.IsResourceSeen("cluster-b", "", "Deployment", "default", "app-0") {
 		t.Error("seen state leaked across cluster contexts")
 	}
 }
@@ -1255,12 +1255,12 @@ func TestPostgresStore_ClearSurvivesQueuePressure(t *testing.T) {
 	// Saturate the queue well past its depth, with the key under test marked
 	// part-way through so a queued mark for it is in flight behind the clear.
 	for i := 0; i < seenWriteQueueDepth*3; i++ {
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("noise-%d", i))
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("noise-%d", i))
 		if i == seenWriteQueueDepth {
-			store.MarkResourceSeen("cluster-a", "Deployment", "default", "recreated")
+			store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "recreated")
 		}
 	}
-	store.ClearResourceSeen("cluster-a", "Deployment", "default", "recreated")
+	store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "recreated")
 
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -1275,7 +1275,7 @@ func TestPostgresStore_ClearSurvivesQueuePressure(t *testing.T) {
 			t.Errorf("Close reopened: %v", err)
 		}
 	})
-	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "recreated") {
+	if reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", "recreated") {
 		t.Fatal("clear was lost under queue pressure: the resource is still marked seen after restart")
 	}
 }

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -750,11 +750,10 @@ func (s *SQLiteStore) GetChangesForOwner(ctx context.Context, ownerKind, ownerNa
 }
 
 // MarkResourceSeen records that a resource has been seen. The key is
-// cluster-qualified: this store outlives kubeconfig context switches, so a bare
-// kind/namespace/name would let a same-named resource in another cluster read
-// as already-seen and drop its add.
-func (s *SQLiteStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+// cluster- and API-group-qualified: this store outlives kubeconfig context
+// switches and distinct groups can define the same kind/namespace/name.
+func (s *SQLiteStore) MarkResourceSeen(clusterContext, group, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, group, kind, namespace, name)
 
 	s.seenMu.Lock()
 	s.seenResources[key] = true
@@ -765,16 +764,16 @@ func (s *SQLiteStore) MarkResourceSeen(clusterContext, kind, namespace, name str
 }
 
 // IsResourceSeen checks if a resource has been seen before in the given cluster
-// context.
-func (s *SQLiteStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+// context and API group.
+func (s *SQLiteStore) IsResourceSeen(clusterContext, group, kind, namespace, name string) bool {
 	s.seenMu.RLock()
 	defer s.seenMu.RUnlock()
-	return s.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return s.seenResources[SeenResourceKey(clusterContext, group, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set
-func (s *SQLiteStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *SQLiteStore) ClearResourceSeen(clusterContext, group, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, group, kind, namespace, name)
 
 	s.seenMu.Lock()
 	delete(s.seenResources, key)
@@ -979,11 +978,15 @@ func (s *SQLiteStore) hydrateSeenResources() {
 	}
 	defer rows.Close()
 
-	var loaded, skipped int
+	var loaded, skipped, obsolete int
 	for rows.Next() {
 		var key string
 		if err := rows.Scan(&key); err != nil {
 			skipped++
+			continue
+		}
+		if !isGroupAwareSeenResourceKey(key) {
+			obsolete++
 			continue
 		}
 		s.seenResources[key] = true
@@ -995,9 +998,17 @@ func (s *SQLiteStore) hydrateSeenResources() {
 	if skipped > 0 {
 		log.Printf("[timeline] skipped %d unreadable seen_resources rows in %s (loaded %d)", skipped, s.path, loaded)
 	}
+	if obsolete > 0 {
+		log.Printf("[timeline] ignored %d obsolete seen_resources rows in %s", obsolete, s.path)
+	}
 	if loaded > 0 {
 		log.Printf("[timeline] loaded %d seen resources from %s", loaded, s.path)
 	}
+}
+
+func isGroupAwareSeenResourceKey(key string) bool {
+	_, resourceKey, ok := strings.Cut(key, "\x00")
+	return ok && strings.Count(resourceKey, "|") == 3
 }
 
 // runCleanup deletes events older than retention and truncates the WAL so the

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -463,24 +463,43 @@ func TestSQLiteStore_ResourceSeen(t *testing.T) {
 	defer cleanup()
 
 	// Initially not seen
-	if store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen initially")
 	}
 
 	// Mark as seen
-	store.MarkResourceSeen("ctx", "Pod", "default", "test-pod")
+	store.MarkResourceSeen("ctx", "", "Pod", "default", "test-pod")
 
 	// Now should be seen
-	if !store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if !store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should be seen after marking")
 	}
 
 	// Clear seen
-	store.ClearResourceSeen("ctx", "Pod", "default", "test-pod")
+	store.ClearResourceSeen("ctx", "", "Pod", "default", "test-pod")
 
 	// Should not be seen again
-	if store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen after clearing")
+	}
+}
+
+func TestSQLiteStore_ResourceSeen_APIGroupScoped(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	store.MarkResourceSeen("ctx", "", "Service", "shop", "api")
+	store.MarkResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api")
+
+	store.ClearResourceSeen("ctx", "", "Service", "shop", "api")
+	if store.IsResourceSeen("ctx", "", "Service", "shop", "api") {
+		t.Fatal("core Service should be cleared")
+	}
+	if !store.IsResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("clearing core Service must not clear Knative Service")
+	}
+	if store.IsResourceSeen("other-ctx", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("same Knative Service in another cluster must remain unseen")
 	}
 }
 
@@ -675,8 +694,9 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore: %v", err)
 	}
-	store1.MarkResourceSeen("ctx", "Pod", "default", "p1")
-	store1.MarkResourceSeen("ctx", "Deployment", "kube-system", "d1")
+	store1.MarkResourceSeen("ctx", "", "Service", "shop", "api")
+	store1.MarkResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api")
+	store1.MarkResourceSeen("ctx", "apps", "Deployment", "kube-system", "d1")
 	store1.Close()
 
 	store2, err := NewSQLiteStore(dbPath)
@@ -685,14 +705,62 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	}
 	defer store2.Close()
 
-	if !store2.IsResourceSeen("ctx", "Pod", "default", "p1") {
-		t.Error("expected Pod default/p1 to be seen after restart")
+	if !store2.IsResourceSeen("ctx", "", "Service", "shop", "api") {
+		t.Error("expected core Service shop/api to be seen after restart")
 	}
-	if !store2.IsResourceSeen("ctx", "Deployment", "kube-system", "d1") {
+	if !store2.IsResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api") {
+		t.Error("expected Knative Service shop/api to be seen after restart")
+	}
+	if !store2.IsResourceSeen("ctx", "apps", "Deployment", "kube-system", "d1") {
 		t.Error("expected Deployment kube-system/d1 to be seen after restart")
 	}
-	if store2.IsResourceSeen("ctx", "Pod", "default", "never-marked") {
+	if store2.IsResourceSeen("ctx", "", "Pod", "default", "never-marked") {
 		t.Error("did not expect unmarked resource to be seen")
+	}
+}
+
+func TestSQLiteStore_OldKindOnlySeenKeysDoNotSuppressResources(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "old-seen-keys.db")
+	store, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+
+	oldKeys := []string{
+		"Service/shop/api",
+		"ctx\x00Service/shop/api",
+	}
+	for _, key := range oldKeys {
+		if _, err := store.db.Exec("INSERT INTO seen_resources (resource_key) VALUES (?)", key); err != nil {
+			store.Close()
+			t.Fatalf("insert old key %q: %v", key, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+
+	if reopened.IsResourceSeen("ctx", "", "Service", "shop", "api") {
+		t.Fatal("old kind-only key must not suppress a core Service")
+	}
+	if reopened.IsResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("old kind-only key must not suppress a Knative Service")
+	}
+	if got := reopened.Stats().SeenResources; got != 0 {
+		t.Fatalf("obsolete keys counted as seen resources: got %d, want 0", got)
+	}
+
+	reopened.MarkResourceSeen("ctx", "", "Service", "shop", "api")
+	reopened.MarkResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api")
+	if !reopened.IsResourceSeen("ctx", "", "Service", "shop", "api") ||
+		!reopened.IsResourceSeen("ctx", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("current group-aware keys should suppress subsequent extraction")
 	}
 }
 

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -311,24 +311,24 @@ func (m *MemoryStore) GetChangesForOwner(ctx context.Context, ownerKind, ownerNa
 }
 
 // MarkResourceSeen records that a resource has been seen
-func (m *MemoryStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
+func (m *MemoryStore) MarkResourceSeen(clusterContext, group, kind, namespace, name string) {
 	m.seenMu.Lock()
 	defer m.seenMu.Unlock()
-	m.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)] = true
+	m.seenResources[SeenResourceKey(clusterContext, group, kind, namespace, name)] = true
 }
 
 // IsResourceSeen checks if a resource has been seen before
-func (m *MemoryStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+func (m *MemoryStore) IsResourceSeen(clusterContext, group, kind, namespace, name string) bool {
 	m.seenMu.RLock()
 	defer m.seenMu.RUnlock()
-	return m.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return m.seenResources[SeenResourceKey(clusterContext, group, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set
-func (m *MemoryStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
+func (m *MemoryStore) ClearResourceSeen(clusterContext, group, kind, namespace, name string) {
 	m.seenMu.Lock()
 	defer m.seenMu.Unlock()
-	delete(m.seenResources, SeenResourceKey(clusterContext, kind, namespace, name))
+	delete(m.seenResources, SeenResourceKey(clusterContext, group, kind, namespace, name))
 }
 
 // Stats returns storage statistics

--- a/pkg/timeline/memory_store_test.go
+++ b/pkg/timeline/memory_store_test.go
@@ -267,23 +267,23 @@ func TestMemoryStore_ResourceSeen(t *testing.T) {
 	store := NewMemoryStore(100)
 
 	// Initially not seen
-	if store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen initially")
 	}
 
 	// Mark as seen
-	store.MarkResourceSeen("cluster-a", "Pod", "default", "test-pod")
+	store.MarkResourceSeen("cluster-a", "", "Pod", "default", "test-pod")
 
 	// Now should be seen
-	if !store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if !store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should be seen after marking")
 	}
 
 	// Clear seen
-	store.ClearResourceSeen("cluster-a", "Pod", "default", "test-pod")
+	store.ClearResourceSeen("cluster-a", "", "Pod", "default", "test-pod")
 
 	// Should not be seen again
-	if store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen after clearing")
 	}
 }
@@ -294,13 +294,43 @@ func TestMemoryStore_ResourceSeen(t *testing.T) {
 func TestMemoryStore_ResourceSeen_ClusterScoped(t *testing.T) {
 	store := NewMemoryStore(100)
 
-	store.MarkResourceSeen("cluster-a", "Deployment", "team-a", "web")
+	store.MarkResourceSeen("cluster-a", "apps", "Deployment", "team-a", "web")
 
-	if !store.IsResourceSeen("cluster-a", "Deployment", "team-a", "web") {
+	if !store.IsResourceSeen("cluster-a", "apps", "Deployment", "team-a", "web") {
 		t.Error("cluster-a/web should be seen after marking")
 	}
-	if store.IsResourceSeen("cluster-b", "Deployment", "team-a", "web") {
+	if store.IsResourceSeen("cluster-b", "apps", "Deployment", "team-a", "web") {
 		t.Error("cluster-b/web must NOT be suppressed by cluster-a's seen entry")
+	}
+}
+
+func TestMemoryStore_ResourceSeen_APIGroupScoped(t *testing.T) {
+	store := NewMemoryStore(100)
+
+	store.MarkResourceSeen("cluster-a", "", "Service", "shop", "api")
+	store.MarkResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api")
+
+	if !store.IsResourceSeen("cluster-a", "", "Service", "shop", "api") {
+		t.Fatal("core Service should be seen")
+	}
+	if !store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("Knative Service should be seen independently")
+	}
+
+	store.ClearResourceSeen("cluster-a", "", "Service", "shop", "api")
+	if store.IsResourceSeen("cluster-a", "", "Service", "shop", "api") {
+		t.Fatal("core Service should be cleared")
+	}
+	if !store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("clearing core Service must not clear Knative Service")
+	}
+}
+
+func TestSeenResourceKey_CanonicalGroupIdentity(t *testing.T) {
+	got := SeenResourceKey("cluster-a", "serving.knative.dev", "Service", "shop", "api")
+	want := "cluster-a\x00serving.knative.dev|Service|shop|api"
+	if got != want {
+		t.Fatalf("SeenResourceKey() = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"regexp"
 	"time"
+
+	"github.com/skyhook-io/radar/pkg/resourceid"
 )
 
 type SequenceOrder string
@@ -40,15 +42,15 @@ type EventStore interface {
 	// MarkResourceSeen records that a resource has been seen (for dedup on
 	// restart). clusterContext scopes the key — the store outlives kubeconfig
 	// context switches, so a same-named resource in another cluster must not
-	// read as already-seen.
-	MarkResourceSeen(clusterContext, kind, namespace, name string)
+	// read as already-seen. group distinguishes colliding Kubernetes kinds.
+	MarkResourceSeen(clusterContext, group, kind, namespace, name string)
 
 	// IsResourceSeen checks if a resource has been seen before in the given
-	// cluster context.
-	IsResourceSeen(clusterContext, kind, namespace, name string) bool
+	// cluster context and API group.
+	IsResourceSeen(clusterContext, group, kind, namespace, name string) bool
 
 	// ClearResourceSeen removes a resource from the seen set (on delete)
-	ClearResourceSeen(clusterContext, kind, namespace, name string)
+	ClearResourceSeen(clusterContext, group, kind, namespace, name string)
 
 	// Stats returns storage statistics
 	Stats() StoreStats
@@ -259,12 +261,11 @@ func ResourceKey(kind, namespace, name string) string {
 	return kind + "/" + namespace + "/" + name
 }
 
-// SeenResourceKey qualifies the seen-tracking key with the cluster context.
-// The NUL separator can't appear in a kubeconfig context name, so it can't
-// collide with the resource portion. Rows written before this qualification
-// (bare kind/namespace/name) simply never match, which is correct: their
-// cluster is unknowable, so the resource is re-extracted once per cluster
-// after upgrade rather than being wrongly suppressed.
-func SeenResourceKey(clusterContext, kind, namespace, name string) string {
-	return clusterContext + "\x00" + ResourceKey(kind, namespace, name)
+// SeenResourceKey qualifies the canonical resource identity with the cluster
+// context. The NUL separator can't appear in a kubeconfig context name or the
+// resource key. Older opaque keys without group identity deliberately don't
+// match: their API group is unknowable, so the resource is re-extracted once
+// rather than a same-named resource in another group being suppressed.
+func SeenResourceKey(clusterContext, group, kind, namespace, name string) string {
+	return clusterContext + "\x00" + resourceid.ResourceKey(group, kind, namespace, name)
 }

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -678,19 +678,43 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 	// two clusters is two distinct sightings.
 	t.Run("seen resources are tracked per cluster and can be cleared", func(t *testing.T) {
 		store := newStore(t)
-		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		if store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource reported seen before it was marked")
 		}
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", "api")
-		if !store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "api")
+		if !store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource not reported seen after MarkResourceSeen")
 		}
-		if store.IsResourceSeen("cluster-b", "Deployment", "default", "api") {
+		if store.IsResourceSeen("cluster-b", "", "Deployment", "default", "api") {
 			t.Fatal("seen state leaked across cluster contexts")
 		}
-		store.ClearResourceSeen("cluster-a", "Deployment", "default", "api")
-		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "api")
+		if store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource still reported seen after ClearResourceSeen")
+		}
+	})
+
+	// Same Kind/namespace/name can legitimately name two different resources
+	// in different API groups (a core Service vs. a Knative Service, say) —
+	// their seen state and clears must stay independent.
+	t.Run("seen resources are isolated by API group and cleared independently", func(t *testing.T) {
+		store := newStore(t)
+		store.MarkResourceSeen("cluster-a", "", "Service", "shop", "api")
+		store.MarkResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api")
+
+		if !store.IsResourceSeen("cluster-a", "", "Service", "shop", "api") {
+			t.Fatal("core Service should be seen")
+		}
+		if !store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+			t.Fatal("Knative Service should be seen independently of the core Service")
+		}
+
+		store.ClearResourceSeen("cluster-a", "", "Service", "shop", "api")
+		if store.IsResourceSeen("cluster-a", "", "Service", "shop", "api") {
+			t.Fatal("core Service should be cleared")
+		}
+		if !store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+			t.Fatal("clearing the core Service must not clear the Knative Service in another group")
 		}
 	})
 }


### PR DESCRIPTION
## Why

Timeline's seen-resource dedup keyed resources by cluster context plus Kind, namespace, and name. Same-named resources from different API groups could therefore suppress or clear each other's initial historical event, such as a core Service colliding with a Knative Service or a core Job colliding with a Volcano Job.

## Stack and program context

Part of the RAD-418 identity program: #1549 (merged) isolated short-lived delete/recreate joins by API group. This PR fixes persisted/in-memory seen-resource dedup on top of that. #1560 then relies on both corrections to make topology, applications, navigation, and timeline consumers exact for same-Kind ecosystem resources. That identity safety is required before the GPU/batch integrations can compose into global surfaces without cross-group attribution.

## What changed

- add API group to the `EventStore` seen-resource contract and all three store implementations (memory, SQLite, Postgres)
- use canonical `resourceid.ResourceKey` values for persisted seen keys
- derive typed built-in groups from Radar's canonical GVR table, with unstructured `apiVersion` taking precedence
- derive identity before add dedup and delete clearing so colliding kinds remain independent
- keep served versions within the same API group on one version-tolerant identity
- cover cross-group collisions, typed non-core resources, cluster isolation, and SQLite/Postgres restart behavior, including a shared conformance case (memory + SQLite + Postgres) proving a clear on one group's identity never clears another group's

## Persistence and proof boundary

Old opaque kind-only SQLite/Postgres keys cannot be assigned safely to an API group. They are intentionally ignored during hydration on both backends, so affected resources may be extracted once after upgrade. Those rows remain inert on disk; they are not guessed, migrated, or counted as active seen resources.

This PR fixes seen-resource identity only. Owner grouping, generic topology, and Applications identity are handled by later slices, including #1560.

## Review focus

- add dedup and delete clearing must derive the same API-group-aware identity for typed and unstructured objects
- served versions in one API group must remain one identity while cross-group collisions remain independent
- SQLite/Postgres restart behavior must ignore ambiguous legacy keys without silently losing new-format state or crossing cluster contexts

## Verification

- `(cd pkg && go test ./timeline)`
- `go test ./internal/timeline ./internal/k8s`
- `(cd pkg && go test -race ./timeline)`
- `go build ./...` and `go vet ./...` (both Go modules)
- `go test ./...` (both Go modules)
- Postgres path run against a real PostgreSQL instance (not just compiled): full `internal/timeline` suite including `TestStoreConformance_Postgres`, `TestNewPostgresStoreHydratesNULSeenResourceKey`, and the new cross-group conformance case, plus `-race`
- focused regression coverage includes core/Knative Service collisions, same-group served versions, typed non-core resources, delete clearing, cluster isolation, and SQLite/Postgres hydration/restart

Visual testing was skipped because this changes Timeline identity and persistence, not rendered layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted timeline dedup identity and restart hydration; wrong group derivation could suppress or duplicate adds, though legacy keys are dropped rather than mis-applied.
> 
> **Overview**
> Timeline **seen-resource** dedup no longer keys only on cluster + kind/namespace/name. The `EventStore` contract and memory, SQLite, and Postgres stores now take an **API group** and build persisted keys via canonical `resourceid.ResourceKey` (`cluster\x00group|kind|namespace|name`).
> 
> In `recordToTimelineStore`, **group is resolved before** add suppression and delete clearing: unstructured objects use `apiVersion`; typed built-ins use the canonical GVR table (`BuiltinGVRAnyGroup`), with unstructured `apiVersion` winning when present. **Mark/clear seen** uses that same identity so core vs Knative `Service` (and similar collisions) stay independent, while **served versions in one group** share one seen slot.
> 
> **Upgrade behavior:** SQLite/Postgres hydration **ignores legacy kind-only seen rows** (no safe group assignment), so affected resources may be historically re-extracted once; new group-aware keys persist normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5d6e6eb16e6ca4e4da26679116f2bf00495941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->