### PR TITLE
Show in-cluster Radar upgrade status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: release release-binaries-dry docker docker-test docker-multiarch docker-push
 .PHONY: desktop desktop-binary desktop-dev desktop-package-darwin desktop-package-windows desktop-package-linux
 
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION ?= $(shell git describe --tags --match 'v*' --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -X main.version=$(VERSION)
 DOCKER_REPO ?= ghcr.io/skyhook-io/radar
 RADAR_FLAGS ?=

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -11,7 +11,6 @@ import (
 	neturl "net/url"
 	"os"
 	"os/signal"
-	"regexp"
 	"sort"
 	"strings"
 	"syscall"
@@ -39,10 +38,6 @@ import (
 var (
 	version = "dev"
 )
-
-// releaseVersionRe matches a published release version ("1.10.3", "v1.10.3").
-// Anything else - git-describe suffixes, "dev", "-dirty" - is a dev build.
-var releaseVersionRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 func main() {
 	// Subcommand dispatch (before flag parsing — subcommands own their flags).
@@ -79,10 +74,10 @@ func main() {
 	// published image tag, so its version-matched default ImagePullBackOffs on
 	// every in-cluster test. Fall back to the latest published release instead -
 	// only for dev-shaped versions; a released binary keeps its exact match.
-	// CheckForUpdate is cached and cheap relative to the probe run it precedes.
-	if !releaseVersionRe.MatchString(version) {
+	// The release-only lookup is cached and cheap relative to the probe run it precedes.
+	if !versionpkg.IsReleaseVersion(version) {
 		reachability.LatestReleaseImage = func() string {
-			if u := versionpkg.CheckForUpdate(context.Background()); u != nil && u.LatestVersion != "" {
+			if u := versionpkg.CheckForUpdateRelease(context.Background()); u != nil && u.LatestVersion != "" {
 				return "ghcr.io/skyhook-io/radar:" + u.LatestVersion
 			}
 			return ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,12 +290,13 @@ kubeconfig before these commands can run.
 
 ### What Radar sends
 
-Until you connect a cluster to Cloud, Radar makes exactly two outbound
-requests, both to Skyhook, neither containing cluster data:
+Until you connect a cluster to Cloud, Radar makes two kinds of outbound
+request, both to Skyhook, neither containing cluster data:
 
-- **Update check** — periodically, to `releases.skyhook.io`, with the Radar
-  version, OS/arch, install method, and whether it's running locally or
-  in-cluster. Skipped entirely on development builds.
+- **Update check** — to `releases.skyhook.io`, with the Radar version, OS/arch,
+  install method, whether it is running locally or in-cluster, and the
+  installation timestamp when Radar can determine it. Radar caches the release
+  result for one hour. Development builds are excluded.
 - **Cloud dialog copy** — only when you *open* the Cloud dialog, to fetch the
   current terms shown in it. No identifiers are sent. `RADAR_CLOUD_FUNNEL=off`
   stops this request from ever happening.

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -4,6 +4,14 @@ Deploy Radar to your Kubernetes cluster for shared team access.
 
 > **Note:** This guide covers deploying Radar as a pod in your cluster. If you're running Radar locally but need to understand cluster connection behavior (e.g., using `KUBECONFIG` to override in-cluster detection), see the [Configuration Guide](configuration.md).
 
+Choose the path that matches what you are trying to do:
+
+- **New installation:** follow [Quick Start](#quick-start), then configure how
+  your team will reach and authenticate to Radar.
+- **Existing installation:** start with [Upgrading](#upgrading). The correct
+  workflow depends on whether Helm, Argo CD, Flux, or another system owns the
+  deployment.
+
 ## Quick Start
 
 ```bash
@@ -17,6 +25,101 @@ Access via port-forward:
 kubectl port-forward svc/radar 9280:9280 -n radar
 open http://localhost:9280
 ```
+
+## Upgrading
+
+Upgrade Radar through the same source that manages the current installation.
+If Argo CD or Flux owns Radar, change the version in Git and let the controller
+reconcile it. Running `helm upgrade` directly against a GitOps-managed release
+creates drift and the controller may revert it.
+
+Before upgrading, review the [release notes](https://github.com/skyhook-io/radar/releases)
+between your current and target versions, especially for a major-version update.
+The Radar version shown on the Home page matches the published Helm chart
+version.
+
+### Helm
+
+If Radar links you to a Helm release, use that release name and namespace. You
+can also find likely releases with:
+
+```bash
+helm list --all-namespaces --filter radar
+```
+
+Update the chart repository, then upgrade while preserving the values already
+set on the release:
+
+```bash
+helm repo update skyhook
+helm upgrade radar skyhook/radar \
+  --namespace radar \
+  --reuse-values \
+  --wait
+```
+
+Replace `radar` with the release name and namespace used by your installation.
+If the deployment is managed from a values file, use that same file with
+`-f values.yaml` instead of `--reuse-values` so Git remains the reproducible
+source of configuration. The command installs the latest published chart; add
+`--version X.Y.Z` to pin the exact version shown in Radar (without the leading
+`v`).
+
+### Argo CD or Flux
+
+Do not upgrade the live Helm release or Deployment directly. Update the
+version in the repository that owns the installation, then reconcile its
+controller:
+
+- **Argo CD Application:** if the Application directly references the Radar
+  chart, update its Helm chart `targetRevision`. Otherwise update the chart or
+  image version in the Git source referenced by the Application, then sync it.
+- **Flux HelmRelease:** update the Radar chart version in the HelmRelease source,
+  usually `spec.chart.spec.version`, then reconcile the HelmRelease.
+- **Flux Kustomization:** update the Radar chart or image version in the Git
+  source referenced by the Kustomization, then reconcile it.
+
+Radar links directly to a verified owning Application, HelmRelease, or
+Kustomization when it can. Open that object to confirm its source and health
+before changing Git.
+
+### If the manager could not be identified
+
+Inspect the Radar Deployment before choosing an upgrade method:
+
+```bash
+kubectl get deployment --all-namespaces \
+  --selector app.kubernetes.io/name=radar \
+  --output yaml
+```
+
+Look at the Deployment's labels and annotations:
+
+- `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` identify the
+  underlying Helm release.
+- `argocd.argoproj.io/tracking-id` or `argocd.argoproj.io/instance` points to
+  Argo CD ownership.
+- `helm.toolkit.fluxcd.io/*` and `kustomize.toolkit.fluxcd.io/*` point to Flux
+  ownership.
+
+A GitOps-managed chart normally has both Helm and GitOps metadata. In that
+case, GitOps is the source of truth: update Git rather than running Helm
+directly. If none of these markers exist, update the manifests or image tag in
+the system that originally deployed Radar.
+
+### Verify or roll back
+
+Wait for the Radar Deployment to finish rolling out, then refresh Radar and
+confirm the new version on the Home page:
+
+```bash
+kubectl rollout status deployment/radar --namespace radar --timeout 5m
+```
+
+Use the actual Deployment name and namespace if they differ. For a Helm-managed
+installation, inspect `helm history` and use `helm rollback` if the rollout
+fails. For a GitOps-managed installation, revert the version change in Git and
+reconcile the owning object.
 
 ## Exposing with Gateway API
 
@@ -36,7 +139,12 @@ With no custom `rules`, the chart routes `/` to Radar. `httpRoute` and `ingress`
 
 ## Exposing with Ingress
 
-### Basic (No Authentication)
+### Ingress without authentication
+
+> **Warning:** Only use this behind a trusted private network boundary. Anyone
+> who can reach Radar can use the permissions granted to its ServiceAccount.
+> For shared or externally reachable installations, configure authentication
+> before exposing the ingress.
 
 ```yaml
 # values.yaml
@@ -114,14 +222,14 @@ want several clusters in one view, that is what
 [Radar Cloud](https://radarhq.io) is for, and its agent dials out so there is no
 per-cluster ingress to wire up.
 
-### With Basic Authentication
+### With ingress basic authentication
 
 1. **Create the auth secret:**
    ```bash
    # Install htpasswd if needed: brew install httpd (macOS) or apt install apache2-utils (Linux)
 
-   # Generate credentials (replace 'admin' and 'your-password')
-   htpasswd -nb admin 'your-password' > auth
+   # Create the file and enter the password when prompted
+   htpasswd -cB auth admin
 
    # Create the secret
    kubectl create secret generic radar-basic-auth \
@@ -428,19 +536,14 @@ kubectl logs -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx
 Verify the secret format:
 ```bash
 kubectl get secret radar-basic-auth -n radar -o jsonpath='{.data.auth}' | base64 -d
-# Should show: username:$apr1$...
-```
-
-## Upgrading
-
-```bash
-helm repo update skyhook
-helm upgrade radar skyhook/radar -n radar -f values.yaml
+# Should show: username:<password-hash>
 ```
 
 ## Uninstalling
 
 ```bash
 helm uninstall radar -n radar
-kubectl delete namespace radar
 ```
+
+If `radar` is a dedicated namespace and contains nothing you need to retain,
+delete it separately with `kubectl delete namespace radar`.

--- a/internal/k8s/installed_at_test.go
+++ b/internal/k8s/installed_at_test.go
@@ -41,8 +41,7 @@ func TestInstalledAtZeroWhenUnknown(t *testing.T) {
 		{"no downward-API name", kc, "radar", ""},
 		{"deployment absent", kc, "radar", "radar"},
 		{"nil client", nil, "radar", "radar"},
-		// GetClient returns a concrete *Clientset; a nil one in an interface is
-		// non-nil at the interface level and panics on first use.
+		// A typed nil in an interface is non-nil and panics on first use without the guard.
 		{"typed-nil client", (*kubernetes.Clientset)(nil), "radar", "radar"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/cloud_connect_self.go
+++ b/internal/server/cloud_connect_self.go
@@ -34,7 +34,8 @@ type cloudConnectSelf struct {
 	DeploymentName string `json:"deploymentName,omitempty"`
 	Chart          string `json:"chart,omitempty"`
 	// Controller names the GitOps object that owns this install, when one does.
-	Controller string `json:"controller,omitempty"`
+	Controller    string       `json:"controller,omitempty"`
+	ControllerRef *subject.Ref `json:"controllerRef,omitempty"`
 	// WizardURL deep-links the Hub's connect wizard with this install's real
 	// target, so it renders the existing-install artifact for the right release
 	// instead of guessing. Empty when the handoff must go through the CLI —
@@ -139,9 +140,13 @@ func (s *Server) inspectSelfInstall(ctx context.Context, r *http.Request, namesp
 		// A release name is required even when verified: the wizard's GitOps
 		// artifact is a Helm values patch, so an installation with no Helm
 		// release identity has nothing for it to patch.
-		if target.Ownership.Classification == cloudinstall.OwnershipGitOpsVerified && target.ReleaseName != "" && owner != nil {
-			if method := wizardMethodFor(owner.Ref); method != "" {
-				self.WizardURL = s.wizardInstallURL(target.Namespace, target.ReleaseName, method)
+		if target.Ownership.Classification == cloudinstall.OwnershipGitOpsVerified && owner != nil {
+			controllerRef := owner.Ref
+			self.ControllerRef = &controllerRef
+			if target.ReleaseName != "" {
+				if method := wizardMethodFor(owner.Ref); method != "" {
+					self.WizardURL = s.wizardInstallURL(target.Namespace, target.ReleaseName, method)
+				}
 			}
 		}
 	case cloudinstall.OwnershipAmbiguous:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,7 +97,6 @@ type Server struct {
 	newExecutor     func(*rest.Config, *url.URL) (remotecommand.Executor, error)
 	cloudConnectCfg CloudConnectConfig
 	cloudInstall    *cloudInstallManager
-
 	// nsPreferences holds each user's active-namespace pick from the in-app
 	// switcher. Key shape: "<username>\x00<contextName>" when auth is enabled,
 	// "\x00<contextName>" when auth is disabled. Cleared on context switch
@@ -517,6 +516,7 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			r.Get("/diagnostics", s.handleDiagnostics)
 			r.Get("/auth/me", s.handleAuthMe)
 			r.Get("/version-check", s.handleVersionCheck)
+			r.Post("/version-check/browser", s.handleVersionCheckBrowser)
 			r.Get("/dashboard", s.handleDashboard)
 			r.Get("/vitals", s.handleVitals)
 			r.Get("/dashboard/crds", s.handleDashboardCRDs)
@@ -1227,8 +1227,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleVersionCheck(w http.ResponseWriter, r *http.Request) {
-	info := version.CheckForUpdate(r.Context())
-	s.writeJSON(w, info)
+	if deploymentMode() == k8s.DeploymentModeCloud {
+		s.writeJSON(w, version.CheckForUpdateRelease(r.Context()))
+		return
+	}
+	s.writeJSON(w, version.CheckForUpdate(r.Context()))
 }
 
 func (s *Server) handleClusterInfo(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/version_check.go
+++ b/internal/server/version_check.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/version"
+)
+
+func (s *Server) handleVersionCheckBrowser(w http.ResponseWriter, r *http.Request) {
+	if deploymentMode() != k8s.DeploymentModeInCluster {
+		s.writeError(w, http.StatusNotFound, "browser update checks are only available on in-cluster deployments")
+		return
+	}
+
+	if err := version.RelayUpdateCheck(context.WithoutCancel(r.Context())); err != nil {
+		log.Printf("[version] relayed update check failed: %v", err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/version_check_test.go
+++ b/internal/server/version_check_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/version"
+)
+
+func TestVersionCheckBrowserAcceptsInClusterRequest(t *testing.T) {
+	previousVersion := version.Current
+	version.SetCurrent("dev")
+	k8s.ForceInCluster = true
+	t.Cleanup(func() {
+		version.SetCurrent(previousVersion)
+		k8s.ForceInCluster = false
+	})
+
+	response := httptest.NewRecorder()
+	(&Server{}).handleVersionCheckBrowser(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/version-check/browser", nil),
+	)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+}
+
+func TestVersionCheckBrowserRejectsOtherDeploymentModes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cloud string
+	}{
+		{name: "local"},
+		{name: "cloud", cloud: "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("RADAR_CLOUD_MODE", tc.cloud)
+			restoreLocalMode := k8s.SetTestLocalMode()
+			t.Cleanup(restoreLocalMode)
+
+			response := httptest.NewRecorder()
+			(&Server{}).handleVersionCheckBrowser(
+				response,
+				httptest.NewRequest(http.MethodPost, "/api/version-check/browser", nil),
+			)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,12 +20,10 @@ import (
 	"github.com/skyhook-io/radar/internal/k8s"
 )
 
-const (
+var (
 	releasesURL = "https://releases.skyhook.io/radar/latest"
 	githubURL   = "https://api.github.com/repos/skyhook-io/radar/releases/latest"
-)
 
-var (
 	// Current is the current version of Radar, set at build time
 	Current = "dev"
 
@@ -33,13 +31,17 @@ var (
 	// Controls install method detection and enables in-app update flow.
 	isDesktop bool
 
-	// cached update check result
-	mu           sync.Mutex
-	cachedResult *UpdateInfo
-	lastCheck    time.Time
-	cacheTTL     = 1 * time.Hour
-	errorTTL     = 5 * time.Minute
+	mu          sync.Mutex
+	updateCache = map[string]updateCacheEntry{}
+	cacheTTL    = 1 * time.Hour
+	errorTTL    = 5 * time.Minute
 )
+
+type updateCacheEntry struct {
+	result    *UpdateInfo
+	checkedAt time.Time
+	loading   chan struct{}
+}
 
 // InstallMethod represents how Radar was installed
 type InstallMethod string
@@ -71,6 +73,10 @@ type githubRelease struct {
 	Body    string `json:"body"`
 }
 
+type checkOptions struct {
+	source string
+}
+
 // SetCurrent sets the current version (called from main)
 func SetCurrent(v string) {
 	Current = v
@@ -90,36 +96,97 @@ func IsDesktop() bool {
 
 // CheckForUpdate checks GitHub for the latest release
 func CheckForUpdate(_ context.Context) *UpdateInfo {
-	mu.Lock()
-
-	// Use shorter TTL for cached errors so transient failures recover quickly
-	ttl := cacheTTL
-	if cachedResult != nil && cachedResult.Error != "" {
-		ttl = errorTTL
+	if buildChannel(Current) == buildChannelDevelopment {
+		return checkForUpdateCached(checkOptions{source: "release-only"})
 	}
-
-	if cachedResult != nil && time.Since(lastCheck) < ttl {
-		result := *cachedResult
-		mu.Unlock()
-		return &result
-	}
-	mu.Unlock()
-
-	// Fetch outside the lock to avoid blocking concurrent callers during HTTP request.
-	// Use a background context so request cancellation doesn't poison the cache.
-	fetchCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	result := fetchLatestRelease(fetchCtx)
-
-	mu.Lock()
-	cachedResult = result
-	lastCheck = time.Now()
-	mu.Unlock()
-
-	return result
+	return checkForUpdateCached(checkOptions{})
 }
 
-func fetchLatestRelease(ctx context.Context) *UpdateInfo {
+// CheckForUpdateRelease returns release information using the release-only source.
+func CheckForUpdateRelease(_ context.Context) *UpdateInfo {
+	return checkForUpdateCached(checkOptions{source: "release-only"})
+}
+
+func RelayUpdateCheck(ctx context.Context) error {
+	if buildChannel(Current) == buildChannelDevelopment {
+		return nil
+	}
+
+	method := detectInstallMethod()
+	params := url.Values{
+		"v":       {Current},
+		"os":      {runtime.GOOS},
+		"arch":    {runtime.GOARCH},
+		"method":  {string(method)},
+		"mode":    {"in-cluster"},
+		"channel": {string(buildChannel(Current))},
+		"source":  {"browser-proxy"},
+	}
+	if installedAt := installTimestamp(ctx, "in-cluster"); installedAt != 0 {
+		params.Set("t", strconv.FormatInt(installedAt, 10))
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, fmt.Sprintf("%s?%s", releasesURL, params.Encode()), nil)
+	if err != nil {
+		return fmt.Errorf("create relayed update check: %w", err)
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("radar/%s", Current))
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("send relayed update check: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("relayed update check returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func checkForUpdateCached(options checkOptions) *UpdateInfo {
+	for {
+		mu.Lock()
+		entry := updateCache[options.source]
+
+		// Use shorter TTL for cached errors so transient failures recover quickly
+		ttl := cacheTTL
+		if entry.result != nil && entry.result.Error != "" {
+			ttl = errorTTL
+		}
+
+		if entry.result != nil && time.Since(entry.checkedAt) < ttl {
+			result := *entry.result
+			mu.Unlock()
+			return &result
+		}
+		if entry.loading != nil {
+			loading := entry.loading
+			mu.Unlock()
+			<-loading
+			continue
+		}
+
+		loading := make(chan struct{})
+		entry.loading = loading
+		updateCache[options.source] = entry
+		mu.Unlock()
+
+		// Use a background context so request cancellation doesn't poison the cache.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		result := fetchLatestRelease(fetchCtx, options)
+		cancel()
+
+		mu.Lock()
+		updateCache[options.source] = updateCacheEntry{result: result, checkedAt: time.Now()}
+		close(loading)
+		mu.Unlock()
+
+		return result
+	}
+}
+
+func fetchLatestRelease(ctx context.Context, options checkOptions) *UpdateInfo {
 	method := detectInstallMethod()
 	result := &UpdateInfo{
 		CurrentVersion: Current,
@@ -127,7 +194,6 @@ func fetchLatestRelease(ctx context.Context) *UpdateInfo {
 		UpdateCommand:  getUpdateCommand(method),
 	}
 
-	// Don't compare dev builds
 	if Current == "dev" {
 		return result
 	}
@@ -139,14 +205,18 @@ func fetchLatestRelease(ctx context.Context) *UpdateInfo {
 		mode = "in-cluster"
 	}
 	params := url.Values{
-		"v":      {Current},
-		"os":     {runtime.GOOS},
-		"arch":   {runtime.GOARCH},
-		"method": {string(method)},
-		"mode":   {mode},
+		"v":       {Current},
+		"os":      {runtime.GOOS},
+		"arch":    {runtime.GOARCH},
+		"method":  {string(method)},
+		"mode":    {mode},
+		"channel": {string(buildChannel(Current))},
 	}
-	if t := installTimestamp(ctx, mode); t != 0 {
-		params.Set("t", strconv.FormatInt(t, 10))
+	if installedAt := installTimestamp(ctx, mode); installedAt != 0 {
+		params.Set("t", strconv.FormatInt(installedAt, 10))
+	}
+	if options.source != "" {
+		params.Set("source", options.source)
 	}
 	proxyURL := fmt.Sprintf("%s?%s", releasesURL, params.Encode())
 
@@ -206,6 +276,93 @@ func fetchLatestRelease(ctx context.Context) *UpdateInfo {
 	result.UpdateAvail = newer
 
 	return result
+}
+
+// IsReleaseVersion accepts only stable x.y.z builds.
+func IsReleaseVersion(value string) bool {
+	v, err := semver.StrictNewVersion(strings.TrimPrefix(value, "v"))
+	return err == nil && v.Prerelease() == "" && v.Metadata() == ""
+}
+
+type buildChannelName string
+
+const (
+	buildChannelStable      buildChannelName = "stable"
+	buildChannelPrerelease  buildChannelName = "prerelease"
+	buildChannelCustom      buildChannelName = "custom"
+	buildChannelDevelopment buildChannelName = "development"
+)
+
+func buildChannel(value string) buildChannelName {
+	normalized := strings.TrimPrefix(strings.ToLower(value), "v")
+	if normalized == "dev" || strings.HasPrefix(normalized, "dev-") ||
+		strings.HasSuffix(normalized, "-dirty") || isCommitVersion(normalized) ||
+		isGitDescribeVersion(normalized) || isPackageReleaseVersion(normalized) {
+		return buildChannelDevelopment
+	}
+	if IsReleaseVersion(value) {
+		return buildChannelStable
+	}
+	if v, err := semver.StrictNewVersion(normalized); err == nil {
+		label := strings.ToLower(v.Prerelease())
+		if isNamedPrerelease(label) {
+			return buildChannelPrerelease
+		}
+	}
+	return buildChannelCustom
+}
+
+func isPackageReleaseVersion(value string) bool {
+	for _, prefix := range []string{"k8s-ui-v", "radar-app-v", "pkg/v"} {
+		if strings.HasPrefix(value, prefix) && IsReleaseVersion(strings.TrimPrefix(value, prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNamedPrerelease(label string) bool {
+	for _, prefix := range []string{"alpha", "beta", "rc"} {
+		if !strings.HasPrefix(label, prefix) {
+			continue
+		}
+		for _, char := range strings.TrimPrefix(label, prefix) {
+			if (char < '0' || char > '9') && char != '.' && char != '-' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func isCommitVersion(value string) bool {
+	if len(value) < 7 || len(value) > 40 {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func isGitDescribeVersion(value string) bool {
+	shaSeparator := strings.LastIndex(value, "-g")
+	if shaSeparator < 0 || !isCommitVersion(value[shaSeparator+2:]) {
+		return false
+	}
+	countSeparator := strings.LastIndex(value[:shaSeparator], "-")
+	if countSeparator < 0 || countSeparator == shaSeparator-1 {
+		return false
+	}
+	for _, char := range value[countSeparator+1 : shaSeparator] {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isNewerVersion compares semver versions using Masterminds/semver

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -2,8 +2,14 @@ package version
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -124,10 +130,6 @@ func TestTruncateNotes(t *testing.T) {
 	}
 }
 
-// When the Deployment is unreadable, in-cluster must report the same timestamp a
-// local install would rather than reporting none. Asserted as equality with the
-// local path so the test holds on filesystems that don't record a birthtime at
-// all (where both are legitimately 0).
 func TestInstallTimestampFallsBackInCluster(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -141,4 +143,231 @@ func TestInstallTimestampFallsBackInCluster(t *testing.T) {
 	if got := installTimestamp(ctx, "in-cluster"); got != local {
 		t.Fatalf("in-cluster timestamp %d did not fall back to the local timestamp %d", got, local)
 	}
+}
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := map[string]bool{
+		"1.2.3":       true,
+		"v1.2.3":      true,
+		"dev":         false,
+		"1.2.3-dirty": false,
+		"1.2.3-rc.1":  false,
+		"1.2":         false,
+		"":            false,
+	}
+	for value, want := range tests {
+		if got := IsReleaseVersion(value); got != want {
+			t.Errorf("IsReleaseVersion(%q) = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestCheckForUpdateSelectsSourceByBuildChannel(t *testing.T) {
+	var queries []url.Values
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.3.0"})
+	}))
+	defer proxy.Close()
+
+	previousURL, previousVersion := releasesURL, Current
+	releasesURL = proxy.URL
+	t.Cleanup(func() {
+		releasesURL = previousURL
+		SetCurrent(previousVersion)
+		resetUpdateCache()
+	})
+
+	for _, current := range []string{
+		"dev-a1b2c3d",
+		"1.2.3-dirty",
+		"k8s-ui-v1.13.3-27-g1197bab6",
+		"1197bab6043c723e557714620758ace2dad36354",
+	} {
+		SetCurrent(current)
+		resetUpdateCache()
+		CheckForUpdate(context.Background())
+		query := queries[len(queries)-1]
+		if query.Get("source") != "release-only" {
+			t.Errorf("CheckForUpdate with %q used source %q, want release-only", current, query.Get("source"))
+		}
+		if got := query.Get("channel"); got != string(buildChannel(current)) {
+			t.Errorf("CheckForUpdate with %q sent channel %q", current, got)
+		}
+	}
+
+	for _, current := range []string{"1.2.3", "1.2.3-rc.1", "1.8.6-pg.2"} {
+		SetCurrent(current)
+		resetUpdateCache()
+		CheckForUpdate(context.Background())
+		query := queries[len(queries)-1]
+		if query.Has("source") {
+			t.Errorf("CheckForUpdate with %q used source %q, want default", current, query.Get("source"))
+		}
+		if got := query.Get("channel"); got != string(buildChannel(current)) {
+			t.Errorf("CheckForUpdate with %q sent channel %q", current, got)
+		}
+	}
+
+	beforeDev := len(queries)
+	SetCurrent("dev")
+	resetUpdateCache()
+	CheckForUpdate(context.Background())
+	if len(queries) != beforeDev {
+		t.Errorf("dev build made %d update requests, want none", len(queries)-beforeDev)
+	}
+}
+
+func TestRelayUpdateCheck(t *testing.T) {
+	var queries []url.Values
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxy.Close()
+
+	previousURL, previousVersion := releasesURL, Current
+	releasesURL = proxy.URL
+	SetCurrent("1.2.3-rc1")
+	resetUpdateCache()
+	updateCache[""] = updateCacheEntry{result: &UpdateInfo{LatestVersion: "cached"}}
+	t.Cleanup(func() {
+		releasesURL = previousURL
+		SetCurrent(previousVersion)
+		resetUpdateCache()
+	})
+
+	if err := RelayUpdateCheck(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("requests = %d, want 1", len(queries))
+	}
+	query := queries[0]
+	for key, want := range map[string]string{
+		"v": "1.2.3-rc1", "mode": "in-cluster", "channel": "prerelease", "source": "browser-proxy",
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("query[%q] = %q, want %q", key, got, want)
+		}
+	}
+	if cached := updateCache[""]; cached.result == nil || cached.result.LatestVersion != "cached" {
+		t.Fatalf("relayed check changed release cache: %+v", cached)
+	}
+
+	SetCurrent("dev-a1b2c3d")
+	if err := RelayUpdateCheck(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("development build made %d relayed requests, want none", len(queries)-1)
+	}
+}
+
+func TestReleaseOnlyCheckDoesNotSatisfyDefaultCheck(t *testing.T) {
+	var queries []url.Values
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.3.0"})
+	}))
+	defer proxy.Close()
+
+	previousURL, previousVersion := releasesURL, Current
+	releasesURL = proxy.URL
+	SetCurrent("1.2.3")
+	resetUpdateCache()
+	t.Cleanup(func() {
+		releasesURL = previousURL
+		SetCurrent(previousVersion)
+		resetUpdateCache()
+	})
+
+	CheckForUpdateRelease(context.Background())
+	CheckForUpdate(context.Background())
+
+	if len(queries) != 2 {
+		t.Fatalf("requests = %d, want separate release-only and default requests", len(queries))
+	}
+	if got := queries[0].Get("source"); got != "release-only" {
+		t.Fatalf("first source = %q, want release-only", got)
+	}
+	if queries[1].Has("source") {
+		t.Fatalf("default request used source %q", queries[1].Get("source"))
+	}
+}
+
+func TestCheckForUpdateSingleFlightsConcurrentCacheMisses(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var requests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v1.3.0"})
+	}))
+	defer proxy.Close()
+
+	previousURL, previousVersion := releasesURL, Current
+	releasesURL = proxy.URL
+	SetCurrent("1.2.3")
+	resetUpdateCache()
+	t.Cleanup(func() {
+		releasesURL = previousURL
+		SetCurrent(previousVersion)
+		resetUpdateCache()
+	})
+
+	const callers = 12
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			CheckForUpdate(context.Background())
+		}()
+	}
+	<-started
+	close(release)
+	wg.Wait()
+
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("release requests = %d, want 1", got)
+	}
+}
+
+func TestBuildChannel(t *testing.T) {
+	tests := map[string]buildChannelName{
+		"1.2.3":                       buildChannelStable,
+		"v1.2.3":                      buildChannelStable,
+		"1.2.3-rc.1":                  buildChannelPrerelease,
+		"1.2.3-rc1":                   buildChannelPrerelease,
+		"1.2.3-beta.2":                buildChannelPrerelease,
+		"1.2.3-alphabet":              buildChannelCustom,
+		"1.2.3-alpha.foo":             buildChannelCustom,
+		"1.8.6-pg.2":                  buildChannelCustom,
+		"acme-radar":                  buildChannelCustom,
+		"1.2.3+vendor.1":              buildChannelCustom,
+		"1.2.3-rc.01":                 buildChannelCustom,
+		"dev":                         buildChannelDevelopment,
+		"dev-a1b2c3d":                 buildChannelDevelopment,
+		"1.2.3-dirty":                 buildChannelDevelopment,
+		"k8s-ui-v1.13.3":              buildChannelDevelopment,
+		"radar-app-v1.2.3":            buildChannelDevelopment,
+		"pkg/v1.12.1":                 buildChannelDevelopment,
+		"k8s-ui-v1.13.3-27-g1197bab6": buildChannelDevelopment,
+		"1197bab6043c723e557714620758ace2dad36354": buildChannelDevelopment,
+	}
+	for value, want := range tests {
+		if got := buildChannel(value); got != want {
+			t.Errorf("buildChannel(%q) = %q, want %q", value, got, want)
+		}
+	}
+}
+
+func resetUpdateCache() {
+	mu.Lock()
+	defer mu.Unlock()
+	updateCache = map[string]updateCacheEntry{}
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2047,6 +2047,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             topology={topology}
             fallbackClusterLoadState={showHomeClusterLoadFallback ? clusterLoadState : undefined}
             onNavigateToView={setMainView}
+            onNavigateToHelmRelease={navCustomization.embedded ? undefined : navigateToHelmRelease}
+            onNavigateToManagerPath={navCustomization.embedded || takeover.gitops ? undefined : (path) => navigate(path)}
             // Upgrade impact lives under /checks, which a Cloud host takes
             // over wholesale — its fleet pages have no upgrade sub-route, so
             // the version line stays plain text there.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1517,7 +1517,7 @@ export interface VersionInfo {
   error?: string;
 }
 
-const UPDATE_CHECK_STORAGE_KEY_PREFIX = 'radar-update-check'
+const UPDATE_CHECK_STORAGE_KEY_PREFIX = 'radar-update-check';
 
 export function utcDay(now: Date): string {
   return now.toISOString().slice(0, 10)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -55,8 +55,9 @@ import type {
   PodEnvironmentRevealResponse,
 } from '../types'
 import type { GitOpsOperationResponse } from '../types/gitops'
-import { getApiBase, getAuthHeaders, getCredentialsMode, getBasename, routePath, stripBasename } from './config'
+import { apiUrl, getApiBase, getAuthHeaders, getCredentialsMode, getBasename, routePath, stripBasename } from './config'
 import { apiVersionToGroup, pluralToKind } from '../utils/navigation'
+import type { DeploymentMode } from '../types'
 
 // Auto-refresh cadences (ms) — named constants for each polled hook's
 // refetchInterval below, so the poll rate reads clearly at each call site.
@@ -1516,13 +1517,68 @@ export interface VersionInfo {
   error?: string;
 }
 
+const UPDATE_CHECK_STORAGE_KEY_PREFIX = 'radar-update-check'
+
+export function utcDay(now: Date): string {
+  return now.toISOString().slice(0, 10)
+}
+
+export function markDailyUpdateCheckAttempt(
+  storage: Pick<Storage, 'getItem' | 'setItem'>,
+  apiBase: string,
+  now: Date,
+): boolean {
+  const storageKey = `${UPDATE_CHECK_STORAGE_KEY_PREFIX}:${apiBase}`
+  const day = utcDay(now)
+  try {
+    if (storage.getItem(storageKey) === day) return false
+
+    storage.setItem(storageKey, day)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function markUpdateCheckAttempt(): boolean {
+  try {
+    return markDailyUpdateCheckAttempt(localStorage, getApiBase(), new Date())
+  } catch {
+    return false
+  }
+}
+
+export async function triggerDailyUpdateCheck(
+  deploymentMode: DeploymentMode | undefined,
+): Promise<void> {
+  if (deploymentMode !== 'in-cluster' || !markUpdateCheckAttempt()) return
+  await fetch(apiUrl('/version-check/browser'), {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    credentials: getCredentialsMode(),
+    keepalive: true,
+  })
+}
+
 export function useVersionCheck() {
-  return useQuery<VersionInfo>({
-    queryKey: ["version-check"],
-    queryFn: () => fetchJSON("/version-check"),
+  const capabilities = useCapabilities()
+  const apiBase = getApiBase()
+  const deploymentMode = capabilities.data
+    ? (capabilities.data.deployment?.mode ?? 'local')
+    : undefined
+
+  const query = useQuery<VersionInfo>({
+    queryKey: ["version-check", apiBase],
+    queryFn: () => fetchJSON('/version-check'),
     staleTime: 60 * 60 * 1000, // 1 hour
     retry: false, // Don't retry on failure
   });
+
+  useEffect(() => {
+    if (query.isSuccess) void triggerDailyUpdateCheck(deploymentMode).catch(() => {})
+  }, [apiBase, deploymentMode, query.isSuccess])
+
+  return query;
 }
 
 // ============================================================================
@@ -1847,6 +1903,12 @@ export interface CloudConnectSelf {
   deploymentName?: string
   chart?: string
   controller?: string
+  controllerRef?: {
+    group?: string
+    kind: string
+    namespace?: string
+    name: string
+  }
   wizardUrl?: string
 }
 

--- a/web/src/api/version-check.test.ts
+++ b/web/src/api/version-check.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { markDailyUpdateCheckAttempt, triggerDailyUpdateCheck, utcDay } from './client'
+
+function memoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  }
+}
+
+describe('daily update checks', () => {
+  it('uses UTC days', () => {
+    expect(utcDay(new Date('2026-08-29T23:59:59-07:00'))).toBe('2026-08-30')
+  })
+
+  it('attempts once per API base and UTC day', () => {
+    const storage = memoryStorage()
+    expect(markDailyUpdateCheckAttempt(storage, '/api', new Date('2026-08-29T10:00:00Z'))).toBe(true)
+    expect(markDailyUpdateCheckAttempt(storage, '/api', new Date('2026-08-29T20:00:00Z'))).toBe(false)
+    expect(markDailyUpdateCheckAttempt(storage, '/api', new Date('2026-08-30T10:00:00Z'))).toBe(true)
+    expect(markDailyUpdateCheckAttempt(storage, '/c/cluster-a/api', new Date('2026-08-30T10:00:00Z'))).toBe(true)
+  })
+
+  it('skips the attempt when storage is unavailable', () => {
+    const storage = {
+      getItem: () => null,
+      setItem: () => { throw new Error('blocked') },
+    }
+    expect(markDailyUpdateCheckAttempt(storage, '/api', new Date('2026-08-29T10:00:00Z'))).toBe(false)
+  })
+})
+
+describe('triggerDailyUpdateCheck', () => {
+  beforeEach(() => {
+    const values = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each(['local', 'cloud', undefined] as const)('does not report in %s mode', async (mode) => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetch)
+    await triggerDailyUpdateCheck(mode)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('sends one bodyless in-cluster attempt per day', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetch)
+
+    await triggerDailyUpdateCheck('in-cluster')
+    await triggerDailyUpdateCheck('in-cluster')
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith('/api/version-check/browser', expect.objectContaining({
+      method: 'POST',
+      credentials: 'same-origin',
+      keepalive: true,
+    }))
+    expect(fetch.mock.calls[0][1]).not.toHaveProperty('body')
+  })
+
+  it('does not retry a failed daily attempt', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => { throw new Error('offline') })
+    vi.stubGlobal('fetch', fetch)
+
+    await expect(triggerDailyUpdateCheck('in-cluster')).rejects.toThrow('offline')
+    await triggerDailyUpdateCheck('in-cluster')
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -13,6 +13,7 @@ import { MCPSetupDialog } from './MCPSetupDialog'
 import { assetUrl, pluralize, parseContextName } from '@skyhook-io/k8s-ui'
 import { Tooltip } from '../ui/Tooltip'
 import { routePath } from '../../api/config'
+import { parseMajorMinor } from '../../utils/version'
 import gkeIcon from '../../assets/platform-icons/google_kubernetes_engine.png'
 import eksIcon from '../../assets/platform-icons/aws_eks.png'
 import aksIcon from '../../assets/platform-icons/azure-aks.svg'
@@ -40,6 +41,7 @@ interface ClusterHealthCardProps {
   // Freshness/refresh control for the dashboard poll — rendered under the
   // cluster metadata so the overview carries a freshness signal without a band.
   freshness?: ReactNode
+  radarVersion?: ReactNode
 }
 
 function getMetricsInstallHint(platform: string): string {
@@ -136,6 +138,7 @@ export function ClusterHealthCard({
   onWarningEventsClick,
   onIssuesClick,
   freshness,
+  radarVersion,
 }: ClusterHealthCardProps) {
   void _topCRDs // Reserved for future CRD display
 
@@ -260,6 +263,7 @@ export function ClusterHealthCard({
                   onNavigate={onNavigateToUpgradeImpact}
                 />
               )}
+              {radarVersion}
               <span><span className="font-mono">{counts.namespaces}</span> namespaces</span>
               {/* Show raw kubeconfig context as muted metadata only when
                   it differs from the headline AND we're in local mode
@@ -524,12 +528,6 @@ export function ClusterHealthCard({
       </div>
     </div>
   )
-}
-
-function parseMajorMinor(version: string): { major: number; minor: number } | null {
-  const m = /^v?(\d+)\.(\d+)/.exec(version.trim())
-  if (!m) return null
-  return { major: Number(m[1]), minor: Number(m[2]) }
 }
 
 // How many minors the running version trails the newest one the upgrade-impact

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -1,5 +1,5 @@
 import { useMemo, type ReactNode } from 'react'
-import { useDashboard, useDashboardCRDs, useDashboardHelm, useIssues, type IssuesResponse } from '../../api/client'
+import { useCloudConnectSelf, useDashboard, useDashboardCRDs, useDashboardHelm, useIssues, useVersionCheck, type IssuesResponse } from '../../api/client'
 import { useConnection } from '../../context/ConnectionContext'
 import type { ClusterLoadState } from '../../types/clusterLoadState'
 import type { ExtendedMainView, Topology, SelectedResource } from '../../types'
@@ -31,6 +31,8 @@ import { formatCompactAge } from '@skyhook-io/k8s-ui/utils/format'
 import { ClusterHealthCard } from './ClusterHealthCard'
 import { AlertTriangle, CheckCircle, Loader2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
+import { getVersionUpdateStatus } from '../../utils/version'
+import { RadarVersionLine } from './RadarVersionLine'
 
 interface HomeViewProps {
   namespaces: string[]
@@ -48,14 +50,17 @@ interface HomeViewProps {
   onNavigateToCerts?: () => void
   // Omitted when an embedded host owns /checks, leaving the version as plain text.
   onNavigateToUpgradeImpact?: () => void
+  onNavigateToHelmRelease?: (namespace: string, release: string) => void
+  onNavigateToManagerPath?: (path: string) => void
 }
 
-export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts, onNavigateToUpgradeImpact }: HomeViewProps) {
+export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts, onNavigateToUpgradeImpact, onNavigateToHelmRelease, onNavigateToManagerPath }: HomeViewProps) {
   // The card itself decides whether the cluster has a capacity story
   // (available, softened-denied, or karpenterless-with-managers/groups) and
   // returns null otherwise — the outer gate only excludes states with nothing
   // to fetch against.
-  const karpenterState = useCapabilitiesContext().karpenter?.state
+  const capabilities = useCapabilitiesContext()
+  const karpenterState = capabilities.karpenter?.state
   const capacityCardPossible =
     karpenterState === 'available' || karpenterState === 'denied' || karpenterState === 'not_detected'
   const { data, isLoading, error, dataUpdatedAt, refetch } = useDashboard(namespaces)
@@ -64,6 +69,12 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
   const issues = issuesData?.issues ?? []
   const issueCount = issuesData?.total_matched ?? issuesData?.total ?? issues.length
   const hasCriticalIssues = issues.some((issue) => issue.severity === 'critical')
+  const deploymentMode = capabilities.deployment?.mode ?? 'local'
+  const { data: versionInfo } = useVersionCheck()
+  const showHomeUpgrade = deploymentMode === 'in-cluster'
+    && !!versionInfo?.updateAvailable
+    && getVersionUpdateStatus(versionInfo.currentVersion, versionInfo.latestVersion).tier !== 'none'
+  const { data: installationManager, isLoading: installationManagerLoading } = useCloudConnectSelf(showHomeUpgrade)
 
   // SSE is cluster-wide on small/medium clusters; the picker only narrows the
   // dashboard summary, so re-apply the filter here or the legend disagrees.
@@ -127,6 +138,15 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
         )}
         {/* Row 1: Cluster Health Card (combined health + resource counts) */}
         <ClusterHealthCard
+          radarVersion={deploymentMode === 'in-cluster' && versionInfo ? (
+            <RadarVersionLine
+              version={versionInfo}
+              manager={installationManager}
+              managerLoading={installationManagerLoading}
+              onNavigateToHelmRelease={onNavigateToHelmRelease}
+              onNavigateToGitOps={onNavigateToManagerPath}
+            />
+          ) : undefined}
           freshness={
             <FreshnessControl
               mode="auto"

--- a/web/src/components/home/RadarVersionLine.test.tsx
+++ b/web/src/components/home/RadarVersionLine.test.tsx
@@ -1,0 +1,145 @@
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { VersionInfo } from '../../api/client'
+import { RadarVersionLine } from './RadarVersionLine'
+
+const version: VersionInfo = {
+  currentVersion: '1.2.3',
+  latestVersion: '1.3.0',
+  updateAvailable: true,
+  installMethod: 'direct',
+  releaseUrl: 'https://github.com/skyhook-io/radar/releases/tag/v1.3.0',
+}
+
+describe('RadarVersionLine', () => {
+  it('shows the running version without an upgrade affordance when up to date', () => {
+    const html = renderToString(
+      <RadarVersionLine version={{ ...version, latestVersion: '1.2.3', updateAvailable: false }} />,
+    )
+    expect(html).toContain('Radar')
+    expect(html).toContain('v1.2.3')
+    expect(html).not.toContain('available')
+  })
+
+  it('shows patch upgrades with the quiet treatment', () => {
+    const html = renderToString(
+      <RadarVersionLine version={{ ...version, latestVersion: '1.2.4' }} />,
+    )
+    expect(html).toContain('v1.2.3')
+    expect(html).toContain('v1.2.4')
+    expect(html).toContain('available')
+    expect(html).toContain('text-accent-text hover:text-accent')
+  })
+
+  it('makes minor upgrades more prominent', () => {
+    const html = renderToString(<RadarVersionLine version={version} />)
+    expect(html).toContain('font-medium text-accent hover:text-accent-light')
+    expect(html).not.toContain('minor releases behind')
+  })
+
+  it('uses warning emphasis and explains when an installation is three minor releases behind', () => {
+    const html = renderToString(
+      <RadarVersionLine version={{ ...version, currentVersion: '1.0.9', latestVersion: '1.3.0' }} />,
+    )
+    expect(html).toContain('font-medium text-warning-text hover:opacity-80')
+    expect(html).toContain('This installation is 3 minor releases behind')
+  })
+
+  it('uses warning emphasis for a major upgrade', () => {
+    const html = renderToString(
+      <RadarVersionLine version={{ ...version, currentVersion: '0.12.0', latestVersion: '1.3.0' }} />,
+    )
+    expect(html).toContain('font-medium text-warning-text hover:opacity-80')
+    expect(html).toContain('A major Radar upgrade is available')
+  })
+
+  it('does not claim manager discovery has failed while it is loading', () => {
+    const html = renderToString(<RadarVersionLine version={version} managerLoading />)
+    expect(html).toContain('v1.3.0')
+    expect(html).toContain('available')
+    expect(html).toContain('lucide-circle-arrow-up')
+    expect(html).toContain('Checking how this installation is managed')
+    expect(html).not.toContain('could not be confirmed')
+    expect(html).not.toContain('<a')
+    expect(html).not.toContain('<button')
+    expect(html).toContain('class="sr-only"')
+    expect(html).not.toContain('aria-label=')
+  })
+
+  it('opens actionable upgrade instructions when the installation manager is unknown', () => {
+    const html = renderToString(<RadarVersionLine version={version} />)
+    expect(html).toContain('https://radarhq.io/docs/configuration/in-cluster')
+    expect(html).not.toContain('#upgrading')
+    expect(html).toContain('Open the in-cluster upgrade instructions')
+    expect(html).not.toContain(version.releaseUrl)
+    expect(html).toContain('font-medium text-accent hover:text-accent-light')
+  })
+
+  it('keeps the visible upgrade label in the accessible name', () => {
+    const html = renderToString(<RadarVersionLine version={version} />)
+    expect(html).toContain('aria-label="v1.3.0 available —')
+  })
+
+  it('deep-links exact Helm ownership when the host supports it', () => {
+    const html = renderToString(
+      <RadarVersionLine
+        version={version}
+        manager={{ ownership: 'helm', namespace: 'radar-system', release: 'radar' }}
+        onNavigateToHelmRelease={() => {}}
+      />,
+    )
+    expect(html).toContain('Managed by Helm release radar-system/radar')
+    expect(html).toContain('Open the release to upgrade')
+  })
+
+  it('describes the docs fallback when a Helm navigation callback is unavailable', () => {
+    const html = renderToString(
+      <RadarVersionLine
+        version={version}
+        manager={{ ownership: 'helm', namespace: 'radar-system', release: 'radar' }}
+      />,
+    )
+    expect(html).toContain('https://radarhq.io/docs/configuration/in-cluster')
+    expect(html).toContain('Managed by Helm release radar-system/radar')
+    expect(html).toContain('Open the in-cluster upgrade instructions')
+    expect(html).not.toContain('Open the release to upgrade')
+  })
+
+  it('deep-links verified GitOps ownership', () => {
+    const controllerRef = { group: 'kustomize.toolkit.fluxcd.io', kind: 'Kustomization', namespace: 'flux-system', name: 'radar' }
+    const verified = renderToString(
+      <RadarVersionLine
+        version={version}
+        manager={{ ownership: 'gitops', controller: 'Kustomization flux-system/radar', controllerRef }}
+        onNavigateToGitOps={() => {}}
+      />,
+    )
+    expect(verified).toContain('Managed by Kustomization flux-system/radar')
+    expect(verified).toContain('Open it to upgrade through GitOps')
+
+    const suspected = renderToString(
+      <RadarVersionLine
+        version={version}
+        manager={{ ownership: 'gitops', controller: 'Kustomization flux-system/radar' }}
+        onNavigateToGitOps={() => {}}
+      />,
+    )
+    expect(suspected).toContain('appears to be managed through GitOps (Kustomization flux-system/radar)')
+    expect(suspected).toContain('Open the upgrade instructions')
+    expect(suspected).not.toContain('Managed by Kustomization')
+  })
+
+  it('describes the docs fallback when a GitOps navigation callback is unavailable', () => {
+    const controllerRef = { group: 'kustomize.toolkit.fluxcd.io', kind: 'Kustomization', namespace: 'flux-system', name: 'radar' }
+    const html = renderToString(
+      <RadarVersionLine
+        version={version}
+        manager={{ ownership: 'gitops', controller: 'Kustomization flux-system/radar', controllerRef }}
+      />,
+    )
+    expect(html).toContain('https://radarhq.io/docs/configuration/in-cluster')
+    expect(html).toContain('Managed by Kustomization flux-system/radar')
+    expect(html).toContain('Open the in-cluster upgrade instructions and apply the change through GitOps')
+    expect(html).not.toContain('Open it to upgrade through GitOps')
+  })
+})

--- a/web/src/components/home/RadarVersionLine.tsx
+++ b/web/src/components/home/RadarVersionLine.tsx
@@ -1,0 +1,137 @@
+import { ArrowUpCircle } from 'lucide-react'
+import { gitOpsRouteForResource } from '@skyhook-io/k8s-ui'
+import type { CloudConnectSelf, VersionInfo } from '../../api/client'
+import {
+  getVersionUpdateStatus,
+  IN_CLUSTER_UPGRADE_URL,
+  type VersionUpdateTier,
+} from '../../utils/version'
+import { Tooltip } from '../ui/Tooltip'
+
+interface RadarVersionLineProps {
+  version: VersionInfo
+  manager?: CloudConnectSelf
+  managerLoading?: boolean
+  onNavigateToHelmRelease?: (namespace: string, release: string) => void
+  onNavigateToGitOps?: (path: string) => void
+}
+
+function displayVersion(version: string): string {
+  return version === 'dev' || version.startsWith('v') ? version : `v${version}`
+}
+
+export function RadarVersionLine({
+  version,
+  manager,
+  managerLoading = false,
+  onNavigateToHelmRelease,
+  onNavigateToGitOps,
+}: RadarVersionLineProps) {
+  const latestVersion = version.latestVersion
+  const updateStatus = getVersionUpdateStatus(version.currentVersion, latestVersion)
+  const showUpgrade = version.updateAvailable && !!latestVersion && updateStatus.tier !== 'none'
+
+  if (!showUpgrade) {
+    return <span>Radar <span className="font-mono">{displayVersion(version.currentVersion)}</span></span>
+  }
+
+  const controller = manager?.controllerRef
+  const gitOpsPath = controller
+    ? gitOpsRouteForResource({
+        apiVersion: controller.group ? `${controller.group}/v1` : undefined,
+        kind: controller.kind,
+        metadata: { namespace: controller.namespace, name: controller.name },
+      })
+    : null
+
+  let detail = managerLoading
+    ? 'Checking how this installation is managed.'
+    : 'The installation manager could not be confirmed. Open the in-cluster upgrade instructions.'
+  let onClick: (() => void) | undefined
+  const actionClassName = `inline-flex items-center gap-1 transition-colors ${upgradeActionClassName(updateStatus.tier)}`
+
+  if (manager?.ownership === 'helm' && manager.namespace && manager.release) {
+    if (onNavigateToHelmRelease) {
+      detail = `Managed by Helm release ${manager.namespace}/${manager.release}. Open the release to upgrade.`
+      onClick = () => onNavigateToHelmRelease(manager.namespace!, manager.release!)
+    } else {
+      detail = `Managed by Helm release ${manager.namespace}/${manager.release}. Open the in-cluster upgrade instructions.`
+    }
+  } else if (controller && gitOpsPath) {
+    const objectName = `${controller.namespace ? `${controller.namespace}/` : ''}${controller.name}`
+    if (onNavigateToGitOps) {
+      detail = `Managed by ${controller.kind} ${objectName}. Open it to upgrade through GitOps.`
+      onClick = () => onNavigateToGitOps(gitOpsPath)
+    } else {
+      detail = `Managed by ${controller.kind} ${objectName}. Open the in-cluster upgrade instructions and apply the change through GitOps.`
+    }
+  } else if (manager?.ownership === 'gitops') {
+    detail = manager.controller
+      ? `This installation appears to be managed through GitOps (${manager.controller}). Open the upgrade instructions and apply the change through its source of truth.`
+      : 'This installation appears to be managed through GitOps. Open the upgrade instructions and apply the change through its source of truth.'
+  }
+
+  const ageDetail = updateAgeDetail(updateStatus)
+  const accessibleLabel = `${displayVersion(latestVersion)} available${ageDetail ? `. ${ageDetail}` : ''} — ${detail}`
+  const action = managerLoading ? (
+    <span className={actionClassName}>
+      <UpgradeLabel version={latestVersion} />
+      <span className="sr-only">{detail}</span>
+    </span>
+  ) : onClick ? (
+    <button
+      type="button"
+      className={actionClassName}
+      onClick={onClick}
+      aria-label={accessibleLabel}
+    >
+      <UpgradeLabel version={latestVersion} />
+    </button>
+  ) : (
+    <a
+      href={IN_CLUSTER_UPGRADE_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={actionClassName}
+      aria-label={accessibleLabel}
+    >
+      <UpgradeLabel version={latestVersion} />
+    </a>
+  )
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-x-1">
+      <span>Radar <span className="font-mono">{displayVersion(version.currentVersion)}</span></span>
+      <span className="inline-flex items-center gap-1">
+        <span aria-hidden>·</span>
+        <Tooltip
+          content={accessibleLabel}
+          className="!whitespace-normal !max-w-sm"
+        >
+          {action}
+        </Tooltip>
+      </span>
+    </span>
+  )
+}
+
+function upgradeActionClassName(tier: VersionUpdateTier): string {
+  if (tier === 'patch') return 'text-accent-text hover:text-accent'
+  if (tier === 'minor') return 'font-medium text-accent hover:text-accent-light'
+  return 'font-medium text-warning-text hover:opacity-80'
+}
+
+function updateAgeDetail(status: ReturnType<typeof getVersionUpdateStatus>): string | undefined {
+  if (status.majorVersionBehind) return 'A major Radar upgrade is available.'
+  if (status.tier !== 'stale' || !status.minorVersionsBehind) return undefined
+  return `This installation is ${status.minorVersionsBehind} minor releases behind.`
+}
+
+function UpgradeLabel({ version }: { version: string }) {
+  return (
+    <>
+      <ArrowUpCircle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span><span className="font-mono">{displayVersion(version)}</span> available</span>
+    </>
+  )
+}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -12,7 +12,7 @@ import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode, routePath } from '../../api/config'
 import {
-  useCloudRole, useVersionCheck, useClusterInfo, usePrometheusStatus, useArgoStatus,
+  useCloudRole, useVersionCheck, useClusterInfo, usePrometheusStatus, useArgoStatus, useCapabilities,
 } from '../../api/client'
 import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 import { Input, SelectMenu } from '@skyhook-io/k8s-ui'
@@ -21,6 +21,7 @@ import { AISettingsSection, type AIDraft } from '../diagnose/AISettings'
 import { MyPermissionsContent } from './MyPermissionsDialog'
 import { useDiagnose } from '../diagnose/DiagnoseContext'
 import { currencyOptionsForValue } from './currency-options'
+import { versionUpdateURL } from '../../utils/version'
 
 // The loopback URL an MCP client is told to connect to. Shared by the overview
 // row and the MCP section: both must carry the base path, or the URL they
@@ -911,6 +912,8 @@ function OverviewPanel({ active, onNavigate }: { active: boolean; onNavigate: (s
   const { data: cluster } = useClusterInfo()
   const { data: prom } = usePrometheusStatus()
   const { data: argo } = useArgoStatus(active)
+  const { data: capabilitiesData } = useCapabilities()
+  const deploymentMode = capabilitiesData ? (capabilitiesData.deployment?.mode ?? 'local') : undefined
   const { data: version } = useVersionCheck()
   const capabilities = useCapabilitiesContext()
   const diag = useDiagnose()
@@ -967,9 +970,9 @@ function OverviewPanel({ active, onNavigate }: { active: boolean; onNavigate: (s
 
   return (
     <div className="space-y-4">
-      {version?.updateAvailable && (
+      {version?.updateAvailable && deploymentMode !== undefined && deploymentMode !== 'cloud' && (
         <a
-          href={version.releaseUrl}
+          href={versionUpdateURL(deploymentMode, version.releaseUrl)}
           target="_blank"
           rel="noreferrer"
           className="flex items-center gap-2 px-3 py-2 text-xs rounded-md border border-skyhook-500/30 bg-skyhook-500/10 hover:bg-skyhook-500/15 transition-colors"

--- a/web/src/components/ui/UpdateNotification.test.tsx
+++ b/web/src/components/ui/UpdateNotification.test.tsx
@@ -1,0 +1,49 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToString } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let deploymentMode = 'local'
+
+vi.mock('../../api/client', () => ({
+  useCapabilities: () => ({ data: { deployment: { mode: deploymentMode } } }),
+  useVersionCheck: () => ({
+    data: {
+      currentVersion: '1.2.3',
+      latestVersion: '1.3.0',
+      updateAvailable: true,
+      installMethod: 'direct',
+      releaseUrl: 'https://github.com/skyhook-io/radar/releases/tag/v1.3.0',
+    },
+  }),
+  useStartDesktopUpdate: () => ({ mutate: vi.fn(), isPending: false }),
+  useDesktopUpdateStatus: () => ({ data: undefined }),
+  useApplyDesktopUpdate: () => ({ mutate: vi.fn() }),
+}))
+
+import { UpdateNotification } from './UpdateNotification'
+
+function renderNotification() {
+  const client = new QueryClient()
+  return renderToString(
+    <QueryClientProvider client={client}>
+      <UpdateNotification />
+    </QueryClientProvider>,
+  )
+}
+
+describe('UpdateNotification', () => {
+  beforeEach(() => {
+    deploymentMode = 'local'
+  })
+
+  it('keeps the update popup for local installations', () => {
+    const html = renderNotification()
+    expect(html).toContain('Update Available')
+    expect(html).toContain('1.3.0')
+  })
+
+  it('suppresses the update popup for shared in-cluster viewers', () => {
+    deploymentMode = 'in-cluster'
+    expect(renderNotification()).toBe('')
+  })
+})

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -3,6 +3,7 @@ import { Download, X, Copy, Check, RotateCw, ArrowDownToLine, Loader2 } from 'lu
 import { useQueryClient } from '@tanstack/react-query'
 import {
   useVersionCheck,
+  useCapabilities,
   useStartDesktopUpdate,
   useDesktopUpdateStatus,
   useApplyDesktopUpdate,
@@ -14,6 +15,8 @@ const DISMISSED_KEY = 'radar-update-dismissed'
 
 export function UpdateNotification() {
   const queryClient = useQueryClient()
+  const { data: capabilities } = useCapabilities()
+  const deploymentMode = capabilities ? (capabilities.deployment?.mode ?? 'local') : undefined
   const { data: versionInfo } = useVersionCheck()
   const [dismissed, setDismissed] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -98,8 +101,9 @@ export function UpdateNotification() {
     })
   }
 
-  // Don't show if no update available, dismissed, or error
-  if (!versionInfo?.updateAvailable || dismissed) {
+  // Shared in-cluster viewers get a persistent Home notice instead of a
+  // floating action prompt they may not be able to act on.
+  if (!versionInfo?.updateAvailable || dismissed || deploymentMode === undefined || deploymentMode === 'in-cluster' || deploymentMode === 'cloud') {
     return null
   }
 

--- a/web/src/utils/version.test.ts
+++ b/web/src/utils/version.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getVersionUpdateStatus,
+  IN_CLUSTER_UPGRADE_URL,
+  parseMajorMinor,
+  versionUpdateURL,
+} from './version'
+
+describe('Radar version helpers', () => {
+  it('parses major and minor versions with an optional v prefix', () => {
+    expect(parseMajorMinor('v1.12.3')).toEqual({ major: 1, minor: 12 })
+    expect(parseMajorMinor('dev')).toBeNull()
+  })
+
+  it('grades available updates by distance from the latest release', () => {
+    expect(getVersionUpdateStatus('1.12.0', '1.12.1')).toEqual({ tier: 'patch' })
+    expect(getVersionUpdateStatus('1.11.4', '1.12.1')).toEqual({ tier: 'minor', minorVersionsBehind: 1 })
+    expect(getVersionUpdateStatus('1.10.4', '1.12.1')).toEqual({ tier: 'minor', minorVersionsBehind: 2 })
+    expect(getVersionUpdateStatus('1.9.4', '1.12.1')).toEqual({ tier: 'stale', minorVersionsBehind: 3 })
+    expect(getVersionUpdateStatus('0.12.4', '1.12.1')).toEqual({ tier: 'stale', majorVersionBehind: true })
+    expect(getVersionUpdateStatus('1.12.1-rc.1', '1.12.1')).toEqual({ tier: 'patch' })
+  })
+
+  it('does not flag invalid, current, or newer local builds', () => {
+    expect(getVersionUpdateStatus('dev', '1.12.1')).toEqual({ tier: 'none' })
+    expect(getVersionUpdateStatus('1.12.1', '1.12.1')).toEqual({ tier: 'none' })
+    expect(getVersionUpdateStatus('1.13.0', '1.12.1')).toEqual({ tier: 'none' })
+    expect(getVersionUpdateStatus('2.0.0', '1.12.1')).toEqual({ tier: 'none' })
+  })
+
+  it('routes in-cluster upgrades to instructions instead of release notes', () => {
+    const releaseURL = 'https://github.com/skyhook-io/radar/releases/tag/v1.2.4'
+    expect(versionUpdateURL('in-cluster', releaseURL)).toBe(IN_CLUSTER_UPGRADE_URL)
+    expect(versionUpdateURL('local', releaseURL)).toBe(releaseURL)
+    expect(versionUpdateURL('cloud', releaseURL)).toBeUndefined()
+  })
+})

--- a/web/src/utils/version.ts
+++ b/web/src/utils/version.ts
@@ -1,0 +1,56 @@
+import type { DeploymentMode } from '../types'
+
+export interface MajorMinorVersion {
+  major: number
+  minor: number
+}
+
+export type VersionUpdateTier = 'none' | 'patch' | 'minor' | 'stale'
+
+export interface VersionUpdateStatus {
+  tier: VersionUpdateTier
+  minorVersionsBehind?: number
+  majorVersionBehind?: boolean
+}
+
+export const IN_CLUSTER_UPGRADE_URL = 'https://radarhq.io/docs/configuration/in-cluster'
+
+export function versionUpdateURL(deploymentMode: DeploymentMode, releaseURL?: string): string | undefined {
+  if (deploymentMode === 'cloud') return undefined
+  return deploymentMode === 'in-cluster' ? IN_CLUSTER_UPGRADE_URL : releaseURL
+}
+
+export function parseMajorMinor(version: string): MajorMinorVersion | null {
+  const match = /^v?(\d+)\.(\d+)/.exec(version.trim())
+  if (!match) return null
+  return { major: Number(match[1]), minor: Number(match[2]) }
+}
+
+function parseVersion(version: string): [major: number, minor: number, patch: number, prerelease: boolean] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(version.trim())
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3]), !!match[4]]
+}
+
+export function getVersionUpdateStatus(current: string, latest?: string): VersionUpdateStatus {
+  if (!latest) return { tier: 'none' }
+
+  const currentVersion = parseVersion(current)
+  const latestVersion = parseVersion(latest)
+  if (!currentVersion || !latestVersion) return { tier: 'none' }
+
+  const [currentMajor, currentMinor, currentPatch, currentPrerelease] = currentVersion
+  const [latestMajor, latestMinor, latestPatch, latestPrerelease] = latestVersion
+
+  if (latestMajor < currentMajor) return { tier: 'none' }
+  if (latestMajor > currentMajor) return { tier: 'stale', majorVersionBehind: true }
+
+  const minorVersionsBehind = latestMinor - currentMinor
+  if (minorVersionsBehind >= 3) return { tier: 'stale', minorVersionsBehind }
+  if (minorVersionsBehind > 0) return { tier: 'minor', minorVersionsBehind }
+  if (minorVersionsBehind < 0 || latestPatch < currentPatch) return { tier: 'none' }
+  if (latestPatch === currentPatch) {
+    return currentPrerelease && !latestPrerelease ? { tier: 'patch' } : { tier: 'none' }
+  }
+  return { tier: 'patch' }
+}


### PR DESCRIPTION
## Summary

Shows standalone in-cluster operators which Radar version is running, whether a newer release is available, and the correct place to make the upgrade. Verified Helm and GitOps ownership links directly to the managing object; uncertain ownership falls back to safe installation-specific guidance.

## What changed

### In-cluster upgrade experience

- Adds the running Radar version and available release to the Home cluster summary, with quiet treatment for patch releases and stronger emphasis as installations fall further behind.
- Links verified Helm releases, Argo CD Applications, Flux HelmReleases, and Flux Kustomizations to their existing Radar views. Suspected, unreadable, ambiguous, and unknown ownership routes to the in-cluster upgrade guide.
- Removes the floating local-style update prompt from shared in-cluster and Cloud deployments. Local and Desktop behavior is unchanged.
- Expands the in-cluster guide with Helm, Argo CD, Flux, verification, rollback, ingress-authentication, and uninstall guidance.

### Version checks

- Keeps release data behind the existing backend update check and one-hour cache, with concurrent cache misses coalesced and Cloud release-only lookups isolated from the default path.
- Allows standalone in-cluster browser profiles to request one additional same-origin update check per API base and UTC day after a successful version lookup. The request is best-effort and is not retried.
- Classifies stable, prerelease, custom, and development build shapes consistently. Development builds use the release-only path and do not use the daily relay.
- Includes the installation timestamp when it can be determined, preferring the Deployment creation time and retaining the local Radar directory fallback.

## Testing

- `make test`
- `make build` (includes frontend type-check and production build)
- Focused frontend version, update-notification, daily-check, and upgrade-link tests: 4 files / 26 tests
- Frontend CI: full suite passed
- Visual test skipped: the upgrade states depend on published-version and ownership responses that the local development build does not produce; the rendered states are covered by component tests

## Deployment note

Deploy the paired receiver change before releasing this Radar change: https://github.com/skyhook-dev/marketing/pull/284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound update telemetry (browser relay, install timestamp, channel/source params) and version-check caching paths used at startup and in Cloud mode; UI routing depends on ownership detection being correct to avoid misleading upgrade CTAs.
> 
> **Overview**
> **In-cluster operators** now see the running Radar version on the Home cluster summary, with tiered emphasis when a newer release exists (patch vs minor vs stale/major). Verified **Helm** or **GitOps** ownership can deep-link into the Helm release or managing Argo/Flux object; uncertain ownership falls back to the **in-cluster upgrade docs** instead of GitHub release notes.
> 
> The floating **Update Available** popup is **suppressed** for in-cluster and Cloud deployments (local/desktop unchanged). Settings upgrade links route in-cluster users to the same docs.
> 
> **Backend version checks** are reworked: per-source caching with single-flight coalescing, **build channel** and `source` query params on `releases.skyhook.io`, **`CheckForUpdateRelease`** for Cloud and dev-shaped builds, and **`IsReleaseVersion`** (semver) replacing ad-hoc regex in the explorer reachability path. A new **`POST /api/version-check/browser`** lets the UI relay one extra telemetry check per API base and UTC day after a successful version lookup (in-cluster only; dev builds skip relay).
> 
> **Cloud connect self** exposes **`controllerRef`** for verified GitOps so the UI can navigate without guessing. Docs expand **Upgrading** (Helm, GitOps, verification/rollback) and tighten ingress auth guidance. **`Makefile`** `VERSION` uses `git describe` with `v*` tags only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb8c29b6103afe3d52d122dd1f19add4858bd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->