### PR TITLE
Make topology and application identity API-group-aware

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/k8score"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -694,7 +695,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
-	apiVersion := extractAPIVersion(obj)
+	apiVersion := extractAPIVersion(kind, obj)
 	apiGroup := ""
 	if gvr, ok := BuiltinGVRAnyGroup(kind); ok {
 		apiGroup = gvr.Group
@@ -904,12 +905,14 @@ func isUnstructuredUpdate(oldObj, newObj any) bool {
 	return oldOK && newOK
 }
 
-// extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")
-// for unstructured objects. Typed informer objects have empty TypeMeta after decoding;
-// identity call sites recover their group from the canonical built-in GVR table.
-func extractAPIVersion(obj any) string {
+// extractAPIVersion returns the exact dynamic apiVersion or restores the
+// canonical version stripped from typed informer objects.
+func extractAPIVersion(kind string, obj any) string {
 	if u, ok := obj.(*unstructured.Unstructured); ok {
 		return u.GetAPIVersion()
+	}
+	if apiVersion, ok := resourceid.BuiltinAPIVersion(kind); ok {
+		return apiVersion
 	}
 	return ""
 }

--- a/internal/k8s/cache_identity_test.go
+++ b/internal/k8s/cache_identity_test.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+	"github.com/skyhook-io/radar/pkg/resourceid"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractAPIVersionRestoresTypedIdentity(t *testing.T) {
+	if got := extractAPIVersion("Deployment", &appsv1.Deployment{}); got != "apps/v1" {
+		t.Fatalf("typed Deployment apiVersion = %q, want apps/v1", got)
+	}
+	custom := &unstructured.Unstructured{}
+	custom.SetAPIVersion("batch.volcano.sh/v1alpha1")
+	if got := extractAPIVersion("Job", custom); got != "batch.volcano.sh/v1alpha1" {
+		t.Fatalf("dynamic Job apiVersion = %q, want exact custom version", got)
+	}
+	if got := extractAPIVersion("Widget", struct{}{}); got != "" {
+		t.Fatalf("unknown typed object apiVersion = %q, want unknown", got)
+	}
+}
+
+func TestTypedInformerKindsHaveCanonicalAPIVersions(t *testing.T) {
+	for _, lister := range k8score.AllKindListers() {
+		if _, ok := resourceid.BuiltinAPIVersion(lister.Kind()); !ok {
+			t.Errorf("typed informer kind %q has no canonical apiVersion", lister.Kind())
+		}
+	}
+}

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -87,8 +87,8 @@ var diffFunctions = map[string]kindDiffRegistration{
 // changes were detected.
 func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 	registration, ok := diffFunctions[kind]
-	oldAPIVersion := extractAPIVersion(oldObj)
-	newAPIVersion := extractAPIVersion(newObj)
+	oldAPIVersion := extractAPIVersion(kind, oldObj)
+	newAPIVersion := extractAPIVersion(kind, newObj)
 	if oldAPIVersion != "" && newAPIVersion != "" && GroupFromAPIVersion(oldAPIVersion) != GroupFromAPIVersion(newAPIVersion) {
 		return nil
 	}

--- a/internal/k8s/topology_adapter.go
+++ b/internal/k8s/topology_adapter.go
@@ -257,3 +257,7 @@ func (a *topologyDynamicProvider) GetKindForGVR(gvr schema.GroupVersionResource)
 func (a *topologyDynamicProvider) IsCRD(kind string) bool {
 	return a.discovery.IsCRD(kind)
 }
+
+func (a *topologyDynamicProvider) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	return a.discovery.IsCRDGVR(gvr)
+}

--- a/internal/mcp/tools_neighborhood.go
+++ b/internal/mcp/tools_neighborhood.go
@@ -156,17 +156,8 @@ func handleGetNeighborhood(ctx context.Context, req *mcp.CallToolRequest, input 
 		return nil, nil, fmt.Errorf("resource not found in topology: %s/%s/%s", input.Kind, input.Namespace, input.Name)
 	}
 
-	// Use the resolved root node's Kind for the response. displayKindForMCP
-	// only normalizes built-in kinds (Pod, Deployment, …); pseudo-kinds
-	// like "nodeclass"/"nodepool" pass through lowercase while subgraph
-	// nodes carry display-form NodeKind ("NodeClass"). Without this rewrite
-	// the response's root.kind would diverge from subgraph.nodes[0].kind
-	// within the same payload. Matches the REST handler's identical fix.
-	rootResp := root
-	rootResp.Kind = topology.KubernetesKindForNode(&sub.Nodes[0])
-
 	result := neighborhoodResult{
-		Root: rootResp,
+		Root: sub.Root,
 		Subgraph: neighborhoodSubgraphMCP{
 			Nodes: sub.Nodes,
 			Edges: sub.Edges,

--- a/internal/mcp/tools_neighborhood.go
+++ b/internal/mcp/tools_neighborhood.go
@@ -163,7 +163,7 @@ func handleGetNeighborhood(ctx context.Context, req *mcp.CallToolRequest, input 
 	// the response's root.kind would diverge from subgraph.nodes[0].kind
 	// within the same payload. Matches the REST handler's identical fix.
 	rootResp := root
-	rootResp.Kind = string(sub.Nodes[0].Kind)
+	rootResp.Kind = topology.KubernetesKindForNode(&sub.Nodes[0])
 
 	result := neighborhoodResult{
 		Root: rootResp,

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -77,6 +77,7 @@ type argoClaim struct {
 // workloadRef identifies one managed workload for the hub to match against a
 // destination cluster's rows.
 type workloadRef struct {
+	Group     string `json:"group,omitempty"`
 	Kind      string `json:"kind"`
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
@@ -919,7 +920,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 			},
 			overlay:      overlay,
 			source:       sourceRefForInput(overlay, rootKind, rootGroup, rootKey),
-			events:       eventsForWorkload(eventsByObj[ns], kind, name, pods),
+			events:       eventsForWorkload(eventsByObj[ns], group, kind, name, pods),
 			rels:         rels,
 			rootKey:      rootKey,
 			rootKind:     rootKind,
@@ -2459,7 +2460,11 @@ func indexWarningEventsByObject(cache *k8s.ResourceCache, namespaces []string) m
 				m = map[string][]*corev1.Event{}
 				out[e.Namespace] = m
 			}
-			key := e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name
+			group := topology.APIVersionGroup(e.InvolvedObject.APIVersion)
+			if builtinGroup, builtin := resourceid.BuiltinGroup(e.InvolvedObject.Kind); group == "" && builtin {
+				group = builtinGroup
+			}
+			key := resourceid.ResourceKey(group, e.InvolvedObject.Kind, "", e.InvolvedObject.Name)
 			m[key] = append(m[key], e)
 		}
 	}
@@ -2523,14 +2528,14 @@ func podsRestarts(pods []*corev1.Pod) (int, string) {
 // index (the workload object + its pods), deduped by (object, reason) with
 // summed counts — the "why is it broken" feed (FailedScheduling, ImagePullBackOff,
 // FailedMount, …) that restarts alone miss.
-func eventsForWorkload(byObject map[string][]*corev1.Event, workloadKind, workloadName string, pods []*corev1.Pod) []appEvent {
+func eventsForWorkload(byObject map[string][]*corev1.Event, workloadGroup, workloadKind, workloadName string, pods []*corev1.Pod) []appEvent {
 	if byObject == nil {
 		return nil
 	}
 	names := make([]string, 0, len(pods)+1)
-	names = append(names, workloadKind+"/"+workloadName)
+	names = append(names, resourceid.ResourceKey(workloadGroup, workloadKind, "", workloadName))
 	for _, p := range pods {
-		names = append(names, "Pod/"+p.Name)
+		names = append(names, resourceid.ResourceKey("", "Pod", "", p.Name))
 	}
 	byKey := map[string]*appEvent{}
 	order := []string{}

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -27,6 +27,7 @@ import (
 	"github.com/skyhook-io/radar/pkg/health"
 	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/rollouts"
 	"github.com/skyhook-io/radar/pkg/subject"
 	"github.com/skyhook-io/radar/pkg/topology"
@@ -105,7 +106,7 @@ type applicationsCacheEntry struct {
 
 // appRow is one logical app in this cluster.
 type appRow struct {
-	Key            string            `json:"key"`                      // overlay key, structural-root key, or "<ns>/<kind>/<name>" raw
+	Key            string            `json:"key"`                      // overlay key or structural-root key; raw CRD roots append "@<api-group>"
 	Name           string            `json:"name"`                     // display name
 	Namespace      string            `json:"namespace,omitempty"`      // the single namespace the WORKLOADS run in (residence, not the GitOps manager's home); empty when they span several — see Namespaces
 	Namespaces     []string          `json:"namespaces,omitempty"`     // all distinct workload namespaces, sorted; the unambiguous form of Namespace
@@ -551,12 +552,12 @@ func firstNonEmptyString(values ...string) string {
 // cleanly: every workload becomes its own structural root and carries no
 // satellites — identity then rests on the label overlay alone, raw-always.
 type appGraph struct {
-	topo     *topology.Topology
-	idx      *topology.RelationshipsIndex
-	provider topology.ResourceProvider
-	dp       topology.DynamicProvider
-	byID     map[string]topology.Node
-	byKNN    map[string]string // lower(kind)|ns|name → node ID
+	topo       *topology.Topology
+	idx        *topology.RelationshipsIndex
+	provider   topology.ResourceProvider
+	dp         topology.DynamicProvider
+	byID       map[string]topology.Node
+	byResource map[string]string
 }
 
 // ListApplications builds the structural topology graph, resolves each app
@@ -657,7 +658,7 @@ func applicationsCacheKeyFor(namespaces []string, canListClusterWorkflowTemplate
 // buildAppGraph constructs the same resources-view topology the /api/topology
 // handler builds, then indexes it for root walks and satellite lookups.
 func buildAppGraph(cache *k8s.ResourceCache, namespaces []string) *appGraph {
-	g := &appGraph{byID: map[string]topology.Node{}, byKNN: map[string]string{}}
+	g := &appGraph{byID: map[string]topology.Node{}, byResource: map[string]string{}}
 	provider := k8s.NewTopologyResourceProvider(cache)
 	if provider == nil {
 		return g
@@ -680,13 +681,19 @@ func buildAppGraph(cache *k8s.ResourceCache, namespaces []string) *appGraph {
 	for _, n := range topo.Nodes {
 		g.byID[n.ID] = n
 		ns, _ := n.Data["namespace"].(string)
-		g.byKNN[knnKey(string(n.Kind), ns, n.Name)] = n.ID
+		kind := topology.KubernetesKindForNode(&n)
+		group := appGraphNodeGroup(&n, kind)
+		g.byResource[resourceid.ResourceKey(group, kind, ns, n.Name)] = n.ID
 	}
 	return g
 }
 
-func knnKey(kind, ns, name string) string {
-	return strings.ToLower(kind) + "|" + ns + "|" + name
+func appGraphNodeGroup(node *topology.Node, kind string) string {
+	apiVersion, _ := node.Data["apiVersion"].(string)
+	if group := topology.APIVersionGroup(apiVersion); group != "" {
+		return group
+	}
+	return resourceid.GroupForBuiltinKind(kind)
 }
 
 // isGitOpsManagerKind reports whether a node is an in-cluster GitOps manager —
@@ -697,13 +704,16 @@ func knnKey(kind, ns, name string) string {
 // union-find would merge them all into one app. ownerRef chains — including
 // operator CRs (CNPG Cluster, Strimzi Kafka) — are not managers and keep
 // climbing to the topmost owner.
-func isGitOpsManagerKind(k topology.NodeKind) bool {
-	switch k {
-	case topology.KindApplication, topology.KindKustomization, topology.KindHelmRelease:
-		return true
-	default:
-		return false
+func isGitOpsManagerKind(kind topology.NodeKind, group string) bool {
+	switch kind {
+	case topology.KindApplication:
+		return group == "argoproj.io"
+	case topology.KindKustomization:
+		return group == "kustomize.toolkit.fluxcd.io"
+	case topology.KindHelmRelease:
+		return group == "helm.toolkit.fluxcd.io"
 	}
+	return false
 }
 
 // structuralRoot walks incoming EdgeManages edges from startID toward the
@@ -738,22 +748,25 @@ func (g *appGraph) structuralRoot(startID string) (topology.Node, bool) {
 			ok = true
 		}
 		cur = next
-		if exists && isGitOpsManagerKind(n.Kind) {
+		if exists && isGitOpsManagerKind(n.Kind, appGraphNodeGroup(&n, topology.KubernetesKindForNode(&n))) {
 			break
 		}
 	}
 	return top, ok
 }
 
-// rootOf returns the structural-root key ("<ns>/<Kind>/<name>") and root Kind
-// for a workload, falling back to the workload itself when the graph is absent.
-func (g *appGraph) rootOf(kind, ns, name string) (rootKey, rootKind string) {
+// rootOf returns the structural-root key ("<ns>/<Kind>/<name>"), root Kind,
+// API group, and exact identity for a workload, falling back to the workload
+// itself when the graph is absent.
+func (g *appGraph) rootOf(group, kind, ns, name string) (rootKey, rootKind, rootGroup, rootIdentity string) {
 	rootKey = ns + "/" + kind + "/" + name
 	rootKind = kind
+	rootGroup = group
+	rootIdentity = resourceid.ResourceKey(group, kind, ns, name)
 	if g.topo == nil {
 		return
 	}
-	nodeID, found := g.byKNN[knnKey(kind, ns, name)]
+	nodeID, found := g.byResource[rootIdentity]
 	if !found {
 		return
 	}
@@ -762,15 +775,19 @@ func (g *appGraph) rootOf(kind, ns, name string) (rootKey, rootKind string) {
 		return
 	}
 	rns, _ := rn.Data["namespace"].(string)
-	return rns + "/" + string(rn.Kind) + "/" + rn.Name, string(rn.Kind)
+	rootKind = string(rn.Kind)
+	identityKind := topology.KubernetesKindForNode(&rn)
+	rootGroup = appGraphNodeGroup(&rn, identityKind)
+	return rns + "/" + rootKind + "/" + rn.Name, rootKind, rootGroup,
+		resourceid.ResourceKey(appGraphNodeGroup(&rn, identityKind), identityKind, rns, rn.Name)
 }
 
 // relationshipsFor pulls the workload's structural satellites from the graph.
-func (g *appGraph) relationshipsFor(kind, ns, name string) *appRelationships {
+func (g *appGraph) relationshipsFor(kind, ns, name string, obj any) *appRelationships {
 	if g.topo == nil {
 		return nil
 	}
-	rel := topology.GetRelationshipsWithIndex(kind, ns, name, g.topo, g.provider, g.dp, g.idx)
+	rel := topology.GetRelationshipsWithObject(kind, ns, name, obj, g.topo, g.provider, g.dp, g.idx)
 	if rel == nil {
 		return nil
 	}
@@ -825,15 +842,17 @@ func isAppRouteKind(kind string) bool {
 // that decide which app it belongs to (structural root + label overlay) and how
 // it is classified.
 type appWorkloadInput struct {
-	wl       appWorkload
-	overlay  *subject.AppOverlay
-	source   *appSourceRef
-	events   []appEvent
-	rels     *appRelationships
-	rootKey  string
-	rootKind string
-	addon    bool
-	addonWhy string
+	wl           appWorkload
+	overlay      *subject.AppOverlay
+	source       *appSourceRef
+	events       []appEvent
+	rels         *appRelationships
+	rootKey      string
+	rootKind     string
+	rootGroup    string
+	rootIdentity string
+	addon        bool
+	addonWhy     string
 }
 
 // collectAppWorkloads walks Deployments/StatefulSets/DaemonSets plus
@@ -859,7 +878,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 		}
 	}
 
-	add := func(kind, ns, name string, lbls, anns map[string]string, image string, workloadHealth packages.Health, ready, desired int, selector *metav1.LabelSelector, rollout *health.WorkloadRolloutActivity, batch *appBatchSummary) {
+	add := func(obj any, kind, ns, name string, lbls, anns map[string]string, image string, workloadHealth packages.Health, ready, desired int, selector *metav1.LabelSelector, rollout *health.WorkloadRolloutActivity, batch *appBatchSummary) {
 		pods := podsForSelector(podsByNS[ns], selector)
 		if rollout != nil && (rollout.Active || rollout.Phase == health.RolloutStalled) && rollout.Phase != health.RolloutApplying {
 			updatedRevisionTargetsOnce.Do(func() {
@@ -870,13 +889,17 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 		restarts, reason := podsRestarts(pods)
 		meta := metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls, Annotations: anns}
 		overlay := subject.ResolveOverlay(&meta, false)
-		rootKey, rootKind := g.rootOf(kind, ns, name)
-		rels := g.relationshipsFor(kind, ns, name)
+		group := appWorkloadAPIGroup(kind)
+		if resource, ok := obj.(*unstructured.Unstructured); ok {
+			group = topology.APIVersionGroup(resource.GetAPIVersion())
+		}
+		rootKey, rootKind, rootGroup, rootIdentity := g.rootOf(group, kind, ns, name)
+		rels := g.relationshipsFor(kind, ns, name, obj)
 		addon, why := packages.ClassifyAddon(lbls["helm.sh/chart"], lbls["app.kubernetes.io/name"], lbls["app.kubernetes.io/part-of"], name, lbls["addonmanager.kubernetes.io/mode"], image)
 		out = append(out, appWorkloadInput{
 			wl: appWorkload{
 				Kind:          kind,
-				Group:         appWorkloadAPIGroup(kind),
+				Group:         group,
 				Namespace:     ns,
 				Name:          name,
 				WorkloadClass: classifyWorkload(kind, rels),
@@ -894,14 +917,16 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 				nameLabel:     lbls["app.kubernetes.io/name"],
 				appAnnotation: strings.TrimSpace(anns[appIdentityAnnotation]),
 			},
-			overlay:  overlay,
-			source:   sourceRefForInput(overlay, rootKind, rootKey),
-			events:   eventsForWorkload(eventsByObj[ns], kind, name, pods),
-			rels:     rels,
-			rootKey:  rootKey,
-			rootKind: rootKind,
-			addon:    addon,
-			addonWhy: why,
+			overlay:      overlay,
+			source:       sourceRefForInput(overlay, rootKind, rootGroup, rootKey),
+			events:       eventsForWorkload(eventsByObj[ns], kind, name, pods),
+			rels:         rels,
+			rootKey:      rootKey,
+			rootKind:     rootKind,
+			rootGroup:    rootGroup,
+			rootIdentity: rootIdentity,
+			addon:        addon,
+			addonWhy:     why,
 		})
 	}
 
@@ -927,7 +952,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 				if rolloutReferencedDeployments[d.Namespace+"/"+d.Name] {
 					continue
 				}
-				add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
+				add(d, "Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
 					primaryImage(d.Spec.Template.Spec.Containers),
 					levelToPackagesHealth(health.Workload(d, time.Now()).Level),
 					int(d.Status.AvailableReplicas), appDesiredReplicas(d.Spec.Replicas), d.Spec.Selector, visibleRolloutActivity(health.WorkloadRollout(d)), nil)
@@ -943,7 +968,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 				items, _ = dsLister.DaemonSets(ns).List(labels.Everything())
 			}
 			for _, d := range items {
-				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+				add(d, "DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
 					primaryImage(d.Spec.Template.Spec.Containers),
 					levelToPackagesHealth(health.Workload(d, time.Now()).Level),
 					int(d.Status.NumberReady), int(d.Status.DesiredNumberScheduled), d.Spec.Selector, visibleRolloutActivity(health.WorkloadRollout(d)), nil)
@@ -959,7 +984,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 				items, _ = ssLister.StatefulSets(ns).List(labels.Everything())
 			}
 			for _, d := range items {
-				add("StatefulSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+				add(d, "StatefulSet", d.Namespace, d.Name, d.Labels, d.Annotations,
 					primaryImage(d.Spec.Template.Spec.Containers),
 					levelToPackagesHealth(health.Workload(d, time.Now()).Level),
 					int(d.Status.ReadyReplicas), appDesiredReplicas(d.Spec.Replicas), d.Spec.Selector, visibleRolloutActivity(health.WorkloadRollout(d)), nil)
@@ -975,7 +1000,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 			activity.Desired = int32(desired)
 		}
 		ready := int(activity.Available)
-		add("Rollout", rollout.GetNamespace(), rollout.GetName(), rollout.GetLabels(), rollout.GetAnnotations(),
+		add(rollout, "Rollout", rollout.GetNamespace(), rollout.GetName(), rollout.GetLabels(), rollout.GetAnnotations(),
 			image, applicationServingHealth(ready, desired), ready, desired, selector, visibleRolloutActivity(activity), nil)
 	}
 	if jobLister := cache.Jobs(); jobLister != nil {
@@ -994,7 +1019,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 					continue
 				}
 				batch := jobBatchSummary(j)
-				add("Job", j.Namespace, j.Name, j.Labels, j.Annotations,
+				add(j, "Job", j.Namespace, j.Name, j.Labels, j.Annotations,
 					primaryImage(j.Spec.Template.Spec.Containers),
 					batchHealth(batch, levelToPackagesHealth(health.Workload(j, time.Now()).Level)),
 					0, 0, j.Spec.Selector, nil, batch)
@@ -1018,7 +1043,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 				batch.Suspended = cj.Spec.Suspend != nil && *cj.Spec.Suspend
 				setLatestBatchTime(&batch.LastScheduledAt, formatMetaTime(cj.Status.LastScheduleTime))
 				setLatestBatchTime(&batch.LastSuccessfulAt, formatMetaTime(cj.Status.LastSuccessfulTime))
-				add("CronJob", cj.Namespace, cj.Name, cj.Labels, cj.Annotations,
+				add(cj, "CronJob", cj.Namespace, cj.Name, cj.Labels, cj.Annotations,
 					primaryImage(cj.Spec.JobTemplate.Spec.Template.Spec.Containers),
 					batchHealth(batch, levelToPackagesHealth(health.Workload(cj, time.Now()).Level)),
 					0, 0, nil, nil, batch)
@@ -1030,7 +1055,7 @@ func collectAppWorkloads(ctx context.Context, cache *k8s.ResourceCache, namespac
 	return out
 }
 
-type addAppWorkloadFunc func(kind, ns, name string, lbls, anns map[string]string, image string, workloadHealth packages.Health, ready, desired int, selector *metav1.LabelSelector, rollout *health.WorkloadRolloutActivity, batch *appBatchSummary)
+type addAppWorkloadFunc func(obj any, kind, ns, name string, lbls, anns map[string]string, image string, workloadHealth packages.Health, ready, desired int, selector *metav1.LabelSelector, rollout *health.WorkloadRolloutActivity, batch *appBatchSummary)
 
 func visibleRolloutActivity(activity health.WorkloadRolloutActivity) *health.WorkloadRolloutActivity {
 	if !activity.Active && activity.Phase != health.RolloutStalled {
@@ -1282,7 +1307,7 @@ func addScaledJobWorkloads(ctx context.Context, cache *k8s.ResourceCache, namesp
 		if batch == nil {
 			batch = &appBatchSummary{}
 		}
-		add("ScaledJob", sj.GetNamespace(), sj.GetName(), sj.GetLabels(), sj.GetAnnotations(),
+		add(sj, "ScaledJob", sj.GetNamespace(), sj.GetName(), sj.GetLabels(), sj.GetAnnotations(),
 			scaledJobPrimaryImage(sj), batchHealth(batch, scaledJobHealth(sj)), 0, 0, nil, nil, batch)
 	}
 }
@@ -1309,7 +1334,7 @@ func addArgoBatchWorkloads(ctx context.Context, cache *k8s.ResourceCache, namesp
 		run := workflowRunInfo(wf)
 		batch := &appBatchSummary{}
 		applyRunToBatch(batch, run)
-		add("Workflow", wf.GetNamespace(), wf.GetName(), wf.GetLabels(), wf.GetAnnotations(),
+		add(wf, "Workflow", wf.GetNamespace(), wf.GetName(), wf.GetLabels(), wf.GetAnnotations(),
 			workflowPrimaryImage(wf), workflowHealth(run.Phase), 0, 0, nil, nil, batch)
 	}
 
@@ -1324,7 +1349,7 @@ func addArgoBatchWorkloads(ctx context.Context, cache *k8s.ResourceCache, namesp
 		if batch == nil {
 			batch = &appBatchSummary{}
 		}
-		add(info.kind, info.namespace, info.name, info.labels, info.annotations,
+		add(info.object, info.kind, info.namespace, info.name, info.labels, info.annotations,
 			templateImage(info.object, "spec", "templates"), batchHealth(batch, packages.HealthNeutral), 0, 0, nil, nil, batch)
 	}
 
@@ -1338,7 +1363,7 @@ func addArgoBatchWorkloads(ctx context.Context, cache *k8s.ResourceCache, namesp
 		batch.Suspended = suspended
 		lastScheduled, _, _ := unstructured.NestedString(cwf.Object, "status", "lastScheduledTime")
 		setLatestBatchTime(&batch.LastScheduledAt, lastScheduled)
-		add("CronWorkflow", cwf.GetNamespace(), cwf.GetName(), cwf.GetLabels(), cwf.GetAnnotations(),
+		add(cwf, "CronWorkflow", cwf.GetNamespace(), cwf.GetName(), cwf.GetLabels(), cwf.GetAnnotations(),
 			cronWorkflowPrimaryImage(cwf), batchHealth(batch, packages.HealthNeutral), 0, 0, nil, nil, batch)
 	}
 }
@@ -1709,7 +1734,7 @@ func groupApplications(inputs []appWorkloadInput) []appRow {
 	order := []string{}
 	members := map[string][]appWorkloadInput{}
 	for _, in := range inputs {
-		comp := d.find("S:" + in.rootKey)
+		comp := d.find("S:" + in.rootIdentity)
 		if _, ok := members[comp]; !ok {
 			order = append(order, comp)
 		}
@@ -1817,11 +1842,11 @@ func groupApplications(inputs []appWorkloadInput) []appRow {
 // atom is always present; overlay and canonical-Argo atoms consolidate roots
 // the graph can't connect.
 func inputAtoms(in appWorkloadInput, argoAppNamespaces map[string]map[string]bool) []string {
-	atoms := []string{"S:" + in.rootKey}
-	atoms = append(atoms, argoCanonicalAtoms(in.rootKind, in.rootKey, argoAppNamespaces)...)
+	atoms := []string{"S:" + in.rootIdentity}
+	atoms = append(atoms, argoCanonicalAtoms(in.rootKind, in.rootGroup, in.rootKey, argoAppNamespaces)...)
 	if in.overlay != nil {
 		atoms = append(atoms, "O:"+in.overlay.Winner.Key)
-		atoms = append(atoms, argoCanonicalAtoms("Application", in.overlay.Winner.Key, argoAppNamespaces)...)
+		atoms = append(atoms, argoCanonicalAtoms("Application", in.overlay.Winner.Ref.Group, in.overlay.Winner.Key, argoAppNamespaces)...)
 	}
 	return atoms
 }
@@ -1854,9 +1879,11 @@ func identifyApp(r *appRow, ins []appWorkloadInput) {
 		r.Key = root.rootKey
 		r.Name = appNameFromKey(root.rootKey)
 		r.Namespace = namespaceFromKey(root.rootKey)
-		if t, c, ok := managerTier(root.rootKind); ok {
+		if t, c, ok := managerTier(root.rootKind, root.rootGroup); ok {
 			r.Tier = t
 			r.Confidence = c
+		} else if root.rootGroup != "" && root.rootGroup != resourceid.GroupForBuiltinKind(root.rootKind) {
+			r.Key += "@" + root.rootGroup
 		}
 	}
 
@@ -1942,7 +1969,7 @@ func collectExactMatchKeys(ins []appWorkloadInput) []string {
 // pickRoot prefers a GitOps-manager root over a raw workload root for identity.
 func pickRoot(ins []appWorkloadInput) appWorkloadInput {
 	for _, in := range ins {
-		if _, _, ok := managerTier(in.rootKind); ok {
+		if _, _, ok := managerTier(in.rootKind, in.rootGroup); ok {
 			return in
 		}
 	}
@@ -1951,25 +1978,25 @@ func pickRoot(ins []appWorkloadInput) appWorkloadInput {
 
 // managerTier maps a structural manager-root kind to the overlay tier it stands
 // in for, so an in-cluster GitOps-managed app without labels still attributes.
-func managerTier(kind string) (tier int, confidence string, ok bool) {
-	switch kind {
-	case string(topology.KindHelmRelease):
+func managerTier(kind, group string) (tier int, confidence string, ok bool) {
+	switch {
+	case kind == string(topology.KindHelmRelease) && group == "helm.toolkit.fluxcd.io":
 		return int(subject.TierFluxHelmRelease), string(subject.ConfidenceHigh), true
-	case string(topology.KindKustomization):
+	case kind == string(topology.KindKustomization) && group == "kustomize.toolkit.fluxcd.io":
 		return int(subject.TierFluxKustomize), string(subject.ConfidenceHigh), true
-	case string(topology.KindApplication):
+	case kind == string(topology.KindApplication) && group == "argoproj.io":
 		return int(subject.TierArgoTrackingID), string(subject.ConfidenceHigh), true
 	}
 	return 0, "", false
 }
 
-func sourceRefForInput(overlay *subject.AppOverlay, rootKind, rootKey string) *appSourceRef {
+func sourceRefForInput(overlay *subject.AppOverlay, rootKind, rootGroup, rootKey string) *appSourceRef {
 	if overlay != nil {
 		if ref := sourceRefFromSubject(overlay.Winner.Ref); ref != nil {
 			return ref
 		}
 	}
-	return sourceRefFromRoot(rootKind, rootKey)
+	return sourceRefFromRoot(rootKind, rootGroup, rootKey)
 }
 
 func sourceRefFromSubject(ref subject.Ref) *appSourceRef {
@@ -1990,18 +2017,18 @@ func sourceRefFromSubject(ref subject.Ref) *appSourceRef {
 	}
 }
 
-func sourceRefFromRoot(rootKind, rootKey string) *appSourceRef {
+func sourceRefFromRoot(rootKind, rootGroup, rootKey string) *appSourceRef {
 	parts := strings.SplitN(rootKey, "/", 3)
 	if len(parts) != 3 || parts[0] == "" || parts[2] == "" {
 		return nil
 	}
 	ns, name := parts[0], parts[2]
-	switch rootKind {
-	case string(topology.KindApplication):
+	switch {
+	case rootKind == string(topology.KindApplication) && rootGroup == "argoproj.io":
 		return &appSourceRef{Type: "gitops", Tool: "argocd", Group: "argoproj.io", Kind: "Application", Namespace: ns, Name: name}
-	case string(topology.KindKustomization):
+	case rootKind == string(topology.KindKustomization) && rootGroup == "kustomize.toolkit.fluxcd.io":
 		return &appSourceRef{Type: "gitops", Tool: "fluxcd", Group: "kustomize.toolkit.fluxcd.io", Kind: "Kustomization", Namespace: ns, Name: name}
-	case string(topology.KindHelmRelease):
+	case rootKind == string(topology.KindHelmRelease) && rootGroup == "helm.toolkit.fluxcd.io":
 		return &appSourceRef{Type: "gitops", Tool: "fluxcd", Group: "helm.toolkit.fluxcd.io", Kind: "HelmRelease", Namespace: ns, Name: name}
 	default:
 		return nil
@@ -2040,8 +2067,8 @@ func sameSourceRef(a, b *appSourceRef) bool {
 
 func argoApplicationNamespaces(inputs []appWorkloadInput) map[string]map[string]bool {
 	out := map[string]map[string]bool{}
-	add := func(kind, key string) {
-		if kind != string(topology.KindApplication) {
+	add := func(kind, group, key string) {
+		if kind != string(topology.KindApplication) || group != "argoproj.io" {
 			return
 		}
 		const marker = "/Application/"
@@ -2060,9 +2087,9 @@ func argoApplicationNamespaces(inputs []appWorkloadInput) map[string]map[string]
 		out[name][ns] = true
 	}
 	for _, in := range inputs {
-		add(in.rootKind, in.rootKey)
+		add(in.rootKind, in.rootGroup, in.rootKey)
 		if in.overlay != nil {
-			add("Application", in.overlay.Winner.Key)
+			add("Application", in.overlay.Winner.Ref.Group, in.overlay.Winner.Key)
 		}
 	}
 	return out
@@ -2076,8 +2103,8 @@ func argoApplicationNamespaces(inputs []appWorkloadInput) map[string]map[string]
 // name-only bridge is emitted only when this result set has at most one concrete
 // namespace for that Argo name, so tier-3 and tier-4 tracking modes can still
 // collapse without mixing separate controller namespaces.
-func argoCanonicalAtoms(kind, key string, argoAppNamespaces map[string]map[string]bool) []string {
-	if kind != string(topology.KindApplication) {
+func argoCanonicalAtoms(kind, group, key string, argoAppNamespaces map[string]map[string]bool) []string {
+	if kind != string(topology.KindApplication) || group != "argoproj.io" {
 		return nil
 	}
 	const marker = "/Application/"
@@ -2265,6 +2292,10 @@ func classifyWorkload(kind string, rels *appRelationships) string {
 
 func appWorkloadAPIGroup(kind string) string {
 	switch kind {
+	case "Deployment", "DaemonSet", "StatefulSet":
+		return "apps"
+	case "Job", "CronJob":
+		return "batch"
 	case "Workflow", "CronWorkflow", "WorkflowTemplate", "ClusterWorkflowTemplate", "Rollout":
 		return "argoproj.io"
 	case "ScaledJob":

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -6,7 +6,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/skyhook-io/radar/pkg/gitops"
 	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
@@ -1057,7 +1059,11 @@ func argoManagedWorkloads(item *unstructured.Unstructured) []workloadRef {
 		if nm == "" {
 			continue
 		}
-		out = append(out, workloadRef{Kind: kind, Namespace: ns, Name: nm})
+		group, _ := m["group"].(string)
+		if builtinGroup, builtin := resourceid.BuiltinGroup(kind); group == "" && builtin {
+			group = builtinGroup
+		}
+		out = append(out, workloadRef{Group: group, Kind: kind, Namespace: ns, Name: nm})
 	}
 	return out
 }
@@ -1172,11 +1178,15 @@ func addArgoManagedSourceRefs(out map[string][]appSourceRef, items []*unstructur
 				continue
 			}
 			name, _ := resMap["name"].(string)
+			group, _ := resMap["group"].(string)
+			if builtinGroup, builtin := resourceid.BuiltinGroup(kind); group == "" && builtin {
+				group = builtinGroup
+			}
 			ns, _ := resMap["namespace"].(string)
 			if ns == "" {
 				ns = destNamespace
 			}
-			addManagedSourceRef(out, kind, ns, name, ref)
+			addManagedSourceRef(out, group, kind, ns, name, ref)
 		}
 	}
 }
@@ -1198,37 +1208,26 @@ func addFluxKustomizationManagedSourceRefs(ctx context.Context, cache resourceLi
 				continue
 			}
 			id, _ := entryMap["id"].(string)
-			kind, namespace, name, ok := parseFluxInventoryWorkloadID(id)
+			group, kind, namespace, name, ok := gitops.ParseFluxInventoryID(id)
 			if !ok {
 				continue
+			}
+			if builtinGroup, builtin := resourceid.BuiltinGroup(kind); group == "" && builtin {
+				group = builtinGroup
 			}
 			if !argoWorkloadKinds[kind] {
 				continue
 			}
-			addManagedSourceRef(out, kind, namespace, name, ref)
+			addManagedSourceRef(out, group, kind, namespace, name, ref)
 		}
 	}
 }
 
-func parseFluxInventoryWorkloadID(id string) (kind, namespace, name string, ok bool) {
-	parts := strings.Split(id, "_")
-	if len(parts) < 4 {
-		return "", "", "", false
-	}
-	kind = parts[len(parts)-1]
-	namespace = parts[0]
-	name = strings.Join(parts[1:len(parts)-2], "_")
-	if kind == "" || namespace == "" || name == "" {
-		return "", "", "", false
-	}
-	return kind, namespace, name, true
-}
-
-func addManagedSourceRef(out map[string][]appSourceRef, kind, namespace, name string, ref appSourceRef) {
+func addManagedSourceRef(out map[string][]appSourceRef, group, kind, namespace, name string, ref appSourceRef) {
 	if kind == "" || namespace == "" || name == "" {
 		return
 	}
-	key := managedWorkloadKey(kind, namespace, name)
+	key := managedWorkloadKey(group, kind, namespace, name)
 	for _, existing := range out[key] {
 		if sameSourceRef(&existing, &ref) {
 			return
@@ -1243,7 +1242,7 @@ func commonManagedSourceRef(workloads []appWorkload, sources map[string][]appSou
 	}
 	var common []appSourceRef
 	for i, w := range workloads {
-		refs := sources[managedWorkloadKey(w.Kind, w.Namespace, w.Name)]
+		refs := sources[managedWorkloadKey(w.Group, w.Kind, w.Namespace, w.Name)]
 		if len(refs) == 0 {
 			return nil
 		}
@@ -1272,8 +1271,8 @@ func commonManagedSourceRef(workloads []appWorkload, sources map[string][]appSou
 	return &cp
 }
 
-func managedWorkloadKey(kind, namespace, name string) string {
-	return kind + "/" + namespace + "/" + name
+func managedWorkloadKey(group, kind, namespace, name string) string {
+	return resourceid.ResourceKey(group, kind, namespace, name)
 }
 
 // appSetFanout is one child's declared identity within a single-app fan-out set.

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -802,7 +802,7 @@ func TestCollectArgoClaims(t *testing.T) {
 	if c.DestName != "prod-cluster" || c.DestNamespace != "billing" {
 		t.Fatalf("claim destination = %q/%q, want prod-cluster/billing", c.DestName, c.DestNamespace)
 	}
-	if len(c.Workloads) != 1 || c.Workloads[0].Kind != "Deployment" || c.Workloads[0].Name != "billing-api" {
+	if len(c.Workloads) != 1 || c.Workloads[0].Group != "apps" || c.Workloads[0].Kind != "Deployment" || c.Workloads[0].Name != "billing-api" {
 		t.Fatalf("claim workloads = %+v, want only the Deployment", c.Workloads)
 	}
 }
@@ -991,11 +991,30 @@ func TestAddFluxKustomizationManagedSourceRefsParsesInventoryIDFromRight(t *test
 	got := map[string][]appSourceRef{}
 	addFluxKustomizationManagedSourceRefs(context.Background(), &stubLister{items: []*unstructured.Unstructured{ks}}, got)
 
-	refs := got[managedWorkloadKey("Deployment", "team", "api_worker")]
+	refs := got[managedWorkloadKey("apps", "Deployment", "team", "api_worker")]
 	if len(refs) != 1 {
 		t.Fatalf("managed source refs = %#v, want one ref keyed by full workload name", got)
 	}
 	if refs[0].Name != "platform" || refs[0].Namespace != "flux-system" || refs[0].Tool != "fluxcd" {
 		t.Fatalf("source ref = %+v, want flux-system/platform flux ref", refs[0])
+	}
+}
+
+func TestAddFluxKustomizationManagedSourceRefsKeepsInventoryGroup(t *testing.T) {
+	ks := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"namespace": "flux-system", "name": "training"},
+		"status": map[string]any{"inventory": map[string]any{"entries": []any{
+			map[string]any{"id": "ml_train_batch.volcano.sh_Job"},
+		}}},
+	}}
+	sources := map[string][]appSourceRef{}
+	addFluxKustomizationManagedSourceRefs(context.Background(), &stubLister{items: []*unstructured.Unstructured{ks}}, sources)
+
+	if ref := commonManagedSourceRef([]appWorkload{{Group: "batch", Kind: "Job", Namespace: "ml", Name: "train"}}, sources); ref != nil {
+		t.Fatalf("core Job inherited the Flux-managed Volcano Job source: %+v", ref)
+	}
+	ref := commonManagedSourceRef([]appWorkload{{Group: "batch.volcano.sh", Kind: "Job", Namespace: "ml", Name: "train"}}, sources)
+	if ref == nil || ref.Name != "training" {
+		t.Fatalf("Volcano Job source ref = %+v, want flux-system/training", ref)
 	}
 }

--- a/internal/server/applications_test.go
+++ b/internal/server/applications_test.go
@@ -159,19 +159,39 @@ func clusterWorkflowRun(ns, name, template, phase, startedAt string) *unstructur
 
 func TestEventsForWorkload_MatchesKindAndName(t *testing.T) {
 	byObject := map[string][]*corev1.Event{
-		"Service/api": {
+		resourceid.ResourceKey("", "Service", "", "api"): {
 			{InvolvedObject: corev1.ObjectReference{Kind: "Service", Name: "api"}, Reason: "NoEndpoints", Type: "Warning", Message: "service has no endpoints"},
 		},
-		"Deployment/api": {
+		resourceid.ResourceKey("apps", "Deployment", "", "api"): {
 			{InvolvedObject: corev1.ObjectReference{Kind: "Deployment", Name: "api"}, Reason: "ProgressDeadlineExceeded", Type: "Warning", Message: "deployment stalled"},
 		},
 	}
-	got := eventsForWorkload(byObject, "Deployment", "api", nil)
+	got := eventsForWorkload(byObject, "apps", "Deployment", "api", nil)
 	if len(got) != 1 {
 		t.Fatalf("eventsForWorkload returned %d events: %+v", len(got), got)
 	}
 	if got[0].Object != "Deployment/api" || got[0].Reason != "ProgressDeadlineExceeded" {
 		t.Fatalf("eventsForWorkload picked wrong event: %+v", got[0])
+	}
+}
+
+func TestEventsForWorkloadPreservesAPIGroup(t *testing.T) {
+	byObject := map[string][]*corev1.Event{
+		resourceid.ResourceKey("batch", "Job", "", "train"): {
+			{InvolvedObject: corev1.ObjectReference{APIVersion: "batch/v1", Kind: "Job", Name: "train"}, Reason: "BackoffLimitExceeded", Type: "Warning"},
+		},
+		resourceid.ResourceKey("batch.volcano.sh", "Job", "", "train"): {
+			{InvolvedObject: corev1.ObjectReference{APIVersion: "batch.volcano.sh/v1alpha1", Kind: "Job", Name: "train"}, Reason: "VolcanoFailed", Type: "Warning"},
+		},
+	}
+
+	core := eventsForWorkload(byObject, "batch", "Job", "train", nil)
+	volcano := eventsForWorkload(byObject, "batch.volcano.sh", "Job", "train", nil)
+	if len(core) != 1 || core[0].Reason != "BackoffLimitExceeded" {
+		t.Fatalf("core Job events = %+v", core)
+	}
+	if len(volcano) != 1 || volcano[0].Reason != "VolcanoFailed" {
+		t.Fatalf("Volcano Job events = %+v", volcano)
 	}
 }
 
@@ -612,18 +632,37 @@ func TestManagedSourceRefs_CrossNamespaceArgoApplication(t *testing.T) {
 			"destination": map[string]any{"namespace": "team-a"},
 		},
 		"status": map[string]any{"resources": []any{
-			map[string]any{"kind": "Deployment", "name": "api"},
-			map[string]any{"kind": "Deployment", "namespace": "team-a", "name": "worker"},
+			map[string]any{"group": "apps", "kind": "Deployment", "name": "api"},
+			map[string]any{"group": "apps", "kind": "Deployment", "namespace": "team-a", "name": "worker"},
 		}},
 	}}
 	sources := map[string][]appSourceRef{}
 	addArgoManagedSourceRefs(sources, []*unstructured.Unstructured{app})
 	ref := commonManagedSourceRef([]appWorkload{
-		{Kind: "Deployment", Namespace: "team-a", Name: "api"},
-		{Kind: "Deployment", Namespace: "team-a", Name: "worker"},
+		{Group: "apps", Kind: "Deployment", Namespace: "team-a", Name: "api"},
+		{Group: "apps", Kind: "Deployment", Namespace: "team-a", Name: "worker"},
 	}, sources)
 	if ref == nil || ref.Tool != "argocd" || ref.Namespace != "argocd" || ref.Name != "billing" {
 		t.Fatalf("cross-namespace Argo source ref = %+v, want argocd/Application/billing", ref)
+	}
+}
+
+func TestManagedSourceRefs_ArgoStatusKeepsWorkloadGroup(t *testing.T) {
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"namespace": "argocd", "name": "training"},
+		"status": map[string]any{"resources": []any{
+			map[string]any{"group": "batch.volcano.sh", "kind": "Job", "namespace": "ml", "name": "train"},
+		}},
+	}}
+	sources := map[string][]appSourceRef{}
+	addArgoManagedSourceRefs(sources, []*unstructured.Unstructured{app})
+
+	if ref := commonManagedSourceRef([]appWorkload{{Group: "batch", Kind: "Job", Namespace: "ml", Name: "train"}}, sources); ref != nil {
+		t.Fatalf("core Job inherited the Volcano Job source: %+v", ref)
+	}
+	ref := commonManagedSourceRef([]appWorkload{{Group: "batch.volcano.sh", Kind: "Job", Namespace: "ml", Name: "train"}}, sources)
+	if ref == nil || ref.Name != "training" {
+		t.Fatalf("Volcano Job source ref = %+v, want argocd/training", ref)
 	}
 }
 

--- a/internal/server/applications_test.go
+++ b/internal/server/applications_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/health"
 	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/rollouts"
 	"github.com/skyhook-io/radar/pkg/subject"
 	"github.com/skyhook-io/radar/pkg/topology"
@@ -23,10 +24,13 @@ import (
 // rawInput builds a workload with no label overlay and its own structural root
 // (a singleton, raw-always).
 func rawInput(kind, ns, name, version, health string) appWorkloadInput {
+	group := appWorkloadAPIGroup(kind)
 	return appWorkloadInput{
-		wl:       appWorkload{Kind: kind, Namespace: ns, Name: name, Version: version, Health: health, WorkloadClass: classifyWorkload(kind, nil)},
-		rootKey:  ns + "/" + kind + "/" + name,
-		rootKind: kind,
+		wl:           appWorkload{Kind: kind, Group: group, Namespace: ns, Name: name, Version: version, Health: health, WorkloadClass: classifyWorkload(kind, nil)},
+		rootKey:      ns + "/" + kind + "/" + name,
+		rootKind:     kind,
+		rootGroup:    group,
+		rootIdentity: resourceid.ResourceKey(group, kind, ns, name),
 	}
 }
 
@@ -97,7 +101,18 @@ func TestWorkflowPrimaryImageUsesStoredTemplateSpec(t *testing.T) {
 // /part-of), keyed by its own structural root.
 func overlayInput(kind, ns, name, version, health string, tier subject.Tier, key string, conf subject.Confidence) appWorkloadInput {
 	in := rawInput(kind, ns, name, version, health)
-	in.overlay = &subject.AppOverlay{Winner: subject.Signal{Tier: tier, Key: key, Confidence: conf}}
+	ref := subject.Ref{}
+	switch tier {
+	case subject.TierFluxHelmRelease:
+		ref = subject.Ref{Kind: "HelmRelease", Group: "helm.toolkit.fluxcd.io"}
+	case subject.TierFluxKustomize:
+		ref = subject.Ref{Kind: "Kustomization", Group: "kustomize.toolkit.fluxcd.io"}
+	case subject.TierArgoTrackingID, subject.TierArgoInstance:
+		ref = subject.Ref{Kind: "Application", Group: "argoproj.io"}
+	case subject.TierHelmRelease:
+		ref = subject.Ref{Kind: "HelmRelease"}
+	}
+	in.overlay = &subject.AppOverlay{Winner: subject.Signal{Tier: tier, Key: key, Ref: ref, Confidence: conf}}
 	return in
 }
 
@@ -432,8 +447,12 @@ func TestGroupApplications_ArgoTrackingModesCollapse(t *testing.T) {
 func TestGroupApplications_SameNameArgoAppsInDifferentNamespacesStaySeparate(t *testing.T) {
 	a := rawInput("Deployment", "team-a", "api", "1.0.0", "healthy")
 	a.rootKey, a.rootKind = "team-a-argocd/Application/storefront", "Application"
+	a.rootGroup = "argoproj.io"
+	a.rootIdentity = resourceid.ResourceKey("argoproj.io", "Application", "team-a-argocd", "storefront")
 	b := rawInput("Deployment", "team-b", "api", "1.0.0", "healthy")
 	b.rootKey, b.rootKind = "team-b-argocd/Application/storefront", "Application"
+	b.rootGroup = "argoproj.io"
+	b.rootIdentity = resourceid.ResourceKey("argoproj.io", "Application", "team-b-argocd", "storefront")
 
 	rows := groupApplications([]appWorkloadInput{a, b})
 	if len(rows) != 2 {
@@ -448,8 +467,12 @@ func TestGroupApplications_StructuralManagerRoot(t *testing.T) {
 	// Two unlabeled Deployments whose structural root is the same Argo App node.
 	a := rawInput("Deployment", "prod", "api", "3.1.0", "healthy")
 	a.rootKey, a.rootKind = "argocd/Application/billing", "Application"
+	a.rootGroup = "argoproj.io"
+	a.rootIdentity = resourceid.ResourceKey("argoproj.io", "Application", "argocd", "billing")
 	b := rawInput("Deployment", "prod", "worker", "3.1.0", "degraded")
 	b.rootKey, b.rootKind = "argocd/Application/billing", "Application"
+	b.rootGroup = "argoproj.io"
+	b.rootIdentity = resourceid.ResourceKey("argoproj.io", "Application", "argocd", "billing")
 
 	rows := groupApplications([]appWorkloadInput{a, b})
 	if len(rows) != 1 {
@@ -467,18 +490,68 @@ func TestGroupApplications_StructuralManagerRoot(t *testing.T) {
 	}
 }
 
+func TestGroupApplications_SameNamedRootsInDifferentGroupsStaySeparate(t *testing.T) {
+	core := rawInput("Job", "ml", "core-run", "", "healthy")
+	core.rootKey, core.rootKind = "ml/Job/train", "Job"
+	core.rootGroup = "batch"
+	core.rootIdentity = resourceid.ResourceKey("batch", "Job", "ml", "train")
+	volcano := rawInput("Job", "ml", "volcano-run", "", "healthy")
+	volcano.wl.Group = "batch.volcano.sh"
+	volcano.rootKey, volcano.rootKind = "ml/Job/train", "Job"
+	volcano.rootGroup = "batch.volcano.sh"
+	volcano.rootIdentity = resourceid.ResourceKey("batch.volcano.sh", "Job", "ml", "train")
+
+	rows := groupApplications([]appWorkloadInput{core, volcano})
+	if len(rows) != 2 {
+		t.Fatalf("same kind/name roots in distinct API groups merged: %+v", rows)
+	}
+	if rows[0].Key == rows[1].Key {
+		t.Fatalf("same kind/name roots in distinct API groups share public key %q", rows[0].Key)
+	}
+	byWorkload := map[string]string{}
+	for _, row := range rows {
+		byWorkload[row.Workloads[0].Name] = row.Key
+	}
+	if byWorkload["core-run"] != "ml/Job/train" {
+		t.Fatalf("built-in raw key changed: %q", byWorkload["core-run"])
+	}
+	if byWorkload["volcano-run"] != "ml/Job/train@batch.volcano.sh" {
+		t.Fatalf("Volcano raw key = %q", byWorkload["volcano-run"])
+	}
+}
+
+func TestGroupApplications_ForeignManagerKindStaysRaw(t *testing.T) {
+	foreign := rawInput("Deployment", "prod", "api", "1.0.0", "healthy")
+	foreign.rootKey = "operators/Application/platform"
+	foreign.rootKind = "Application"
+	foreign.rootGroup = "apps.example.io"
+	foreign.rootIdentity = resourceid.ResourceKey(foreign.rootGroup, foreign.rootKind, "operators", "platform")
+	foreign.source = sourceRefForInput(nil, foreign.rootKind, foreign.rootGroup, foreign.rootKey)
+
+	rows := groupApplications([]appWorkloadInput{foreign})
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Key != "operators/Application/platform@apps.example.io" || row.Tier != 0 || row.SourceRef != nil {
+		t.Fatalf("foreign Application was attributed as Argo CD: %+v", row)
+	}
+}
+
 func TestGroupApplications_SourceRefRequiresExactSource(t *testing.T) {
 	helmApp := overlayInput("Deployment", "prod", "api", "1.0", "healthy", subject.TierHelmRelease, "prod/HelmRelease/checkout", subject.ConfidenceMedium)
 	helmApp.overlay.Winner.Ref = subject.Ref{Kind: "HelmRelease", Namespace: "prod", Name: "checkout"}
-	helmApp.source = sourceRefForInput(helmApp.overlay, helmApp.rootKind, helmApp.rootKey)
+	helmApp.source = sourceRefForInput(helmApp.overlay, helmApp.rootKind, helmApp.rootGroup, helmApp.rootKey)
 
 	labelApp := overlayInput("Deployment", "prod", "payments-worker", "1.0", "healthy", subject.TierPartOf, "prod/app/payments", subject.ConfidenceMedium)
 	labelApp.overlay.Winner.Ref = subject.Ref{Kind: "app", Namespace: "prod", Name: "payments"}
-	labelApp.source = sourceRefForInput(labelApp.overlay, labelApp.rootKind, labelApp.rootKey)
+	labelApp.source = sourceRefForInput(labelApp.overlay, labelApp.rootKind, labelApp.rootGroup, labelApp.rootKey)
 
 	structuralApp := rawInput("Deployment", "prod", "admin", "1.0", "healthy")
 	structuralApp.rootKey, structuralApp.rootKind = "argocd/Application/admin", "Application"
-	structuralApp.source = sourceRefForInput(structuralApp.overlay, structuralApp.rootKind, structuralApp.rootKey)
+	structuralApp.rootGroup = "argoproj.io"
+	structuralApp.rootIdentity = resourceid.ResourceKey("argoproj.io", "Application", "argocd", "admin")
+	structuralApp.source = sourceRefForInput(structuralApp.overlay, structuralApp.rootKind, structuralApp.rootGroup, structuralApp.rootKey)
 
 	rows := groupApplications([]appWorkloadInput{helmApp, labelApp, structuralApp})
 
@@ -499,7 +572,7 @@ func TestGroupApplications_SourceRefRequiresExactSource(t *testing.T) {
 func TestGroupApplications_SourceRefRequiresEveryWorkload(t *testing.T) {
 	api := overlayInput("Deployment", "prod", "checkout-api", "1.0", "healthy", subject.TierHelmRelease, "prod/HelmRelease/checkout", subject.ConfidenceMedium)
 	api.overlay.Winner.Ref = subject.Ref{Kind: "HelmRelease", Namespace: "prod", Name: "checkout"}
-	api.source = sourceRefForInput(api.overlay, api.rootKind, api.rootKey)
+	api.source = sourceRefForInput(api.overlay, api.rootKind, api.rootGroup, api.rootKey)
 
 	worker := overlayInput("Deployment", "prod", "checkout-worker", "1.0", "healthy", subject.TierHelmRelease, "prod/HelmRelease/checkout", subject.ConfidenceMedium)
 
@@ -771,7 +844,7 @@ func TestAppGraphRelationshipsForIncludesServiceUpstreamEntrypoints(t *testing.T
 	}
 	g := &appGraph{topo: topo, idx: topology.IndexByResource(topo)}
 
-	rels := g.relationshipsFor("Deployment", "prod", "api")
+	rels := g.relationshipsFor("Deployment", "prod", "api", nil)
 	if rels == nil {
 		t.Fatal("relationshipsFor returned nil")
 	}
@@ -798,6 +871,32 @@ func TestAppGraphRelationshipsForIncludesServiceUpstreamEntrypoints(t *testing.T
 	}
 }
 
+func TestAppGraphRelationshipsForUsesFetchedObjectGroup(t *testing.T) {
+	topo := &topology.Topology{
+		Nodes: []topology.Node{
+			{ID: "service/ml/core", Kind: topology.KindService, Name: "core", Data: map[string]any{"namespace": "ml"}},
+			{ID: "service/ml/volcano", Kind: topology.KindService, Name: "volcano", Data: map[string]any{"namespace": "ml"}},
+			{ID: "job/ml/train", Kind: topology.KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+			{ID: "job/ml/train/batch.volcano.sh", Kind: topology.NodeKind("Job"), Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+		},
+		Edges: []topology.Edge{
+			{ID: "core", Source: "service/ml/core", Target: "job/ml/train", Type: topology.EdgeExposes},
+			{ID: "volcano", Source: "service/ml/volcano", Target: "job/ml/train/batch.volcano.sh", Type: topology.EdgeExposes},
+		},
+	}
+	volcano := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch.volcano.sh/v1alpha1",
+		"kind":       "Job",
+		"metadata":   map[string]any{"namespace": "ml", "name": "train"},
+	}}
+	g := &appGraph{topo: topo, idx: topology.IndexByResource(topo)}
+
+	rels := g.relationshipsFor("Job", "ml", "train", volcano)
+	if rels == nil || len(rels.Services) != 1 || rels.Services[0] != "volcano" {
+		t.Fatalf("relationships = %+v, want only the Volcano Job service", rels)
+	}
+}
+
 // structuralRoot must stop AT the in-cluster GitOps manager (Flux
 // Kustomization) and NOT climb the EdgeManages edge to the GitRepository source
 // that feeds it. The topology builder models GitRepository → Kustomization as
@@ -806,7 +905,13 @@ func TestAppGraphRelationshipsForIncludesServiceUpstreamEntrypoints(t *testing.T
 // GitRepository root and union-find merges all installations into one app.
 func TestStructuralRoot_StopsAtManagerNotSource(t *testing.T) {
 	node := func(id, kind, ns, name string) topology.Node {
-		return topology.Node{ID: id, Kind: topology.NodeKind(kind), Name: name, Data: map[string]any{"namespace": ns}}
+		data := map[string]any{"namespace": ns}
+		if kind == "Kustomization" {
+			data["apiVersion"] = "kustomize.toolkit.fluxcd.io/v1"
+		} else if kind == "GitRepository" {
+			data["apiVersion"] = "source.toolkit.fluxcd.io/v1"
+		}
+		return topology.Node{ID: id, Kind: topology.NodeKind(kind), Name: name, Data: data}
 	}
 	manages := func(src, dst string) topology.Edge {
 		return topology.Edge{ID: src + "->" + dst, Source: src, Target: dst, Type: topology.EdgeManages}
@@ -826,24 +931,57 @@ func TestStructuralRoot_StopsAtManagerNotSource(t *testing.T) {
 			manages("ks-infra", "dep-grafana"), // manager → workload
 		},
 	}
-	g := &appGraph{byID: map[string]topology.Node{}, byKNN: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
+	g := &appGraph{byID: map[string]topology.Node{}, byResource: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
 	for _, n := range topo.Nodes {
 		g.byID[n.ID] = n
 		ns, _ := n.Data["namespace"].(string)
-		g.byKNN[knnKey(string(n.Kind), ns, n.Name)] = n.ID
+		kind := topology.KubernetesKindForNode(&n)
+		g.byResource[resourceid.ResourceKey(appGraphNodeGroup(&n, kind), kind, ns, n.Name)] = n.ID
 	}
 
-	apiRoot, _ := g.rootOf("Deployment", "prod", "api")
-	grafanaRoot, _ := g.rootOf("Deployment", "monitoring", "grafana")
+	apiRoot, _, apiGroup, apiIdentity := g.rootOf("apps", "Deployment", "prod", "api")
+	grafanaRoot, _, _, _ := g.rootOf("apps", "Deployment", "monitoring", "grafana")
 
 	if apiRoot != "flux-system/Kustomization/apps" {
 		t.Errorf("api root = %q, want the apps Kustomization (not the GitRepository)", apiRoot)
+	}
+	if apiIdentity != resourceid.ResourceKey("kustomize.toolkit.fluxcd.io", "Kustomization", "flux-system", "apps") {
+		t.Errorf("api root identity = %q, want exact Flux Kustomization identity", apiIdentity)
+	}
+	if apiGroup != "kustomize.toolkit.fluxcd.io" {
+		t.Errorf("api root group = %q, want exact Flux Kustomization group", apiGroup)
 	}
 	if grafanaRoot != "flux-system/Kustomization/infrastructure" {
 		t.Errorf("grafana root = %q, want the infrastructure Kustomization (not the GitRepository)", grafanaRoot)
 	}
 	if apiRoot == grafanaRoot {
 		t.Fatalf("two Kustomizations under one GitRepository share root %q — the mono-repo over-merge", apiRoot)
+	}
+}
+
+func TestStructuralRoot_DoesNotStopAtForeignManagerKind(t *testing.T) {
+	topo := &topology.Topology{
+		Nodes: []topology.Node{
+			{ID: "platform/prod/root/platform.example.io", Kind: "Platform", Name: "root", Data: map[string]any{"namespace": "prod", "apiVersion": "platform.example.io/v1"}},
+			{ID: "application/prod/app/apps.example.io", Kind: topology.KindApplication, Name: "app", Data: map[string]any{"namespace": "prod", "apiVersion": "apps.example.io/v1"}},
+			{ID: "deployment/prod/api", Kind: topology.KindDeployment, Name: "api", Data: map[string]any{"namespace": "prod"}},
+		},
+		Edges: []topology.Edge{
+			{Source: "platform/prod/root/platform.example.io", Target: "application/prod/app/apps.example.io", Type: topology.EdgeManages},
+			{Source: "application/prod/app/apps.example.io", Target: "deployment/prod/api", Type: topology.EdgeManages},
+		},
+	}
+	g := &appGraph{byID: map[string]topology.Node{}, byResource: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
+	for _, node := range topo.Nodes {
+		g.byID[node.ID] = node
+		kind := topology.KubernetesKindForNode(&node)
+		ns, _ := node.Data["namespace"].(string)
+		g.byResource[resourceid.ResourceKey(appGraphNodeGroup(&node, kind), kind, ns, node.Name)] = node.ID
+	}
+
+	root, _, group, _ := g.rootOf("apps", "Deployment", "prod", "api")
+	if root != "prod/Platform/root" || group != "platform.example.io" {
+		t.Fatalf("foreign Application stopped the structural walk: root=%q group=%q", root, group)
 	}
 }
 
@@ -865,9 +1003,9 @@ func TestRelationshipsFor_RoutesCarryConcreteKind(t *testing.T) {
 			{ID: "gw->web", Source: "gateway/prod/gw", Target: "httproute/prod/web", Type: topology.EdgeRoutesTo},
 		},
 	}
-	g := &appGraph{byID: map[string]topology.Node{}, byKNN: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
+	g := &appGraph{byID: map[string]topology.Node{}, byResource: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
 
-	rels := g.relationshipsFor("Gateway", "prod", "gw")
+	rels := g.relationshipsFor("Gateway", "prod", "gw", nil)
 	if rels == nil {
 		t.Fatal("relationshipsFor returned nil; want Routes populated")
 	}

--- a/internal/server/neighborhood_handler.go
+++ b/internal/server/neighborhood_handler.go
@@ -182,7 +182,7 @@ func (s *Server) handleAINeighborhood(w http.ResponseWriter, r *http.Request) {
 	// within-response matching and diverging from MCP's shape despite
 	// the header comment claiming both surfaces "parse identically".
 	rootResp := root
-	rootResp.Kind = string(sub.Nodes[0].Kind)
+	rootResp.Kind = topology.KubernetesKindForNode(&sub.Nodes[0])
 
 	resp := neighborhoodResponse{
 		Root: rootResp,

--- a/internal/server/neighborhood_handler.go
+++ b/internal/server/neighborhood_handler.go
@@ -174,18 +174,8 @@ func (s *Server) handleAINeighborhood(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use the resolved root node's Kind for the response, not the
-	// URL-derived (lowercase) form. Subgraph nodes carry display-form
-	// NodeKind values ("Pod", "KnativeService") — without this rewrite,
-	// the response's root.kind would be lowercase while
-	// subgraph.nodes[0].kind is display-form, breaking case-sensitive
-	// within-response matching and diverging from MCP's shape despite
-	// the header comment claiming both surfaces "parse identically".
-	rootResp := root
-	rootResp.Kind = topology.KubernetesKindForNode(&sub.Nodes[0])
-
 	resp := neighborhoodResponse{
-		Root: rootResp,
+		Root: sub.Root,
 		Subgraph: neighborhoodSubgraph{
 			Nodes: sub.Nodes,
 			Edges: sub.Edges,

--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
@@ -31,12 +31,14 @@ import { EmptyState } from "../ui/EmptyState";
 import { ResourceRefBadge } from "../ui/drawer-components";
 import { TopologyGraph } from "../topology/TopologyGraph";
 import { pluralize } from "../../utils/pluralize";
+import { canonicalResourceGroup } from "../../utils/api-resources";
 import { kindToPluralWithGroup, refToSelectedResource } from "../../utils/navigation";
 import {
   batchRunParentNodes,
   tagWorkloadOwnership,
   seedNodeIds,
   ownershipOf,
+  topologyNodeResourceKind,
   workloadKey,
   type NeighborhoodSeed,
 } from "../../utils/topology-neighborhood";
@@ -528,9 +530,14 @@ export function ApplicationDetail({
         return;
       }
       const ns = (node.data?.namespace as string) || "";
+      const resourceKind = topologyNodeResourceKind(node);
+      const group = topologyGroup(node);
       const match = workloads.find(
         (w) =>
-          w.kind === node.kind && w.name === node.name && w.namespace === ns,
+          w.kind === resourceKind &&
+          canonicalResourceGroup(w.kind, w.group) === canonicalResourceGroup(resourceKind, group) &&
+          w.name === node.name &&
+          w.namespace === ns,
       );
       if (match) {
         setSelected(workloadKey(match));
@@ -539,9 +546,12 @@ export function ApplicationDetail({
       const parents = appGraph ? batchRunParentNodes(appGraph, node) : [];
       const parentWorkload = parents.flatMap((parent) => {
         const parentNamespace = (parent.data?.namespace as string) || "";
+        const parentKind = topologyNodeResourceKind(parent);
+        const parentGroup = topologyGroup(parent);
         const workload = workloads.find(
           (candidate) =>
-            candidate.kind === parent.kind &&
+            candidate.kind === parentKind &&
+            canonicalResourceGroup(candidate.kind, candidate.group) === canonicalResourceGroup(parentKind, parentGroup) &&
             candidate.name === parent.name &&
             candidate.namespace === parentNamespace,
         );
@@ -551,9 +561,8 @@ export function ApplicationDetail({
         onSelectWorkloadRun(parentWorkload, node);
         return;
       }
-      const group = topologyGroup(node);
       onNavigateToResource?.({
-        kind: kindToPluralWithGroup(node.kind, group ?? ""),
+        kind: kindToPluralWithGroup(resourceKind, group ?? ""),
         namespace: ns,
         name: node.name,
         group,
@@ -2444,6 +2453,7 @@ function ApplicationHistoryLine({
     ? workloads.find(
         (candidate) =>
           candidate.kind.toLowerCase() === item.resource!.kind.toLowerCase() &&
+          canonicalResourceGroup(candidate.kind, candidate.group) === canonicalResourceGroup(item.resource!.kind, item.resource!.group) &&
           candidate.namespace === item.resource!.namespace &&
           candidate.name === item.resource!.name,
       )

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -45,7 +45,7 @@ import { getHealthBadgeColor, getEventTypeColor } from '../../utils/badge-colors
 import { MiddleEllipsis } from '../ui/MiddleEllipsis'
 import { Tooltip } from '../ui/Tooltip'
 import { ResourceRefBadge } from '../ui/drawer-components'
-import { buildResourceHierarchy, extractPinnedLanes, removePinnedLanes, isProblematicEvent, laneTrackEvents, isChildVisibleInWindow, collidingLaneKeys, laneCollisionKey, type ResourceLane as BaseResourceLane, type TimelineGrouping, type PinnedLaneRef } from '../../utils/resource-hierarchy'
+import { buildResourceHierarchy, extractPinnedLanes, removePinnedLanes, resolvePinnedLaneIds, isProblematicEvent, laneTrackEvents, isChildVisibleInWindow, collidingLaneKeys, laneCollisionKey, type ResourceLane as BaseResourceLane, type TimelineGrouping, type PinnedLaneRef } from '../../utils/resource-hierarchy'
 import { groupQualifiesLaneId } from '../../utils/navigation'
 import type { AppMembershipIndex } from '../../utils/applications'
 import { Layers } from 'lucide-react'
@@ -765,7 +765,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   // already telling the user "this controller had changes/events"; the GitOps
   // tab is the right place to investigate further.
   const handleLaneOpen = useCallback((kind: string, namespace: string, name: string, group?: string) => {
-    const gitOpsPath = gitOpsRouteForKind(kind, namespace, name)
+    const gitOpsPath = gitOpsRouteForKind(kind, namespace, name, group)
     if (gitOpsPath && onNavigatePath) {
       onNavigatePath(gitOpsPath)
       return
@@ -1187,7 +1187,10 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
 
   // Pin MOVES a row: pinned lanes (and pinned children inside groups) leave
   // the regular list entirely — the pinned section is their only home.
-  const pinnedIdSetForFilter = useMemo(() => new Set((pinnedLanes ?? []).map((p) => p.id)), [pinnedLanes])
+  const pinnedIdSetForFilter = useMemo(
+    () => resolvePinnedLaneIds(lanes, pinnedLanes ?? []),
+    [lanes, pinnedLanes],
+  )
   const pinnedAppKeys = useMemo(
     () => new Set((pinnedLanes ?? []).flatMap((p) => (p.type === 'appGroup' ? [p.appKey] : []))),
     [pinnedLanes],
@@ -1232,7 +1235,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
     return n
   }, [pinnedLaneRows, visibleWindow])
 
-  const pinnedIdSet = useMemo(() => new Set((pinnedLanes ?? []).map((p) => p.id)), [pinnedLanes])
+  const pinnedIdSet = pinnedIdSetForFilter
   // A pin button for a lane, or null when the host wired no pin handler. A pinned
   // lane's button is filled and always visible (in the pinned section or its
   // original spot); an unpinned one reveals on row hover.
@@ -1241,7 +1244,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
     const pinned = pinnedIdSet.has(lane.id)
     const ref: PinnedLaneRef = lane.isAppGroup && lane.appKey
       ? { type: 'appGroup', id: lane.id, appKey: lane.appKey, appName: lane.title ?? lane.name }
-      : { id: lane.id, kind: lane.kind, namespace: lane.namespace, name: lane.name }
+      : { id: lane.id, kind: lane.kind, group: lane.group, namespace: lane.namespace, name: lane.name }
     return (
       <PinButton
         pinned={pinned}

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -764,8 +764,8 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   // deep-link to GitOps detail rather than the resource drawer — the lane is
   // already telling the user "this controller had changes/events"; the GitOps
   // tab is the right place to investigate further.
-  const handleLaneOpen = useCallback((kind: string, namespace: string, name: string, group?: string) => {
-    const gitOpsPath = gitOpsRouteForKind(kind, namespace, name, group)
+  const handleLaneOpen = useCallback((kind: string, namespace: string, name: string, group?: string, identityResolved?: boolean) => {
+    const gitOpsPath = gitOpsRouteForKind(kind, namespace, name, group, identityResolved)
     if (gitOpsPath && onNavigatePath) {
       onNavigatePath(gitOpsPath)
       return
@@ -1666,7 +1666,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                     <div className="flex items-center gap-1.5 min-w-0">
                       <Tooltip content={lane.name} wrapperClassName="min-w-0 flex-1">
                         <span
-                          onClick={() => handleLaneOpen(lane.kind, lane.namespace, lane.name, lane.group)}
+                          onClick={() => handleLaneOpen(lane.kind, lane.namespace, lane.name, lane.group, lane.identityResolved)}
                           className={clsx('min-w-0 w-full text-sm text-theme-text-primary hover:text-accent-text hover:underline cursor-pointer', compact ? 'font-medium' : 'font-semibold font-mono')}
                         >
                           <MiddleEllipsis text={lane.name} className="block" />
@@ -1720,7 +1720,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
             hasChildren={hasVisibleChildren}
             expanded={isExpanded}
             onToggle={hasVisibleChildren ? () => toggleLane(lane.id) : undefined}
-            onClick={() => handleLaneOpen(lane.kind, lane.namespace, lane.name, lane.group)}
+            onClick={() => handleLaneOpen(lane.kind, lane.namespace, lane.name, lane.group, lane.identityResolved)}
             pinButton={renderPinButton(lane)}
             title={
               lane.nestedByContract ? `${lane.name} · linked by naming`

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -37,7 +37,7 @@ import type { TimelineEvent, ResourceRef, Relationships, SelectedResource, Resol
 import type { GitOpsStatus } from '../../types/gitops'
 import type { NavigateToResource } from '../../utils/navigation'
 import { refToSelectedResource, pluralToKind, kindToPlural, kindToPluralWithGroup, apiVersionToGroup } from '../../utils/navigation'
-import { neighborhoodFor, seedNodeIds } from '../../utils/topology-neighborhood'
+import { neighborhoodFor, seedNodeIds, topologyNodeResourceKind } from '../../utils/topology-neighborhood'
 import { TopologyGraph } from '../topology/TopologyGraph'
 import { gitOpsOwnerFromRelationships, type GitOpsOwnerRef } from '../../utils/gitops-owner'
 import { gitOpsRouteForResource } from '../../utils/gitops-route'
@@ -538,7 +538,7 @@ export function WorkloadView({
       .filter((n) => n.kind !== 'Internet' && n.kind !== 'PodGroup')
       .map((n) => ({
         id: n.id,
-        kind: (typeof n.data?.resourceKind === 'string' ? n.data.resourceKind : n.kind) as string,
+        kind: topologyNodeResourceKind(n),
         namespace: (n.data?.namespace as string) || namespace,
         name: n.name,
         group: apiVersionToGroup(n.data?.apiVersion as string | undefined),
@@ -556,7 +556,7 @@ export function WorkloadView({
   const yamlObject = yamlObjectId ? yamlObjects.find((o) => o.id === yamlObjectId) : undefined
   const handleTopologyNodeClick = useCallback(
     (node: TopologyNode) => {
-      const resourceKind = typeof node.data?.resourceKind === 'string' ? node.data.resourceKind : node.kind
+      const resourceKind = topologyNodeResourceKind(node)
       if (!onNavigateToResource || !resourceKind || !node.name) return
       const group = apiVersionToGroup(node.data?.apiVersion as string | undefined)
       onNavigateToResource({

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -440,8 +440,9 @@ export function WorkloadView({
   onOpenHelmRelease,
   onNavigateGitOpsPath,
 }: WorkloadViewProps) {
-  // Normalize kind: URL has plural lowercase, internal logic uses singular PascalCase
-  const kind = pluralToKind(kindProp)
+  // The live object preserves exact CRD capitalization (RayJob, TFJob); the URL
+  // plural remains the API resource name used by fetches and mutations.
+  const kind = resource?.kind || pluralToKind(kindProp)
   const apiKind = kindProp
 
   // Tab state — controlled or uncontrolled
@@ -497,14 +498,14 @@ export function WorkloadView({
     return buildResourceHierarchy({
       events: allEvents,
       topology,
-      rootResource: { kind, namespace, name },
+      rootResource: { kind, group, namespace, name },
       groupByApp: true,
     })
-  }, [allEvents, topology, kind, namespace, name])
+  }, [allEvents, topology, kind, group, namespace, name])
 
   // Topology tab — the seeded neighborhood around this one workload (its
   // ownership core + attached Services/config/policies), not the whole namespace.
-  const neighborhoodSeed = useMemo(() => [{ kind, namespace, name }], [kind, namespace, name])
+  const neighborhoodSeed = useMemo(() => [{ kind, group, namespace, name }], [kind, group, namespace, name])
   const neighborhood = useMemo(
     () => (topology ? neighborhoodFor(topology, neighborhoodSeed) : null),
     [topology, neighborhoodSeed],
@@ -537,7 +538,7 @@ export function WorkloadView({
       .filter((n) => n.kind !== 'Internet' && n.kind !== 'PodGroup')
       .map((n) => ({
         id: n.id,
-        kind: n.kind as string,
+        kind: (typeof n.data?.resourceKind === 'string' ? n.data.resourceKind : n.kind) as string,
         namespace: (n.data?.namespace as string) || namespace,
         name: n.name,
         group: apiVersionToGroup(n.data?.apiVersion as string | undefined),
@@ -555,10 +556,11 @@ export function WorkloadView({
   const yamlObject = yamlObjectId ? yamlObjects.find((o) => o.id === yamlObjectId) : undefined
   const handleTopologyNodeClick = useCallback(
     (node: TopologyNode) => {
-      if (!onNavigateToResource || !node.kind || !node.name) return
+      const resourceKind = typeof node.data?.resourceKind === 'string' ? node.data.resourceKind : node.kind
+      if (!onNavigateToResource || !resourceKind || !node.name) return
       const group = apiVersionToGroup(node.data?.apiVersion as string | undefined)
       onNavigateToResource({
-        kind: kindToPluralWithGroup(node.kind, group),
+        kind: kindToPluralWithGroup(resourceKind, group),
         namespace: (node.data?.namespace as string) || '',
         name: node.name,
         group,

--- a/packages/k8s-ui/src/utils/api-resources.test.ts
+++ b/packages/k8s-ui/src/utils/api-resources.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { categorizeResources, findAPIResourceForRoute, formatGroupName, isCoreBatchJob, shortenGroupName } from './api-resources'
+import { builtinGroupForKind, canonicalResourceGroup, categorizeResources, findAPIResourceForRoute, formatGroupName, isCoreBatchJob, shortenGroupName } from './api-resources'
+
+describe('canonicalResourceGroup', () => {
+  it('infers built-in groups from either Kind or resource name', () => {
+    expect(builtinGroupForKind('Service')).toBe('')
+    expect(builtinGroupForKind('jobs')).toBe('batch')
+    expect(builtinGroupForKind('PodDisruptionBudget')).toBe('policy')
+    expect(canonicalResourceGroup('Deployment', undefined)).toBe('apps')
+    expect(canonicalResourceGroup('Job', '')).toBe('batch')
+  })
+
+  it('never overwrites an explicit custom group', () => {
+    expect(canonicalResourceGroup('Job', 'batch.volcano.sh')).toBe('batch.volcano.sh')
+    expect(canonicalResourceGroup('Widget', undefined)).toBeUndefined()
+  })
+})
 
 describe('findAPIResourceForRoute', () => {
   const resources = [

--- a/packages/k8s-ui/src/utils/api-resources.ts
+++ b/packages/k8s-ui/src/utils/api-resources.ts
@@ -35,6 +35,9 @@ export const CORE_RESOURCES: APIResource[] = [
   { group: 'networking.k8s.io', version: 'v1', kind: 'NetworkPolicy', name: 'networkpolicies', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'discovery.k8s.io', version: 'v1', kind: 'EndpointSlice', name: 'endpointslices', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'autoscaling', version: 'v2', kind: 'HorizontalPodAutoscaler', name: 'horizontalpodautoscalers', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
+  { group: 'policy', version: 'v1', kind: 'PodDisruptionBudget', name: 'poddisruptionbudgets', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
+  { group: '', version: 'v1', kind: 'LimitRange', name: 'limitranges', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
+  { group: '', version: 'v1', kind: 'ResourceQuota', name: 'resourcequotas', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: '', version: 'v1', kind: 'Event', name: 'events', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'rbac.authorization.k8s.io', version: 'v1', kind: 'Role', name: 'roles', namespaced: true, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'rbac.authorization.k8s.io', version: 'v1', kind: 'ClusterRole', name: 'clusterroles', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
@@ -49,6 +52,19 @@ export const CORE_RESOURCES: APIResource[] = [
   { group: 'storage.k8s.io', version: 'v1', kind: 'StorageClass', name: 'storageclasses', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
   { group: 'storage.k8s.io', version: 'v1', kind: 'VolumeAttachment', name: 'volumeattachments', namespaced: false, isCrd: false, verbs: ['list', 'get', 'watch'] },
 ]
+
+export function builtinGroupForKind(kindOrResource: string): string | undefined {
+  const value = kindOrResource.toLowerCase()
+  return CORE_RESOURCES.find(resource =>
+    resource.kind.toLowerCase() === value || resource.name.toLowerCase() === value,
+  )?.group
+}
+
+export function canonicalResourceGroup(kindOrResource: string, group: string | undefined): string | undefined {
+  const builtin = builtinGroupForKind(kindOrResource)
+  if (group === undefined || (group === '' && builtin !== undefined)) return builtin
+  return group
+}
 
 export function findAPIResourceForRoute(
   resources: APIResource[] | undefined,

--- a/packages/k8s-ui/src/utils/application-topology.test.ts
+++ b/packages/k8s-ui/src/utils/application-topology.test.ts
@@ -103,6 +103,31 @@ describe('layerDeploymentInventory', () => {
     expect(result.managedOnly.map((node) => node.id)).toEqual(['core-service'])
   })
 
+  it('joins a pseudo topology node to inventory by its real Kubernetes kind', () => {
+    const runtime: Topology = {
+      nodes: [{
+        id: 'knativeservice/default/api',
+        kind: 'KnativeService',
+        name: 'api',
+        status: 'healthy',
+        data: { namespace: 'default', apiVersion: 'serving.knative.dev/v1', resourceKind: 'Service' },
+      }],
+      edges: [],
+    }
+    const result = layerDeploymentInventory(runtime, deploymentInventoryFromGitOps({
+      root: inventory().root,
+      edges: [],
+      nodes: [
+        inventory().root,
+        { id: 'knative-service', ref: { group: 'serving.knative.dev', kind: 'Service', namespace: 'default', name: 'api' }, role: 'declared', tool: 'argocd' },
+      ],
+    })!, 'Argo CD')
+
+    expect(result.managedRuntimeCount).toBe(1)
+    expect(result.runtimeOnlyCount).toBe(0)
+    expect(result.managedOnly).toEqual([])
+  })
+
   it('does not classify synthetic graph nodes as runtime-only resources', () => {
     const syntheticTopology: Topology = {
       nodes: [

--- a/packages/k8s-ui/src/utils/application-topology.ts
+++ b/packages/k8s-ui/src/utils/application-topology.ts
@@ -1,6 +1,7 @@
 import type { GitOpsResourceTree, HealthStatus, HelmOwnedResource, Topology, TopologyNode } from '../types'
 import { apiVersionToGroup, groupQualifiesLaneId } from './navigation'
 import { pluralize } from './pluralize'
+import { topologyNodeResourceKind } from './topology-neighborhood'
 
 export type DeploymentMembership = 'runtime-only' | 'source-only'
 
@@ -157,7 +158,7 @@ export function layerDeploymentInventory(
   const runtimeNodes = topology.nodes.map((node) => {
     if (node.kind === 'PodGroup' || node.kind === 'Internet') return node
     const namespace = (node.data?.namespace as string) || ''
-    const match = inventoryByExact.get(identityKey(node.kind, topologyGroup(node), namespace, node.name))
+    const match = inventoryByExact.get(identityKey(topologyNodeResourceKind(node), topologyGroup(node), namespace, node.name))
     if (match) {
       matchedInventoryIds.add(match.id)
       managedRuntimeCount += 1

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -260,6 +260,15 @@ describe('matchWorkloadAcrossInstances', () => {
     expect(matchWorkloadAcrossInstances('Deployment/dev/billing', [dep('finops')])).toBeNull()
     expect(matchWorkloadAcrossInstances('garbage', [dep('billing')])).toBeNull()
   })
+
+  it('keeps same-kind CRD workloads separate by API group', () => {
+    const targets = [
+      { kind: 'Job', group: 'batch', namespace: 'prod', name: 'train' },
+      { kind: 'Job', group: 'batch.volcano.sh', namespace: 'prod', name: 'train' },
+    ]
+    expect(matchWorkloadAcrossInstances('Job.batch.volcano.sh/dev/train', targets)).toEqual(targets[1])
+    expect(matchWorkloadAcrossInstances('Job/dev/train', targets)).toEqual(targets[0])
+  })
 })
 
 // foldAppGroups pins the collapse experiment's safety rails — each fails
@@ -460,6 +469,23 @@ describe('buildAppMembershipIndex', () => {
     expect(idx.byResource.get('Ingress/team-a/billing-ing')?.appName).toBe('billing')
   })
 
+  it('keeps built-in workload keys stable and separates a same-name CRD workload by group', () => {
+    const idx = buildAppMembershipIndex([
+      row({
+        key: 'core', name: 'core-job',
+        workloads: [{ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      }),
+      row({
+        key: 'volcano', name: 'volcano-job',
+        workloads: [{ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      }),
+    ])
+
+    expect(idx.byResource.get('Job/ml/train')?.appName).toBe('core-job')
+    expect(idx.byResource.get('Job.batch.volcano.sh/ml/train')?.appName).toBe('volcano-job')
+    expect(idx.byResource.size).toBe(2)
+  })
+
   it('indexes routes under their concrete kind, not a generic "Route"', () => {
     // The server ships "Kind/name" for polymorphic routes; the index must key on
     // the concrete kind so it matches the route lane id (HTTPRoute/…/name).
@@ -489,6 +515,50 @@ describe('buildAppMembershipIndex', () => {
     expect(idx.byResource.get('Service/team-a/billing-api')?.appName).toBe('billing')
     expect(idx.byResource.get('ConfigMap/shared/billing-config')?.appName).toBe('billing')
     expect(idx.byResource.get('PersistentVolumeClaim/team-a/billing-data')?.appName).toBe('billing')
+  })
+
+  it('does not let summary relationship names overwrite exact same-kind refs', () => {
+    const idx = buildAppMembershipIndex([
+      row({
+        key: 'foreign', name: 'foreign', namespace: 'team-a',
+        relationships: {
+          services: ['api'],
+          serviceRefs: [{ kind: 'Service', group: 'platform.example.io', namespace: 'team-a', name: 'api' }],
+        },
+      }),
+      row({
+        key: 'core', name: 'core', namespace: 'team-a',
+        relationships: {
+          services: ['api'],
+          serviceRefs: [{ kind: 'Service', namespace: 'team-a', name: 'api' }],
+        },
+      }),
+    ])
+
+    expect(idx.byResource.get('Service.platform.example.io/team-a/api')?.appName).toBe('foreign')
+    expect(idx.byResource.get('Service/team-a/api')?.appName).toBe('core')
+  })
+
+  it('only builds group-less aliases for unambiguous persisted-event identity', () => {
+    const exact = buildAppMembershipIndex([
+      row({
+        key: 'ray', name: 'ray',
+        workloads: [{ kind: 'RayJob', group: 'ray.io', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      }),
+    ])
+    expect(exact.byUnqualifiedResource?.get('RayJob/ml/train')?.appName).toBe('ray')
+
+    const collision = buildAppMembershipIndex([
+      row({
+        key: 'core', name: 'core',
+        workloads: [{ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      }),
+      row({
+        key: 'volcano', name: 'volcano',
+        workloads: [{ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      }),
+    ])
+    expect(collision.byUnqualifiedResource?.has('Job/ml/train')).toBe(false)
   })
 
   it('indexes the exact deployment source object', () => {

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -1,4 +1,5 @@
 import type { ResourceRef } from '../types/core'
+import { groupQualifiesLaneId, laneId, laneResourceKey, parseLaneId } from './navigation'
 import { rolloutActivityLevel, type WorkloadRolloutActivity } from './workload-rollout'
 
 // Shared model for the Applications surface — host-agnostic. The OSS single-
@@ -640,8 +641,12 @@ export interface AppMembership {
 }
 
 export interface AppMembershipIndex {
-  /** 'Kind/namespace/name' → app. Built from row.workloads + satellite arrays. */
+  /** Canonical lane id → app. Built-in groups stay `Kind/namespace/name`;
+   *  CRD groups use `Kind.group/namespace/name`. */
   byResource: Map<string, AppMembership>;
+  /** Group-less aliases that resolve to exactly one canonical resource. This is
+   *  used only when persisted timeline events predate apiVersion capture. */
+  byUnqualifiedResource?: Map<string, AppMembership>;
   /** 'kind:namespace:value' (instance/part-of/name/app/helm/argo) → app. Built
    *  from row.matchKeys EXCLUDING name-stem (v1 matches exact kinds only). Keys
    *  are namespace-scoped so a shared label value across namespaces can't
@@ -657,7 +662,7 @@ function setFirst<V>(map: Map<string, V>, key: string, value: V): void {
 }
 
 /** Build the resource + evidence membership index from the applications rows.
- *  Pure; no fetching. `byResource` keys workloads by their own kind/ns/name and
+ *  Pure; no fetching. `byResource` keys workloads by their canonical lane id and
  *  satellites (Services/Ingresses/Routes) by the app's single namespace — a
  *  multi-namespace app can't place its satellites unambiguously, so those are
  *  skipped (workloads still index fine). `byEvidence` drops name-stem keys: the
@@ -674,21 +679,27 @@ export function buildAppMembershipIndex(rows: AppRow[]): AppMembershipIndex {
     };
     for (const w of row.workloads || []) {
       if (w.kind && w.name)
-        setFirst(byResource, `${w.kind}/${w.namespace}/${w.name}`, membership);
+        setFirst(byResource, laneId(w.kind, w.group, w.namespace, w.name), membership);
     }
     const ns = namespaceOf(row);
     if (ns && row.relationships) {
-      for (const s of row.relationships.services || [])
-        setFirst(byResource, `Service/${ns}/${s}`, membership);
-      for (const i of row.relationships.ingresses || [])
-        setFirst(byResource, `Ingress/${ns}/${i}`, membership);
+      if (!row.relationships.serviceRefs?.length) {
+        for (const s of row.relationships.services || [])
+          setFirst(byResource, `Service/${ns}/${s}`, membership);
+      }
+      if (!row.relationships.ingressRefs?.length) {
+        for (const i of row.relationships.ingresses || [])
+          setFirst(byResource, `Ingress/${ns}/${i}`, membership);
+      }
       // Routes ship as "Kind/name" (HTTPRoute/GRPCRoute/…); index under the
       // concrete kind so the key matches the route lane's id, not a generic "Route".
-      for (const r of row.relationships.routes || []) {
-        const slash = r.indexOf("/");
-        const routeKind = slash > 0 ? r.slice(0, slash) : "Route";
-        const routeName = slash > 0 ? r.slice(slash + 1) : r;
-        setFirst(byResource, `${routeKind}/${ns}/${routeName}`, membership);
+      if (!row.relationships.routeRefs?.length) {
+        for (const r of row.relationships.routes || []) {
+          const slash = r.indexOf("/");
+          const routeKind = slash > 0 ? r.slice(0, slash) : "Route";
+          const routeName = slash > 0 ? r.slice(slash + 1) : r;
+          setFirst(byResource, `${routeKind}/${ns}/${routeName}`, membership);
+        }
       }
     }
     if (row.relationships) {
@@ -705,14 +716,14 @@ export function buildAppMembershipIndex(rows: AppRow[]): AppMembershipIndex {
       for (const refs of explicitRefs) {
         for (const ref of refs ?? []) {
           if (ref.kind && ref.name)
-            setFirst(byResource, `${ref.kind}/${ref.namespace}/${ref.name}`, membership);
+            setFirst(byResource, laneId(ref.kind, ref.group, ref.namespace, ref.name), membership);
         }
       }
     }
     if (row.sourceRef?.kind && row.sourceRef.name) {
       setFirst(
         byResource,
-        `${row.sourceRef.kind}/${row.sourceRef.namespace}/${row.sourceRef.name}`,
+        laneId(row.sourceRef.kind, row.sourceRef.group, row.sourceRef.namespace, row.sourceRef.name),
         membership,
       );
     }
@@ -721,7 +732,23 @@ export function buildAppMembershipIndex(rows: AppRow[]): AppMembershipIndex {
       setFirst(byEvidence, mk, membership);
     }
   }
-  return { byResource, byEvidence };
+  const byUnqualifiedResource = new Map<string, AppMembership>();
+  const canonicalByUnqualified = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  for (const [canonical, membership] of byResource) {
+    const parsed = parseLaneId(canonical);
+    if (!parsed) continue;
+    const unqualified = laneResourceKey(parsed.kind, parsed.namespace, parsed.name);
+    const previous = canonicalByUnqualified.get(unqualified);
+    if (previous && previous !== canonical) {
+      ambiguous.add(unqualified);
+      byUnqualifiedResource.delete(unqualified);
+      continue;
+    }
+    canonicalByUnqualified.set(unqualified, canonical);
+    if (!ambiguous.has(unqualified)) byUnqualifiedResource.set(unqualified, membership);
+  }
+  return { byResource, byUnqualifiedResource, byEvidence };
 }
 
 // -----------------------------------------------------------------------------
@@ -775,21 +802,24 @@ export function stripEnvAffix(
 export function matchWorkloadAcrossInstances(
   workloadKey: string,
   targetWorkloads:
-    Pick<AppWorkload, "kind" | "namespace" | "name">[] | undefined,
+    Pick<AppWorkload, "kind" | "group" | "namespace" | "name">[] | undefined,
   extraTokens?: ReadonlySet<string>,
-): Pick<AppWorkload, "kind" | "namespace" | "name"> | null {
-  const [kind, namespace, name] = workloadKey.split("/");
-  if (!kind || !name) return null;
+): Pick<AppWorkload, "kind" | "group" | "namespace" | "name"> | null {
+  const parsed = parseLaneId(workloadKey);
+  if (!parsed) return null;
+  const { kind, group, namespace, name } = parsed;
+  const sameKindGroup = (w: Pick<AppWorkload, "kind" | "group">) =>
+    w.kind === kind && (groupQualifiesLaneId(w.group) ? w.group : "") === group;
   const ws = targetWorkloads ?? [];
   return (
     ws.find(
-      (w) => w.kind === kind && w.namespace === namespace && w.name === name,
+      (w) => sameKindGroup(w) && w.namespace === namespace && w.name === name,
     ) ??
-    uniqueMatch(ws, (w) => w.kind === kind && w.name === name) ??
+    uniqueMatch(ws, (w) => sameKindGroup(w) && w.name === name) ??
     uniqueMatch(
       ws,
       (w) =>
-        w.kind === kind &&
+        sameKindGroup(w) &&
         stripEnvAffix(w.name, extraTokens) === stripEnvAffix(name, extraTokens),
     ) ??
     null

--- a/packages/k8s-ui/src/utils/gitops-route.test.ts
+++ b/packages/k8s-ui/src/utils/gitops-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { gitOpsRouteForOwner, gitOpsRouteForResource } from './gitops-route'
+import { gitOpsRouteForKind, gitOpsRouteForOwner, gitOpsRouteForResource } from './gitops-route'
 
 describe('gitOpsRouteForOwner', () => {
   it('routes to detail URL for Argo with known namespace', () => {
@@ -74,5 +74,18 @@ describe('gitOpsRouteForResource', () => {
     expect(gitOpsRouteForResource(mk('serving.knative.dev/v1', 'Service'))).toBeNull()
     // A hypothetical "Application" CR in another group must not portal.
     expect(gitOpsRouteForResource(mk('example.com/v1', 'Application'))).toBeNull()
+  })
+})
+
+describe('gitOpsRouteForKind', () => {
+  it('uses an available group to reject foreign same-named CRDs', () => {
+    expect(gitOpsRouteForKind('Application', 'default', 'demo', 'argoproj.io'))
+      .toBe('/gitops/detail/applications/default/demo')
+    expect(gitOpsRouteForKind('Application', 'default', 'demo', 'example.com')).toBeNull()
+  })
+
+  it('retains the kind-only fallback for callers without group evidence', () => {
+    expect(gitOpsRouteForKind('Application', 'default', 'demo'))
+      .toBe('/gitops/detail/applications/default/demo')
   })
 })

--- a/packages/k8s-ui/src/utils/gitops-route.test.ts
+++ b/packages/k8s-ui/src/utils/gitops-route.test.ts
@@ -88,4 +88,10 @@ describe('gitOpsRouteForKind', () => {
     expect(gitOpsRouteForKind('Application', 'default', 'demo'))
       .toBe('/gitops/detail/applications/default/demo')
   })
+
+  it('retains the fallback for an unresolved historical lane with an empty placeholder group', () => {
+    expect(gitOpsRouteForKind('HelmRelease', 'flux-system', 'demo', '', false))
+      .toBe('/gitops/detail/helmreleases/flux-system/demo')
+    expect(gitOpsRouteForKind('HelmRelease', 'flux-system', 'demo', '', true)).toBeNull()
+  })
 })

--- a/packages/k8s-ui/src/utils/gitops-route.ts
+++ b/packages/k8s-ui/src/utils/gitops-route.ts
@@ -81,10 +81,18 @@ function gitOpsDetailUrl(kindPlural: string, namespace: string, name: string): s
 
 // gitOpsRouteForKind accepts an exact group when the caller has one. Callers
 // such as older Audit findings can omit it and retain the kind-only fallback.
-export function gitOpsRouteForKind(kind: string, namespace: string, name: string, group?: string): string | null {
+// Persisted timeline lanes may carry an empty placeholder group while explicitly
+// reporting that identity was not resolved; those retain the same fallback.
+export function gitOpsRouteForKind(
+  kind: string,
+  namespace: string,
+  name: string,
+  group?: string,
+  identityResolved = group !== undefined,
+): string | null {
   if (!kind || !name) return null
-  if (group !== undefined) {
-    const plural = portalPluralFor(kind.toLowerCase(), group)
+  if (identityResolved) {
+    const plural = portalPluralFor(kind.toLowerCase(), group ?? '')
     return plural ? gitOpsDetailUrl(plural, namespace, name) : null
   }
   switch (kind) {

--- a/packages/k8s-ui/src/utils/gitops-route.ts
+++ b/packages/k8s-ui/src/utils/gitops-route.ts
@@ -79,14 +79,14 @@ function gitOpsDetailUrl(kindPlural: string, namespace: string, name: string): s
   return `/gitops/detail/${encodeURIComponent(kindPlural)}/${ns}/${encodeURIComponent(name)}`
 }
 
-// gitOpsRouteForKind is a kind-only variant for callers that only have
-// (kind, namespace, name) — e.g. Audit findings, which today don't carry the
-// apiGroup of the resource they subject. Matches by kind alone, accepting the
-// (very small) risk of routing a CRD named "Application" or "Kustomization"
-// from a non-GitOps group to a "not found" GitOps detail page. When/if those
-// callers grow apiGroup access, prefer gitOpsRouteForResource.
-export function gitOpsRouteForKind(kind: string, namespace: string, name: string): string | null {
+// gitOpsRouteForKind accepts an exact group when the caller has one. Callers
+// such as older Audit findings can omit it and retain the kind-only fallback.
+export function gitOpsRouteForKind(kind: string, namespace: string, name: string, group?: string): string | null {
   if (!kind || !name) return null
+  if (group !== undefined) {
+    const plural = portalPluralFor(kind.toLowerCase(), group)
+    return plural ? gitOpsDetailUrl(plural, namespace, name) : null
+  }
   switch (kind) {
     case 'Application':
       return gitOpsDetailUrl('applications', namespace, name)

--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -303,6 +303,7 @@ describe('lane identity helpers', () => {
     expect(groupQualifiesLaneId('apps')).toBe(false)       // built-in
     expect(groupQualifiesLaneId('batch')).toBe(false)
     expect(groupQualifiesLaneId('networking.k8s.io')).toBe(false)
+    expect(groupQualifiesLaneId('resource.k8s.io')).toBe(false)
     expect(groupQualifiesLaneId('postgresql.cnpg.io')).toBe(true)
     expect(groupQualifiesLaneId('cluster.x-k8s.io')).toBe(true)
   })
@@ -310,6 +311,7 @@ describe('lane identity helpers', () => {
   test('laneId: bare for core/built-in, qualified for CRD groups', () => {
     expect(laneId('Pod', '', 'team-a', 'x')).toBe('Pod/team-a/x')
     expect(laneId('Deployment', 'apps', 'ns', 'web')).toBe('Deployment/ns/web')
+    expect(laneId('ResourceClaim', 'resource.k8s.io', 'ml', 'gpu')).toBe('ResourceClaim/ml/gpu')
     expect(laneId('Cluster', 'postgresql.cnpg.io', 'prod', 'main-db')).toBe('Cluster.postgresql.cnpg.io/prod/main-db')
   })
 

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -212,7 +212,7 @@ const BUILTIN_API_GROUPS: ReadonlySet<string> = new Set([
   'rbac.authorization.k8s.io', 'admissionregistration.k8s.io',
   'authentication.k8s.io', 'authorization.k8s.io', 'certificates.k8s.io',
   'apiextensions.k8s.io', 'apiregistration.k8s.io', 'events.k8s.io',
-  'flowcontrol.apiserver.k8s.io',
+  'flowcontrol.apiserver.k8s.io', 'resource.k8s.io',
 ])
 
 /** Whether a resource's API group must appear in its lane id to prevent a

--- a/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 
 import type { TimelineEvent, Topology } from '../types/core'
 
-import { buildResourceHierarchy, eventsForApplication, extractPinnedLanes, removePinnedLanes, isPinnedLaneRef, laneTrackEvents, laneHasEventInWindow, isChildVisibleInWindow, subtreeEvents, getAllEventsFromHierarchy, collidingLaneKeys, laneCollisionKey, type ResourceLane } from './resource-hierarchy'
-import type { AppMembershipIndex, AppMembership } from './applications'
+import { buildResourceHierarchy, eventsForApplication, extractPinnedLanes, removePinnedLanes, isPinnedLaneRef, laneTrackEvents, laneHasEventInWindow, isChildVisibleInWindow, subtreeEvents, getAllEventsFromHierarchy, collidingLaneKeys, laneCollisionKey, matchLaneByMemberNamePrefix, type ResourceLane } from './resource-hierarchy'
+import { buildAppMembershipIndex, type AppMembershipIndex, type AppMembership } from './applications'
 
 function svcEvent(namespace: string, name: string): TimelineEvent {
   return {
@@ -20,7 +20,10 @@ function svcEvent(namespace: string, name: string): TimelineEvent {
 function svcNode(namespace: string, name: string, app: string) {
   return {
     id: `service/${namespace}/${name}`,
-    data: { apiVersion: 'v1', labels: { 'app.kubernetes.io/name': app } },
+    kind: 'Service',
+    name,
+    status: 'healthy',
+    data: { namespace, apiVersion: 'v1', labels: { 'app.kubernetes.io/name': app } },
   }
 }
 
@@ -296,8 +299,8 @@ describe('eventsForApplication', () => {
     const deployment = changeEvent('Deployment', 'team-a', 'billing-api', { id: 'deployment' })
     const topology = {
       nodes: [
-        { id: 'service/team-a/billing-api', data: {} },
-        { id: 'deployment/team-a/billing-api', data: {} },
+        { id: 'service/team-a/billing-api', kind: 'Service', name: 'billing-api', status: 'healthy', data: { namespace: 'team-a', apiVersion: 'v1' } },
+        { id: 'deployment/team-a/billing-api', kind: 'Deployment', name: 'billing-api', status: 'healthy', data: { namespace: 'team-a', apiVersion: 'apps/v1' } },
       ],
       edges: [{ id: 'edge', source: 'service/team-a/billing-api', target: 'deployment/team-a/billing-api', type: 'exposes' }],
     } as unknown as Topology
@@ -928,6 +931,15 @@ describe('group-qualified lane identity', () => {
     expect(new Set(lanes.map((l) => l.group))).toEqual(new Set(['cluster.x-k8s.io', 'postgresql.cnpg.io']))
   })
 
+  it('uses the requested API group when filtering a detail timeline root', () => {
+    const lanes = buildResourceHierarchy({
+      events: [capiCluster(), cnpgCluster()],
+      grouping: 'owner',
+      rootResource: { kind: 'Cluster', group: 'postgresql.cnpg.io', namespace: 'prod', name: 'main' },
+    })
+    expect(lanes.map((lane) => lane.id)).toEqual(['Cluster.postgresql.cnpg.io/prod/main'])
+  })
+
   it('keeps core/built-in resource ids bare (byte-stable)', () => {
     const lanes = buildResourceHierarchy({
       events: [
@@ -948,10 +960,10 @@ describe('group-qualified lane identity', () => {
     expect(collidingLaneKeys(unique).size).toBe(0)
   })
 
-  it('a CRD lane still joins its app via the group-less byResource key', () => {
+  it('a CRD lane joins its app through its exact group-qualified membership key', () => {
     const db: AppMembership = { appKey: 'prod/app/shop', appName: 'shop', env: 'prod' }
     const appIndex = index({
-      'Cluster/prod/main': db,          // group-less key, as AppRow workloads ship
+      'Cluster.postgresql.cnpg.io/prod/main': db,
       'Deployment/prod/web': db,
     })
     const lanes = buildResourceHierarchy({
@@ -964,6 +976,145 @@ describe('group-qualified lane identity', () => {
     expect(lanes[0].isAppGroup).toBe(true)
     const childIds = (lanes[0].children ?? []).map((c) => c.id).sort()
     expect(childIds).toEqual(['Cluster.postgresql.cnpg.io/prod/main', 'Deployment/prod/web'])
+  })
+
+  it('prefix-matches generated children against group-qualified workload memberships', () => {
+    const volcano: AppMembership = { appKey: 'ml/app/volcano', appName: 'volcano' }
+    const appIndex = index({ 'Job.batch.volcano.sh/ml/train': volcano })
+    expect(matchLaneByMemberNamePrefix(
+      { kind: 'Pod', namespace: 'ml', name: 'train-abc12' },
+      appIndex,
+    )).toBe(volcano)
+  })
+
+  it('fails closed when a generated child equally matches workloads from different groups', () => {
+    const appIndex = index({
+      'Job.batch.volcano.sh/ml/train': { appKey: 'volcano', appName: 'volcano' },
+      'Job.scheduling.example.io/ml/train': { appKey: 'other', appName: 'other' },
+    })
+    expect(matchLaneByMemberNamePrefix(
+      { kind: 'Pod', namespace: 'ml', name: 'train-abc12' },
+      appIndex,
+    )).toBeNull()
+  })
+
+  it('joins persisted group-less CRD events only when their membership is unambiguous', () => {
+    const appIndex = buildAppMembershipIndex([{
+      key: 'ml/app/training', name: 'training', health: 'healthy',
+      workloads: [
+        { kind: 'RayJob', group: 'ray.io', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 },
+        { kind: 'Deployment', group: 'apps', namespace: 'ml', name: 'dashboard', health: 'healthy', ready: 1, desired: 1, restarts: 0 },
+      ],
+    }])
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('RayJob', 'ml', 'train'),
+        changeEvent('Deployment', 'ml', 'dashboard', { apiVersion: 'apps/v1' }),
+      ],
+      grouping: 'app',
+      appIndex,
+    })
+    expect(lanes).toHaveLength(1)
+    expect(lanes[0].isAppGroup).toBe(true)
+    expect(lanes[0].children?.map((lane) => lane.name).sort()).toEqual(['dashboard', 'train'])
+  })
+
+  it('does not guess app membership for a group-less event with colliding identities', () => {
+    const appIndex = buildAppMembershipIndex([
+      {
+        key: 'core', name: 'core', health: 'healthy',
+        workloads: [{ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      },
+      {
+        key: 'volcano', name: 'volcano', health: 'healthy',
+        workloads: [{ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      },
+    ])
+    const lanes = buildResourceHierarchy({
+      events: [changeEvent('Job', 'ml', 'train')],
+      grouping: 'app',
+      appIndex,
+    })
+    expect(lanes).toHaveLength(1)
+    expect(lanes[0].appKey).toBeUndefined()
+  })
+
+  it('keeps a persisted group-less event bare when topology reveals a collision', () => {
+    const topology = {
+      nodes: [
+        { id: 'job/ml/train', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch/v1' } },
+        { id: 'job/ml/train/batch.volcano.sh', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch.volcano.sh/v1alpha1' } },
+      ],
+      edges: [],
+    } as unknown as Topology
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'new', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'persisted' }),
+      ],
+      topology,
+      grouping: 'flat',
+    })
+    expect(lanes.map((lane) => lane.id).sort()).toEqual([
+      'Job.batch.volcano.sh/ml/train',
+      'Job/ml/train',
+    ])
+    expect(lanes.find((lane) => lane.id === 'Job/ml/train')?.events.map((event) => event.id)).toEqual(['persisted'])
+  })
+
+  it('joins collision-labeled topology nodes to their real Kubernetes kind', () => {
+    const topology = {
+      nodes: [
+        {
+          id: 'knativeservice/prod/api', kind: 'KnativeService', name: 'api', status: 'healthy',
+          data: { namespace: 'prod', apiVersion: 'serving.knative.dev/v1', resourceKind: 'Service' },
+        },
+        {
+          id: 'revision/prod/api-v1', kind: 'KnativeRevision', name: 'api-v1', status: 'healthy',
+          data: { namespace: 'prod', apiVersion: 'serving.knative.dev/v1', resourceKind: 'Revision' },
+        },
+      ],
+      edges: [{ id: 'serves', source: 'knativeservice/prod/api', target: 'revision/prod/api-v1', type: 'exposes' }],
+    } as unknown as Topology
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Service', 'prod', 'api', { apiVersion: 'serving.knative.dev/v1' }),
+        changeEvent('Revision', 'prod', 'api-v1', { apiVersion: 'serving.knative.dev/v1' }),
+      ],
+      topology,
+      grouping: 'owner',
+    })
+    expect(lanes).toHaveLength(1)
+    expect(lanes[0].id).toBe('Service.serving.knative.dev/prod/api')
+    expect(lanes[0].children?.map((lane) => lane.id)).toEqual(['Revision.serving.knative.dev/prod/api-v1'])
+  })
+
+  it('uses exact topology endpoint identities for core and Volcano Jobs', () => {
+    const topology = {
+      nodes: [
+        { id: 'service/ml/core', kind: 'Service', name: 'core', status: 'healthy', data: { namespace: 'ml', apiVersion: 'v1' } },
+        { id: 'service/ml/volcano', kind: 'Service', name: 'volcano', status: 'healthy', data: { namespace: 'ml', apiVersion: 'v1' } },
+        { id: 'job/ml/train', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch/v1' } },
+        { id: 'job/ml/train/batch.volcano.sh', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch.volcano.sh/v1alpha1' } },
+      ],
+      edges: [
+        { id: 'core-edge', source: 'service/ml/core', target: 'job/ml/train', type: 'exposes' },
+        { id: 'volcano-edge', source: 'service/ml/volcano', target: 'job/ml/train/batch.volcano.sh', type: 'exposes' },
+      ],
+    } as unknown as Topology
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core-job', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano-job', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+        changeEvent('Service', 'ml', 'core', { apiVersion: 'v1' }),
+        changeEvent('Service', 'ml', 'volcano', { apiVersion: 'v1' }),
+      ],
+      topology,
+      grouping: 'owner',
+    })
+    expect(lanes.find((lane) => lane.name === 'core')?.children?.map((lane) => lane.id)).toEqual(['Job/ml/train'])
+    expect(lanes.find((lane) => lane.name === 'volcano')?.children?.map((lane) => lane.id))
+      .toEqual(['Job.batch.volcano.sh/ml/train'])
   })
 
   it('owner parenting reconciles a CRD owner across the qualified/bare boundary', () => {

--- a/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import type { TimelineEvent, Topology } from '../types/core'
 
-import { buildResourceHierarchy, eventsForApplication, extractPinnedLanes, removePinnedLanes, isPinnedLaneRef, laneTrackEvents, laneHasEventInWindow, isChildVisibleInWindow, subtreeEvents, getAllEventsFromHierarchy, collidingLaneKeys, laneCollisionKey, matchLaneByMemberNamePrefix, type ResourceLane } from './resource-hierarchy'
+import { buildResourceHierarchy, eventsForApplication, extractPinnedLanes, removePinnedLanes, resolvePinnedLaneIds, isPinnedLaneRef, pinnedLaneRefMatches, laneTrackEvents, laneHasEventInWindow, isChildVisibleInWindow, subtreeEvents, getAllEventsFromHierarchy, collidingLaneKeys, laneCollisionKey, matchLaneByMemberNamePrefix, type ResourceLane } from './resource-hierarchy'
 import { buildAppMembershipIndex, type AppMembershipIndex, type AppMembership } from './applications'
 
 function svcEvent(namespace: string, name: string): TimelineEvent {
@@ -742,6 +742,86 @@ describe('extractPinnedLanes', () => {
     expect(pinned[0].isAppGroup).toBeFalsy()
   })
 
+  it('migrates an unambiguous pre-api-group CRD pin to its canonical live lane', () => {
+    const lanes = buildResourceHierarchy({
+      events: [changeEvent('Job', 'ml', 'train', { apiVersion: 'batch.volcano.sh/v1alpha1' })],
+      grouping: 'flat',
+    })
+    const refs = [{ id: 'Job/ml/train', kind: 'Job', namespace: 'ml', name: 'train' }]
+
+    expect(extractPinnedLanes(lanes, refs)[0].id).toBe('Job.batch.volcano.sh/ml/train')
+    const resolved = resolvePinnedLaneIds(lanes, refs)
+    expect([...resolved]).toEqual(['Job.batch.volcano.sh/ml/train'])
+    expect(removePinnedLanes(lanes, resolved)).toEqual([])
+  })
+
+  it('does not guess which live lane an old group-less pin meant after a collision', () => {
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+      ],
+      grouping: 'flat',
+    })
+    const refs = [{ id: 'Job/ml/train', kind: 'Job', namespace: 'ml', name: 'train' }]
+
+    expect(resolvePinnedLaneIds(lanes, refs).size).toBe(0)
+    expect(removePinnedLanes(lanes, resolvePinnedLaneIds(lanes, refs))).toHaveLength(2)
+    expect(extractPinnedLanes(lanes, refs)).toEqual([])
+  })
+
+  it('uses the stored group to distinguish new core and CRD pins with the same name', () => {
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+      ],
+      grouping: 'flat',
+    })
+    const coreRef = { id: 'Job/ml/train', kind: 'Job', group: 'batch', namespace: 'ml', name: 'train' }
+    const volcanoRef = { id: 'Job.batch.volcano.sh/ml/train', kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train' }
+
+    expect(extractPinnedLanes(lanes, [coreRef])[0].events[0].id).toBe('core')
+    expect(extractPinnedLanes(lanes, [volcanoRef])[0].events[0].id).toBe('volcano')
+  })
+
+  it('keeps an absent group-qualified pin distinct from a same-named live group', () => {
+    const lanes = buildResourceHierarchy({
+      events: [changeEvent('Cluster', 'prod', 'main', { apiVersion: 'cluster.x-k8s.io/v1beta2' })],
+      grouping: 'flat',
+    })
+    const cnpgRef = {
+      id: 'Cluster.postgresql.cnpg.io/prod/main',
+      kind: 'Cluster',
+      group: 'postgresql.cnpg.io',
+      namespace: 'prod',
+      name: 'main',
+    }
+
+    expect([...resolvePinnedLaneIds(lanes, [cnpgRef])]).toEqual([cnpgRef.id])
+    expect(extractPinnedLanes(lanes, [cnpgRef])[0].id).toBe(cnpgRef.id)
+  })
+
+  it('keeps a built-in pin resolved when the lane stops carrying apiVersion', () => {
+    const lane = {
+      id: 'Deployment/team-a/web', kind: 'Deployment', group: '', namespace: 'team-a', name: 'web',
+      events: [], isWorkload: true,
+    } as ResourceLane
+    const ref = { id: 'Deployment/team-a/web', kind: 'Deployment', group: 'apps', namespace: 'team-a', name: 'web' }
+
+    expect(extractPinnedLanes([lane], [ref])[0].id).toBe(lane.id)
+    expect([...resolvePinnedLaneIds([lane], [ref])]).toEqual([lane.id])
+  })
+
+  it('matches a migrated legacy pin for unpin without conflating explicit groups', () => {
+    const legacy = { id: 'Cluster/prod/main', kind: 'Cluster', namespace: 'prod', name: 'main' }
+    const cnpg = { id: 'Cluster.postgresql.cnpg.io/prod/main', kind: 'Cluster', group: 'postgresql.cnpg.io', namespace: 'prod', name: 'main' }
+    const capi = { id: 'Cluster.cluster.x-k8s.io/prod/main', kind: 'Cluster', group: 'cluster.x-k8s.io', namespace: 'prod', name: 'main' }
+
+    expect(pinnedLaneRefMatches(legacy, cnpg)).toBe(true)
+    expect(pinnedLaneRefMatches(cnpg, capi)).toBe(false)
+  })
+
   // Dedup: a pinned app group subsumes a separately-pinned member of that group,
   // regardless of pin order — the app-group wins so the member renders once
   // (inside the group's roll-up), never a second standalone row that would
@@ -796,7 +876,7 @@ describe('isPinnedLaneRef (localStorage validation)', () => {
     expect(isPinnedLaneRef({ id: 'Deployment/team-a/web', kind: 'Deployment', namespace: 'team-a', name: 'web' })).toBe(true)
   })
   it('accepts an explicit resource ref', () => {
-    expect(isPinnedLaneRef({ type: 'resource', id: 'Deployment/team-a/web', kind: 'Deployment', namespace: 'team-a', name: 'web' })).toBe(true)
+    expect(isPinnedLaneRef({ type: 'resource', id: 'Deployment/team-a/web', kind: 'Deployment', group: 'apps', namespace: 'team-a', name: 'web' })).toBe(true)
   })
   it('accepts an app-group ref', () => {
     expect(isPinnedLaneRef({ type: 'appGroup', id: 'app:team-a/app/billing', appKey: 'team-a/app/billing', appName: 'billing' })).toBe(true)
@@ -806,6 +886,9 @@ describe('isPinnedLaneRef (localStorage validation)', () => {
   })
   it('rejects a resource ref missing required fields', () => {
     expect(isPinnedLaneRef({ id: 'Deployment/team-a/web', kind: 'Deployment' })).toBe(false)
+  })
+  it('rejects a resource ref with a non-string group', () => {
+    expect(isPinnedLaneRef({ id: 'Deployment/team-a/web', kind: 'Deployment', group: 1, namespace: 'team-a', name: 'web' })).toBe(false)
   })
   it('rejects non-objects and null', () => {
     expect(isPinnedLaneRef(null)).toBe(false)
@@ -1039,6 +1122,30 @@ describe('group-qualified lane identity', () => {
     expect(lanes[0].appKey).toBeUndefined()
   })
 
+  it('keeps exact core and custom lanes in their own app memberships after a collision', () => {
+    const appIndex = buildAppMembershipIndex([
+      {
+        key: 'core', name: 'core', health: 'healthy',
+        workloads: [{ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      },
+      {
+        key: 'volcano', name: 'volcano', health: 'healthy',
+        workloads: [{ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }],
+      },
+    ])
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+      ],
+      grouping: 'app',
+      appIndex,
+    })
+
+    expect(lanes.find(lane => lane.id === 'Job/ml/train')?.structuralMember).toBe(true)
+    expect(lanes.find(lane => lane.id === 'Job.batch.volcano.sh/ml/train')?.structuralMember).toBe(true)
+  })
+
   it('keeps a persisted group-less event bare when topology reveals a collision', () => {
     const topology = {
       nodes: [
@@ -1117,6 +1224,46 @@ describe('group-qualified lane identity', () => {
       .toEqual(['Job.batch.volcano.sh/ml/train'])
   })
 
+  it('uses an exact manages edge when a persisted owner ref is group-less', () => {
+    const topology = {
+      nodes: [
+        { id: 'job/ml/train', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml' } },
+        { id: 'job/ml/train/batch.volcano.sh', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch.volcano.sh/v1alpha1' } },
+        { id: 'pod/ml/train-worker', kind: 'Pod', name: 'train-worker', status: 'healthy', data: { namespace: 'ml' } },
+      ],
+      edges: [
+        { id: 'owns', source: 'job/ml/train/batch.volcano.sh', target: 'pod/ml/train-worker', type: 'manages' },
+      ],
+    } as unknown as Topology
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+        changeEvent('Pod', 'ml', 'train-worker', { owner: { kind: 'Job', name: 'train' } }),
+      ],
+      topology,
+      grouping: 'owner',
+    })
+
+    expect(lanes.find(lane => lane.id === 'Job/ml/train')?.children ?? []).toEqual([])
+    expect(lanes.find(lane => lane.id === 'Job.batch.volcano.sh/ml/train')?.children?.map(child => child.id))
+      .toEqual(['Pod/ml/train-worker'])
+  })
+
+  it('leaves a historical group-less owner unresolved when live identities collide', () => {
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Job', 'ml', 'train', { id: 'core', apiVersion: 'batch/v1' }),
+        changeEvent('Job', 'ml', 'train', { id: 'volcano', apiVersion: 'batch.volcano.sh/v1alpha1' }),
+        changeEvent('Pod', 'ml', 'train-worker', { owner: { kind: 'Job', name: 'train' } }),
+      ],
+      grouping: 'owner',
+    })
+
+    expect(lanes.find(lane => lane.id === 'Pod/ml/train-worker')).toBeDefined()
+    expect(lanes.filter(lane => lane.name === 'train').every(lane => (lane.children ?? []).length === 0)).toBe(true)
+  })
+
   it('owner parenting reconciles a CRD owner across the qualified/bare boundary', () => {
     // A Pod owned by a CNPG Cluster: the owner ref carries no group, but it must
     // nest under the Cluster's group-qualified lane, not fork a bare duplicate.
@@ -1132,17 +1279,14 @@ describe('group-qualified lane identity', () => {
     expect((lanes[0].children ?? []).map((c) => c.id)).toEqual(['Pod/prod/main-1'])
   })
 
-  it('ignores an old-format (group-less) CRD pin gracefully — no crash, empty ghost row', () => {
+  it('migrates an old-format CRD pin when the live identity is unambiguous', () => {
     const lanes = buildResourceHierarchy({ events: [cnpgCluster()], grouping: 'flat' })
-    // Stale pin written before group-qualified ids existed: bare id, no match.
     const stale = { type: 'resource' as const, id: 'Cluster/prod/main', kind: 'Cluster', namespace: 'prod', name: 'main' }
-    expect(isPinnedLaneRef(stale)).toBe(true) // still a well-formed record
+    expect(isPinnedLaneRef(stale)).toBe(true)
     const pinned = extractPinnedLanes(lanes, [stale])
     expect(pinned).toHaveLength(1)
-    expect(pinned[0].id).toBe('Cluster/prod/main')
-    expect(pinned[0].events).toHaveLength(0) // synthesized empty — did not hijack the live lane
-    // The live qualified lane is untouched by the stale pin.
-    expect(lanes[0].id).toBe('Cluster.postgresql.cnpg.io/prod/main')
+    expect(pinned[0].id).toBe('Cluster.postgresql.cnpg.io/prod/main')
+    expect(pinned[0].events).toHaveLength(1)
   })
 })
 

--- a/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
@@ -1146,7 +1146,7 @@ describe('group-qualified lane identity', () => {
     expect(lanes.find(lane => lane.id === 'Job.batch.volcano.sh/ml/train')?.structuralMember).toBe(true)
   })
 
-  it('keeps a persisted group-less event bare when topology reveals a collision', () => {
+  it('gives a persisted group-less event its own identity, distinct from the built-in lane, when topology reveals a collision', () => {
     const topology = {
       nodes: [
         { id: 'job/ml/train', kind: 'Job', name: 'train', status: 'healthy', data: { namespace: 'ml', apiVersion: 'batch/v1' } },
@@ -1162,11 +1162,14 @@ describe('group-qualified lane identity', () => {
       topology,
       grouping: 'flat',
     })
-    expect(lanes.map((lane) => lane.id).sort()).toEqual([
-      'Job.batch.volcano.sh/ml/train',
-      'Job/ml/train',
-    ])
-    expect(lanes.find((lane) => lane.id === 'Job/ml/train')?.events.map((event) => event.id)).toEqual(['persisted'])
+    // The unresolved event must NOT land on 'Job/ml/train' -- that is the
+    // real core Job's own canonical (bare) id, and merging onto it would
+    // silently attribute unknown-group activity to the core Job.
+    const ids = lanes.map((lane) => lane.id).sort()
+    expect(ids).toContain('Job.batch.volcano.sh/ml/train')
+    expect(ids).not.toContain('Job/ml/train')
+    const ambiguousLane = lanes.find((lane) => lane.id !== 'Job.batch.volcano.sh/ml/train')
+    expect(ambiguousLane?.events.map((event) => event.id)).toEqual(['persisted'])
   })
 
   it('joins collision-labeled topology nodes to their real Kubernetes kind', () => {

--- a/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
@@ -1253,6 +1253,33 @@ describe('group-qualified lane identity', () => {
       .toEqual(['Pod/ml/train-worker'])
   })
 
+  it('does not nest a Kustomization under its GitRepository source via a manages edge', () => {
+    // GitRepository->Kustomization is spec.sourceRef, not an ownerReference the
+    // source controls. Applying the same "exact topology edge wins" override used
+    // for real ownership chains would nest the Kustomization -- which has its own
+    // events and should render as a top-level app-group root -- under a
+    // materialized, event-less GitRepository lane, hiding it from the top level.
+    const topology = {
+      nodes: [
+        { id: 'gitrepository/flux-system/app', kind: 'GitRepository', name: 'app', status: 'healthy', data: { namespace: 'flux-system', apiVersion: 'source.toolkit.fluxcd.io/v1' } },
+        { id: 'kustomization/flux-system/app', kind: 'Kustomization', name: 'app', status: 'healthy', data: { namespace: 'flux-system', apiVersion: 'kustomize.toolkit.fluxcd.io/v1' } },
+      ],
+      edges: [
+        { id: 'sources', source: 'gitrepository/flux-system/app', target: 'kustomization/flux-system/app', type: 'manages' },
+      ],
+    } as unknown as Topology
+    const lanes = buildResourceHierarchy({
+      events: [
+        changeEvent('Kustomization', 'flux-system', 'app', { apiVersion: 'kustomize.toolkit.fluxcd.io/v1' }),
+      ],
+      topology,
+      grouping: 'owner',
+    })
+
+    const kustomizationLane = lanes.find((lane) => lane.name === 'app' && lane.kind === 'Kustomization')
+    expect(kustomizationLane).toBeDefined()
+  })
+
   it('leaves a historical group-less owner unresolved when live identities collide', () => {
     const lanes = buildResourceHierarchy({
       events: [

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -13,8 +13,10 @@
 
 import type { TimelineEvent, Topology } from '../types/core'
 import { isWorkloadKind } from '../types/core'
+import { canonicalResourceGroup } from './api-resources'
 import { apiVersionToGroup, laneId, laneResourceKey, groupQualifiesLaneId, parseLaneId } from './navigation'
 import type { AppMembership, AppMembershipIndex } from './applications'
+import { topologyNodeResourceKind } from './topology-neighborhood'
 
 /** Timeline grouping mode (replaces the legacy groupByApp boolean).
  *  - app   = owner/topology parenting + the app-membership cascade (default)
@@ -36,6 +38,9 @@ export interface ResourceLane {
    * (e.g. CAPI Cluster vs CNPG Cluster) when the lane is clicked.
    */
   group?: string
+  /** True when group identity came from apiVersion/topology or an unambiguous
+   *  live identity, including the explicit core group (`''`). */
+  identityResolved?: boolean
   namespace: string
   name: string
   events: TimelineEvent[]
@@ -297,7 +302,7 @@ function contractParentId(
  *  retention-grade fix) exist. */
 function cascadeRootMembership(lane: ResourceLane, appIndex: AppMembershipIndex): RootGroupAssignment | null {
   const unqualified = laneResourceKey(lane.kind, lane.namespace, lane.name)
-  const direct = lane.group
+  const direct = lane.identityResolved
     ? appIndex.byResource.get(lane.id)
     : appIndex.byUnqualifiedResource?.get(unqualified)
       ?? (!appIndex.byUnqualifiedResource ? appIndex.byResource.get(lane.id) : undefined)
@@ -422,8 +427,7 @@ export function isProblematicEvent(event: TimelineEvent): boolean {
 function topologyNodeLaneId(node: Topology['nodes'][number]): string {
   const namespace = typeof node.data?.namespace === 'string' ? node.data.namespace : ''
   const apiVersion = typeof node.data?.apiVersion === 'string' ? node.data.apiVersion : ''
-  const resourceKind = typeof node.data?.resourceKind === 'string' ? node.data.resourceKind : node.kind
-  return laneId(resourceKind, apiVersionToGroup(apiVersion), namespace, node.name)
+  return laneId(topologyNodeResourceKind(node), apiVersionToGroup(apiVersion), namespace, node.name)
 }
 
 /**
@@ -558,6 +562,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       id,
       kind: p.kind,
       group,
+      identityResolved: groupByKey.has(rk) && !ambiguousResourceKeys.has(rk),
       namespace: p.namespace,
       name: p.name,
       events: seedEvent ? [seedEvent] : [],
@@ -575,6 +580,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       id,
       kind: parsed.kind,
       group: parsed.group,
+      identityResolved: true,
       namespace: parsed.namespace,
       name: parsed.name,
       events: [],
@@ -623,6 +629,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
         id,
         kind: event.kind,
         group,
+        identityResolved: hasAPIVersion || (groupByKey.has(rk) && !ambiguousResourceKeys.has(rk)),
         namespace: event.namespace,
         name: event.name,
         events: [event],
@@ -633,6 +640,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       registerLaneKey(rk, id)
     } else {
       if (!existing.group && group) existing.group = group
+      if (hasAPIVersion || (groupByKey.has(rk) && !ambiguousResourceKeys.has(rk))) existing.identityResolved = true
       existing.events.push(event)
     }
   }
@@ -659,7 +667,9 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   for (const [id, lane] of laneMap) {
     const eventWithOwner = lane.events.find(e => e.owner)
     if (eventWithOwner?.owner) {
-      const ownerId = ensureRefLane(laneResourceKey(eventWithOwner.owner.kind, lane.namespace, eventWithOwner.owner.name))
+      const ownerKey = laneResourceKey(eventWithOwner.owner.kind, lane.namespace, eventWithOwner.owner.name)
+      if (ambiguousResourceKeys.has(ownerKey)) continue
+      const ownerId = ensureRefLane(ownerKey)
       laneParent.set(id, ownerId)
     }
   }
@@ -670,9 +680,6 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       const sourceId = topologyLaneIdByNodeId.get(edge.source)
       const targetId = topologyLaneIdByNodeId.get(edge.target)
       if (!sourceId || !targetId) continue
-
-      // manages: Deployment→RS→Pod (already covered by owner refs, skip)
-      if (edge.type === 'manages') continue
 
       // At least one side must have events
       const sourceExists = laneMap.has(sourceId)
@@ -702,6 +709,15 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
         if (sameAppMembers(childId, parentId)) return
         if (laneParent.has(childId)) return
         laneParent.set(childId, ensureTopologyLane(parentId))
+      }
+
+      // Exact topology ownership supersedes the persisted group-less owner ref.
+      // This matters when two controller API groups share kind/namespace/name.
+      if (edge.type === 'manages') {
+        if (targetExists && !sameAppMembers(targetId, sourceId)) {
+          laneParent.set(targetId, ensureTopologyLane(sourceId))
+        }
+        continue
       }
 
       // exposes: Service→Deployment (Service is parent of Deployment)
@@ -895,8 +911,9 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
 
   // If rootResource is specified, filter to only include lanes related to that resource
   if (rootResource) {
-    const rootLaneId = rootResource.group
-      ? laneId(rootResource.kind, rootResource.group, rootResource.namespace, rootResource.name)
+    const rootGroup = canonicalResourceGroup(rootResource.kind, rootResource.group)
+    const rootLaneId = rootGroup !== undefined
+      ? laneId(rootResource.kind, rootGroup, rootResource.namespace, rootResource.name)
       : resolveId(laneResourceKey(rootResource.kind, rootResource.namespace, rootResource.name))
     const rootLane = topLevelLanes.find(l => l.id === rootLaneId)
 
@@ -941,6 +958,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       id: rootLaneId,
       kind: rootResource.kind,
       group: parseLaneId(rootLaneId)?.group || '',
+      identityResolved: rootGroup !== undefined,
       namespace: rootResource.namespace,
       name: rootResource.name,
       events: [],
@@ -1110,9 +1128,12 @@ export function getAllEventsFromHierarchy(lanes: ResourceLane[]): TimelineEvent[
  */
 export interface PinnedResourceRef {
   type?: 'resource'
-  /** "Kind/namespace/name" — the same id form buildResourceHierarchy emits. */
+  /** Canonical lane id emitted by buildResourceHierarchy. */
   id: string
   kind: string
+  /** Present on newly written pins so a built-in lane remains distinguishable
+   *  from a same-kind CRD. Older localStorage records legitimately omit it. */
+  group?: string
   namespace: string
   name: string
 }
@@ -1143,7 +1164,75 @@ export function isPinnedLaneRef(value: unknown): value is PinnedLaneRef {
   if (v.type === 'appGroup') {
     return typeof v.appKey === 'string' && typeof v.appName === 'string'
   }
-  return typeof v.kind === 'string' && typeof v.namespace === 'string' && typeof v.name === 'string'
+  return typeof v.kind === 'string'
+    && (v.group === undefined || typeof v.group === 'string')
+    && typeof v.namespace === 'string'
+    && typeof v.name === 'string'
+}
+
+interface LaneIdentityIndex {
+  byId: Map<string, ResourceLane>
+  byUnqualified: Map<string, ResourceLane[]>
+}
+
+function indexLanesByIdentity(allLanes: ResourceLane[]): LaneIdentityIndex {
+  const byId = new Map<string, ResourceLane>()
+  const byUnqualified = new Map<string, ResourceLane[]>()
+  const indexLane = (lane: ResourceLane): void => {
+    if (!byId.has(lane.id)) byId.set(lane.id, lane)
+    const parsed = parseLaneId(lane.id)
+    if (parsed && !lane.isAppGroup) {
+      const key = laneResourceKey(parsed.kind, parsed.namespace, parsed.name)
+      const candidates = byUnqualified.get(key) ?? []
+      if (!candidates.some((candidate) => candidate.id === lane.id)) candidates.push(lane)
+      byUnqualified.set(key, candidates)
+    }
+    for (const child of lane.children ?? []) indexLane(child)
+  }
+  for (const lane of allLanes) indexLane(lane)
+  return { byId, byUnqualified }
+}
+
+function resolvePinnedResourceLane(ref: PinnedResourceRef, index: LaneIdentityIndex): ResourceLane | undefined {
+  const key = laneResourceKey(ref.kind, ref.namespace, ref.name)
+  const candidates = index.byUnqualified.get(key) ?? []
+  if (ref.group !== undefined) {
+    const canonical = laneId(ref.kind, ref.group, ref.namespace, ref.name)
+    const exact = index.byId.get(canonical)
+    const refGroup = canonicalResourceGroup(ref.kind, ref.group)
+    if (exact && canonicalResourceGroup(exact.kind, exact.group) === refGroup) return exact
+    const matching = candidates.filter((candidate) => canonicalResourceGroup(candidate.kind, candidate.group) === refGroup)
+    return matching.length === 1 ? matching[0] : undefined
+  }
+  return candidates.length === 1 ? candidates[0] : undefined
+}
+
+/** Resolve persisted resource pins onto current canonical lane IDs. Older pins
+ *  omitted API group, so they migrate only when kind/namespace/name identifies
+ *  exactly one live lane; collisions intentionally stay unresolved. */
+export function resolvePinnedLaneIds(allLanes: ResourceLane[], pinnedRefs: PinnedLaneRef[]): Set<string> {
+  const index = indexLanesByIdentity(allLanes)
+  const resolved = new Set<string>()
+  for (const ref of pinnedRefs) {
+    if (ref.type === 'appGroup') {
+      resolved.add(ref.id)
+      continue
+    }
+    const candidates = index.byUnqualified.get(laneResourceKey(ref.kind, ref.namespace, ref.name)) ?? []
+    const lane = resolvePinnedResourceLane(ref, index)
+    if (lane) resolved.add(lane.id)
+    else if (ref.group !== undefined || candidates.length === 0) resolved.add(ref.id)
+  }
+  return resolved
+}
+
+export function pinnedLaneRefMatches(stored: PinnedLaneRef, incoming: PinnedLaneRef): boolean {
+  if (stored.type === 'appGroup' || incoming.type === 'appGroup') {
+    return stored.type === 'appGroup' && incoming.type === 'appGroup' && stored.appKey === incoming.appKey
+  }
+  if (stored.kind !== incoming.kind || stored.namespace !== incoming.namespace || stored.name !== incoming.name) return false
+  if (stored.group === undefined) return true
+  return canonicalResourceGroup(stored.kind, stored.group) === canonicalResourceGroup(incoming.kind, incoming.group)
 }
 
 /** Ensure a lane carries a merged allEventsSorted (own + descendants). Roots and
@@ -1159,9 +1248,8 @@ function synthesizeEmptyPinnedLane(ref: PinnedResourceRef): ResourceLane {
   return {
     id: ref.id,
     kind: ref.kind,
-    // Recover the group from the id so an absent CRD pin still carries it (the
-    // pin record itself stores none). Bare/built-in ids yield ''.
-    group: parseLaneId(ref.id)?.group || '',
+    group: ref.group ?? parseLaneId(ref.id)?.group ?? '',
+    identityResolved: ref.group !== undefined,
     namespace: ref.namespace,
     name: ref.name,
     events: [],
@@ -1245,12 +1333,11 @@ export function removePinnedLanes(
  */
 export function extractPinnedLanes(allLanes: ResourceLane[], pinnedRefs: PinnedLaneRef[]): ResourceLane[] {
   if (pinnedRefs.length === 0) return []
-  const byId = new Map<string, ResourceLane>()
+  const identityIndex = indexLanesByIdentity(allLanes)
   // App-group headers re-resolve by appKey (live members), independent of the
   // deterministic "app:<appKey>" id, so a group survives grouping-mode churn.
   const groupByAppKey = new Map<string, ResourceLane>()
   const indexLane = (lane: ResourceLane): void => {
-    if (!byId.has(lane.id)) byId.set(lane.id, lane)
     if (lane.isAppGroup && lane.appKey && !groupByAppKey.has(lane.appKey)) {
       groupByAppKey.set(lane.appKey, lane)
     }
@@ -1285,9 +1372,15 @@ export function extractPinnedLanes(allLanes: ResourceLane[], pinnedRefs: PinnedL
       out.push(found ? withAllEventsSorted(found) : synthesizeQuietAppGroupLane(ref))
       continue
     }
-    if (coveredByPinnedGroup.has(ref.id)) continue // folded into a pinned app group
-    const found = byId.get(ref.id)
-    out.push(found ? withAllEventsSorted(found) : synthesizeEmptyPinnedLane(ref))
+    const found = resolvePinnedResourceLane(ref, identityIndex)
+    if (found && coveredByPinnedGroup.has(found.id)) continue // folded into a pinned app group
+    if (found) {
+      out.push(withAllEventsSorted(found))
+      continue
+    }
+    const candidates = identityIndex.byUnqualified.get(laneResourceKey(ref.kind, ref.namespace, ref.name)) ?? []
+    if (ref.group === undefined && candidates.length > 1) continue
+    out.push(synthesizeEmptyPinnedLane(ref))
   }
   return out
 }

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -84,7 +84,7 @@ export interface HierarchyOptions {
   events: TimelineEvent[]
   topology?: Topology
   /** If provided, returns only the hierarchy rooted at this resource */
-  rootResource?: { kind: string; namespace: string; name: string }
+  rootResource?: { kind: string; group?: string; namespace: string; name: string }
   /** Legacy toggle. Kept for back-compat (WorkloadView): true→'app', false→'owner'
    *  when `grouping` is omitted. Prefer `grouping`. */
   groupByApp?: boolean
@@ -184,7 +184,7 @@ function isGeneratedNameChildOf(laneName: string, memberName: string): boolean {
  *  owner:null + labels:null (connector cache miss) but whose name still encodes
  *  its Deployment. Scoped to the SAME namespace; only workload-ish member kinds
  *  count. Longest member-name wins (so "web-admin" beats "web" for a
- *  web-admin-xyz pod); ties resolve to the first key in index order. */
+ *  web-admin-xyz pod); an equal-length cross-app tie fails closed. */
 export function matchLaneByMemberNamePrefix(
   lane: { kind: string; namespace: string; name: string },
   index: AppMembershipIndex,
@@ -192,25 +192,21 @@ export function matchLaneByMemberNamePrefix(
   if (!GENERATED_NAME_LANE_KINDS.has(lane.kind)) return null
   let best: AppMembership | null = null
   let bestLen = -1
+  let ambiguous = false
   for (const [key, membership] of index.byResource) {
-    // key form: 'Kind/namespace/name'. Namespaces + names can't contain '/', so
-    // the first two slashes bound the kind and namespace segments.
-    const slash1 = key.indexOf('/')
-    if (slash1 < 0) continue
-    const slash2 = key.indexOf('/', slash1 + 1)
-    if (slash2 < 0) continue
-    const kind = key.slice(0, slash1)
-    if (!NAME_PREFIX_MEMBER_KINDS.has(kind)) continue
-    const ns = key.slice(slash1 + 1, slash2)
-    if (ns !== lane.namespace) continue
-    const memberName = key.slice(slash2 + 1)
-    if (!isGeneratedNameChildOf(lane.name, memberName)) continue
-    if (memberName.length > bestLen) {
+    const member = parseLaneId(key)
+    if (!member || !NAME_PREFIX_MEMBER_KINDS.has(member.kind)) continue
+    if (member.namespace !== lane.namespace) continue
+    if (!isGeneratedNameChildOf(lane.name, member.name)) continue
+    if (member.name.length > bestLen) {
       best = membership
-      bestLen = memberName.length
+      bestLen = member.name.length
+      ambiguous = false
+    } else if (member.name.length === bestLen && best && membership.appKey !== best.appKey) {
+      ambiguous = true
     }
   }
-  return best
+  return ambiguous ? null : best
 }
 
 // Parent-driven naming contracts. Confidence ladder: ownerRef (fact) >
@@ -300,9 +296,11 @@ function contractParentId(
  *  falls back to owner grouping until hub-side membership snapshots (the
  *  retention-grade fix) exist. */
 function cascadeRootMembership(lane: ResourceLane, appIndex: AppMembershipIndex): RootGroupAssignment | null {
-  // byResource is keyed group-less (AppRow workloads carry no group), so a
-  // CRD lane's group-qualified id must join via its group-less resource key.
-  const direct = appIndex.byResource.get(laneResourceKey(lane.kind, lane.namespace, lane.name))
+  const unqualified = laneResourceKey(lane.kind, lane.namespace, lane.name)
+  const direct = lane.group
+    ? appIndex.byResource.get(lane.id)
+    : appIndex.byUnqualifiedResource?.get(unqualified)
+      ?? (!appIndex.byUnqualifiedResource ? appIndex.byResource.get(lane.id) : undefined)
   if (direct) return { membership: direct, structural: true }
   for (const key of evidenceKeysForLane(lane)) {
     const m = appIndex.byEvidence.get(key)
@@ -421,63 +419,11 @@ export function isProblematicEvent(event: TimelineEvent): boolean {
   return false
 }
 
-/**
- * Convert topology node ID to lane ID format.
- * Node IDs are formatted as: kind/namespace/name (e.g., "pod/default/nginx-abc123")
- * Lane IDs are formatted as: Kind/namespace/name (e.g., "Pod/default/nginx-abc123")
- */
-function nodeIdToLaneId(nodeId: string): string | null {
-  const parts = nodeId.split('/')
-  if (parts.length < 3) return null
-  const kind = parts[0]
-  const namespace = parts[1]
-  const name = parts[2]
-  // Maps lowercase topology node IDs to PascalCase kind names used in timeline lane IDs.
-  const kindMap: Record<string, string> = {
-    pod: 'Pod', service: 'Service', deployment: 'Deployment',
-    replicaset: 'ReplicaSet', statefulset: 'StatefulSet', daemonset: 'DaemonSet',
-    ingress: 'Ingress', gateway: 'Gateway', httproute: 'HTTPRoute',
-    grpcroute: 'GRPCRoute', tcproute: 'TCPRoute', tlsroute: 'TLSRoute',
-    configmap: 'ConfigMap', secret: 'Secret',
-    persistentvolumeclaim: 'PersistentVolumeClaim',
-    persistentvolume: 'PersistentVolume', storageclass: 'StorageClass',
-    job: 'Job', cronjob: 'CronJob',
-    horizontalpodautoscaler: 'HorizontalPodAutoscaler',
-    verticalpodautoscaler: 'VerticalPodAutoscaler',
-    poddisruptionbudget: 'PodDisruptionBudget',
-    podgroup: 'PodGroup', rollout: 'Rollout', namespace: 'Namespace',
-    node: 'Node',
-    application: 'Application', applicationset: 'ApplicationSet', appproject: 'AppProject',
-    kustomization: 'Kustomization',
-    helmrelease: 'HelmRelease', helmrepository: 'HelmRepository',
-    helmchart: 'HelmChart', gitrepository: 'GitRepository',
-    ocirepository: 'OCIRepository', certificate: 'Certificate',
-    // Istio
-    virtualservice: 'VirtualService', destinationrule: 'DestinationRule',
-    istiogateway: 'IstioGateway', serviceentry: 'ServiceEntry',
-    peerauthentication: 'PeerAuthentication', authorizationpolicy: 'AuthorizationPolicy',
-    // KEDA
-    scaledobject: 'ScaledObject', scaledjob: 'ScaledJob',
-    // Karpenter
-    nodepool: 'NodePool', nodeclaim: 'NodeClaim',
-    // cert-manager
-    issuer: 'Issuer', clusterissuer: 'ClusterIssuer',
-    // Knative
-    knativeservice: 'KnativeService', knativeconfiguration: 'KnativeConfiguration',
-    knativerevision: 'KnativeRevision', knativeroute: 'KnativeRoute',
-    broker: 'Broker', trigger: 'Trigger', channel: 'Channel',
-    pingsource: 'PingSource', apiserversource: 'ApiServerSource',
-    containersource: 'ContainerSource', sinkbinding: 'SinkBinding',
-    // Traefik
-    ingressroute: 'IngressRoute', ingressroutetcp: 'IngressRouteTCP',
-    ingressrouteudp: 'IngressRouteUDP', middleware: 'Middleware',
-    middlewaretcp: 'MiddlewareTCP', traefikservice: 'TraefikService',
-    serverstransport: 'ServersTransport', serverstransporttcp: 'ServersTransportTCP',
-    tlsoption: 'TLSOption', tlsstore: 'TLSStore',
-    // Contour
-    httpproxy: 'HTTPProxy',
-  }
-  return `${kindMap[kind] || kind}/${namespace}/${name}`
+function topologyNodeLaneId(node: Topology['nodes'][number]): string {
+  const namespace = typeof node.data?.namespace === 'string' ? node.data.namespace : ''
+  const apiVersion = typeof node.data?.apiVersion === 'string' ? node.data.apiVersion : ''
+  const resourceKind = typeof node.data?.resourceKind === 'string' ? node.data.resourceKind : node.kind
+  return laneId(resourceKind, apiVersionToGroup(apiVersion), namespace, node.name)
 }
 
 /**
@@ -554,49 +500,53 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   const grouping: TimelineGrouping = options.grouping ?? (options.groupByApp === false ? 'owner' : 'app')
   const laneMap = new Map<string, ResourceLane>()
 
-  // API group lookup by group-less resource key (Kind/ns/name) sourced from
-  // topology nodes — the fallback group for lanes/refs whose events don't carry
-  // apiVersion (owner refs and topology endpoints never do).
-  const topoGroupByKey = new Map<string, string>()
-  if (topology?.nodes) {
-    for (const node of topology.nodes) {
-      const key = nodeIdToLaneId(node.id)
-      if (!key) continue
-      const group = apiVersionToGroup(node.data?.apiVersion as string | undefined)
-      if (group) topoGroupByKey.set(key, group)
-    }
+  const topologyLaneIdByNodeId = new Map<string, string>()
+  const identityGroupsByResourceKey = new Map<string, Set<string>>()
+  for (const node of topology?.nodes ?? []) {
+    const id = topologyNodeLaneId(node)
+    topologyLaneIdByNodeId.set(node.id, id)
+    const parsed = parseLaneId(id)!
+    const rk = laneResourceKey(parsed.kind, parsed.namespace, parsed.name)
+    const groups = identityGroupsByResourceKey.get(rk) ?? new Set<string>()
+    groups.add(parsed.group)
+    identityGroupsByResourceKey.set(rk, groups)
   }
-  // First apiVersion-derived group seen per resource key — the fallback used to
-  // attribute a same-resource event that shipped WITHOUT apiVersion (a stored
-  // event) onto the group-qualified lane its apiVersion-carrying siblings built,
-  // instead of forking a bare duplicate. It does NOT collapse a genuine
-  // collision: colliding events differ in apiVersion, so each still qualifies to
-  // its own group; only truly group-less events fall back here.
-  const groupByKey = new Map<string, string>()
+
+  // Merge exact identities from topology and timeline. Built-in groups share
+  // the same bare lane identity; CRD groups remain distinct.
   for (const event of events) {
-    if (event.kind === 'Event' && event.owner) continue
-    const g = apiVersionToGroup(event.apiVersion)
-    if (g) {
-      const rk = laneResourceKey(event.kind, event.namespace, event.name)
-      if (!groupByKey.has(rk)) groupByKey.set(rk, g)
-    }
+    if ((event.kind === 'Event' && event.owner) || !event.apiVersion) continue
+    const rk = laneResourceKey(event.kind, event.namespace, event.name)
+    const groups = identityGroupsByResourceKey.get(rk) ?? new Set<string>()
+    const group = apiVersionToGroup(event.apiVersion)
+    groups.add(groupQualifiesLaneId(group) ? group : '')
+    identityGroupsByResourceKey.set(rk, groups)
+  }
+
+  // API group fallback for a stored event that shipped without apiVersion.
+  // A same-kind/name collision is ambiguous and therefore supplies no fallback.
+  const groupByKey = new Map<string, string>()
+  const ambiguousResourceKeys = new Set<string>()
+  for (const [rk, groups] of identityGroupsByResourceKey) {
+    if (groups.size === 1) groupByKey.set(rk, groups.values().next().value ?? '')
+    else ambiguousResourceKeys.add(rk)
   }
   // The group for a resource key when the reference itself carries none.
-  const fallbackGroup = (rk: string): string => groupByKey.get(rk) ?? topoGroupByKey.get(rk) ?? ''
+  const fallbackGroup = (rk: string): string => groupByKey.get(rk) ?? ''
 
   // Group-less resource key → canonical (possibly group-qualified) lane id. Lets
-  // group-less references (owner refs, K8s-event involvedObject, topology node
-  // ids — none carry a group) reconcile onto the real lane instead of forking a
-  // bare duplicate. First writer wins: when two CRDs collide on kind+ns+name the
-  // map holds one, and a group-agnostic owner/topology match resolving to it is
-  // the accepted residual (see the confidence-ladder note above).
+  // owner refs and K8s-event involvedObjects reconcile onto the real lane instead
+  // of forking a bare duplicate when identity is unambiguous. Ambiguous refs stay
+  // bare; topology endpoints use the exact node-id map above.
   const laneIdByKey = new Map<string, string>()
   const registerLaneKey = (rk: string, id: string): void => {
     if (!laneIdByKey.has(rk)) laneIdByKey.set(rk, id)
   }
   // Get-or-create the lane for a group-less reference, returning its canonical id.
   const ensureRefLane = (rk: string, seedEvent?: TimelineEvent): string => {
-    const existing = laneIdByKey.get(rk)
+    const existing = ambiguousResourceKeys.has(rk)
+      ? (laneMap.has(rk) ? rk : undefined)
+      : laneIdByKey.get(rk)
     if (existing) {
       if (seedEvent) laneMap.get(existing)!.events.push(seedEvent)
       return existing
@@ -618,10 +568,29 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     registerLaneKey(rk, id)
     return id
   }
+  const ensureTopologyLane = (id: string): string => {
+    if (laneMap.has(id)) return id
+    const parsed = parseLaneId(id)!
+    laneMap.set(id, {
+      id,
+      kind: parsed.kind,
+      group: parsed.group,
+      namespace: parsed.namespace,
+      name: parsed.name,
+      events: [],
+      isWorkload: isWorkloadKind(parsed.kind),
+      children: [],
+      childEventCount: 0,
+    })
+    registerLaneKey(laneResourceKey(parsed.kind, parsed.namespace, parsed.name), id)
+    return id
+  }
   // The canonical id a group-less key resolves to, WITHOUT creating a lane —
   // agrees with ensureRefLane so guards keyed by canonical id line up.
   const resolveId = (rk: string): string => {
-    const existing = laneIdByKey.get(rk)
+    const existing = ambiguousResourceKeys.has(rk)
+      ? (laneMap.has(rk) ? rk : undefined)
+      : laneIdByKey.get(rk)
     if (existing) return existing
     const p = parseLaneId(rk)!
     return laneId(p.kind, fallbackGroup(rk), p.namespace, p.name)
@@ -639,13 +608,15 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     }
 
     const rk = laneResourceKey(event.kind, event.namespace, event.name)
-    // Per-event group qualifies the id, so two same-kind CRDs from different
-    // vendors (CAPI vs CNPG `Cluster`) never merge. A group-less event reconciles
-    // onto whatever lane already exists for the resource (or a bare one).
-    const group = apiVersionToGroup(event.apiVersion) || fallbackGroup(rk)
-    const id = groupQualifiesLaneId(group)
+    // An explicit apiVersion always chooses its canonical lane, including a
+    // built-in group whose canonical id is bare. Only an event that omitted
+    // apiVersion reconciles through the group-less registry.
+    const hasAPIVersion = !!event.apiVersion
+    const group = hasAPIVersion ? apiVersionToGroup(event.apiVersion) : fallbackGroup(rk)
+    const id = hasAPIVersion || groupQualifiesLaneId(group)
       ? laneId(event.kind, group, event.namespace, event.name)
-      : (laneIdByKey.get(rk) ?? laneResourceKey(event.kind, event.namespace, event.name))
+      : (!ambiguousResourceKeys.has(rk) ? laneIdByKey.get(rk) : undefined)
+        ?? laneResourceKey(event.kind, event.namespace, event.name)
     const existing = laneMap.get(id)
     if (!existing) {
       laneMap.set(id, {
@@ -694,21 +665,18 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   }
 
   // Source 2: Topology edges (for Service→Deployment, Ingress→Service, ConfigMap→Deployment).
-  // Node ids are group-less keys; endpoints resolve onto their canonical lanes via
-  // the registry (parenting a child under a possibly group-qualified parent), and a
-  // missing endpoint is materialized with its topology-known group.
   if (topology?.edges) {
     for (const edge of topology.edges) {
-      const sourceKey = nodeIdToLaneId(edge.source)
-      const targetKey = nodeIdToLaneId(edge.target)
-      if (!sourceKey || !targetKey) continue
+      const sourceId = topologyLaneIdByNodeId.get(edge.source)
+      const targetId = topologyLaneIdByNodeId.get(edge.target)
+      if (!sourceId || !targetId) continue
 
       // manages: Deployment→RS→Pod (already covered by owner refs, skip)
       if (edge.type === 'manages') continue
 
       // At least one side must have events
-      const sourceExists = laneIdByKey.has(sourceKey)
-      const targetExists = laneIdByKey.has(targetKey)
+      const sourceExists = laneMap.has(sourceId)
+      const targetExists = laneMap.has(targetId)
       if (!sourceExists && !targetExists) continue
 
       // App membership outranks topology attachment: two members of the SAME
@@ -718,64 +686,57 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       // the whole stack with the attachment (a health-less Service) instead of
       // the app. Only the byResource tier applies — both endpoints here are
       // concrete resources the server either claims or doesn't.
-      const sameAppMembers = (aKey: string, bKey: string): boolean => {
+      const sameAppMembers = (aId: string, bId: string): boolean => {
         if (grouping !== 'app' || !appIndex) return false
-        const toResourceKey = (key: string): string | null => {
-          const parsed = parseLaneId(key)
-          return parsed ? laneResourceKey(parsed.kind, parsed.namespace, parsed.name) : null
-        }
-        const aRes = toResourceKey(aKey)
-        const a = aRes ? appIndex.byResource.get(aRes) : undefined
+        const a = appIndex.byResource.get(aId)
         if (!a) return false
-        const bRes = toResourceKey(bKey)
-        const b = bRes ? appIndex.byResource.get(bRes) : undefined
+        const b = appIndex.byResource.get(bId)
         return b != null && a.appKey === b.appKey
       }
 
       // Parent `child` under `parent`, materializing `parent`'s lane if absent.
       // `childHasEvents` mirrors the old guard (only parent an endpoint that
       // actually exists). Guards read canonical ids so laneParent lines up.
-      const link = (childKey: string, parentKey: string, childHasEvents: boolean): void => {
+      const link = (childId: string, parentId: string, childHasEvents: boolean): void => {
         if (!childHasEvents) return
-        if (sameAppMembers(childKey, parentKey)) return
-        const childId = resolveId(childKey)
+        if (sameAppMembers(childId, parentId)) return
         if (laneParent.has(childId)) return
-        laneParent.set(childId, ensureRefLane(parentKey))
+        laneParent.set(childId, ensureTopologyLane(parentId))
       }
 
       // exposes: Service→Deployment (Service is parent of Deployment)
       if (edge.type === 'exposes') {
-        link(targetKey, sourceKey, targetExists)
+        link(targetId, sourceId, targetExists)
       }
 
       // routes-to has two cases:
       // 1. Ingress→Service: Service should be parent (representative)
       // 2. Service→Pod/PodGroup: Service should be parent (normal hierarchy)
       if (edge.type === 'routes-to') {
-        const sourceKind = sourceKey.split('/')[0]
-        const targetKind = targetKey.split('/')[0]
+        const sourceKind = parseLaneId(sourceId)!.kind
+        const targetKind = parseLaneId(targetId)!.kind
 
         // Gateway→Route: Gateway is parent of Route
         if (sourceKind === 'Gateway' && (targetKind === 'HTTPRoute' || targetKind === 'GRPCRoute' || targetKind === 'TCPRoute' || targetKind === 'TLSRoute')) {
-          link(targetKey, sourceKey, targetExists)
+          link(targetId, sourceId, targetExists)
         }
         // Route→Service: reverse (Service is representative, like Ingress)
         else if ((sourceKind === 'HTTPRoute' || sourceKind === 'GRPCRoute' || sourceKind === 'TCPRoute' || sourceKind === 'TLSRoute') && targetKind === 'Service') {
-          link(sourceKey, targetKey, sourceExists)
+          link(sourceId, targetId, sourceExists)
         }
         // Ingress→Service: reverse relationship (Service is representative)
         else if (sourceKind === 'Ingress' && targetKind === 'Service') {
-          link(sourceKey, targetKey, sourceExists)
+          link(sourceId, targetId, sourceExists)
         }
         // Service→Pod/PodGroup: normal direction (Service is parent)
         else if (sourceKind === 'Service') {
-          link(targetKey, sourceKey, targetExists)
+          link(targetId, sourceId, targetExists)
         }
       }
 
       // configures/uses/protects: ConfigMap→Deployment, HPA→Deployment, PDB→Deployment (target is parent)
       if (edge.type === 'configures' || edge.type === 'uses' || edge.type === 'protects') {
-        link(sourceKey, targetKey, sourceExists)
+        link(sourceId, targetId, sourceExists)
       }
     }
   }
@@ -787,16 +748,13 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   // membership cascade below replaces this. Kept so WorkloadView and index-less
   // callers keep today's behavior.
   if (grouping === 'app' && !appIndex && topology?.nodes) {
-    // Keyed by group-less resource key (the topology node id form), so a CRD
-    // lane's group-qualified id still matches via its key.
     const laneAppLabels = new Map<string, string>()
     for (const node of topology.nodes) {
-      const key = nodeIdToLaneId(node.id)
-      if (!key) continue
+      const id = topologyLaneIdByNodeId.get(node.id)!
       const labels = node.data?.labels as Record<string, string> | undefined
       const appLabel = labels?.['app.kubernetes.io/name'] || labels?.['app']
       if (appLabel) {
-        laneAppLabels.set(key, appLabel)
+        laneAppLabels.set(id, appLabel)
       }
     }
 
@@ -820,7 +778,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     for (const [id, lane] of laneMap) {
       if (laneParent.has(id)) continue
       if (!appLabelEligibleKinds.has(lane.kind)) continue
-      const appLabel = laneAppLabels.get(laneResourceKey(lane.kind, lane.namespace, lane.name))
+      const appLabel = laneAppLabels.get(id)
       if (!appLabel) continue
       const groupKey = `${lane.namespace}/${appLabel}`
       if (!appGroups.has(groupKey)) {
@@ -937,10 +895,9 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
 
   // If rootResource is specified, filter to only include lanes related to that resource
   if (rootResource) {
-    // Resolve to the canonical (possibly group-qualified) id so a CRD root matches
-    // the lanes built from its events. rootResource carries no group; resolveId
-    // uses the registry (its own events) or the topology/event group fallback.
-    const rootLaneId = resolveId(laneResourceKey(rootResource.kind, rootResource.namespace, rootResource.name))
+    const rootLaneId = rootResource.group
+      ? laneId(rootResource.kind, rootResource.group, rootResource.namespace, rootResource.name)
+      : resolveId(laneResourceKey(rootResource.kind, rootResource.namespace, rootResource.name))
     const rootLane = topLevelLanes.find(l => l.id === rootLaneId)
 
     if (rootLane) {

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -727,9 +727,19 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       }
 
       // Exact topology ownership supersedes the persisted group-less owner ref.
-      // This matters when two controller API groups share kind/namespace/name.
+      // This matters when two controller API groups share kind/namespace/name
+      // (a real Kubernetes ownerReference chain, e.g. Deployment->RS->Pod or a
+      // collision-prone controller like Volcano's Job).
+      //
+      // A FluxCD source (GitRepository/OCIRepository/HelmRepository) also
+      // reaches its Kustomization/HelmRelease through a 'manages' edge, but
+      // that's spec.sourceRef, not an ownerReference the source controls --
+      // applying the same override here would nest an app-group root under a
+      // materialized, event-less source lane and hide it from the top level.
+      const sourceKind = parseLaneId(sourceId)?.kind
+      const sourceIsGitOpsSource = sourceKind === 'GitRepository' || sourceKind === 'OCIRepository' || sourceKind === 'HelmRepository'
       if (edge.type === 'manages') {
-        if (targetExists && !sameAppMembers(targetId, sourceId)) {
+        if (targetExists && !sourceIsGitOpsSource && !sameAppMembers(targetId, sourceId)) {
           laneParent.set(targetId, ensureTopologyLane(sourceId))
         }
         continue

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -535,8 +535,16 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     if (groups.size === 1) groupByKey.set(rk, groups.values().next().value ?? '')
     else ambiguousResourceKeys.add(rk)
   }
+  // Reserved pseudo-group for a genuinely ambiguous key (2+ groups collide on
+  // this kind/ns/name and the reference itself carries no apiVersion to pick
+  // one). No real Kubernetes API group can equal this string, so laneId()
+  // always group-qualifies it — the synthesized lane can never coincide with
+  // a real group's canonical id, including a built-in's bare `Kind/ns/name`
+  // form (an empty-string fallback would silently collapse into that).
+  const AMBIGUOUS_GROUP = ' ambiguous'
   // The group for a resource key when the reference itself carries none.
-  const fallbackGroup = (rk: string): string => groupByKey.get(rk) ?? ''
+  const fallbackGroup = (rk: string): string =>
+    ambiguousResourceKeys.has(rk) ? AMBIGUOUS_GROUP : (groupByKey.get(rk) ?? '')
 
   // Group-less resource key → canonical (possibly group-qualified) lane id. Lets
   // owner refs and K8s-event involvedObjects reconcile onto the real lane instead
@@ -546,10 +554,17 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   const registerLaneKey = (rk: string, id: string): void => {
     if (!laneIdByKey.has(rk)) laneIdByKey.set(rk, id)
   }
+  // The lane id an ambiguous key resolves to — same computation ensureRefLane
+  // and resolveId use to create one, so a lookup here always agrees with a
+  // subsequent get-or-create.
+  const ambiguousLaneId = (rk: string): string => {
+    const p = parseLaneId(rk)!
+    return laneId(p.kind, AMBIGUOUS_GROUP, p.namespace, p.name)
+  }
   // Get-or-create the lane for a group-less reference, returning its canonical id.
   const ensureRefLane = (rk: string, seedEvent?: TimelineEvent): string => {
     const existing = ambiguousResourceKeys.has(rk)
-      ? (laneMap.has(rk) ? rk : undefined)
+      ? (laneMap.has(ambiguousLaneId(rk)) ? ambiguousLaneId(rk) : undefined)
       : laneIdByKey.get(rk)
     if (existing) {
       if (seedEvent) laneMap.get(existing)!.events.push(seedEvent)
@@ -595,7 +610,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   // agrees with ensureRefLane so guards keyed by canonical id line up.
   const resolveId = (rk: string): string => {
     const existing = ambiguousResourceKeys.has(rk)
-      ? (laneMap.has(rk) ? rk : undefined)
+      ? (laneMap.has(ambiguousLaneId(rk)) ? ambiguousLaneId(rk) : undefined)
       : laneIdByKey.get(rk)
     if (existing) return existing
     const p = parseLaneId(rk)!
@@ -1196,10 +1211,18 @@ function indexLanesByIdentity(allLanes: ResourceLane[]): LaneIdentityIndex {
 function resolvePinnedResourceLane(ref: PinnedResourceRef, index: LaneIdentityIndex): ResourceLane | undefined {
   const key = laneResourceKey(ref.kind, ref.namespace, ref.name)
   const candidates = index.byUnqualified.get(key) ?? []
-  if (ref.group !== undefined) {
-    const canonical = laneId(ref.kind, ref.group, ref.namespace, ref.name)
+  // A pin's `group` field is a later addition (PinnedResourceRef's own
+  // comment: "Older localStorage records legitimately omit it"), but its
+  // persisted `id` — the canonical lane id at save time — already carries a
+  // CRD group in its `.group` suffix, if it had one. Recovering that instead
+  // of treating an absent field as "group unknown" is what stops an old
+  // qualified pin from resolving onto a same-named lane in the WRONG group
+  // once its own group's lane goes away.
+  const group = ref.group ?? (parseLaneId(ref.id)?.group || undefined)
+  if (group !== undefined) {
+    const canonical = laneId(ref.kind, group, ref.namespace, ref.name)
     const exact = index.byId.get(canonical)
-    const refGroup = canonicalResourceGroup(ref.kind, ref.group)
+    const refGroup = canonicalResourceGroup(ref.kind, group)
     if (exact && canonicalResourceGroup(exact.kind, exact.group) === refGroup) return exact
     const matching = candidates.filter((candidate) => canonicalResourceGroup(candidate.kind, candidate.group) === refGroup)
     return matching.length === 1 ? matching[0] : undefined
@@ -1231,8 +1254,13 @@ export function pinnedLaneRefMatches(stored: PinnedLaneRef, incoming: PinnedLane
     return stored.type === 'appGroup' && incoming.type === 'appGroup' && stored.appKey === incoming.appKey
   }
   if (stored.kind !== incoming.kind || stored.namespace !== incoming.namespace || stored.name !== incoming.name) return false
-  if (stored.group === undefined) return true
-  return canonicalResourceGroup(stored.kind, stored.group) === canonicalResourceGroup(incoming.kind, incoming.group)
+  // A group-less `stored.group` is a wildcard ONLY when the stored id itself
+  // never encoded a group either — an old id that already carries a CRD
+  // group (`Cluster.postgresql.cnpg.io/...`) must not be treated as matching
+  // every group, or a CNPG pin would report a match against a CAPI ref.
+  const storedGroup = stored.group ?? (parseLaneId(stored.id)?.group || undefined)
+  if (storedGroup === undefined) return true
+  return canonicalResourceGroup(stored.kind, storedGroup) === canonicalResourceGroup(incoming.kind, incoming.group)
 }
 
 /** Ensure a lane carries a merged allEventsSorted (own + descendants). Roots and
@@ -1249,7 +1277,7 @@ function synthesizeEmptyPinnedLane(ref: PinnedResourceRef): ResourceLane {
     id: ref.id,
     kind: ref.kind,
     group: ref.group ?? parseLaneId(ref.id)?.group ?? '',
-    identityResolved: ref.group !== undefined,
+    identityResolved: (ref.group ?? (parseLaneId(ref.id)?.group || undefined)) !== undefined,
     namespace: ref.namespace,
     name: ref.name,
     events: [],

--- a/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { batchRunParentNodes, neighborhoodFor, tagWorkloadOwnership } from './topology-neighborhood'
+import { batchRunParentNodes, neighborhoodFor, tagWorkloadOwnership, workloadKey } from './topology-neighborhood'
 import type { Topology, NodeKind, EdgeType } from '../types/core'
 
 function node(id: string, kind: string, ns: string, name: string): Topology['nodes'][number] {
@@ -177,6 +177,33 @@ describe('neighborhoodFor', () => {
     }
     const out = neighborhoodFor(topo, [{ kind: 'Workflow', group: 'argoproj.io', namespace: 'app', name: 'run' }])
     expect(out.nodes.map((n) => n.id)).toEqual(['argo'])
+  })
+
+  it('matches typed built-ins whose topology node omits apiVersion', () => {
+    const topo: Topology = {
+      nodes: [node('dep', 'Deployment', 'app', 'web')],
+      edges: [],
+    }
+    const out = neighborhoodFor(topo, [
+      { kind: 'Deployment', group: 'apps', namespace: 'app', name: 'web' },
+    ])
+    expect(out.nodes.map((n) => n.id)).toEqual(['dep'])
+  })
+
+  it('matches collision pseudo-nodes through their Kubernetes resource kind', () => {
+    const service = crdNode('knative', 'KnativeService', 'app', 'web', 'serving.knative.dev/v1')
+    service.data = { ...service.data, resourceKind: 'Service' }
+    const topo: Topology = { nodes: [service], edges: [] }
+    const out = neighborhoodFor(topo, [
+      { kind: 'Service', group: 'serving.knative.dev', namespace: 'app', name: 'web' },
+    ])
+    expect(out.nodes.map((n) => n.id)).toEqual(['knative'])
+  })
+
+  it('qualifies workload keys only for CRD groups', () => {
+    expect(workloadKey({ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train' })).toBe('Job/ml/train')
+    expect(workloadKey({ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train' }))
+      .toBe('Job.batch.volcano.sh/ml/train')
   })
 
   it('expands from an Argo WorkflowTemplate to its runs and run pods', () => {

--- a/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
@@ -200,6 +200,23 @@ describe('neighborhoodFor', () => {
     expect(out.nodes.map((n) => n.id)).toEqual(['knative'])
   })
 
+  it('does not blend a core Service seed with a same-named Knative Service', () => {
+    const core = node('core', 'Service', 'app', 'web')
+    const knative = crdNode('knative', 'KnativeService', 'app', 'web', 'serving.knative.dev/v1')
+    knative.data = { ...knative.data, resourceKind: 'Service' }
+    const topology: Topology = { nodes: [knative, core], edges: [] }
+
+    const explicit = neighborhoodFor(topology, [
+      { kind: 'Service', group: '', namespace: 'app', name: 'web' },
+    ])
+    expect(explicit.nodes.map((n) => n.id)).toEqual(['core'])
+
+    const inferred = neighborhoodFor(topology, [
+      { kind: 'Service', namespace: 'app', name: 'web' },
+    ])
+    expect(inferred.nodes.map((n) => n.id)).toEqual(['core'])
+  })
+
   it('qualifies workload keys only for CRD groups', () => {
     expect(workloadKey({ kind: 'Job', group: 'batch', namespace: 'ml', name: 'train' })).toBe('Job/ml/train')
     expect(workloadKey({ kind: 'Job', group: 'batch.volcano.sh', namespace: 'ml', name: 'train' }))

--- a/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.test.ts
@@ -179,6 +179,28 @@ describe('neighborhoodFor', () => {
     expect(out.nodes.map((n) => n.id)).toEqual(['argo'])
   })
 
+  it('resolves an omitted custom-resource group when exactly one node matches', () => {
+    const topo: Topology = {
+      nodes: [crdNode('ray', 'RayJob', 'ml', 'train', 'ray.io/v1')],
+      edges: [],
+    }
+    const out = neighborhoodFor(topo, [{ kind: 'RayJob', namespace: 'ml', name: 'train' }])
+    expect(out.nodes.map((node) => node.id)).toEqual(['ray'])
+  })
+
+  it('fails closed when an omitted custom-resource group has multiple candidates', () => {
+    const topo: Topology = {
+      nodes: [
+        crdNode('ray', 'RayJob', 'ml', 'train', 'ray.io/v1'),
+        crdNode('other', 'RayJob', 'ml', 'train', 'example.com/v1'),
+      ],
+      edges: [],
+    }
+    const out = neighborhoodFor(topo, [{ kind: 'RayJob', namespace: 'ml', name: 'train' }])
+    expect(out.nodes).toHaveLength(0)
+    expect(out.warnings?.some((warning) => warning.includes('No topology nodes matched'))).toBe(true)
+  })
+
   it('matches typed built-ins whose topology node omits apiVersion', () => {
     const topo: Topology = {
       nodes: [node('dep', 'Deployment', 'app', 'web')],
@@ -215,6 +237,11 @@ describe('neighborhoodFor', () => {
       { kind: 'Service', namespace: 'app', name: 'web' },
     ])
     expect(inferred.nodes.map((n) => n.id)).toEqual(['core'])
+
+    const customOnly = neighborhoodFor({ nodes: [knative], edges: [] }, [
+      { kind: 'Service', namespace: 'app', name: 'web' },
+    ])
+    expect(customOnly.nodes).toHaveLength(0)
   })
 
   it('qualifies workload keys only for CRD groups', () => {

--- a/packages/k8s-ui/src/utils/topology-neighborhood.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.ts
@@ -160,12 +160,26 @@ export function workloadKey(ref: NeighborhoodSeed): string {
   return laneId(ref.kind, ref.group, ref.namespace, ref.name)
 }
 
-function matchSeedNode(node: TopologyNode, seeds: NeighborhoodSeed[]): boolean {
-  return seeds.some((s) => {
-    const resourceKind = topologyNodeResourceKind(node)
-    if (s.kind !== resourceKind || s.name !== node.name || s.namespace !== nodeNamespace(node)) return false
-    return canonicalResourceGroup(s.kind, s.group) === canonicalResourceGroup(resourceKind, nodeGroup(node))
-  })
+function resolveSeedNodes(nodes: TopologyNode[], seeds: NeighborhoodSeed[]): Map<string, NeighborhoodSeed> {
+  const resolved = new Map<string, NeighborhoodSeed>()
+  for (const seed of seeds) {
+    const candidates = nodes.filter((node) =>
+      topologyNodeResourceKind(node) === seed.kind
+      && node.name === seed.name
+      && nodeNamespace(node) === seed.namespace,
+    )
+    const seedGroup = canonicalResourceGroup(seed.kind, seed.group)
+    if (seedGroup !== undefined) {
+      for (const candidate of candidates) {
+        if (canonicalResourceGroup(seed.kind, nodeGroup(candidate)) === seedGroup && !resolved.has(candidate.id)) {
+          resolved.set(candidate.id, seed)
+        }
+      }
+    } else if (candidates.length === 1) {
+      if (!resolved.has(candidates[0].id)) resolved.set(candidates[0].id, seed)
+    }
+  }
+  return resolved
 }
 
 /** Filter a topology to the neighborhood of `seeds`. Returns the subgraph; an
@@ -174,10 +188,7 @@ export function neighborhoodFor(topology: Topology, seeds: NeighborhoodSeed[]): 
   const nodeById = new Map<string, TopologyNode>()
   for (const n of topology.nodes) nodeById.set(n.id, n)
 
-  const seedIds = new Set<string>()
-  for (const n of topology.nodes) {
-    if (matchSeedNode(n, seeds)) seedIds.add(n.id)
-  }
+  const seedIds = new Set(resolveSeedNodes(topology.nodes, seeds).keys())
   if (seedIds.size === 0) {
     return {
       ...topology,
@@ -349,15 +360,10 @@ export function tagWorkloadOwnership(topology: Topology, seeds: NeighborhoodSeed
   // The seed nodes present in the subgraph, by their workload key.
   const seedKeyById = new Map<string, string>()
   const subNodeById = new Map(sub.nodes.map((node) => [node.id, node]))
+  const resolvedSeeds = resolveSeedNodes(sub.nodes, seeds)
   for (const n of sub.nodes) {
-    if (matchSeedNode(n, seeds)) {
-      seedKeyById.set(n.id, workloadKey({
-        kind: topologyNodeResourceKind(n),
-        group: nodeGroup(n),
-        namespace: nodeNamespace(n),
-        name: n.name,
-      }))
-    }
+    const seed = resolvedSeeds.get(n.id)
+    if (seed) seedKeyById.set(n.id, workloadKey(seed))
   }
 
   // manages-DOWN children, template-to-run provenance, and undirected neighbors.
@@ -454,5 +460,6 @@ export function tagWorkloadOwnership(topology: Topology, seeds: NeighborhoodSeed
 /** The set of node IDs that are the seeds themselves — handy for the caller to
  *  pass `focusNodeId` (pan/zoom to the workload) into <TopologyGraph/>. */
 export function seedNodeIds(topology: Topology, seeds: NeighborhoodSeed[]): string[] {
-  return topology.nodes.filter((n) => matchSeedNode(n, seeds)).map((n) => n.id)
+  const resolved = resolveSeedNodes(topology.nodes, seeds)
+  return topology.nodes.filter((node) => resolved.has(node.id)).map((node) => node.id)
 }

--- a/packages/k8s-ui/src/utils/topology-neighborhood.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.ts
@@ -1,4 +1,5 @@
 import type { Topology, TopologyNode, TopologyEdge, EdgeType, NodeKind } from '../types/core'
+import { groupQualifiesLaneId, laneId } from './navigation'
 
 // Seeded neighborhood query — the shared primitive behind the WorkloadView
 // Topology tab (seed = one workload) and the Application topology (seed = the
@@ -57,6 +58,11 @@ function nodeNamespace(node: TopologyNode): string {
 function nodeGroup(node: TopologyNode): string {
   const apiVersion = node.data?.apiVersion
   return typeof apiVersion === 'string' && apiVersion.includes('/') ? apiVersion.split('/')[0] : ''
+}
+
+function nodeResourceKind(node: TopologyNode): string {
+  const resourceKind = node.data?.resourceKind
+  return typeof resourceKind === 'string' && resourceKind ? resourceKind : node.kind
 }
 
 function isWorkflowTemplateKind(kind: NodeKind | string): boolean {
@@ -142,19 +148,23 @@ function batchFanoutLimit(edge: TopologyEdge, nodeById: Map<string, TopologyNode
   return isBatchRunFanoutEdge(edge, nodeById) ? BATCH_RUN_FANOUT_LIMIT : null
 }
 
-/** The identity string for a workload/seed — `kind/namespace/name`. This format
- *  is a cross-module contract: rail rows, the `?workload=` URL param, hover
+/** The identity string for a workload/seed. Built-ins use `kind/namespace/name`;
+ *  CRDs add their group to keep same-named resources distinct. This format is a
+ *  cross-module contract: rail rows, the `?workload=` URL param, hover
  *  focus, and the ownership stamp all compare these strings. Always construct
  *  through here; never inline the template. (Unambiguous: K8s kinds and
  *  DNS-1123 names cannot contain `/`.) */
 export function workloadKey(ref: NeighborhoodSeed): string {
-  return `${ref.kind}/${ref.namespace}/${ref.name}`
+  return laneId(ref.kind, ref.group, ref.namespace, ref.name)
 }
 
 function matchSeedNode(node: TopologyNode, seeds: NeighborhoodSeed[]): boolean {
   return seeds.some((s) => {
-    if (s.kind !== node.kind || s.name !== node.name || s.namespace !== nodeNamespace(node)) return false
-    return !s.group || s.group === nodeGroup(node)
+    if (s.kind !== nodeResourceKind(node) || s.name !== node.name || s.namespace !== nodeNamespace(node)) return false
+    if (!s.group) return true
+    const group = nodeGroup(node)
+    if (group) return s.group === group
+    return !groupQualifiesLaneId(s.group)
   })
 }
 
@@ -341,7 +351,12 @@ export function tagWorkloadOwnership(topology: Topology, seeds: NeighborhoodSeed
   const subNodeById = new Map(sub.nodes.map((node) => [node.id, node]))
   for (const n of sub.nodes) {
     if (matchSeedNode(n, seeds)) {
-      seedKeyById.set(n.id, workloadKey({ kind: n.kind, namespace: nodeNamespace(n), name: n.name }))
+      seedKeyById.set(n.id, workloadKey({
+        kind: nodeResourceKind(n),
+        group: nodeGroup(n),
+        namespace: nodeNamespace(n),
+        name: n.name,
+      }))
     }
   }
 

--- a/packages/k8s-ui/src/utils/topology-neighborhood.ts
+++ b/packages/k8s-ui/src/utils/topology-neighborhood.ts
@@ -1,5 +1,6 @@
 import type { Topology, TopologyNode, TopologyEdge, EdgeType, NodeKind } from '../types/core'
-import { groupQualifiesLaneId, laneId } from './navigation'
+import { canonicalResourceGroup } from './api-resources'
+import { laneId } from './navigation'
 
 // Seeded neighborhood query — the shared primitive behind the WorkloadView
 // Topology tab (seed = one workload) and the Application topology (seed = the
@@ -55,12 +56,13 @@ function nodeNamespace(node: TopologyNode): string {
   return typeof ns === 'string' ? ns : ''
 }
 
-function nodeGroup(node: TopologyNode): string {
+function nodeGroup(node: TopologyNode): string | undefined {
   const apiVersion = node.data?.apiVersion
-  return typeof apiVersion === 'string' && apiVersion.includes('/') ? apiVersion.split('/')[0] : ''
+  if (typeof apiVersion !== 'string' || apiVersion === '') return undefined
+  return apiVersion.includes('/') ? apiVersion.split('/')[0] : ''
 }
 
-function nodeResourceKind(node: TopologyNode): string {
+export function topologyNodeResourceKind(node: TopologyNode): string {
   const resourceKind = node.data?.resourceKind
   return typeof resourceKind === 'string' && resourceKind ? resourceKind : node.kind
 }
@@ -160,11 +162,9 @@ export function workloadKey(ref: NeighborhoodSeed): string {
 
 function matchSeedNode(node: TopologyNode, seeds: NeighborhoodSeed[]): boolean {
   return seeds.some((s) => {
-    if (s.kind !== nodeResourceKind(node) || s.name !== node.name || s.namespace !== nodeNamespace(node)) return false
-    if (!s.group) return true
-    const group = nodeGroup(node)
-    if (group) return s.group === group
-    return !groupQualifiesLaneId(s.group)
+    const resourceKind = topologyNodeResourceKind(node)
+    if (s.kind !== resourceKind || s.name !== node.name || s.namespace !== nodeNamespace(node)) return false
+    return canonicalResourceGroup(s.kind, s.group) === canonicalResourceGroup(resourceKind, nodeGroup(node))
   })
 }
 
@@ -352,7 +352,7 @@ export function tagWorkloadOwnership(topology: Topology, seeds: NeighborhoodSeed
   for (const n of sub.nodes) {
     if (matchSeedNode(n, seeds)) {
       seedKeyById.set(n.id, workloadKey({
-        kind: nodeResourceKind(n),
+        kind: topologyNodeResourceKind(n),
         group: nodeGroup(n),
         namespace: nodeNamespace(n),
         name: n.name,

--- a/pkg/gitops/helpers.go
+++ b/pkg/gitops/helpers.go
@@ -23,3 +23,23 @@ func GroupFromAPIVersion(apiVersion string) string {
 	}
 	return apiVersion
 }
+
+// ParseFluxInventoryID parses Flux's namespace_name_group_kind inventory key
+// from the right so resource names containing underscores remain intact.
+func ParseFluxInventoryID(id string) (group, kind, namespace, name string, ok bool) {
+	parts := strings.Split(id, "_")
+	if len(parts) < 4 {
+		return "", "", "", "", false
+	}
+	kind = parts[len(parts)-1]
+	group = parts[len(parts)-2]
+	namespace = parts[0]
+	name = strings.Join(parts[1:len(parts)-2], "_")
+	if kind == "" || name == "" {
+		return "", "", "", "", false
+	}
+	if group == "core" {
+		group = ""
+	}
+	return group, kind, namespace, name, true
+}

--- a/pkg/gitops/helpers_test.go
+++ b/pkg/gitops/helpers_test.go
@@ -1,0 +1,30 @@
+package gitops
+
+import "testing"
+
+func TestParseFluxInventoryID(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		group     string
+		kind      string
+		namespace string
+		resource  string
+		ok        bool
+	}{
+		{name: "deployment", id: "flux-system_podinfo_apps_Deployment", group: "apps", kind: "Deployment", namespace: "flux-system", resource: "podinfo", ok: true},
+		{name: "underscores", id: "ns_my_weird_name_apps_Deployment", group: "apps", kind: "Deployment", namespace: "ns", resource: "my_weird_name", ok: true},
+		{name: "core", id: "default_my-cm_core_ConfigMap", kind: "ConfigMap", namespace: "default", resource: "my-cm", ok: true},
+		{name: "custom", id: "ml_train_batch.volcano.sh_Job", group: "batch.volcano.sh", kind: "Job", namespace: "ml", resource: "train", ok: true},
+		{name: "cluster scoped", id: "_global_rbac.authorization.k8s.io_ClusterRole", group: "rbac.authorization.k8s.io", kind: "ClusterRole", resource: "global", ok: true},
+		{name: "invalid", id: "only_three_parts", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			group, kind, namespace, resource, ok := ParseFluxInventoryID(test.id)
+			if ok != test.ok || group != test.group || kind != test.kind || namespace != test.namespace || resource != test.resource {
+				t.Fatalf("ParseFluxInventoryID(%q) = (%q, %q, %q, %q, %v)", test.id, group, kind, namespace, resource, ok)
+			}
+		})
+	}
+}

--- a/pkg/gitops/tree/inventory.go
+++ b/pkg/gitops/tree/inventory.go
@@ -1,8 +1,6 @@
 package tree
 
 import (
-	"strings"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/skyhook-io/radar/pkg/gitops"
@@ -73,19 +71,9 @@ func parseFluxManagedResources(root *unstructured.Unstructured) []managedResourc
 }
 
 func parseFluxInventoryID(id string) (ResourceRef, bool) {
-	parts := strings.Split(id, "_")
-	if len(parts) < 4 {
+	group, kind, namespace, name, ok := gitops.ParseFluxInventoryID(id)
+	if !ok {
 		return ResourceRef{}, false
-	}
-	kind := parts[len(parts)-1]
-	group := parts[len(parts)-2]
-	namespace := parts[0]
-	name := strings.Join(parts[1:len(parts)-2], "_")
-	if kind == "" || name == "" {
-		return ResourceRef{}, false
-	}
-	if group == "core" {
-		group = ""
 	}
 	return ResourceRef{Group: group, Kind: kind, Namespace: namespace, Name: name}, true
 }

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -78,6 +78,20 @@ var coreAPIGroups = map[string]bool{
 	"scheduling.k8s.io":            true,
 }
 
+var dynamicallyWatchedBuiltInAPIGroups = map[string]bool{
+	"apiregistration.k8s.io": true,
+	"authentication.k8s.io":  true,
+	"authorization.k8s.io":   true,
+	"resource.k8s.io":        true,
+}
+
+// IsBuiltInAPIGroup reports whether group is shipped by Kubernetes rather than
+// introduced by a CRD. Some built-in groups remain outside coreAPIGroups so the
+// dynamic cache can observe them.
+func IsBuiltInAPIGroup(group string) bool {
+	return coreAPIGroups[group] || dynamicallyWatchedBuiltInAPIGroups[group]
+}
+
 // versionStability returns a score for API version stability.
 // Higher is more stable: stable (3) > beta (2) > alpha (1).
 func versionStability(version string) int {
@@ -566,6 +580,23 @@ func (d *ResourceDiscovery) IsKnownResource(kindOrName string) bool {
 func (d *ResourceDiscovery) IsCRD(kindOrName string) bool {
 	res, ok := d.GetResource(kindOrName)
 	return ok && res.IsCRD
+}
+
+// IsCRDGVR reports whether the exact discovered resource is a CRD.
+func (d *ResourceDiscovery) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	if d == nil {
+		return false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, res := range d.resources {
+		if res.Group == gvr.Group && res.Version == gvr.Version && res.Name == gvr.Resource {
+			return res.IsCRD
+		}
+	}
+	return false
 }
 
 // SupportsWatch checks if a resource supports list and watch verbs.

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -19,6 +19,31 @@ type countingDiscovery struct {
 	calls atomic.Int32
 }
 
+func TestIsBuiltInAPIGroupKeepsDynamicBuiltInsDistinctFromCRDs(t *testing.T) {
+	for _, group := range []string{"apps", "resource.k8s.io", "authentication.k8s.io", "authorization.k8s.io", "apiregistration.k8s.io"} {
+		if !IsBuiltInAPIGroup(group) {
+			t.Errorf("IsBuiltInAPIGroup(%q) = false", group)
+		}
+	}
+	if IsBuiltInAPIGroup("batch.volcano.sh") {
+		t.Fatal("a CRD API group was classified as built in")
+	}
+
+	fakeDiscovery := fakeclientset.NewSimpleClientset().Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "resource.k8s.io/v1",
+		APIResources: []metav1.APIResource{{Name: "resourceclaims", Kind: "ResourceClaim", Verbs: []string{"get", "list", "watch"}}},
+	}}
+	d, err := NewResourceDiscovery(fakeDiscovery)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery: %v", err)
+	}
+	resource, ok := d.GetResourceWithGroup("ResourceClaim", "resource.k8s.io")
+	if !ok || !resource.IsCRD {
+		t.Fatalf("DRA must remain dynamically watched: resource=%+v ok=%v", resource, ok)
+	}
+}
+
 func (d *countingDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	d.calls.Add(1)
 	return d.DiscoveryInterface.ServerGroupsAndResources()

--- a/pkg/resourceid/resourceid.go
+++ b/pkg/resourceid/resourceid.go
@@ -18,26 +18,63 @@ func ResourceKey(group, kind, namespace, name string) string {
 	return fmt.Sprintf("%s|%s|%s|%s", group, kind, namespace, name)
 }
 
-// GroupForBuiltinKind maps a built-in Kubernetes Kind to its API group. Returns
-// "" for kinds it doesn't recognize (core-group built-ins and unrecognized
-// kinds both return ""). Keeps the Kind→Group mapping in one place rather than
-// at every emission site; the audit suite, the issues classifier, and any other
-// consumer share it so they can't drift.
-func GroupForBuiltinKind(kind string) string {
+// BuiltinGroup returns the canonical API group for a built-in Kubernetes Kind.
+// The boolean distinguishes core-group kinds from unrecognized custom kinds.
+func BuiltinGroup(kind string) (string, bool) {
 	switch kind {
 	case "Pod", "Service", "ConfigMap", "Secret", "Node", "Namespace",
-		"PersistentVolume", "PersistentVolumeClaim", "ServiceAccount":
-		return ""
+		"PersistentVolume", "PersistentVolumeClaim", "ServiceAccount", "Event",
+		"LimitRange", "ResourceQuota", "Endpoints":
+		return "", true
 	case "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet":
-		return "apps"
+		return "apps", true
 	case "Job", "CronJob":
-		return "batch"
+		return "batch", true
 	case "HorizontalPodAutoscaler":
-		return "autoscaling"
-	case "Ingress", "NetworkPolicy":
-		return "networking.k8s.io"
+		return "autoscaling", true
+	case "Ingress", "IngressClass", "NetworkPolicy":
+		return "networking.k8s.io", true
 	case "PodDisruptionBudget":
-		return "policy"
+		return "policy", true
+	case "StorageClass", "VolumeAttachment":
+		return "storage.k8s.io", true
+	case "EndpointSlice":
+		return "discovery.k8s.io", true
+	case "Role", "ClusterRole", "RoleBinding", "ClusterRoleBinding":
+		return "rbac.authorization.k8s.io", true
+	case "PriorityClass":
+		return "scheduling.k8s.io", true
+	case "RuntimeClass":
+		return "node.k8s.io", true
+	case "Lease":
+		return "coordination.k8s.io", true
+	case "MutatingWebhookConfiguration", "ValidatingWebhookConfiguration":
+		return "admissionregistration.k8s.io", true
 	}
-	return ""
+	return "", false
+}
+
+// GroupForBuiltinKind maps a built-in Kubernetes Kind to its API group. Returns
+// "" for both core-group built-ins and unrecognized kinds; callers that must
+// distinguish those cases should use BuiltinGroup.
+func GroupForBuiltinKind(kind string) string {
+	group, _ := BuiltinGroup(kind)
+	return group
+}
+
+// BuiltinAPIVersion returns the stable API version used by Radar's typed
+// informer for a built-in Kind.
+func BuiltinAPIVersion(kind string) (string, bool) {
+	group, ok := BuiltinGroup(kind)
+	if !ok {
+		return "", false
+	}
+	version := "v1"
+	if kind == "HorizontalPodAutoscaler" {
+		version = "v2"
+	}
+	if group == "" {
+		return version, true
+	}
+	return group + "/" + version, true
 }

--- a/pkg/resourceid/resourceid_test.go
+++ b/pkg/resourceid/resourceid_test.go
@@ -31,12 +31,53 @@ func TestGroupForBuiltinKind(t *testing.T) {
 		"HorizontalPodAutoscaler": "autoscaling",
 		"Ingress":                 "networking.k8s.io",
 		"NetworkPolicy":           "networking.k8s.io",
+		"IngressClass":            "networking.k8s.io",
 		"PodDisruptionBudget":     "policy",
+		"StorageClass":            "storage.k8s.io",
+		"Role":                    "rbac.authorization.k8s.io",
+		"ClusterRoleBinding":      "rbac.authorization.k8s.io",
+		"LimitRange":              "",
+		"ResourceQuota":           "",
+		"Event":                   "",
 		"UnknownCRD":              "",
 	}
 	for kind, want := range cases {
 		if got := GroupForBuiltinKind(kind); got != want {
 			t.Errorf("GroupForBuiltinKind(%q) = %q, want %q", kind, got, want)
 		}
+	}
+}
+
+func TestBuiltinAPIVersion(t *testing.T) {
+	for _, test := range []struct {
+		kind string
+		want string
+		ok   bool
+	}{
+		{kind: "Service", want: "v1", ok: true},
+		{kind: "Deployment", want: "apps/v1", ok: true},
+		{kind: "Job", want: "batch/v1", ok: true},
+		{kind: "HorizontalPodAutoscaler", want: "autoscaling/v2", ok: true},
+		{kind: "PodDisruptionBudget", want: "policy/v1", ok: true},
+		{kind: "IngressClass", want: "networking.k8s.io/v1", ok: true},
+		{kind: "StorageClass", want: "storage.k8s.io/v1", ok: true},
+		{kind: "Role", want: "rbac.authorization.k8s.io/v1", ok: true},
+		{kind: "LimitRange", want: "v1", ok: true},
+		{kind: "ResourceQuota", want: "v1", ok: true},
+		{kind: "Widget"},
+	} {
+		got, ok := BuiltinAPIVersion(test.kind)
+		if got != test.want || ok != test.ok {
+			t.Errorf("BuiltinAPIVersion(%q) = (%q, %v), want (%q, %v)", test.kind, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestBuiltinGroupDistinguishesCoreFromCustom(t *testing.T) {
+	if group, ok := BuiltinGroup("Service"); !ok || group != "" {
+		t.Fatalf("BuiltinGroup(Service) = %q, %v; want core group and recognized", group, ok)
+	}
+	if group, ok := BuiltinGroup("Widget"); ok || group != "" {
+		t.Fatalf("BuiltinGroup(Widget) = %q, %v; want unrecognized", group, ok)
 	}
 }

--- a/pkg/topology/auditkey.go
+++ b/pkg/topology/auditkey.go
@@ -1,6 +1,10 @@
 package topology
 
-import "github.com/skyhook-io/radar/pkg/resourceid"
+import (
+	"strings"
+
+	"github.com/skyhook-io/radar/pkg/resourceid"
+)
 
 // collisionKindToK8sKind maps the disambiguated NodeKind labels Radar uses for
 // CRDs whose Kind collides with a core (or another) kind back to the real
@@ -10,12 +14,66 @@ import "github.com/skyhook-io/radar/pkg/resourceid"
 // K8s Kind. None of these collision kinds are audited today; this keeps topology
 // badges correct if one ever gains a check — the single place that needs to know.
 var collisionKindToK8sKind = map[NodeKind]string{
-	KindIstioGateway:         "Gateway",
-	KindKnativeService:       "Service",
-	KindKnativeConfiguration: "Configuration",
-	KindKnativeRevision:      "Revision",
-	KindKnativeRoute:         "Route",
-	KindCAPICluster:          "Cluster",
+	KindIstioGateway:                        "Gateway",
+	KindKnativeService:                      "Service",
+	KindKnativeConfiguration:                "Configuration",
+	KindKnativeRevision:                     "Revision",
+	KindKnativeRoute:                        "Route",
+	KindCAPICluster:                         "Cluster",
+	KindCalicoNetworkPolicy:                 "NetworkPolicy",
+	KindCalicoGlobalNetworkPolicy:           "GlobalNetworkPolicy",
+	KindCalicoStagedNetworkPolicy:           "StagedNetworkPolicy",
+	KindCalicoStagedGlobalNetworkPolicy:     "StagedGlobalNetworkPolicy",
+	KindCalicoStagedKubernetesNetworkPolicy: "StagedKubernetesNetworkPolicy",
+}
+
+// KubernetesKindForNode returns the Kubernetes Kind represented by a topology
+// node, undoing Radar's collision and provider-specific pseudo-kinds.
+func KubernetesKindForNode(node *Node) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind == KindNodeClass {
+		if kind, ok := node.Data["resourceKind"].(string); ok && kind != "" {
+			return kind
+		}
+	}
+	if kind, ok := collisionKindToK8sKind[node.Kind]; ok {
+		return kind
+	}
+	return string(node.Kind)
+}
+
+// nodeResourceKeys returns every exact Kubernetes identity a topology node can
+// be addressed through. Most nodes have one identity; Calico policies may be
+// served through both their native and CRD API groups while remaining one
+// logical resource.
+func nodeResourceKeys(node *Node) []string {
+	if node == nil || node.Name == "" {
+		return nil
+	}
+	kind := KubernetesKindForNode(node)
+	namespace := nodeNamespaceFromData(node)
+	if namespace == "" {
+		parts := strings.Split(node.ID, "/")
+		if len(parts) >= 3 {
+			namespace = parts[1]
+		}
+	}
+	group := nodeAPIGroupFromData(node)
+	if group == "" {
+		group = resourceid.GroupForBuiltinKind(kind)
+	}
+	keys := []string{resourceid.ResourceKey(group, kind, namespace, node.Name)}
+	if !IsCalicoPolicyKind(node.Kind) {
+		return keys
+	}
+	for _, servedGroup := range calicoNodeAPIGroups(node) {
+		if servedGroup != "" && servedGroup != group {
+			keys = append(keys, resourceid.ResourceKey(servedGroup, kind, namespace, node.Name))
+		}
+	}
+	return keys
 }
 
 // stampAuditKeys annotates every node with the resource-identity key the audit
@@ -26,16 +84,20 @@ var collisionKindToK8sKind = map[NodeKind]string{
 // audit convention exactly: built-ins → their group, everything else → "".
 func stampAuditKeys(nodes []Node) []Node {
 	for i := range nodes {
-		k8sKind := string(nodes[i].Kind)
-		if real, ok := collisionKindToK8sKind[nodes[i].Kind]; ok {
-			k8sKind = real
-		}
+		k8sKind := KubernetesKindForNode(&nodes[i])
 		if nodes[i].Data == nil {
 			nodes[i].Data = map[string]any{}
 		}
+		if k8sKind != string(nodes[i].Kind) {
+			nodes[i].Data["resourceKind"] = k8sKind
+		}
 		ns, _ := nodes[i].Data["namespace"].(string)
+		group := resourceid.GroupForBuiltinKind(k8sKind)
+		if nodeGroup := nodeAPIGroupFromData(&nodes[i]); nodeGroup != "" && nodeGroup != group {
+			group = ""
+		}
 		nodes[i].Data["auditKey"] = resourceid.ResourceKey(
-			resourceid.GroupForBuiltinKind(k8sKind), k8sKind, ns, nodes[i].Name)
+			group, k8sKind, ns, nodes[i].Name)
 	}
 	return nodes
 }

--- a/pkg/topology/auditkey_test.go
+++ b/pkg/topology/auditkey_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestStampAuditKeys(t *testing.T) {
 	nodes := []Node{
-		{Kind: KindDeployment, Name: "api", Data: map[string]any{"namespace": "prod"}},
+		{Kind: KindDeployment, Name: "api", Data: map[string]any{"namespace": "prod", "apiVersion": "apps/v1"}},
 		{Kind: "IngressRoute", Name: "r", Data: map[string]any{"namespace": "web"}},     // CRD → group ""
 		{Kind: KindIstioGateway, Name: "gw", Data: map[string]any{"namespace": "mesh"}}, // collision → real kind "Gateway"
 		{Kind: KindNamespace, Name: "team-a", Data: nil},                                // nil Data + cluster-scoped (no ns)
@@ -23,5 +23,11 @@ func TestStampAuditKeys(t *testing.T) {
 		if got != want[n.Name] {
 			t.Errorf("auditKey for %q = %q, want %q", n.Name, got, want[n.Name])
 		}
+	}
+	if got := out[2].Data["resourceKind"]; got != "Gateway" {
+		t.Errorf("resourceKind for Istio Gateway = %v, want Gateway", got)
+	}
+	if _, ok := out[0].Data["resourceKind"]; ok {
+		t.Error("ordinary topology node unexpectedly received resourceKind")
 	}
 }

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -76,6 +76,25 @@ func targetRefMatchesTopologyKind(kind, apiVersion string) bool {
 	return APIVersionGroup(apiVersion) == group
 }
 
+// ownerGroupMatches reports whether an owner reference's group is consistent
+// with kind's canonical built-in group, so a CRD that shadows a typed Kind
+// (Volcano's Job, say) is never joined to a same-named typed workload. An
+// owner ref with no recorded apiVersion is unknown, not mismatched -- many
+// call sites (tests included) construct references without it -- so it is
+// treated permissively, the same way targetRefMatchesTopologyKind treats an
+// empty apiVersion. Kinds outside resourceid.BuiltinGroup's table have no
+// single canonical group to check against and are permissive too.
+func ownerGroupMatches(kind, apiVersion string) bool {
+	if apiVersion == "" {
+		return true
+	}
+	expected, known := resourceid.BuiltinGroup(kind)
+	if !known {
+		return true
+	}
+	return gitops.GroupFromAPIVersion(apiVersion) == expected
+}
+
 // Build constructs a topology based on the given options
 func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 	if b.provider == nil {
@@ -2866,6 +2885,12 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 		// Track owner for shortcut edges regardless of visibility
 		for _, ownerRef := range rs.OwnerReferences {
+			// A CRD can shadow "Deployment" (no canonical group table entry
+			// exists for Rollout, which is itself a CRD kind, so it stays
+			// unguarded here as before).
+			if ownerRef.Kind == "Deployment" && !ownerGroupMatches(ownerRef.Kind, ownerRef.APIVersion) {
+				continue
+			}
 			ownerKey := rs.Namespace + "/" + ownerRef.Name
 			rsKey := rs.Namespace + "/" + rs.Name
 			if ownerRef.Kind == "Deployment" {
@@ -2902,6 +2927,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 			// Connect to owner Deployment or Rollout
 			for _, ownerRef := range rs.OwnerReferences {
+				if ownerRef.Kind == "Deployment" && !ownerGroupMatches(ownerRef.Kind, ownerRef.APIVersion) {
+					continue
+				}
 				ownerKey := rs.Namespace + "/" + ownerRef.Name
 				var ownerID string
 				var found bool
@@ -7149,6 +7177,13 @@ func (b *Builder) resolvePodWorkloadID(
 		if ownerRef.Controller == nil || !*ownerRef.Controller {
 			continue
 		}
+		// A CRD can shadow a typed owner Kind (Volcano's Job, say). These maps
+		// are keyed by bare namespace/name with no group component, so an
+		// unverified match would attribute the pod to a same-named typed
+		// workload it does not belong to.
+		if !ownerGroupMatches(ownerRef.Kind, ownerRef.APIVersion) {
+			continue
+		}
 		ownerKey := pod.Namespace + "/" + ownerRef.Name
 		switch ownerRef.Kind {
 		case "ReplicaSet":
@@ -7269,6 +7304,13 @@ func (b *Builder) createPodOwnerEdges(
 	}
 
 	for _, ownerRef := range pod.OwnerReferences {
+		// A CRD can shadow a typed owner Kind (Volcano's Job, say). These maps
+		// are keyed by bare namespace/name with no group component, so an
+		// unverified match would attribute the pod to a same-named typed
+		// workload it does not belong to.
+		if !ownerGroupMatches(ownerRef.Kind, ownerRef.APIVersion) {
+			continue
+		}
 		ownerKey := pod.Namespace + "/" + ownerRef.Name
 		switch ownerRef.Kind {
 		case "ReplicaSet":

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/skyhook-io/radar/pkg/gitops"
 	"github.com/skyhook-io/radar/pkg/health"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
 	"github.com/skyhook-io/radar/pkg/k8score"
@@ -57,6 +58,22 @@ func preferredTraefikGVR(provider DynamicProvider, kind string) (schema.GroupVer
 		return gvr, true
 	}
 	return provider.GetGVRWithGroup(kind, "traefik.containo.us")
+}
+
+func targetRefMatchesTopologyKind(kind, apiVersion string) bool {
+	if apiVersion == "" {
+		return true
+	}
+	var group string
+	switch kind {
+	case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet":
+		group = "apps"
+	case "Rollout":
+		group = "argoproj.io"
+	default:
+		return false
+	}
+	return APIVersionGroup(apiVersion) == group
 }
 
 // Build constructs a topology based on the given options
@@ -1067,12 +1084,13 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			})
 
 			// ScaledObject → target workload edge (via spec.scaleTargetRef)
+			targetAPIVersion, _, _ := unstructured.NestedString(so.Object, "spec", "scaleTargetRef", "apiVersion")
 			targetKind, _, _ := unstructured.NestedString(so.Object, "spec", "scaleTargetRef", "kind")
 			targetName, _, _ := unstructured.NestedString(so.Object, "spec", "scaleTargetRef", "name")
 			if targetKind == "" {
 				targetKind = "Deployment" // KEDA defaults to Deployment when kind is omitted
 			}
-			if targetName != "" {
+			if targetName != "" && targetRefMatchesTopologyKind(targetKind, targetAPIVersion) {
 				targetKey := ns + "/" + targetName
 				var targetID string
 				switch targetKind {
@@ -3660,20 +3678,23 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		})
 
 		// Connect to target
+		targetAPIVersion := hpa.Spec.ScaleTargetRef.APIVersion
 		targetKind := hpa.Spec.ScaleTargetRef.Kind
 		targetName := hpa.Spec.ScaleTargetRef.Name
 		targetKey := hpa.Namespace + "/" + targetName
 
 		var targetID string
-		switch targetKind {
-		case "Deployment":
-			targetID = deploymentIDs[targetKey]
-		case "Rollout":
-			targetID = rolloutIDs[targetKey]
-		case "StatefulSet":
-			targetID = statefulSetIDs[targetKey]
-		case "ReplicaSet":
-			targetID = replicaSetIDs[targetKey]
+		if targetRefMatchesTopologyKind(targetKind, targetAPIVersion) {
+			switch targetKind {
+			case "Deployment":
+				targetID = deploymentIDs[targetKey]
+			case "Rollout":
+				targetID = rolloutIDs[targetKey]
+			case "StatefulSet":
+				targetID = statefulSetIDs[targetKey]
+			case "ReplicaSet":
+				targetID = replicaSetIDs[targetKey]
+			}
 		}
 
 		if targetID != "" {
@@ -4021,9 +4042,10 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			})
 
 			// Connect to target workload via spec.targetRef
+			targetAPIVersion, _, _ := unstructured.NestedString(vpa.Object, "spec", "targetRef", "apiVersion")
 			targetKind, _, _ := unstructured.NestedString(vpa.Object, "spec", "targetRef", "kind")
 			targetName, _, _ := unstructured.NestedString(vpa.Object, "spec", "targetRef", "name")
-			if targetKind != "" && targetName != "" {
+			if targetKind != "" && targetName != "" && targetRefMatchesTopologyKind(targetKind, targetAPIVersion) {
 				targetKey := ns + "/" + targetName
 				var targetID string
 				switch targetKind {
@@ -4050,140 +4072,12 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-	// 12. Second pass: Create ArgoCD Application edges to managed resources
-	// This is done after all resource IDs are populated
-	for _, app := range applicationResources {
-		ns := app.GetNamespace()
-		name := app.GetName()
-		appID := applicationIDs[ns+"/"+name]
-		destNamespace := applicationDestNamespaces[appID]
-
-		status, _, _ := unstructured.NestedMap(app.Object, "status")
-		if status == nil {
-			continue
-		}
-
-		resources, _, _ := unstructured.NestedSlice(status, "resources")
-		for _, res := range resources {
-			resMap, ok := res.(map[string]any)
-			if !ok {
-				continue
-			}
-			resKind, _ := resMap["kind"].(string)
-			resName, _ := resMap["name"].(string)
-			resNS, _ := resMap["namespace"].(string)
-			if resNS == "" {
-				resNS = destNamespace
-			}
-
-			// Build target ID based on kind
-			var targetID string
-			resKey := resNS + "/" + resName
-			switch resKind {
-			case "Deployment":
-				targetID = deploymentIDs[resKey]
-			case "StatefulSet":
-				targetID = statefulSetIDs[resKey]
-			case "DaemonSet":
-				targetID = fmt.Sprintf("daemonset/%s/%s", resNS, resName)
-			case "Service":
-				targetID = serviceIDs[resKey]
-			case "Rollout":
-				targetID = rolloutIDs[resKey]
-			case "Job":
-				targetID = jobIDs[resKey]
-			case "CronJob":
-				targetID = cronJobIDs[resKey]
-			case "Gateway":
-				targetID = gatewayIDs[resKey]
-			case "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
-				targetID = routeIDs[resKind+"/"+resNS+"/"+resName]
-			}
-
-			// Only create edge if target exists in current cluster view
-			if targetID != "" {
-				edges = append(edges, Edge{
-					ID:     fmt.Sprintf("%s-to-%s", appID, targetID),
-					Source: appID,
-					Target: targetID,
-					Type:   EdgeManages,
-				})
-			}
-		}
-	}
-
-	// 13. Second pass: Create FluxCD Kustomization edges to managed resources
-	// Kustomization inventory contains refs like "Deployment/ns/name" or "_namespace_name_Kind"
+	// 13. Create Flux source edges. Managed-resource edges are resolved after
+	// generic CRD nodes have been added so their exact API identity is available.
 	for _, ks := range kustomizationResources {
 		ns := ks.GetNamespace()
 		name := ks.GetName()
 		ksID := kustomizationIDs[ns+"/"+name]
-
-		status, _, _ := unstructured.NestedMap(ks.Object, "status")
-		if status == nil {
-			continue
-		}
-
-		inventory, _, _ := unstructured.NestedSlice(status, "inventory", "entries")
-		for _, entry := range inventory {
-			entryMap, ok := entry.(map[string]any)
-			if !ok {
-				continue
-			}
-			// FluxCD inventory entry has "id" field with format "namespace_name_group_kind" or "id" field
-			entryID, _ := entryMap["id"].(string)
-			if entryID == "" {
-				continue
-			}
-
-			// Parse the inventory ID (format: namespace_name_group_kind)
-			// Example: "default_my-deployment_apps_Deployment"
-			parts := strings.Split(entryID, "_")
-			if len(parts) < 3 {
-				continue
-			}
-
-			resNS := parts[0]
-			resName := parts[1]
-			// Last part is kind, second to last is group (might be empty)
-			resKind := parts[len(parts)-1]
-
-			// Build target ID based on kind
-			var targetID string
-			resKey := resNS + "/" + resName
-			switch resKind {
-			case "Deployment":
-				targetID = deploymentIDs[resKey]
-			case "StatefulSet":
-				targetID = statefulSetIDs[resKey]
-			case "DaemonSet":
-				targetID = fmt.Sprintf("daemonset/%s/%s", resNS, resName)
-			case "Service":
-				targetID = serviceIDs[resKey]
-			case "Rollout":
-				targetID = rolloutIDs[resKey]
-			case "Job":
-				targetID = jobIDs[resKey]
-			case "CronJob":
-				targetID = cronJobIDs[resKey]
-			case "Ingress":
-				targetID = fmt.Sprintf("ingress/%s/%s", resNS, resName)
-			case "Gateway":
-				targetID = gatewayIDs[resKey]
-			case "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
-				targetID = routeIDs[resKind+"/"+resNS+"/"+resName]
-			}
-
-			// Only create edge if target exists in current cluster view
-			if targetID != "" {
-				edges = append(edges, Edge{
-					ID:     fmt.Sprintf("%s-to-%s", ksID, targetID),
-					Source: ksID,
-					Target: targetID,
-					Type:   EdgeManages,
-				})
-			}
-		}
 
 		// Also create edge from GitRepository to Kustomization if source ref exists
 		spec, _, _ := unstructured.NestedMap(ks.Object, "spec")
@@ -5577,6 +5471,15 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if opts.IncludeGenericCRDs {
 		nodes, edges = b.addGenericCRDNodes(nodes, edges, opts)
 	}
+	edges = addGitOpsManagedResourceEdges(
+		nodes,
+		edges,
+		applicationResources,
+		applicationIDs,
+		applicationDestNamespaces,
+		kustomizationResources,
+		kustomizationIDs,
+	)
 
 	// 17. Annotate workload nodes with NetworkPolicy coverage (optional)
 	if opts.ShowPolicyEffect {
@@ -5594,6 +5497,96 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 
 	return topo, nil
+}
+
+func addGitOpsManagedResourceEdges(
+	nodes []Node,
+	edges []Edge,
+	applications []*unstructured.Unstructured,
+	applicationIDs map[string]string,
+	applicationDestNamespaces map[string]string,
+	kustomizations []*unstructured.Unstructured,
+	kustomizationIDs map[string]string,
+) []Edge {
+	resourceIDs := make(map[string]string, len(nodes))
+	for i := range nodes {
+		for _, key := range nodeResourceKeys(&nodes[i]) {
+			resourceIDs[key] = nodes[i].ID
+		}
+	}
+	seenEdges := make(map[string]bool, len(edges))
+	for _, edge := range edges {
+		seenEdges[edge.ID] = true
+	}
+	appendManaged := func(sourceID, group, kind, namespace, name string) {
+		if sourceID == "" || kind == "" || name == "" {
+			return
+		}
+		if builtinGroup, builtin := resourceid.BuiltinGroup(kind); group == "" && builtin {
+			group = builtinGroup
+		}
+		targetID := resourceIDs[resourceid.ResourceKey(group, kind, namespace, name)]
+		if targetID == "" {
+			return
+		}
+		edgeID := fmt.Sprintf("%s-to-%s", sourceID, targetID)
+		if seenEdges[edgeID] {
+			return
+		}
+		seenEdges[edgeID] = true
+		edges = append(edges, Edge{ID: edgeID, Source: sourceID, Target: targetID, Type: EdgeManages})
+	}
+
+	argoKinds := map[string]bool{
+		"Deployment": true, "StatefulSet": true, "DaemonSet": true,
+		"Service": true, "Rollout": true, "Job": true, "CronJob": true,
+		"Gateway": true, "HTTPRoute": true, "GRPCRoute": true,
+		"TCPRoute": true, "TLSRoute": true,
+	}
+	for _, app := range applications {
+		appID := applicationIDs[app.GetNamespace()+"/"+app.GetName()]
+		destNamespace := applicationDestNamespaces[appID]
+		resources, _, _ := unstructured.NestedSlice(app.Object, "status", "resources")
+		for _, resource := range resources {
+			m, ok := resource.(map[string]any)
+			if !ok {
+				continue
+			}
+			kind := gitops.StringValue(m["kind"])
+			if !argoKinds[kind] {
+				continue
+			}
+			namespace := gitops.StringValue(m["namespace"])
+			if namespace == "" {
+				namespace = destNamespace
+			}
+			appendManaged(appID, gitops.StringValue(m["group"]), kind, namespace, gitops.StringValue(m["name"]))
+		}
+	}
+
+	fluxKinds := map[string]bool{
+		"Deployment": true, "StatefulSet": true, "DaemonSet": true,
+		"Service": true, "Rollout": true, "Job": true, "CronJob": true,
+		"Ingress": true, "Gateway": true, "HTTPRoute": true,
+		"GRPCRoute": true, "TCPRoute": true, "TLSRoute": true,
+	}
+	for _, kustomization := range kustomizations {
+		ksID := kustomizationIDs[kustomization.GetNamespace()+"/"+kustomization.GetName()]
+		entries, _, _ := unstructured.NestedSlice(kustomization.Object, "status", "inventory", "entries")
+		for _, entry := range entries {
+			m, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			group, kind, namespace, name, ok := gitops.ParseFluxInventoryID(gitops.StringValue(m["id"]))
+			if !ok || !fluxKinds[kind] {
+				continue
+			}
+			appendManaged(ksID, group, kind, namespace, name)
+		}
+	}
+
+	return edges
 }
 
 // buildTrafficTopology creates a network-focused view

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -20,8 +20,10 @@ import (
 
 	"github.com/skyhook-io/radar/pkg/health"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/karpenter"
 	"github.com/skyhook-io/radar/pkg/perfstats"
+	"github.com/skyhook-io/radar/pkg/resourceid"
 )
 
 // Builder constructs topology graphs from K8s resources
@@ -45,6 +47,16 @@ func NewBuilder(provider ResourceProvider) *Builder {
 func (b *Builder) WithDynamic(dp DynamicProvider) *Builder {
 	b.dynamic = dp
 	return b
+}
+
+func preferredTraefikGVR(provider DynamicProvider, kind string) (schema.GroupVersionResource, bool) {
+	if provider == nil {
+		return schema.GroupVersionResource{}, false
+	}
+	if gvr, ok := provider.GetGVRWithGroup(kind, "traefik.io"); ok {
+		return gvr, true
+	}
+	return provider.GetGVRWithGroup(kind, "traefik.containo.us")
 }
 
 // Build constructs a topology based on the given options
@@ -385,7 +397,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	hasRollouts := false
 	rolloutsByNamespace := make(map[string][]*unstructured.Unstructured)
 	if resourceDiscovery != nil {
-		rolloutGVR, hasRollouts = resourceDiscovery.GetGVR("Rollout")
+		rolloutGVR, hasRollouts = resourceDiscovery.GetGVRWithGroup("Rollout", "argoproj.io")
 	}
 	if hasRollouts && dynamicCache != nil {
 		rollouts, err := dynamicCache.ListNamespaces(rolloutGVR, opts.Namespaces)
@@ -577,7 +589,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var kustomizationGVR schema.GroupVersionResource
 	hasKustomizations := false
 	if resourceDiscovery != nil {
-		kustomizationGVR, hasKustomizations = resourceDiscovery.GetGVR("Kustomization")
+		kustomizationGVR, hasKustomizations = resourceDiscovery.GetGVRWithGroup("Kustomization", "kustomize.toolkit.fluxcd.io")
 	}
 	kustomizationIDs := make(map[string]string)             // ns/name -> kustomizationID
 	var kustomizationResources []*unstructured.Unstructured // Store for second pass
@@ -648,7 +660,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var gitRepoGVR schema.GroupVersionResource
 	hasGitRepos := false
 	if resourceDiscovery != nil {
-		gitRepoGVR, hasGitRepos = resourceDiscovery.GetGVR("GitRepository")
+		gitRepoGVR, hasGitRepos = resourceDiscovery.GetGVRWithGroup("GitRepository", "source.toolkit.fluxcd.io")
 	}
 	gitRepoIDs := make(map[string]string) // ns/name -> gitRepoID
 	if hasGitRepos && dynamicCache != nil {
@@ -713,7 +725,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var helmReleaseGVR schema.GroupVersionResource
 	hasHelmReleases := false
 	if resourceDiscovery != nil {
-		helmReleaseGVR, hasHelmReleases = resourceDiscovery.GetGVR("HelmRelease")
+		helmReleaseGVR, hasHelmReleases = resourceDiscovery.GetGVRWithGroup("HelmRelease", "helm.toolkit.fluxcd.io")
 	}
 	helmReleaseIDs := make(map[string]string) // ns/name -> helmReleaseID
 	if hasHelmReleases && dynamicCache != nil {
@@ -786,7 +798,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var certificateGVR schema.GroupVersionResource
 	hasCertificates := false
 	if resourceDiscovery != nil {
-		certificateGVR, hasCertificates = resourceDiscovery.GetGVR("Certificate")
+		certificateGVR, hasCertificates = resourceDiscovery.GetGVRWithGroup("Certificate", "cert-manager.io")
 	}
 	var certificateResources []unstructured.Unstructured
 	if hasCertificates && dynamicCache != nil {
@@ -1026,7 +1038,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var scaledObjectGVR schema.GroupVersionResource
 	hasScaledObjects := false
 	if resourceDiscovery != nil {
-		scaledObjectGVR, hasScaledObjects = resourceDiscovery.GetGVR("ScaledObject")
+		scaledObjectGVR, hasScaledObjects = resourceDiscovery.GetGVRWithGroup("ScaledObject", "keda.sh")
 	}
 	if hasScaledObjects && dynamicCache != nil {
 		scaledObjects, soErr := dynamicCache.ListNamespaces(scaledObjectGVR, opts.Namespaces)
@@ -1086,7 +1098,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var scaledJobGVR schema.GroupVersionResource
 	hasScaledJobs := false
 	if resourceDiscovery != nil {
-		scaledJobGVR, hasScaledJobs = resourceDiscovery.GetGVR("ScaledJob")
+		scaledJobGVR, hasScaledJobs = resourceDiscovery.GetGVRWithGroup("ScaledJob", "keda.sh")
 	}
 	if hasScaledJobs && dynamicCache != nil {
 		scaledJobs, sjErr := dynamicCache.ListNamespaces(scaledJobGVR, opts.Namespaces)
@@ -1160,7 +1172,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var capiClusterClassGVR schema.GroupVersionResource
 	hasCAPIClusterClasses := false
 	if resourceDiscovery != nil {
-		capiClusterClassGVR, hasCAPIClusterClasses = resourceDiscovery.GetGVR("ClusterClass")
+		capiClusterClassGVR, hasCAPIClusterClasses = resourceDiscovery.GetGVRWithGroup("ClusterClass", "cluster.x-k8s.io")
 	}
 	if hasCAPIClusterClasses && dynamicCache != nil {
 		clusterClasses, ccErr := dynamicCache.ListNamespaces(capiClusterClassGVR, opts.Namespaces)
@@ -1226,7 +1238,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var kcpGVR schema.GroupVersionResource
 	hasKCPs := false
 	if resourceDiscovery != nil {
-		kcpGVR, hasKCPs = resourceDiscovery.GetGVR("KubeadmControlPlane")
+		kcpGVR, hasKCPs = resourceDiscovery.GetGVRWithGroup("KubeadmControlPlane", "controlplane.cluster.x-k8s.io")
 	}
 	if hasKCPs && dynamicCache != nil {
 		kcps, kcpErr := dynamicCache.ListNamespaces(kcpGVR, opts.Namespaces)
@@ -1275,7 +1287,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var mdGVR schema.GroupVersionResource
 	hasMDs := false
 	if resourceDiscovery != nil {
-		mdGVR, hasMDs = resourceDiscovery.GetGVR("MachineDeployment")
+		mdGVR, hasMDs = resourceDiscovery.GetGVRWithGroup("MachineDeployment", "cluster.x-k8s.io")
 	}
 	if hasMDs && dynamicCache != nil {
 		mds, mdErr := dynamicCache.ListNamespaces(mdGVR, opts.Namespaces)
@@ -1324,7 +1336,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var mpGVR schema.GroupVersionResource
 	hasMPs := false
 	if resourceDiscovery != nil {
-		mpGVR, hasMPs = resourceDiscovery.GetGVR("MachinePool")
+		mpGVR, hasMPs = resourceDiscovery.GetGVRWithGroup("MachinePool", "cluster.x-k8s.io")
 	}
 	if hasMPs && dynamicCache != nil {
 		mps, mpErr := dynamicCache.ListNamespaces(mpGVR, opts.Namespaces)
@@ -1517,7 +1529,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var mhcGVR schema.GroupVersionResource
 	hasMHCs := false
 	if resourceDiscovery != nil {
-		mhcGVR, hasMHCs = resourceDiscovery.GetGVR("MachineHealthCheck")
+		mhcGVR, hasMHCs = resourceDiscovery.GetGVRWithGroup("MachineHealthCheck", "cluster.x-k8s.io")
 	}
 	if hasMHCs && dynamicCache != nil {
 		mhcs, mhcErr := dynamicCache.ListNamespaces(mhcGVR, opts.Namespaces)
@@ -1566,7 +1578,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var gatewayClassGVR schema.GroupVersionResource
 	hasGatewayClasses := false
 	if resourceDiscovery != nil {
-		gatewayClassGVR, hasGatewayClasses = resourceDiscovery.GetGVR("GatewayClass")
+		gatewayClassGVR, hasGatewayClasses = resourceDiscovery.GetGVRWithGroup("GatewayClass", "gateway.networking.k8s.io")
 	}
 	if hasGatewayClasses && dynamicCache != nil {
 		gatewayClasses, gcErr := dynamicCache.List(gatewayClassGVR, "")
@@ -1837,7 +1849,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var knativeRevisionGVR schema.GroupVersionResource
 	hasKnativeRevisions := false
 	if resourceDiscovery != nil {
-		knativeRevisionGVR, hasKnativeRevisions = resourceDiscovery.GetGVR("Revision")
+		knativeRevisionGVR, hasKnativeRevisions = resourceDiscovery.GetGVRWithGroup("Revision", "serving.knative.dev")
 	}
 	knativeRevisionIDs := make(map[string]string)             // ns/name -> krevID
 	var knativeRevisionResources []*unstructured.Unstructured // Store for edge creation
@@ -2010,7 +2022,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var srcGVR schema.GroupVersionResource
 		hasSrc := false
 		if resourceDiscovery != nil {
-			srcGVR, hasSrc = resourceDiscovery.GetGVR(srcDef.kind)
+			srcGVR, hasSrc = resourceDiscovery.GetGVRWithGroup(srcDef.kind, "sources.knative.dev")
 		}
 		if !hasSrc || dynamicCache == nil {
 			continue
@@ -2109,7 +2121,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var gvr schema.GroupVersionResource
 		hasKind := false
 		if resourceDiscovery != nil {
-			gvr, hasKind = resourceDiscovery.GetGVR(def.kind)
+			gvr, hasKind = preferredTraefikGVR(resourceDiscovery, def.kind)
 		}
 		if !hasKind || dynamicCache == nil {
 			continue
@@ -2182,7 +2194,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var gvr schema.GroupVersionResource
 		hasKind := false
 		if resourceDiscovery != nil {
-			gvr, hasKind = resourceDiscovery.GetGVR(def.kind)
+			gvr, hasKind = preferredTraefikGVR(resourceDiscovery, def.kind)
 		}
 		if !hasKind || dynamicCache == nil {
 			continue
@@ -2225,7 +2237,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var traefikServiceGVR schema.GroupVersionResource
 	hasTraefikServices := false
 	if resourceDiscovery != nil {
-		traefikServiceGVR, hasTraefikServices = resourceDiscovery.GetGVR("TraefikService")
+		traefikServiceGVR, hasTraefikServices = preferredTraefikGVR(resourceDiscovery, "TraefikService")
 	}
 	traefikServiceIDs := make(map[string]string)             // ns/name -> tsID
 	var traefikServiceResources []*unstructured.Unstructured // Store for edge creation
@@ -2315,7 +2327,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var gvr schema.GroupVersionResource
 		hasKind := false
 		if resourceDiscovery != nil {
-			gvr, hasKind = resourceDiscovery.GetGVR(def.kind)
+			gvr, hasKind = preferredTraefikGVR(resourceDiscovery, def.kind)
 		}
 		if !hasKind || dynamicCache == nil {
 			continue
@@ -2367,7 +2379,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var httpProxyGVR schema.GroupVersionResource
 		hasHTTPProxy := false
 		if resourceDiscovery != nil {
-			httpProxyGVR, hasHTTPProxy = resourceDiscovery.GetGVR("HTTPProxy")
+			httpProxyGVR, hasHTTPProxy = resourceDiscovery.GetGVRWithGroup("HTTPProxy", "projectcontour.io")
 		}
 		if hasHTTPProxy && dynamicCache != nil {
 			resources, listErr := dynamicCache.ListNamespaces(httpProxyGVR, opts.Namespaces)
@@ -3274,7 +3286,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var gatewayGVR schema.GroupVersionResource
 	hasGateways := false
 	if resourceDiscovery != nil {
-		gatewayGVR, hasGateways = resourceDiscovery.GetGVR("Gateway")
+		gatewayGVR, hasGateways = resourceDiscovery.GetGVRWithGroup("Gateway", "gateway.networking.k8s.io")
 	}
 	if hasGateways && dynamicCache != nil {
 		gateways, gwErr := dynamicCache.ListNamespaces(gatewayGVR, opts.Namespaces)
@@ -3357,7 +3369,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		var routeGVR schema.GroupVersionResource
 		hasRoutes := false
 		if resourceDiscovery != nil {
-			routeGVR, hasRoutes = resourceDiscovery.GetGVR(routeKind)
+			routeGVR, hasRoutes = resourceDiscovery.GetGVRWithGroup(routeKind, "gateway.networking.k8s.io")
 		}
 		if !hasRoutes || dynamicCache == nil {
 			continue
@@ -3839,7 +3851,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var cnpGVR schema.GroupVersionResource
 	hasCNPs := false
 	if resourceDiscovery != nil {
-		cnpGVR, hasCNPs = resourceDiscovery.GetGVR("CiliumNetworkPolicy")
+		cnpGVR, hasCNPs = resourceDiscovery.GetGVRWithGroup("CiliumNetworkPolicy", "cilium.io")
 	}
 	if hasCNPs && dynamicCache != nil {
 		cnps, cnpErr := dynamicCache.ListNamespaces(cnpGVR, opts.Namespaces)
@@ -3909,7 +3921,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var ccnpGVR schema.GroupVersionResource
 	hasCCNPs := false
 	if resourceDiscovery != nil {
-		ccnpGVR, hasCCNPs = resourceDiscovery.GetGVR("CiliumClusterwideNetworkPolicy")
+		ccnpGVR, hasCCNPs = resourceDiscovery.GetGVRWithGroup("CiliumClusterwideNetworkPolicy", "cilium.io")
 	}
 	if hasCCNPs && dynamicCache != nil {
 		ccnps, ccnpErr := dynamicCache.List(ccnpGVR, "")
@@ -3980,7 +3992,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var vpaGVR schema.GroupVersionResource
 	hasVPAs := false
 	if resourceDiscovery != nil {
-		vpaGVR, hasVPAs = resourceDiscovery.GetGVR("VerticalPodAutoscaler")
+		vpaGVR, hasVPAs = resourceDiscovery.GetGVRWithGroup("VerticalPodAutoscaler", "autoscaling.k8s.io")
 	}
 	if hasVPAs && dynamicCache != nil {
 		vpas, vpaErr := dynamicCache.ListNamespaces(vpaGVR, opts.Namespaces)
@@ -5628,7 +5640,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficRoutes []*unstructured.Unstructured
 	var trafficRouteKinds []string
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
-		if gwGVR, ok := trafficResourceDiscovery.GetGVR("Gateway"); ok {
+		if gwGVR, ok := trafficResourceDiscovery.GetGVRWithGroup("Gateway", "gateway.networking.k8s.io"); ok {
 			gws, err := trafficDynamicCache.ListNamespaces(gwGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Gateways: %v", err)
@@ -5638,7 +5650,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		for _, routeKind := range []string{"HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute"} {
-			if rGVR, ok := trafficResourceDiscovery.GetGVR(routeKind); ok {
+			if rGVR, ok := trafficResourceDiscovery.GetGVRWithGroup(routeKind, "gateway.networking.k8s.io"); ok {
 				rts, err := trafficDynamicCache.ListNamespaces(rGVR, opts.Namespaces)
 				if err != nil {
 					log.Printf("WARNING [topology/traffic] Failed to list %s: %v", routeKind, err)
@@ -5815,7 +5827,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficMiddlewareTCPs []*unstructured.Unstructured
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		for _, routeKind := range []string{"IngressRoute", "IngressRouteTCP", "IngressRouteUDP"} {
-			if gvr, ok := trafficResourceDiscovery.GetGVR(routeKind); ok {
+			if gvr, ok := preferredTraefikGVR(trafficResourceDiscovery, routeKind); ok {
 				rts, err := trafficDynamicCache.ListNamespaces(gvr, opts.Namespaces)
 				if err != nil {
 					log.Printf("WARNING [topology/traffic] Failed to list Traefik %s: %v", routeKind, err)
@@ -5828,7 +5840,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				}
 			}
 		}
-		if tsGVR, ok := trafficResourceDiscovery.GetGVR("TraefikService"); ok {
+		if tsGVR, ok := preferredTraefikGVR(trafficResourceDiscovery, "TraefikService"); ok {
 			tss, err := trafficDynamicCache.ListNamespaces(tsGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list TraefikServices: %v", err)
@@ -5837,7 +5849,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				trafficTraefikServices = tss
 			}
 		}
-		if mwGVR, ok := trafficResourceDiscovery.GetGVR("Middleware"); ok {
+		if mwGVR, ok := preferredTraefikGVR(trafficResourceDiscovery, "Middleware"); ok {
 			mws, err := trafficDynamicCache.ListNamespaces(mwGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Traefik Middlewares: %v", err)
@@ -5846,7 +5858,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				trafficMiddlewares = mws
 			}
 		}
-		if mtGVR, ok := trafficResourceDiscovery.GetGVR("MiddlewareTCP"); ok {
+		if mtGVR, ok := preferredTraefikGVR(trafficResourceDiscovery, "MiddlewareTCP"); ok {
 			mts, err := trafficDynamicCache.ListNamespaces(mtGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Traefik MiddlewareTCPs: %v", err)
@@ -5950,7 +5962,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	// Collect Contour HTTPProxy resources from dynamic cache
 	var trafficHTTPProxies []*unstructured.Unstructured
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
-		if gvr, ok := trafficResourceDiscovery.GetGVR("HTTPProxy"); ok {
+		if gvr, ok := trafficResourceDiscovery.GetGVRWithGroup("HTTPProxy", "projectcontour.io"); ok {
 			hps, err := trafficDynamicCache.ListNamespaces(gvr, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Contour HTTPProxy: %v", err)
@@ -8309,54 +8321,87 @@ func extractCAPIReadyConditionStatus(obj unstructured.Unstructured) HealthStatus
 	return StatusUnknown
 }
 
-// Kinds with a dedicated node builder, or deliberately kept out of the graph.
-// addGenericCRDNodes copies this and adds discovered NodeClass kinds per build.
-var kindsHandledOutsideGenericCRDPass = map[string]bool{
-	// analysisrun: graphed by activeAnalysisRuns, current runs only
-	"analysisrun": true,
-	"rollout":     true, "application": true, "kustomization": true,
-	"helmrelease": true, "gitrepository": true, "certificate": true,
-	"gateway": true, "httproute": true, "grpcroute": true, "tcproute": true, "tlsroute": true,
-	"nodepool": true, "nodeclaim": true, // Karpenter
-	"ec2nodeclass": true, "aksnodeclass": true, "gcenodeclass": true, // Karpenter NodeClass
-	"scaledobject": true, "scaledjob": true, // KEDA
-	"workflowtemplate": true, "clusterworkflowtemplate": true, // Argo Workflows
-	"gatewayclass":   true,                                                // Gateway API
-	"virtualservice": true, "destinationrule": true, "serviceentry": true, // Istio networking
-	"peerauthentication": true, "authorizationpolicy": true, // Istio security
-	"knativeservice": true, "configuration": true, "revision": true, "route": true, // KNative Serving
-	"domainmapping": true, "serverlessservice": true, // KNative Serving (internal)
-	"broker": true, "trigger": true, "eventtype": true, // KNative Eventing
-	"channel": true, "inmemorychannel": true, "subscription": true, // KNative Messaging
-	"apiserversource": true, "containersource": true, "pingsource": true, "sinkbinding": true, // KNative Sources
-	"sequence": true, "parallel": true, // KNative Flows
-	"ingressroute": true, "ingressroutetcp": true, "ingressrouteudp": true, // Traefik routing
-	"middleware": true, "middlewaretcp": true, // Traefik middleware
-	"traefikservice":   true,                              // Traefik service
-	"serverstransport": true, "serverstransporttcp": true, // Traefik transport
-	"tlsoption": true, "tlsstore": true, // Traefik TLS
-	"httpproxy":    true,                                                // Contour
-	"clusterclass": true,                                                // Cluster API
-	"machine":      true, "machineset": true, "machinedeployment": true, // Cluster API
-	"machinepool": true, "kubeadmcontrolplane": true, "machinehealthcheck": true, // Cluster API
-	"machinedrainrule": true, // Cluster API
-	// Trivy Operator reports - high cardinality, excluded from topology
-	"vulnerabilityreport": true, "configauditreport": true,
-	"exposedsecretreport": true, "sbomreport": true,
-	"rbacassessmentreport": true, "clusterrbacassessmentreport": true,
-	"clustercompliancereport": true, "clustersbomreport": true,
-	"infraassessmentreport": true, "clusterinfraassessmentreport": true,
-	// Core types handled by typed informers
-	"deployment": true, "daemonset": true, "statefulset": true,
-	"replicaset": true, "pod": true, "service": true, "ingress": true,
-	"job": true, "cronjob": true, "configmap": true, "secret": true,
-	"serviceaccount": true, "sealedsecret": true,
-	"servicemonitor": true, "podmonitor": true,
-	"persistentvolumeclaim": true, "horizontalpodautoscaler": true,
-	// Argo Workflows handled explicitly above
-	"workflow": true, "cronworkflow": true,
-	// Also skip namespace (not typically owned)
-	"namespace": true,
+// Exact integrations with a dedicated builder or a deliberate topology
+// exclusion. The API group is part of the policy: an unrelated CRD that happens
+// to reuse Rollout, Gateway, Certificate, or another kind still reaches the
+// generic owner-reference pass.
+var genericCRDExclusions = map[string]map[string]bool{
+	"argoproj.io": {
+		"analysisrun": true, "rollout": true, "application": true,
+		"workflow": true, "cronworkflow": true,
+		"workflowtemplate": true, "clusterworkflowtemplate": true,
+	},
+	"kustomize.toolkit.fluxcd.io": {"kustomization": true},
+	"helm.toolkit.fluxcd.io":      {"helmrelease": true},
+	"source.toolkit.fluxcd.io":    {"gitrepository": true},
+	"cert-manager.io":             {"certificate": true},
+	"gateway.networking.k8s.io": {
+		"gateway": true, "gatewayclass": true, "httproute": true,
+		"grpcroute": true, "tcproute": true, "tlsroute": true,
+	},
+	"karpenter.sh": {"nodepool": true, "nodeclaim": true},
+	"keda.sh":      {"scaledobject": true, "scaledjob": true},
+	"networking.istio.io": {
+		"gateway": true, "virtualservice": true, "destinationrule": true, "serviceentry": true,
+	},
+	"security.istio.io": {"peerauthentication": true, "authorizationpolicy": true},
+	"serving.knative.dev": {
+		"service": true, "configuration": true, "revision": true, "route": true,
+		"domainmapping": true,
+	},
+	"networking.internal.knative.dev": {"serverlessservice": true},
+	"eventing.knative.dev":            {"broker": true, "trigger": true, "eventtype": true},
+	"messaging.knative.dev": {
+		"channel": true, "inmemorychannel": true, "subscription": true,
+	},
+	"sources.knative.dev": {
+		"apiserversource": true, "containersource": true, "pingsource": true, "sinkbinding": true,
+	},
+	"flows.knative.dev": {"sequence": true, "parallel": true},
+	"traefik.io": {
+		"ingressroute": true, "ingressroutetcp": true, "ingressrouteudp": true,
+		"middleware": true, "middlewaretcp": true, "traefikservice": true,
+		"serverstransport": true, "serverstransporttcp": true,
+		"tlsoption": true, "tlsstore": true,
+	},
+	"traefik.containo.us": {
+		"ingressroute": true, "ingressroutetcp": true, "ingressrouteudp": true,
+		"middleware": true, "middlewaretcp": true, "traefikservice": true,
+		"serverstransport": true, "serverstransporttcp": true,
+		"tlsoption": true, "tlsstore": true,
+	},
+	"projectcontour.io": {"httpproxy": true},
+	"cluster.x-k8s.io": {
+		"clusterclass": true, "machine": true, "machineset": true,
+		"machinedeployment": true, "machinepool": true, "machinehealthcheck": true,
+		"machinedrainrule": true,
+	},
+	"controlplane.cluster.x-k8s.io": {"kubeadmcontrolplane": true},
+	"monitoring.coreos.com":         {"servicemonitor": true, "podmonitor": true},
+	"bitnami.com":                   {"sealedsecret": true},
+	"policy.networking.k8s.io":      {"clusternetworkpolicy": true},
+	"aquasecurity.github.io": {
+		"vulnerabilityreport": true, "configauditreport": true,
+		"exposedsecretreport": true, "sbomreport": true,
+		"rbacassessmentreport": true, "clusterrbacassessmentreport": true,
+		"clustercompliancereport": true, "clustersbomreport": true,
+		"infraassessmentreport": true, "clusterinfraassessmentreport": true,
+	},
+}
+
+func genericCRDExcluded(gvr schema.GroupVersionResource, kind string) bool {
+	return genericCRDExclusions[gvr.Group][strings.ToLower(kind)]
+}
+
+type exactCRDProvider interface {
+	IsCRDGVR(gvr schema.GroupVersionResource) bool
+}
+
+func isCRDGVR(provider DynamicProvider, gvr schema.GroupVersionResource, kind string) bool {
+	if exact, ok := provider.(exactCRDProvider); ok {
+		return exact.IsCRDGVR(gvr)
+	}
+	return provider.IsCRD(kind)
 }
 
 // addGenericCRDNodes adds CRD nodes connected to the topology via owner references.
@@ -8371,60 +8416,85 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 		return nodes, edges
 	}
 
-	// Build set of existing node IDs for fast lookup
+	// Build indexes for both graph IDs and exact Kubernetes resource identities.
 	existingIDs := make(map[string]bool, len(nodes))
-	for _, node := range nodes {
+	existingResourceIDs := make(map[string]string, len(nodes))
+	for i := range nodes {
+		node := &nodes[i]
 		existingIDs[node.ID] = true
+		for _, resourceKey := range nodeResourceKeys(node) {
+			existingResourceIDs[resourceKey] = node.ID
+		}
 	}
 
-	// Skip kinds handled explicitly by buildResourcesTopology or excluded from topology entirely
-	processedKinds := make(map[string]bool, len(kindsHandledOutsideGenericCRDPass))
-	for kind := range kindsHandledOutsideGenericCRDPass {
-		processedKinds[kind] = true
-	}
+	processedTypes := make(map[string]bool)
 	for _, node := range nodes {
 		if node.Kind != KindNodeClass {
 			continue
 		}
 		if resourceKind, ok := node.Data["resourceKind"].(string); ok && resourceKind != "" {
-			processedKinds[strings.ToLower(resourceKind)] = true
+			processedTypes[resourceid.ResourceKey(nodeAPIGroupFromData(&node), resourceKind, "", "")] = true
 		}
 	}
 
-	// Track per-kind counts to prevent any single CRD type from overwhelming the topology
+	// Track per-resource-type counts to prevent any single CRD type from overwhelming the topology.
 	crdCounts := make(map[string]int)
 	maxPerKind := 50
 
 	// Phase 1: Collect all candidate CRD resources
 	type candidate struct {
-		nodeID    string
-		node      Node
-		ownerRefs []string // ownerKind/ns/name IDs
-		ns        string
+		nodeID      string
+		node        Node
+		ownerRefs   []ResourceRef
+		resourceKey string
+		typeKey     string
 	}
 	var candidates []candidate
 
-	for _, gvr := range dynamicCache.GetWatchedResources() {
-		kind := resourceDiscovery.GetKindForGVR(gvr)
-		if kind == "" {
+	type watchedCRD struct {
+		gvr  schema.GroupVersionResource
+		kind string
+	}
+	watched := append([]schema.GroupVersionResource(nil), dynamicCache.GetWatchedResources()...)
+	sort.Slice(watched, func(i, j int) bool {
+		if watched[i].Group != watched[j].Group {
+			return watched[i].Group < watched[j].Group
+		}
+		if watched[i].Resource != watched[j].Resource {
+			return watched[i].Resource < watched[j].Resource
+		}
+		return watched[i].Version < watched[j].Version
+	})
+	selected := make(map[string]watchedCRD)
+	var selectedKeys []string
+	for _, gvr := range watched {
+		if k8score.IsBuiltInAPIGroup(gvr.Group) {
 			continue
 		}
-		kindLower := strings.ToLower(kind)
-
-		// Skip if already processed or not a CRD. Calico's policy kinds are
-		// skipped by group rather than by name, so another CNI's CRD of the same
-		// name still reaches this path. It renders as a generic node like any
-		// other CRD — which is what it got before Calico was handled here.
-		if processedKinds[kindLower] {
+		kind := resourceDiscovery.GetKindForGVR(gvr)
+		if kind == "" || !isCRDGVR(resourceDiscovery, gvr, kind) || genericCRDExcluded(gvr, kind) {
 			continue
 		}
 		if isCalicoPolicyGVR(gvr) {
 			continue
 		}
-		if !resourceDiscovery.IsCRD(kind) {
+		typeKey := resourceid.ResourceKey(gvr.Group, kind, "", "")
+		current, ok := selected[typeKey]
+		if !ok {
+			selectedKeys = append(selectedKeys, typeKey)
+			selected[typeKey] = watchedCRD{gvr: gvr, kind: kind}
+		} else if k8score.IsMoreStableVersion(gvr.Version, current.gvr.Version) {
+			selected[typeKey] = watchedCRD{gvr: gvr, kind: kind}
+		}
+	}
+
+	for _, typeKey := range selectedKeys {
+		selection := selected[typeKey]
+		gvr, kind := selection.gvr, selection.kind
+		if processedTypes[typeKey] {
 			continue
 		}
-		processedKinds[kindLower] = true
+		processedTypes[typeKey] = true
 
 		resources, err := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if err != nil {
@@ -8444,20 +8514,29 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 			}
 
 			name := resource.GetName()
-			nodeID := fmt.Sprintf("%s/%s/%s", kindLower, ns, name)
+			resourceKey := resourceid.ResourceKey(gvr.Group, kind, ns, name)
+			if _, exists := existingResourceIDs[resourceKey]; exists {
+				continue
+			}
+			nodeID := fmt.Sprintf("%s/%s/%s/%s", strings.ToLower(kind), ns, name, gvr.Group)
 
 			// Skip if already in topology
 			if existingIDs[nodeID] {
 				continue
 			}
 
-			// Collect owner IDs
-			var ownerNodeIDs []string
+			var ownerResources []ResourceRef
 			for _, ref := range ownerRefs {
-				ownerKindLower := strings.ToLower(ref.Kind)
-				ownerNodeIDs = append(ownerNodeIDs, fmt.Sprintf("%s/%s/%s", ownerKindLower, ns, ref.Name))
+				if ref.APIVersion == "" || ref.Kind == "" || ref.Name == "" {
+					continue
+				}
+				ownerResources = append(ownerResources, ResourceRef{
+					Group: APIVersionGroup(ref.APIVersion), Kind: ref.Kind, Namespace: ns, Name: ref.Name,
+				})
 			}
-
+			if len(ownerResources) == 0 {
+				continue
+			}
 			candidates = append(candidates, candidate{
 				nodeID: nodeID,
 				node: Node{
@@ -8471,8 +8550,9 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 						"apiVersion": resource.GetAPIVersion(),
 					},
 				},
-				ownerRefs: ownerNodeIDs,
-				ns:        ns,
+				ownerRefs:   ownerResources,
+				resourceKey: resourceKey,
+				typeKey:     typeKey,
 			})
 		}
 	}
@@ -8482,14 +8562,17 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 		added := 0
 		remaining := candidates[:0] // reuse slice
 		for _, c := range candidates {
-			kindLower := strings.ToLower(string(c.node.Kind))
-			if crdCounts[kindLower] >= maxPerKind {
+			if crdCounts[c.typeKey] >= maxPerKind {
 				continue // drop — kind at capacity
 			}
 
 			var ownerEdges []Edge
-			for _, ownerID := range c.ownerRefs {
-				if existingIDs[ownerID] {
+			for _, owner := range c.ownerRefs {
+				ownerID, ok := existingResourceIDs[resourceid.ResourceKey(owner.Group, owner.Kind, owner.Namespace, owner.Name)]
+				if !ok && owner.Namespace != "" {
+					ownerID, ok = existingResourceIDs[resourceid.ResourceKey(owner.Group, owner.Kind, "", owner.Name)]
+				}
+				if ok {
 					ownerEdges = append(ownerEdges, Edge{
 						ID:     fmt.Sprintf("%s-to-%s", ownerID, c.nodeID),
 						Source: ownerID,
@@ -8503,7 +8586,8 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 				nodes = append(nodes, c.node)
 				edges = append(edges, ownerEdges...)
 				existingIDs[c.nodeID] = true
-				crdCounts[kindLower]++
+				existingResourceIDs[c.resourceKey] = c.nodeID
+				crdCounts[c.typeKey]++
 				added++
 			} else {
 				remaining = append(remaining, c)

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -133,6 +133,9 @@ func (m *monitorDynamicProvider) IsCRD(kind string) bool {
 	_, ok := m.gvrs[kind]
 	return ok
 }
+func (m *monitorDynamicProvider) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	return m.GetKindForGVR(gvr) != ""
+}
 
 func (m *rolloutDynamicProvider) List(_ schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
 	m.listCalls++
@@ -176,6 +179,9 @@ func (m *rolloutDynamicProvider) GetKindForGVR(gvr schema.GroupVersionResource) 
 
 func (m *rolloutDynamicProvider) IsCRD(kind string) bool {
 	return kind == "Rollout"
+}
+func (m *rolloutDynamicProvider) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	return gvr == m.gvr
 }
 
 func TestArgoWorkflowTemplateRefsFromWorkflowSpec(t *testing.T) {

--- a/pkg/topology/calico_test.go
+++ b/pkg/topology/calico_test.go
@@ -70,7 +70,7 @@ func (d *calicoTestDynamic) GetKindForGVR(gvr schema.GroupVersionResource) strin
 	}
 	return ""
 }
-func (d *calicoTestDynamic) IsCRD(string) bool { return true }
+func (d *calicoTestDynamic) IsCRD(string) bool                         { return true }
 func (d *calicoTestDynamic) IsCRDGVR(schema.GroupVersionResource) bool { return true }
 
 func calicoTestObject(group, version, kind, namespace, name string, spec map[string]any) *unstructured.Unstructured {

--- a/pkg/topology/calico_test.go
+++ b/pkg/topology/calico_test.go
@@ -71,6 +71,7 @@ func (d *calicoTestDynamic) GetKindForGVR(gvr schema.GroupVersionResource) strin
 	return ""
 }
 func (d *calicoTestDynamic) IsCRD(string) bool { return true }
+func (d *calicoTestDynamic) IsCRDGVR(schema.GroupVersionResource) bool { return true }
 
 func calicoTestObject(group, version, kind, namespace, name string, spec map[string]any) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: map[string]any{
@@ -221,7 +222,7 @@ func TestStagedKubernetesCalicoPolicyIsExcludedFromGenericCRDs(t *testing.T) {
 	}
 	dynamic := calicoTestDynamicFor("projectcalico.org")
 	gvr := dynamic.gvrs["projectcalico.org\x00StagedKubernetesNetworkPolicy"]
-	dynamic.resources[gvr][0].SetOwnerReferences([]metav1.OwnerReference{{Kind: "Deployment", Name: "frontend"}})
+	dynamic.resources[gvr][0].SetOwnerReferences([]metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "frontend"}})
 	dynamic.watched = []schema.GroupVersionResource{gvr}
 
 	topo, err := NewBuilder(provider).WithDynamic(dynamic).Build(BuildOptions{IncludeGenericCRDs: true})
@@ -708,7 +709,7 @@ func TestForeignNetworkPolicyCRDStillRendersAsGenericNode(t *testing.T) {
 	policy := calicoTestObject("crd.antrea.io", "v1alpha1", "NetworkPolicy", "demo", "antrea-policy", map[string]any{
 		"priority": int64(5),
 	})
-	policy.SetOwnerReferences([]metav1.OwnerReference{{Kind: "Deployment", Name: "frontend"}})
+	policy.SetOwnerReferences([]metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "frontend"}})
 
 	dynamic := &antreaTestDynamic{
 		calicoTestDynamic: calicoTestDynamicFor(calicoProjectGroup),

--- a/pkg/topology/config_edges_test.go
+++ b/pkg/topology/config_edges_test.go
@@ -48,6 +48,9 @@ func (p *sealedSecretDynamicProvider) GetKindForGVR(gvr schema.GroupVersionResou
 	return ""
 }
 func (p *sealedSecretDynamicProvider) IsCRD(kind string) bool { return kind == "SealedSecret" }
+func (p *sealedSecretDynamicProvider) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	return gvr == p.gvr
+}
 
 // deployWithRefs builds a Deployment that references a ConfigMap, Secret, and
 // PVC by name via pod-spec volumes (the shapes extractWorkloadReferences reads).

--- a/pkg/topology/crossplane.go
+++ b/pkg/topology/crossplane.go
@@ -247,7 +247,7 @@ func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptio
 
 	for _, gvr := range dynamicCache.GetWatchedResources() {
 		kind := dynamicCache.GetKindForGVR(gvr)
-		if kind == "" || !dynamicCache.IsCRD(kind) {
+		if kind == "" || !isCRDGVR(dynamicCache, gvr, kind) {
 			continue
 		}
 		resources, err := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
@@ -268,9 +268,10 @@ func (b *Builder) addCrossplaneNodes(nodes []Node, edges []Edge, opts BuildOptio
 				continue
 			}
 			name := r.GetName()
-			nodeID := fmt.Sprintf("%s/%s/%s", strings.ToLower(kind), ns, name)
+			group := groupFromAPIVersion(r.GetAPIVersion())
+			nodeID := fmt.Sprintf("%s/%s/%s/%s", strings.ToLower(kind), ns, name, group)
 			objects = append(objects, xpObject{obj: r, nodeID: nodeID})
-			index[crossplaneIndexKey(groupFromAPIVersion(r.GetAPIVersion()), kind, ns, name)] = nodeID
+			index[crossplaneIndexKey(group, kind, ns, name)] = nodeID
 
 			if existingIDs[nodeID] {
 				continue

--- a/pkg/topology/crossplane_test.go
+++ b/pkg/topology/crossplane_test.go
@@ -60,9 +60,9 @@ func TestBuildCrossplaneV1ClaimChainEdges(t *testing.T) {
 		t.Fatalf("Build() error: %v", err)
 	}
 
-	claimID := "databaseclaim/demo-app/example-database"
-	xrID := "xdatabase//example-database-xr"
-	composed := []string{"object//example-database-configmap", "object//example-database-service", "object//example-database-connection"}
+	claimID := "databaseclaim/demo-app/example-database/demo.example.io"
+	xrID := "xdatabase//example-database-xr/demo.example.io"
+	composed := []string{"object//example-database-configmap/kubernetes.crossplane.io", "object//example-database-service/kubernetes.crossplane.io", "object//example-database-connection/kubernetes.crossplane.io"}
 
 	for _, id := range append([]string{claimID, xrID}, composed...) {
 		if findNode(topo, id) == nil {
@@ -129,8 +129,8 @@ func TestBuildCrossplaneV2NamespacedXREdges(t *testing.T) {
 		t.Fatalf("Build() error: %v", err)
 	}
 
-	xrID := "appstack/v2-app/web-stack"
-	composed := []string{"object/v2-app/web-stack-configmap", "object/v2-app/web-stack-service"}
+	xrID := "appstack/v2-app/web-stack/demo.example.io"
+	composed := []string{"object/v2-app/web-stack-configmap/kubernetes.m.crossplane.io", "object/v2-app/web-stack-service/kubernetes.m.crossplane.io"}
 	if findNode(topo, xrID) == nil {
 		t.Fatalf("missing namespaced XR node %q; nodes=%+v", xrID, topo.Nodes)
 	}
@@ -194,20 +194,20 @@ func TestCrossplaneClusterScopedNodesAreRBACStrippable(t *testing.T) {
 
 	// deny everything: cluster-scoped XR + MR gone, namespaced Claim stays
 	topo.StripClusterScopedDynamicExcept(map[SARTuple]bool{})
-	if findNode(topo, "databaseclaim/demo-app/db") == nil {
+	if findNode(topo, "databaseclaim/demo-app/db/demo.example.io") == nil {
 		t.Fatal("namespaced Claim node was wrongly stripped")
 	}
-	if findNode(topo, "xdatabase//db-xr") != nil || findNode(topo, "object//db-cm") != nil {
+	if findNode(topo, "xdatabase//db-xr/demo.example.io") != nil || findNode(topo, "object//db-cm/kubernetes.crossplane.io") != nil {
 		t.Fatalf("unauthorized cluster-scoped node leaked through strip; nodes=%+v", topo.Nodes)
 	}
 
 	// allow only the XR's GVR: XR stays, MR still stripped
 	topo2, _ := NewBuilder(&mockProvider{}).WithDynamic(newProvider()).Build(DefaultBuildOptions())
 	topo2.StripClusterScopedDynamicExcept(map[SARTuple]bool{xrTuple: true})
-	if findNode(topo2, "xdatabase//db-xr") == nil {
+	if findNode(topo2, "xdatabase//db-xr/demo.example.io") == nil {
 		t.Fatal("authorized XR node was wrongly stripped")
 	}
-	if findNode(topo2, "object//db-cm") != nil {
+	if findNode(topo2, "object//db-cm/kubernetes.crossplane.io") != nil {
 		t.Fatal("unauthorized MR node leaked (only XR was allowed)")
 	}
 }
@@ -253,10 +253,10 @@ func TestBuildCrossplaneClusterScopedSurvivesNamespaceFilter(t *testing.T) {
 		t.Fatalf("Build() error: %v", err)
 	}
 
-	if !hasKarpenterTopologyEdge(topo, "databaseclaim/demo-app/db", "xdatabase//db-xr", EdgeManages) {
+	if !hasKarpenterTopologyEdge(topo, "databaseclaim/demo-app/db/demo.example.io", "xdatabase//db-xr/demo.example.io", EdgeManages) {
 		t.Fatalf("cluster-scoped XR dropped under namespace filter; edges=%+v", topo.Edges)
 	}
-	if !hasKarpenterTopologyEdge(topo, "xdatabase//db-xr", "object//db-cm", EdgeManages) {
+	if !hasKarpenterTopologyEdge(topo, "xdatabase//db-xr/demo.example.io", "object//db-cm/kubernetes.crossplane.io", EdgeManages) {
 		t.Fatalf("cluster-scoped composed MR dropped under namespace filter; edges=%+v", topo.Edges)
 	}
 }
@@ -303,17 +303,53 @@ func TestBuildCrossplaneSameNameDifferentNamespaceNoCollision(t *testing.T) {
 	}
 
 	// each XR wires to the MR in its OWN namespace, not the other's
-	if !hasKarpenterTopologyEdge(topo, "appstack/team-a/stack", "object/team-a/shared-config", EdgeManages) {
+	if !hasKarpenterTopologyEdge(topo, "appstack/team-a/stack/demo.example.io", "object/team-a/shared-config/kubernetes.m.crossplane.io", EdgeManages) {
 		t.Fatalf("team-a XR did not wire to its own composed MR; edges=%+v", topo.Edges)
 	}
-	if !hasKarpenterTopologyEdge(topo, "appstack/team-b/stack", "object/team-b/shared-config", EdgeManages) {
+	if !hasKarpenterTopologyEdge(topo, "appstack/team-b/stack/demo.example.io", "object/team-b/shared-config/kubernetes.m.crossplane.io", EdgeManages) {
 		t.Fatalf("team-b XR did not wire to its own composed MR; edges=%+v", topo.Edges)
 	}
 	// and NOT to the other namespace's MR
-	if hasKarpenterTopologyEdge(topo, "appstack/team-a/stack", "object/team-b/shared-config", EdgeManages) {
+	if hasKarpenterTopologyEdge(topo, "appstack/team-a/stack/demo.example.io", "object/team-b/shared-config/kubernetes.m.crossplane.io", EdgeManages) {
 		t.Fatalf("cross-namespace collision: team-a XR wired to team-b MR")
 	}
-	if hasKarpenterTopologyEdge(topo, "appstack/team-b/stack", "object/team-a/shared-config", EdgeManages) {
+	if hasKarpenterTopologyEdge(topo, "appstack/team-b/stack/demo.example.io", "object/team-a/shared-config/kubernetes.m.crossplane.io", EdgeManages) {
 		t.Fatalf("cross-namespace collision: team-b XR wired to team-a MR")
+	}
+}
+
+func TestBuildCrossplaneSameIdentityAcrossProviderGroups(t *testing.T) {
+	awsGVR := schema.GroupVersionResource{Group: "s3.aws.upbound.io", Version: "v1beta1", Resource: "buckets"}
+	gcpGVR := schema.GroupVersionResource{Group: "storage.gcp.upbound.io", Version: "v1beta1", Resource: "buckets"}
+	bucket := func(apiVersion, uid string) *unstructured.Unstructured {
+		o := karpenterTopologyObject(apiVersion, "Bucket", "artifacts", uid, map[string]any{
+			"spec": map[string]any{"providerConfigRef": map[string]any{"name": "default"}},
+		})
+		o.SetNamespace("platform")
+		return o
+	}
+	dynamic := &karpenterDynamicProvider{
+		exact: map[string]schema.GroupVersionResource{},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			awsGVR: {bucket("s3.aws.upbound.io/v1beta1", "aws")},
+			gcpGVR: {bucket("storage.gcp.upbound.io/v1beta1", "gcp")},
+		},
+		kinds:              map[schema.GroupVersionResource]string{awsGVR: "Bucket", gcpGVR: "Bucket"},
+		watched:            []schema.GroupVersionResource{awsGVR, gcpGVR},
+		listCalls:          make(map[schema.GroupVersionResource]int),
+		listNamespaceCalls: make(map[schema.GroupVersionResource]int),
+	}
+
+	topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	for _, id := range []string{
+		"bucket/platform/artifacts/s3.aws.upbound.io",
+		"bucket/platform/artifacts/storage.gcp.upbound.io",
+	} {
+		if findNode(topo, id) == nil {
+			t.Fatalf("missing exact Crossplane node %q; nodes=%+v", id, topo.Nodes)
+		}
 	}
 }

--- a/pkg/topology/generic_crd_identity_test.go
+++ b/pkg/topology/generic_crd_identity_test.go
@@ -1,0 +1,486 @@
+package topology
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+type genericIdentityDynamic struct {
+	watched   []schema.GroupVersionResource
+	kinds     map[schema.GroupVersionResource]string
+	resources map[schema.GroupVersionResource][]*unstructured.Unstructured
+	listCalls map[schema.GroupVersionResource]int
+}
+
+type dynamicProviderWithoutExactCRD struct {
+	DynamicProvider
+}
+
+func (d *genericIdentityDynamic) List(gvr schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
+	return d.resources[gvr], nil
+}
+
+func (d *genericIdentityDynamic) ListNamespaces(gvr schema.GroupVersionResource, _ []string) ([]*unstructured.Unstructured, error) {
+	d.listCalls[gvr]++
+	return d.resources[gvr], nil
+}
+
+func (d *genericIdentityDynamic) Get(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+	for _, resource := range d.resources[gvr] {
+		if resource.GetNamespace() == namespace && resource.GetName() == name {
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (d *genericIdentityDynamic) GetWatchedResources() []schema.GroupVersionResource {
+	return d.watched
+}
+
+func (d *genericIdentityDynamic) GetDiscoveryStatus() k8score.CRDDiscoveryStatus {
+	return k8score.CRDDiscoveryComplete
+}
+
+func (d *genericIdentityDynamic) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) {
+	for _, gvr := range d.watched {
+		if strings.EqualFold(d.kinds[gvr], kindOrName) || strings.EqualFold(gvr.Resource, kindOrName) {
+			return gvr, true
+		}
+	}
+	return schema.GroupVersionResource{}, false
+}
+
+func (d *genericIdentityDynamic) GetGVRWithGroup(kindOrName, group string) (schema.GroupVersionResource, bool) {
+	for _, gvr := range d.watched {
+		if gvr.Group == group && (strings.EqualFold(d.kinds[gvr], kindOrName) || strings.EqualFold(gvr.Resource, kindOrName)) {
+			return gvr, true
+		}
+	}
+	return schema.GroupVersionResource{}, false
+}
+
+func (d *genericIdentityDynamic) GetKindForGVR(gvr schema.GroupVersionResource) string {
+	return d.kinds[gvr]
+}
+
+func (d *genericIdentityDynamic) IsCRD(kind string) bool {
+	for _, candidate := range d.kinds {
+		if candidate == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *genericIdentityDynamic) IsCRDGVR(gvr schema.GroupVersionResource) bool {
+	_, ok := d.kinds[gvr]
+	return ok
+}
+
+func genericIdentityObject(gvr schema.GroupVersionResource, kind, namespace, name string, owners ...metav1.OwnerReference) *unstructured.Unstructured {
+	apiVersion := gvr.Version
+	if gvr.Group != "" {
+		apiVersion = gvr.Group + "/" + gvr.Version
+	}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}}
+	obj.SetOwnerReferences(owners)
+	return obj
+}
+
+func nodeByID(nodes []Node, id string) *Node {
+	for i := range nodes {
+		if nodes[i].ID == id {
+			return &nodes[i]
+		}
+	}
+	return nil
+}
+
+func TestGenericCRDIdentitySeparatesCoreAndCrossGroupJobs(t *testing.T) {
+	volcano := schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1alpha1", Resource: "jobs"}
+	other := schema.GroupVersionResource{Group: "jobs.example.io", Version: "v1", Resource: "jobs"}
+	owner := metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "trainer"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{other, volcano},
+		kinds:   map[schema.GroupVersionResource]string{volcano: "Job", other: "Job"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			volcano: {genericIdentityObject(volcano, "Job", "ml", "train", owner)},
+			other:   {genericIdentityObject(other, "Job", "ml", "train", owner)},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	nodes := []Node{
+		{ID: "deployment/ml/trainer", Kind: KindDeployment, Name: "trainer", Data: map[string]any{"namespace": "ml"}},
+		{ID: "job/ml/train", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+	}
+
+	nodes, edges := (&Builder{dynamic: dynamic}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+
+	for _, id := range []string{"job/ml/train", "job/ml/train/batch.volcano.sh", "job/ml/train/jobs.example.io"} {
+		if nodeByID(nodes, id) == nil {
+			t.Fatalf("missing distinct Job node %q: %+v", id, nodes)
+		}
+	}
+	for _, target := range []string{"job/ml/train/batch.volcano.sh", "job/ml/train/jobs.example.io"} {
+		found := false
+		for _, edge := range edges {
+			found = found || edge.Source == "deployment/ml/trainer" && edge.Target == target && edge.Type == EdgeManages
+		}
+		if !found {
+			t.Errorf("missing exact owner edge to %s: %+v", target, edges)
+		}
+	}
+}
+
+func TestGenericCRDOwnerResolutionUsesOwnerAPIGroup(t *testing.T) {
+	groupA := schema.GroupVersionResource{Group: "a.example.io", Version: "v1", Resource: "widgets"}
+	groupB := schema.GroupVersionResource{Group: "b.example.io", Version: "v1", Resource: "widgets"}
+	childGVR := schema.GroupVersionResource{Group: "children.example.io", Version: "v1", Resource: "children"}
+	deploymentOwner := metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "operator"}
+	childOwner := metav1.OwnerReference{APIVersion: "b.example.io/v1", Kind: "Widget", Name: "shared"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{childGVR, groupB, groupA},
+		kinds: map[schema.GroupVersionResource]string{
+			groupA: "Widget", groupB: "Widget", childGVR: "Child",
+		},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			groupA:   {genericIdentityObject(groupA, "Widget", "demo", "shared", deploymentOwner)},
+			groupB:   {genericIdentityObject(groupB, "Widget", "demo", "shared", deploymentOwner)},
+			childGVR: {genericIdentityObject(childGVR, "Child", "demo", "leaf", childOwner)},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	nodes := []Node{{ID: "deployment/demo/operator", Kind: KindDeployment, Name: "operator", Data: map[string]any{"namespace": "demo"}}}
+
+	nodes, edges := (&Builder{dynamic: dynamic}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+	childID := "child/demo/leaf/children.example.io"
+	if nodeByID(nodes, childID) == nil {
+		t.Fatalf("missing child node: %+v", nodes)
+	}
+	var ownerSources []string
+	for _, edge := range edges {
+		if edge.Target == childID {
+			ownerSources = append(ownerSources, edge.Source)
+		}
+	}
+	if len(ownerSources) != 1 || ownerSources[0] != "widget/demo/shared/b.example.io" {
+		t.Fatalf("child owners = %v, want only b.example.io Widget", ownerSources)
+	}
+}
+
+func TestGenericCRDSelectsOneStableVersionPerGroupKind(t *testing.T) {
+	alpha := schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1alpha1", Resource: "jobs"}
+	stable := schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1", Resource: "jobs"}
+	owner := metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "trainer"}
+	for _, watched := range [][]schema.GroupVersionResource{{alpha, stable}, {stable, alpha}} {
+		dynamic := &genericIdentityDynamic{
+			watched: watched,
+			kinds:   map[schema.GroupVersionResource]string{alpha: "Job", stable: "Job"},
+			resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+				alpha:  {genericIdentityObject(alpha, "Job", "ml", "alpha-only", owner)},
+				stable: {genericIdentityObject(stable, "Job", "ml", "stable", owner)},
+			},
+			listCalls: map[schema.GroupVersionResource]int{},
+		}
+		nodes := []Node{{ID: "deployment/ml/trainer", Kind: KindDeployment, Name: "trainer", Data: map[string]any{"namespace": "ml"}}}
+
+		nodes, _ = (&Builder{dynamic: dynamic}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+		if nodeByID(nodes, "job/ml/stable/batch.volcano.sh") == nil || nodeByID(nodes, "job/ml/alpha-only/batch.volcano.sh") != nil {
+			t.Fatalf("stable-version selection produced the wrong nodes for order %v: %+v", watched, nodes)
+		}
+		if dynamic.listCalls[stable] != 1 || dynamic.listCalls[alpha] != 0 {
+			t.Fatalf("list calls for order %v = stable:%d alpha:%d, want 1/0", watched, dynamic.listCalls[stable], dynamic.listCalls[alpha])
+		}
+	}
+}
+
+func TestGenericCRDReusesSpecializedResourceIdentityAndPseudoOwner(t *testing.T) {
+	bucketGVR := schema.GroupVersionResource{Group: "s3.aws.upbound.io", Version: "v1beta1", Resource: "buckets"}
+	childGVR := schema.GroupVersionResource{Group: "infra.example.io", Version: "v1", Resource: "children"}
+	childOwner := metav1.OwnerReference{APIVersion: "karpenter.k8s.aws/v1", Kind: "EC2NodeClass", Name: "shared"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{bucketGVR, childGVR},
+		kinds:   map[schema.GroupVersionResource]string{bucketGVR: "Bucket", childGVR: "Child"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			bucketGVR: {genericIdentityObject(bucketGVR, "Bucket", "infra", "logs", metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "operator"})},
+			childGVR:  {genericIdentityObject(childGVR, "Child", "infra", "leaf", childOwner)},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	nodeClassID := "nodeclass//shared/karpenter.k8s.aws/EC2NodeClass"
+	nodes := []Node{
+		{ID: "deployment/infra/operator", Kind: KindDeployment, Name: "operator", Data: map[string]any{"namespace": "infra"}},
+		{ID: "crossplane/infra/logs", Kind: NodeKind("Bucket"), Name: "logs", Data: map[string]any{"namespace": "infra", "apiVersion": "s3.aws.upbound.io/v1beta1"}},
+		{ID: nodeClassID, Kind: KindNodeClass, Name: "shared", Data: map[string]any{"apiVersion": "karpenter.k8s.aws/v1", "resourceKind": "EC2NodeClass"}},
+	}
+
+	nodes, edges := (&Builder{dynamic: dynamic}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+	buckets := 0
+	for _, node := range nodes {
+		if KubernetesKindForNode(&node) == "Bucket" && node.Name == "logs" {
+			buckets++
+		}
+	}
+	if buckets != 1 || nodeByID(nodes, "bucket/infra/logs/s3.aws.upbound.io") != nil {
+		t.Fatalf("specialized Bucket was duplicated: %+v", nodes)
+	}
+	childID := "child/infra/leaf/infra.example.io"
+	found := false
+	for _, edge := range edges {
+		found = found || edge.Source == nodeClassID && edge.Target == childID
+	}
+	if !found {
+		t.Fatalf("generic child did not resolve its pseudo-kind owner: %+v", edges)
+	}
+}
+
+func TestGenericCRDExclusionsAreQualifiedWhereKindsCollide(t *testing.T) {
+	tests := []struct {
+		name     string
+		gvr      schema.GroupVersionResource
+		kind     string
+		excluded bool
+	}{
+		{name: "knative service stays specialized", gvr: schema.GroupVersionResource{Group: "serving.knative.dev"}, kind: "Service", excluded: true},
+		{name: "foreign service survives builtin collision", gvr: schema.GroupVersionResource{Group: "platform.example.io"}, kind: "Service", excluded: false},
+		{name: "argo analysis run stays specialized", gvr: schema.GroupVersionResource{Group: "argoproj.io"}, kind: "AnalysisRun", excluded: true},
+		{name: "foreign analysis run survives", gvr: schema.GroupVersionResource{Group: "analysis.example.io"}, kind: "AnalysisRun", excluded: false},
+		{name: "trivy report stays excluded", gvr: schema.GroupVersionResource{Group: "aquasecurity.github.io"}, kind: "VulnerabilityReport", excluded: true},
+		{name: "foreign report survives", gvr: schema.GroupVersionResource{Group: "security.example.io"}, kind: "VulnerabilityReport", excluded: false},
+		{name: "foreign rollout survives", gvr: schema.GroupVersionResource{Group: "rollouts.example.io"}, kind: "Rollout", excluded: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := genericCRDExcluded(tt.gvr, tt.kind); got != tt.excluded {
+				t.Fatalf("genericCRDExcluded(%s, %s) = %v, want %v", tt.gvr.Group, tt.kind, got, tt.excluded)
+			}
+		})
+	}
+}
+
+func TestGenericCRDAddsForeignKindUsedByDedicatedIntegration(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "rollouts.example.io", Version: "v1", Resource: "rollouts"}
+	owner := metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "operator"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{gvr},
+		kinds:   map[schema.GroupVersionResource]string{gvr: "Rollout"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			gvr: {genericIdentityObject(gvr, "Rollout", "demo", "release", owner)},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	provider := &mockProvider{deployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "operator", Namespace: "demo"}}}}
+	topo, err := NewBuilder(provider).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	id := "rollout/demo/release/rollouts.example.io"
+	if nodeByID(topo.Nodes, id) == nil {
+		t.Fatalf("foreign Rollout was suppressed by the Argo integration: %+v", topo.Nodes)
+	}
+	if nodeByID(topo.Nodes, "rollout/demo/release") != nil {
+		t.Fatalf("foreign Rollout was also rendered as an Argo Rollout: %+v", topo.Nodes)
+	}
+	foundOwner := false
+	for _, edge := range topo.Edges {
+		foundOwner = foundOwner || edge.Source == "deployment/demo/operator" && edge.Target == id && edge.Type == EdgeManages
+	}
+	if !foundOwner {
+		t.Fatalf("foreign Rollout owner edge missing: %+v", topo.Edges)
+	}
+}
+
+func TestBuildDoesNotTreatIstioGatewayAsGatewayAPI(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "gateways"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{gvr},
+		kinds:   map[schema.GroupVersionResource]string{gvr: "Gateway"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			gvr: {genericIdentityObject(gvr, "Gateway", "demo", "mesh")},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+
+	for _, viewMode := range []ViewMode{ViewModeResources, ViewModeTraffic} {
+		t.Run(string(viewMode), func(t *testing.T) {
+			opts := DefaultBuildOptions()
+			opts.ViewMode = viewMode
+			topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(opts)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			if nodeByID(topo.Nodes, "istiogateway/demo/mesh") == nil {
+				t.Fatalf("Istio Gateway missing from %s topology: %+v", viewMode, topo.Nodes)
+			}
+			if nodeByID(topo.Nodes, "gateway/demo/mesh") != nil {
+				t.Fatalf("Istio Gateway was also rendered as Gateway API in %s topology: %+v", viewMode, topo.Nodes)
+			}
+		})
+	}
+}
+
+func TestBuildPrefersModernTraefikGroupWithoutDoubleRendering(t *testing.T) {
+	modern := schema.GroupVersionResource{Group: "traefik.io", Version: "v1alpha1", Resource: "ingressroutes"}
+	legacy := schema.GroupVersionResource{Group: "traefik.containo.us", Version: "v1alpha1", Resource: "ingressroutes"}
+
+	for _, viewMode := range []ViewMode{ViewModeResources, ViewModeTraffic} {
+		t.Run(string(viewMode), func(t *testing.T) {
+			dynamic := &genericIdentityDynamic{
+				watched: []schema.GroupVersionResource{legacy, modern},
+				kinds:   map[schema.GroupVersionResource]string{modern: "IngressRoute", legacy: "IngressRoute"},
+				resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+					modern: {genericIdentityObject(modern, "IngressRoute", "demo", "route")},
+					legacy: {genericIdentityObject(legacy, "IngressRoute", "demo", "route")},
+				},
+				listCalls: map[schema.GroupVersionResource]int{},
+			}
+			opts := DefaultBuildOptions()
+			opts.ViewMode = viewMode
+			topo, err := NewBuilder(&mockProvider{}).WithDynamic(dynamic).Build(opts)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			selected, ok := preferredTraefikGVR(dynamic, "IngressRoute")
+			if !ok || selected != modern {
+				t.Fatalf("preferred Traefik GVR = %s (%v), want %s", selected, ok, modern)
+			}
+			var matches []Node
+			for _, node := range topo.Nodes {
+				if node.ID == "ingressroute/demo/route" {
+					matches = append(matches, node)
+				}
+			}
+			if len(matches) != 1 || matches[0].Data["apiVersion"] != "traefik.io/v1alpha1" {
+				t.Fatalf("Traefik nodes = %+v, want one node from the modern API group", matches)
+			}
+		})
+	}
+
+	legacyOnly := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{legacy},
+		kinds:   map[schema.GroupVersionResource]string{legacy: "IngressRoute"},
+	}
+	selected, ok := preferredTraefikGVR(legacyOnly, "IngressRoute")
+	if !ok || selected != legacy {
+		t.Fatalf("legacy-only Traefik GVR = %s (%v), want %s", selected, ok, legacy)
+	}
+}
+
+func TestGenericCRDSkipsBuiltInGroupsBeforeProviderFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		gvr  schema.GroupVersionResource
+		kind string
+	}{
+		{name: "typed apps API", gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, kind: "Deployment"},
+		{name: "dynamically watched DRA API", gvr: schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}, kind: "ResourceClaim"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dynamic := &genericIdentityDynamic{
+				watched: []schema.GroupVersionResource{tt.gvr},
+				kinds:   map[schema.GroupVersionResource]string{tt.gvr: tt.kind},
+				resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+					tt.gvr: {genericIdentityObject(tt.gvr, tt.kind, "demo", "duplicate", metav1.OwnerReference{APIVersion: "apps/v1", Kind: "Deployment", Name: "operator"})},
+				},
+				listCalls: map[schema.GroupVersionResource]int{},
+			}
+			nodes := []Node{{ID: "deployment/demo/operator", Kind: KindDeployment, Name: "operator", Data: map[string]any{"namespace": "demo"}}}
+			fallbackProvider := &dynamicProviderWithoutExactCRD{DynamicProvider: dynamic}
+
+			nodes, _ = (&Builder{dynamic: fallbackProvider}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+			if dynamic.listCalls[tt.gvr] != 0 {
+				t.Fatalf("generic CRD fallback listed built-in %s %d times", tt.gvr, dynamic.listCalls[tt.gvr])
+			}
+			if len(nodes) != 1 {
+				t.Fatalf("built-in %s was rendered as a generic CRD: %+v", tt.kind, nodes)
+			}
+		})
+	}
+}
+
+func TestGenericCRDOwnerResolutionUsesIndexedCalicoAlias(t *testing.T) {
+	childGVR := schema.GroupVersionResource{Group: "children.example.io", Version: "v1", Resource: "children"}
+	dynamic := &genericIdentityDynamic{
+		watched: []schema.GroupVersionResource{childGVR},
+		kinds:   map[schema.GroupVersionResource]string{childGVR: "Child"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{
+			childGVR: {genericIdentityObject(childGVR, "Child", "demo", "leaf", metav1.OwnerReference{
+				APIVersion: "crd.projectcalico.org/v1", Kind: "NetworkPolicy", Name: "allow",
+			})},
+		},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	calicoID := "caliconetworkpolicy/demo/allow"
+	nodes := []Node{{
+		ID: calicoID, Kind: KindCalicoNetworkPolicy, Name: "allow",
+		Data: map[string]any{
+			"namespace":   "demo",
+			"apiVersion":  "projectcalico.org/v3",
+			"apiVersions": []string{"projectcalico.org/v3", "crd.projectcalico.org/v1"},
+		},
+	}}
+
+	nodes, edges := (&Builder{dynamic: dynamic}).addGenericCRDNodes(nodes, nil, DefaultBuildOptions())
+	childID := "child/demo/leaf/children.example.io"
+	if nodeByID(nodes, childID) == nil {
+		t.Fatalf("generic child missing: %+v", nodes)
+	}
+	for _, edge := range edges {
+		if edge.Source == calicoID && edge.Target == childID && edge.Type == EdgeManages {
+			return
+		}
+	}
+	t.Fatalf("generic child did not resolve the Calico CRD-group alias: %+v", edges)
+}
+
+func TestRelationshipsWithObjectUsesExactGroupWhenDirectIDCollides(t *testing.T) {
+	volcanoGVR := schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1alpha1", Resource: "jobs"}
+	jobSetGVR := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
+	dynamic := &genericIdentityDynamic{
+		watched:   []schema.GroupVersionResource{volcanoGVR, jobSetGVR},
+		kinds:     map[schema.GroupVersionResource]string{volcanoGVR: "Job", jobSetGVR: "JobSet"},
+		resources: map[schema.GroupVersionResource][]*unstructured.Unstructured{},
+		listCalls: map[schema.GroupVersionResource]int{},
+	}
+	volcano := genericIdentityObject(volcanoGVR, "Job", "ml", "train")
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "cronjob/ml/train", Kind: KindCronJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+			{ID: "jobset/ml/train/jobset.x-k8s.io", Kind: NodeKind("JobSet"), Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "jobset.x-k8s.io/v1alpha2"}},
+			{ID: "job/ml/train", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+			{ID: "job/ml/train/batch.volcano.sh", Kind: NodeKind("Job"), Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+		},
+		Edges: []Edge{
+			{ID: "cron-core", Source: "cronjob/ml/train", Target: "job/ml/train", Type: EdgeManages},
+			{ID: "jobset-volcano", Source: "jobset/ml/train/jobset.x-k8s.io", Target: "job/ml/train/batch.volcano.sh", Type: EdgeManages},
+		},
+	}
+
+	rel := GetRelationshipsWithObject("Job", "ml", "train", volcano, topo, nil, dynamic, IndexByResource(topo))
+	if rel == nil || rel.Owner == nil {
+		t.Fatalf("exact-group relationships missing: %+v", rel)
+	}
+	if *rel.Owner != (ResourceRef{Group: "jobset.x-k8s.io", Kind: "JobSet", Namespace: "ml", Name: "train"}) {
+		t.Fatalf("owner = %+v, want JobSet rather than core CronJob", rel.Owner)
+	}
+	if len(rel.ManagedBy) != 1 || rel.ManagedBy[0] != *rel.Owner {
+		t.Fatalf("managed-by = %+v, want exact JobSet owner %+v", rel.ManagedBy, rel.Owner)
+	}
+}

--- a/pkg/topology/gitops_identity_test.go
+++ b/pkg/topology/gitops_identity_test.go
@@ -1,0 +1,89 @@
+package topology
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestAddGitOpsManagedResourceEdgesPreservesArgoAPIGroup(t *testing.T) {
+	nodes := []Node{
+		{ID: "application/argocd/training", Kind: KindApplication, Name: "training", Data: map[string]any{"namespace": "argocd", "apiVersion": "argoproj.io/v1alpha1"}},
+		{ID: "job/ml/train", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+		{ID: "job/ml/train/batch.volcano.sh", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+	}
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"namespace": "argocd", "name": "training"},
+		"status": map[string]any{"resources": []any{
+			map[string]any{"group": "batch.volcano.sh", "kind": "Job", "namespace": "ml", "name": "train"},
+		}},
+	}}
+
+	edges := addGitOpsManagedResourceEdges(
+		nodes,
+		nil,
+		[]*unstructured.Unstructured{app},
+		map[string]string{"argocd/training": "application/argocd/training"},
+		nil,
+		nil,
+		nil,
+	)
+	if len(edges) != 1 || edges[0].Target != "job/ml/train/batch.volcano.sh" {
+		t.Fatalf("Argo edges = %+v, want only the exact Volcano Job", edges)
+	}
+}
+
+func TestAddGitOpsManagedResourceEdgesDefaultsArgoBuiltinGroup(t *testing.T) {
+	nodes := []Node{
+		{ID: "application/argocd/training", Kind: KindApplication, Name: "training", Data: map[string]any{"namespace": "argocd", "apiVersion": "argoproj.io/v1alpha1"}},
+		{ID: "job/ml/train", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+		{ID: "job/ml/train/batch.volcano.sh", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+	}
+	app := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"namespace": "argocd", "name": "training"},
+		"spec":     map[string]any{"destination": map[string]any{"namespace": "ml"}},
+		"status": map[string]any{"resources": []any{
+			map[string]any{"kind": "Job", "name": "train"},
+		}},
+	}}
+
+	edges := addGitOpsManagedResourceEdges(
+		nodes,
+		nil,
+		[]*unstructured.Unstructured{app},
+		map[string]string{"argocd/training": "application/argocd/training"},
+		map[string]string{"application/argocd/training": "ml"},
+		nil,
+		nil,
+	)
+	if len(edges) != 1 || edges[0].Target != "job/ml/train" {
+		t.Fatalf("Argo edges = %+v, want only the built-in Job", edges)
+	}
+}
+
+func TestAddGitOpsManagedResourceEdgesParsesFluxIdentityFromRight(t *testing.T) {
+	nodes := []Node{
+		{ID: "kustomization/flux-system/training", Kind: KindKustomization, Name: "training", Data: map[string]any{"namespace": "flux-system", "apiVersion": "kustomize.toolkit.fluxcd.io/v1"}},
+		{ID: "job/ml/train_run", Kind: KindJob, Name: "train_run", Data: map[string]any{"namespace": "ml"}},
+		{ID: "job/ml/train_run/batch.volcano.sh", Kind: KindJob, Name: "train_run", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+	}
+	ks := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"namespace": "flux-system", "name": "training"},
+		"status": map[string]any{"inventory": map[string]any{"entries": []any{
+			map[string]any{"id": "ml_train_run_batch.volcano.sh_Job"},
+		}}},
+	}}
+
+	edges := addGitOpsManagedResourceEdges(
+		nodes,
+		nil,
+		nil,
+		nil,
+		nil,
+		[]*unstructured.Unstructured{ks},
+		map[string]string{"flux-system/training": "kustomization/flux-system/training"},
+	)
+	if len(edges) != 1 || edges[0].Target != "job/ml/train_run/batch.volcano.sh" {
+		t.Fatalf("Flux edges = %+v, want only the exact underscore-named Volcano Job", edges)
+	}
+}

--- a/pkg/topology/karpenter_test.go
+++ b/pkg/topology/karpenter_test.go
@@ -72,6 +72,7 @@ func (p *karpenterDynamicProvider) GetKindForGVR(gvr schema.GroupVersionResource
 func (p *karpenterDynamicProvider) IsCRD(string) bool {
 	return true
 }
+func (p *karpenterDynamicProvider) IsCRDGVR(schema.GroupVersionResource) bool { return true }
 
 func TestBuildKarpenterTopologyUsesReferencedNodeClassTypes(t *testing.T) {
 	nodePoolGVR := schema.GroupVersionResource{Group: karpenter.Group, Version: "v1", Resource: "nodepools"}

--- a/pkg/topology/managedby.go
+++ b/pkg/topology/managedby.go
@@ -63,6 +63,16 @@ func SynthesizeManagedBy(obj metav1.Object, kind, namespace, name string, topo *
 	return nil
 }
 
+func synthesizeManagedByFromNode(obj metav1.Object, nodeID string, topo *Topology, dp DynamicProvider, idx *RelationshipsIndex) []ResourceRef {
+	if ref := detectManagedByFromMeta(obj); ref != nil {
+		return []ResourceRef{*ref}
+	}
+	if top := walkTopmostOwnerFromNodeID(nodeID, topo, dp, idx); top != nil {
+		return []ResourceRef{*top}
+	}
+	return nil
+}
+
 // detectManagedByFromMeta inspects labels/annotations on obj for GitOps / Helm
 // ownership signals and returns the implied manager ref. Returns nil if no
 // signal is present. Mirrors detectGitOpsOwner precedence in the web package.
@@ -162,6 +172,10 @@ func parseArgoTrackingID(value string) (namespace, name string, ok bool) {
 // map (O(E)) — fine for single-resource calls, but high-fanout callers
 // (list/search enrichment) MUST pass a shared index to avoid O(N × E).
 func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicProvider, idx *RelationshipsIndex) *ResourceRef {
+	return walkTopmostOwnerFromNodeID(buildNodeID(kind, namespace, name, dp), topo, dp, idx)
+}
+
+func walkTopmostOwnerFromNodeID(startID string, topo *Topology, dp DynamicProvider, idx *RelationshipsIndex) *ResourceRef {
 	if topo == nil {
 		return nil
 	}
@@ -198,7 +212,7 @@ func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicPr
 	// Seed visited with the starting node so a cycle that loops back to the
 	// queried resource (A→B→A) returns the first found owner (B) instead of
 	// walking one extra hop and producing a self-referential ManagedBy ref.
-	cur := buildNodeID(kind, namespace, name, dp)
+	cur := startID
 	visited := map[string]bool{cur: true}
 	var topRef *ResourceRef
 	for {

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -49,6 +49,7 @@ func (s *stubDP) GetKindForGVR(gvr schema.GroupVersionResource) string {
 	return s.kindByGVR[gvr]
 }
 func (s *stubDP) IsCRD(_ string) bool { return true }
+func (s *stubDP) IsCRDGVR(schema.GroupVersionResource) bool { return true }
 
 func meta(labels, annos map[string]string) metav1.Object {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annos}}

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -48,7 +48,7 @@ func (s *stubDP) GetGVRWithGroup(kindOrName, group string) (schema.GroupVersionR
 func (s *stubDP) GetKindForGVR(gvr schema.GroupVersionResource) string {
 	return s.kindByGVR[gvr]
 }
-func (s *stubDP) IsCRD(_ string) bool { return true }
+func (s *stubDP) IsCRD(_ string) bool                       { return true }
 func (s *stubDP) IsCRDGVR(schema.GroupVersionResource) bool { return true }
 
 func meta(labels, annos map[string]string) metav1.Object {

--- a/pkg/topology/neighborhood.go
+++ b/pkg/topology/neighborhood.go
@@ -2,6 +2,8 @@ package topology
 
 import (
 	"strings"
+
+	"github.com/skyhook-io/radar/pkg/resourceid"
 )
 
 // Profile controls how broadly a neighborhood expands. The public surface is
@@ -580,6 +582,9 @@ func nodeMatchesAPIGroup(n *Node, group string) bool {
 		return true
 	}
 	if nodeAPIGroupFromData(n) == group {
+		return true
+	}
+	if nodeAPIGroupFromData(n) == "" && resourceid.GroupForBuiltinKind(KubernetesKindForNode(n)) == group {
 		return true
 	}
 	if !IsCalicoPolicyKind(n.Kind) {

--- a/pkg/topology/neighborhood.go
+++ b/pkg/topology/neighborhood.go
@@ -166,13 +166,15 @@ func BuildNeighborhoodWithIndex(t *Topology, root ResourceRef, opts Neighborhood
 	if ok && root.Group != "" && !nodeMatchesAPIGroup(rootNode, root.Group) {
 		ok = false
 	}
-	if !ok {
-		// Fallback: try matching by (kind, namespace, name [+ group]) tuple.
+	if !ok || root.Group == "" && !nodeIsCanonicalBuiltin(rootNode) {
+		// Match by (kind, namespace, name [+ group]) tuple. A group-less known
+		// built-in keeps the established default-to-core behavior; custom kinds
+		// must be unambiguous when their group is omitted.
 		// Mostly for CRDs whose topology node ID uses a different prefix than
 		// the lowercase kind (e.g. "knativeservice/"). When root.Group is set,
 		// findNodeByRef also disambiguates kind-collisions across API groups
 		// (CAPI cluster.x-k8s.io/Cluster vs Fleet cluster.fleet.io/Cluster).
-		matched, ambiguous := findNodeByRef(t.Nodes, root)
+		matched, ambiguous := findNodeByRef(t.Nodes, root, dp)
 		if ambiguous {
 			sub.AmbiguousRoot = true
 			return sub
@@ -182,6 +184,20 @@ func BuildNeighborhoodWithIndex(t *Topology, root ResourceRef, opts Neighborhood
 		}
 		rootNode = matched
 		rootID = rootNode.ID
+	}
+	resolvedKind := KubernetesKindForNode(rootNode)
+	resolvedGroup := root.Group
+	if resolvedGroup == "" {
+		resolvedGroup = nodeAPIGroupFromData(rootNode)
+		if builtinGroup, builtin := resourceid.BuiltinGroup(resolvedKind); resolvedGroup == "" && builtin {
+			resolvedGroup = builtinGroup
+		}
+	}
+	sub.Root = ResourceRef{
+		Kind:      resolvedKind,
+		Namespace: nodeNamespaceFromData(rootNode),
+		Name:      rootNode.Name,
+		Group:     resolvedGroup,
 	}
 
 	// Apply the Allow gate to the root itself. Callers' upfront RBAC checks
@@ -433,19 +449,18 @@ func edgeTypesForAuto(rootKind NodeKind) map[EdgeType]bool {
 // for kind=Service&group=serving.knative.dev finds the KnativeService topology
 // node. Without this, the comparison Node.Kind="KnativeService" vs
 // ref.Kind="Service" never matches and the root lookup silently fails.
-func findNodeByRef(nodes []Node, ref ResourceRef) (*Node, bool) {
-	// Resolve the caller-facing (kind, group) tuple to the kind the topology
-	// builder uses on Node.Kind. Falls back to ref.Kind unchanged when there's
-	// no pseudo-kind mapping for this (kind, group).
-	wantKind := pseudoKindFor(ref.Kind, ref.Group)
+func findNodeByRef(nodes []Node, ref ResourceRef, dp DynamicProvider) (*Node, bool) {
+	// Resolve plural API resource names through discovery before comparing the
+	// caller-facing Kubernetes kind and Radar's topology pseudo-kind.
+	resourceKind := normalizeKindWithGroup(ref.Kind, ref.Group, dp)
+	wantKind := pseudoKindFor(resourceKind, ref.Group)
 	var match *Node
 	matchGroup := ""
 	for i := range nodes {
 		n := &nodes[i]
-		// Compare against the resolved pseudo-kind first; if that misses fall
-		// back to the original ref.Kind so callers that don't supply a group,
-		// or kinds that aren't pseudo-mapped, still work when unambiguous.
-		if !strings.EqualFold(string(n.Kind), wantKind) && !strings.EqualFold(string(n.Kind), ref.Kind) {
+		// The real Kubernetes kind catches group-less pseudo-kind lookups; the
+		// topology kind catches an explicitly grouped pseudo-kind.
+		if !strings.EqualFold(string(n.Kind), wantKind) && !strings.EqualFold(KubernetesKindForNode(n), resourceKind) {
 			continue
 		}
 		if n.Name != ref.Name {
@@ -468,6 +483,12 @@ func findNodeByRef(nodes []Node, ref ResourceRef) (*Node, bool) {
 		matchGroup = group
 	}
 	return match, false
+}
+
+func nodeIsCanonicalBuiltin(node *Node) bool {
+	group, ok := resourceid.BuiltinGroup(KubernetesKindForNode(node))
+	advertisedGroup := nodeAPIGroupFromData(node)
+	return ok && (advertisedGroup == "" || advertisedGroup == group)
 }
 
 // pseudoKindFor maps an (API kind, API group) to the synthesized topology

--- a/pkg/topology/neighborhood_test.go
+++ b/pkg/topology/neighborhood_test.go
@@ -566,6 +566,89 @@ func TestBuildNeighborhood_GroupEmptyRootAmbiguous(t *testing.T) {
 	}
 }
 
+func TestBuildNeighborhood_GroupEmptyRootDefaultsToCoreWhenCRDCollides(t *testing.T) {
+	core := Node{
+		ID:     "job/ml/train",
+		Kind:   KindJob,
+		Name:   "train",
+		Status: StatusHealthy,
+		Data: map[string]any{
+			"namespace": "ml",
+		},
+	}
+	volcano := Node{
+		ID:     "job/ml/train/batch.volcano.sh",
+		Kind:   KindJob,
+		Name:   "train",
+		Status: StatusHealthy,
+		Data: map[string]any{
+			"namespace":  "ml",
+			"apiVersion": "batch.volcano.sh/v1alpha1",
+		},
+	}
+	topo := &Topology{Nodes: []Node{core, volcano}}
+
+	sub := BuildNeighborhoodWithIndex(
+		topo,
+		ResourceRef{Kind: "Job", Namespace: "ml", Name: "train"},
+		NeighborhoodOptions{Profile: ProfileAll, Hops: 1},
+		nil,
+		nil,
+	)
+	if sub.AmbiguousRoot || len(sub.Nodes) != 1 || sub.Nodes[0].ID != core.ID {
+		t.Fatalf("group-less Job resolved to nodes=%v ambiguous=%v, want core %q", nodeIDs(sub), sub.AmbiguousRoot, core.ID)
+	}
+	if sub.Root.Kind != "Job" || sub.Root.Group != "batch" {
+		t.Fatalf("resolved root = %#v, want exact core Job identity", sub.Root)
+	}
+
+	for _, tc := range []struct {
+		group string
+		want  string
+	}{
+		{group: "batch", want: core.ID},
+		{group: "batch.volcano.sh", want: volcano.ID},
+	} {
+		sub = BuildNeighborhoodWithIndex(
+			topo,
+			ResourceRef{Kind: "Job", Namespace: "ml", Name: "train", Group: tc.group},
+			NeighborhoodOptions{Profile: ProfileAll, Hops: 1},
+			nil,
+			nil,
+		)
+		if sub.AmbiguousRoot || len(sub.Nodes) != 1 || sub.Nodes[0].ID != tc.want {
+			t.Fatalf("group %q resolved to nodes=%v ambiguous=%v, want %q", tc.group, nodeIDs(sub), sub.AmbiguousRoot, tc.want)
+		}
+	}
+}
+
+func TestBuildNeighborhood_GroupEmptyUniqueCustomBuiltinKindKeepsGroup(t *testing.T) {
+	volcano := Node{
+		ID:     "job/ml/train/batch.volcano.sh",
+		Kind:   KindJob,
+		Name:   "train",
+		Status: StatusHealthy,
+		Data: map[string]any{
+			"namespace":  "ml",
+			"apiVersion": "batch.volcano.sh/v1alpha1",
+		},
+	}
+
+	sub := BuildNeighborhoodWithIndex(
+		&Topology{Nodes: []Node{volcano}},
+		ResourceRef{Kind: "Job", Namespace: "ml", Name: "train"},
+		NeighborhoodOptions{Profile: ProfileAll, Hops: 1},
+		nil,
+		nil,
+	)
+	if sub.AmbiguousRoot || len(sub.Nodes) != 1 || sub.Nodes[0].ID != volcano.ID {
+		t.Fatalf("group-less unique custom Job resolved to nodes=%v ambiguous=%v", nodeIDs(sub), sub.AmbiguousRoot)
+	}
+	if sub.Root.Kind != "Job" || sub.Root.Group != "batch.volcano.sh" {
+		t.Fatalf("resolved root = %#v, want exact Volcano Job identity", sub.Root)
+	}
+}
+
 // TestBuildNeighborhood_AllowDeniesRoot verifies the root is gated by Allow,
 // not just the BFS frontier. A Secret root with namespace access but no
 // per-namespace `get secrets` SAR is the load-bearing case: callers' upfront

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/skyhook-io/radar/pkg/resourceid"
 )
 
 // RelationshipsIndex is a precomputed map from node ID to the edges touching
@@ -17,7 +19,9 @@ import (
 // Build once via IndexByResource(topo). Pass to GetRelationshipsWithIndex on
 // each call. Lookups are read-only and goroutine-safe; mutation is not.
 type RelationshipsIndex struct {
-	byNodeID map[string]*nodeEdgeSlots
+	byNodeID           map[string]*nodeEdgeSlots
+	nodesByID          map[string]*Node
+	nodesByResourceKey map[string]*Node
 }
 
 type nodeEdgeSlots struct {
@@ -29,9 +33,24 @@ type nodeEdgeSlots struct {
 // nil topology — returns an empty index whose lookups all miss.
 func IndexByResource(topo *Topology) *RelationshipsIndex {
 	if topo == nil {
-		return &RelationshipsIndex{byNodeID: map[string]*nodeEdgeSlots{}}
+		return &RelationshipsIndex{
+			byNodeID:           map[string]*nodeEdgeSlots{},
+			nodesByID:          map[string]*Node{},
+			nodesByResourceKey: map[string]*Node{},
+		}
 	}
-	idx := &RelationshipsIndex{byNodeID: make(map[string]*nodeEdgeSlots, len(topo.Nodes))}
+	idx := &RelationshipsIndex{
+		byNodeID:           make(map[string]*nodeEdgeSlots, len(topo.Nodes)),
+		nodesByID:          make(map[string]*Node, len(topo.Nodes)),
+		nodesByResourceKey: make(map[string]*Node, len(topo.Nodes)),
+	}
+	for i := range topo.Nodes {
+		node := &topo.Nodes[i]
+		idx.nodesByID[node.ID] = node
+		for _, key := range nodeResourceKeys(node) {
+			idx.nodesByResourceKey[key] = node
+		}
+	}
 	for _, e := range topo.Edges {
 		if e.Source != "" {
 			slot := idx.byNodeID[e.Source]
@@ -184,14 +203,10 @@ func GetCascadeDeletePreview(root ResourceRef, topo *Topology, dp DynamicProvide
 			}
 			visited[targetID] = true
 
-			ref := parseNodeID(targetID, dp)
+			ref := resourceRefForNode(nodeByID[targetID], dp)
 			if ref == nil {
 				continue
 			}
-			if node := nodeByID[targetID]; node != nil {
-				ref.Group = nodeAPIGroupFromData(node)
-			}
-			enrichRef(ref, dp)
 			dependents = append(dependents, *ref)
 			queue = append(queue, targetID)
 		}
@@ -296,34 +311,30 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 
 	// Build the node ID for this resource (matches format used in builder.go)
 	resolvedKind := kind
-	if objectKind, objectGroup := objectGVK(obj); objectGroup != "" {
+	objectKind, objectGroup := objectGVK(obj)
+	if objectGroup != "" {
 		if objectKind != "" {
 			resolvedKind = objectKind
 		}
 		resolvedKind = KindForGVK(resolvedKind, objectGroup)
 	}
 	nodeID := buildNodeID(resolvedKind, namespace, name, dp)
-	nodeByID := make(map[string]*Node, len(topo.Nodes))
-	for i := range topo.Nodes {
-		nodeByID[topo.Nodes[i].ID] = &topo.Nodes[i]
+	lookupIndex := idx
+	if lookupIndex == nil {
+		lookupIndex = IndexByResource(topo)
 	}
-	if _, exists := nodeByID[nodeID]; !exists {
-		_, objectGroup := objectGVK(obj)
+	nodeByID := lookupIndex.nodesByID
+	directNode, directExists := nodeByID[nodeID]
+	if !directExists || objectGroup != "" && !nodeMatchesAPIGroup(directNode, objectGroup) {
 		if matched, _ := findNodeByRef(topo.Nodes, ResourceRef{Kind: resolvedKind, Namespace: namespace, Name: name, Group: objectGroup}); matched != nil {
 			nodeID = matched.ID
+		} else if objectGroup != "" {
+			nodeID = ""
 		}
 	}
-	incomingEdges, outgoingEdges := edgesForNode(topo, idx, nodeID)
+	incomingEdges, outgoingEdges := edgesForNode(topo, lookupIndex, nodeID)
 	refForNodeID := func(id string) *ResourceRef {
-		ref := parseNodeID(id, dp)
-		if ref == nil {
-			return nil
-		}
-		if node := nodeByID[id]; node != nil {
-			ref.Group = nodeAPIGroupFromData(node)
-		}
-		enrichRef(ref, dp)
-		return ref
+		return resourceRefForNode(nodeByID[id], dp)
 	}
 
 	rel := &Relationships{}
@@ -431,8 +442,8 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 			switch ref.Kind {
 			case "PodDisruptionBudget":
 				rel.PDBs = append(rel.PDBs, *ref)
-			case "NetworkPolicy", "CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy",
-				"CalicoNetworkPolicy", "CalicoGlobalNetworkPolicy", "CalicoStagedNetworkPolicy", "CalicoStagedGlobalNetworkPolicy", "CalicoStagedKubernetesNetworkPolicy":
+			case "NetworkPolicy", "GlobalNetworkPolicy", "StagedNetworkPolicy", "StagedGlobalNetworkPolicy", "StagedKubernetesNetworkPolicy",
+				"CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy":
 				rel.NetworkPolicies = append(rel.NetworkPolicies, *ref)
 			}
 		case EdgeConfigures:
@@ -448,7 +459,7 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 		}
 	}
 
-	addServiceEntrypoints(rel, topo, idx, dp)
+	addServiceEntrypoints(rel, topo, lookupIndex)
 
 	// Convenience shortcuts: bridge the Deployment↔ReplicaSet↔Pod gap
 	// so users see Pods directly under Deployments and vice versa.
@@ -458,7 +469,7 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 		for _, child := range rel.Children {
 			if strings.EqualFold(child.Kind, "ReplicaSet") {
 				childID := buildNodeID(child.Kind, child.Namespace, child.Name, dp)
-				_, childOutgoing := edgesForNode(topo, idx, childID)
+				_, childOutgoing := edgesForNode(topo, lookupIndex, childID)
 				for _, edge := range childOutgoing {
 					if edge.Type != EdgeManages {
 						continue
@@ -476,7 +487,7 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 	if kindLower == "pods" || kindLower == "pod" {
 		if rel.Owner != nil && strings.EqualFold(rel.Owner.Kind, "ReplicaSet") {
 			ownerID := buildNodeID(rel.Owner.Kind, rel.Owner.Namespace, rel.Owner.Name, dp)
-			ownerIncoming, _ := edgesForNode(topo, idx, ownerID)
+			ownerIncoming, _ := edgesForNode(topo, lookupIndex, ownerID)
 			for _, edge := range ownerIncoming {
 				if edge.Type != EdgeManages {
 					continue
@@ -646,7 +657,7 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 	if m, ok := queriedObj.(metav1.Object); ok {
 		managedByMeta = m
 	}
-	if mb := SynthesizeManagedBy(managedByMeta, resolvedKind, namespace, name, topo, dp, idx); len(mb) > 0 {
+	if mb := synthesizeManagedByFromNode(managedByMeta, nodeID, topo, dp, idx); len(mb) > 0 {
 		rel.ManagedBy = mb
 	}
 
@@ -664,18 +675,21 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 	return rel
 }
 
-func addServiceEntrypoints(rel *Relationships, topo *Topology, idx *RelationshipsIndex, dp DynamicProvider) {
+func addServiceEntrypoints(rel *Relationships, topo *Topology, idx *RelationshipsIndex) {
 	for _, service := range rel.Services {
-		if !strings.EqualFold(service.Kind, "Service") {
+		if service.Group != "" {
 			continue
 		}
-		serviceID := buildNodeID(service.Kind, service.Namespace, service.Name, dp)
-		incoming, _ := edgesForNode(topo, idx, serviceID)
+		serviceNode := idx.nodesByResourceKey[resourceid.ResourceKey(service.Group, service.Kind, service.Namespace, service.Name)]
+		if serviceNode == nil || !strings.EqualFold(KubernetesKindForNode(serviceNode), "Service") {
+			continue
+		}
+		incoming, _ := edgesForNode(topo, idx, serviceNode.ID)
 		for _, edge := range incoming {
 			if edge.Type != EdgeRoutesTo && edge.Type != EdgeExposes {
 				continue
 			}
-			ref := resourceRefForNodeID(edge.Source, topo, dp)
+			ref := resourceRefForNode(idx.nodesByID[edge.Source], nil)
 			if ref == nil {
 				continue
 			}
@@ -695,19 +709,29 @@ func addServiceEntrypoints(rel *Relationships, topo *Topology, idx *Relationship
 }
 
 func resourceRefForNodeID(nodeID string, topo *Topology, dp DynamicProvider) *ResourceRef {
-	ref := parseNodeID(nodeID, dp)
-	if ref == nil {
-		return nil
-	}
 	if topo != nil {
 		for i := range topo.Nodes {
 			if topo.Nodes[i].ID == nodeID {
-				ref.Group = nodeAPIGroupFromData(&topo.Nodes[i])
-				break
+				return resourceRefForNode(&topo.Nodes[i], dp)
 			}
 		}
 	}
-	enrichRef(ref, dp)
+	return nil
+}
+
+func resourceRefForNode(node *Node, dp DynamicProvider) *ResourceRef {
+	if node == nil {
+		return nil
+	}
+	ref := parseNodeID(node.ID, dp)
+	if ref == nil {
+		return nil
+	}
+	ref.Kind = KubernetesKindForNode(node)
+	ref.Group = nodeAPIGroupFromData(node)
+	if ref.Group == "" {
+		ref.Group = resourceid.GroupForBuiltinKind(ref.Kind)
+	}
 	return ref
 }
 

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -146,37 +146,29 @@ func GetCascadeDeletePreview(root ResourceRef, topo *Topology, dp DynamicProvide
 			// Two CRDs can share a lowercase plural, so the deterministic
 			// kind/ns/name ID may resolve to the wrong API group. Resolve
 			// against each node's recorded API group instead.
-			if matched, _ := findNodeByRef(topo.Nodes, root); matched != nil {
+			if matched, _ := findNodeByRef(topo.Nodes, root, dp); matched != nil {
 				rootNode = matched
 				rootID = matched.ID
 				ok = true
 			}
 		}
-	} else {
-		if !ok {
+	} else if !ok || !nodeIsCanonicalBuiltin(rootNode) {
+		matched, ambiguous := findNodeByRef(topo.Nodes, root, dp)
+		if ambiguous || matched == nil {
 			return preview
 		}
-		rootKind := string(rootNode.Kind)
-		if externalKind, found := collisionKindToK8sKind[rootNode.Kind]; found {
-			rootKind = externalKind
-		}
-		matches := 0
-		for i := range topo.Nodes {
-			node := &topo.Nodes[i]
-			nodeKind := string(node.Kind)
-			if externalKind, found := collisionKindToK8sKind[node.Kind]; found {
-				nodeKind = externalKind
-			}
-			if strings.EqualFold(nodeKind, rootKind) && node.Name == root.Name && nodeNamespaceFromData(node) == root.Namespace {
-				matches++
-			}
-		}
-		if matches > 1 {
-			return preview
-		}
+		rootNode = matched
+		rootID = matched.ID
+		ok = true
 	}
 	if !ok {
 		return preview
+	}
+	if resolved := resourceRefForNode(rootNode, dp); resolved != nil {
+		if root.Group != "" {
+			resolved.Group = root.Group
+		}
+		preview.Root = *resolved
 	}
 	preview.RootResolved = true
 
@@ -325,8 +317,21 @@ func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Top
 	}
 	nodeByID := lookupIndex.nodesByID
 	directNode, directExists := nodeByID[nodeID]
+	resourceKind := objectKind
+	if resourceKind == "" {
+		resourceKind = normalizeKindWithGroup(kind, objectGroup, dp)
+	}
+	resourceGroup := objectGroup
+	if builtinGroup, builtin := resourceid.BuiltinGroup(resourceKind); resourceGroup == "" && builtin {
+		resourceGroup = builtinGroup
+	}
+	if exactNode := lookupIndex.nodesByResourceKey[resourceid.ResourceKey(resourceGroup, resourceKind, namespace, name)]; exactNode != nil {
+		nodeID = exactNode.ID
+		directNode = exactNode
+		directExists = true
+	}
 	if !directExists || objectGroup != "" && !nodeMatchesAPIGroup(directNode, objectGroup) {
-		if matched, _ := findNodeByRef(topo.Nodes, ResourceRef{Kind: resolvedKind, Namespace: namespace, Name: name, Group: objectGroup}); matched != nil {
+		if matched, _ := findNodeByRef(topo.Nodes, ResourceRef{Kind: resolvedKind, Namespace: namespace, Name: name, Group: objectGroup}, dp); matched != nil {
 			nodeID = matched.ID
 		} else if objectGroup != "" {
 			nodeID = ""

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -130,6 +130,36 @@ func TestGetCascadeDeletePreview_ResolutionState(t *testing.T) {
 	}
 }
 
+func TestGetCascadeDeletePreview_UnqualifiedUniqueGenericRoot(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "widget/demo/root/example.io", Kind: "Widget", Name: "root", Data: map[string]any{"namespace": "demo", "apiVersion": "example.io/v1"}},
+			{ID: "gadget/demo/child/example.io", Kind: "Gadget", Name: "child", Data: map[string]any{"namespace": "demo", "apiVersion": "example.io/v1"}},
+		},
+		Edges: []Edge{{Source: "widget/demo/root/example.io", Target: "gadget/demo/child/example.io", Type: EdgeManages}},
+	}
+
+	preview := GetCascadeDeletePreview(ResourceRef{Kind: "Widget", Namespace: "demo", Name: "root"}, topo, nil)
+	if !preview.RootResolved || preview.Root.Group != "example.io" {
+		t.Fatalf("generic preview root = %+v, want exact resolved identity", preview)
+	}
+	if len(preview.Dependents) != 1 || preview.Dependents[0].Name != "child" || preview.Dependents[0].Group != "example.io" {
+		t.Fatalf("generic preview dependents = %+v, want exact child", preview.Dependents)
+	}
+}
+
+func TestGetCascadeDeletePreview_UnqualifiedBuiltinDefaultsToTypedRoot(t *testing.T) {
+	topo := &Topology{Nodes: []Node{
+		{ID: "job/ml/train", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml"}},
+		{ID: "job/ml/train/batch.volcano.sh", Kind: KindJob, Name: "train", Data: map[string]any{"namespace": "ml", "apiVersion": "batch.volcano.sh/v1alpha1"}},
+	}}
+
+	preview := GetCascadeDeletePreview(ResourceRef{Kind: "Job", Namespace: "ml", Name: "train"}, topo, nil)
+	if !preview.RootResolved || preview.Root.Group != "batch" || preview.Root.Kind != "Job" {
+		t.Fatalf("cascade root = %+v, want exact typed Job identity", preview)
+	}
+}
+
 func TestGetCascadeDeletePreview_RouteCollisionUsesGroup(t *testing.T) {
 	knativeGVR := schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "routes"}
 	openshiftGVR := schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -344,7 +344,7 @@ func TestGetRelationships_ConfiguresDispatchesByKind(t *testing.T) {
 	for _, ref := range rel.ConfigRefs {
 		gotConfigKinds[ref.Kind] = true
 	}
-	for _, kind := range []string{"SealedSecret", "ConfigMap", "destinationrule"} {
+	for _, kind := range []string{"SealedSecret", "ConfigMap", "DestinationRule"} {
 		if !gotConfigKinds[kind] {
 			t.Errorf("ConfigRefs missing %s; got kinds=%v", kind, gotConfigKinds)
 		}
@@ -395,6 +395,85 @@ func TestGetRelationships_WorkloadIncludesServiceEntrypoints(t *testing.T) {
 	}
 	if len(serviceRel.Services) != 0 {
 		t.Fatalf("Service Services = %+v, route CRDs must not be labeled as Services", serviceRel.Services)
+	}
+}
+
+func TestGetRelationships_ServiceEntrypointsUseExactAPIGroup(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/core", Kind: KindDeployment, Name: "core", Data: map[string]any{"namespace": "demo", "apiVersion": "apps/v1"}},
+			{ID: "deployment/demo/custom", Kind: KindDeployment, Name: "custom", Data: map[string]any{"namespace": "demo", "apiVersion": "apps/v1"}},
+			{ID: "service/demo/api", Kind: KindService, Name: "api", Data: map[string]any{"namespace": "demo", "apiVersion": "v1"}},
+			{ID: "service/demo/api/platform.example.io", Kind: KindService, Name: "api", Data: map[string]any{"namespace": "demo", "apiVersion": "platform.example.io/v1"}},
+			{ID: "ingress/demo/core", Kind: KindIngress, Name: "core", Data: map[string]any{"namespace": "demo", "apiVersion": "networking.k8s.io/v1"}},
+			{ID: "route/demo/custom/platform.example.io", Kind: NodeKind("Route"), Name: "custom", Data: map[string]any{"namespace": "demo", "apiVersion": "platform.example.io/v1"}},
+		},
+		Edges: []Edge{
+			{ID: "core-service", Source: "service/demo/api", Target: "deployment/demo/core", Type: EdgeExposes},
+			{ID: "custom-service", Source: "service/demo/api/platform.example.io", Target: "deployment/demo/custom", Type: EdgeExposes},
+			{ID: "core-entrypoint", Source: "ingress/demo/core", Target: "service/demo/api", Type: EdgeRoutesTo},
+			{ID: "custom-entrypoint", Source: "route/demo/custom/platform.example.io", Target: "service/demo/api/platform.example.io", Type: EdgeRoutesTo},
+		},
+	}
+	idx := IndexByResource(topo)
+
+	core := GetRelationshipsWithIndex("Deployment", "demo", "core", topo, nil, nil, idx)
+	if core == nil || len(core.Ingresses) != 1 || core.Ingresses[0].Name != "core" || len(core.Routes) != 0 {
+		t.Fatalf("core workload borrowed custom Service entrypoints: %+v", core)
+	}
+	custom := GetRelationshipsWithIndex("Deployment", "demo", "custom", topo, nil, nil, idx)
+	if custom == nil || len(custom.Services) != 1 || custom.Services[0].Group != "platform.example.io" || len(custom.Routes) != 0 || len(custom.Ingresses) != 0 {
+		t.Fatalf("custom Service kind was given core Service entrypoint semantics: %+v", custom)
+	}
+}
+
+func TestGetRelationships_ServiceEntrypointsSkipKnativeService(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "ingress/demo/web", Kind: KindIngress, Name: "web", Data: map[string]any{"namespace": "demo"}},
+			{ID: "knativeservice/demo/web", Kind: KindKnativeService, Name: "web", Data: map[string]any{"namespace": "demo", "apiVersion": "serving.knative.dev/v1"}},
+			{ID: "service/demo/web", Kind: KindService, Name: "web", Data: map[string]any{"namespace": "demo"}},
+		},
+		Edges: []Edge{
+			{ID: "ingress-to-knative", Source: "ingress/demo/web", Target: "knativeservice/demo/web", Type: EdgeRoutesTo},
+			{ID: "knative-to-service", Source: "knativeservice/demo/web", Target: "service/demo/web", Type: EdgeExposes},
+		},
+	}
+
+	rel := GetRelationshipsWithIndex("Service", "demo", "web", topo, nil, nil, IndexByResource(topo))
+	if len(rel.Ingresses) != 0 {
+		t.Fatalf("core Service inherited an entrypoint through a Knative Service: %+v", rel.Ingresses)
+	}
+}
+
+func TestGetRelationshipsWithObjectMatchesTypedBuiltinGroup(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web", Data: map[string]any{"namespace": "demo"}},
+			{ID: "service/demo/web", Kind: KindService, Name: "web", Data: map[string]any{"namespace": "demo"}},
+		},
+		Edges: []Edge{{Source: "service/demo/web", Target: "deployment/demo/web", Type: EdgeExposes}},
+	}
+	deployment := &appsv1.Deployment{TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}, ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "web"}}
+
+	rel := GetRelationshipsWithObject("deployments", "demo", "web", deployment, topo, nil, nil, IndexByResource(topo))
+	if rel == nil || len(rel.Services) != 1 || rel.Services[0].Name != "web" {
+		t.Fatalf("typed Deployment lost topology relationships: %+v", rel)
+	}
+}
+
+func TestGetRelationshipsEmitsKubernetesKindForPseudoNode(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "knativeservice/demo/shop", Kind: KindKnativeService, Name: "shop", Data: map[string]any{"namespace": "demo", "apiVersion": "serving.knative.dev/v1"}},
+			{ID: "revision/demo/shop-v1", Kind: KindKnativeRevision, Name: "shop-v1", Data: map[string]any{"namespace": "demo", "apiVersion": "serving.knative.dev/v1"}},
+		},
+		Edges: []Edge{{Source: "knativeservice/demo/shop", Target: "revision/demo/shop-v1", Type: EdgeManages}},
+	}
+
+	rel := GetRelationships("Revision", "demo", "shop-v1", topo, nil, nil)
+	if rel == nil || rel.Owner == nil || rel.Owner.Kind != "Service" || rel.Owner.Group != "serving.knative.dev" {
+		t.Fatalf("pseudo owner leaked as a non-Kubernetes tuple: %+v", rel)
 	}
 }
 

--- a/pkg/topology/rollout_analysis_test.go
+++ b/pkg/topology/rollout_analysis_test.go
@@ -138,10 +138,10 @@ func TestRolloutManagesItsAnalysisRuns(t *testing.T) {
 }
 
 func TestAnalysisRunIsExcludedFromGenericCRDPass(t *testing.T) {
-	if !kindsHandledOutsideGenericCRDPass["analysisrun"] {
+	if !genericCRDExcluded(schema.GroupVersionResource{Group: "argoproj.io"}, "AnalysisRun") {
 		t.Fatal("analysisrun must be excluded from the generic owner-ref pass")
 	}
-	if !kindsHandledOutsideGenericCRDPass["rollout"] {
+	if !genericCRDExcluded(schema.GroupVersionResource{Group: "argoproj.io"}, "Rollout") {
 		t.Fatal("rollout lost its exclusion")
 	}
 }

--- a/pkg/topology/target_ref_identity_test.go
+++ b/pkg/topology/target_ref_identity_test.go
@@ -1,0 +1,22 @@
+package topology
+
+import "testing"
+
+func TestTargetRefMatchesTopologyKind(t *testing.T) {
+	for _, test := range []struct {
+		kind       string
+		apiVersion string
+		want       bool
+	}{
+		{kind: "Deployment", apiVersion: "apps/v1", want: true},
+		{kind: "Deployment", want: true},
+		{kind: "Rollout", apiVersion: "argoproj.io/v1alpha1", want: true},
+		{kind: "Rollout", apiVersion: "rollouts.example.io/v1"},
+		{kind: "Deployment", apiVersion: "apps.example.io/v1"},
+		{kind: "Widget", apiVersion: "example.io/v1"},
+	} {
+		if got := targetRefMatchesTopologyKind(test.kind, test.apiVersion); got != test.want {
+			t.Errorf("targetRefMatchesTopologyKind(%q, %q) = %v, want %v", test.kind, test.apiVersion, got, test.want)
+		}
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { useDiagnoseLayout } from './components/diagnose/DiagnoseContext'
 import { DiagnoseSurface } from './components/diagnose/DiagnoseSurface'
 import { TopologyGraph, TopologySearch, TopologyBreadcrumb, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill, PaneLoader, assetUrl } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
+import { topologyNodeResourceKind } from '@skyhook-io/k8s-ui/utils/topology-neighborhood'
 import { useAPIResources, findAPIResourceForRoute } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
 import { ResourcesView } from './components/resources/ResourcesView'
@@ -1283,6 +1284,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     if (node.kind === 'Internet') return
 
     const nodeGroup = apiVersionToGroup(node.data.apiVersion as string | undefined)
+    const resourceKind = topologyNodeResourceKind(node)
     // Radar's topology PodGroup is a virtual pod aggregate. A Kubernetes
     // scheduling.k8s.io PodGroup carries apiVersion and is a real resource.
     if (node.kind === 'PodGroup' && !nodeGroup) return
@@ -1292,14 +1294,14 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     // detail page with tree + insights + ops that the drawer can't reproduce.
     // Route there from the main topology when the node is one of those kinds;
     // everything else falls back to the drawer.
-    const gitOpsPath = gitOpsRouteForKind(node.kind, namespace, node.name)
+    const gitOpsPath = gitOpsRouteForKind(resourceKind, namespace, node.name, nodeGroup)
     if (gitOpsPath) {
       navigate(gitOpsPath)
       return
     }
 
     navigateToResource({
-      kind: kindToPluralWithGroup(node.kind, nodeGroup),
+      kind: kindToPluralWithGroup(resourceKind, nodeGroup),
       namespace,
       name: node.name,
       group: nodeGroup,

--- a/web/src/components/applications/ApplicationsView.identity.test.ts
+++ b/web/src/components/applications/ApplicationsView.identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AppWorkload, Issue } from '@skyhook-io/k8s-ui'
+import { appIssuesForWorkloads } from './ApplicationsView'
+
+function workload(group: string): AppWorkload {
+  return { kind: 'Job', group, namespace: 'ml', name: 'train', health: 'healthy', ready: 1, desired: 1, restarts: 0 }
+}
+
+function issue(id: string, group?: string): Issue {
+  return {
+    id,
+    severity: 'warning',
+    source: 'condition',
+    category: 'job_failed',
+    category_group: 'runtime',
+    grouping_scope: 'workload',
+    kind: 'Job',
+    group,
+    namespace: 'ml',
+    name: 'train',
+    reason: id,
+    message: id,
+  }
+}
+
+describe('appIssuesForWorkloads identity', () => {
+  it('does not share an issue between same-named core and Volcano Jobs', () => {
+    const issues = [issue('core', 'batch'), issue('volcano', 'batch.volcano.sh')]
+
+    expect(appIssuesForWorkloads(issues, [workload('batch')]).map(item => item.id)).toEqual(['core'])
+    expect(appIssuesForWorkloads(issues, [workload('batch.volcano.sh')]).map(item => item.id)).toEqual(['volcano'])
+  })
+
+  it('treats an omitted built-in group as the canonical built-in identity', () => {
+    expect(appIssuesForWorkloads([issue('legacy')], [workload('batch')]).map(item => item.id)).toEqual(['legacy'])
+    expect(appIssuesForWorkloads([issue('legacy')], [workload('batch.volcano.sh')])).toEqual([])
+  })
+})

--- a/web/src/components/applications/ApplicationsView.tsx
+++ b/web/src/components/applications/ApplicationsView.tsx
@@ -23,6 +23,7 @@ import {
   memberRef,
   subjectRef,
   compareIssueSortAnchors,
+  canonicalResourceGroup,
   type AppRow,
   type AppWorkload,
   type AppIdentityInstance,
@@ -490,6 +491,7 @@ function AppDetailRoute({
           source.kind,
           source.namespace,
           source.name,
+          source.group,
         );
         if (path) navigate(path);
         return;
@@ -899,7 +901,7 @@ function compareAppOverviewIssues(a: Issue, b: Issue): number {
   return a.id.localeCompare(b.id);
 }
 
-function appIssuesForWorkloads(
+export function appIssuesForWorkloads(
   issues: Issue[],
   workloads: AppWorkload[],
 ): Issue[] {
@@ -918,11 +920,11 @@ function appIssuesForWorkloads(
 }
 
 function workloadIssueKey(workload: AppWorkload): string {
-  return `${workload.kind.toLowerCase()}|${workload.namespace}|${workload.name}`;
+  return `${canonicalResourceGroup(workload.kind, workload.group) ?? "?"}|${workload.kind.toLowerCase()}|${workload.namespace}|${workload.name}`;
 }
 
 function issueRefKey(ref: IssueResourceRef): string {
-  return `${ref.kind.toLowerCase()}|${ref.namespace ?? ""}|${ref.name}`;
+  return `${canonicalResourceGroup(ref.kind, ref.group) ?? "?"}|${ref.kind.toLowerCase()}|${ref.namespace ?? ""}|${ref.name}`;
 }
 
 function issueRefs(issue: Issue): IssueResourceRef[] {

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -10,6 +10,7 @@ import {
   buildAppMembershipIndex,
   eventsForApplication,
   isPinnedLaneRef,
+  pinnedLaneRefMatches,
   LIVE_TICK_MS,
   SEVERITY_TEXT,
   type ScrubberRange,
@@ -48,6 +49,13 @@ function loadPinnedLanes(): PinnedLaneRef[] {
   } catch {
     return []
   }
+}
+
+export function togglePinnedLaneRefs(previous: PinnedLaneRef[], ref: PinnedLaneRef): PinnedLaneRef[] {
+  const pinned = previous.some((stored) => pinnedLaneRefMatches(stored, ref))
+  return pinned
+    ? previous.filter((stored) => !pinnedLaneRefMatches(stored, ref))
+    : [...previous, ref]
 }
 
 // Helper to check if topology has meaningfully changed
@@ -348,9 +356,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     }
   }, [pinnedLanes])
   const togglePin = useCallback((ref: PinnedLaneRef) => {
-    setPinnedLanes((prev) => (
-      prev.some((p) => p.id === ref.id) ? prev.filter((p) => p.id !== ref.id) : [...prev, ref]
-    ))
+    setPinnedLanes((prev) => togglePinnedLaneRefs(prev, ref))
   }, [])
   // pinnedOnly is meaningless with no pins: unpinning the last lane (or landing
   // on ?pinnedOnly=1 with no stored pins) would otherwise leave the filter stuck

--- a/web/src/components/timeline/TimelineView.urlparams.test.ts
+++ b/web/src/components/timeline/TimelineView.urlparams.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it } from 'vitest'
-import type { ActivityFilterKey, TimelineGrouping, TimelineSort } from '@skyhook-io/k8s-ui'
+import type { ActivityFilterKey, PinnedLaneRef, TimelineGrouping, TimelineSort } from '@skyhook-io/k8s-ui'
 import {
   parseTimeMode,
   resolveApplicationTimelineScope,
   writeTimelineParams,
   onlyHighFreqDiffer,
   timeModeEqual,
+  togglePinnedLaneRefs,
   type TimelineMode,
   type PersistedTimelineState,
   type TimelineViewMode,
 } from './TimelineView'
+
+describe('togglePinnedLaneRefs', () => {
+  it('unpins a migrated legacy CRD pin by its canonical live identity', () => {
+    const legacy: PinnedLaneRef = { id: 'Cluster/prod/main', kind: 'Cluster', namespace: 'prod', name: 'main' }
+    const live: PinnedLaneRef = { id: 'Cluster.postgresql.cnpg.io/prod/main', kind: 'Cluster', group: 'postgresql.cnpg.io', namespace: 'prod', name: 'main' }
+
+    expect(togglePinnedLaneRefs([legacy], live)).toEqual([])
+  })
+
+  it('does not unpin a different explicit API group', () => {
+    const cnpg: PinnedLaneRef = { id: 'Cluster.postgresql.cnpg.io/prod/main', kind: 'Cluster', group: 'postgresql.cnpg.io', namespace: 'prod', name: 'main' }
+    const capi: PinnedLaneRef = { id: 'Cluster.cluster.x-k8s.io/prod/main', kind: 'Cluster', group: 'cluster.x-k8s.io', namespace: 'prod', name: 'main' }
+
+    expect(togglePinnedLaneRefs([cnpg], capi)).toEqual([cnpg, capi])
+  })
+})
 
 // These mirror the module-private defaults writeTimelineParams omits at (and
 // parseTimeMode falls back to). Kept in sync deliberately: the round-trip tests

--- a/web/src/utils/topology-selection.test.ts
+++ b/web/src/utils/topology-selection.test.ts
@@ -37,4 +37,60 @@ describe('findSelectedTopologyNode', () => {
 
     expect(findSelectedTopologyNode(topology, selected('two.example', 'widgets'))?.id).toBe('second')
   })
+
+  it('matches a pseudo topology kind through its real Kubernetes kind', () => {
+    const knative = node('knative', 'KnativeService', 'api', 'serving.knative.dev/v1')
+    knative.data.resourceKind = 'Service'
+
+    expect(findSelectedTopologyNode(
+      { nodes: [knative], edges: [] },
+      { kind: 'services', namespace: 'default', name: 'api', group: 'serving.knative.dev' },
+    )?.id).toBe('knative')
+  })
+
+  it('keeps an omitted or explicit core Service selection on the core node', () => {
+    const core = node('core', 'Service', 'api')
+    const knative = node('knative', 'KnativeService', 'api', 'serving.knative.dev/v1')
+    knative.data.resourceKind = 'Service'
+    const topology: Topology = { nodes: [knative, core], edges: [] }
+
+    expect(findSelectedTopologyNode(topology, {
+      kind: 'services', namespace: 'default', name: 'api',
+    })?.id).toBe('core')
+    expect(findSelectedTopologyNode(topology, {
+      kind: 'services', namespace: 'default', name: 'api', group: '',
+    })?.id).toBe('core')
+  })
+
+  it('infers a typed Job group when its topology node omits apiVersion', () => {
+    const core = node('core', 'Job', 'train')
+    const volcano = node('volcano', 'Job', 'train', 'batch.volcano.sh/v1alpha1')
+    const topology: Topology = { nodes: [volcano, core], edges: [] }
+
+    expect(findSelectedTopologyNode(topology, {
+      kind: 'jobs', namespace: 'default', name: 'train', group: 'batch',
+    })?.id).toBe('core')
+    expect(findSelectedTopologyNode(topology, {
+      kind: 'jobs', namespace: 'default', name: 'train', group: 'batch.volcano.sh',
+    })?.id).toBe('volcano')
+  })
+
+  it('infers the policy group for a typed PodDisruptionBudget node', () => {
+    const pdb = node('pdb', 'PodDisruptionBudget', 'budget')
+
+    expect(findSelectedTopologyNode(
+      { nodes: [pdb], edges: [] },
+      { kind: 'poddisruptionbudgets', namespace: 'default', name: 'budget', group: 'policy' },
+    )?.id).toBe('pdb')
+  })
+
+  it('fails closed for an omitted unknown group when custom resources collide', () => {
+    const one = node('one', 'Widget', 'same', 'one.example/v1')
+    const two = node('two', 'Widget', 'same', 'two.example/v1')
+
+    expect(findSelectedTopologyNode(
+      { nodes: [one, two], edges: [] },
+      { kind: 'widgets', namespace: 'default', name: 'same' },
+    )).toBeUndefined()
+  })
 })

--- a/web/src/utils/topology-selection.ts
+++ b/web/src/utils/topology-selection.ts
@@ -1,16 +1,16 @@
 import type { SelectedResource, Topology, TopologyNode } from '@skyhook-io/k8s-ui/types/core'
+import { builtinGroupForKind, canonicalResourceGroup } from '@skyhook-io/k8s-ui/utils/api-resources'
 import { apiVersionToGroup, kindToPluralWithGroup } from '@skyhook-io/k8s-ui/utils/navigation'
+import { topologyNodeResourceKind } from '@skyhook-io/k8s-ui/utils/topology-neighborhood'
 
 function topologyNodeGroup(node: TopologyNode): string | undefined {
-  const apiVersionGroup = apiVersionToGroup(node.data.apiVersion as string | undefined)
-  if (apiVersionGroup) return apiVersionGroup
+  const apiVersion = node.data.apiVersion
+  if (typeof apiVersion === 'string' && apiVersion) return apiVersionToGroup(apiVersion)
 
   const sourceGroup = node.data.sourceGroup
-  if (typeof sourceGroup === 'string' && sourceGroup) return sourceGroup
+  if (typeof sourceGroup === 'string') return sourceGroup
 
-  // Native NetworkPolicy nodes predate apiVersion in the topology payload.
-  if (node.kind === 'NetworkPolicy') return 'networking.k8s.io'
-  return undefined
+  return builtinGroupForKind(topologyNodeResourceKind(node))
 }
 
 export function findSelectedTopologyNode(
@@ -22,13 +22,13 @@ export function findSelectedTopologyNode(
   const candidates = topology?.nodes.filter(node =>
     ((node.data.namespace as string) || '') === namespace &&
     node.name === selectedResource.name &&
-    (kindToPluralWithGroup(node.kind, topologyNodeGroup(node) ?? '') === selectedKind || node.kind === selectedResource.kind),
+    (kindToPluralWithGroup(topologyNodeResourceKind(node), topologyNodeGroup(node) ?? '') === selectedKind || topologyNodeResourceKind(node) === selectedResource.kind),
   ) ?? []
 
   if (candidates.length === 0) return undefined
 
-  const selectedGroup = selectedResource.group || undefined
-  if (!selectedGroup) return candidates[0]
+  const selectedGroup = canonicalResourceGroup(selectedResource.kind, selectedResource.group)
+  if (selectedGroup === undefined) return candidates.length === 1 ? candidates[0] : undefined
 
   const groupMatch = candidates.find(node => topologyNodeGroup(node) === selectedGroup)
   if (groupMatch) return groupMatch


### PR DESCRIPTION
## Status — ready for review

Gate 1 (#1553) merged; this branch is rebased onto it. Gate 2 (collision correctness) is verified live end-to-end for the Cluster and Service collision classes — see Testing below; the literal Volcano-Job/Knative-Service fixtures and a full UI deep-link click-through were not separately exercised, since the underlying mechanism is identical and was proven on an equivalent live collision. Gate 3 (Radar Hub's own group-propagation + package publish order) is a separate, cross-repo coordination item this PR does not close.

## Why this exists

The GPU, batch, and AI/ML breadth work exposed a shared prerequisite: Kubernetes identity is API group + Kind + namespace + name, while several Radar joins still used only Kind + namespace + name. On clusters with core and Volcano Jobs, core and Knative Services, or CAPI and CNPG Clusters, Radar could select, group, navigate to, or attribute the wrong object.

This is shared exact-identity plumbing, not a controller-native GPU vertical or a new rendered destination.

## What changed

- preserve exact API-group identity in dedicated and generic topology nodes, Crossplane, owners, relationships, cascade previews, REST neighborhoods, and MCP neighborhoods
- default an omitted group only for known built-ins; resolve group-less custom references only when one candidate exists, otherwise fail closed
- make Argo CD and Flux attribution, KEDA/HPA/VPA targets, Applications joins, warning events, inventory, history, and workload joins group-aware
- restore canonical `apiVersion` on typed informer events
- migrate persisted group-less Timeline pins only when the live identity is unambiguous — recovering a group already encoded in an older pin's saved id takes precedence over treating it as unqualified; keep built-in lane IDs stable and group-qualify custom-resource lanes
- return real Kubernetes Kinds rather than Radar pseudo-kinds in references and navigation paths
- resolve Pod ownership (including the ReplicaSet → Deployment shortcut) by the owner reference's actual API group, so a CRD that shadows a typed workload Kind can't attach a pod to an unrelated same-named typed workload
- give a timeline event whose group is genuinely ambiguous its own reserved identity, distinct from every real lane including a built-in's, instead of letting unresolvable activity fall onto a real resource's lane
- let an exact topology ownership edge override a persisted group-less owner reference for real ownership chains (Deployment→RS→Pod, collision-prone controllers like Volcano's Job), without extending that override to FluxCD source edges (GitRepository/OCIRepository/HelmRepository → Kustomization/HelmRelease) — those are `spec.sourceRef`, not ownership, so a GitOps app root with its own timeline activity keeps its top-level lane instead of nesting under a synthesized, event-less source placeholder

## Dependency and merge map

- [#1549](https://github.com/skyhook-io/radar/pull/1549) and [#1553](https://github.com/skyhook-io/radar/pull/1553) are merged; this branch is rebased onto current `main`.
- [#1557](https://github.com/skyhook-io/radar/pull/1557) is an independent, unused controller-owner foundation; this PR does not globally switch consumers to it.
- [#1558](https://github.com/skyhook-io/radar/pull/1558) -> [#1559](https://github.com/skyhook-io/radar/pull/1559) is the independent observation-coverage track.
- Controller-native contexts and drilldowns such as JobSet are separate verticals.
- Radar Hub's own group-propagation fix and publish-order verification remain a follow-up outside this repo.

## Review focus

- group identity survives every topology/application/relationship/navigation boundary and never attaches to a foreign same-named Kind
- group-less built-ins retain compatibility; ambiguous custom references fail closed instead of guessing
- Timeline lane IDs and legacy pin migration preserve built-in stability without cross-group collisions
- REST, MCP, UI selection, GitOps links, and workload deep links resolve the same exact root
- public `@skyhook-io/radar-app` and `@skyhook-io/k8s-ui` compatibility, including Radar Hub's current group-dropping paths
- regression blast radius across GitOps, Karpenter, CAPI/CNPG, Knative/core, Rollouts, DRA, and NVIDIA relationships

## Compatibility and boundaries

The wire schema is additive: application workload and claim references gain an optional group. Behavior intentionally changes where previously ambiguous/colliding identities could resolve incorrectly. Unambiguous built-in routes and lane IDs stay stable; collision cases now resolve correctly instead of guessing.

This PR does not invent groups for producers that do not emit them, complete Traefik dual-group coexistence, add root-level Issues, or introduce a dedicated accelerator surface. The Radar Hub group-propagation fix is a coordinated package/consumer gate, not evidence that dropping group is acceptable.

## Testing

- `make tsc`, `make build`, `go build ./...` and `go vet ./...` (both Go modules), `go test ./...` (both Go modules) — all pass
- `go test -race ./internal/k8s ./internal/server`, `(cd pkg && go test -race ./topology ./resourceid ./gitops ./gitops/tree)`
- `packages/k8s-ui` suite: 172 files / 3584 tests pass
- Live end-to-end verification on a real cluster: built the binary from this branch and ran it against a `kind` cluster seeded with a genuine same-name, same-namespace collision (a `Service` in a second API group alongside a real core `Service`, and a `Cluster` CRD alongside a real CNPG `Cluster`). Confirmed via the REST API that both resources resolve independently, and that deleting and recreating the collision resource live produces a correctly-attributed recreate-diff on the timeline with zero cross-contamination of the real core resource's own history or identity.

Visual layout testing was skipped — no rendered layout changes in this PR; the identity resolution was verified through the API, topology data, and timeline hierarchy directly.

Part of RAD-418.
