### PR TITLE
fix(k8s-ui): label CNPG Backup spec.target as "Backup Target", not "Recovery Target"

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -794,7 +794,7 @@ They roll up under three categories, split by what you'd go and look at: `backup
 - Phase, backup method, duration, start/stop timestamps
 - Cluster reference with clickable link
 - Destination path and server name
-- Recovery target
+- Backup target
 - Failure detection (AlertBanner with error message)
 
 **ScheduledBackup Detail View:**

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { CNPGBackupRenderer } from './CNPGBackupRenderer'
+
+const backup = (extra: any = {}) => ({
+  apiVersion: 'postgresql.cnpg.io/v1',
+  kind: 'Backup',
+  metadata: { name: 'pg-backup', namespace: 'db' },
+  spec: { cluster: { name: 'pg' }, ...extra.spec },
+  status: { phase: 'completed', ...extra.status },
+})
+
+const html = (resource: any) => renderToString(<CNPGBackupRenderer data={resource} />)
+
+describe('CNPGBackupRenderer — spec.target is instance selection, not a restore destination', () => {
+  it('labels spec.target as the instance the backup runs on, not a recovery target', () => {
+    // Backup.spec.target is `primary` | `prefer-standby`: the policy for which
+    // instance role performs the backup. "Recovery Target" would read as a
+    // PITR restore destination, which this field is not.
+    const out = html(backup({ spec: { target: 'prefer-standby' } }))
+    expect(out).toContain('prefer-standby')
+    expect(out).toContain('Backup Target')
+    expect(out).not.toContain('Recovery Target')
+  })
+
+  it('omits the target section entirely when spec.target is unset', () => {
+    expect(html(backup())).not.toContain('Backup Target')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
@@ -127,11 +127,12 @@ export function CNPGBackupRenderer({ data, onNavigate }: CNPGBackupRendererProps
         </Section>
       )}
 
-      {/* Target - for PITR backups */}
+      {/* spec.target is the policy for which instance runs the backup
+          (primary / prefer-standby); it is not a restore destination. */}
       {target !== '-' && (
         <Section title="Target" defaultExpanded>
           <PropertyList>
-            <Property label="Recovery Target" value={target} />
+            <Property label="Backup Target" value={target} />
           </PropertyList>
         </Section>
       )}


### PR DESCRIPTION
## Problem

CloudNativePG `Backup.spec.target` (enum `primary | prefer-standby`) is the policy deciding **which instance runs the backup** — it is not a restore destination. Radar's Backup detail renderer labeled it "Recovery Target", which names a different, real CNPG concept (point-in-time recovery target, which lives on `Cluster.spec.bootstrap.recovery.recoveryTarget`). An operator reading "Recovery Target" on a Backup would reasonably conclude it controlled restore behavior; it does not.

## Fix

- Relabel the field to **"Backup Target"** in `CNPGBackupRenderer`, mirroring the upstream `BackupTarget` type name so a CNPG operator recognizes it. ("Target Instance" was rejected — `prefer-standby` is a policy, not a specific pod, and it would collide with the renderer's existing "Instance" property.)
- Fix the same term in `docs/integrations.md`.

No logic, accessor, data-key, or section changes.

## Tests

Added a renderer test (none existed) asserting the corrected label renders, the misleading "Recovery Target" is gone, and the section is omitted when `spec.target` is unset — the label assertions fail against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and documentation-only change with regression tests; no backup or restore behavior is modified.
> 
> **Overview**
> Fixes misleading UI/docs for CloudNativePG **Backup** `spec.target` (`primary` / `prefer-standby`): that field is the **instance selection policy** for where the backup runs, not a point-in-time **recovery** destination (which lives on Cluster bootstrap/recovery config).
> 
> **CNPGBackupRenderer** now shows **Backup Target** instead of **Recovery Target**, with an inline comment clarifying the semantics. **docs/integrations.md** uses the same wording in the Backup detail bullet list. No accessors, keys, or rendering logic changed.
> 
> Adds **CNPGBackupRenderer** tests that assert the new label, forbid **Recovery Target**, and hide the target section when `spec.target` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e31cbbe6b0d3d076bd86aebd4cddac535dddfac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
