### PR TITLE
Fix Helm upgrade values guidance

### DIFF
--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -54,16 +54,22 @@ set on the release:
 helm repo update skyhook
 helm upgrade radar skyhook/radar \
   --namespace radar \
-  --reuse-values \
+  --reset-then-reuse-values \
   --wait
 ```
 
 Replace `radar` with the release name and namespace used by your installation.
+`--reset-then-reuse-values` requires Helm 3.14 or newer. It starts from the
+target chart's defaults, then reapplies the release's existing values, so keys
+introduced by the new chart are not omitted. With an older Helm client, upgrade
+Helm or use the installation's maintained values file; plain `--reuse-values`
+is not equivalent and can omit new defaults.
+
 If the deployment is managed from a values file, use that same file with
-`-f values.yaml` instead of `--reuse-values` so Git remains the reproducible
-source of configuration. The command installs the latest published chart; add
-`--version X.Y.Z` to pin the exact version shown in Radar (without the leading
-`v`).
+`-f values.yaml` instead of `--reset-then-reuse-values` so Git remains the
+reproducible source of configuration. The command installs the latest published
+chart; add `--version X.Y.Z` to pin the exact version shown in Radar (without
+the leading `v`).
 
 ### Argo CD or Flux
 


### PR DESCRIPTION
## Summary

- replace the recommended plain --reuse-values upgrade with --reset-then-reuse-values
- explain that the safer flag starts from target-chart defaults before reapplying existing release values
- document the Helm 3.14 requirement and the maintained-values-file path for older clients

This prevents newly introduced chart keys from being omitted during an upgrade. The public radar-docs page is generated from this authoritative OSS source and will be refreshed after this lands.

## Validation

- git diff --check
- visual-test: skipped (documentation-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Helm upgrade guidance; no runtime or application code is modified.
> 
> **Overview**
> Updates the **Helm upgrade** instructions in `docs/in-cluster.md` so operators use **`--reset-then-reuse-values`** instead of **`--reuse-values`**, reducing the chance that new chart default keys are skipped on upgrade.
> 
> The doc now states the **Helm 3.14+** requirement, explains that the flag merges **target-chart defaults** with the release’s saved values, and notes that older clients should upgrade Helm or use a **maintained `-f values.yaml`** file because plain `--reuse-values` is not equivalent. The GitOps-style values-file path is aligned to recommend `-f` over **`--reset-then-reuse-values`** (replacing the previous `--reuse-values` wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3072a32e9d4db65671555a73c2c5d3e29c4cfc01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->