### PR TITLE
fix(k8s-ui): treat lowercase Kyverno enforce action as blocking

### DIFF
--- a/packages/k8s-ui/src/components/resources/kyverno-legacy-action.test.ts
+++ b/packages/k8s-ui/src/components/resources/kyverno-legacy-action.test.ts
@@ -95,4 +95,48 @@ describe('getKyvernoPolicyAction', () => {
     expect(getKyvernoPolicyAction(cpol({ rules: [{ name: 'r', validate: {} }] }))).toBe('Audit')
     expect(getKyvernoPolicyAction(cpol({}))).toBe('Audit')
   })
+
+  // Kyverno's ValidationFailureAction enum accepts the deprecated lowercase
+  // `enforce`/`audit` alongside the capitalized spelling, and the admission
+  // controller blocks on lowercase `enforce` exactly as on `Enforce`. A legacy
+  // policy carrying the lowercase value must not read as non-blocking.
+  it('treats a lowercase spec-level enforce as Enforce (no rules)', () => {
+    expect(getKyvernoPolicyAction(cpol({ validationFailureAction: 'enforce' }))).toBe('Enforce')
+  })
+
+  it('treats a lowercase spec-level enforce inherited by a validating rule as Enforce', () => {
+    expect(
+      getKyvernoPolicyAction(
+        cpol({
+          validationFailureAction: 'enforce',
+          rules: [{ name: 'v', validate: { pattern: {} } }],
+        }),
+      ),
+    ).toBe('Enforce')
+  })
+
+  it('canonicalizes a lowercase spec-level audit to Audit', () => {
+    expect(getKyvernoPolicyAction(cpol({ validationFailureAction: 'audit' }))).toBe('Audit')
+    expect(
+      getKyvernoPolicyAction(
+        cpol({
+          validationFailureAction: 'audit',
+          rules: [{ name: 'v', validate: { pattern: {} } }],
+        }),
+      ),
+    ).toBe('Audit')
+  })
+
+  // A per-rule failureAction is capitalized-only per its CRD enum, but matching
+  // case-insensitively there too keeps a single rule for reading the field.
+  it('treats a lowercase per-rule failureAction override as Enforce', () => {
+    expect(
+      getKyvernoPolicyAction(
+        cpol({
+          validationFailureAction: 'Audit',
+          rules: [{ name: 'r', validate: { failureAction: 'enforce' } }],
+        }),
+      ),
+    ).toBe('Enforce')
+  })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/PolicyCoverageSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PolicyCoverageSection.tsx
@@ -13,7 +13,7 @@ import {
   getKyvernoEffectiveFailurePolicy,
   type KyvernoPolicyFamily,
 } from '../resource-utils-kyverno-modern'
-import { getKyvernoPolicyAction } from '../resource-utils-kyverno'
+import { getKyvernoPolicyAction, isKyvernoEnforceAction } from '../resource-utils-kyverno'
 import type {
   PolicyCoverageResponse,
   PolicyCoverageRule,
@@ -160,7 +160,7 @@ function legacyActionsAgree(resource: any): boolean {
           : []),
       ].filter(Boolean)
       const effective = declared.length > 0 ? declared : [spec]
-      return effective.includes('Enforce')
+      return effective.some(isKyvernoEnforceAction)
     })
   return answers.every((a: boolean) => a === answers[0])
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils-kyverno.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kyverno.ts
@@ -115,6 +115,16 @@ export function getKyvernoPolicyStatus(resource: any): StatusBadge {
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
 }
 
+/**
+ * Kyverno's ValidationFailureAction enum accepts the deprecated lowercase
+ * `enforce` alongside `Enforce`, and the admission controller blocks on the
+ * lowercase spelling exactly as on the capitalized one. Match case-insensitively
+ * so a legacy policy carrying the lowercase value is not read as non-blocking.
+ */
+export function isKyvernoEnforceAction(action: unknown): boolean {
+  return String(action ?? '').toLowerCase() === 'enforce'
+}
+
 /** The rule blocks whose failure an admission request can be rejected for. */
 function rejectingActions(rule: any): string[] {
   if (!rule) return []
@@ -148,14 +158,14 @@ function rejectingActions(rule: any): string[] {
 export function getKyvernoPolicyAction(resource: any): string {
   const specAction = resource.spec?.validationFailureAction
   const rules = resource.spec?.rules || []
-  if (rules.length === 0) return specAction || 'Audit'
+  if (rules.length === 0) return isKyvernoEnforceAction(specAction) ? 'Enforce' : 'Audit'
   const rejecting = rules.filter((rule: any) => rule?.validate || rule?.verifyImages)
   // Rules, but none that can reject: the spec-level action governs nothing here.
   if (rejecting.length === 0) return 'Audit'
   for (const rule of rejecting) {
     const overrides = rejectingActions(rule)
     const effective = overrides.length > 0 ? overrides : [specAction]
-    if (effective.includes('Enforce')) return 'Enforce'
+    if (effective.some(isKyvernoEnforceAction)) return 'Enforce'
   }
   return 'Audit'
 }


### PR DESCRIPTION
## Problem

A legacy Kyverno `ClusterPolicy`/`Policy` with `spec.validationFailureAction: enforce` (lowercase) is a valid, API-server-stored value that Kyverno still treats as **blocking** on admission (`ValidationFailureAction.Enforce()` returns true for the deprecated lowercase `enforce`). The CRD enum is `[audit, enforce, Audit, Enforce]`, and lowercase was the only accepted form before Kyverno v1.9, so it is still common in existing clusters and Helm charts.

Radar compared the action against the exact string `'Enforce'` (capitalized) in several places, so such a blocking policy rendered a yellow **Audit** badge and `blocksAdmission` returned false — the UI showed a blocking policy as non-blocking.

## Fix

- Add a shared case-insensitive predicate `isKyvernoEnforceAction`.
- `getKyvernoPolicyAction` now canonicalizes its return to `'Enforce'`/`'Audit'`, which transitively corrects the badge color, the policy-report renderer, and the `blocksAdmission` decision.
- Reuse the predicate in `legacyActionsAgree`, which had the same lowercase bug independently.

Scope is the legacy `kyverno.io` family only; the modern `policies.kyverno.io` `validationActions` enum is capitalized-only and untouched.

## Tests

Added lowercase cases (spec-level, inherited-by-rule, and per-rule) to the legacy-action test — each fails against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to legacy Kyverno policy display and enforcement inference in k8s-ui, with regression tests and no changes to cluster APIs or modern policies.kyverno.io types.
> 
> **Overview**
> Legacy **kyverno.io** policies often still use deprecated lowercase `validationFailureAction: enforce` / `audit`, which Kyverno treats like **Enforce** on admission. The UI compared the literal string `'Enforce'`, so blocking policies could show an **Audit** badge and policy coverage could treat them as non-blocking.
> 
> This PR adds **`isKyvernoEnforceAction`** (case-insensitive) and wires it through **`getKyvernoPolicyAction`** so effective actions canonicalize to `'Enforce'` or `'Audit'` at spec and per-rule override levels. **`legacyActionsAgree`** in policy coverage uses the same helper instead of `includes('Enforce')`. Tests cover lowercase spec-level, inherited, and per-rule `failureAction` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 201c8d0e88ff552b30408ee806c39ff577708210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
