### PR TITLE
Add controller-reference subject owner adapter

### DIFF
--- a/pkg/subject/controller_owner.go
+++ b/pkg/subject/controller_owner.go
@@ -1,0 +1,36 @@
+package subject
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// ControllerOwnerResolver adapts already-observed Kubernetes objects to the
+// controller-only owner contracts used by subject resolution.
+type ControllerOwnerResolver struct {
+	Lookup func(Ref) (metav1.Object, bool)
+}
+
+var _ OwnerResolver = ControllerOwnerResolver{}
+var _ OwnerLookup = ControllerOwnerResolver{}
+
+func (r ControllerOwnerResolver) ParentOf(child Ref) (Ref, bool) {
+	if r.Lookup == nil {
+		return Ref{}, false
+	}
+	obj, ok := r.Lookup(child)
+	if !ok || obj == nil {
+		return Ref{}, false
+	}
+	owner := metav1.GetControllerOf(obj)
+	if owner == nil || owner.APIVersion == "" || owner.Kind == "" || owner.Name == "" {
+		return Ref{}, false
+	}
+	return Ref{
+		Group:     groupFromAPIVersion(owner.APIVersion),
+		Kind:      owner.Kind,
+		Namespace: child.Namespace,
+		Name:      owner.Name,
+	}, true
+}
+
+func (r ControllerOwnerResolver) ImmediateOwner(child Ref) (Ref, bool) {
+	return r.ParentOf(child)
+}

--- a/pkg/subject/controller_owner.go
+++ b/pkg/subject/controller_owner.go
@@ -6,6 +6,9 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // controller-only owner contracts used by subject resolution.
 type ControllerOwnerResolver struct {
 	Lookup func(Ref) (metav1.Object, bool)
+	// IsNamespaced must resolve the exact API group and kind. OwnerReference
+	// omits namespace, so namespaced children fail closed when scope is unknown.
+	IsNamespaced func(group, kind string) (namespaced, known bool)
 }
 
 var _ OwnerResolver = ControllerOwnerResolver{}
@@ -23,10 +26,24 @@ func (r ControllerOwnerResolver) ParentOf(child Ref) (Ref, bool) {
 	if owner == nil || owner.APIVersion == "" || owner.Kind == "" || owner.Name == "" {
 		return Ref{}, false
 	}
+	group := groupFromAPIVersion(owner.APIVersion)
+	namespace := ""
+	if child.Namespace != "" {
+		if r.IsNamespaced == nil {
+			return Ref{}, false
+		}
+		namespaced, known := r.IsNamespaced(group, owner.Kind)
+		if !known {
+			return Ref{}, false
+		}
+		if namespaced {
+			namespace = child.Namespace
+		}
+	}
 	return Ref{
-		Group:     groupFromAPIVersion(owner.APIVersion),
+		Group:     group,
 		Kind:      owner.Kind,
-		Namespace: child.Namespace,
+		Namespace: namespace,
 		Name:      owner.Name,
 	}, true
 }

--- a/pkg/subject/controller_owner_test.go
+++ b/pkg/subject/controller_owner_test.go
@@ -1,0 +1,241 @@
+package subject
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ownerFixtureCatalog map[Ref]metav1.Object
+
+func (c ownerFixtureCatalog) resolver() ControllerOwnerResolver {
+	return ControllerOwnerResolver{Lookup: func(ref Ref) (metav1.Object, bool) {
+		obj, ok := c[ref]
+		return obj, ok
+	}}
+}
+
+func TestControllerOwnerResolverChainParity(t *testing.T) {
+	type fixture struct {
+		name             string
+		chain            []Ref
+		ownerAPIVersions []string
+		terminalOwner    *metav1.OwnerReference
+	}
+	nonController := false
+	fixtures := []fixture{
+		{
+			name: "deployment",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "apps", Name: "web-6d8f9-abcde"},
+				{Group: "apps", Kind: "ReplicaSet", Namespace: "apps", Name: "web-6d8f9"},
+				{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web"},
+			},
+			ownerAPIVersions: []string{"apps/v1", "apps/v1"},
+		},
+		{
+			name: "cronjob",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "ops", Name: "backup-29384-abcd"},
+				{Group: "batch", Kind: "Job", Namespace: "ops", Name: "backup-29384"},
+				{Group: "batch", Kind: "CronJob", Namespace: "ops", Name: "backup"},
+			},
+			ownerAPIVersions: []string{"batch/v1", "batch/v1"},
+		},
+		{
+			name: "argo rollout",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "apps", Name: "canary-7548f-abcde"},
+				{Group: "apps", Kind: "ReplicaSet", Namespace: "apps", Name: "canary-7548f"},
+				{Group: "argoproj.io", Kind: "Rollout", Namespace: "apps", Name: "canary"},
+			},
+			ownerAPIVersions: []string{"apps/v1", "argoproj.io/v1alpha1"},
+		},
+		{
+			name: "jobset",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "training", Name: "train-worker-0-abcde"},
+				{Group: "batch", Kind: "Job", Namespace: "training", Name: "train-worker-0"},
+				{Group: "jobset.x-k8s.io", Kind: "JobSet", Namespace: "training", Name: "train"},
+			},
+			ownerAPIVersions: []string{"batch/v1", "jobset.x-k8s.io/v1alpha2"},
+		},
+		{
+			name: "ray service",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "serving", Name: "serve-raycluster-head-abcde"},
+				{Group: "ray.io", Kind: "RayCluster", Namespace: "serving", Name: "serve-raycluster"},
+				{Group: "ray.io", Kind: "RayService", Namespace: "serving", Name: "serve"},
+			},
+			ownerAPIVersions: []string{"ray.io/v1", "ray.io/v1"},
+		},
+		{
+			name: "cloudnativepg",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "data", Name: "postgres-1"},
+				{Group: "postgresql.cnpg.io", Kind: "Cluster", Namespace: "data", Name: "postgres"},
+			},
+			ownerAPIVersions: []string{"postgresql.cnpg.io/v1"},
+		},
+		{
+			name: "strimzi",
+			chain: []Ref{
+				{Kind: "Pod", Namespace: "data", Name: "events-brokers-0"},
+				{Group: "core.strimzi.io", Kind: "StrimziPodSet", Namespace: "data", Name: "events-brokers"},
+			},
+			ownerAPIVersions: []string{"core.strimzi.io/v1beta2"},
+			terminalOwner: &metav1.OwnerReference{
+				APIVersion: "kafka.strimzi.io/v1",
+				Kind:       "KafkaNodePool",
+				Name:       "brokers",
+				Controller: &nonController,
+			},
+		},
+		{
+			name: "crossplane controller reference",
+			chain: []Ref{
+				{Group: "database.example.io", Kind: "ManagedDatabase", Namespace: "data", Name: "orders"},
+				{Group: "platform.example.io", Kind: "XDatabase", Namespace: "data", Name: "orders"},
+			},
+			ownerAPIVersions: []string{"platform.example.io/v1alpha1"},
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			if len(fixture.ownerAPIVersions) != len(fixture.chain)-1 {
+				t.Fatalf("fixture has %d owner API versions for %d edges", len(fixture.ownerAPIVersions), len(fixture.chain)-1)
+			}
+			catalog := ownerFixtureCatalog{}
+			for i, ref := range fixture.chain {
+				if i+1 < len(fixture.chain) {
+					next := fixture.chain[i+1]
+					catalog[ref] = obj(ref.Namespace, ref.Name, nil, nil,
+						ctrlRef(next.Kind, next.Name, fixture.ownerAPIVersions[i]))
+					continue
+				}
+				if fixture.terminalOwner != nil {
+					catalog[ref] = obj(ref.Namespace, ref.Name, nil, nil, *fixture.terminalOwner)
+					continue
+				}
+				catalog[ref] = obj(ref.Namespace, ref.Name, nil, nil)
+			}
+
+			resolver := catalog.resolver()
+			root := fixture.chain[len(fixture.chain)-1]
+			if fixture.terminalOwner != nil {
+				if parent, ok := resolver.ParentOf(root); ok {
+					t.Fatalf("non-controller terminal owner produced parent %+v", parent)
+				}
+			}
+			for _, start := range fixture.chain {
+				got := ResolveSubject(start, resolver, nil)
+				if got.Ref != root {
+					t.Errorf("ResolveSubject(%+v).Ref = %+v, want %+v", start, got.Ref, root)
+				}
+			}
+		})
+	}
+}
+
+func TestControllerOwnerResolverExactGroupIdentity(t *testing.T) {
+	batchJob := Ref{Group: "batch", Kind: "Job", Namespace: "jobs", Name: "same"}
+	volcanoJob := Ref{Group: "batch.volcano.sh", Kind: "Job", Namespace: "jobs", Name: "same"}
+	catalog := ownerFixtureCatalog{
+		batchJob:   obj("jobs", "same", nil, nil, ctrlRef("CronJob", "nightly", "batch/v1")),
+		volcanoJob: obj("jobs", "same", nil, nil, ctrlRef("JobFlow", "pipeline", "batch.volcano.sh/v1alpha1")),
+	}
+	resolver := catalog.resolver()
+
+	gotBatch, ok := resolver.ParentOf(batchJob)
+	if !ok || gotBatch != (Ref{Group: "batch", Kind: "CronJob", Namespace: "jobs", Name: "nightly"}) {
+		t.Fatalf("batch Job parent = %+v, %v", gotBatch, ok)
+	}
+	gotVolcano, ok := resolver.ParentOf(volcanoJob)
+	if !ok || gotVolcano != (Ref{Group: "batch.volcano.sh", Kind: "JobFlow", Namespace: "jobs", Name: "pipeline"}) {
+		t.Fatalf("Volcano Job parent = %+v, %v", gotVolcano, ok)
+	}
+	if immediate, ok := resolver.ImmediateOwner(volcanoJob); !ok || immediate != gotVolcano {
+		t.Fatalf("ImmediateOwner = %+v, %v; ParentOf = %+v", immediate, ok, gotVolcano)
+	}
+}
+
+func TestControllerOwnerResolverCoreGroupAndUID(t *testing.T) {
+	child := Ref{Group: "example.io", Kind: "Worker", Namespace: "apps", Name: "worker"}
+	owner := ctrlRef("Pod", "worker-pod", "v1")
+	owner.UID = types.UID("observed-owner-uid")
+	catalog := ownerFixtureCatalog{
+		child: obj("apps", "worker", nil, nil, owner),
+	}
+
+	got, ok := catalog.resolver().ParentOf(child)
+	want := Ref{Kind: "Pod", Namespace: "apps", Name: "worker-pod"}
+	if !ok || got != want {
+		t.Fatalf("ParentOf = %+v, %v; want %+v, true", got, ok, want)
+	}
+	owner.UID = types.UID("replacement-owner-uid")
+	catalog[child] = obj("apps", "worker", nil, nil, owner)
+	if replacement, ok := catalog.resolver().ParentOf(child); !ok || replacement != got {
+		t.Fatalf("replacement UID changed parent identity: %+v, %v; want %+v, true", replacement, ok, got)
+	}
+}
+
+func TestControllerOwnerResolverPreservesOwnerName(t *testing.T) {
+	child := Ref{Group: "apps", Kind: "ReplicaSet", Namespace: "apps", Name: "web-6d8f9"}
+	resolver := ownerFixtureCatalog{
+		child: obj("apps", child.Name, nil, nil, ctrlRef("Deployment", "web-controller-6d8f9", "apps/v1")),
+	}.resolver()
+
+	got, ok := resolver.ParentOf(child)
+	want := Ref{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web-controller-6d8f9"}
+	if !ok || got != want {
+		t.Fatalf("ParentOf = %+v, %v; want exact owner-ref name %+v, true", got, ok, want)
+	}
+}
+
+func TestControllerOwnerResolverRequiresCompleteControllerReference(t *testing.T) {
+	child := Ref{Kind: "Pod", Namespace: "apps", Name: "worker"}
+	controller := true
+	nonController := false
+	tests := map[string]metav1.OwnerReference{
+		"non-controller":     {APIVersion: "argoproj.io/v1alpha1", Kind: "Application", Name: "apps", Controller: &nonController},
+		"missing apiVersion": {Kind: "Deployment", Name: "worker", Controller: &controller},
+		"missing kind":       {APIVersion: "apps/v1", Name: "worker", Controller: &controller},
+		"missing name":       {APIVersion: "apps/v1", Kind: "Deployment", Controller: &controller},
+	}
+	for name, owner := range tests {
+		t.Run(name, func(t *testing.T) {
+			resolver := ownerFixtureCatalog{child: obj("apps", "worker", nil, nil, owner)}.resolver()
+			if got, ok := resolver.ParentOf(child); ok {
+				t.Fatalf("ParentOf = %+v, true; want no evidenced parent", got)
+			}
+		})
+	}
+}
+
+func TestControllerOwnerResolverStopsAfterUnobservedParent(t *testing.T) {
+	pod := Ref{Kind: "Pod", Namespace: "training", Name: "train-worker-abcde"}
+	job := Ref{Group: "batch", Kind: "Job", Namespace: "training", Name: "train-worker"}
+	resolver := ownerFixtureCatalog{
+		pod: obj("training", pod.Name, nil, nil, ctrlRef("Job", job.Name, "batch/v1")),
+	}.resolver()
+
+	parent, ok := resolver.ParentOf(pod)
+	if !ok || parent != job {
+		t.Fatalf("ParentOf(Pod) = %+v, %v; want controllerRef-evidenced %+v", parent, ok, job)
+	}
+	if next, ok := resolver.ParentOf(job); ok {
+		t.Fatalf("ParentOf(unobserved Job) = %+v, true; want the walk to stop", next)
+	}
+	got := ResolveSubject(pod, resolver, nil)
+	if got.Ref != job {
+		t.Fatalf("ResolveSubject(Pod).Ref = %+v, want last evidenced parent %+v", got.Ref, job)
+	}
+}
+
+func TestControllerOwnerResolverNilLookup(t *testing.T) {
+	if got, ok := (ControllerOwnerResolver{}).ParentOf(Ref{Kind: "Pod", Namespace: "apps", Name: "worker"}); ok {
+		t.Fatalf("ParentOf with nil lookup = %+v, true", got)
+	}
+}

--- a/pkg/subject/controller_owner_test.go
+++ b/pkg/subject/controller_owner_test.go
@@ -9,11 +9,24 @@ import (
 
 type ownerFixtureCatalog map[Ref]metav1.Object
 
-func (c ownerFixtureCatalog) resolver() ControllerOwnerResolver {
-	return ControllerOwnerResolver{Lookup: func(ref Ref) (metav1.Object, bool) {
-		obj, ok := c[ref]
-		return obj, ok
-	}}
+type ownerFixtureType struct {
+	group string
+	kind  string
+}
+
+type ownerFixtureScopes map[ownerFixtureType]bool
+
+func (c ownerFixtureCatalog) resolver(scopes ownerFixtureScopes) ControllerOwnerResolver {
+	return ControllerOwnerResolver{
+		Lookup: func(ref Ref) (metav1.Object, bool) {
+			obj, ok := c[ref]
+			return obj, ok
+		},
+		IsNamespaced: func(group, kind string) (bool, bool) {
+			namespaced, ok := scopes[ownerFixtureType{group: group, kind: kind}]
+			return namespaced, ok
+		},
+	}
 }
 
 func TestControllerOwnerResolverChainParity(t *testing.T) {
@@ -21,6 +34,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 		name             string
 		chain            []Ref
 		ownerAPIVersions []string
+		ownerNamespaced  []bool
 		terminalOwner    *metav1.OwnerReference
 	}
 	nonController := false
@@ -33,6 +47,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web"},
 			},
 			ownerAPIVersions: []string{"apps/v1", "apps/v1"},
+			ownerNamespaced:  []bool{true, true},
 		},
 		{
 			name: "cronjob",
@@ -42,6 +57,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "batch", Kind: "CronJob", Namespace: "ops", Name: "backup"},
 			},
 			ownerAPIVersions: []string{"batch/v1", "batch/v1"},
+			ownerNamespaced:  []bool{true, true},
 		},
 		{
 			name: "argo rollout",
@@ -51,6 +67,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "argoproj.io", Kind: "Rollout", Namespace: "apps", Name: "canary"},
 			},
 			ownerAPIVersions: []string{"apps/v1", "argoproj.io/v1alpha1"},
+			ownerNamespaced:  []bool{true, true},
 		},
 		{
 			name: "jobset",
@@ -60,6 +77,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "jobset.x-k8s.io", Kind: "JobSet", Namespace: "training", Name: "train"},
 			},
 			ownerAPIVersions: []string{"batch/v1", "jobset.x-k8s.io/v1alpha2"},
+			ownerNamespaced:  []bool{true, true},
 		},
 		{
 			name: "ray service",
@@ -69,6 +87,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "ray.io", Kind: "RayService", Namespace: "serving", Name: "serve"},
 			},
 			ownerAPIVersions: []string{"ray.io/v1", "ray.io/v1"},
+			ownerNamespaced:  []bool{true, true},
 		},
 		{
 			name: "cloudnativepg",
@@ -77,6 +96,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "postgresql.cnpg.io", Kind: "Cluster", Namespace: "data", Name: "postgres"},
 			},
 			ownerAPIVersions: []string{"postgresql.cnpg.io/v1"},
+			ownerNamespaced:  []bool{true},
 		},
 		{
 			name: "strimzi",
@@ -85,6 +105,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				{Group: "core.strimzi.io", Kind: "StrimziPodSet", Namespace: "data", Name: "events-brokers"},
 			},
 			ownerAPIVersions: []string{"core.strimzi.io/v1beta2"},
+			ownerNamespaced:  []bool{true},
 			terminalOwner: &metav1.OwnerReference{
 				APIVersion: "kafka.strimzi.io/v1",
 				Kind:       "KafkaNodePool",
@@ -93,12 +114,13 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 			},
 		},
 		{
-			name: "crossplane controller reference",
+			name: "crossplane cluster-scoped controller reference",
 			chain: []Ref{
-				{Group: "database.example.io", Kind: "ManagedDatabase", Namespace: "data", Name: "orders"},
-				{Group: "platform.example.io", Kind: "XDatabase", Namespace: "data", Name: "orders"},
+				{Group: "database.example.io", Kind: "Database", Namespace: "data", Name: "orders"},
+				{Group: "platform.example.io", Kind: "XDatabase", Name: "orders"},
 			},
 			ownerAPIVersions: []string{"platform.example.io/v1alpha1"},
+			ownerNamespaced:  []bool{false},
 		},
 	}
 
@@ -107,10 +129,15 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 			if len(fixture.ownerAPIVersions) != len(fixture.chain)-1 {
 				t.Fatalf("fixture has %d owner API versions for %d edges", len(fixture.ownerAPIVersions), len(fixture.chain)-1)
 			}
+			if len(fixture.ownerNamespaced) != len(fixture.chain)-1 {
+				t.Fatalf("fixture has %d owner scopes for %d edges", len(fixture.ownerNamespaced), len(fixture.chain)-1)
+			}
 			catalog := ownerFixtureCatalog{}
+			scopes := ownerFixtureScopes{}
 			for i, ref := range fixture.chain {
 				if i+1 < len(fixture.chain) {
 					next := fixture.chain[i+1]
+					scopes[ownerFixtureType{group: next.Group, kind: next.Kind}] = fixture.ownerNamespaced[i]
 					catalog[ref] = obj(ref.Namespace, ref.Name, nil, nil,
 						ctrlRef(next.Kind, next.Name, fixture.ownerAPIVersions[i]))
 					continue
@@ -122,7 +149,7 @@ func TestControllerOwnerResolverChainParity(t *testing.T) {
 				catalog[ref] = obj(ref.Namespace, ref.Name, nil, nil)
 			}
 
-			resolver := catalog.resolver()
+			resolver := catalog.resolver(scopes)
 			root := fixture.chain[len(fixture.chain)-1]
 			if fixture.terminalOwner != nil {
 				if parent, ok := resolver.ParentOf(root); ok {
@@ -146,7 +173,10 @@ func TestControllerOwnerResolverExactGroupIdentity(t *testing.T) {
 		batchJob:   obj("jobs", "same", nil, nil, ctrlRef("CronJob", "nightly", "batch/v1")),
 		volcanoJob: obj("jobs", "same", nil, nil, ctrlRef("JobFlow", "pipeline", "batch.volcano.sh/v1alpha1")),
 	}
-	resolver := catalog.resolver()
+	resolver := catalog.resolver(ownerFixtureScopes{
+		{group: "batch", kind: "CronJob"}:            true,
+		{group: "batch.volcano.sh", kind: "JobFlow"}: true,
+	})
 
 	gotBatch, ok := resolver.ParentOf(batchJob)
 	if !ok || gotBatch != (Ref{Group: "batch", Kind: "CronJob", Namespace: "jobs", Name: "nightly"}) {
@@ -169,14 +199,15 @@ func TestControllerOwnerResolverCoreGroupAndUID(t *testing.T) {
 		child: obj("apps", "worker", nil, nil, owner),
 	}
 
-	got, ok := catalog.resolver().ParentOf(child)
+	scopes := ownerFixtureScopes{{kind: "Pod"}: true}
+	got, ok := catalog.resolver(scopes).ParentOf(child)
 	want := Ref{Kind: "Pod", Namespace: "apps", Name: "worker-pod"}
 	if !ok || got != want {
 		t.Fatalf("ParentOf = %+v, %v; want %+v, true", got, ok, want)
 	}
 	owner.UID = types.UID("replacement-owner-uid")
 	catalog[child] = obj("apps", "worker", nil, nil, owner)
-	if replacement, ok := catalog.resolver().ParentOf(child); !ok || replacement != got {
+	if replacement, ok := catalog.resolver(scopes).ParentOf(child); !ok || replacement != got {
 		t.Fatalf("replacement UID changed parent identity: %+v, %v; want %+v, true", replacement, ok, got)
 	}
 }
@@ -185,7 +216,7 @@ func TestControllerOwnerResolverPreservesOwnerName(t *testing.T) {
 	child := Ref{Group: "apps", Kind: "ReplicaSet", Namespace: "apps", Name: "web-6d8f9"}
 	resolver := ownerFixtureCatalog{
 		child: obj("apps", child.Name, nil, nil, ctrlRef("Deployment", "web-controller-6d8f9", "apps/v1")),
-	}.resolver()
+	}.resolver(ownerFixtureScopes{{group: "apps", kind: "Deployment"}: true})
 
 	got, ok := resolver.ParentOf(child)
 	want := Ref{Group: "apps", Kind: "Deployment", Namespace: "apps", Name: "web-controller-6d8f9"}
@@ -206,7 +237,7 @@ func TestControllerOwnerResolverRequiresCompleteControllerReference(t *testing.T
 	}
 	for name, owner := range tests {
 		t.Run(name, func(t *testing.T) {
-			resolver := ownerFixtureCatalog{child: obj("apps", "worker", nil, nil, owner)}.resolver()
+			resolver := ownerFixtureCatalog{child: obj("apps", "worker", nil, nil, owner)}.resolver(nil)
 			if got, ok := resolver.ParentOf(child); ok {
 				t.Fatalf("ParentOf = %+v, true; want no evidenced parent", got)
 			}
@@ -219,7 +250,7 @@ func TestControllerOwnerResolverStopsAfterUnobservedParent(t *testing.T) {
 	job := Ref{Group: "batch", Kind: "Job", Namespace: "training", Name: "train-worker"}
 	resolver := ownerFixtureCatalog{
 		pod: obj("training", pod.Name, nil, nil, ctrlRef("Job", job.Name, "batch/v1")),
-	}.resolver()
+	}.resolver(ownerFixtureScopes{{group: "batch", kind: "Job"}: true})
 
 	parent, ok := resolver.ParentOf(pod)
 	if !ok || parent != job {
@@ -237,5 +268,49 @@ func TestControllerOwnerResolverStopsAfterUnobservedParent(t *testing.T) {
 func TestControllerOwnerResolverNilLookup(t *testing.T) {
 	if got, ok := (ControllerOwnerResolver{}).ParentOf(Ref{Kind: "Pod", Namespace: "apps", Name: "worker"}); ok {
 		t.Fatalf("ParentOf with nil lookup = %+v, true", got)
+	}
+}
+
+func TestControllerOwnerResolverFailsClosedForUnknownNamespacedOwnerScope(t *testing.T) {
+	child := Ref{Kind: "Pod", Namespace: "apps", Name: "worker"}
+	catalog := ownerFixtureCatalog{
+		child: obj("apps", "worker", nil, nil, ctrlRef("Widget", "worker", "example.io/v1")),
+	}
+	tests := map[string]ControllerOwnerResolver{
+		"missing scope resolver": {Lookup: catalog.resolver(nil).Lookup},
+		"unknown exact scope":    catalog.resolver(nil),
+	}
+	for name, resolver := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := resolver.ParentOf(child); ok {
+				t.Fatalf("ParentOf with unknown owner scope = %+v, true", got)
+			}
+		})
+	}
+}
+
+func TestControllerOwnerResolverClusterScopedOwner(t *testing.T) {
+	child := Ref{Group: "example.io", Kind: "Worker", Namespace: "apps", Name: "worker"}
+	resolver := ownerFixtureCatalog{
+		child: obj("apps", "worker", nil, nil, ctrlRef("GlobalController", "workers", "control.example.io/v1")),
+	}.resolver(ownerFixtureScopes{{group: "control.example.io", kind: "GlobalController"}: false})
+
+	got, ok := resolver.ParentOf(child)
+	want := Ref{Group: "control.example.io", Kind: "GlobalController", Name: "workers"}
+	if !ok || got != want {
+		t.Fatalf("ParentOf = %+v, %v; want cluster-scoped %+v, true", got, ok, want)
+	}
+}
+
+func TestControllerOwnerResolverClusterScopedChildKeepsEmptyNamespace(t *testing.T) {
+	child := Ref{Group: "example.io", Kind: "GlobalWorker", Name: "worker"}
+	resolver := ownerFixtureCatalog{
+		child: obj("", "worker", nil, nil, ctrlRef("GlobalController", "workers", "control.example.io/v1")),
+	}.resolver(nil)
+
+	got, ok := resolver.ParentOf(child)
+	want := Ref{Group: "control.example.io", Kind: "GlobalController", Name: "workers"}
+	if !ok || got != want {
+		t.Fatalf("ParentOf = %+v, %v; want cluster-scoped %+v, true", got, ok, want)
 	}
 }

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -130,7 +130,8 @@ func ScopeForKind(kind string) Scope {
 //
 // Returns the immediate controller-parent of the given ref, or (zero, false)
 // when there is no further controller. Object-backed implementations preserve
-// the exact owner-reference name; only explicitly heuristic implementations may
+// the exact owner-reference name and resolve the owner's namespace from
+// authoritative resource scope; only explicitly heuristic implementations may
 // derive a name when the owner object is unavailable.
 type OwnerResolver interface {
 	// ParentOf returns the next CONTROLLER up the chain, or (zero, false) at root.

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -14,11 +14,12 @@
 // PLACEMENT NOTE: pkg/subject imports only the canonical-key helper from
 // pkg/resourceid (ResourceKey). It does NOT import internal/* or pkg/topology (the
 // plan's layering rule). The Tier-1 owner walk is parameterized over an
-// OwnerResolver interface — which a topology adapter must satisfy with a
-// CONTROLLER-ownership resolver, NOT a raw walkTopmostOwner (see OwnerResolver's
-// contract: EdgeManages also carries GitOps/Helm management edges, which are
-// Tier-2, not identity). A heuristic single-pod walk is built in. Tier-2 takes
-// only a metav1.Object's labels/annotations, so it has zero topology dependency.
+// OwnerResolver interface. ControllerOwnerResolver adapts an injected exact-ref
+// object lookup; any topology adapter must likewise use CONTROLLER ownership,
+// NOT a raw walkTopmostOwner (see OwnerResolver's contract: EdgeManages also
+// carries GitOps/Helm management edges, which are Tier-2, not identity). A
+// heuristic single-pod walk is also built in. Tier-2 takes only a metav1.Object's
+// labels/annotations, so it has zero topology dependency.
 package subject
 
 import (
@@ -128,7 +129,9 @@ func ScopeForKind(kind string) Scope {
 // the detectors (a depth-0/1 walk).
 //
 // Returns the immediate controller-parent of the given ref, or (zero, false)
-// when there is no further controller. Names already RS-hash-stripped per impl.
+// when there is no further controller. Object-backed implementations preserve
+// the exact owner-reference name; only explicitly heuristic implementations may
+// derive a name when the owner object is unavailable.
 type OwnerResolver interface {
 	// ParentOf returns the next CONTROLLER up the chain, or (zero, false) at root.
 	ParentOf(child Ref) (parent Ref, ok bool)
@@ -151,8 +154,8 @@ const maxOwnerWalkDepth = 16
 
 // ResolveSubject is the Tier-1 entrypoint. It collapses ownerReferences to the
 // root controller and classifies the terminal Anchor. It SUBSUMES:
-//   - topOwnerForPod's single-hop RS->Deployment + name-strip (generalized to a
-//     multi-hop walk via OwnerResolver), AND extends it with Job->CronJob,
+//   - topOwnerForPod's owner collapse (generalized to a multi-hop walk via
+//     OwnerResolver), AND extends it with Job->CronJob,
 //     owner=nil -> AnchorBare, owner=Node -> AnchorNode, operator-CR root hop.
 //   - enrichIdentity / foldGroup's owner-else-self collapse (the single hop is
 //     just a depth-1 walk with no further parent).


### PR DESCRIPTION
## Status and program context

**Ready for review as an independent foundation. No production consumer uses this resolver yet.**

The GPU, batch, and AI/ML breadth work exposed a shared prerequisite: Radar cannot compose controller-generated resources across Topology, Applications, Issues, Timeline, and MCP while owner identity is only Kind + namespace + name. This PR is the P0.1c subject-parity foundation for resolving Kubernetes controller ownership with exact API-group identity. Controller-native contexts and drilldowns such as JobSet are separate verticals.

## Summary

- add a pure, group-aware `ControllerOwnerResolver` over injected exact-resource lookup and exact group/kind scope resolution
- follow only Kubernetes controller references, preserving authoritative group, kind, and owner name while deriving namespace from known resource scope
- fail closed when a namespaced child's controller scope is unknown instead of fabricating a namespaced or cluster-scoped identity
- add a parity corpus for Deployment, CronJob, Rollout, JobSet, RayService, CloudNativePG, Strimzi, and Crossplane ownership chains
- pin partial-cache behavior: a child may identify an unobserved controller when its scope is known, but the walk stops there

## Dependency and merge map

- This PR targets `main` and is independently mergeable.
- It is independent of the observation-coverage stack [#1558](https://github.com/skyhook-io/radar/pull/1558) -> [#1559](https://github.com/skyhook-io/radar/pull/1559).
- [#1560](https://github.com/skyhook-io/radar/pull/1560) is separate exact-resource, Topology, and Applications identity work. It does not consume or wire this owner resolver; reviewers should not infer that #1557 is production-connected through #1560.
- It does not block the JobSet stack [#1552](https://github.com/skyhook-io/radar/pull/1552) -> [#1562](https://github.com/skyhook-io/radar/pull/1562) -> [#1561](https://github.com/skyhook-io/radar/pull/1561).
- A later production-adapter PR must wire the scope callback to group-aware API discovery and migrate consumers one at a time. This PR deliberately does not make that global switch.

## Review focus

- controller references only: never follow non-controller owner references or broad topology management edges
- exact API group and Kind preservation across multi-hop chains
- scope resolution for namespaced children whose controller may be namespaced or cluster-scoped
- fail-closed behavior when scope is unknown, and bounded behavior when an identified parent is not cached
- parity fixtures for existing integrations, not only the new GPU ecosystem

## Deliberate boundaries

This PR does not switch a production consumer, expand operator allowlists, follow broad topology management edges, or aggregate root-level Issues. The Strimzi fixture intentionally stops at `StrimziPodSet`: current Strimzi creates the KafkaNodePool reference with `controller=false`, so following it would violate the contract.

## Source revalidation

- Kubernetes ownership scope rules: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owners-and-dependents
- JobSet v0.12.0 makes JobSet the Job controller: https://github.com/kubernetes-sigs/jobset/blob/v0.12.0/pkg/controllers/jobset_controller.go#L740
- KubeRay v1.7.0 makes RayService the RayCluster controller and RayCluster the Pod controller: https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/controllers/ray/rayservice_controller.go#L1544 and https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/controllers/ray/raycluster_controller.go#L1753
- CloudNativePG makes Cluster the Pod controller: https://github.com/cloudnative-pg/cloudnative-pg/blob/8179beb0592398b9ae3221d8488c815b73e94b2c/internal/controller/cluster_create.go#L1495
- Strimzi marks KafkaNodePool as a non-controller owner: https://github.com/strimzi/strimzi-kafka-operator/blob/035bdf3026a477d3ffe017b8bc0640e9779961cc/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java#L72
- Crossplane composed-resource controller references retain the author-defined XR group: https://github.com/crossplane/crossplane/blob/0e4f8c1d78ef7a4b1cb2d95d92cafa9a905c2280/internal/controller/apiextensions/composite/composition_render.go#L114-L116

## Verification

- `(cd pkg && go test ./subject)`
- `make tsc`
- `make test`
- `make build`
- `git diff --check`

Visual testing was skipped because this has no rendered UI path or production consumer change.

Part of RAD-418.
