### PR TITLE
Warm recognized GPU ecosystem resources

### DIFF
--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -171,6 +171,12 @@ type supportedCRDResource struct {
 	Namespaced bool
 }
 
+// supportedCRDFallbacks is the server-side catalog of dynamic integrations
+// Radar intentionally observes. Discovery supplies the served GVR; this
+// catalog supplies the supported identity and version fallback order used by
+// partial-discovery recovery, startup warmup, capability probes, and chart-RBAC
+// drift checks. Only installed catalog entries are warmed, so watch identities
+// stay bounded even when discovery exposes an unbounded CRD set.
 var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "applications", Kind: "Application", Namespaced: true},
 	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "applicationsets", Kind: "ApplicationSet", Namespaced: true},
@@ -389,6 +395,48 @@ var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "policies.kyverno.io", Versions: []string{"v1", "v1beta1"}, Resource: "namespacedgeneratingpolicies", Kind: "NamespacedGeneratingPolicy", Namespaced: true},
 	{Group: "policies.kyverno.io", Versions: []string{"v1", "v1beta1"}, Resource: "namespaceddeletingpolicies", Kind: "NamespacedDeletingPolicy", Namespaced: true},
 	{Group: "policies.kyverno.io", Versions: []string{"v1", "v1beta1", "v1alpha1"}, Resource: "policyexceptions", Kind: "PolicyException", Namespaced: true},
+	// GPU, batch, distributed-training, and inference integrations. These are
+	// observed regardless of object count so cross-resource consumers do not
+	// depend on a user first opening the resource kind.
+	{Group: "kueue.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "clusterqueues", Kind: "ClusterQueue", Namespaced: false},
+	{Group: "kueue.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "localqueues", Kind: "LocalQueue", Namespaced: true},
+	{Group: "kueue.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "workloads", Kind: "Workload", Namespaced: true},
+	{Group: "kueue.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "resourceflavors", Kind: "ResourceFlavor", Namespaced: false},
+	{Group: "kueue.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "admissionchecks", Kind: "AdmissionCheck", Namespaced: false},
+	{Group: "autoscaling.x-k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "provisioningrequests", Kind: "ProvisioningRequest", Namespaced: true},
+	{Group: "ray.io", Versions: []string{"v1"}, Resource: "rayclusters", Kind: "RayCluster", Namespaced: true},
+	{Group: "ray.io", Versions: []string{"v1"}, Resource: "rayjobs", Kind: "RayJob", Namespaced: true},
+	{Group: "ray.io", Versions: []string{"v1"}, Resource: "rayservices", Kind: "RayService", Namespaced: true},
+	{Group: "ray.io", Versions: []string{"v1"}, Resource: "raycronjobs", Kind: "RayCronJob", Namespaced: true},
+	{Group: "serving.kserve.io", Versions: []string{"v1beta1"}, Resource: "inferenceservices", Kind: "InferenceService", Namespaced: true},
+	{Group: "serving.kserve.io", Versions: []string{"v1alpha1"}, Resource: "servingruntimes", Kind: "ServingRuntime", Namespaced: true},
+	{Group: "serving.kserve.io", Versions: []string{"v1alpha1"}, Resource: "clusterservingruntimes", Kind: "ClusterServingRuntime", Namespaced: false},
+	{Group: "serving.kserve.io", Versions: []string{"v1alpha1"}, Resource: "inferencegraphs", Kind: "InferenceGraph", Namespaced: true},
+	{Group: "serving.kserve.io", Versions: []string{"v1alpha1"}, Resource: "trainedmodels", Kind: "TrainedModel", Namespaced: true},
+	{Group: "serving.kserve.io", Versions: []string{"v1alpha2", "v1alpha1"}, Resource: "llminferenceservices", Kind: "LLMInferenceService", Namespaced: true},
+	{Group: "inference.networking.k8s.io", Versions: []string{"v1"}, Resource: "inferencepools", Kind: "InferencePool", Namespaced: true},
+	{Group: "inference.networking.x-k8s.io", Versions: []string{"v1alpha2"}, Resource: "inferencepools", Kind: "InferencePool", Namespaced: true},
+	{Group: "llm-d.ai", Versions: []string{"v1alpha2"}, Resource: "inferenceobjectives", Kind: "InferenceObjective", Namespaced: true},
+	{Group: "inference.networking.x-k8s.io", Versions: []string{"v1alpha2"}, Resource: "inferenceobjectives", Kind: "InferenceObjective", Namespaced: true},
+	{Group: "leaderworkerset.x-k8s.io", Versions: []string{"v1"}, Resource: "leaderworkersets", Kind: "LeaderWorkerSet", Namespaced: true},
+	{Group: "jobset.x-k8s.io", Versions: []string{"v1alpha2"}, Resource: "jobsets", Kind: "JobSet", Namespaced: true},
+	{Group: "batch.volcano.sh", Versions: []string{"v1alpha1"}, Resource: "jobs", Kind: "Job", Namespaced: true},
+	{Group: "scheduling.volcano.sh", Versions: []string{"v1beta1"}, Resource: "queues", Kind: "Queue", Namespaced: false},
+	{Group: "scheduling.volcano.sh", Versions: []string{"v1beta1"}, Resource: "podgroups", Kind: "PodGroup", Namespaced: true},
+	{Group: "flow.volcano.sh", Versions: []string{"v1alpha1"}, Resource: "jobflows", Kind: "JobFlow", Namespaced: true},
+	{Group: "flow.volcano.sh", Versions: []string{"v1alpha1"}, Resource: "jobtemplates", Kind: "JobTemplate", Namespaced: true},
+	{Group: "scheduling.run.ai", Versions: []string{"v2"}, Resource: "queues", Kind: "Queue", Namespaced: false},
+	{Group: "scheduling.run.ai", Versions: []string{"v2alpha2"}, Resource: "podgroups", Kind: "PodGroup", Namespaced: true},
+	{Group: "kubeflow.org", Versions: []string{"v1"}, Resource: "pytorchjobs", Kind: "PyTorchJob", Namespaced: true},
+	{Group: "kubeflow.org", Versions: []string{"v1"}, Resource: "tfjobs", Kind: "TFJob", Namespaced: true},
+	{Group: "kubeflow.org", Versions: []string{"v1", "v2beta1"}, Resource: "mpijobs", Kind: "MPIJob", Namespaced: true},
+	{Group: "trainer.kubeflow.org", Versions: []string{"v1alpha1"}, Resource: "trainjobs", Kind: "TrainJob", Namespaced: true},
+	{Group: "kaito.sh", Versions: []string{"v1beta1"}, Resource: "workspaces", Kind: "Workspace", Namespaced: true},
+	{Group: "kaito.sh", Versions: []string{"v1beta1", "v1alpha1"}, Resource: "ragengines", Kind: "RAGEngine", Namespaced: true},
+	{Group: "apps.nvidia.com", Versions: []string{"v1alpha1"}, Resource: "nimservices", Kind: "NIMService", Namespaced: true},
+	{Group: "apps.nvidia.com", Versions: []string{"v1alpha1"}, Resource: "nimcaches", Kind: "NIMCache", Namespaced: true},
+	{Group: "apps.nvidia.com", Versions: []string{"v1alpha1"}, Resource: "nimpipelines", Kind: "NIMPipeline", Namespaced: true},
+	{Group: "amd.com", Versions: []string{"v1alpha1"}, Resource: "deviceconfigs", Kind: "DeviceConfig", Namespaced: true},
 	// DRA (built-in resource.k8s.io, GA in K8s 1.34). Normal discovery flags
 	// these IsCRD (group not in coreAPIGroups) and watches them; the fallback
 	// entries cover partial-discovery clusters. v1beta2 serves 1.32-1.33.
@@ -566,7 +614,8 @@ func isExpectedFallbackProbeDenial(err error) bool {
 	return apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsNotFound(err)
 }
 
-// WarmupCommonCRDs starts watching common CRDs (Rollouts, Workflows, etc.) at startup.
+// WarmupCommonCRDs starts watching discovered resources in the supported
+// dynamic-integration catalog at startup.
 func WarmupCommonCRDs() {
 	cache := GetDynamicResourceCache()
 	if cache == nil {
@@ -581,7 +630,7 @@ func WarmupCommonCRDs() {
 	var gvrs []schema.GroupVersionResource
 	seen := make(map[schema.GroupVersionResource]bool)
 	for _, candidate := range supportedCRDFallbacks {
-		if gvr, ok := discovery.GetGVRWithGroup(candidate.Kind, candidate.Group); ok && !seen[gvr] {
+		if gvr, ok := discovery.GetGVRWithGroup(candidate.Kind, candidate.Group); ok && discovery.SupportsWatchGVR(gvr) && !seen[gvr] {
 			seen[gvr] = true
 			gvrs = append(gvrs, gvr)
 			log.Printf("Warming up CRD: %s (%s)", candidate.Kind, candidate.Group)

--- a/internal/k8s/gpu_ecosystem_warmup_test.go
+++ b/internal/k8s/gpu_ecosystem_warmup_test.go
@@ -1,0 +1,130 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+func TestGPUEcosystemRegistryIsInSupportedWarmupCatalog(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "scripts", "gpu-ecosystem-demo", "resources.tsv"))
+	if err != nil {
+		t.Fatalf("read GPU ecosystem registry: %v", err)
+	}
+
+	type catalogKey struct {
+		group    string
+		resource string
+	}
+	type lookupKey struct {
+		group string
+		kind  string
+	}
+	catalog := make(map[catalogKey]supportedCRDResource, len(supportedCRDFallbacks))
+	lookups := make(map[lookupKey]supportedCRDResource, len(supportedCRDFallbacks))
+	for _, candidate := range supportedCRDFallbacks {
+		key := catalogKey{group: candidate.Group, resource: candidate.Resource}
+		if previous, exists := catalog[key]; exists {
+			t.Fatalf("duplicate supported dynamic resource %s.%s: %s and %s", candidate.Resource, candidate.Group, previous.Kind, candidate.Kind)
+		}
+		catalog[key] = candidate
+		lookup := lookupKey{group: candidate.Group, kind: candidate.Kind}
+		if previous, exists := lookups[lookup]; exists {
+			t.Fatalf("ambiguous supported dynamic kind %s.%s: %s and %s", candidate.Kind, candidate.Group, previous.Resource, candidate.Resource)
+		}
+		lookups[lookup] = candidate
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) < 2 || strings.TrimPrefix(lines[0], "# ") != "logical_id\tgroup\tplural\tkind\tscope\tapi_version\tscenario\tcrd_url" {
+		t.Fatalf("unexpected GPU ecosystem registry header: %q", lines[0])
+	}
+	for lineNumber, line := range lines[1:] {
+		fields := strings.Split(line, "\t")
+		if len(fields) != 8 {
+			t.Fatalf("registry line %d has %d fields, want 8", lineNumber+2, len(fields))
+		}
+		group, resource, kind, scope, version := fields[1], fields[2], fields[3], fields[4], fields[5]
+		candidate, ok := catalog[catalogKey{group: group, resource: resource}]
+		if !ok {
+			t.Errorf("%s.%s is curated but absent from supportedCRDFallbacks", resource, group)
+			continue
+		}
+		if candidate.Kind != kind {
+			t.Errorf("%s.%s kind = %s, want %s", resource, group, candidate.Kind, kind)
+		}
+		if candidate.Namespaced != (scope == "Namespaced") {
+			t.Errorf("%s.%s namespaced = %t, registry scope = %s", resource, group, candidate.Namespaced, scope)
+		}
+		if len(candidate.Versions) == 0 || candidate.Versions[0] != version {
+			t.Errorf("%s.%s preferred fallback version = %v, want registry version %s first", resource, group, candidate.Versions, version)
+		}
+	}
+}
+
+func TestRecognizedLargeResourceWarmsWhileUnknownLargeResourceDefers(t *testing.T) {
+	ResetTestDynamicState()
+	t.Cleanup(ResetTestDynamicState)
+
+	recognized := schema.GroupVersionResource{Group: "kueue.x-k8s.io", Version: "v1beta2", Resource: "workloads"}
+	listOnly := schema.GroupVersionResource{Group: "kueue.x-k8s.io", Version: "v1beta2", Resource: "localqueues"}
+	unknown := schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			recognized: "WorkloadList",
+			unknown:    "WidgetList",
+		},
+	)
+	dynamicClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		remaining := int64(101)
+		list := &unstructured.UnstructuredList{}
+		list.SetRemainingItemCount(&remaining)
+		return true, list, nil
+	})
+	if err := InitTestDynamicResourceCache(dynamicClient, []APIResource{
+		{Group: recognized.Group, Version: recognized.Version, Name: recognized.Resource, Kind: "Workload", Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+		{Group: listOnly.Group, Version: listOnly.Version, Name: listOnly.Resource, Kind: "LocalQueue", Namespaced: true, IsCRD: true, Verbs: []string{"get", "list"}},
+		{Group: unknown.Group, Version: unknown.Version, Name: unknown.Resource, Kind: "Widget", Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	cache := GetDynamicResourceCache()
+
+	WarmupCommonCRDs()
+	if !cache.WaitForSync(recognized, 3*time.Second) {
+		t.Fatal("recognized Workload informer did not sync")
+	}
+	if got := cache.Observation(recognized); got.State != k8score.DynamicObservationWatched || got.Origin != k8score.DynamicObservationOriginWarmup {
+		t.Fatalf("recognized large resource observation = %+v, want watched warmup", got)
+	}
+	if got := cache.Observation(listOnly); got.State != k8score.DynamicObservationUnsupported || got.ReasonCode != "list_watch_unsupported" {
+		t.Fatalf("recognized list-only resource observation = %+v, want unsupported", got)
+	}
+
+	cache.DiscoverAllCRDs()
+	deadline := time.Now().Add(3 * time.Second)
+	for cache.GetDiscoveryStatus() != k8score.CRDDiscoveryComplete && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if cache.GetDiscoveryStatus() != k8score.CRDDiscoveryComplete {
+		t.Fatal("CRD discovery did not complete")
+	}
+	if got := cache.Observation(unknown); got.State != k8score.DynamicObservationDeferred || got.ReasonCode != "resource_count_exceeds_eager_limit" {
+		t.Fatalf("unknown large resource observation = %+v, want size-gated deferred", got)
+	}
+	if got := cache.Observation(recognized); got.Origin != k8score.DynamicObservationOriginWarmup {
+		t.Fatalf("full discovery replaced recognized warmup origin: %+v", got)
+	}
+}


### PR DESCRIPTION
## Status and program context

**Ready for stacked review. #1558's scope-integrity fixes are present in this PR's base; merge #1558 first, then retarget and merge this unchanged patch.**

The GPU, batch, and AI/ML breadth work exposed a shared observation prerequisite: recognized resources need proactive observation, while consumers need explicit coverage metadata before making complete claims. This PR warms the 37 curated resource identities represented by 39 current/experimental group-resource variants; #1558 reports whether that observation is complete, partial, syncing, deferred, denied, or unsupported. This PR does **not** add 37 deep integrations, typed semantics, Issues, relationships, or controller-native drilldowns.

## Summary

- add the 37 curated GPU, batch, training, and inference identities to Radar's existing supported dynamic-integration warmup catalog
- resolve the exact served GVR through discovery and warm it only when the installed resource supports both `list` and `watch`
- let recognized integrations bypass the generic `>100` object deferral so aggregate consumers do not depend on a user first opening a resource page
- retain the generic deferral for unknown CRDs
- test catalog identity, group-qualified lookup uniqueness, scope, and preferred fallback version against the GPU demo registry

## Dependency and merge map

- Git stack: [#1558](https://github.com/skyhook-io/radar/pull/1558) -> **#1559**.
- #1558 supplies the exact-GVR observation/readiness contract; this PR changes which installed recognized resources are warmed.
- #1558 now includes the namespace-authority, request-scoped denial, and transient-fallback corrections. Merge #1558 first, then retarget #1559 to `main` and rerun required checks.
- Exact-identity work and controller-native verticals such as JobSet remain separate tracks.

## Review focus

- startup API traffic, informer count, memory, namespace fan-out, and Timeline churn across the whole dynamic catalog—not only these 39 additions
- exact group/resource/version/scope mapping and uniqueness against the demo registry
- `list` + `watch` capability gating and served-version fallback behavior
- recognized `>100`-object resources warm while unknown large CRDs remain deferred
- installed-only behavior: no watch should be created for an absent integration

## Observation and scale boundary

The finite catalog bounds possible watch identities, and the existing namespace-fallback cap bounds namespace fan-out. It does **not** bound retained object count for an installed recognized GVR. This PR extends an existing policy; representative scale measurement should govern the whole catalog. If that evidence requires a budget, use one deterministic global priority/deferral policy and expose the result through #1558 rather than adding a GPU-only exception.

The demo TSV is test evidence only. Runtime identity and version resolution remain in discovery plus the existing server catalog.

## Verification

- `make tsc`
- `make test`
- `make build`
- `go test ./internal/k8s -count=1`
- `(cd pkg && go test ./k8score -count=1)`
- `git diff --check e000f576...9aaa8dfc`
- stable patch ID and `git range-diff` match the pre-restack patch exactly
- focused current-stack tests: `go test ./internal/k8s -run 'Test(GPUEcosystemRegistryIsInSupportedWarmupCatalog|RecognizedLargeResourceWarmsWhileUnknownLargeResourceDefers|CheckResourcePermissionsCacheHitCopiesScopeNamespaces|ScopeCandidateSetIncomplete)$' -count=3`
- focused current-stack tests: `(cd pkg && go test ./k8score -run 'TestDynamicResource(Cache_ProbeCountDefersWhenNamespaceFallbackFailsTransiently|Observation)' -count=3)`
- visual test skipped: no rendered UI delta

Part of RAD-418.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases startup informer fan-out for clusters with many of these operators installed, though scope stays limited to the finite catalog and list+watch-capable GVRs only.
> 
> **Overview**
> Expands **`supportedCRDFallbacks`** with GPU, batch, training, and inference integrations (Kueue, Ray, KServe, Volcano, Kubeflow, NVIDIA/AMD operators, and related groups) so Radar can **eagerly watch** those kinds at startup instead of waiting on the generic **>100 object** deferral used for unknown CRDs.
> 
> Documents the catalog's role (identity, version fallbacks, bounded warmup) and tightens **`WarmupCommonCRDs`** so only discovered GVRs that pass **`SupportsWatchGVR`** are warmed—list-only APIs are skipped.
> 
> Adds tests that keep the catalog aligned with **`scripts/gpu-ecosystem-demo/resources.tsv`** (uniqueness, scope, preferred version) and assert a catalog **`Workload`** still warms when lists report **101+** items while an unknown large CRD stays deferred after full discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37e96cc87d4da6e9993cba0ef330ed3188a1c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
