### PR TITLE
Clear per-user capability caches during cluster transitions

### DIFF
--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -383,6 +383,8 @@ func InvalidateCapabilitiesCache() {
 	nsCapMu.Lock()
 	nsCapCache = nil
 	nsCapMu.Unlock()
+
+	InvalidateUserCapabilitiesCache()
 }
 
 // CheckNamespaceCapabilities performs namespace-scoped RBAC checks for

--- a/internal/k8s/capabilities_cache_test.go
+++ b/internal/k8s/capabilities_cache_test.go
@@ -1,0 +1,22 @@
+package k8s
+
+import "testing"
+
+func TestInvalidateCapabilitiesCacheClearsUserCaches(t *testing.T) {
+	InvalidateCapabilitiesCache()
+	t.Cleanup(InvalidateCapabilitiesCache)
+
+	const username = "alice"
+	namespaceKey := userNamespaceCapabilitiesCacheKey(username, "default")
+	userCapabilitiesCache.Store(username, &userCapEntry{})
+	userNamespaceCapabilitiesCache.Store(namespaceKey, &userNSCapEntry{})
+
+	InvalidateCapabilitiesCache()
+
+	if _, ok := userCapabilitiesCache.Load(username); ok {
+		t.Error("user capabilities cache was not cleared")
+	}
+	if _, ok := userNamespaceCapabilitiesCache.Load(namespaceKey); ok {
+		t.Error("user namespace capabilities cache was not cleared")
+	}
+}


### PR DESCRIPTION
## Summary

Radar capability invalidation now treats authenticated-user SubjectAccessReview results as cluster-scoped state. Client swaps and cache rebuilds clear those entries alongside global capabilities at the existing invalidation point, instead of relying solely on a later server callback that may not run when transition initialization fails.

## What changed

- Clear top-level and namespace-specific per-user capability caches through the existing `InvalidateCapabilitiesCache` path.
- Retain the existing post-transition cleanup as an idempotent second boundary.
- Add focused regression coverage for both per-user cache families.

This intentionally does not change cache keys, TTLs, endpoint authorization, or capability semantics. Kubernetes RBAC and endpoint handlers remain authoritative; this change keeps capability advertisement aligned with the active cluster transition.

## Testing

- `make tsc`
- `make test`
- `make build`
- `go test -race ./internal/k8s -count=1`
- Visual test skipped: no UI delta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow cache-lifecycle change at an existing invalidation hook; no new authorization paths or capability rules.
> 
> **Overview**
> **Cluster transitions and client swaps** now drop cached **per-user** SubjectAccessReview results at the same time as global and namespace capability caches, by calling `InvalidateUserCapabilitiesCache()` from `InvalidateCapabilitiesCache()`.
> 
> That closes a gap where stale user-level exec/logs/UI flags could linger until a separate server callback ran—and that callback might not run if transition setup fails.
> 
> A regression test asserts both the username-keyed cache and the user+namespace cache are empty after invalidation. Cache keys, TTLs, and RBAC semantics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d89f55d08b074ed6fe7a08b057f39afb0869c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->