### PR TITLE
Close port-forward listeners during session teardown

### DIFF
--- a/internal/server/portforward.go
+++ b/internal/server/portforward.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -61,6 +62,8 @@ var pfManager = &PortForwardManager{
 	sessions: make(map[string]*PortForwardSession),
 }
 
+var errPortForwardStoppedWhileStarting = errors.New("port forward stopped while starting")
+
 // GetPortForwardCount returns the number of active port forward sessions
 func GetPortForwardCount() int {
 	pfManager.mu.RLock()
@@ -70,17 +73,49 @@ func GetPortForwardCount() int {
 
 // StopAllPortForwards stops all active port forward sessions
 func StopAllPortForwards() {
-	pfManager.mu.Lock()
-	defer pfManager.mu.Unlock()
+	pfManager.stopAll()
+}
 
-	for id, session := range pfManager.sessions {
+func (m *PortForwardManager) stopAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for id, session := range m.sessions {
 		log.Printf("Stopping port forward %s (%s/%s)", id, session.Namespace, session.PodName)
-		if session.cancel != nil {
-			session.cancel()
-		}
-		session.Status = "stopped"
-		delete(pfManager.sessions, id)
+		stopPortForwardSessionLocked(session)
+		delete(m.sessions, id)
 	}
+}
+
+func stopPortForwardSessionLocked(session *PortForwardSession) {
+	if session.cancel != nil {
+		session.cancel()
+	}
+	if session.stopCh != nil {
+		select {
+		case <-session.stopCh:
+		default:
+			close(session.stopCh)
+		}
+	}
+	session.Status = "stopped"
+}
+
+func (m *PortForwardManager) finishStart(sessionID string) (*PortForwardSession, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[sessionID]
+	if !ok || session.Status == "stopped" {
+		return nil, errPortForwardStoppedWhileStarting
+	}
+	if session.Status == "error" {
+		return nil, errors.New(session.Error)
+	}
+
+	session.Status = "running"
+	response := *session
+	return &response, nil
 }
 
 // handleListPortForwards returns all active port forward sessions
@@ -243,18 +278,17 @@ func (s *Server) handleStartPortForward(w http.ResponseWriter, r *http.Request) 
 	// Wait briefly for port forward to start
 	time.Sleep(100 * time.Millisecond)
 
-	pfManager.mu.Lock()
-	session = pfManager.sessions[sessionID]
-	if session.Status == "error" {
-		errMsg := session.Error
-		pfManager.mu.Unlock()
-		s.writeError(w, http.StatusInternalServerError, errMsg)
+	response, err := pfManager.finishStart(sessionID)
+	if errors.Is(err, errPortForwardStoppedWhileStarting) {
+		s.writeError(w, http.StatusConflict, "Port forward was stopped while starting")
 		return
 	}
-	session.Status = "running"
-	pfManager.mu.Unlock()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 
-	s.writeJSON(w, session)
+	s.writeJSON(w, response)
 }
 
 // handleStopPortForward stops an active port forward session
@@ -269,10 +303,7 @@ func (s *Server) handleStopPortForward(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Signal stop
-	session.cancel()
-	close(session.stopCh)
-	session.Status = "stopped"
+	stopPortForwardSessionLocked(session)
 	delete(pfManager.sessions, sessionID)
 	pfManager.mu.Unlock()
 

--- a/internal/server/portforward_stop_test.go
+++ b/internal/server/portforward_stop_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPortForwardManagerStopAllClosesSessions(t *testing.T) {
+	firstCtx, firstCancel := context.WithCancel(context.Background())
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	firstStop := make(chan struct{})
+	secondStop := make(chan struct{})
+	first := &PortForwardSession{ID: "pf-1", Status: "running", cancel: firstCancel, stopCh: firstStop}
+	second := &PortForwardSession{ID: "pf-2", Status: "starting", cancel: secondCancel, stopCh: secondStop}
+	manager := &PortForwardManager{
+		sessions: map[string]*PortForwardSession{
+			first.ID:  first,
+			second.ID: second,
+		},
+	}
+
+	manager.stopAll()
+
+	if len(manager.sessions) != 0 {
+		t.Fatalf("expected all sessions removed, got %d", len(manager.sessions))
+	}
+	for _, session := range []*PortForwardSession{first, second} {
+		if session.Status != "stopped" {
+			t.Errorf("session %s status = %q, want stopped", session.ID, session.Status)
+		}
+	}
+	for name, ctx := range map[string]context.Context{"first": firstCtx, "second": secondCtx} {
+		select {
+		case <-ctx.Done():
+		default:
+			t.Errorf("%s session context was not canceled", name)
+		}
+	}
+	for name, stopCh := range map[string]chan struct{}{"first": firstStop, "second": secondStop} {
+		select {
+		case <-stopCh:
+		default:
+			t.Errorf("%s session stop channel was not closed", name)
+		}
+	}
+}
+
+func TestPortForwardManagerFinishStart(t *testing.T) {
+	t.Run("missing session", func(t *testing.T) {
+		manager := &PortForwardManager{sessions: make(map[string]*PortForwardSession)}
+
+		response, err := manager.finishStart("pf-missing")
+
+		if response != nil {
+			t.Fatalf("response = %#v, want nil", response)
+		}
+		if !errors.Is(err, errPortForwardStoppedWhileStarting) {
+			t.Fatalf("error = %v, want %v", err, errPortForwardStoppedWhileStarting)
+		}
+	})
+
+	t.Run("stopped session", func(t *testing.T) {
+		session := &PortForwardSession{ID: "pf-1", Status: "stopped"}
+		manager := &PortForwardManager{sessions: map[string]*PortForwardSession{session.ID: session}}
+
+		response, err := manager.finishStart(session.ID)
+
+		if response != nil {
+			t.Fatalf("response = %#v, want nil", response)
+		}
+		if !errors.Is(err, errPortForwardStoppedWhileStarting) {
+			t.Fatalf("error = %v, want %v", err, errPortForwardStoppedWhileStarting)
+		}
+	})
+
+	t.Run("startup error", func(t *testing.T) {
+		session := &PortForwardSession{ID: "pf-1", Status: "error", Error: "dial failed"}
+		manager := &PortForwardManager{sessions: map[string]*PortForwardSession{session.ID: session}}
+
+		response, err := manager.finishStart(session.ID)
+
+		if response != nil {
+			t.Fatalf("response = %#v, want nil", response)
+		}
+		if err == nil || err.Error() != session.Error {
+			t.Fatalf("error = %v, want %q", err, session.Error)
+		}
+	})
+
+	t.Run("successful startup", func(t *testing.T) {
+		session := &PortForwardSession{ID: "pf-1", Status: "starting", LocalPort: 12345}
+		manager := &PortForwardManager{sessions: map[string]*PortForwardSession{session.ID: session}}
+
+		response, err := manager.finishStart(session.ID)
+
+		if err != nil {
+			t.Fatalf("finishStart() error = %v", err)
+		}
+		if session.Status != "running" || response.Status != "running" {
+			t.Fatalf("statuses = session %q, response %q; want running", session.Status, response.Status)
+		}
+		if response == session {
+			t.Fatal("finishStart returned the live session instead of a response snapshot")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Keeps port-forward lifecycle consistent during context changes and other session resets. Radar previously canceled its wrapper context and removed the session record, while client-go waits on a separate stop channel; this could leave a local forwarding listener active after it disappeared from Radar.

## What changed

- Stop registered port forwards by canceling their context and closing the client-go stop channel before removing them.
- Reuse the same idempotent teardown path for bulk stops and explicit DELETE requests.
- Finalize the delayed start response under the manager lock. If teardown wins, return HTTP 409; if startup failed, preserve that error; otherwise respond from a snapshot instead of the live mutable session.
- Add focused tests for cancellation, stop-channel closure, registry removal, interrupted startup, startup errors, and successful response snapshots.

## Testing

- `make tsc`
- `make test`
- `make build`
- `go test -race ./internal/server -run TestPortForwardManager -count=1`
- Real-cluster smoke: forwarded CoreDNS metrics, confirmed the listener accepted traffic, then confirmed context teardown removed the session and closed the OS listener. An overlapping start and context switch returned HTTP 409 and left no listener behind.
- Playwright smoke: Overview loaded with no console errors.
- Visual test skipped: no UI delta.

## Scope

This PR does not change other session types or broader cluster-transition registration semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches port-forward lifecycle and HTTP start/stop semantics (new 409 path); limited to `internal/server` but incorrect teardown could leave listeners open or confuse clients.
> 
> **Overview**
> **Fixes orphaned local listeners** when a port forward is torn down during cluster/context switches or explicit stop: teardown now cancels the session context **and** idempotently closes client-go’s `stopCh`, shared by bulk `StopAllPortForwards` and per-session DELETE.
> 
> **Start API behavior** after the brief startup wait is centralized in `finishStart`: if the session was removed or marked stopped during that window, the handler returns **HTTP 409** instead of reporting success; startup failures still surface as 500; success returns a **snapshot** of the session (not the live mutable object).
> 
> Adds unit tests for `stopAll` (cancel + `stopCh` + registry clear) and `finishStart` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c370ff9764f2f1c04f8e0d5193262a06a292fff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->