### PR TITLE
feat(install): support a custom INSTALL_DIR

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -42,6 +42,24 @@ jobs:
           sh ./install.sh
           /usr/local/bin/kubectl-radar --version
 
+      - name: Install to a custom INSTALL_DIR
+        run: |
+          INSTALL_DIR="$RUNNER_TEMP/radar-custom/bin" sh ./install.sh
+          "$RUNNER_TEMP/radar-custom/bin/kubectl-radar" --version
+          "$RUNNER_TEMP/radar-custom/bin/radar" --version
+
+      - name: Reject a relative INSTALL_DIR before doing any work
+        run: |
+          cd "$RUNNER_TEMP"
+          if INSTALL_DIR="radar-relative/bin" sh "$GITHUB_WORKSPACE/install.sh"; then
+            echo "Expected a relative INSTALL_DIR to fail the install" >&2
+            exit 1
+          fi
+          if [ -e "$RUNNER_TEMP/radar-relative" ]; then
+            echo "Rejected install should not have created any directories" >&2
+            exit 1
+          fi
+
   windows:
     name: Windows installers
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ scoop install radar
 irm https://get.radarhq.io/install.ps1 | iex
 ```
 
+**Custom install location (macOS/Linux):**
+```bash
+curl -fsSL https://get.radarhq.io | INSTALL_DIR="$HOME/.local/bin" sh
+```
+Quick install writes to `/usr/local/bin` unless `INSTALL_DIR` says otherwise. The directory is created if missing, and needs to be on your `PATH` for `radar` and `kubectl radar` to resolve.
+
 **Direct download** — [GitHub Releases](https://github.com/skyhook-io/radar/releases) for macOS, Linux, or Windows.
 
 #### Desktop App

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,17 @@ set -e
 
 REPO="skyhook-io/radar"
 BINARY_NAME="kubectl-radar"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Relative paths would resolve inside the temp dir this script extracts into
+# and then deletes, so reject them before doing any work.
+case "$INSTALL_DIR" in
+  /*) ;;
+  *)
+    echo "INSTALL_DIR must be an absolute path (got: ${INSTALL_DIR})" >&2
+    exit 1
+    ;;
+esac
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -82,14 +92,17 @@ else
 fi
 
 # Install
+mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+
 if [ -w "$INSTALL_DIR" ]; then
-  mv "$BINARY_NAME" "$INSTALL_DIR/"
   SUDO=""
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
-  sudo mv "$BINARY_NAME" "$INSTALL_DIR/"
   SUDO="sudo"
+  $SUDO mkdir -p "$INSTALL_DIR"
 fi
+
+$SUDO mv "$BINARY_NAME" "$INSTALL_DIR/"
 
 # Symlink so the binary can also be invoked as `radar`. Best-effort —
 # the primary install already succeeded, and `radar` is a common-enough
@@ -107,8 +120,14 @@ fi
 rm -rf "$TMP_DIR"
 
 echo ""
-echo "Radar v${VERSION} installed successfully!"
+echo "Radar v${VERSION} installed successfully to ${INSTALL_DIR}!"
 echo ""
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) echo "Note: ${INSTALL_DIR} is not in your PATH — add it to run the commands below." >&2; echo "" ;;
+esac
+
 echo "Usage:"
 echo "  radar                  # standalone"
 echo "  kubectl radar          # as kubectl plugin"

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,11 @@ case "$INSTALL_DIR" in
     ;;
 esac
 
+if [ -e "$INSTALL_DIR" ] && [ ! -d "$INSTALL_DIR" ]; then
+  echo "INSTALL_DIR is not a directory: ${INSTALL_DIR}" >&2
+  exit 1
+fi
+
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)


### PR DESCRIPTION
## Description

The quick-install script hardcoded `/usr/local/bin`, which forces sudo on machines where the user has a perfectly good `~/.local/bin`. `INSTALL_DIR` now overrides it, the directory is created when missing, and the success message names where the binary landed plus a note when that path is not on `PATH`.

Relative paths are rejected up front: the script `cd`s into the temp dir it extracts to and then deletes, so a relative `INSTALL_DIR` would install into that dir and vanish.

Default behaviour is unchanged — with no `INSTALL_DIR` set, the install still goes to `/usr/local/bin` and still escalates to sudo when that directory isn't writable.

```bash
curl -fsSL https://get.radarhq.io | INSTALL_DIR="$HOME/.local/bin" sh
```

Files touched:
- `install.sh` — `INSTALL_DIR` env override, absolute-path guard, `mkdir -p` (via sudo when needed), install path in the success message, `PATH` membership note
- `.github/workflows/installers.yml` — two smoke steps covering the new behaviour
- `README.md` — documents the custom install location

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How has this been tested?

Installer-only change — it never touches a cluster, so the minikube/remote-cluster boxes don't apply.

- `sh -n install.sh` — POSIX sh syntax check passes.
- The install block (`mkdir` / `-w` / `$SUDO` / PATH check) was exercised directly in a scratch directory: writable custom dir, missing custom dir that gets created, and a relative `INSTALL_DIR`, which exits 1 before any download or extract.
- Two new CI steps in `installers.yml` run the real script end to end on the ubuntu and macOS runners:
  - custom absolute `INSTALL_DIR` → asserts both `kubectl-radar --version` and `radar --version` from that directory
  - relative `INSTALL_DIR` → asserts the install fails
- The workflow's existing `shellcheck --shell=sh install.sh` step is the lint gate for the new code; it was not run locally (shellcheck isn't installed on this machine).
- The existing default-path step (`sh ./install.sh` → `/usr/local/bin/kubectl-radar --version`) is unchanged and still passes, which is the regression guard on the default.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only change with default behavior preserved; risk is limited to where binaries are placed on the user’s machine, with guards against relative paths and invalid targets.
> 
> **Overview**
> The macOS/Linux quick-install script now accepts **`INSTALL_DIR`** to override the default `/usr/local/bin`, so users can install into writable paths like `~/.local/bin` without sudo. **Relative paths are rejected before download/extract** (they would land in the temp dir that gets deleted), and an existing non-directory path fails fast.
> 
> Install flow **creates the target directory** when missing (`mkdir -p`, with sudo when the dir isn’t writable), consolidates the binary move behind `$SUDO`, and improves post-install messaging: success names the install path and warns when that path isn’t on **`PATH`**.
> 
> **README** documents the custom-location one-liner; **CI** adds smoke tests for a custom absolute `INSTALL_DIR` and for a relative path that must fail without creating directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9fbced630e5a185368fe7b6cf41aa11257a119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->