### PR TITLE
fix(cnpg): report a promoted replica cluster as primary, not replica

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -116,3 +116,45 @@ describe('recovery points must be readable as ages, not raw machine timestamps',
     expect(html).toContain('2026-01-30 09:40:37 UTC')
   })
 })
+
+describe('CNPGClusterRenderer — the replica-cluster role tracks live state, not stanza presence', () => {
+  const withReplica = (replica: any, name = 'pg-eu') => ({
+    apiVersion: 'postgresql.cnpg.io/v1',
+    kind: 'Cluster',
+    metadata: { name, namespace: 'db' },
+    spec: { instances: 3, replica },
+    status: { phase: 'Cluster in healthy state', readyInstances: 3 },
+  })
+
+  it('shows the Replica Cluster section for a genuine replica (replica mode enabled)', () => {
+    const out = renderToString(<CNPGClusterRenderer data={withReplica({ source: 'pg-us', enabled: true })} />)
+    expect(out).toContain('Replica Cluster')
+    expect(out).toContain('Role')
+    expect(out).toContain('pg-us')
+  })
+
+  it('shows Replica for a distributed-topology cluster whose primary is elsewhere', () => {
+    const out = renderToString(
+      <CNPGClusterRenderer data={withReplica({ source: 'pg-us', primary: 'pg-us', self: 'pg-eu' })} />,
+    )
+    expect(out).toContain('Replica Cluster')
+  })
+
+  it('drops the Replica label once a distributed replica is promoted, though the stanza remains', () => {
+    // Promotion sets replica.primary to this cluster; the stanza is not removed.
+    const out = renderToString(
+      <CNPGClusterRenderer data={withReplica({ source: 'pg-us', primary: 'pg-eu', self: 'pg-eu' })} />,
+    )
+    expect(out).not.toContain('Replica Cluster')
+  })
+
+  it('drops the Replica label once a standalone replica is promoted (replica.enabled off)', () => {
+    const out = renderToString(<CNPGClusterRenderer data={withReplica({ source: 'pg-us', enabled: false })} />)
+    expect(out).not.toContain('Replica Cluster')
+  })
+
+  it('a normal standalone cluster shows no Replica Cluster section', () => {
+    const out = renderToString(<CNPGClusterRenderer data={cluster('Cluster in healthy state', 3)} />)
+    expect(out).not.toContain('Replica Cluster')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -27,6 +27,8 @@ import {
   getCNPGClusterDisplayState,
   getCNPGClusterInstances,
   getCNPGPoolerInstances,
+  getCNPGClusterIsReplica,
+  getCNPGClusterReplicaSource,
 } from './resource-utils-cnpg'
 import { getCellFilterValue } from './resource-utils'
 
@@ -714,5 +716,75 @@ describe('CNPG scheduled backup lateness', () => {
   it('says nothing when the operator published no next-run time', () => {
     expect(getCNPGScheduledBackupNextSchedule(sb(false))).toBe('-')
     expect(getCNPGScheduledBackupStatus(sb(false, undefined, at(-24 * 60 * MIN))).level).toBe('healthy')
+  })
+})
+
+describe('getCNPGClusterIsReplica — the live replica-cluster role, per CNPG semantics', () => {
+  // CNPG carries replica-cluster state in `spec.replica` (enabled/primary/self/source),
+  // and its own Cluster.IsReplica() reads: enabled wins when set; otherwise the
+  // cluster is a replica only while (self || name) != primary. Promotion mutates
+  // those fields but leaves the stanza in place, so presence alone cannot be the
+  // signal.
+
+  it('standalone replica cluster (replica mode enabled) reads as a replica', () => {
+    const resource = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', enabled: true } },
+    }
+    expect(getCNPGClusterIsReplica(resource)).toBe(true)
+  })
+
+  it('a promoted standalone cluster (replica.enabled turned off) is no longer a replica', () => {
+    const resource = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', enabled: false } },
+    }
+    expect(getCNPGClusterIsReplica(resource)).toBe(false)
+  })
+
+  it('distributed topology: a designated replica (primary names another cluster) reads as a replica', () => {
+    const resource = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', primary: 'pg-us', self: 'pg-eu' } },
+    }
+    expect(getCNPGClusterIsReplica(resource)).toBe(true)
+  })
+
+  it('distributed topology: after promotion (primary now names this cluster) it is the primary, stanza still present', () => {
+    const resource = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', primary: 'pg-eu', self: 'pg-eu' } },
+    }
+    expect(getCNPGClusterIsReplica(resource)).toBe(false)
+  })
+
+  it('distributed topology without self falls back to the resource name', () => {
+    const promoted = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', primary: 'pg-eu' } },
+    }
+    expect(getCNPGClusterIsReplica(promoted)).toBe(false)
+
+    const stillReplica = {
+      metadata: { name: 'pg-eu' },
+      spec: { replica: { source: 'pg-us', primary: 'pg-us' } },
+    }
+    expect(getCNPGClusterIsReplica(stillReplica)).toBe(true)
+  })
+
+  it('a bootstrapping standalone replica with only a source (no enabled, no primary) is a replica', () => {
+    // The stanza's source is required; before the operator writes enabled, the
+    // cluster is still a replica — (self || name) never equals an unset primary.
+    const resource = { metadata: { name: 'pg-eu' }, spec: { replica: { source: 'pg-us' } } }
+    expect(getCNPGClusterIsReplica(resource)).toBe(true)
+  })
+
+  it('an ordinary standalone cluster with no replica stanza is not a replica', () => {
+    expect(getCNPGClusterIsReplica({ metadata: { name: 'pg' }, spec: { instances: 3 } })).toBe(false)
+  })
+
+  it('getCNPGClusterReplicaSource reads the source from the replica stanza', () => {
+    const resource = { metadata: { name: 'pg-eu' }, spec: { replica: { source: 'pg-us', enabled: true } } }
+    expect(getCNPGClusterReplicaSource(resource)).toBe('pg-us')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -554,12 +554,21 @@ export function getCNPGClusterMonitoring(resource: any): {
   }
 }
 
+// CNPG carries replica-cluster state in `spec.replica`. Presence is not the
+// signal: promoting a replica to primary mutates the stanza's fields but leaves
+// it in place. This mirrors the operator's own Cluster.IsReplica() — `enabled`
+// decides when set; otherwise the cluster is a replica only while it is not the
+// designated primary of the distributed topology ((self || name) != primary).
 export function getCNPGClusterIsReplica(resource: any): boolean {
-  return !!resource.spec?.replicaCluster
+  const replica = resource.spec?.replica
+  if (!replica) return false
+  if (replica.enabled != null) return replica.enabled === true
+  const self = replica.self || resource.metadata?.name
+  return self !== replica.primary
 }
 
 export function getCNPGClusterReplicaSource(resource: any): string {
-  const replica = resource.spec?.replicaCluster
+  const replica = resource.spec?.replica
   if (!replica) return '-'
   return replica.source || replica.primary || '-'
 }


### PR DESCRIPTION
## Problem

`getCNPGClusterIsReplica` read `resource.spec?.replicaCluster` — but CloudNativePG never serves that key. The Go field `ReplicaCluster` has the json tag `replica`, so the served field is `spec.replica`. Reading `spec.replicaCluster` was therefore always `undefined`, so:

1. The Cluster detail's "Replica Cluster" / `Role: Replica` section was **dead for every user** — a genuine replica cluster never showed as one.
2. The check was presence-only, so had the key ever been populated it would have kept reporting "Replica" after a promotion (which leaves the stanza in place) — wrong exactly during a failover.

## Fix

Rewrite the helper to mirror CloudNativePG's own `Cluster.IsReplica()`, reading `spec.replica`:

- no stanza → not a replica
- `enabled` set → use it (`enabled: false` = promoted → not a replica)
- otherwise → `(self || metadata.name) !== primary` (distributed topology; promotion sets `primary` to self)

`getCNPGClusterReplicaSource` reads the same `spec.replica` key. The renderer's hardcoded `Role: Replica` is gated on this helper, so it is now correct in every rendering case. The per-instance Primary/Replica label (pod role from `status`) is a different concept and is untouched.

## Tests

Added unit + renderer coverage: genuine replica (`enabled: true`), distributed `primary != self`, promoted (`enabled: false`, stanza present), promoted distributed (`primary == self`), standalone (no stanza), and self-absent fallback — every assertion fails against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CNPG helper fix in k8s-ui with broad test coverage; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes CNPG cluster **replica vs primary** labeling in k8s-ui by reading **`spec.replica`** (the API field CloudNativePG actually serves) instead of the nonexistent **`spec.replicaCluster`**, which left the “Replica Cluster” detail dead for every cluster.
> 
> **`getCNPGClusterIsReplica`** now follows the operator’s **`Cluster.IsReplica()`** rules: no stanza → not a replica; when **`enabled`** is set, use it (promoted standalone → **`enabled: false`**); otherwise treat as replica only while **`(self || metadata.name) !== primary`**, so promoted distributed clusters no longer show as replica when the stanza remains. **`getCNPGClusterReplicaSource`** uses the same stanza for upstream source.
> 
> Unit and **`CNPGClusterRenderer`** tests cover enabled replicas, distributed topology, post-promotion cases, and standalone clusters without a replica stanza.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d178be144166c2b31ac9bab0d231087ed74230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
