### PR TITLE
fix(kyverno): count template-form GeneratingPolicy targets

### DIFF
--- a/packages/k8s-ui/src/components/resources/kyverno-modern-posture.test.ts
+++ b/packages/k8s-ui/src/components/resources/kyverno-modern-posture.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   getKyvernoEnforcementPosture,
+  getKyvernoGenerations,
   getKyvernoPolicyFamily,
   getKyvernoValidationActions,
   getKyvernoMatchSummary,
@@ -286,5 +287,40 @@ describe('match summary', () => {
 
   it('returns a dash when nothing is matched', () => {
     expect(getKyvernoMatchSummary(vpol({}))).toBe('-')
+  })
+})
+
+// A GeneratingPolicy declares each generated target as exactly one of an
+// `expression` (CEL returning the resources) or a `template` (a YAML document,
+// optionally CEL-interpolated). Both are first-class; the "Generates" count and
+// list must see either form.
+describe('generation targets', () => {
+  it('counts expression-form generations', () => {
+    const gen = getKyvernoGenerations(vpol({ generate: [{ expression: 'generator.Apply(ns, [cm])' }] }))
+    expect(gen).toEqual(['generator.Apply(ns, [cm])'])
+  })
+
+  it('counts template-form generations', () => {
+    const value = 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n'
+    const gen = getKyvernoGenerations(vpol({ generate: [{ template: { interpolate: 'none', value } }] }))
+    expect(gen).toHaveLength(1)
+    expect(gen[0]).toContain('ConfigMap')
+  })
+
+  it('counts a mix of expression and template forms', () => {
+    const gen = getKyvernoGenerations(
+      vpol({
+        generate: [
+          { expression: 'generator.Apply(ns, [cm])' },
+          { template: { value: 'kind: NetworkPolicy\n' } },
+        ],
+      }),
+    )
+    expect(gen).toHaveLength(2)
+  })
+
+  it('returns nothing for an empty or absent generate block', () => {
+    expect(getKyvernoGenerations(vpol({ generate: [] }))).toEqual([])
+    expect(getKyvernoGenerations(vpol({}))).toEqual([])
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-kyverno-modern.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kyverno-modern.ts
@@ -472,7 +472,9 @@ export function getKyvernoMutations(resource: any): KyvernoMutation[] {
 export function getKyvernoGenerations(resource: any): string[] {
   const generate = resource?.spec?.generate
   if (!Array.isArray(generate)) return []
-  return generate.map((g: any) => g?.expression || '').filter(Boolean)
+  // Each entry declares its target as exactly one of a CEL `expression` or a
+  // YAML `template.value`; both are first-class ways to say what gets generated.
+  return generate.map((g: any) => g?.expression || g?.template?.value || '').filter(Boolean)
 }
 
 /**


### PR DESCRIPTION
## Problem

A modern Kyverno `GeneratingPolicy` (`policies.kyverno.io`) declares each `spec.generate[]` target as exactly one of a CEL `expression` or a `template.value` (YAML). Radar's `getKyvernoGenerations` read only `expression`, so a GeneratingPolicy written in the template form rendered "Generates (0)" with an empty target list.

## Fix

Read the template form too — `g?.expression || g?.template?.value` — mirroring the existing alternate-key accessor pattern used by `getKyvernoMutations` in the same file. Upstream forbids both keys in one entry, so entry count stays one-per-target.

## Tests

Added coverage: expression-form (regression), template-form (now counted), mixed (=2), empty/absent (=[]) — the template and mixed assertions fail against the pre-fix code. Full k8s-ui suite passes with no regressions.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Kyverno modern policy display logic with regression tests; no auth, data, or API changes.
> 
> **Overview**
> **Fixes under-counted generation targets** for modern Kyverno `GeneratingPolicy` resources in the k8s UI. Each `spec.generate[]` entry can declare what gets created via a CEL **`expression`** or a YAML **`template.value`**; `getKyvernoGenerations` only read `expression`, so template-only policies showed **Generates (0)** and hid the list in `KyvernoGeneratingPolicyRenderer`.
> 
> The accessor now returns `g?.expression || g?.template?.value` (same alternate-key pattern as `getKyvernoMutations`). Tests cover expression, template, mixed, and empty/absent `generate` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0af1292bb9b591042b54892fa4f34d587d7fe5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
