### PR TITLE
feat(velero): show restore scope — namespace mapping and label selectors

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.test.tsx
@@ -8,6 +8,12 @@ const restore = (status: Record<string, unknown>) => ({
   status,
 })
 
+const scopedRestore = (spec: Record<string, unknown>) => ({
+  metadata: { name: 'live-restore', namespace: 'velero' },
+  spec: { backupName: 'live-completed', ...spec },
+  status: { phase: 'Completed' },
+})
+
 /**
  * The restore side carries the same claims as the backup side and its own
  * wording for them, so pinning one does not pin the other. Both banners below
@@ -51,5 +57,87 @@ describe('what a restore claims about itself', () => {
     )
     expect(html).toContain('nothing was restored')
     expect(html).toContain('Backup live-completed not found')
+  })
+})
+
+/**
+ * Scope is where an operator reads what a restore will touch and where it lands.
+ * namespaceMapping remaps source namespaces to different targets on restore, so
+ * omitting it hides where the data actually goes; a labelSelector narrows the
+ * restore to a subset of objects.
+ */
+// react-dom/server inserts <!-- --> markers between adjacent text nodes, which
+// splits a badge like `app=nginx` in the raw markup; strip them so assertions
+// read the visible text.
+const renderScope = (data: unknown) =>
+  renderToString(<VeleroRestoreRenderer data={data} />).replace(/<!-- -->/g, '')
+
+describe('what a restore says it will touch', () => {
+  it('shows namespaceMapping as source to target', () => {
+    const html = renderScope(
+      scopedRestore({ namespaceMapping: { prod: 'prod-clone', staging: 'staging-clone' } }),
+    )
+    expect(html).toContain('Scope')
+    expect(html).toContain('Namespace Mapping')
+    expect(html).toContain('prod')
+    expect(html).toContain('prod-clone')
+    expect(html).toContain('staging-clone')
+  })
+
+  it('shows the label selector that narrows the restore', () => {
+    const html = renderScope(
+      scopedRestore({
+        labelSelector: {
+          matchLabels: { app: 'nginx' },
+          matchExpressions: [{ key: 'tier', operator: 'In', values: ['frontend'] }],
+        },
+      }),
+    )
+    expect(html).toContain('Scope')
+    expect(html).toContain('app=nginx')
+    expect(html).toContain('tier In frontend')
+  })
+
+  it('renders a Scope section for a restore filtered only by label selector', () => {
+    const html = renderScope(scopedRestore({ labelSelector: { matchLabels: { app: 'nginx' } } }))
+    expect(html).toContain('Scope')
+    expect(html).toContain('app=nginx')
+  })
+
+  it('shows orLabelSelectors joined by OR', () => {
+    const html = renderScope(
+      scopedRestore({
+        orLabelSelectors: [{ matchLabels: { app: 'nginx' } }, { matchLabels: { app: 'redis' } }],
+      }),
+    )
+    expect(html).toContain('Scope')
+    expect(html).toContain('app=nginx')
+    expect(html).toContain('app=redis')
+  })
+
+  it('shows included and excluded namespaces alongside mapping', () => {
+    const html = renderScope(
+      scopedRestore({
+        includedNamespaces: ['prod'],
+        excludedNamespaces: ['kube-system'],
+        namespaceMapping: { prod: 'prod-clone' },
+      }),
+    )
+    expect(html).toContain('Included Namespaces')
+    expect(html).toContain('Excluded Namespaces')
+    expect(html).toContain('kube-system')
+    expect(html).toContain('prod-clone')
+  })
+
+  it('renders no empty Scope section for an unscoped restore', () => {
+    const html = renderScope(scopedRestore({}))
+    expect(html).not.toContain('Scope')
+  })
+
+  // An empty selector matches everything, so it is not scope. Presenting it as
+  // scope would tell an operator a restore is filtered when it is not.
+  it('treats an empty label selector as unscoped', () => {
+    const html = renderScope(scopedRestore({ labelSelector: {}, orLabelSelectors: [{}] }))
+    expect(html).not.toContain('Scope')
   })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.tsx
@@ -1,5 +1,5 @@
 import { ArchiveRestore, Filter } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink, LabelSelectorDisplay } from '../../ui/drawer-components'
 import {
   getRestoreStatus,
   getRestoreBackupName,
@@ -7,6 +7,10 @@ import {
   getRestoreExcludedNamespaces,
   getRestoreIncludedResources,
   getRestoreExcludedResources,
+  getRestoreNamespaceMapping,
+  getRestoreLabelSelector,
+  getRestoreOrLabelSelectors,
+  hasLabelSelectorTerms,
   getRestoreDuration,
   getRestoreErrors,
   getRestoreWarnings,
@@ -41,6 +45,19 @@ export function VeleroRestoreRenderer({ data, messages, onNavigate }: VeleroRest
   const excludedNamespaces = getRestoreExcludedNamespaces(data)
   const includedResources = getRestoreIncludedResources(data)
   const excludedResources = getRestoreExcludedResources(data)
+  const namespaceMapping = getRestoreNamespaceMapping(data)
+  const rawLabelSelector = getRestoreLabelSelector(data)
+  const labelSelector = hasLabelSelectorTerms(rawLabelSelector) ? rawLabelSelector : null
+  const orLabelSelectors = getRestoreOrLabelSelectors(data).filter(hasLabelSelectorTerms)
+  const namespaceMappingEntries = Object.entries(namespaceMapping)
+  const hasScope =
+    includedNamespaces.length > 0 ||
+    excludedNamespaces.length > 0 ||
+    includedResources.length > 0 ||
+    excludedResources.length > 0 ||
+    namespaceMappingEntries.length > 0 ||
+    Boolean(labelSelector) ||
+    orLabelSelectors.length > 0
 
   const phase = status.phase || ''
   const validationErrors = getRestoreValidationErrors(data)
@@ -148,7 +165,7 @@ export function VeleroRestoreRenderer({ data, messages, onNavigate }: VeleroRest
       )}
 
       {/* Scope section */}
-      {(includedNamespaces.length > 0 || excludedNamespaces.length > 0 || includedResources.length > 0 || excludedResources.length > 0) && (
+      {hasScope && (
         <Section title="Scope" icon={Filter} defaultExpanded>
           <PropertyList>
             {includedNamespaces.length > 0 && (
@@ -172,6 +189,19 @@ export function VeleroRestoreRenderer({ data, messages, onNavigate }: VeleroRest
                 </div>
               } />
             )}
+            {namespaceMappingEntries.length > 0 && (
+              <Property label="Namespace Mapping" value={
+                <div className="flex flex-col gap-1">
+                  {namespaceMappingEntries.map(([source, target]) => (
+                    <div key={source} className="flex items-center gap-1.5">
+                      <span className="badge-sm bg-theme-hover text-theme-text-secondary">{source}</span>
+                      <span className="text-theme-text-tertiary" aria-hidden="true">&rarr;</span>
+                      <span className="badge-sm bg-theme-hover text-theme-text-secondary">{String(target)}</span>
+                    </div>
+                  ))}
+                </div>
+              } />
+            )}
             {includedResources.length > 0 && (
               <Property label="Included Resources" value={
                 <div className="flex flex-wrap gap-1">
@@ -186,6 +216,18 @@ export function VeleroRestoreRenderer({ data, messages, onNavigate }: VeleroRest
                 <div className="flex flex-wrap gap-1">
                   {excludedResources.map((r: string) => (
                     <span key={r} className="badge-sm bg-red-500/10 text-red-400">{r}</span>
+                  ))}
+                </div>
+              } />
+            )}
+            {labelSelector && (
+              <Property label="Label Selector" value={<LabelSelectorDisplay selector={labelSelector} />} />
+            )}
+            {orLabelSelectors.length > 0 && (
+              <Property label="Label Selectors (match any)" value={
+                <div className="flex flex-col gap-1">
+                  {orLabelSelectors.map((sel: any, i: number) => (
+                    <LabelSelectorDisplay key={i} selector={sel} />
                   ))}
                 </div>
               } />

--- a/packages/k8s-ui/src/components/resources/resource-utils-velero.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-velero.ts
@@ -306,6 +306,30 @@ export function getRestoreExcludedResources(resource: any): string[] {
   return resource.spec?.excludedResources || []
 }
 
+export function getRestoreNamespaceMapping(resource: any): Record<string, string> {
+  return resource.spec?.namespaceMapping || {}
+}
+
+export function getRestoreLabelSelector(resource: any): any {
+  return resource.spec?.labelSelector
+}
+
+export function getRestoreOrLabelSelectors(resource: any): any[] {
+  return resource.spec?.orLabelSelectors || []
+}
+
+/**
+ * A label selector only narrows a restore when it carries at least one term. An
+ * empty selector matches everything, so it must not be presented as scope: doing
+ * so would tell an operator a restore is filtered when it is not.
+ */
+export function hasLabelSelectorTerms(selector: any): boolean {
+  if (!selector || typeof selector !== 'object') return false
+  const hasLabels = selector.matchLabels && Object.keys(selector.matchLabels).length > 0
+  const hasExpressions = Array.isArray(selector.matchExpressions) && selector.matchExpressions.length > 0
+  return Boolean(hasLabels || hasExpressions)
+}
+
 export function getRestoreDuration(resource: any): string {
   const start = resource.status?.startTimestamp
   const end = resource.status?.completionTimestamp


### PR DESCRIPTION
## Problem

The Velero `Restore` detail renderer showed included/excluded namespaces and resources, but never surfaced `spec.namespaceMapping` or label selectors, and it gated its Scope section only on namespaces/resources. So:

- `spec.namespaceMapping` (source → target namespace remap) was invisible — an operator couldn't see **where** a restore would land.
- A restore scoped **only** by a label selector rendered no Scope section at all.

## Fix

Add namespace mapping and label selectors to the Scope section, reusing the shared components:

- `namespaceMapping` rendered as source → target rows.
- `labelSelector` / `orLabelSelectors` via the shared `LabelSelectorDisplay` (never hand-rolled).
- The section gates on non-empty terms, so an empty `{}` selector (which matches everything) does not force a spurious "matches all" Scope box.

Layout, badge tokens, and label style match the sibling Backup renderer.

## Tests

Added renderer tests: namespace mapping shown (source → target), label selector shown, an or-selector shown, a label-only restore now renders Scope, and unscoped / empty-selector restores render no Scope section — the positive assertions fail against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only k8s-ui display and test changes for Velero restore details; no cluster API or restore execution behavior.
> 
> **Overview**
> The Velero **Restore** detail drawer now surfaces **namespace mapping** and **label selectors** in **Scope**, so operators can see remap targets and label-only filters—not only included/excluded namespaces and resources.
> 
> **Scope** appears when any of those fields (or mapping / non-empty selectors) are set. **Namespace Mapping** renders source → target rows; **labelSelector** and **orLabelSelectors** use shared **`LabelSelectorDisplay`**. Empty `{}` selectors are ignored so the UI does not imply a filter when Velero would match everything.
> 
> Velero restore helpers add **`getRestoreNamespaceMapping`**, selector getters, and **`hasLabelSelectorTerms`**. Renderer tests cover mapping, selectors, label-only scope, and no spurious Scope for unscoped or empty-selector restores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5be4a0861f4fc2b8cd632e4458d2ee2762819a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
