### PR TITLE
Remove legacy embedded pill navigation

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -42,7 +42,9 @@ See `RadarAppProps` + `NavCustomization` in the type declarations for the full s
 
 When `navSlots.embedded` is true, Radar sizes itself to the host container (`height: 100%`) instead of owning the browser viewport. Mount it inside a container with a definite height so the host chrome owns the page scrollbar.
 
-Chromeless hosts (`navSlots.chrome = 'none'`) can pass `onClusterLoadStateChange` and render `state.message` in their own topbar while Radar finishes loading deferred cluster resources.
+Embedded hosts own primary view navigation. With the default `navSlots.chrome = 'full'`, Radar retains its top bar for the brand, context, and action slots, but does not render a view switcher or sidebar. Use Radar's routes (such as `/topology` and `/resources`) to drive the active view from the host navigation.
+
+Chromeless hosts (`navSlots.chrome = 'none'`) own the top bar as well. They can pass `onClusterLoadStateChange` and render `state.message` in their own chrome while Radar finishes loading deferred cluster resources.
 
 ## Tailwind
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,7 +58,7 @@ import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
 import type { ClusterLoadState } from './types/clusterLoadState'
 import { useClusterLoadState } from './hooks/useClusterLoadState'
-import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, Gauge, HelpCircle, Loader2, RefreshCw } from 'lucide-react'
+import { Network, Sun, Moon, Star, Search, Bug, SquareTerminal, HelpCircle, Loader2, RefreshCw } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -334,8 +334,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     [navCustomization],
   )
   // Resolve every host-takeover URL ONCE (memoized on navCustomization) so the
-  // setMainView intercept, redirect effect, nav-pill filtering, inline-view
-  // gating, and the cert click handler all consume the SAME value — host
+  // setMainView intercept, redirect effect, inline-view gating, and the cert
+  // click handler all consume the SAME value — host
   // callbacks aren't guaranteed idempotent (scope / flags / signed URLs can
   // shift between calls). undefined = not taken over → Radar renders the view
   // itself. `clusterChecksHref` is the deprecated pre-1.7 hook, folded into the
@@ -350,13 +350,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     [navCustomization],
   )
   const { pinned: navRailPinned, togglePinned: toggleNavRailPinned } = useNavRailPinned()
-  // Standalone Radar gets the left nav rail; embedded hosts (Radar Hub) own
-  // the left chrome via their own fleet rail and keep Radar's top-bar pills.
+  // Standalone Radar gets the left nav rail. Embedded hosts own view navigation
+  // in their surrounding chrome; Radar never renders a second primary nav.
   const showNavRail = !navCustomization.embedded
-  // Chromeless embed: the host (Radar Hub) owns ALL chrome and drives view
-  // navigation + scope from its own UI, so Radar renders just the active view's
-  // content — no top bar, no view-switcher. Used for per-cluster views surfaced
-  // as native cloud destinations behind a cluster picker.
+  // Chromeless embed: the host (Radar Hub) also owns scope and actions, so Radar
+  // renders just the active view's content with no top bar. Used for per-cluster
+  // views surfaced as native cloud destinations behind a cluster picker.
   const chromeless = navCustomization.embedded === true && navCustomization.chrome === 'none'
   // Force the slim rail on narrow windows: a pinned 176px rail needs viewport
   // ≥976 to keep content above its ~800px floor (collapsed needs only ≥856).
@@ -486,15 +485,14 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   }, [navigate, searchParams, takeover, goHost])
 
   // Cloud (embedded) takes over the "fleet-shaped" per-cluster views with its
-  // own fleet pages scoped to this cluster — owned by the host's left rail — so
-  // Radar drops the matching pills (see the nav below). In-app nav hands off in
+  // own fleet pages scoped to this cluster. In-app navigation hands off in
   // setMainView (above); direct /<view> URL entry funnels through the redirect
   // effect below. Both consume the memoized `takeover` resolved above. Standalone
   // OSS (no fleetTakeoverHref) is unaffected and renders the in-app view.
   //
   // Has the host claimed this view? View-shaped targets only ('certs' has no
-  // Radar view — only its Home card consults `takeover`). Used to drop the nav
-  // pill and gate the inline view render in favor of the "Opening…" splash.
+  // Radar view — only its Home card consults `takeover`). Used to gate the
+  // inline view render in favor of the "Opening…" splash.
   const isViewTakenOver = (view: ExtendedMainView): boolean =>
     (view === 'issues' || view === 'gitops' || view === 'checks') && !!takeover[view]
   // The host's URL for the CURRENT view, if taken over. Drives the redirect
@@ -1683,11 +1681,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             is a FIXED-WIDTH column so the omnibar after it is force-pinned: the
             scope pill + status dot can change width (cluster/namespace value)
             without ever shifting the search box. The pill's own name/value caps
-            keep it inside this width; the embedded/pill layout keeps auto width
-            (its center bar is absolutely positioned). */}
+            keep it inside this width; the embedded layout keeps auto width. */}
         <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[492px]' : ''}`}>
-          {/* Standalone rail owns the brand; only the embedded/pill layout
-              shows it in the header (host may override via brandSlot). */}
+          {/* Standalone rail owns the brand; only an embedded header shows it
+              here (the host may override it via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}
 
           <div className={`flex items-center gap-2 min-w-0 ${showNavRail ? 'flex-1' : ''}`}>
@@ -1766,65 +1763,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             <PortForwardIndicator />
           </div>
         </div>
-
-        {/* Center: View tabs — embedded/pill layout only. Standalone Radar
-            navigates via the left rail (showNavRail), so the pill bar is
-            suppressed there to avoid a duplicate primary nav. */}
-        {!showNavRail && (
-        <div className="@min-[920px]:absolute @min-[920px]:left-1/2 @min-[920px]:-translate-x-1/2 flex items-center gap-0.5 bg-theme-elevated/50 rounded-full p-1 ml-2 @min-[920px]:ml-0">
-          {([
-            { view: 'home' as const, icon: Home, label: 'Home' },
-            { view: 'topology' as const, icon: Network, label: 'Topology' },
-            { view: 'resources' as const, icon: List, label: 'Resources' },
-            { view: 'capacity' as const, icon: Gauge, label: 'Capacity' },
-            { view: 'timeline' as const, icon: Clock, label: 'Timeline' },
-            { view: 'helm' as const, icon: Package, label: 'Helm' },
-            { view: 'gitops' as const, icon: GitBranch, label: 'GitOps' },
-            // Applications is intentionally hidden from the pill bar for now —
-            // the bar is full, and the view's primary home is Cloud's fleet
-            // rail. The view still exists and is reachable via /applications
-            // and the view-switching shortcuts. Same treatment as Cost below.
-            { view: 'traffic' as const, icon: Activity, label: 'Live Traffic' },
-            // Cost is intentionally hidden from the pill bar for now — the view still
-            // exists and is reachable via /cost, the Home dashboard card, and the
-            // command palette (⌘K). Remove this comment to restore it.
-            { view: 'checks' as const, icon: ShieldCheck, label: 'Checks' },
-          ] as const)
-            // In Cloud, fleet-shaped views (Checks, Issues, GitOps) are owned by
-            // the host's left rail; the per-cluster view is just that fleet page
-            // filtered to this cluster, so duplicating it as a peer pill here
-            // would be a second copy that teleports out of the cluster shell.
-            // Drop any pill the host took over — cluster-scoped access stays
-            // available via the Home cards (redirected by the takeover effect
-            // above), ⌘K, and bookmarks. Standalone OSS keeps every pill.
-            .filter(({ view }) => !isViewTakenOver(view))
-            .map(({ view, icon: Icon, label }) => (
-            <Tooltip key={view} content={label} delay={100} position="bottom">
-              <button
-                onClick={() => setMainView(view)}
-                className={`flex items-center gap-1 px-2 py-1 text-[13px] rounded-full transition-colors ${
-                  mainView === view || (mainView === 'helmCompare' && view === 'helm')
-                    ? 'bg-skyhook-600 dark:bg-skyhook-500 text-white shadow-glow-brand-sm'
-                    : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover'
-                }`}
-              >
-                <Icon className="w-4 h-4" />
-                {/* Labels appear only when the absolute-centered nav has
-                    enough horizontal room past the left section. Right-side
-                    chrome that adds further pressure (Connected text, star
-                    count) is intentionally pushed to the next tier (xl) so
-                    label rendering and right-side expansion stay decoupled.
-                    Per-button Tooltip discloses labels on hover when the
-                    icon-only viewport is in effect. The 1440 anchor is an
-                    off-system breakpoint chosen by measurement at the time
-                    of this PR — recompute if the cluster switcher cap or
-                    other left-section chrome changes appreciably. */}
-                <span className="hidden @min-[1264px]:inline">{label}</span>
-              </button>
-            </Tooltip>
-          ))}
-        </div>
-        )}
 
         {/* Center: omnibar — standalone search + command surface (the ⌘K entry).
             Its container is one of three EQUAL flex-1 columns (see the left/right

--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -84,9 +84,10 @@ export interface RadarAppProps {
    */
   queryClient?: QueryClient;
   /**
-   * Slot-based customization of Radar's top nav. Use to inject host-app
+   * Slot-based customization of Radar's top bar. Use to inject host-app
    * brand, replace the kubeconfig context picker with a product-level
-   * cluster switcher, and append items to the right action bar.
+   * cluster switcher, and append items to the right action bar. Embedded hosts
+   * own primary view navigation outside Radar.
    * See ./context/NavCustomization for the slot shape.
    */
   navSlots?: NavCustomization;

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -49,9 +49,8 @@ type NavRailView =
 //                content under the cursor).
 //
 // In embedded mode (Radar Hub) this rail is not rendered at all — the host
-// owns the left chrome via its own fleet LeftRail, and Radar falls back to
-// its top-bar pill nav. That keeps the @skyhook-io/radar-app surface
-// non-breaking and avoids triple-stacked left chrome.
+// owns primary view navigation via its own fleet LeftRail. That keeps the
+// @skyhook-io/radar-app surface non-breaking and avoids stacked chrome.
 
 interface NavItemDef {
   view: NavRailView;
@@ -66,8 +65,7 @@ interface NavItemDef {
 // sits there — next to Cost, its spend-lever sibling. It renders on every
 // cluster (like Issues/Topology): the view itself reads the cluster's capacity
 // posture across all node managers, not just Karpenter. The rail's vertical
-// room lets us surface the views the 8-slot pill bar dropped (Issues,
-// Applications, Cost).
+// room lets us surface every supported standalone destination.
 const NAV_ITEMS: NavItemDef[] = [
   { view: "home", icon: Home, label: "Home" },
   { view: "resources", icon: List, label: "Resources" },

--- a/web/src/context/NavCustomization.tsx
+++ b/web/src/context/NavCustomization.tsx
@@ -1,8 +1,8 @@
-// Slot-based customization of Radar's top nav.
+// Slot-based customization of Radar's top bar.
 //
 // Lets library consumers (e.g. Radar Hub) swap out the brand area, the
 // context picker, and append items on the right of the action bar —
-// without forking App.tsx or building a parallel nav.
+// without forking App.tsx or rebuilding Radar's action chrome.
 //
 // The `embedded` flag hides chrome that only makes sense for Radar's
 // standalone OSS binary: GitHub star link, update-from-GitHub notifier,
@@ -83,26 +83,27 @@ interface NavCustomizationBase {
    */
   onHostNavigate?: (url: string) => void;
   /**
-   * Chrome level for embedded hosts. Default ('full', or omitted) renders
-   * Radar's top bar + the view-switcher. 'none' suppresses BOTH — the host
-   * drives view navigation and cluster/namespace scope from its OWN chrome, and
-   * Radar renders just the active view's content full-bleed. Radar Hub uses this
-   * to surface per-cluster views (Topology / Resources / Traffic / Cost) that
-   * don't aggregate to the fleet as native cloud destinations under one chrome,
-   * gated by a cluster picker — instead of a second, redundant in-cluster nav.
-   * Only meaningful with `embedded: true`.
+   * Chrome level for embedded hosts. Embedded hosts own primary view
+   * navigation in either mode. Default ('full', or omitted) retains Radar's
+   * top bar for the brand, context, and action slots. 'none' suppresses the top
+   * bar too, so the host owns all chrome and Radar renders only the active
+   * view's content full-bleed. Radar Hub uses this to surface per-cluster views
+   * (Topology / Resources / Traffic / Cost) as native cloud destinations under
+   * one host-owned chrome, gated by a cluster picker. Only meaningful with
+   * `embedded: true`.
    */
   chrome?: 'full' | 'none';
 }
 
 /**
- * Slot-based customization of Radar's top nav.
+ * Slot-based customization of Radar's top bar.
  *
  * Standalone-mode consumers pass `embedded: false` (or omit it) and may
  * optionally append items via `rightExtras`. Embedded-mode consumers must
  * supply `rightExtras` — Radar's OSS chrome (GitHub star, update notifier,
  * built-in UserMenu) is hidden, so the host app owns the right side of the
- * nav and must render its own user/auth UI there.
+ * top bar and must render its own user/auth UI there. Embedded hosts provide
+ * primary view navigation outside Radar.
  */
 export type NavCustomization =
   | (NavCustomizationBase & {


### PR DESCRIPTION
## Status — DRAFT

Not ready for review: the supported embedded full-chrome configuration still needs a host harness and browser smoke.

## Why

Standalone Radar has used `PrimaryNavRail` as its primary navigation for some time. The embedded top-bar pill switcher remains reachable through the public embedded full-chrome configuration, but no known first-party consumer uses it. Removing this legacy path makes the embedding contract explicit and prevents an obsolete eight-slot control from constraining future information architecture.

## Program context

This is independent navigation/package cleanup identified while planning the GPU and accelerator work. It does not add, remove, or relocate any Radar destination, and no GPU integration PR depends on it.

## Proof boundary

This PR removes only the embedded full-chrome pill switcher. It does not change Radar's route set, standalone rail, chromeless embed, or host-takeover hooks. It intentionally changes how embedded full-chrome consumers reach those existing routes, as detailed below.

## Behavior compatibility and release implication

`web/` is the public `@skyhook-io/radar-app` package. No `RadarAppProps` or `NavCustomization` field is removed, but this PR intentionally changes rendered behavior for one supported configuration:

- standalone (`embedded` false or omitted): `PrimaryNavRail` remains the primary navigation; behavior is unchanged
- embedded with default `chrome: 'full'`: Radar keeps its top bar for brand, context, and action slots, but no longer renders primary-view pills; the host must provide navigation and drive Radar's existing routes
- embedded with `chrome: 'none'`: Radar renders neither rail nor top bar; host-owned navigation/chrome is unchanged. The known Radar Hub consumer uses this mode

This is source-compatible but not behavior-identical for embedded full-chrome consumers. `@skyhook-io/radar-app` is currently `0.3.1`, and this change must not ride a patch release. Publish it only in a deliberately migration-signaled package release—normally `0.4.0` while the package is pre-1.0—with release notes and host navigation in place before full-chrome consumers upgrade. Standalone Radar and the known chromeless Radar Hub consumer are unaffected.

## What changed

- remove the embedded top-bar pill switcher and now-unused icon imports
- update package docs and public type comments to describe host-owned embedded navigation
- keep existing routes, takeover hooks, top-bar slots, and public prop/type shapes intact

## Review focus

- embedded full-chrome hosts must retain brand/context/action slots while losing only the pill switcher
- standalone rail and chromeless embedding must remain unchanged
- public package documentation must make the behavioral migration requirement explicit without implying a type-level API break

## Verification

- from `web/`: `npx vitest run src/components/nav/PrimaryNavRail.test.tsx`
- `make tsc`
- `make test`
- `make build`
- `git diff --check`
- `git grep -n -E 'pill bar|pill nav|view-switcher' -- web` returned no stale implementation references
- standalone visual smoke at 1920×1080 on the exact PR head: sidebar navigation remained intact, no pill navigation rendered, and the browser reported zero console warnings or errors
- pending before ready: render `embedded={true}` with `chrome=full` in a host harness and verify that brand/context/right-side slots remain, pills and the standalone rail are absent, and host-driven route changes still work

Part of RAD-418.
