### PR TITLE
Expose exact-GVR observation coverage

### DIFF
--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -68,35 +68,37 @@ type ResourcePermissions struct {
 //     namespace-scoped on the same cluster, and a namespace-scoped kind may
 //     be readable in several explicitly named namespaces.
 type PermissionCheckResult struct {
-	Perms           *ResourcePermissions
-	NamespaceScoped bool   // True if at least one resource type ended up namespace-scoped
-	Namespace       string // The fallback namespace used for namespace-scoped probes
-	Scopes          map[string]k8score.ResourceScope
-	ScopeNamespaces map[string][]string // Per-kind namespace-scoped informer fanout; nil/empty means use Scopes[key].Namespace
-	ScopeCandidates []string            // The candidate namespaces the probe walked — the dynamic CRD cache probes these per-GVR as its namespace fallbacks
+	Perms                    *ResourcePermissions
+	NamespaceScoped          bool   // True if at least one resource type ended up namespace-scoped
+	Namespace                string // The fallback namespace used for namespace-scoped probes
+	Scopes                   map[string]k8score.ResourceScope
+	ScopeNamespaces          map[string][]string // Per-kind namespace-scoped informer fanout; nil/empty means use Scopes[key].Namespace
+	ScopeCandidates          []string            // The candidate namespaces the probe walked — the dynamic CRD cache probes these per-GVR as its namespace fallbacks
+	ScopeCandidatesTruncated bool                // Additional candidates were omitted by MaxScopeCandidates
 }
 
 // Capabilities represents the features available based on RBAC permissions
 type Capabilities struct {
-	Exec           bool                     `json:"exec"`                    // Can create pods/exec (terminal feature)
-	LocalTerminal  bool                     `json:"localTerminal"`           // Local terminal available (not in-cluster, not disabled)
-	Logs           bool                     `json:"logs"`                    // Can get pods/log (log viewer)
-	PortForward    bool                     `json:"portForward"`             // Can create pods/portforward
-	Secrets        bool                     `json:"secrets"`                 // Can list secrets
-	SecretsUpdate  bool                     `json:"secretsUpdate"`           // Can update secrets (inline editing)
-	HelmWrite      bool                     `json:"helmWrite"`               // Helm write ops (detected via secrets/create as sentinel RBAC check)
-	NodeWrite      bool                     `json:"nodeWrite"`               // Can patch nodes (cordon/uncordon/drain)
-	WorkloadWrites WorkloadWritePermissions `json:"workloadWrites"`          // Can patch workload kinds (restart/scale controls)
-	MCPEnabled     bool                     `json:"mcpEnabled"`              // MCP server is running
-	Deployment     DeploymentInfo           `json:"deployment"`              // How / where this Radar binary is running. Tells the UI which chrome to render or suppress (e.g. embedded mode hides the cluster headline + local-MCP card because the hub already renders both).
-	Features       FeatureCapabilities      `json:"features"`                // Versioned server features that newer embedded frontends must negotiate
-	AuthEnabled    bool                     `json:"authEnabled,omitempty"`   // Auth is enabled on the server
-	Username       string                   `json:"username,omitempty"`      // Authenticated username (when auth enabled)
-	Resources      *ResourcePermissions     `json:"resources,omitempty"`     // Per-resource-type permissions
-	Visibility     *VisibilitySummary       `json:"visibility,omitempty"`    // Present when resource visibility is limited enough to make diagnostics incomplete
-	Karpenter      IntegrationCapability    `json:"karpenter"`               // Per-request Karpenter discovery + NodePool read state; populated by the HTTP layer after user SAR.
-	PolicyReports  *PolicyReportStatus      `json:"policyReports,omitempty"` // Why the Kyverno PolicyReport index is (or is not) populated, so an empty policy view can say which.
-	CloudConnect   *CloudConnectCapability  `json:"cloudConnect,omitempty"`
+	Exec              bool                        `json:"exec"`                  // Can create pods/exec (terminal feature)
+	LocalTerminal     bool                        `json:"localTerminal"`         // Local terminal available (not in-cluster, not disabled)
+	Logs              bool                        `json:"logs"`                  // Can get pods/log (log viewer)
+	PortForward       bool                        `json:"portForward"`           // Can create pods/portforward
+	Secrets           bool                        `json:"secrets"`               // Can list secrets
+	SecretsUpdate     bool                        `json:"secretsUpdate"`         // Can update secrets (inline editing)
+	HelmWrite         bool                        `json:"helmWrite"`             // Helm write ops (detected via secrets/create as sentinel RBAC check)
+	NodeWrite         bool                        `json:"nodeWrite"`             // Can patch nodes (cordon/uncordon/drain)
+	WorkloadWrites    WorkloadWritePermissions    `json:"workloadWrites"`        // Can patch workload kinds (restart/scale controls)
+	MCPEnabled        bool                        `json:"mcpEnabled"`            // MCP server is running
+	Deployment        DeploymentInfo              `json:"deployment"`            // How / where this Radar binary is running. Tells the UI which chrome to render or suppress (e.g. embedded mode hides the cluster headline + local-MCP card because the hub already renders both).
+	Features          FeatureCapabilities         `json:"features"`              // Versioned server features that newer embedded frontends must negotiate
+	AuthEnabled       bool                        `json:"authEnabled,omitempty"` // Auth is enabled on the server
+	Username          string                      `json:"username,omitempty"`    // Authenticated username (when auth enabled)
+	Resources         *ResourcePermissions        `json:"resources,omitempty"`   // Per-resource-type permissions
+	Visibility        *VisibilitySummary          `json:"visibility,omitempty"`  // Present when resource visibility is limited enough to make diagnostics incomplete
+	Karpenter         IntegrationCapability       `json:"karpenter"`             // Per-request Karpenter discovery + NodePool read state; populated by the HTTP layer after user SAR.
+	ResourceDiscovery *capacityapi.SourceCoverage `json:"resourceDiscovery,omitempty"`
+	PolicyReports     *PolicyReportStatus         `json:"policyReports,omitempty"` // Why the Kyverno PolicyReport index is (or is not) populated, so an empty policy view can say which.
+	CloudConnect      *CloudConnectCapability     `json:"cloudConnect,omitempty"`
 }
 
 type IntegrationCapability struct {
@@ -930,12 +932,13 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 			scopeNamespacesCopy[k] = append([]string(nil), v...)
 		}
 		result := &PermissionCheckResult{
-			Perms:           &permsCopy,
-			NamespaceScoped: cachedPermResult.NamespaceScoped,
-			Namespace:       cachedPermResult.Namespace,
-			Scopes:          scopesCopy,
-			ScopeNamespaces: scopeNamespacesCopy,
-			ScopeCandidates: append([]string(nil), cachedPermResult.ScopeCandidates...),
+			Perms:                    &permsCopy,
+			NamespaceScoped:          cachedPermResult.NamespaceScoped,
+			Namespace:                cachedPermResult.Namespace,
+			Scopes:                   scopesCopy,
+			ScopeNamespaces:          scopeNamespacesCopy,
+			ScopeCandidates:          append([]string(nil), cachedPermResult.ScopeCandidates...),
+			ScopeCandidatesTruncated: cachedPermResult.ScopeCandidatesTruncated,
 		}
 		resourcePermsMu.RUnlock()
 		return result
@@ -953,7 +956,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 	}
 
 	forceNamespace := ForceNamespaceScope
-	scopeNamespaces := buildScopeCandidates(ctx)
+	scopeNamespaces, scopeCandidatesTruncated := buildScopeCandidates(ctx)
 	if forceNamespace {
 		if target := GetNamespaceScopeTarget(); target != "" {
 			scopeNamespaces = mergeForcedScopeCandidate(target, scopeNamespaces)
@@ -963,6 +966,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 	}
 
 	result, hadErrors := probeResourceAccess(ctx, GetDynamicClient(), scopeNamespaces, forceNamespace)
+	result.ScopeCandidatesTruncated = scopeCandidatesTruncated
 
 	resourcePermsMu.Lock()
 	cachedPermResult = result
@@ -987,7 +991,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 // cluster-list order (alphabetical). Empty when no fallback is configured
 // and the user can't enumerate namespaces — caller treats that as "no
 // fallback".
-func buildScopeCandidates(ctx context.Context) []string {
+func buildScopeCandidates(ctx context.Context) ([]string, bool) {
 	// GetEffectiveNamespace would return only one (kubeconfig context wins
 	// over --namespace). Reach into both globals so when an operator sets
 	// `--namespace` distinct from the context, both surface as candidates.
@@ -1012,7 +1016,7 @@ func buildScopeCandidates(ctx context.Context) []string {
 		// kinds" has a breadcrumb instead of silence.
 		log.Printf("RBAC: namespace discovery non-authoritative (cluster-wide list namespaces denied); fallback candidates limited to %v", out)
 	}
-	return out
+	return out, dropped > 0
 }
 
 func mergeForcedScopeCandidate(target string, candidates []string) []string {
@@ -1355,12 +1359,13 @@ func GetCachedPermissionResult() *PermissionCheckResult {
 		scopeNamespacesCopy[k] = append([]string(nil), v...)
 	}
 	return &PermissionCheckResult{
-		Perms:           &permsCopy,
-		NamespaceScoped: cachedPermResult.NamespaceScoped,
-		Namespace:       cachedPermResult.Namespace,
-		Scopes:          scopesCopy,
-		ScopeNamespaces: scopeNamespacesCopy,
-		ScopeCandidates: append([]string(nil), cachedPermResult.ScopeCandidates...),
+		Perms:                    &permsCopy,
+		NamespaceScoped:          cachedPermResult.NamespaceScoped,
+		Namespace:                cachedPermResult.Namespace,
+		Scopes:                   scopesCopy,
+		ScopeNamespaces:          scopeNamespacesCopy,
+		ScopeCandidates:          append([]string(nil), cachedPermResult.ScopeCandidates...),
+		ScopeCandidatesTruncated: cachedPermResult.ScopeCandidatesTruncated,
 	}
 }
 

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -74,7 +74,7 @@ type PermissionCheckResult struct {
 	Scopes                   map[string]k8score.ResourceScope
 	ScopeNamespaces          map[string][]string // Per-kind namespace-scoped informer fanout; nil/empty means use Scopes[key].Namespace
 	ScopeCandidates          []string            // The candidate namespaces the probe walked — the dynamic CRD cache probes these per-GVR as its namespace fallbacks
-	ScopeCandidatesTruncated bool                // Additional candidates were omitted by MaxScopeCandidates
+	ScopeCandidatesTruncated bool                // Candidate set is incomplete: namespace enumeration was non-authoritative or MaxScopeCandidates omitted entries
 }
 
 // Capabilities represents the features available based on RBAC permissions
@@ -956,7 +956,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 	}
 
 	forceNamespace := ForceNamespaceScope
-	scopeNamespaces, scopeCandidatesTruncated := buildScopeCandidates(ctx)
+	scopeNamespaces, scopeCandidatesIncomplete := buildScopeCandidates(ctx)
 	if forceNamespace {
 		if target := GetNamespaceScopeTarget(); target != "" {
 			scopeNamespaces = mergeForcedScopeCandidate(target, scopeNamespaces)
@@ -966,7 +966,7 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 	}
 
 	result, hadErrors := probeResourceAccess(ctx, GetDynamicClient(), scopeNamespaces, forceNamespace)
-	result.ScopeCandidatesTruncated = scopeCandidatesTruncated
+	result.ScopeCandidatesTruncated = scopeCandidatesIncomplete
 
 	resourcePermsMu.Lock()
 	cachedPermResult = result
@@ -988,9 +988,10 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 // buildScopeCandidates returns the namespace candidates for the fallback
 // probe when cluster-wide list is denied. Kubeconfig context (or
 // --namespace) first; then namespaces from GetAccessibleNamespaces, in the
-// cluster-list order (alphabetical). Empty when no fallback is configured
-// and the user can't enumerate namespaces — caller treats that as "no
-// fallback".
+// cluster-list order (alphabetical). The bool reports an incomplete candidate
+// set: either namespace enumeration was non-authoritative or the safety cap
+// omitted candidates. Empty and incomplete is materially different from an
+// authoritative empty set — dynamic-resource denial must remain partial.
 func buildScopeCandidates(ctx context.Context) ([]string, bool) {
 	// GetEffectiveNamespace would return only one (kubeconfig context wins
 	// over --namespace). Reach into both globals so when an operator sets
@@ -1016,7 +1017,11 @@ func buildScopeCandidates(ctx context.Context) ([]string, bool) {
 		// kinds" has a breadcrumb instead of silence.
 		log.Printf("RBAC: namespace discovery non-authoritative (cluster-wide list namespaces denied); fallback candidates limited to %v", out)
 	}
-	return out, dropped > 0
+	return out, scopeCandidateSetIncomplete(authoritative, dropped)
+}
+
+func scopeCandidateSetIncomplete(authoritative bool, dropped int) bool {
+	return !authoritative || dropped > 0
 }
 
 func mergeForcedScopeCandidate(target string, candidates []string) []string {

--- a/internal/k8s/capabilities_probe_test.go
+++ b/internal/k8s/capabilities_probe_test.go
@@ -308,9 +308,11 @@ func TestCheckResourcePermissionsCacheHitCopiesScopeNamespaces(t *testing.T) {
 	const nsA, nsB = "team-a", "team-b"
 	resourcePermsMu.Lock()
 	cachedPermResult = &PermissionCheckResult{
-		Perms:           &ResourcePermissions{Pods: true},
-		NamespaceScoped: true,
-		Namespace:       nsA,
+		Perms:                    &ResourcePermissions{Pods: true},
+		NamespaceScoped:          true,
+		Namespace:                nsA,
+		ScopeCandidates:          []string{nsA, nsB},
+		ScopeCandidatesTruncated: true,
 		Scopes: map[string]k8score.ResourceScope{
 			k8score.Pods: {Enabled: true, Namespace: nsA},
 		},
@@ -322,15 +324,28 @@ func TestCheckResourcePermissionsCacheHitCopiesScopeNamespaces(t *testing.T) {
 	resourcePermsMu.Unlock()
 	t.Cleanup(InvalidateResourcePermissionsCache)
 
+	direct := GetCachedPermissionResult()
+	if direct == nil || !direct.ScopeCandidatesTruncated || !reflect.DeepEqual(direct.ScopeCandidates, []string{nsA, nsB}) {
+		t.Fatalf("GetCachedPermissionResult lost candidate metadata: %+v", direct)
+	}
+	direct.ScopeCandidates[0] = "mutated-direct"
+
 	got := CheckResourcePermissions(context.Background())
 	if !reflect.DeepEqual(got.ScopeNamespaces[k8score.Pods], []string{nsA, nsB}) {
 		t.Fatalf("ScopeNamespaces = %v, want [%s %s]", got.ScopeNamespaces[k8score.Pods], nsA, nsB)
 	}
+	if !got.ScopeCandidatesTruncated {
+		t.Fatal("ScopeCandidatesTruncated was lost on cache hit")
+	}
 	got.ScopeNamespaces[k8score.Pods][0] = "mutated"
+	got.ScopeCandidates[0] = "mutated"
 
 	got = CheckResourcePermissions(context.Background())
 	if !reflect.DeepEqual(got.ScopeNamespaces[k8score.Pods], []string{nsA, nsB}) {
 		t.Fatalf("cached ScopeNamespaces was mutated through caller copy: %v", got.ScopeNamespaces[k8score.Pods])
+	}
+	if !reflect.DeepEqual(got.ScopeCandidates, []string{nsA, nsB}) || !got.ScopeCandidatesTruncated {
+		t.Fatalf("cached ScopeCandidates metadata was mutated through caller copy: %v truncated=%v", got.ScopeCandidates, got.ScopeCandidatesTruncated)
 	}
 }
 

--- a/internal/k8s/capabilities_probe_test.go
+++ b/internal/k8s/capabilities_probe_test.go
@@ -213,6 +213,27 @@ func TestMergeScopeCandidates_NonAuthoritativeIgnoresAccessible(t *testing.T) {
 	}
 }
 
+func TestScopeCandidateSetIncomplete(t *testing.T) {
+	tests := []struct {
+		name          string
+		authoritative bool
+		dropped       int
+		want          bool
+	}{
+		{name: "authoritative complete", authoritative: true, want: false},
+		{name: "authoritative capped", authoritative: true, dropped: 1, want: true},
+		{name: "non-authoritative empty", authoritative: false, want: true},
+		{name: "non-authoritative capped", authoritative: false, dropped: 1, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := scopeCandidateSetIncomplete(test.authoritative, test.dropped); got != test.want {
+				t.Fatalf("scopeCandidateSetIncomplete(%t, %d) = %t, want %t", test.authoritative, test.dropped, got, test.want)
+			}
+		})
+	}
+}
+
 // Operator-named namespaces (--namespaces) can exceed the cap on the
 // non-authoritative path too; the count must be reported so the truncation
 // warning fires for exactly the users who typed the list out.

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -44,6 +44,7 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 		// the HTTP layer (see internal/server/namespace_scope.go).
 		var nsFallback string
 		var nsFallbacks []string
+		var nsFallbacksTruncated bool
 		if permResult := GetCachedPermissionResult(); permResult != nil {
 			if permResult.NamespaceScoped && permResult.Namespace != "" {
 				nsFallback = permResult.Namespace
@@ -52,6 +53,7 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 			// can hold cluster-wide built-in access but namespace-only CRD
 			// access (or the reverse) — the per-GVR probe decides.
 			nsFallbacks = permResult.ScopeCandidates
+			nsFallbacksTruncated = permResult.ScopeCandidatesTruncated
 		}
 
 		// --namespace-scope pins namespaced CRD informers to the target namespace
@@ -77,14 +79,15 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 		recordClusterContext := ActiveClusterContext()
 
 		core, err := k8score.NewDynamicResourceCache(k8score.DynamicCacheConfig{
-			DynamicClient:      client,
-			Discovery:          sharedDiscovery,
-			Changes:            changeCh,
-			NamespaceFallback:  nsFallback,
-			NamespaceFallbacks: nsFallbacks,
-			NamespaceScoped:    nsScoped,
-			Namespace:          nsTarget,
-			DebugEvents:        DebugEvents,
+			DynamicClient:               client,
+			Discovery:                   sharedDiscovery,
+			Changes:                     changeCh,
+			NamespaceFallback:           nsFallback,
+			NamespaceFallbacks:          nsFallbacks,
+			NamespaceFallbacksTruncated: nsFallbacksTruncated,
+			NamespaceScoped:             nsScoped,
+			Namespace:                   nsTarget,
+			DebugEvents:                 DebugEvents,
 			OnReceived: func(kind string) {
 				timeline.IncrementReceived(kind)
 			},

--- a/internal/server/resource_discovery_coverage.go
+++ b/internal/server/resource_discovery_coverage.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/capacityapi"
+)
+
+func resourceDiscoveryCoverage(discovery *k8s.ResourceDiscovery) *capacityapi.SourceCoverage {
+	coverage := capacityapi.NewSourceCoverage(capacityapi.CoverageUnavailable, capacityapi.CoverageScopeCluster)
+	coverage.ReasonCode = "not_initialized"
+	coverage.ImpactFields = []string{"apiResources"}
+	if discovery == nil {
+		return &coverage
+	}
+
+	stats := discovery.Stats()
+	if !stats.LastSuccessfulRefresh.IsZero() {
+		observedAt := stats.LastSuccessfulRefresh
+		coverage.ObservedAt = &observedAt
+	}
+	switch {
+	case stats.Stale || (stats.LastSuccessfulRefresh.IsZero() && stats.LastError != ""):
+		coverage.Status = capacityapi.CoverageError
+		coverage.ReasonCode = "discovery_refresh_failed"
+	case stats.Partial:
+		coverage.Status = capacityapi.CoveragePartial
+		coverage.ReasonCode = "partial_discovery"
+	case stats.LastSuccessfulRefresh.IsZero():
+		coverage.ReasonCode = "not_attempted"
+	default:
+		coverage.Status = capacityapi.CoverageAvailable
+		coverage.ReasonCode = ""
+		coverage.ImpactFields = []string{}
+	}
+	return &coverage
+}

--- a/internal/server/resource_discovery_coverage_test.go
+++ b/internal/server/resource_discovery_coverage_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/capacityapi"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+type mutableResourceDiscovery struct {
+	discovery.DiscoveryInterface
+	resources []*metav1.APIResourceList
+	err       error
+}
+
+func (d *mutableResourceDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, d.resources, d.err
+}
+
+func TestResourceDiscoveryCoverageStates(t *testing.T) {
+	availableResources := []*metav1.APIResourceList{{
+		GroupVersion: "example.io/v1",
+		APIResources: []metav1.APIResource{{Name: "widgets", Kind: "Widget", Verbs: []string{"list", "watch"}}},
+	}}
+
+	t.Run("not initialized", func(t *testing.T) {
+		got := resourceDiscoveryCoverage(nil)
+		if got.Status != capacityapi.CoverageUnavailable || got.ReasonCode != "not_initialized" || got.ObservedAt != nil {
+			t.Fatalf("coverage = %+v", got)
+		}
+	})
+
+	t.Run("available", func(t *testing.T) {
+		client := &mutableResourceDiscovery{resources: availableResources}
+		core, err := k8score.NewResourceDiscovery(client)
+		if err != nil {
+			t.Fatalf("NewResourceDiscovery: %v", err)
+		}
+		got := resourceDiscoveryCoverage(&k8s.ResourceDiscovery{ResourceDiscovery: core})
+		if got.Status != capacityapi.CoverageAvailable || got.ReasonCode != "" || got.ObservedAt == nil || len(got.ImpactFields) != 0 {
+			t.Fatalf("coverage = %+v", got)
+		}
+	})
+
+	t.Run("fresh partial", func(t *testing.T) {
+		client := &mutableResourceDiscovery{resources: availableResources, err: errors.New("one group failed")}
+		core, err := k8score.NewResourceDiscovery(client)
+		if err != nil {
+			t.Fatalf("NewResourceDiscovery: %v", err)
+		}
+		got := resourceDiscoveryCoverage(&k8s.ResourceDiscovery{ResourceDiscovery: core})
+		if got.Status != capacityapi.CoveragePartial || got.ReasonCode != "partial_discovery" || got.ObservedAt == nil {
+			t.Fatalf("coverage = %+v", got)
+		}
+	})
+
+	t.Run("failed initial refresh", func(t *testing.T) {
+		client := &mutableResourceDiscovery{err: errors.New("discovery unavailable")}
+		core, err := k8score.NewResourceDiscovery(client)
+		if err != nil {
+			t.Fatalf("NewResourceDiscovery: %v", err)
+		}
+		got := resourceDiscoveryCoverage(&k8s.ResourceDiscovery{ResourceDiscovery: core})
+		if got.Status != capacityapi.CoverageError || got.ReasonCode != "discovery_refresh_failed" || got.ObservedAt != nil {
+			t.Fatalf("coverage = %+v", got)
+		}
+	})
+
+	t.Run("stale preserved snapshot", func(t *testing.T) {
+		client := &mutableResourceDiscovery{resources: availableResources}
+		core, err := k8score.NewResourceDiscovery(client)
+		if err != nil {
+			t.Fatalf("NewResourceDiscovery: %v", err)
+		}
+		client.resources = nil
+		client.err = errors.New("refresh failed")
+		if err := core.Refresh(); err == nil {
+			t.Fatal("Refresh unexpectedly succeeded")
+		}
+		got := resourceDiscoveryCoverage(&k8s.ResourceDiscovery{ResourceDiscovery: core})
+		if got.Status != capacityapi.CoverageError || got.ReasonCode != "discovery_refresh_failed" || got.ObservedAt == nil {
+			t.Fatalf("coverage = %+v", got)
+		}
+	})
+}
+
+func TestAPIResourceResponseObservationWireShape(t *testing.T) {
+	response := apiResourceResponse{
+		APIResource: k8score.APIResource{
+			Group: "kueue.x-k8s.io", Version: "v1beta1", Kind: "Workload", Name: "workloads", IsCRD: true,
+		},
+		Observation: &k8score.DynamicResourceObservation{
+			State:      k8score.DynamicObservationDeferred,
+			ReasonCode: "resource_count_exceeds_eager_limit",
+		},
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	observation, ok := got["observation"].(map[string]any)
+	if !ok {
+		t.Fatalf("observation missing from %s", encoded)
+	}
+	if observation["state"] != "deferred" || observation["reasonCode"] != "resource_count_exceeds_eager_limit" {
+		t.Fatalf("observation = %#v", observation)
+	}
+	if _, exists := observation["origin"]; exists {
+		t.Fatalf("unstarted observation serialized an origin: %s", encoded)
+	}
+
+	builtIn, err := json.Marshal(apiResourceResponse{APIResource: k8score.APIResource{Version: "v1", Kind: "Pod", Name: "pods"}})
+	if err != nil {
+		t.Fatalf("Marshal built-in: %v", err)
+	}
+	var builtInWire map[string]any
+	if err := json.Unmarshal(builtIn, &builtInWire); err != nil {
+		t.Fatalf("Unmarshal built-in: %v", err)
+	}
+	if _, exists := builtInWire["observation"]; exists {
+		t.Fatalf("built-in resource serialized dynamic observation: %s", builtIn)
+	}
+}
+
+func TestFilterDynamicObservationNamespaces(t *testing.T) {
+	observation := k8score.DynamicResourceObservation{
+		State:            k8score.DynamicObservationWatched,
+		Scope:            k8score.DynamicObservationScopeExplicitNamespaces,
+		Namespaces:       []string{"team-a", "team-b"},
+		NamespacePartial: true,
+		Truncated:        true,
+	}
+
+	filtered := filterDynamicObservationNamespaces(observation, []string{"team-b"})
+	if !slices.Equal(filtered.Namespaces, []string{"team-b"}) {
+		t.Fatalf("filtered namespaces = %v", filtered.Namespaces)
+	}
+	if !filtered.NamespacePartial || !filtered.Truncated {
+		t.Fatalf("filter weakened coverage bounds: %+v", filtered)
+	}
+
+	unrestricted := filterDynamicObservationNamespaces(observation, nil)
+	if !slices.Equal(unrestricted.Namespaces, observation.Namespaces) {
+		t.Fatalf("unrestricted namespaces = %v", unrestricted.Namespaces)
+	}
+	empty := observation
+	empty.Namespaces = nil
+	if got := filterDynamicObservationNamespaces(empty, []string{"team-b"}); len(got.Namespaces) != 0 {
+		t.Fatalf("empty observation expanded to caller namespaces: %+v", got)
+	}
+
+	cluster := k8score.DynamicResourceObservation{
+		State:      k8score.DynamicObservationWatched,
+		Scope:      k8score.DynamicObservationScopeCluster,
+		Namespaces: []string{"sentinel"},
+	}
+	cluster = filterDynamicObservationNamespaces(cluster, []string{"team-b"})
+	if !slices.Equal(cluster.Namespaces, []string{"sentinel"}) {
+		t.Fatalf("cluster observation was namespace-filtered: %+v", cluster)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -1272,6 +1273,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	caps.AuthEnabled = s.authConfig.Enabled()
 	status, _ := s.localTerminalUnavailable(r)
 	caps.LocalTerminal = status == 0
+	caps.ResourceDiscovery = resourceDiscoveryCoverage(k8s.GetResourceDiscovery())
 	if user := auth.UserFromContext(r.Context()); user != nil {
 		caps.Username = user.Username
 	}
@@ -1883,6 +1885,20 @@ func (s *Server) handleNamespaces(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, result)
 }
 
+type apiResourceResponse struct {
+	k8score.APIResource
+	Featured    bool                                `json:"featured,omitempty"`
+	Observation *k8score.DynamicResourceObservation `json:"observation,omitempty"`
+}
+
+func filterDynamicObservationNamespaces(observation k8score.DynamicResourceObservation, allowed []string) k8score.DynamicResourceObservation {
+	if observation.Scope != k8score.DynamicObservationScopeExplicitNamespaces || len(observation.Namespaces) == 0 {
+		return observation
+	}
+	observation.Namespaces = intersectNamespaces(allowed, observation.Namespaces)
+	return observation
+}
+
 func (s *Server) handleAPIResources(w http.ResponseWriter, r *http.Request) {
 	discovery := k8s.GetResourceDiscovery()
 	if discovery == nil {
@@ -1896,16 +1912,31 @@ func (s *Server) handleAPIResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type apiResourceResponse struct {
-		k8score.APIResource
-		Featured bool `json:"featured,omitempty"`
-	}
 	result := make([]apiResourceResponse, 0, len(resources))
+	dynamicCache := k8s.GetDynamicResourceCache()
+	var visibleNamespaces []string
+	visibleNamespacesResolved := false
 	for _, resource := range resources {
-		result = append(result, apiResourceResponse{
+		response := apiResourceResponse{
 			APIResource: resource,
 			Featured:    isFeaturedKubernetesAPI(resource.Group, resource.Kind),
-		})
+		}
+		if resource.IsCRD && dynamicCache != nil {
+			observation := dynamicCache.Observation(schema.GroupVersionResource{
+				Group:    resource.Group,
+				Version:  resource.Version,
+				Resource: resource.Name,
+			})
+			if observation.Scope == k8score.DynamicObservationScopeExplicitNamespaces {
+				if !visibleNamespacesResolved {
+					visibleNamespaces = s.getUserNamespaces(r, nil)
+					visibleNamespacesResolved = true
+				}
+				observation = filterDynamicObservationNamespaces(observation, visibleNamespaces)
+			}
+			response.Observation = &observation
+		}
+		result = append(result, response)
 	}
 	s.writeJSON(w, result)
 }

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -1,4 +1,4 @@
-import type { CapacityIntegrationState } from './capacity'
+import type { CapacityIntegrationState, CapacitySourceCoverage } from './capacity'
 
 // Topology types matching the Go backend
 
@@ -130,6 +130,7 @@ export interface Capabilities {
   // same newer-frontend/older-backend reason as `deployment` below — consumers
   // must treat absence as "unknown" and fall back to discovery signals.
   karpenter?: IntegrationCapability
+  resourceDiscovery?: CapacitySourceCoverage
   // How / where this Radar binary is running. Optional on the wire so a
   // newer frontend (e.g. radar-hub-web bundling a fresher @skyhook-io/radar-app)
   // doesn't crash against an older backend that hasn't shipped the field yet —
@@ -728,6 +729,28 @@ export interface ResourceWithRelationships<T = unknown> {
 }
 
 // API Resource (from discovery endpoint)
+export type DynamicObservationState =
+  | 'unwatched'
+  | 'deferred'
+  | 'syncing'
+  | 'watched'
+  | 'denied'
+  | 'unsupported'
+
+export type DynamicObservationOrigin = 'warmup' | 'small_eager' | 'on_demand'
+export type DynamicObservationScope = 'cluster' | 'explicit_namespaces'
+
+export interface DynamicResourceObservation {
+  state: DynamicObservationState
+  origin?: DynamicObservationOrigin
+  observationStart?: string
+  scope?: DynamicObservationScope
+  namespaces?: string[]
+  namespacePartial?: boolean
+  truncated?: boolean
+  reasonCode?: string
+}
+
 export interface APIResource {
   group: string
   version: string
@@ -737,6 +760,7 @@ export interface APIResource {
   isCrd: boolean
   featured?: boolean
   verbs: string[]
+  observation?: DynamicResourceObservation
 }
 
 // Helm release types

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -27,24 +27,33 @@ type APIResource struct {
 
 // DiscoveryStats holds read-only stats about API discovery state.
 type DiscoveryStats struct {
-	TotalResources int
-	CRDCount       int
-	LastRefresh    time.Time
+	TotalResources        int
+	CRDCount              int
+	LastRefresh           time.Time
+	LastAttempt           time.Time
+	LastSuccessfulRefresh time.Time
+	LastError             string
+	Partial               bool
+	Stale                 bool
 }
 
 // ResourceDiscovery manages discovery and caching of API resources.
 // It is safe for concurrent use.
 type ResourceDiscovery struct {
-	client      discovery.DiscoveryInterface
-	resources   []APIResource
-	resourceMap map[string]APIResource // keyed by lowercase kind
-	gvrMap      map[string]schema.GroupVersionResource
-	lastRefresh time.Time
-	partial     bool
-	failedGroup map[string]bool
-	cacheTTL    time.Duration
-	refreshMu   sync.Mutex
-	mu          sync.RWMutex
+	client                discovery.DiscoveryInterface
+	resources             []APIResource
+	resourceMap           map[string]APIResource // keyed by lowercase kind
+	gvrMap                map[string]schema.GroupVersionResource
+	lastRefresh           time.Time
+	lastSuccessfulRefresh time.Time
+	lastError             string
+	stale                 bool
+	partial               bool
+	freshPartial          bool
+	failedGroup           map[string]bool
+	cacheTTL              time.Duration
+	refreshMu             sync.Mutex
+	mu                    sync.RWMutex
 }
 
 // DiscoveryOption is a functional option for NewResourceDiscovery.
@@ -196,6 +205,8 @@ func (d *ResourceDiscovery) refresh() error {
 	if err != nil && !hasResourceData {
 		d.mu.Lock()
 		d.lastRefresh = time.Now()
+		d.lastError = err.Error()
+		d.stale = !d.lastSuccessfulRefresh.IsZero()
 		d.mu.Unlock()
 		return err
 	}
@@ -206,6 +217,7 @@ func (d *ResourceDiscovery) refresh() error {
 		}
 	}
 	partial := discovery.IsGroupDiscoveryFailedError(err) || len(failedGroups) > 0
+	freshPartial := err != nil
 	log.Printf("API resource discovery took %v", time.Since(start))
 
 	d.mu.Lock()
@@ -246,7 +258,14 @@ func (d *ResourceDiscovery) refresh() error {
 	}
 
 	d.lastRefresh = time.Now()
+	d.lastSuccessfulRefresh = d.lastRefresh
+	d.lastError = ""
+	if err != nil {
+		d.lastError = err.Error()
+	}
+	d.stale = false
 	d.partial = partial
+	d.freshPartial = freshPartial
 	d.failedGroup = failedGroups
 	log.Printf("Discovered %d API resources (%d unique kinds)", len(d.resources), len(d.resourceMap)/2)
 
@@ -393,9 +412,14 @@ func (d *ResourceDiscovery) Stats() DiscoveryStats {
 	}
 
 	return DiscoveryStats{
-		TotalResources: len(d.resources),
-		CRDCount:       crdCount,
-		LastRefresh:    d.lastRefresh,
+		TotalResources:        len(d.resources),
+		CRDCount:              crdCount,
+		LastRefresh:           d.lastRefresh,
+		LastAttempt:           d.lastRefresh,
+		LastSuccessfulRefresh: d.lastSuccessfulRefresh,
+		LastError:             d.lastError,
+		Partial:               d.freshPartial,
+		Stale:                 d.stale,
 	}
 }
 

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -78,7 +78,7 @@ func TestRefreshPreservesSnapshotOnEmptyDiscoveryError(t *testing.T) {
 
 	client.resources = nil
 	client.err = errors.New("temporary discovery failure")
-	beforeRefresh := d.Stats().LastRefresh
+	before := d.Stats()
 	if err := d.Refresh(); err == nil {
 		t.Fatal("Refresh unexpectedly succeeded")
 	}
@@ -86,8 +86,81 @@ func TestRefreshPreservesSnapshotOnEmptyDiscoveryError(t *testing.T) {
 	if !ok || gvr.Version != "v1" {
 		t.Fatalf("preserved metrics GVR = %v, ok=%v, want metrics.k8s.io/v1", gvr, ok)
 	}
-	if !d.Stats().LastRefresh.After(beforeRefresh) {
+	after := d.Stats()
+	if !after.LastAttempt.After(before.LastAttempt) {
 		t.Fatal("failed refresh did not advance the retry cooldown")
+	}
+	if !after.LastSuccessfulRefresh.Equal(before.LastSuccessfulRefresh) {
+		t.Fatalf("last successful refresh changed on failure: got %v, want %v", after.LastSuccessfulRefresh, before.LastSuccessfulRefresh)
+	}
+	if after.LastError != "temporary discovery failure" {
+		t.Fatalf("last error = %q, want temporary discovery failure", after.LastError)
+	}
+	if !after.Stale {
+		t.Fatal("preserved snapshot was not marked stale after total refresh failure")
+	}
+
+	client.resources = initial
+	client.err = nil
+	if err := d.Refresh(); err != nil {
+		t.Fatalf("recovery refresh: %v", err)
+	}
+	recovered := d.Stats()
+	if recovered.Stale || recovered.LastError != "" {
+		t.Fatalf("successful recovery retained stale/error state: %+v", recovered)
+	}
+	if !recovered.LastSuccessfulRefresh.After(before.LastSuccessfulRefresh) {
+		t.Fatal("successful recovery did not advance last successful refresh")
+	}
+}
+
+func TestRefreshMarksEmptySuccessfulSnapshotStaleOnLaterFailure(t *testing.T) {
+	client := &snapshotDiscovery{}
+	d, err := NewResourceDiscovery(client)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery: %v", err)
+	}
+	if d.Stats().LastSuccessfulRefresh.IsZero() {
+		t.Fatal("empty successful discovery did not record a successful refresh")
+	}
+
+	client.err = errors.New("temporary discovery failure")
+	if err := d.Refresh(); err == nil {
+		t.Fatal("Refresh unexpectedly succeeded")
+	}
+	if stats := d.Stats(); !stats.Stale || stats.LastError == "" {
+		t.Fatalf("failed refresh after empty success = %+v, want stale error", stats)
+	}
+}
+
+func TestRefreshWithResourceDataRecordsFreshPartialSnapshot(t *testing.T) {
+	client := &snapshotDiscovery{
+		resources: []*metav1.APIResourceList{{
+			GroupVersion: "example.io/v1",
+			APIResources: []metav1.APIResource{{Name: "widgets", Kind: "Widget"}},
+		}},
+		err: errors.New("one discovery group failed"),
+	}
+	d, err := NewResourceDiscovery(client)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery: %v", err)
+	}
+
+	stats := d.Stats()
+	if !stats.Partial || stats.Stale {
+		t.Fatalf("partial/stale = %v/%v, want true/false", stats.Partial, stats.Stale)
+	}
+	if stats.LastSuccessfulRefresh.IsZero() || stats.LastAttempt.IsZero() {
+		t.Fatalf("partial refresh did not record successful data-bearing attempt: %+v", stats)
+	}
+	if stats.LastError != "one discovery group failed" {
+		t.Fatalf("last error = %q", stats.LastError)
+	}
+	if d.HasPartialDiscovery() {
+		t.Fatal("generic data-bearing error broadened group-partial discovery semantics")
+	}
+	if _, ok := d.GetGVRWithGroup("Widget", "example.io"); !ok {
+		t.Fatal("fresh partial snapshot did not retain returned resource data")
 	}
 }
 

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -38,9 +39,17 @@ type informerKey struct {
 // informerEntry is one running informer plus its lifecycle handle. synced is
 // guarded by DynamicResourceCache.mu.
 type informerEntry struct {
-	informer cache.SharedIndexInformer
-	cancel   context.CancelFunc
-	synced   bool
+	informer  cache.SharedIndexInformer
+	cancel    context.CancelFunc
+	synced    bool
+	startedAt time.Time
+	origin    DynamicObservationOrigin
+}
+
+type retainedObservation struct {
+	state      DynamicObservationState
+	reasonCode string
+	truncated  bool
 }
 
 // DynamicResourceCache provides on-demand caching for CRDs and other dynamic
@@ -55,6 +64,12 @@ type DynamicResourceCache struct {
 	// all-namespaces read of a fallback-scoped GVR would re-probe cluster-wide
 	// plus each candidate namespace. Guarded by mu.
 	fallbackResolved map[schema.GroupVersionResource]bool
+	// observations retain watch decisions and probe outcomes for installed GVRs
+	// that do not currently have an informer. Active informers take precedence.
+	observations map[schema.GroupVersionResource]retainedObservation
+	// fanoutIncomplete records that a namespace fallback walk ended before all
+	// configured candidates were classified. Guarded by mu.
+	fanoutIncomplete map[schema.GroupVersionResource]bool
 	stopCh           chan struct{} // global shutdown; parent of every per-informer context
 	stopOnce         sync.Once
 	stopped          bool // set under mu by Stop; startWatching refuses new informers after
@@ -107,6 +122,8 @@ func NewDynamicResourceCache(cfg DynamicCacheConfig) (*DynamicResourceCache, err
 		factory:          factory,
 		nsFactories:      make(map[string]dynamicinformer.DynamicSharedInformerFactory),
 		fallbackResolved: make(map[schema.GroupVersionResource]bool),
+		observations:     make(map[schema.GroupVersionResource]retainedObservation),
+		fanoutIncomplete: make(map[schema.GroupVersionResource]bool),
 		informers:        make(map[informerKey]*informerEntry),
 		stopCh:           make(chan struct{}),
 		config:           cfg,
@@ -117,6 +134,97 @@ func NewDynamicResourceCache(cfg DynamicCacheConfig) (*DynamicResourceCache, err
 
 	log.Println("Dynamic resource cache initialized")
 	return d, nil
+}
+
+func (d *DynamicResourceCache) retainObservation(gvr schema.GroupVersionResource, state DynamicObservationState, reasonCode string, truncated bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.observations[gvr] = retainedObservation{state: state, reasonCode: reasonCode, truncated: truncated}
+}
+
+// Observation returns the current observation contract for one exact GVR.
+// It only reads cache bookkeeping; it never probes the API server, creates an
+// informer, or waits for sync.
+func (d *DynamicResourceCache) Observation(gvr schema.GroupVersionResource) DynamicResourceObservation {
+	if d == nil {
+		return DynamicResourceObservation{State: DynamicObservationUnwatched, ReasonCode: "not_observed"}
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var (
+		entries []struct {
+			ns    string
+			entry *informerEntry
+		}
+		clusterWide bool
+		namespaces  []string
+	)
+	for key, entry := range d.informers {
+		if key.gvr != gvr {
+			continue
+		}
+		entries = append(entries, struct {
+			ns    string
+			entry *informerEntry
+		}{ns: key.ns, entry: entry})
+		if key.ns == "" {
+			clusterWide = true
+		} else {
+			namespaces = append(namespaces, key.ns)
+		}
+	}
+	if len(entries) == 0 {
+		if retained, ok := d.observations[gvr]; ok {
+			return DynamicResourceObservation{State: retained.state, Truncated: retained.truncated, ReasonCode: retained.reasonCode}
+		}
+		if d.config.Discovery != nil && d.config.Discovery.GetKindForGVR(gvr) != "" && !d.config.Discovery.SupportsWatchGVR(gvr) {
+			return DynamicResourceObservation{State: DynamicObservationUnsupported, ReasonCode: "list_watch_unsupported"}
+		}
+		return DynamicResourceObservation{State: DynamicObservationUnwatched, ReasonCode: "not_observed"}
+	}
+
+	state := DynamicObservationWatched
+	var latest *informerEntry
+	for _, candidate := range entries {
+		if !candidate.entry.informer.HasSynced() {
+			state = DynamicObservationSyncing
+		}
+		if latest == nil || candidate.entry.startedAt.After(latest.startedAt) {
+			latest = candidate.entry
+		}
+	}
+
+	startedAt := latest.startedAt
+	observation := DynamicResourceObservation{
+		State:            state,
+		Origin:           latest.origin,
+		ObservationStart: &startedAt,
+	}
+	if clusterWide {
+		observation.Scope = DynamicObservationScopeCluster
+	} else {
+		sort.Strings(namespaces)
+		observation.Scope = DynamicObservationScopeExplicitNamespaces
+		observation.Namespaces = namespaces
+		observation.NamespacePartial = true
+		observation.Truncated = !d.config.NamespaceScoped && (d.config.NamespaceFallbacksTruncated || d.fanoutIncomplete[gvr])
+	}
+
+	switch {
+	case state == DynamicObservationSyncing:
+		observation.ReasonCode = "initial_sync"
+	case observation.Truncated:
+		observation.ReasonCode = "namespace_fanout_truncated"
+	case observation.NamespacePartial:
+		observation.ReasonCode = "namespace_partial"
+	case observation.Origin == DynamicObservationOriginOnDemand:
+		observation.ReasonCode = "on_demand_since"
+	default:
+		observation.ReasonCode = "continuously_watched"
+	}
+	return observation
 }
 
 // factoryForNs returns the informer factory for ns, creating and caching a
@@ -189,10 +297,25 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 		}
 		scopes, complete, err := d.probeScopes(gvr, preferredNS)
 		if err != nil {
+			if isAuthProbeError(err) {
+				truncated := d.namespaceProbeTruncated(gvr, preferredNS, complete)
+				reasonCode := "access_denied"
+				if truncated {
+					reasonCode = "access_denied_partial_probe"
+				}
+				d.retainObservation(gvr, DynamicObservationDenied, reasonCode, truncated)
+			}
 			return nil, fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
 		}
+		if preferredNS == "" {
+			d.mu.Lock()
+			d.fanoutIncomplete[gvr] = !complete
+			d.mu.Unlock()
+		}
 		for _, scopeNS := range scopes {
-			if err := d.startWatching(gvr, scopeNS); err != nil {
+			if err := d.startWatchingWithOrigin(gvr, scopeNS, DynamicObservationOriginOnDemand); err != nil {
+				truncated := preferredNS == "" && len(scopes) > 0 && scopes[0] != "" && (!complete || d.config.NamespaceFallbacksTruncated)
+				d.retainObservation(gvr, DynamicObservationDeferred, "watch_start_failed", truncated)
 				return nil, err
 			}
 		}
@@ -242,6 +365,10 @@ func (d *DynamicResourceCache) hasCoveringInformer(gvr schema.GroupVersionResour
 // stop channel, so a single informer can be cancelled independently (the
 // idle reaper relies on this) while Stop() still tears them all down.
 func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, scopeNS string) error {
+	return d.startWatchingWithOrigin(gvr, scopeNS, DynamicObservationOriginOnDemand)
+}
+
+func (d *DynamicResourceCache) startWatchingWithOrigin(gvr schema.GroupVersionResource, scopeNS string, origin DynamicObservationOrigin) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -294,7 +421,13 @@ func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, sc
 		case <-ctx.Done():
 		}
 	}()
-	d.informers[key] = &informerEntry{informer: informer, cancel: cancel}
+	d.informers[key] = &informerEntry{
+		informer:  informer,
+		cancel:    cancel,
+		startedAt: time.Now().UTC(),
+		origin:    origin,
+	}
+	delete(d.observations, gvr)
 
 	kind := d.gvrToKind(gvr)
 	d.addDynamicChangeHandlers(informer, kind, gvr)
@@ -475,6 +608,13 @@ func (d *DynamicResourceCache) probeScopes(gvr schema.GroupVersionResource, pref
 	return granted, complete, nil
 }
 
+func (d *DynamicResourceCache) namespaceProbeTruncated(gvr schema.GroupVersionResource, preferredNS string, complete bool) bool {
+	if preferredNS != "" || d.config.NamespaceScoped {
+		return false
+	}
+	return !complete || (d.config.NamespaceFallbacksTruncated && d.gvrIsNamespaced(gvr))
+}
+
 func (d *DynamicResourceCache) listProbe(ctx context.Context, gvr schema.GroupVersionResource, namespace string) error {
 	if namespace != "" {
 		_, err := d.config.DynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1})
@@ -543,6 +683,9 @@ func (d *DynamicResourceCache) ProbeCount(gvr schema.GroupVersionResource) int {
 	list, err = d.probeCountList(ctx, gvr)
 
 	if err != nil {
+		if ctx.Err() != nil {
+			return -2
+		}
 		if isAuthProbeError(err) {
 			return -1
 		}
@@ -1454,6 +1597,10 @@ func (d *DynamicResourceCache) getDirect(ctx context.Context, gvr schema.GroupVe
 
 // WarmupParallel starts watching multiple resources in parallel and waits for all to sync.
 func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource, timeout time.Duration) {
+	d.warmupParallelWithOrigin(gvrs, timeout, DynamicObservationOriginWarmup)
+}
+
+func (d *DynamicResourceCache) warmupParallelWithOrigin(gvrs []schema.GroupVersionResource, timeout time.Duration, origin DynamicObservationOrigin) {
 	if d == nil || len(gvrs) == 0 {
 		return
 	}
@@ -1463,7 +1610,7 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 		gvr      schema.GroupVersionResource
 		scopes   []string
 		complete bool
-		ok       bool
+		err      error
 	}
 	results := make(chan probeResult, len(gvrs))
 	sem := make(chan struct{}, maxConcurrentProbes)
@@ -1472,16 +1619,27 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 			sem <- struct{}{}
 			scopes, complete, err := d.probeScopes(g, "")
 			<-sem
-			results <- probeResult{gvr: g, scopes: scopes, complete: complete, ok: err == nil}
+			results <- probeResult{gvr: g, scopes: scopes, complete: complete, err: err}
 		}(gvr)
 	}
 
 	var accessible []probeResult
 	for range gvrs {
 		r := <-results
-		if r.ok {
-			accessible = append(accessible, r)
+		if r.err != nil {
+			if isAuthProbeError(r.err) {
+				truncated := d.namespaceProbeTruncated(r.gvr, "", r.complete)
+				reasonCode := "access_denied"
+				if truncated {
+					reasonCode = "access_denied_partial_probe"
+				}
+				d.retainObservation(r.gvr, DynamicObservationDenied, reasonCode, truncated)
+			} else {
+				d.retainObservation(r.gvr, DynamicObservationDeferred, "scope_probe_failed", false)
+			}
+			continue
 		}
+		accessible = append(accessible, r)
 	}
 
 	if len(accessible) == 0 {
@@ -1490,12 +1648,17 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 
 	var started []informerKey
 	for _, r := range accessible {
+		d.mu.Lock()
+		d.fanoutIncomplete[r.gvr] = !r.complete
+		d.mu.Unlock()
 		allStarted := true
 		for _, scope := range r.scopes {
-			if err := d.startWatching(r.gvr, scope); err == nil {
+			if err := d.startWatchingWithOrigin(r.gvr, scope, origin); err == nil {
 				started = append(started, informerKey{gvr: r.gvr, ns: scope})
 			} else {
 				allStarted = false
+				truncated := len(r.scopes) > 0 && r.scopes[0] != "" && (!r.complete || d.config.NamespaceFallbacksTruncated)
+				d.retainObservation(r.gvr, DynamicObservationDeferred, "watch_start_failed", truncated)
 			}
 		}
 		if allStarted && r.complete {
@@ -1590,9 +1753,15 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 			if !res.IsCRD {
 				continue
 			}
+			gvr := schema.GroupVersionResource{
+				Group:    res.Group,
+				Version:  res.Version,
+				Resource: res.Name,
+			}
 			// Crossplane serves this legacy API with a deprecation warning on every
 			// informer watch renewal. Keep it available on demand, but don't eagerly watch it.
 			if res.Group == "apiextensions.crossplane.io" && res.Name == "usages" {
+				d.retainObservation(gvr, DynamicObservationDeferred, "legacy_api_deferred", false)
 				continue
 			}
 			hasList := false
@@ -1614,11 +1783,7 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 					continue
 				}
 			}
-			best[key] = schema.GroupVersionResource{
-				Group:    res.Group,
-				Version:  res.Version,
-				Resource: res.Name,
-			}
+			best[key] = gvr
 		}
 
 		var gvrs []schema.GroupVersionResource
@@ -1669,7 +1834,7 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 					<-sem
 					if r := recover(); r != nil {
 						log.Printf("[CRD Discovery] Panic probing %s.%s/%s: %v", g.Resource, g.Group, g.Version, r)
-						results <- probeResult{gvr: g, count: -1}
+						results <- probeResult{gvr: g, count: -2}
 					}
 				}()
 				count := d.ProbeCount(g)
@@ -1684,17 +1849,26 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 			r := <-results
 			if r.count == -1 {
 				noAccessCount++
+				truncated := d.namespaceProbeTruncated(r.gvr, "", true)
+				reasonCode := "access_denied"
+				if truncated {
+					reasonCode = "access_denied_partial_probe"
+				}
+				d.retainObservation(r.gvr, DynamicObservationDenied, reasonCode, truncated)
 				continue
 			}
 			if r.count == -2 {
 				// Probe failed (timeout, network error) — defer to be safe
 				deferredCount++
+				d.retainObservation(r.gvr, DynamicObservationDeferred, "resource_count_probe_failed", false)
 				continue
 			}
 			if r.count <= maxEagerResources {
 				eager = append(eager, r.gvr)
+				d.retainObservation(r.gvr, DynamicObservationDeferred, "eager_watch_pending", false)
 			} else {
 				deferredCount++
+				d.retainObservation(r.gvr, DynamicObservationDeferred, "resource_count_exceeds_eager_limit", false)
 				if d.config.DebugEvents {
 					kind := d.gvrToKind(r.gvr)
 					log.Printf("[CRD Discovery] Deferring %s (%d resources > %d threshold)", kind, r.count, maxEagerResources)
@@ -1706,7 +1880,7 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 			len(gvrs), alreadyWatching, len(eager), deferredCount, noAccessCount)
 
 		if len(eager) > 0 {
-			d.WarmupParallel(eager, 30*time.Second)
+			d.warmupParallelWithOrigin(eager, 30*time.Second, DynamicObservationOriginEager)
 		}
 	}()
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -142,6 +142,20 @@ func (d *DynamicResourceCache) retainObservation(gvr schema.GroupVersionResource
 	d.observations[gvr] = retainedObservation{state: state, reasonCode: reasonCode, truncated: truncated}
 }
 
+func (d *DynamicResourceCache) retainDeniedObservation(gvr schema.GroupVersionResource, preferredNS string, complete bool) {
+	// A preferred-namespace denial proves only that request scope; it cannot
+	// replace the observation retained for the GVR as a whole.
+	if preferredNS != "" {
+		return
+	}
+	truncated := d.namespaceProbeTruncated(gvr, preferredNS, complete)
+	reasonCode := "access_denied"
+	if truncated {
+		reasonCode = "access_denied_partial_probe"
+	}
+	d.retainObservation(gvr, DynamicObservationDenied, reasonCode, truncated)
+}
+
 // Observation returns the current observation contract for one exact GVR.
 // It only reads cache bookkeeping; it never probes the API server, creates an
 // informer, or waits for sync.
@@ -298,12 +312,7 @@ func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, p
 		scopes, complete, err := d.probeScopes(gvr, preferredNS)
 		if err != nil {
 			if isAuthProbeError(err) {
-				truncated := d.namespaceProbeTruncated(gvr, preferredNS, complete)
-				reasonCode := "access_denied"
-				if truncated {
-					reasonCode = "access_denied_partial_probe"
-				}
-				d.retainObservation(gvr, DynamicObservationDenied, reasonCode, truncated)
+				d.retainDeniedObservation(gvr, preferredNS, complete)
 			}
 			return nil, fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
 		}
@@ -721,10 +730,18 @@ func (d *DynamicResourceCache) probeCountList(ctx context.Context, gvr schema.Gr
 	if isAuthProbeError(err) && d.gvrIsNamespaced(gvr) {
 		// Size heuristic only — the first granted fallback namespace is a
 		// good-enough sample for the eager-warm decision.
+		var fallbackErr error
 		for _, ns := range d.fallbackNamespaces() {
-			if nsList, nsErr := d.config.DynamicClient.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1}); nsErr == nil {
+			nsList, nsErr := d.config.DynamicClient.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1})
+			if nsErr == nil {
 				return nsList, nil
 			}
+			if !isAuthProbeError(nsErr) && fallbackErr == nil {
+				fallbackErr = nsErr
+			}
+		}
+		if fallbackErr != nil {
+			return nil, fallbackErr
 		}
 	}
 	return list, err
@@ -1628,12 +1645,7 @@ func (d *DynamicResourceCache) warmupParallelWithOrigin(gvrs []schema.GroupVersi
 		r := <-results
 		if r.err != nil {
 			if isAuthProbeError(r.err) {
-				truncated := d.namespaceProbeTruncated(r.gvr, "", r.complete)
-				reasonCode := "access_denied"
-				if truncated {
-					reasonCode = "access_denied_partial_probe"
-				}
-				d.retainObservation(r.gvr, DynamicObservationDenied, reasonCode, truncated)
+				d.retainDeniedObservation(r.gvr, "", r.complete)
 			} else {
 				d.retainObservation(r.gvr, DynamicObservationDeferred, "scope_probe_failed", false)
 			}
@@ -1849,12 +1861,7 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 			r := <-results
 			if r.count == -1 {
 				noAccessCount++
-				truncated := d.namespaceProbeTruncated(r.gvr, "", true)
-				reasonCode := "access_denied"
-				if truncated {
-					reasonCode = "access_denied_partial_probe"
-				}
-				d.retainObservation(r.gvr, DynamicObservationDenied, reasonCode, truncated)
+				d.retainDeniedObservation(r.gvr, "", true)
 				continue
 			}
 			if r.count == -2 {

--- a/pkg/k8score/dynamic_cache_count_test.go
+++ b/pkg/k8score/dynamic_cache_count_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -189,6 +190,32 @@ func TestDynamicResourceCache_ProbeCountDefersWithoutRemainingCount(t *testing.T
 
 	if got := d.ProbeCount(gvr); got != -2 {
 		t.Fatalf("ProbeCount = %d, want -2", got)
+	}
+}
+
+func TestDynamicResourceCache_ProbeCountDefersWhenNamespaceFallbackFailsTransiently(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "WidgetList"},
+	)
+	dyn.PrependReactor("list", "widgets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "team-a" {
+			return true, nil, apierrors.NewServiceUnavailable("apiserver hiccup")
+		}
+		return true, nil, apierrors.NewForbidden(gvr.GroupResource(), "", errors.New("denied"))
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:      dyn,
+		NamespaceFallbacks: []string{"team-a"},
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	if got := d.ProbeCount(gvr); got != -2 {
+		t.Fatalf("ProbeCount = %d, want -2 after non-authoritative fallback failure", got)
 	}
 }
 

--- a/pkg/k8score/dynamic_cache_observation_test.go
+++ b/pkg/k8score/dynamic_cache_observation_test.go
@@ -182,6 +182,26 @@ func TestDynamicResourceObservationRetainsDeniedAndDeferredOutcomes(t *testing.T
 		t.Fatalf("truncated denied observation = %+v", truncatedDenied)
 	}
 
+	incompleteCandidatesClient := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{deniedGVR: "DeniedWidgetList"}, func(schema.GroupVersionResource, string) bool {
+		return false
+	})
+	incompleteCandidatesCache, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:               incompleteCandidatesClient,
+		Discovery:                   deniedDiscovery,
+		NamespaceFallbacksTruncated: true,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache incomplete candidates: %v", err)
+	}
+	t.Cleanup(incompleteCandidatesCache.Stop)
+	if err := incompleteCandidatesCache.EnsureWatching(deniedGVR); err == nil {
+		t.Fatal("EnsureWatching incomplete-candidate denied GVR succeeded")
+	}
+	incompleteDenied := incompleteCandidatesCache.Observation(deniedGVR)
+	if incompleteDenied.State != DynamicObservationDenied || !incompleteDenied.Truncated || incompleteDenied.ReasonCode != "access_denied_partial_probe" {
+		t.Fatalf("incomplete-candidate denied observation = %+v", incompleteDenied)
+	}
+
 	clusterScopedGVR := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "clustersummaries"}
 	clusterScopedDiscovery := &ResourceDiscovery{
 		resourceMap: make(map[string]APIResource),
@@ -285,6 +305,37 @@ func TestDynamicResourceObservationRetainsDeniedAndDeferredOutcomes(t *testing.T
 				}
 			}
 		})
+	}
+}
+
+func TestDynamicResourceObservationPreferredNamespaceDenialDoesNotOverwriteGVRState(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+	discovery := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	discovery.AddAPIResource(APIResource{
+		Group: gvr.Group, Version: gvr.Version, Kind: "Widget", Name: gvr.Resource,
+		Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+	})
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{gvr: "WidgetList"}, func(schema.GroupVersionResource, string) bool {
+		return false
+	})
+	cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: discovery})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(cache.Stop)
+	cache.retainObservation(gvr, DynamicObservationDeferred, "prior_global_state", false)
+
+	if err := cache.ensureWatching(gvr, "team-a"); err == nil {
+		t.Fatal("ensureWatching denied preferred namespace succeeded")
+	}
+	got := cache.Observation(gvr)
+	if got.State != DynamicObservationDeferred || got.ReasonCode != "prior_global_state" {
+		t.Fatalf("preferred-namespace denial overwrote GVR observation: %+v", got)
 	}
 }
 

--- a/pkg/k8score/dynamic_cache_observation_test.go
+++ b/pkg/k8score/dynamic_cache_observation_test.go
@@ -1,0 +1,368 @@
+package k8score
+
+import (
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDynamicResourceObservationUnwatchedAndUnsupportedHaveNoOrigin(t *testing.T) {
+	watchable := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+	unsupported := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "summaries"}
+	discovery := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+	discovery.AddAPIResource(APIResource{
+		Group: watchable.Group, Version: watchable.Version, Kind: "Widget", Name: watchable.Resource,
+		IsCRD: true, Verbs: []string{"get", "list", "watch"},
+	})
+	discovery.AddAPIResource(APIResource{
+		Group: unsupported.Group, Version: unsupported.Version, Kind: "Summary", Name: unsupported.Resource,
+		IsCRD: true, Verbs: []string{"get", "list"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		watchable: "WidgetList",
+	})
+	cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: discovery})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(cache.Stop)
+
+	for _, test := range []struct {
+		name   string
+		gvr    schema.GroupVersionResource
+		state  DynamicObservationState
+		reason string
+	}{
+		{name: "unwatched", gvr: watchable, state: DynamicObservationUnwatched, reason: "not_observed"},
+		{name: "unsupported", gvr: unsupported, state: DynamicObservationUnsupported, reason: "list_watch_unsupported"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := cache.Observation(test.gvr)
+			if got.State != test.state || got.ReasonCode != test.reason {
+				t.Fatalf("observation = %+v, want state=%s reason=%s", got, test.state, test.reason)
+			}
+			if got.Origin != "" || got.ObservationStart != nil {
+				t.Fatalf("unstarted observation assigned causal watch metadata: %+v", got)
+			}
+		})
+	}
+	if err := cache.EnsureWatching(unsupported); err == nil {
+		t.Fatal("EnsureWatching unsupported GVR succeeded")
+	}
+	discovery.AddAPIResource(APIResource{
+		Group: unsupported.Group, Version: unsupported.Version, Kind: "Summary", Name: unsupported.Resource,
+		IsCRD: true, Verbs: []string{"get", "list", "watch"},
+	})
+	if got := cache.Observation(unsupported); got.State != DynamicObservationUnwatched || got.ReasonCode != "not_observed" {
+		t.Fatalf("refreshed watchable GVR retained unsupported state: %+v", got)
+	}
+	if actions := dyn.Actions(); len(actions) != 0 {
+		t.Fatalf("read-only observations touched the API server: %v", actions)
+	}
+}
+
+func TestDynamicResourceObservationTracksOnDemandSyncAndExactGVR(t *testing.T) {
+	observed := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	colliding := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "gateways"}
+	discovery := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+	for _, gvr := range []schema.GroupVersionResource{observed, colliding} {
+		discovery.AddAPIResource(APIResource{
+			Group: gvr.Group, Version: gvr.Version, Kind: "Gateway", Name: gvr.Resource,
+			Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+		})
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		observed:  "GatewayList",
+		colliding: "GatewayList",
+	})
+	releaseSync := make(chan struct{})
+	var observedLists atomic.Int32
+	dyn.PrependReactor("list", "gateways", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource() != observed {
+			return false, nil, nil
+		}
+		if observedLists.Add(1) > 1 {
+			<-releaseSync
+		}
+		return false, nil, nil
+	})
+	cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: discovery})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(cache.Stop)
+
+	if err := cache.EnsureWatching(observed); err != nil {
+		t.Fatalf("EnsureWatching: %v", err)
+	}
+	syncing := cache.Observation(observed)
+	if syncing.State != DynamicObservationSyncing || syncing.Origin != DynamicObservationOriginOnDemand || syncing.ObservationStart == nil {
+		t.Fatalf("syncing observation = %+v", syncing)
+	}
+	if syncing.Scope != DynamicObservationScopeCluster || syncing.ReasonCode != "initial_sync" {
+		t.Fatalf("syncing scope/reason = %+v", syncing)
+	}
+	if got := cache.Observation(colliding); got.State != DynamicObservationUnwatched {
+		t.Fatalf("same-named GVR inherited observation from another group: %+v", got)
+	}
+
+	close(releaseSync)
+	if !cache.WaitForSync(observed, 3*time.Second) {
+		t.Fatal("on-demand informer did not sync")
+	}
+	watched := cache.Observation(observed)
+	if watched.State != DynamicObservationWatched || watched.ReasonCode != "on_demand_since" {
+		t.Fatalf("watched observation = %+v", watched)
+	}
+	if !watched.ObservationStart.Equal(*syncing.ObservationStart) {
+		t.Fatalf("observation start changed across initial sync: before=%v after=%v", syncing.ObservationStart, watched.ObservationStart)
+	}
+}
+
+func TestDynamicResourceObservationRetainsDeniedAndDeferredOutcomes(t *testing.T) {
+	deniedGVR := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "deniedwidgets"}
+	deniedDiscovery := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	deniedDiscovery.AddAPIResource(APIResource{
+		Group: deniedGVR.Group, Version: deniedGVR.Version, Kind: "DeniedWidget", Name: deniedGVR.Resource,
+		Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+	})
+	deniedClient := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{deniedGVR: "DeniedWidgetList"}, func(schema.GroupVersionResource, string) bool {
+		return false
+	})
+	deniedCache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: deniedClient, Discovery: deniedDiscovery})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache denied: %v", err)
+	}
+	t.Cleanup(deniedCache.Stop)
+	if err := deniedCache.EnsureWatching(deniedGVR); err == nil {
+		t.Fatal("EnsureWatching denied GVR succeeded")
+	}
+	denied := deniedCache.Observation(deniedGVR)
+	if denied.State != DynamicObservationDenied || denied.ReasonCode != "access_denied" || denied.Origin != "" {
+		t.Fatalf("denied observation = %+v", denied)
+	}
+
+	truncatedClient := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{deniedGVR: "DeniedWidgetList"}, func(schema.GroupVersionResource, string) bool {
+		return false
+	})
+	truncatedCache, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:               truncatedClient,
+		Discovery:                   deniedDiscovery,
+		NamespaceFallbacks:          []string{"team-a"},
+		NamespaceFallbacksTruncated: true,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache truncated denial: %v", err)
+	}
+	t.Cleanup(truncatedCache.Stop)
+	if err := truncatedCache.EnsureWatching(deniedGVR); err == nil {
+		t.Fatal("EnsureWatching truncated denied GVR succeeded")
+	}
+	truncatedDenied := truncatedCache.Observation(deniedGVR)
+	if truncatedDenied.State != DynamicObservationDenied || !truncatedDenied.Truncated || truncatedDenied.ReasonCode != "access_denied_partial_probe" {
+		t.Fatalf("truncated denied observation = %+v", truncatedDenied)
+	}
+
+	clusterScopedGVR := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "clustersummaries"}
+	clusterScopedDiscovery := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	clusterScopedDiscovery.AddAPIResource(APIResource{
+		Group: clusterScopedGVR.Group, Version: clusterScopedGVR.Version, Kind: "ClusterSummary", Name: clusterScopedGVR.Resource,
+		IsCRD: true, Verbs: []string{"get", "list", "watch"},
+	})
+	clusterScopedClient := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{clusterScopedGVR: "ClusterSummaryList"}, func(schema.GroupVersionResource, string) bool {
+		return false
+	})
+	clusterScopedCache, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:               clusterScopedClient,
+		Discovery:                   clusterScopedDiscovery,
+		NamespaceFallbacks:          []string{"team-a"},
+		NamespaceFallbacksTruncated: true,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache cluster-scoped denial: %v", err)
+	}
+	t.Cleanup(clusterScopedCache.Stop)
+	if err := clusterScopedCache.EnsureWatching(clusterScopedGVR); err == nil {
+		t.Fatal("EnsureWatching denied cluster-scoped GVR succeeded")
+	}
+	clusterScopedDenied := clusterScopedCache.Observation(clusterScopedGVR)
+	if clusterScopedDenied.State != DynamicObservationDenied || clusterScopedDenied.Truncated || clusterScopedDenied.ReasonCode != "access_denied" {
+		t.Fatalf("cluster-scoped denied observation = %+v", clusterScopedDenied)
+	}
+
+	for _, test := range []struct {
+		name       string
+		probeError error
+		panicProbe bool
+		remaining  int64
+		reason     string
+	}{
+		{name: "probe failed", probeError: errors.New("temporary proxy failure"), reason: "resource_count_probe_failed"},
+		{name: "probe panicked", panicProbe: true, reason: "resource_count_probe_failed"},
+		{name: "large resource", remaining: 101, reason: "resource_count_exceeds_eager_limit"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gvr := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+			discovery := &ResourceDiscovery{
+				resources: []APIResource{{
+					Group: gvr.Group, Version: gvr.Version, Kind: "Widget", Name: gvr.Resource,
+					Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+				}},
+				resourceMap: make(map[string]APIResource),
+				gvrMap:      make(map[string]schema.GroupVersionResource),
+				lastRefresh: time.Now(),
+				cacheTTL:    time.Hour,
+			}
+			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{gvr: "WidgetList"})
+			dyn.PrependReactor("list", "widgets", func(k8stesting.Action) (bool, runtime.Object, error) {
+				if test.panicProbe {
+					panic("probe panic")
+				}
+				if test.probeError != nil {
+					return true, nil, test.probeError
+				}
+				list := &unstructured.UnstructuredList{}
+				list.SetRemainingItemCount(&test.remaining)
+				return true, list, nil
+			})
+			cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: discovery})
+			if err != nil {
+				t.Fatalf("NewDynamicResourceCache: %v", err)
+			}
+			t.Cleanup(cache.Stop)
+			cache.DiscoverAllCRDs()
+			select {
+			case <-cache.discoveryDone:
+			case <-time.After(3 * time.Second):
+				t.Fatal("DiscoverAllCRDs did not complete")
+			}
+
+			got := cache.Observation(gvr)
+			if got.State != DynamicObservationDeferred || got.ReasonCode != test.reason {
+				t.Fatalf("deferred observation = %+v, want reason=%s", got, test.reason)
+			}
+			if got.Origin != "" || got.ObservationStart != nil {
+				t.Fatalf("deferred observation assigned causal watch metadata: %+v", got)
+			}
+			if test.name == "large resource" {
+				if err := cache.EnsureWatching(gvr); err != nil {
+					t.Fatalf("EnsureWatching deferred GVR: %v", err)
+				}
+				cache.mu.Lock()
+				for key, entry := range cache.informers {
+					if key.gvr == gvr {
+						entry.cancel()
+						delete(cache.informers, key)
+					}
+				}
+				cache.mu.Unlock()
+				if after := cache.Observation(gvr); after.State != DynamicObservationUnwatched {
+					t.Fatalf("successful watch retained stale deferred decision after informer removal: %+v", after)
+				}
+			}
+		})
+	}
+}
+
+func TestDynamicResourceObservationTracksWarmupEagerAndNamespaceFanout(t *testing.T) {
+	t.Run("warmup", func(t *testing.T) {
+		gvr := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+		dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{gvr: "WidgetList"})
+		cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+		if err != nil {
+			t.Fatalf("NewDynamicResourceCache: %v", err)
+		}
+		t.Cleanup(cache.Stop)
+		cache.WarmupParallel([]schema.GroupVersionResource{gvr}, 3*time.Second)
+		got := cache.Observation(gvr)
+		if got.State != DynamicObservationWatched || got.Origin != DynamicObservationOriginWarmup {
+			t.Fatalf("warmup observation = %+v", got)
+		}
+	})
+
+	t.Run("small eager", func(t *testing.T) {
+		gvr := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+		discovery := &ResourceDiscovery{
+			resources: []APIResource{{
+				Group: gvr.Group, Version: gvr.Version, Kind: "Widget", Name: gvr.Resource,
+				Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+			}},
+			resourceMap: make(map[string]APIResource),
+			gvrMap:      make(map[string]schema.GroupVersionResource),
+			lastRefresh: time.Now(),
+			cacheTTL:    time.Hour,
+		}
+		dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{gvr: "WidgetList"})
+		cache, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: discovery})
+		if err != nil {
+			t.Fatalf("NewDynamicResourceCache: %v", err)
+		}
+		t.Cleanup(cache.Stop)
+		cache.DiscoverAllCRDs()
+		select {
+		case <-cache.discoveryDone:
+		case <-time.After(3 * time.Second):
+			t.Fatal("DiscoverAllCRDs did not complete")
+		}
+		got := cache.Observation(gvr)
+		if got.State != DynamicObservationWatched || got.Origin != DynamicObservationOriginEager {
+			t.Fatalf("small-eager observation = %+v", got)
+		}
+	})
+
+	t.Run("namespace partial truncated", func(t *testing.T) {
+		gvr := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+		dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{gvr: "WidgetList"}, func(_ schema.GroupVersionResource, namespace string) bool {
+			return namespace == "team-a" || namespace == "team-b"
+		})
+		cache, err := NewDynamicResourceCache(DynamicCacheConfig{
+			DynamicClient:               dyn,
+			NamespaceFallbacks:          []string{"team-b", "team-a"},
+			NamespaceFallbacksTruncated: true,
+		})
+		if err != nil {
+			t.Fatalf("NewDynamicResourceCache: %v", err)
+		}
+		t.Cleanup(cache.Stop)
+		if err := cache.EnsureWatching(gvr); err != nil {
+			t.Fatalf("EnsureWatching: %v", err)
+		}
+		if !cache.WaitForSync(gvr, 3*time.Second) {
+			t.Fatal("namespace-scoped informers did not sync")
+		}
+		got := cache.Observation(gvr)
+		if got.State != DynamicObservationWatched || got.Scope != DynamicObservationScopeExplicitNamespaces {
+			t.Fatalf("namespace observation = %+v", got)
+		}
+		if !got.NamespacePartial || !got.Truncated || got.ReasonCode != "namespace_fanout_truncated" {
+			t.Fatalf("namespace bounds = %+v", got)
+		}
+		if !reflect.DeepEqual(got.Namespaces, []string{"team-a", "team-b"}) {
+			t.Fatalf("namespaces = %v", got.Namespaces)
+		}
+	})
+}

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -270,6 +270,46 @@ const (
 	CRDDiscoveryComplete   CRDDiscoveryStatus = "ready"       // Discovery complete
 )
 
+type DynamicObservationState string
+
+const (
+	DynamicObservationUnwatched   DynamicObservationState = "unwatched"
+	DynamicObservationDeferred    DynamicObservationState = "deferred"
+	DynamicObservationSyncing     DynamicObservationState = "syncing"
+	DynamicObservationWatched     DynamicObservationState = "watched"
+	DynamicObservationDenied      DynamicObservationState = "denied"
+	DynamicObservationUnsupported DynamicObservationState = "unsupported"
+)
+
+type DynamicObservationOrigin string
+
+const (
+	DynamicObservationOriginWarmup   DynamicObservationOrigin = "warmup"
+	DynamicObservationOriginEager    DynamicObservationOrigin = "small_eager"
+	DynamicObservationOriginOnDemand DynamicObservationOrigin = "on_demand"
+)
+
+type DynamicObservationScope string
+
+const (
+	DynamicObservationScopeCluster            DynamicObservationScope = "cluster"
+	DynamicObservationScopeExplicitNamespaces DynamicObservationScope = "explicit_namespaces"
+)
+
+// DynamicResourceObservation describes what the dynamic cache can truthfully
+// claim for one exact GVR. It is an introspection snapshot: reading it never
+// probes the API server or starts an informer.
+type DynamicResourceObservation struct {
+	State            DynamicObservationState  `json:"state"`
+	Origin           DynamicObservationOrigin `json:"origin,omitempty"`
+	ObservationStart *time.Time               `json:"observationStart,omitempty"`
+	Scope            DynamicObservationScope  `json:"scope,omitempty"`
+	Namespaces       []string                 `json:"namespaces,omitempty"`
+	NamespacePartial bool                     `json:"namespacePartial,omitempty"`
+	Truncated        bool                     `json:"truncated,omitempty"`
+	ReasonCode       string                   `json:"reasonCode,omitempty"`
+}
+
 // DynamicCacheConfig holds configuration for creating a DynamicResourceCache.
 // All application-specific behavior is injected via callbacks — the cache
 // itself has no imports of any internal/ package.
@@ -320,6 +360,10 @@ type DynamicCacheConfig struct {
 	// precedence over NamespaceFallback.
 	NamespaceFallback  string
 	NamespaceFallbacks []string
+	// NamespaceFallbacksTruncated means additional candidate namespaces were
+	// omitted by the configured safety bound. It matters only when a GVR cannot
+	// be watched cluster-wide and falls back to per-namespace informers.
+	NamespaceFallbacksTruncated bool
 
 	// DebugEvents enables verbose debug logging.
 	DebugEvents bool

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -360,9 +360,10 @@ type DynamicCacheConfig struct {
 	// precedence over NamespaceFallback.
 	NamespaceFallback  string
 	NamespaceFallbacks []string
-	// NamespaceFallbacksTruncated means additional candidate namespaces were
-	// omitted by the configured safety bound. It matters only when a GVR cannot
-	// be watched cluster-wide and falls back to per-namespace informers.
+	// NamespaceFallbacksTruncated means the candidate set is incomplete because
+	// namespace enumeration was non-authoritative or the configured safety bound
+	// omitted candidates. It matters only when a GVR cannot be watched
+	// cluster-wide and falls back to per-namespace informers.
 	NamespaceFallbacksTruncated bool
 
 	// DebugEvents enables verbose debug logging.


### PR DESCRIPTION
## Status — DRAFT

Unit, race, build, and full-privilege live API verification are green. A real restricted-RBAC/apiserver run is still required before this truth contract is ready for review.

## Why this exists

The GPU, batch, and AI/ML breadth work exposed a shared observation prerequisite: “Radar found zero” is not equivalent to “Radar continuously observed the complete authorized scope and found zero.” This P0.2a foundation records whether an installed exact GVR is watched, syncing, deferred, denied, unsupported, namespace-partial, or stale. It exposes the truth contract; later consumers must propagate it rather than presenting false-complete aggregate results.

Controller-native contexts and drilldowns are separate verticals. This PR does not add a GPU view or semantic controller integration.

## Summary

- add a read-only, exact-GVR dynamic-cache observation contract for unwatched, deferred, syncing, watched, denied, and unsupported resources
- retain warmup, small-eager, and on-demand origins plus observation start, scope, namespace partiality, and bounded-fanout state
- retain discovery attempt, last-successful refresh, error, partial, and stale state through the existing source-coverage vocabulary
- add CRD observations to the API-resources envelope and filter namespace identities to the authenticated caller's RBAC ceiling

## Scope-integrity fixes

- Non-authoritative namespace enumeration remains incomplete even when it yields no explicit fallback candidates. A resulting GVR-global denial is exposed as partial/truncated (`access_denied_partial_probe`), never as authoritative proof that no authorized namespace exists.
- A denial from a request for one preferred namespace remains request-scoped and cannot replace the retained observation for the GVR as a whole.
- If cluster-wide count probing is denied and any namespace fallback fails transiently, Radar defers the discovery decision unless another fallback succeeds. Only conclusive authorization failures become denial evidence.

## Remaining validation gate

Before marking this ready, run Radar with an identity that is denied cluster-wide list access but has mixed namespace grants and denials. Verify that the API reports namespace-partial observation honestly, filters namespace identities to the caller, and that a preferred-namespace denial cannot replace the GVR-global observation. Those cases are covered by unit tests today, but have not been exercised against a real API server. #1559 and user-visible aggregate coverage claims remain gated on this run.

## Dependency and merge map

- This PR targets `main` and is the base of [#1559](https://github.com/skyhook-io/radar/pull/1559).
- Merge order: merge **#1558**, then rebase/retarget and merge **#1559**.
- #1559 makes the 37 curated identities continuously warm when installed; #1558 makes the resulting watch/readiness/partiality state observable.
- The exact-identity work [#1557](https://github.com/skyhook-io/radar/pull/1557) and [#1560](https://github.com/skyhook-io/radar/pull/1560), and the JobSet vertical, are independent tracks.

## Review focus

- whether each observation state is authoritative for the exact GVR and scope it names
- namespace-candidate authority, truncation, and denial propagation under restricted RBAC
- auth-versus-transient precedence across cluster-wide and namespace-fallback probes
- distinction between installed-but-denied, unsupported list/watch verbs, deferred, syncing, and not discovered
- discovery freshness and recovery transitions without converting missing evidence into absence
- authenticated response filtering: never expose namespace identities above the caller's RBAC ceiling

## Deliberate boundaries

This is an enabling contract only. It does not add a runtime-kind catalog, force watches, or change Issues, Search, Timeline, Topology, resource lists, or MCP to consume coverage. Unsupported means an installed exact GVR lacks required list/watch support; it does not mean an undiscovered API is absent.

## Verification

- `make test`
- `make build`
- `(cd pkg && go test -race ./k8score)`
- `go test ./internal/k8s ./internal/server`
- `make tsc`
- `git diff --check origin/main...HEAD`
- independent read-only review of the final scope-integrity and probe-error semantics: clean
- live full-privilege run against `kind-radar-gpu-ecosystem-demo`: `/api/health`, `/api/api-resources`, and `/api/capabilities` returned successfully; installed Kueue v1beta2, JobSet v1alpha2, and Ray v1 GVRs reported continuously watched; the snapshot contained 42 watched and 6 list/watch-unsupported resources
- restricted-RBAC live run: pending, as described above

Visual testing was skipped because there is no rendered UI change.

Part of RAD-418.
