### PR TITLE
fix(velero): surface BackupStorageLocation status.message on the detail page

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/VeleroBSLRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroBSLRenderer.test.tsx
@@ -177,6 +177,53 @@ describe('what a storage location holds', () => {
 })
 
 /**
+ * Velero writes why a location is unavailable into `status.message`, and the
+ * BSL object carries no conditions, so that field is the only place the reason
+ * exists. A page opened from an unavailable-location problem has to show it -
+ * the same way the sibling BackupRepository renderer leads with its own reason.
+ */
+describe('an unavailable location Velero gave a reason for', () => {
+  const bslMsg = (phase: string, message?: string) => ({
+    metadata: { name: 'dr-replica', namespace: 'velero' },
+    spec: { provider: 'aws', objectStorage: { bucket: 'dr' } },
+    status: { phase, ...(message !== undefined ? { message } : {}) },
+  })
+
+  it('leads with the reason Velero gave', () => {
+    const html = renderToString(
+      <VeleroBSLRenderer
+        data={bslMsg('Unavailable', 'BackupStorageLocation is invalid: rpc error: code = Unknown desc = NoSuchBucket')}
+      />,
+    )
+    expect(html).toContain('NoSuchBucket')
+  })
+
+  // Velero can set Unavailable with no message. Saying nothing would leave a red
+  // badge and no consequence, so the page states what unavailable costs.
+  it('names the consequence when Velero gave no reason', () => {
+    const html = renderToString(<VeleroBSLRenderer data={bslMsg('Unavailable')} />)
+    expect(html).toContain('cannot be written')
+  })
+
+  it('says nothing alarming when the location is available', () => {
+    const html = renderToString(
+      <VeleroBSLRenderer data={bslMsg('Available', 'stale message left on the object')} />,
+    )
+    expect(html).not.toContain('Storage Location Unavailable')
+    expect(html).not.toContain('stale message left on the object')
+    expect(html).not.toContain('cannot be written')
+  })
+
+  // A location Velero has not validated yet has no phase. It is not unavailable,
+  // so it gets no alarm even if a message lingers from a prior state.
+  it('raises no alarm on a location Velero has not reported on', () => {
+    const html = renderToString(<VeleroBSLRenderer data={bslMsg('', 'old message')} />)
+    expect(html).not.toContain('Storage Location Unavailable')
+    expect(html).not.toContain('old message')
+  })
+})
+
+/**
  * The list counts what is stored; the restorable point is derived from what
  * completed. On a healthy location those are the only two numbers on the page,
  * and when they disagree something has to say why — "Backups (2)" above a

--- a/packages/k8s-ui/src/components/resources/renderers/VeleroBSLRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroBSLRenderer.tsx
@@ -1,5 +1,5 @@
 import { HardDrive, Clock, Archive } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, RelationshipGroup } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, RelationshipGroup, AlertBanner } from '../../ui/drawer-components'
 import { TimeValue } from '../../ui/ScheduleValue'
 import {
   getBSLStatus,
@@ -11,6 +11,7 @@ import {
   getBSLAccessMode,
   getBSLLastValidation,
   getBSLLastSynced,
+  getBSLMessage,
 } from '../resource-utils-velero'
 import { VeleroPhaseValue } from './velero-cells'
 
@@ -66,6 +67,7 @@ export function VeleroBSLRenderer({ data, storedBackups, storedTotal, restorable
   const status = data.status || {}
   const conditions = status.conditions || []
   const bslStatus = getBSLStatus(data)
+  const message = getBSLMessage(data)
   const config = data.spec?.config || {}
   // Two things falsify "restorable", and the phase sees neither. A backup that
   // did complete is still not something to go back to once its TTL has passed —
@@ -90,6 +92,19 @@ export function VeleroBSLRenderer({ data, storedBackups, storedTotal, restorable
 
   return (
     <>
+      {/* The reason, not just the state. An unavailable location means Velero's
+          last validation of the bucket failed, and status.message is the only
+          place that reason exists — the object carries no conditions. */}
+      {bslStatus.level === 'unhealthy' && (
+        <AlertBanner
+          variant="error"
+          title="Storage Location Unavailable"
+          message={message
+            ? message
+            : 'Velero reported this location as unavailable and gave no reason. New backups cannot be written here, and backups already stored here cannot be restored from, while it stays that way.'}
+        />
+      )}
+
       {/* Status section */}
       <Section title="Status" icon={Clock} defaultExpanded>
         <PropertyList>

--- a/packages/k8s-ui/src/components/resources/resource-utils-velero.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-velero.ts
@@ -486,6 +486,14 @@ export function getBSLLastSynced(resource: any): string {
   return formatAge(lastSynced)
 }
 
+// Why the location is unavailable, in the validation controller's own words.
+// A BackupStorageLocation carries no conditions, so status.message is the only
+// place the reason exists — without it the phase is the whole story a reader
+// gets.
+export function getBSLMessage(resource: any): string {
+  return resource.status?.message || ''
+}
+
 // ============================================================================
 // VOLUME SNAPSHOT LOCATION UTILITIES
 // ============================================================================


### PR DESCRIPTION
## Problem

When a Velero `BackupStorageLocation` (BSL) is `Unavailable`, Velero writes the reason (bad bucket, credentials, etc.) into `status.message` — there is no `Conditions` field on the BSL status, so that message is the only place the reason lives. Radar's BSL detail renderer showed the phase but dropped `status.message`, so an operator who clicked through from an "unavailable location" problem to the page meant to diagnose it saw "Unavailable" and nothing else — a dead end.

## Fix

Render the reason using the existing problem-surface component, mirroring the sibling `BackupRepository` renderer (same conditionless resource, same single unhealthy phase, reason only in `status.message`):

- Add `getBSLMessage` (mirrors `getBackupRepositoryMessage`).
- Show a leading `AlertBanner` (error) when the BSL is unhealthy, with the message, falling back to a consequence sentence when Velero gave no reason.

No new display component or helper is introduced; the banner is gated on the unhealthy phase, so a stale message on an `Available` location is not surfaced.

## Tests

Added renderer tests: message shown, fallback when absent, `Available`-with-stale-message suppressed, unknown-phase suppressed — the load-bearing assertions fail against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to Velero BSL detail rendering with no auth, data, or API impact.
> 
> **Overview**
> When a Velero **BackupStorageLocation** is unhealthy (`Unavailable`), the BSL detail page now leads with an error **AlertBanner** so operators see Velero’s validation failure, not only the phase badge.
> 
> The banner shows **`status.message`** via new **`getBSLMessage`** (BSL has no conditions, so that field is the only reason text). If Velero marks the location unavailable without a message, a fixed consequence sentence explains that new backups cannot be written and existing ones cannot be restored. The banner is gated on unhealthy phase only, so stale messages on **`Available`** or empty-phase locations are not shown.
> 
> Renderer tests cover message display, the no-message fallback, and suppression for healthy or unreported phases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35aef18d8256ae28305a505559a0b3b1ff250938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
