### PR TITLE
Add stable investigation links and hosted sharing UI

### DIFF
--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -247,11 +248,12 @@ Flags:
 		return 1
 	}
 	if o.jsonOut {
+		radarURL := base + "/?ai-run=" + url.QueryEscape(run.ID)
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		_ = enc.Encode(map[string]any{
 			"run": run.ID, "kind": run.Kind, "namespace": run.Namespace, "name": run.Name,
-			"agent": run.Agent, "diagnosis": diag,
+			"agent": run.Agent, "radar_url": radarURL, "diagnosis": diag,
 		})
 	}
 	return 0

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -345,6 +345,21 @@ func (s *Server) handleDiagnoseList(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleDiagnoseGet resolves one retained run by its stable id. Local Radar has
+// no sharing boundary—all callers are the same local user—but the direct route
+// keeps deep links independent of the bounded history list.
+func (s *Server) handleDiagnoseGet(w http.ResponseWriter, r *http.Request) {
+	if !s.aiReady(w) {
+		return
+	}
+	run := s.aiRuns.Get(chi.URLParam(r, "id"))
+	if run == nil {
+		s.writeError(w, http.StatusNotFound, "investigation not found")
+		return
+	}
+	s.writeJSON(w, run.Summary())
+}
+
 // handleDiagnoseHistoryClear wipes the persisted investigation history (and
 // drops finished runs from memory). Live runs survive. POST, same-origin only.
 func (s *Server) handleDiagnoseHistoryClear(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -510,6 +510,7 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			// AI investigations as durable server-side jobs (start/list/turn/stop).
 			r.Post("/diagnose/runs", s.handleDiagnoseStart)
 			r.Get("/diagnose/runs", s.handleDiagnoseList)
+			r.Get("/diagnose/runs/{id}", s.handleDiagnoseGet)
 			r.Post("/diagnose/runs/{id}/turns", s.handleDiagnoseTurn)
 			r.Post("/diagnose/runs/{id}/stop", s.handleDiagnoseStop)
 			r.Post("/diagnose/history/clear", s.handleDiagnoseHistoryClear)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -468,11 +468,18 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
     const path = view === 'home' ? '/' : `/${view}`
 
-    // Start fresh — keep only cross-view params (namespaces), discard all view-specific ones
+    // Start fresh — keep only cross-view params, discard view-specific ones.
+    // Read the live location because Diagnose owns `ai-run` through the History
+    // API; React Router's searchParams snapshot does not update for that write.
     const newParams = new URLSearchParams()
-    const globalNamespaces = searchParams.get('namespaces')
+    const currentParams = new URLSearchParams(window.location.search)
+    const globalNamespaces = currentParams.get('namespaces')
     if (globalNamespaces) {
       newParams.set('namespaces', globalNamespaces)
+    }
+    const diagnoseRun = currentParams.get('ai-run')
+    if (diagnoseRun) {
+      newParams.set('ai-run', diagnoseRun)
     }
 
     // Add any new params
@@ -483,7 +490,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     }
 
     navigate({ pathname: path, search: newParams.toString() })
-  }, [navigate, searchParams, takeover, goHost])
+  }, [navigate, takeover, goHost])
 
   // Cloud (embedded) takes over the "fleet-shaped" per-cluster views with its
   // own fleet pages scoped to this cluster — owned by the host's left rail — so
@@ -1135,9 +1142,13 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       setSelectedResource(null)
       setSelectedHelmRelease(null)
 
-      // Reset URL to current view with no resource-specific params.
-      // Old cluster's selected pod/resource/kind don't exist on the new cluster.
-      navigate({ pathname: location.pathname, search: '' }, { replace: true })
+      // Reset resource-specific params while retaining the durable investigation
+      // focus. Diagnose resolves runs by id and owns whether the focused run is
+      // still readable after the context switch.
+      const nextParams = new URLSearchParams()
+      const diagnoseRun = new URLSearchParams(window.location.search).get('ai-run')
+      if (diagnoseRun) nextParams.set('ai-run', diagnoseRun)
+      navigate({ pathname: location.pathname, search: nextParams.toString() }, { replace: true })
 
       // Auto-unpause so the new cluster's topology loads immediately
       setTopologyPaused(false)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import { CloudFunnelButton } from './components/CloudFunnelButton'
 import { useNavCustomization } from './context/NavCustomization'
 import type { FleetTakeoverTarget } from './context/NavCustomization'
 import { PrimaryNavRail } from './components/nav/PrimaryNavRail'
+import { navigateFromPrimaryRail } from './components/nav/navigation'
 import { useNavRailPinned } from './hooks/useNavRailPinned'
 import { useMediaQuery } from './hooks/useMediaQuery'
 import { ContextSwitchProvider, useContextSwitch } from './context/ContextSwitchContext'
@@ -322,7 +323,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   // The AI panel is an absolute slot in the body frame (the column under the header):
   // it reserves a right gutter on the CONTENT only, so the navbar + nav rail stay
   // static. contentGutter is the docked panel width (0 when closed/overlay/maximized).
-  const { open: diagnoseOpen, contentGutter } = useDiagnoseLayout()
+  const {
+    open: diagnoseOpen,
+    close: closeDiagnose,
+    contentGutter,
+    maximized: diagnoseMaximized,
+  } = useDiagnoseLayout()
   // Hand off to a host-owned URL. The host's `onHostNavigate` (Radar Cloud's
   // cross-tree swap) navigates same-document so the chrome morphs instead of
   // cold-booting; without it we fall back to a hard `window.location` nav.
@@ -491,6 +497,17 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
 
     navigate({ pathname: path, search: newParams.toString() })
   }, [navigate, takeover, goHost])
+
+  // The standalone rail expresses intent to leave the full-width investigation
+  // workspace. Close it before routing so the destination is immediately visible;
+  // docked investigations stay open across views as a persistent side panel.
+  const handlePrimaryNavigate = useCallback((view: ExtendedMainView) => {
+    navigateFromPrimaryRail(
+      diagnoseOpen && diagnoseMaximized,
+      closeDiagnose,
+      () => setMainView(view),
+    )
+  }, [diagnoseOpen, diagnoseMaximized, closeDiagnose, setMainView])
 
   // Cloud (embedded) takes over the "fleet-shaped" per-cluster views with its
   // own fleet pages scoped to this cluster — owned by the host's left rail — so
@@ -1669,7 +1686,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {showNavRail && (
         <PrimaryNavRail
           activeView={navActiveView}
-          onNavigate={setMainView}
+          onNavigate={handlePrimaryNavigate}
           pinned={navRailEffectivePinned}
           onTogglePinned={toggleNavRailPinned}
           showPinToggle={!railForcedSlim}

--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -228,7 +228,7 @@ export function RadarApp({
                   value={renderDiagnoseAction ?? defaultDiagnoseAction}
                   consentCopy={diagnoseConsent}
                 >
-                  <DiagnoseProvider>
+                  <DiagnoseProvider browserURLState={router !== "memory"}>
                     <App
                       manageDocumentTitle={manageDocumentTitle}
                       documentTitleSuffix={documentTitleSuffix}

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -1,7 +1,7 @@
 // Client for the local AI-diagnose engine (OSS BYO-agent). The agent CLI runs
 // on the user's own machine/subscription against Radar's MCP; this just starts
 // the investigation and consumes its SSE event stream.
-import { getApiBase, getCredentialsMode } from "./config";
+import { getApiBase, getAuthHeaders, getCredentialsMode } from "./config";
 
 export interface AgentInfo {
   name: string;
@@ -120,6 +120,7 @@ export async function fetchAgents(
 ): Promise<AgentsResponse> {
   const res = await fetch(`${getApiBase()}/agents`, {
     credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
     signal,
   });
   if (!res.ok) throw new Error(`agents: ${res.status}`);
@@ -174,7 +175,7 @@ export async function createRun(
   const res = await fetch(RUNS(), {
     method: "POST",
     credentials: getCredentialsMode(),
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify({ ...target, ...opts }),
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -193,6 +194,7 @@ export interface RunsResponse {
 export async function listRuns(signal?: AbortSignal): Promise<RunsResponse> {
   const res = await fetch(RUNS(), {
     credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
     signal,
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -208,6 +210,7 @@ export async function getRun(
 ): Promise<RunSummary> {
   const res = await fetch(`${RUNS()}/${encodeURIComponent(id)}`, {
     credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
     signal,
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -221,7 +224,7 @@ export async function updateRunVisibility(
   const res = await fetch(`${RUNS()}/${encodeURIComponent(id)}`, {
     method: "PATCH",
     credentials: getCredentialsMode(),
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify({ visibility }),
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -233,7 +236,7 @@ export async function recordConsent(surface: string): Promise<void> {
   const res = await fetch(`${getApiBase()}/diagnose/consent`, {
     method: "POST",
     credentials: getCredentialsMode(),
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify({ surface }),
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -245,6 +248,7 @@ export async function clearHistory(): Promise<void> {
   const res = await fetch(`${getApiBase()}/diagnose/history/clear`, {
     method: "POST",
     credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
 }
@@ -257,7 +261,7 @@ export async function addTurn(
   const res = await fetch(`${RUNS()}/${id}/turns`, {
     method: "POST",
     credentials: getCredentialsMode(),
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
@@ -268,6 +272,7 @@ export async function stopRun(id: string): Promise<void> {
   await fetch(`${RUNS()}/${id}/stop`, {
     method: "POST",
     credentials: getCredentialsMode(),
+    headers: getAuthHeaders(),
   }).catch(() => {});
 }
 

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -81,6 +81,7 @@ export interface DiagnoseStreamEvent {
   error?: string;
   question?: string; // on "turn"
   apply?: boolean; // on "turn"
+  actor?: string; // human author on shared hosted transcripts
 }
 
 // A run is a durable, server-owned investigation. Its lifetime is independent of
@@ -106,6 +107,12 @@ export interface RunSummary {
   preview?: string;
   createdAt: string;
   updatedAt: string;
+  visibility?: "private" | "organization";
+  ownedByMe?: boolean;
+  canManageVisibility?: boolean;
+  canContinue?: boolean;
+  trigger?: "interactive" | "background";
+  radarUrl?: string;
 }
 
 export async function fetchAgents(
@@ -191,6 +198,34 @@ export async function listRuns(signal?: AbortSignal): Promise<RunsResponse> {
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
   const d = await res.json();
   return { runs: d.runs ?? [], historyDegraded: !!d.historyDegraded };
+}
+
+// getRun resolves a stable run id directly. Deep links use this rather than
+// relying on a bounded history page to happen to contain the target.
+export async function getRun(
+  id: string,
+  signal?: AbortSignal,
+): Promise<RunSummary> {
+  const res = await fetch(`${RUNS()}/${encodeURIComponent(id)}`, {
+    credentials: getCredentialsMode(),
+    signal,
+  });
+  if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
+  return res.json();
+}
+
+export async function updateRunVisibility(
+  id: string,
+  visibility: "private" | "organization",
+): Promise<RunSummary> {
+  const res = await fetch(`${RUNS()}/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    credentials: getCredentialsMode(),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ visibility }),
+  });
+  if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
+  return res.json();
 }
 
 // recordConsent acknowledges the current disclosure for an execution profile, server-side.

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -102,7 +102,7 @@ export interface RunSummary {
   effort?: string;
   managedBy?: string; // GitOps/Helm owner of the target ("Argo CD"/"Flux"/"Helm"), for the Apply warning
   health?: ResourceHealthSignal;
-  status: "running" | "done" | "error" | "stopped" | "stale";
+  status: "running" | "stopping" | "done" | "error" | "stopped" | "stale";
   sessionId?: string;
   preview?: string;
   createdAt: string;

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -49,7 +49,7 @@ function ClearHistoryRow({
     <div className="mt-3 flex items-center justify-between gap-2 border-t border-theme-border/60 pt-3">
       <p className="text-[11px] leading-snug text-theme-text-tertiary">
         {hosted ? (
-          `Investigation transcripts are stored by ${agentLabel} so history survives restarts.`
+          `${agentLabel} stores private, organization-shared, and automatic investigation transcripts so history survives restarts.`
         ) : (
           <>
             Investigation transcripts are kept on this machine (
@@ -65,6 +65,12 @@ function ClearHistoryRow({
         {state === "error" && (
           <span className="ml-1 font-medium text-red-400">
             Couldn&apos;t clear history.
+          </span>
+        )}
+        {hosted && confirming && state === "idle" && (
+          <span className="ml-1 font-medium text-red-400">
+            This also removes terminal automatic and organization-shared
+            investigations for this cluster.
           </span>
         )}
       </p>
@@ -133,9 +139,8 @@ export function AISettingsSection({
           selectedAgent={draft.agent}
           // Model + effort are agent-specific; reset them when the agent changes.
           onSelectAgent={(a) => {
-            const nextProfile = agents.find(
-              (agent) => agent.name === a,
-            )?.profiles?.[0];
+            const nextProfile = agents.find((agent) => agent.name === a)
+              ?.profiles?.[0];
             onChange({
               agent: a,
               profile: nextProfile ?? draft.profile,

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -69,8 +69,8 @@ function ClearHistoryRow({
         )}
         {hosted && confirming && state === "idle" && (
           <span className="ml-1 font-medium text-red-400">
-            This also removes terminal automatic and organization-shared
-            investigations for this cluster.
+            This permanently deletes every member&apos;s investigations for this
+            cluster — private, organization-shared, and automatic.
           </span>
         )}
       </p>

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -474,11 +474,11 @@ export function DiagnoseProvider({
     );
   }, []);
 
-  // A content-stable signature of the resources with a live (running) investigation,
+  // A content-stable signature of the resources with a live investigation,
   // so the per-resource Diagnose buttons can show a "running" indicator even with the
   // panel closed — and only re-render when the set actually changes, not every poll.
   const runningSig = runs
-    .filter((r) => r.status === "running")
+    .filter((r) => r.status === "running" || r.status === "stopping")
     .map((r) => runTargetKey(r.kind, r.namespace, r.name))
     .sort()
     .join("|");

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -421,12 +421,26 @@ export function DiagnoseProvider({
         }
       }
       setRuns((prev) => {
-        if (focusedRun) return [focusedRun, ...r.runs];
+        let nextRuns = r.runs;
+        if (focusedRun) nextRuns = [focusedRun, ...nextRuns];
         if (focusedID && retainFocusedSnapshot) {
           const previous = prev.find((run) => run.id === focusedID);
-          if (previous) return [previous, ...r.runs];
+          if (previous) nextRuns = [previous, ...nextRuns];
         }
-        return r.runs;
+
+        // openRun/start can focus and insert a run while the direct fetch above
+        // is in flight. Preserve that newer focus instead of replacing it with
+        // the snapshot for the run that was active when this refresh started.
+        const currentFocusedID = activeRunIdRef.current;
+        if (
+          currentFocusedID &&
+          currentFocusedID !== focusedID &&
+          !nextRuns.some((run) => run.id === currentFocusedID)
+        ) {
+          const current = prev.find((run) => run.id === currentFocusedID);
+          if (current) nextRuns = [current, ...nextRuns];
+        }
+        return nextRuns;
       });
       setRunsLoaded(true);
       setRunsLoadFailed(false);

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -189,8 +189,8 @@ function writeStored(key: string, value: string) {
   }
 }
 
-function runIDFromLocation(): string | null {
-  if (!diagnoseURLStateEnabled()) return null;
+function runIDFromLocation(browserURLState: boolean): string | null {
+  if (!diagnoseURLStateEnabled(browserURLState)) return null;
   try {
     return new URLSearchParams(window.location.search).get("ai-run");
   } catch {
@@ -198,8 +198,12 @@ function runIDFromLocation(): string | null {
   }
 }
 
-function writeRunIDToLocation(id: string | null, push: boolean) {
-  if (!diagnoseURLStateEnabled()) return;
+function writeRunIDToLocation(
+  id: string | null,
+  push: boolean,
+  browserURLState: boolean,
+) {
+  if (!diagnoseURLStateEnabled(browserURLState)) return;
   try {
     const url = new URL(window.location.href);
     if (id) url.searchParams.set("ai-run", id);
@@ -224,12 +228,19 @@ function writeRunIDToLocation(id: string | null, push: boolean) {
 // hub route such as /issues. Writing ?ai-run there would create a non-reloadable
 // pseudo-link. The embedded /c/:id Radar tree and local Radar own their route and
 // therefore keep the query as navigation state; Fleet copies run.radarUrl instead.
-function diagnoseURLStateEnabled(): boolean {
+function diagnoseURLStateEnabled(browserURLState: boolean): boolean {
+  if (!browserURLState) return false;
   const clusterScopedAPI = /\/c\/[^/]+\/api\/?$/.test(getApiBase());
   return !clusterScopedAPI || /^\/c\/[^/]+/.test(window.location.pathname);
 }
 
-export function DiagnoseProvider({ children }: { children: ReactNode }) {
+export function DiagnoseProvider({
+  children,
+  browserURLState = true,
+}: {
+  children: ReactNode;
+  browserURLState?: boolean;
+}) {
   const [available, setAvailable] = useState(false);
   const [eligible, setEligible] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
@@ -254,13 +265,13 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // Tracks whether the panel focus belongs to browser history. Fleet opens the
   // same panel on /issues, where URL state is deliberately disabled; a generic
   // panel launch must never be closed by the deep-link synchronization effect.
-  const urlRunIdRef = useRef(runIDFromLocation());
+  const urlRunIdRef = useRef(runIDFromLocation(browserURLState));
   const writeFocusedRunID = useCallback((id: string | null, push: boolean) => {
     // Set this before writeRunIDToLocation's synthetic popstate so our own
     // listener can distinguish a programmatic close/home write from Back.
-    if (diagnoseURLStateEnabled()) urlRunIdRef.current = id;
-    writeRunIDToLocation(id, push);
-  }, []);
+    if (diagnoseURLStateEnabled(browserURLState)) urlRunIdRef.current = id;
+    writeRunIDToLocation(id, push, browserURLState);
+  }, [browserURLState]);
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runsLoaded, setRunsLoaded] = useState(false);
   const [runsLoadFailed, setRunsLoadFailed] = useState(false);
@@ -540,9 +551,9 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // exact run, and the query remains in place so the address bar is copyable.
   // Fetch by id rather than assuming the bounded recent list contains it.
   useEffect(() => {
-    if (!available || !diagnoseURLStateEnabled()) return;
+    if (!available || !diagnoseURLStateEnabled(browserURLState)) return;
     const focusFromLocation = (fromPopState: boolean) => {
-      const id = runIDFromLocation();
+      const id = runIDFromLocation(browserURLState);
       if (!id) {
         // A missing id on first mount is ordinary. On popstate it means "back
         // out of this investigation" only when the focused run was itself
@@ -571,7 +582,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     const onPopState = () => focusFromLocation(true);
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, [available, updateRunSummary]);
+  }, [available, browserURLState, updateRunSummary]);
   // Leaving the detail pane drops the failure that belonged to it. startError
   // renders as the entire pane (maximized home still shows `detail`), where a
   // message about a resource you just navigated away from has nothing to attach

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -17,11 +17,13 @@ import {
 } from "react";
 import {
   fetchAgents,
+  getRun,
   listRuns,
   createRun,
   recordConsent,
   DiagnoseError,
 } from "../../api/diagnose";
+import { getApiBase } from "../../api/config";
 import {
   type RunSummary,
   type AgentInfo,
@@ -86,6 +88,7 @@ interface DiagnoseCtx {
   approveConsent: () => void;
   cancelConsent: () => void;
   refreshRuns: () => void;
+  updateRunSummary: (run: RunSummary) => void;
   dismissError: () => void;
 }
 
@@ -186,6 +189,40 @@ function writeStored(key: string, value: string) {
   }
 }
 
+function runIDFromLocation(): string | null {
+  if (!diagnoseURLStateEnabled()) return null;
+  try {
+    return new URLSearchParams(window.location.search).get("ai-run");
+  } catch {
+    return null;
+  }
+}
+
+function writeRunIDToLocation(id: string | null, push: boolean) {
+  if (!diagnoseURLStateEnabled()) return;
+  try {
+    const url = new URL(window.location.href);
+    if (id) url.searchParams.set("ai-run", id);
+    else url.searchParams.delete("ai-run");
+    window.history[push ? "pushState" : "replaceState"](
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    /* URL APIs unavailable — panel state still works for this session */
+  }
+}
+
+// Fleet pages host the panel against a cluster-scoped API while remaining on a
+// hub route such as /issues. Writing ?ai-run there would create a non-reloadable
+// pseudo-link. The embedded /c/:id Radar tree and local Radar own their route and
+// therefore keep the query as navigation state; Fleet copies run.radarUrl instead.
+function diagnoseURLStateEnabled(): boolean {
+  const clusterScopedAPI = /\/c\/[^/]+\/api\/?$/.test(getApiBase());
+  return !clusterScopedAPI || /^\/c\/[^/]+/.test(window.location.pathname);
+}
+
 export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState(false);
   const [eligible, setEligible] = useState(false);
@@ -206,6 +243,16 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<DiagnoseView>("home");
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const activeRunIdRef = useRef(activeRunId);
+  activeRunIdRef.current = activeRunId;
+  // Tracks whether the panel focus belongs to browser history. Fleet opens the
+  // same panel on /issues, where URL state is deliberately disabled; a generic
+  // panel launch must never be closed by the deep-link synchronization effect.
+  const urlRunIdRef = useRef(runIDFromLocation());
+  const writeFocusedRunID = useCallback((id: string | null, push: boolean) => {
+    writeRunIDToLocation(id, push);
+    if (diagnoseURLStateEnabled()) urlRunIdRef.current = id;
+  }, []);
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runsLoaded, setRunsLoaded] = useState(false);
   const [runsLoadFailed, setRunsLoadFailed] = useState(false);
@@ -336,7 +383,16 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     if (!available) return;
     listRuns()
       .then((r) => {
-        setRuns(r.runs);
+        const focusedID = activeRunIdRef.current;
+        setRuns((prev) => {
+          if (!focusedID || r.runs.some((run) => run.id === focusedID)) {
+            return r.runs;
+          }
+          // A stable deep link can target a retained run older than the bounded
+          // history page. Keep that directly fetched summary while it is open.
+          const focusedRun = prev.find((run) => run.id === focusedID);
+          return focusedRun ? [focusedRun, ...r.runs] : r.runs;
+        });
         setRunsLoaded(true);
         setRunsLoadFailed(false);
         setHistoryDegraded(!!r.historyDegraded);
@@ -348,6 +404,13 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
         setRunsLoadFailed(true);
       });
   }, [available]);
+  const updateRunSummary = useCallback((run: RunSummary) => {
+    setRuns((prev) =>
+      prev.some((item) => item.id === run.id)
+        ? prev.map((item) => (item.id === run.id ? run : item))
+        : [run, ...prev],
+    );
+  }, []);
 
   // A content-stable signature of the resources with a live (running) investigation,
   // so the per-resource Diagnose buttons can show a "running" indicator even with the
@@ -397,6 +460,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
         if (seq !== startSeqRef.current) return;
         setActiveRunId(run.id);
         setView("investigation");
+        writeFocusedRunID(run.id, true);
       })
       .catch((e) => {
         if (seq !== startSeqRef.current) return;
@@ -431,38 +495,60 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     },
     [consentSurface, hosted],
   );
-  const openRun = useCallback((id: string) => {
-    setStartError(null);
-    setActiveRunId(id);
-    setView("investigation");
-    setOpen(true);
-  }, []);
+  const openRun = useCallback(
+    (id: string) => {
+      setStartError(null);
+      setActiveRunId(id);
+      setView("investigation");
+      setOpen(true);
+      writeFocusedRunID(id, true);
+      // A Fleet issue can point at a retained automatic run older than the
+      // bounded history page. Resolve the exact id instead of waiting for list.
+      getRun(id)
+        .then(updateRunSummary)
+        .catch(() => {
+          // The loaded-list state renders the durable unavailable message.
+        });
+    },
+    [updateRunSummary, writeFocusedRunID],
+  );
 
-  // Deep link: ?ai-run=<id> opens the panel focused on that investigation —
-  // the URL `radar diagnose --open` prints/opens. Consumed once (then stripped)
-  // so back/forward and copied URLs don't keep re-opening the panel.
+  // The run id is durable navigation state: direct loads and popstate focus the
+  // exact run, and the query remains in place so the address bar is copyable.
+  // Fetch by id rather than assuming the bounded recent list contains it.
   useEffect(() => {
-    if (!available) return;
-    let id: string | null = null;
-    try {
-      const params = new URLSearchParams(window.location.search);
-      id = params.get("ai-run");
-      if (id) {
-        params.delete("ai-run");
-        const qs = params.toString();
-        window.history.replaceState(
-          null,
-          "",
-          window.location.pathname +
-            (qs ? `?${qs}` : "") +
-            window.location.hash,
-        );
+    if (!available || !diagnoseURLStateEnabled()) return;
+    const focusFromLocation = (fromPopState: boolean) => {
+      const id = runIDFromLocation();
+      if (!id) {
+        // A missing id on first mount is ordinary. On popstate it means "back
+        // out of this investigation" only when the focused run was itself
+        // installed by URL history; unrelated synthetic popstate events must
+        // not tear down a panel opened by an in-app action.
+        if (fromPopState && urlRunIdRef.current) {
+          setActiveRunId(null);
+          setView("home");
+          setOpen(false);
+        }
+        urlRunIdRef.current = null;
+        return;
       }
-    } catch {
-      /* URL APIs unavailable — skip the deep link */
-    }
-    if (id) openRun(id);
-  }, [available, openRun]);
+      urlRunIdRef.current = id;
+      setStartError(null);
+      setActiveRunId(id);
+      setView("investigation");
+      setOpen(true);
+      getRun(id)
+        .then(updateRunSummary)
+        .catch(() => {
+          // The list load owns the final missing/degraded state and keeps retrying.
+        });
+    };
+    focusFromLocation(false);
+    const onPopState = () => focusFromLocation(true);
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [available, updateRunSummary]);
   // Leaving the detail pane drops the failure that belonged to it. startError
   // renders as the entire pane (maximized home still shows `detail`), where a
   // message about a resource you just navigated away from has nothing to attach
@@ -471,12 +557,17 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     setView("home");
     setStartError(null);
     setOpen(true);
-  }, []);
+    writeFocusedRunID(null, false);
+  }, [writeFocusedRunID]);
   const goHome = useCallback(() => {
     setView("home");
     setStartError(null);
-  }, []);
-  const close = useCallback(() => setOpen(false), []);
+    writeFocusedRunID(null, false);
+  }, [writeFocusedRunID]);
+  const close = useCallback(() => {
+    setOpen(false);
+    writeFocusedRunID(null, false);
+  }, [writeFocusedRunID]);
   const consentBusyRef = useRef(false);
   const approveConsent = useCallback(() => {
     if (consentBusyRef.current) return;
@@ -557,6 +648,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     approveConsent,
     cancelConsent,
     refreshRuns,
+    updateRunSummary,
     dismissError,
   };
 

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -98,6 +98,7 @@ interface DiagnoseCtx {
 // churns the business context) doesn't re-render the whole shell.
 interface DiagnoseLayoutCtx {
   open: boolean;
+  close: () => void;
   contentGutter: number; // px right-gutter for the content area when docked (0 = overlay/closed)
   maximized: boolean;
   setMaximized: Dispatch<SetStateAction<boolean>>;
@@ -732,6 +733,7 @@ export function DiagnoseProvider({
   const layout = useMemo<DiagnoseLayoutCtx>(
     () => ({
       open,
+      close,
       contentGutter,
       maximized,
       setMaximized,
@@ -744,6 +746,7 @@ export function DiagnoseProvider({
     }),
     [
       open,
+      close,
       contentGutter,
       maximized,
       width,

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -262,16 +262,24 @@ export function DiagnoseProvider({
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const activeRunIdRef = useRef(activeRunId);
   activeRunIdRef.current = activeRunId;
+  // A missing/revoked durable link is terminal until the user explicitly
+  // navigates to it again. Keep polling the bounded history list (so a newly
+  // shared run can reappear), but do not hammer the exact 404 endpoint every
+  // four seconds while the unavailable state is already on screen.
+  const unavailableRunIDsRef = useRef(new Set<string>());
   // Tracks whether the panel focus belongs to browser history. Fleet opens the
   // same panel on /issues, where URL state is deliberately disabled; a generic
   // panel launch must never be closed by the deep-link synchronization effect.
   const urlRunIdRef = useRef(runIDFromLocation(browserURLState));
-  const writeFocusedRunID = useCallback((id: string | null, push: boolean) => {
-    // Set this before writeRunIDToLocation's synthetic popstate so our own
-    // listener can distinguish a programmatic close/home write from Back.
-    if (diagnoseURLStateEnabled(browserURLState)) urlRunIdRef.current = id;
-    writeRunIDToLocation(id, push, browserURLState);
-  }, [browserURLState]);
+  const writeFocusedRunID = useCallback(
+    (id: string | null, push: boolean) => {
+      // Set this before writeRunIDToLocation's synthetic popstate so our own
+      // listener can distinguish a programmatic close/home write from Back.
+      if (diagnoseURLStateEnabled(browserURLState)) urlRunIdRef.current = id;
+      writeRunIDToLocation(id, push, browserURLState);
+    },
+    [browserURLState],
+  );
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runsLoaded, setRunsLoaded] = useState(false);
   const [runsLoadFailed, setRunsLoadFailed] = useState(false);
@@ -405,7 +413,12 @@ export function DiagnoseProvider({
       const focusedID = activeRunIdRef.current;
       let focusedRun: RunSummary | null = null;
       let retainFocusedSnapshot = false;
-      if (focusedID && !r.runs.some((run) => run.id === focusedID)) {
+      const listedFocusedRun = focusedID
+        ? r.runs.find((run) => run.id === focusedID)
+        : undefined;
+      if (focusedID && listedFocusedRun) {
+        unavailableRunIDsRef.current.delete(focusedID);
+      } else if (focusedID && !unavailableRunIDsRef.current.has(focusedID)) {
         try {
           // A stable deep link can target a retained run older than the bounded
           // history page. Refresh it directly too: its status and capabilities
@@ -415,9 +428,10 @@ export function DiagnoseProvider({
           // The bounded list is still authoritative for everything else. A
           // missing/revoked focused run falls out and renders unavailable;
           // transient direct-fetch failures keep the last useful snapshot.
-          retainFocusedSnapshot = !(
-            error instanceof DiagnoseError && error.status === 404
-          );
+          const unavailable =
+            error instanceof DiagnoseError && error.status === 404;
+          if (unavailable) unavailableRunIDsRef.current.add(focusedID);
+          retainFocusedSnapshot = !unavailable;
         }
       }
       setRuns((prev) => {
@@ -545,6 +559,7 @@ export function DiagnoseProvider({
   );
   const openRun = useCallback(
     (id: string) => {
+      unavailableRunIDsRef.current.delete(id);
       setStartError(null);
       setActiveRunId(id);
       setView("investigation");
@@ -554,7 +569,10 @@ export function DiagnoseProvider({
       // bounded history page. Resolve the exact id instead of waiting for list.
       getRun(id)
         .then(updateRunSummary)
-        .catch(() => {
+        .catch((error) => {
+          if (error instanceof DiagnoseError && error.status === 404) {
+            unavailableRunIDsRef.current.add(id);
+          }
           // The loaded-list state renders the durable unavailable message.
         });
     },
@@ -582,13 +600,17 @@ export function DiagnoseProvider({
         return;
       }
       urlRunIdRef.current = id;
+      unavailableRunIDsRef.current.delete(id);
       setStartError(null);
       setActiveRunId(id);
       setView("investigation");
       setOpen(true);
       getRun(id)
         .then(updateRunSummary)
-        .catch(() => {
+        .catch((error) => {
+          if (error instanceof DiagnoseError && error.status === 404) {
+            unavailableRunIDsRef.current.add(id);
+          }
           // The list load owns the final missing/degraded state and keeps retrying.
         });
     };
@@ -602,17 +624,20 @@ export function DiagnoseProvider({
   // message about a resource you just navigated away from has nothing to attach
   // to and no way to be dismissed.
   const openHome = useCallback(() => {
+    unavailableRunIDsRef.current.clear();
     setView("home");
     setStartError(null);
     setOpen(true);
     writeFocusedRunID(null, false);
   }, [writeFocusedRunID]);
   const goHome = useCallback(() => {
+    unavailableRunIDsRef.current.clear();
     setView("home");
     setStartError(null);
     writeFocusedRunID(null, false);
   }, [writeFocusedRunID]);
   const close = useCallback(() => {
+    unavailableRunIDsRef.current.clear();
     setOpen(false);
     writeFocusedRunID(null, false);
   }, [writeFocusedRunID]);

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -209,6 +209,12 @@ function writeRunIDToLocation(id: string | null, push: boolean) {
       "",
       `${url.pathname}${url.search}${url.hash}`,
     );
+    // History API writes do not notify BrowserRouter. Replaying the new state as
+    // popstate keeps every later navigate/setSearchParams call on the same live
+    // query string instead of letting a stale router snapshot erase ai-run.
+    window.dispatchEvent(
+      new PopStateEvent("popstate", { state: window.history.state }),
+    );
   } catch {
     /* URL APIs unavailable — panel state still works for this session */
   }
@@ -250,8 +256,10 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // panel launch must never be closed by the deep-link synchronization effect.
   const urlRunIdRef = useRef(runIDFromLocation());
   const writeFocusedRunID = useCallback((id: string | null, push: boolean) => {
-    writeRunIDToLocation(id, push);
+    // Set this before writeRunIDToLocation's synthetic popstate so our own
+    // listener can distinguish a programmatic close/home write from Back.
     if (diagnoseURLStateEnabled()) urlRunIdRef.current = id;
+    writeRunIDToLocation(id, push);
   }, []);
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runsLoaded, setRunsLoaded] = useState(false);
@@ -379,30 +387,45 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  const refreshRuns = useCallback(() => {
+  const refreshRuns = useCallback(async () => {
     if (!available) return;
-    listRuns()
-      .then((r) => {
-        const focusedID = activeRunIdRef.current;
-        setRuns((prev) => {
-          if (!focusedID || r.runs.some((run) => run.id === focusedID)) {
-            return r.runs;
-          }
+    try {
+      const r = await listRuns();
+      const focusedID = activeRunIdRef.current;
+      let focusedRun: RunSummary | null = null;
+      let retainFocusedSnapshot = false;
+      if (focusedID && !r.runs.some((run) => run.id === focusedID)) {
+        try {
           // A stable deep link can target a retained run older than the bounded
-          // history page. Keep that directly fetched summary while it is open.
-          const focusedRun = prev.find((run) => run.id === focusedID);
-          return focusedRun ? [focusedRun, ...r.runs] : r.runs;
-        });
-        setRunsLoaded(true);
-        setRunsLoadFailed(false);
-        setHistoryDegraded(!!r.historyDegraded);
-      })
-      .catch(() => {
-        // Leave runsLoaded false (a missing-run verdict needs a real list) but
-        // record the failure so the panel can say "retrying" instead of
-        // pretending nothing happened. The 4s poll keeps retrying while open.
-        setRunsLoadFailed(true);
+          // history page. Refresh it directly too: its status and capabilities
+          // must not freeze at the first snapshot while the panel stays open.
+          focusedRun = await getRun(focusedID);
+        } catch (error) {
+          // The bounded list is still authoritative for everything else. A
+          // missing/revoked focused run falls out and renders unavailable;
+          // transient direct-fetch failures keep the last useful snapshot.
+          retainFocusedSnapshot = !(
+            error instanceof DiagnoseError && error.status === 404
+          );
+        }
+      }
+      setRuns((prev) => {
+        if (focusedRun) return [focusedRun, ...r.runs];
+        if (focusedID && retainFocusedSnapshot) {
+          const previous = prev.find((run) => run.id === focusedID);
+          if (previous) return [previous, ...r.runs];
+        }
+        return r.runs;
       });
+      setRunsLoaded(true);
+      setRunsLoadFailed(false);
+      setHistoryDegraded(!!r.historyDegraded);
+    } catch {
+      // Leave runsLoaded false (a missing-run verdict needs a real list) but
+      // record the failure so the panel can say "retrying" instead of
+      // pretending nothing happened. The 4s poll keeps retrying while open.
+      setRunsLoadFailed(true);
+    }
   }, [available]);
   const updateRunSummary = useCallback((run: RunSummary) => {
     setRuns((prev) =>

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  canCopyRunLink,
-  canStartNewInvestigation,
-} from "./DiagnoseSurface";
+import { canCopyRunLink, canStartNewInvestigation } from "./DiagnoseSurface";
 import type { RunSummary } from "../../api/diagnose";
 
 // The "new investigation" button dispatches an agent and spends the user's own
@@ -37,9 +34,19 @@ describe("canStartNewInvestigation", () => {
 
   it("stays hidden while a turn is in flight", () => {
     // A start would be handed back the live run, so the button does nothing.
-    expect(canStartNewInvestigation("investigation", run("running"), false)).toBe(
-      false,
-    );
+    expect(
+      canStartNewInvestigation("investigation", run("running"), false),
+    ).toBe(false);
+  });
+
+  it("offers a separate human investigation while an automatic run is in flight", () => {
+    expect(
+      canStartNewInvestigation(
+        "investigation",
+        { ...run("running"), trigger: "background" },
+        false,
+      ),
+    ).toBe(true);
   });
 
   it("stays hidden on a stale run", () => {
@@ -66,9 +73,9 @@ describe("canStartNewInvestigation", () => {
     expect(canStartNewInvestigation("investigation", run("error"), false)).toBe(
       true,
     );
-    expect(canStartNewInvestigation("investigation", run("stopped"), false)).toBe(
-      true,
-    );
+    expect(
+      canStartNewInvestigation("investigation", run("stopped"), false),
+    ).toBe(true);
   });
 });
 

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { canCopyRunLink, canStartNewInvestigation } from "./DiagnoseSurface";
+import {
+  canContinueInvestigation,
+  canStopInvestigation,
+} from "./InvestigationView";
 import type { RunSummary } from "../../api/diagnose";
 
 // The "new investigation" button dispatches an agent and spends the user's own
@@ -36,6 +40,12 @@ describe("canStartNewInvestigation", () => {
     // A start would be handed back the live run, so the button does nothing.
     expect(
       canStartNewInvestigation("investigation", run("running"), false),
+    ).toBe(false);
+  });
+
+  it("stays hidden while a stopped turn is draining", () => {
+    expect(
+      canStartNewInvestigation("investigation", run("stopping"), false),
     ).toBe(false);
   });
 
@@ -76,6 +86,70 @@ describe("canStartNewInvestigation", () => {
     expect(
       canStartNewInvestigation("investigation", run("stopped"), false),
     ).toBe(true);
+  });
+});
+
+describe("canStopInvestigation", () => {
+  it("lets the terminal transcript outrank a lagging running summary", () => {
+    expect(canStopInvestigation(run("running"), false, false, "done")).toBe(
+      false,
+    );
+    expect(canStopInvestigation(run("running"), false, false, "error")).toBe(
+      false,
+    );
+  });
+
+  it("keeps Stop available for an active human turn", () => {
+    expect(canStopInvestigation(run("running"), true, false, "running")).toBe(
+      true,
+    );
+  });
+
+  it("does not offer another Stop while the server drains the turn", () => {
+    expect(canStopInvestigation(run("stopping"), true, false, "running")).toBe(
+      false,
+    );
+  });
+
+  it("never lets a missing or automatic run expose Stop", () => {
+    expect(canStopInvestigation(run("running"), true, true, "running")).toBe(
+      false,
+    );
+    expect(
+      canStopInvestigation(
+        { ...run("running"), trigger: "background" },
+        true,
+        false,
+        "running",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("canContinueInvestigation", () => {
+  it("lets a terminal transcript outrank only a lagging running human summary", () => {
+    expect(
+      canContinueInvestigation(
+        { ...run("running"), canContinue: false },
+        "done",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps genuinely read-only and sessionless investigations read-only", () => {
+    expect(
+      canContinueInvestigation(
+        {
+          ...run("running"),
+          trigger: "background",
+          canContinue: false,
+        },
+        "done",
+      ),
+    ).toBe(false);
+    expect(
+      canContinueInvestigation({ ...run("done"), canContinue: false }, "done"),
+    ).toBe(false);
   });
 });
 

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canStartNewInvestigation } from "./DiagnoseSurface";
+import {
+  canCopyRunLink,
+  canStartNewInvestigation,
+} from "./DiagnoseSurface";
 import type { RunSummary } from "../../api/diagnose";
 
 // The "new investigation" button dispatches an agent and spends the user's own
@@ -66,5 +69,24 @@ describe("canStartNewInvestigation", () => {
     expect(canStartNewInvestigation("investigation", run("stopped"), false)).toBe(
       true,
     );
+  });
+});
+
+describe("canCopyRunLink", () => {
+  it("does not expose collaboration UI for an OSS run", () => {
+    expect(canCopyRunLink(run("done"))).toBe(false);
+  });
+
+  it("exposes the copy action only for a canonical hosted URL", () => {
+    expect(
+      canCopyRunLink({
+        ...run("done"),
+        radarUrl: "/c/cluster-1?org=org-1&ai-run=r1",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an empty hosted URL as unavailable", () => {
+    expect(canCopyRunLink({ ...run("done"), radarUrl: "" })).toBe(false);
   });
 });

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -151,6 +151,16 @@ describe("canContinueInvestigation", () => {
       canContinueInvestigation({ ...run("done"), canContinue: false }, "done"),
     ).toBe(false);
   });
+
+  it("does not offer a follow-up after the retained run disappears", () => {
+    expect(
+      canContinueInvestigation(
+        { ...run("running"), canContinue: false },
+        "error",
+        true,
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("canCopyRunLink", () => {

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -272,7 +272,7 @@ function VisibilityControl({
         onClose={() => !busy && setConfirmShare(false)}
         onConfirm={update}
         title="Share this investigation?"
-        message="Everyone in your organization who can access this cluster can read this entire investigation—including your questions and the logs and manifests Radar read—and can continue or stop it."
+        message="Everyone in your organization can read this entire investigation—including your questions and the logs and manifests Radar read—and can continue or stop it."
         confirmLabel="Share with organization"
         variant="warning"
         isLoading={busy}
@@ -292,7 +292,7 @@ function VisibilityControl({
 //                 the last focused run. Without this the button dispatches an
 //                 agent — real tokens — from a screen showing an unrelated list.
 //   run           nothing to take a resource from.
-//   running       a human start is handed back the live run, so the click does
+//   running/stopping a human start is handed back the live run, so the click does
 //                 nothing. An automatic run is a different, immutable session,
 //                 so it deliberately keeps the fresh human escape hatch.
 //   stale         the body already offers "Re-run on current cluster" WITH the
@@ -307,7 +307,8 @@ export function canStartNewInvestigation(
   return (
     view === "investigation" &&
     !!run &&
-    (run.status !== "running" || run.trigger === "background") &&
+    ((run.status !== "running" && run.status !== "stopping") ||
+      run.trigger === "background") &&
     run.status !== "stale" &&
     !needsConsent
   );

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -154,21 +154,22 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
   );
 }
 
-function stableRunURL(run: RunSummary): string {
-  if (run.radarUrl) return new URL(run.radarUrl, window.location.origin).href;
-  const url = new URL(window.location.href);
-  url.searchParams.set("ai-run", run.id);
-  return url.href;
+export function canCopyRunLink(
+  run: RunSummary | null | undefined,
+): run is RunSummary & { radarUrl: string } {
+  return typeof run?.radarUrl === "string" && run.radarUrl.length > 0;
 }
 
-function CopyRunLink({ run }: { run: RunSummary }) {
+function CopyRunLink({ radarUrl }: { radarUrl: string }) {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
     "idle",
   );
   const copy = async () => {
     try {
       if (!navigator.clipboard) throw new Error("clipboard unavailable");
-      await navigator.clipboard.writeText(stableRunURL(run));
+      await navigator.clipboard.writeText(
+        new URL(radarUrl, window.location.origin).href,
+      );
       setCopyState("copied");
     } catch {
       setCopyState("error");
@@ -528,7 +529,9 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           {activeRun && (
             <VisibilityControl run={activeRun} onChanged={d.updateRunSummary} />
           )}
-          {activeRun && <CopyRunLink run={activeRun} />}
+          {canCopyRunLink(activeRun) && (
+            <CopyRunLink radarUrl={activeRun.radarUrl} />
+          )}
           {activeRun && <InvestigationMenu run={activeRun} />}
           <Tooltip content={maximized ? "Restore" : "Expand"} position="bottom">
             <button

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -162,15 +162,28 @@ function stableRunURL(run: RunSummary): string {
 }
 
 function CopyRunLink({ run }: { run: RunSummary }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    void navigator.clipboard?.writeText(stableRunURL(run));
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1100);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
+    "idle",
+  );
+  const copy = async () => {
+    try {
+      if (!navigator.clipboard) throw new Error("clipboard unavailable");
+      await navigator.clipboard.writeText(stableRunURL(run));
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+    setTimeout(() => setCopyState("idle"), 1500);
   };
   return (
     <Tooltip
-      content={copied ? "Link copied" : "Copy investigation link"}
+      content={
+        copyState === "copied"
+          ? "Link copied"
+          : copyState === "error"
+            ? "Couldn’t copy link"
+            : "Copy investigation link"
+      }
       position="bottom"
     >
       <button
@@ -178,7 +191,7 @@ function CopyRunLink({ run }: { run: RunSummary }) {
         className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
         aria-label="Copy investigation link"
       >
-        {copied ? (
+        {copyState === "copied" ? (
           <Check className="h-4 w-4 text-emerald-500" />
         ) : (
           <Link className="h-4 w-4" />

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -245,7 +245,7 @@ function VisibilityControl({
             ? "Couldn't change sharing"
             : shared
               ? "Shared with your organization — make private"
-              : "Private — share with your organization"
+              : "Private — click to let organization members access this investigation"
         }
         position="bottom"
       >
@@ -256,7 +256,7 @@ function VisibilityControl({
           aria-label={
             shared
               ? "Shared with your organization — make private"
-              : "Private — share with your organization"
+              : "Private — click to let organization members access this investigation"
           }
         >
           {shared ? (

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -16,8 +16,12 @@ import {
   Copy,
   Check,
   Plus,
+  Link,
+  Lock,
+  Users,
 } from "lucide-react";
 import { Tooltip } from "../ui/Tooltip";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import {
   useDiagnose,
   useDiagnoseLayout,
@@ -31,7 +35,11 @@ import { RecentList } from "./Home";
 import { AgentSetupNotice } from "./AgentSetupNotice";
 import { ConsentCard } from "./parts";
 import { buildLaunchCommand, launchAgentLabel, openInTerminal } from "./launch";
-import { type RunSummary, type ExecutionProfile } from "../../api/diagnose";
+import {
+  updateRunVisibility,
+  type RunSummary,
+  type ExecutionProfile,
+} from "../../api/diagnose";
 import { routePath } from "../../api/config";
 import { useCapabilitiesContext } from "../../contexts/CapabilitiesContext";
 
@@ -71,7 +79,10 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
   const [copied, setCopied] = useState(false);
   const { localTerminal } = useCapabilitiesContext();
   const label = launchAgentLabel(run);
-  const command = buildLaunchCommand(run, `${window.location.origin}${routePath('/mcp')}`);
+  const command = buildLaunchCommand(
+    run,
+    `${window.location.origin}${routePath("/mcp")}`,
+  );
   // No resumable session yet (or stale run) → nothing to hand off.
   if (!command) return null;
 
@@ -140,6 +151,109 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
         </>
       )}
     </div>
+  );
+}
+
+function stableRunURL(run: RunSummary): string {
+  if (run.radarUrl) return new URL(run.radarUrl, window.location.origin).href;
+  const url = new URL(window.location.href);
+  url.searchParams.set("ai-run", run.id);
+  return url.href;
+}
+
+function CopyRunLink({ run }: { run: RunSummary }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard?.writeText(stableRunURL(run));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1100);
+  };
+  return (
+    <Tooltip
+      content={copied ? "Link copied" : "Copy investigation link"}
+      position="bottom"
+    >
+      <button
+        onClick={copy}
+        className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+        aria-label="Copy investigation link"
+      >
+        {copied ? (
+          <Check className="h-4 w-4 text-emerald-500" />
+        ) : (
+          <Link className="h-4 w-4" />
+        )}
+      </button>
+    </Tooltip>
+  );
+}
+
+function VisibilityControl({
+  run,
+  onChanged,
+}: {
+  run: RunSummary;
+  onChanged: (run: RunSummary) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+  const [confirmShare, setConfirmShare] = useState(false);
+  if (!run.canManageVisibility) return null;
+  const shared = run.visibility === "organization";
+  const update = () => {
+    if (busy) return;
+    setBusy(true);
+    setError(false);
+    updateRunVisibility(run.id, shared ? "private" : "organization")
+      .then((updated) => {
+        onChanged(updated);
+        setConfirmShare(false);
+      })
+      .catch(() => setError(true))
+      .finally(() => setBusy(false));
+  };
+  const label = shared ? "Organization" : "Private";
+  return (
+    <>
+      <Tooltip
+        content={
+          error
+            ? "Couldn't change sharing"
+            : shared
+              ? "Shared with your organization — make private"
+              : "Private — share with your organization"
+        }
+        position="bottom"
+      >
+        <button
+          onClick={() => (shared ? update() : setConfirmShare(true))}
+          disabled={busy}
+          className="flex items-center gap-1 rounded-md border border-theme-border/70 px-1.5 py-1 text-[11px] font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:opacity-50"
+          aria-label={
+            shared
+              ? "Shared with your organization — make private"
+              : "Private — share with your organization"
+          }
+        >
+          {shared ? (
+            <Users className="h-3.5 w-3.5" />
+          ) : (
+            <Lock className="h-3.5 w-3.5" />
+          )}
+          {label}
+        </button>
+      </Tooltip>
+      <ConfirmDialog
+        open={confirmShare}
+        onClose={() => !busy && setConfirmShare(false)}
+        onConfirm={update}
+        title="Share this investigation?"
+        message="Everyone in your organization who can access this cluster can read this entire investigation—including your questions and the logs and manifests Radar read—and can continue or stop it."
+        confirmLabel="Share with organization"
+        variant="warning"
+        isLoading={busy}
+      />
+    </>
   );
 }
 
@@ -377,24 +491,31 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
         <div className="flex shrink-0 items-center gap-0.5">
           {activeRun &&
             canStartNewInvestigation(d.view, activeRun, d.needsConsent) && (
-            <Tooltip content="New investigation on this resource" position="bottom">
-              <button
-                onClick={() =>
-                  d.openInvestigation({
-                    kind: activeRun.kind,
-                    namespace: activeRun.namespace,
-                    name: activeRun.name,
-                    issueId: activeRun.issueId,
-                    fresh: true,
-                  })
-                }
-                className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
-                aria-label="New investigation on this resource"
+              <Tooltip
+                content="New investigation on this resource"
+                position="bottom"
               >
-                <Plus className="h-4 w-4" />
-              </button>
-            </Tooltip>
+                <button
+                  onClick={() =>
+                    d.openInvestigation({
+                      kind: activeRun.kind,
+                      namespace: activeRun.namespace,
+                      name: activeRun.name,
+                      issueId: activeRun.issueId,
+                      fresh: true,
+                    })
+                  }
+                  className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+                  aria-label="New investigation on this resource"
+                >
+                  <Plus className="h-4 w-4" />
+                </button>
+              </Tooltip>
+            )}
+          {activeRun && (
+            <VisibilityControl run={activeRun} onChanged={d.updateRunSummary} />
           )}
+          {activeRun && <CopyRunLink run={activeRun} />}
           {activeRun && <InvestigationMenu run={activeRun} />}
           <Tooltip content={maximized ? "Restore" : "Expand"} position="bottom">
             <button

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { Tooltip } from "../ui/Tooltip";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { Badge } from "@skyhook-io/k8s-ui/components/ui/Badge";
 import {
   useDiagnose,
   useDiagnoseLayout,
@@ -212,7 +213,16 @@ function VisibilityControl({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(false);
   const [confirmShare, setConfirmShare] = useState(false);
-  if (!run.canManageVisibility) return null;
+  if (!run.canManageVisibility) {
+    return run.visibility === "organization" ? (
+      <Tooltip content="Shared with your organization" position="bottom">
+        <Badge severity="neutral" size="sm" className="shrink-0">
+          <Users className="h-3 w-3" />
+          Organization
+        </Badge>
+      </Tooltip>
+    ) : null;
+  }
   const shared = run.visibility === "organization";
   const update = () => {
     if (busy) return;
@@ -282,8 +292,9 @@ function VisibilityControl({
 //                 the last focused run. Without this the button dispatches an
 //                 agent — real tokens — from a screen showing an unrelated list.
 //   run           nothing to take a resource from.
-//   running       a start is handed back the live run, so the click does nothing
-//                 and the button reads as broken.
+//   running       a human start is handed back the live run, so the click does
+//                 nothing. An automatic run is a different, immutable session,
+//                 so it deliberately keeps the fresh human escape hatch.
 //   stale         the body already offers "Re-run on current cluster" WITH the
 //                 warning that the context changed; a bare + carries none of it,
 //                 and the resource may not exist in the context it'd run against.
@@ -296,7 +307,7 @@ export function canStartNewInvestigation(
   return (
     view === "investigation" &&
     !!run &&
-    run.status !== "running" &&
+    (run.status !== "running" || run.trigger === "background") &&
     run.status !== "stale" &&
     !needsConsent
   );
@@ -348,23 +359,28 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
     d.setupState === "needs-install" || d.setupState === "needs-restart";
 
   const activeRun = d.runs.find((r) => r.id === d.activeRunId) ?? null;
+  // Docked Home is a list, not the previously focused run. Scope every header
+  // label/action to what is visibly on screen so Copy/Share cannot act on a run
+  // the user has navigated away from. Expanded mode remains master-detail and
+  // therefore keeps the selected run active beside its history list.
+  const headerRun = !maximized && d.view === "home" ? null : activeRun;
   // A focused run shows the agent it actually ran with; Home reflects the current pick.
-  const activeAgentLabel = activeRun?.agent
-    ? agentLabelFor(activeRun.agent)
+  const activeAgentLabel = headerRun?.agent
+    ? agentLabelFor(headerRun.agent)
     : d.agentLabel;
   // Header subtitle: the config a focused run actually used (it records agent /
   // profile / model / effort), or the current defaults on Home. Codex shows mode
   // + reasoning effort; model is shown only when overridden. Clicking opens Settings.
   const configLine = buildConfigLine(
-    activeRun ?? {
+    headerRun ?? {
       agent: d.selectedAgent,
       profile: d.hosted ? undefined : d.profile,
       model: d.model,
       effort: d.effort,
     },
   );
-  const detailTitle = activeRun
-    ? `${activeRun.kind} ${activeRun.namespace ? `${activeRun.namespace}/` : ""}${activeRun.name}`
+  const detailTitle = headerRun
+    ? `${headerRun.kind} ${headerRun.namespace ? `${headerRun.namespace}/` : ""}${headerRun.name}`
     : "AI investigations";
 
   // Absolute within the body frame: maximized fills it; docked is a right slot.
@@ -503,8 +519,8 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
-          {activeRun &&
-            canStartNewInvestigation(d.view, activeRun, d.needsConsent) && (
+          {headerRun &&
+            canStartNewInvestigation(d.view, headerRun, d.needsConsent) && (
               <Tooltip
                 content="New investigation on this resource"
                 position="bottom"
@@ -512,10 +528,10 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
                 <button
                   onClick={() =>
                     d.openInvestigation({
-                      kind: activeRun.kind,
-                      namespace: activeRun.namespace,
-                      name: activeRun.name,
-                      issueId: activeRun.issueId,
+                      kind: headerRun.kind,
+                      namespace: headerRun.namespace,
+                      name: headerRun.name,
+                      issueId: headerRun.issueId,
                       fresh: true,
                     })
                   }
@@ -526,13 +542,13 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
                 </button>
               </Tooltip>
             )}
-          {activeRun && (
-            <VisibilityControl run={activeRun} onChanged={d.updateRunSummary} />
+          {headerRun && (
+            <VisibilityControl run={headerRun} onChanged={d.updateRunSummary} />
           )}
-          {canCopyRunLink(activeRun) && (
-            <CopyRunLink radarUrl={activeRun.radarUrl} />
+          {canCopyRunLink(headerRun) && (
+            <CopyRunLink radarUrl={headerRun.radarUrl} />
           )}
-          {activeRun && <InvestigationMenu run={activeRun} />}
+          {headerRun && <InvestigationMenu run={headerRun} />}
           <Tooltip content={maximized ? "Restore" : "Expand"} position="bottom">
             <button
               onClick={() => setMaximized((v) => !v)}

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -83,80 +83,104 @@ export function RecentList({
   if (runs.length === 0) {
     return (
       <div>
-      {degradedNote}
-      <div className="flex flex-col items-center px-4 py-12 text-center">
-        <Sparkles className="mb-3 h-7 w-7 text-accent" />
-        <div className="text-sm font-medium text-theme-text-primary">
-          No investigations yet
+        {degradedNote}
+        <div className="flex flex-col items-center px-4 py-12 text-center">
+          <Sparkles className="mb-3 h-7 w-7 text-accent" />
+          <div className="text-sm font-medium text-theme-text-primary">
+            No investigations yet
+          </div>
+          <p className="mt-1 max-w-xs text-sm text-theme-text-tertiary">
+            Open a resource and use its{" "}
+            <Sparkles className="inline h-3.5 w-3.5 align-text-bottom text-accent" />{" "}
+            action to investigate it with {agentLabel} —{" "}
+            <span className="font-medium text-theme-text-secondary">
+              Diagnose
+            </span>{" "}
+            a problem, or just ask about it. Investigations run in the
+            background and are kept in your history here.
+          </p>
         </div>
-        <p className="mt-1 max-w-xs text-sm text-theme-text-tertiary">
-          Open a resource and use its{" "}
-          <Sparkles className="inline h-3.5 w-3.5 align-text-bottom text-accent" />{" "}
-          action to investigate it with {agentLabel} —{" "}
-          <span className="font-medium text-theme-text-secondary">Diagnose</span>{" "}
-          a problem, or just ask about it. Investigations run in the background
-          and are kept in your history here.
-        </p>
-      </div>
       </div>
     );
   }
 
+  const organizationRuns = runs.filter(
+    (r) => r.trigger === "background" || r.ownedByMe === false,
+  );
+  const yourRuns = runs.filter((r) => !organizationRuns.includes(r));
+  const groups = organizationRuns.length
+    ? [
+        { label: "Your investigations", runs: yourRuns },
+        { label: "Organization", runs: organizationRuns },
+      ].filter((group) => group.runs.length > 0)
+    : [{ label: "Investigations", runs }];
+
   return (
     <div className="space-y-2">
       {degradedNote}
-      <div className="text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
-        Investigations
-      </div>
-      {runs.map((r) => (
-        <button
-          key={r.id}
-          onClick={() => onSelect(r.id)}
-          className={`flex w-full flex-col gap-0.5 rounded-md border px-2.5 py-2 text-left ${
-            r.id === selectedId
-              ? "border-accent/50 bg-accent/10"
-              : "border-theme-border/60 bg-theme-base/40 hover:bg-theme-hover"
-          }`}
-        >
-          <div className="flex items-center gap-2">
-            {statusDot(r.status)}
-            <span className="min-w-0 flex-1 truncate text-sm text-theme-text-primary">
-              {r.kind} {r.namespace ? `${r.namespace}/` : ""}
-              {r.name}
-            </span>
-            <span className="shrink-0 text-[11px] text-theme-text-tertiary">
-              {r.status === "running" ? (
-                "running…"
-              ) : (
-                <>
-                  {(() => {
-                    const w = statusWord(r.status);
-                    return w ? (
-                      <span className={`font-medium ${w.cls}`}>
-                        {w.text} ·{" "}
-                      </span>
-                    ) : null;
-                  })()}
-                  {relativeTime(new Date(r.updatedAt).getTime(), now)}
-                </>
-              )}
-            </span>
+      {groups.map((group) => (
+        <div key={group.label} className="space-y-2">
+          <div className="pt-1 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
+            {group.label}
           </div>
-          {(r.status === "stale" && r.context) || r.preview ? (
-            <div className="truncate pl-3.5 text-xs text-theme-text-tertiary">
-              {/* A foreign-cluster run names its cluster — in mixed multi-
-                  context history, identical-looking rows otherwise give no way
-                  to tell WHICH cluster an investigation was about. */}
-              {r.status === "stale" && r.context ? (
-                <span className="text-amber-600/80 dark:text-amber-500/80">
-                  {r.context}
+          {group.runs.map((r) => (
+            <button
+              key={r.id}
+              onClick={() => onSelect(r.id)}
+              className={`flex w-full flex-col gap-0.5 rounded-md border px-2.5 py-2 text-left ${
+                r.id === selectedId
+                  ? "border-accent/50 bg-accent/10"
+                  : "border-theme-border/60 bg-theme-base/40 hover:bg-theme-hover"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {statusDot(r.status)}
+                <span className="min-w-0 flex-1 truncate text-sm text-theme-text-primary">
+                  {r.kind} {r.namespace ? `${r.namespace}/` : ""}
+                  {r.name}
                 </span>
+                <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium text-theme-text-tertiary">
+                  {r.trigger === "background"
+                    ? "Automatic"
+                    : r.visibility === "organization"
+                      ? "Shared"
+                      : "Private"}
+                </span>
+                <span className="shrink-0 text-[11px] text-theme-text-tertiary">
+                  {r.status === "running" ? (
+                    "running…"
+                  ) : (
+                    <>
+                      {(() => {
+                        const w = statusWord(r.status);
+                        return w ? (
+                          <span className={`font-medium ${w.cls}`}>
+                            {w.text} ·{" "}
+                          </span>
+                        ) : null;
+                      })()}
+                      {relativeTime(new Date(r.updatedAt).getTime(), now)}
+                    </>
+                  )}
+                </span>
+              </div>
+              {(r.status === "stale" && r.context) || r.preview ? (
+                <div className="truncate pl-3.5 text-xs text-theme-text-tertiary">
+                  {/* A foreign-cluster run names its cluster — in mixed multi-
+                      context history, identical-looking rows otherwise give no way
+                      to tell WHICH cluster an investigation was about. */}
+                  {r.status === "stale" && r.context ? (
+                    <span className="text-amber-600/80 dark:text-amber-500/80">
+                      {r.context}
+                    </span>
+                  ) : null}
+                  {r.status === "stale" && r.context && r.preview ? " · " : ""}
+                  {r.preview}
+                </div>
               ) : null}
-              {r.status === "stale" && r.context && r.preview ? " · " : ""}
-              {r.preview}
-            </div>
-          ) : null}
-        </button>
+            </button>
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -32,7 +32,7 @@ function runTone(status: RunSummary["status"]): StatusTone {
 }
 
 function statusDot(status: RunSummary["status"]) {
-  if (status === "running")
+  if (status === "running" || status === "stopping")
     return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-accent" />;
   return <StatusDot tone={runTone(status)} className="shrink-0" />;
 }
@@ -48,6 +48,8 @@ function statusWord(
       return { text: "Failed", cls: "text-red-400" };
     case "stopped":
       return { text: "Stopped", cls: "text-theme-text-tertiary" };
+    case "stopping":
+      return { text: "Stopping", cls: "text-theme-text-tertiary" };
     case "stale":
       // Plain words, not the internal status name: "stale" means the run was
       // about a cluster that's no longer connected.
@@ -150,8 +152,8 @@ export function RecentList({
                   </Badge>
                 )}
                 <span className="shrink-0 text-[11px] text-theme-text-tertiary">
-                  {r.status === "running" ? (
-                    "running…"
+                  {r.status === "running" || r.status === "stopping" ? (
+                    r.status === "stopping" ? "stopping…" : "running…"
                   ) : (
                     <>
                       {(() => {

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -3,6 +3,7 @@
 // docked Home view and the master pane of the maximized workspace.
 import { Loader2, Sparkles } from "lucide-react";
 import { StatusDot, type StatusTone } from "@skyhook-io/k8s-ui";
+import { Badge } from "@skyhook-io/k8s-ui/components/ui/Badge";
 import { type RunSummary } from "../../api/diagnose";
 
 // Compact "3m ago" / "2h ago" / date label.
@@ -140,13 +141,13 @@ export function RecentList({
                   {r.name}
                 </span>
                 {(r.trigger || r.visibility) && (
-                  <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium text-theme-text-tertiary">
+                  <Badge severity="neutral" size="sm" className="shrink-0">
                     {r.trigger === "background"
                       ? "Automatic"
                       : r.visibility === "organization"
                         ? "Shared"
                         : "Private"}
-                  </span>
+                  </Badge>
                 )}
                 <span className="shrink-0 text-[11px] text-theme-text-tertiary">
                   {r.status === "running" ? (

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -139,13 +139,15 @@ export function RecentList({
                   {r.kind} {r.namespace ? `${r.namespace}/` : ""}
                   {r.name}
                 </span>
-                <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium text-theme-text-tertiary">
-                  {r.trigger === "background"
-                    ? "Automatic"
-                    : r.visibility === "organization"
-                      ? "Shared"
-                      : "Private"}
-                </span>
+                {(r.trigger || r.visibility) && (
+                  <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium text-theme-text-tertiary">
+                    {r.trigger === "background"
+                      ? "Automatic"
+                      : r.visibility === "organization"
+                        ? "Shared"
+                        : "Private"}
+                  </span>
+                )}
                 <span className="shrink-0 text-[11px] text-theme-text-tertiary">
                   {r.status === "running" ? (
                     "running…"

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -34,6 +34,43 @@ import {
 const RECHECK_QUESTION =
   "Did the fix resolve the issue? Re-check the resource's current status and health now, and say whether it's healthy.";
 
+export function canStopInvestigation(
+  run: RunSummary,
+  busy: boolean,
+  gone: boolean,
+  latestTurnStatus?: Turn["status"],
+): boolean {
+  // The transcript is fresher than the polled run summary. Once it has a
+  // terminal frame, a lagging/failed summary refresh must not resurrect Stop.
+  const transcriptTerminal =
+    latestTurnStatus === "done" || latestTurnStatus === "error";
+  return (
+    run.trigger !== "background" &&
+    run.status !== "stale" &&
+    run.status !== "stopping" &&
+    !gone &&
+    !transcriptTerminal &&
+    (busy || run.status === "running")
+  );
+}
+
+export function canContinueInvestigation(
+  run: RunSummary,
+  latestTurnStatus?: Turn["status"],
+): boolean {
+  const transcriptTerminal =
+    latestTurnStatus === "done" || latestTurnStatus === "error";
+  const summaryIsLaggingTerminalTranscript =
+    run.status === "running" &&
+    run.trigger !== "background" &&
+    transcriptTerminal;
+  return (
+    run.status !== "stale" &&
+    run.status !== "stopping" &&
+    (run.canContinue !== false || summaryIsLaggingTerminalTranscript)
+  );
+}
+
 export function InvestigationView({
   run,
   agentLabel,
@@ -44,7 +81,6 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
-  const canContinue = run.canContinue !== false && run.status !== "stale";
   // Apply is off for hosted agents (read-only server-side). Keyed on the selected
   // agent, which matches run.agent unless a deployment mixes hosted + local agents.
   const { refreshRuns, openInvestigation, startError, dismissError, hosted } =
@@ -70,13 +106,6 @@ export function InvestigationView({
   // show a silent blank panel; instead we render a "no longer available" state.
   const [gone, setGone] = useState(false);
   const [busy, setBusy] = useState(false);
-  // Continuation needs a resumable session, but stopping does not. A brand-new
-  // hosted turn can be running before the SDK has reported its session id, so
-  // keep Stop available for human investigations without advertising a
-  // follow-up composer that the server would reject. Automatic runs remain
-  // immutable even while their stream marks this view busy.
-  const canStop =
-    run.trigger !== "background" && (busy || run.status === "running");
   const [input, setInput] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -103,6 +132,14 @@ export function InvestigationView({
   // unfolds in beats: "rca" = root cause only (+ a "weighing remediation" beat),
   // "full" = everything. null/"full" for replayed turns (no choreography on rebuild).
   const [reveal, setReveal] = useState<"rca" | "full" | null>(null);
+  const latestTurnStatus = turns[turns.length - 1]?.status;
+  const canContinue = canContinueInvestigation(run, latestTurnStatus);
+  // Continuation needs a resumable session, but stopping does not. A brand-new
+  // hosted turn can be running before the SDK has reported its session id, so
+  // keep Stop available for human investigations without advertising a
+  // follow-up composer that the server would reject. Automatic runs remain
+  // immutable even while their stream marks this view busy.
+  const canStop = canStopInvestigation(run, busy, gone, latestTurnStatus);
   const synthTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const clearSynth = () => {
     synthTimers.current.forEach(clearTimeout);
@@ -639,6 +676,10 @@ export function InvestigationView({
           >
             Stop
           </button>
+        ) : run.status === "stopping" ? (
+          <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
+            Stopping investigation…
+          </div>
         ) : !canContinue ? (
           <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
             {run.trigger === "background"
@@ -657,7 +698,7 @@ export function InvestigationView({
                 }
               }}
               rows={1}
-              disabled={!canContinue}
+              disabled={!canContinue || busy}
               placeholder={
                 stale
                   ? "Cluster changed — re-run Diagnose"
@@ -667,7 +708,7 @@ export function InvestigationView({
             />
             <button
               onClick={submitFollowup}
-              disabled={!input.trim() || !canContinue}
+              disabled={!input.trim() || !canContinue || busy}
               className="shrink-0 rounded-lg btn-brand p-2 disabled:opacity-40"
               aria-label="Send follow-up"
             >

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -57,6 +57,7 @@ export function canStopInvestigation(
 export function canContinueInvestigation(
   run: RunSummary,
   latestTurnStatus?: Turn["status"],
+  gone = false,
 ): boolean {
   const transcriptTerminal =
     latestTurnStatus === "done" || latestTurnStatus === "error";
@@ -65,6 +66,7 @@ export function canContinueInvestigation(
     run.trigger !== "background" &&
     transcriptTerminal;
   return (
+    !gone &&
     run.status !== "stale" &&
     run.status !== "stopping" &&
     (run.canContinue !== false || summaryIsLaggingTerminalTranscript)
@@ -133,7 +135,7 @@ export function InvestigationView({
   // "full" = everything. null/"full" for replayed turns (no choreography on rebuild).
   const [reveal, setReveal] = useState<"rca" | "full" | null>(null);
   const latestTurnStatus = turns[turns.length - 1]?.status;
-  const canContinue = canContinueInvestigation(run, latestTurnStatus);
+  const canContinue = canContinueInvestigation(run, latestTurnStatus, gone);
   // Continuation needs a resumable session, but stopping does not. A brand-new
   // hosted turn can be running before the SDK has reported its session id, so
   // keep Stop available for human investigations without advertising a

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -44,6 +44,7 @@ export function InvestigationView({
   maximized: boolean;
 }) {
   const { kind, namespace, name } = run;
+  const canContinue = run.canContinue !== false && run.status !== "stale";
   // Apply is off for hosted agents (read-only server-side). Keyed on the selected
   // agent, which matches run.agent unless a deployment mixes hosted + local agents.
   const { refreshRuns, openInvestigation, startError, dismissError, hosted } =
@@ -216,6 +217,7 @@ export function InvestigationView({
               ...prev,
               {
                 question: ev.question,
+                actor: ev.actor,
                 timeline: [],
                 diagnosis: null,
                 error: null,
@@ -521,7 +523,7 @@ export function InvestigationView({
                   synthLabel={isLast ? synth : null}
                   reveal={isLast ? (reveal ?? "full") : "full"}
                   onApply={canApply ? requestApply : undefined}
-                  onAsk={isLast && !busy && !stale ? askFollowup : undefined}
+                  onAsk={isLast && !busy && canContinue ? askFollowup : undefined}
                   onCheckStatus={canCheck ? checkStatus : undefined}
                   onRetryDiagnosis={
                     isLast &&
@@ -585,7 +587,7 @@ export function InvestigationView({
                 ? requestApply
                 : undefined
             }
-            onAsk={!busy && !stale ? askFollowup : undefined}
+            onAsk={!busy && canContinue ? askFollowup : undefined}
             reveal="full"
           />
         </aside>
@@ -616,7 +618,12 @@ export function InvestigationView({
       <div
         className={`border-t border-theme-border px-3 py-2.5 ${maximized ? "[&>*]:mx-auto [&>*]:max-w-3xl" : ""}`}
       >
-        {busy ? (
+        {!canContinue && run.trigger === "background" ? (
+          <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
+            Automatic investigation · read-only. Start a new investigation on
+            this resource to continue digging.
+          </div>
+        ) : busy ? (
           <button
             onClick={stop}
             className="w-full rounded-lg border border-theme-border py-1.5 text-sm text-theme-text-secondary hover:bg-theme-hover"
@@ -635,7 +642,7 @@ export function InvestigationView({
                 }
               }}
               rows={1}
-              disabled={stale}
+              disabled={!canContinue}
               placeholder={
                 stale
                   ? "Cluster changed — re-run Diagnose"

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -390,7 +390,7 @@ export function InvestigationView({
 
   const submitFollowup = () => {
     const q = input.trim();
-    if (!q || busy || stale) return;
+    if (!q || busy || !canContinue) return;
     setInput("");
     setActionError(null);
     pinnedRef.current = true; // a user-initiated turn always follows to the bottom
@@ -403,7 +403,7 @@ export function InvestigationView({
   // Ask a canned follow-up (e.g. "explain simply") — a one-tap path that turns the
   // prompt's plain-language instruction into something the user controls.
   const askFollowup = (q: string) => {
-    if (busy || stale) return;
+    if (busy || !canContinue) return;
     setActionError(null);
     pinnedRef.current = true;
     addTurn(run.id, { question: q }).catch((e) =>
@@ -618,10 +618,11 @@ export function InvestigationView({
       <div
         className={`border-t border-theme-border px-3 py-2.5 ${maximized ? "[&>*]:mx-auto [&>*]:max-w-3xl" : ""}`}
       >
-        {!canContinue && run.trigger === "background" ? (
+        {!canContinue ? (
           <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
-            Automatic investigation · read-only. Start a new investigation on
-            this resource to continue digging.
+            {run.trigger === "background"
+              ? "Automatic investigation · read-only. Start a new investigation on this resource to continue digging."
+              : "This investigation is read-only."}
           </div>
         ) : busy ? (
           <button
@@ -652,7 +653,7 @@ export function InvestigationView({
             />
             <button
               onClick={submitFollowup}
-              disabled={!input.trim() || stale}
+              disabled={!input.trim() || !canContinue}
               className="shrink-0 rounded-lg btn-brand p-2 disabled:opacity-40"
               aria-label="Send follow-up"
             >

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -70,6 +70,13 @@ export function InvestigationView({
   // show a silent blank panel; instead we render a "no longer available" state.
   const [gone, setGone] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Continuation needs a resumable session, but stopping does not. A brand-new
+  // hosted turn can be running before the SDK has reported its session id, so
+  // keep Stop available for human investigations without advertising a
+  // follow-up composer that the server would reject. Automatic runs remain
+  // immutable even while their stream marks this view busy.
+  const canStop =
+    run.trigger !== "background" && (busy || run.status === "running");
   const [input, setInput] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -425,10 +432,13 @@ export function InvestigationView({
     autoRecheckRef.current = true; // verify the write automatically once it lands
     addTurn(run.id, { apply: true, fix: pendingFix }).catch((e) => {
       autoRecheckRef.current = false; // the apply never started — don't auto-recheck
-      setActionError(e instanceof DiagnoseError ? e.message : "Couldn't apply.");
+      setActionError(
+        e instanceof DiagnoseError ? e.message : "Couldn't apply.",
+      );
     });
   };
-  const checkStatus = () => addTurn(run.id, { question: RECHECK_QUESTION }).catch(() => {});
+  const checkStatus = () =>
+    addTurn(run.id, { question: RECHECK_QUESTION }).catch(() => {});
 
   // Apply tracks the latest turn that produced remediation (so follow-ups don't
   // strip it) and is blocked on a stale (context-switched) run.
@@ -463,135 +473,139 @@ export function InvestigationView({
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-0 flex-1">
-      <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 [scrollbar-gutter:stable]"
-      >
-        <div className={maximized ? "mx-auto max-w-3xl" : ""}>
-          <div className="space-y-4">
-            {stale && (
-              <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-theme-text-secondary">
-                <div className="flex items-start gap-2">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-                  <span>
-                    This investigation ran against{" "}
-                    <span className="font-medium text-theme-text-primary">
-                      {run.context || "a different cluster"}
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 [scrollbar-gutter:stable]"
+        >
+          <div className={maximized ? "mx-auto max-w-3xl" : ""}>
+            <div className="space-y-4">
+              {stale && (
+                <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-theme-text-secondary">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                    <span>
+                      This investigation ran against{" "}
+                      <span className="font-medium text-theme-text-primary">
+                        {run.context || "a different cluster"}
+                      </span>
+                      . The cluster context has changed — it's read-only now.
                     </span>
-                    . The cluster context has changed — it's read-only now.
-                  </span>
+                  </div>
+                  <button
+                    onClick={retryDiagnosis}
+                    className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/50 px-2.5 py-1 font-medium text-amber-600 hover:bg-amber-500/10 dark:text-amber-400"
+                  >
+                    <Send className="h-3 w-3" />
+                    Re-run on current cluster
+                  </button>
                 </div>
-                <button
-                  onClick={retryDiagnosis}
-                  className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/50 px-2.5 py-1 font-medium text-amber-600 hover:bg-amber-500/10 dark:text-amber-400"
-                >
-                  <Send className="h-3 w-3" />
-                  Re-run on current cluster
-                </button>
-              </div>
-            )}
-            {gone && turns.length === 0 && (
-              <div className="rounded-lg border border-theme-border bg-theme-elevated p-3 text-sm text-theme-text-secondary">
-                <div className="flex items-start gap-2">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-                  <span>
-                    This investigation is no longer available — history keeps
-                    the most recent investigations, and this one has been
-                    cleared. Re-run Diagnose to analyze the current cluster.
-                  </span>
+              )}
+              {gone && turns.length === 0 && (
+                <div className="rounded-lg border border-theme-border bg-theme-elevated p-3 text-sm text-theme-text-secondary">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                    <span>
+                      This investigation is no longer available — history keeps
+                      the most recent investigations, and this one has been
+                      cleared. Re-run Diagnose to analyze the current cluster.
+                    </span>
+                  </div>
+                  <button
+                    onClick={retryDiagnosis}
+                    className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-theme-border px-2.5 py-1 font-medium text-theme-text-primary hover:bg-theme-hover"
+                  >
+                    <Send className="h-3 w-3" />
+                    Re-run Diagnose
+                  </button>
                 </div>
-                <button
-                  onClick={retryDiagnosis}
-                  className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-theme-border px-2.5 py-1 font-medium text-theme-text-primary hover:bg-theme-hover"
-                >
-                  <Send className="h-3 w-3" />
-                  Re-run Diagnose
-                </button>
-              </div>
-            )}
-            <RunContextCard run={run} />
-            {turns.map((t, i) => {
-              const isLast = i === turns.length - 1;
-              // Hosted runners are read-only — the server refuses apply turns.
-              const canApply = i === lastRemediationIdx && !stale && !hosted;
-              const canCheck = isLast && t.status === "done" && !!t.apply;
-              return (
-                <TurnView
-                  key={i}
-                  turn={t}
-                  synthLabel={isLast ? synth : null}
-                  reveal={isLast ? (reveal ?? "full") : "full"}
-                  onApply={canApply ? requestApply : undefined}
-                  onAsk={isLast && !busy && canContinue ? askFollowup : undefined}
-                  onCheckStatus={canCheck ? checkStatus : undefined}
-                  onRetryDiagnosis={
-                    isLast &&
-                    t.status === "error" &&
-                    !t.question &&
-                    !t.apply &&
-                    !stale
-                      ? retryDiagnosis
-                      : undefined
-                  }
-                  hideVerdict={pinned && i === pinnedIdx}
-                />
-              );
-            })}
-            {actionError && (
-              <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary">
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
-                <span>{actionError}</span>
-              </div>
-            )}
-            {/* A start that failed belongs to the investigation that never began,
+              )}
+              <RunContextCard run={run} />
+              {turns.map((t, i) => {
+                const isLast = i === turns.length - 1;
+                // Hosted runners are read-only — the server refuses apply turns.
+                const canApply = i === lastRemediationIdx && !stale && !hosted;
+                const canCheck = isLast && t.status === "done" && !!t.apply;
+                return (
+                  <TurnView
+                    key={i}
+                    turn={t}
+                    synthLabel={isLast ? synth : null}
+                    reveal={isLast ? (reveal ?? "full") : "full"}
+                    onApply={canApply ? requestApply : undefined}
+                    onAsk={
+                      isLast && !busy && canContinue ? askFollowup : undefined
+                    }
+                    onCheckStatus={canCheck ? checkStatus : undefined}
+                    onRetryDiagnosis={
+                      isLast &&
+                      t.status === "error" &&
+                      !t.question &&
+                      !t.apply &&
+                      !stale
+                        ? retryDiagnosis
+                        : undefined
+                    }
+                    hideVerdict={pinned && i === pinnedIdx}
+                  />
+                );
+              })}
+              {actionError && (
+                <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+                  <span>{actionError}</span>
+                </div>
+              )}
+              {/* A start that failed belongs to the investigation that never began,
                 not to the one on screen. Unlabelled at the foot of a finished
                 transcript — verdict directly above — it reads as "this
                 investigation failed". It also outlives the click that caused it,
                 and this is the only place it surfaces while a run is focused, so
                 it needs a way out. */}
-            {startError && (
-              <div
-                role="alert"
-                className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary"
-              >
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
-                <div className="min-w-0 flex-1">
-                  <div className="font-medium">
-                    Couldn&apos;t start a new investigation
-                  </div>
-                  <div className="text-theme-text-secondary">{startError}</div>
-                </div>
-                <button
-                  onClick={dismissError}
-                  className="shrink-0 rounded px-1.5 py-0.5 text-xs text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+              {startError && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-theme-text-primary"
                 >
-                  Dismiss
-                </button>
-              </div>
-            )}
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium">
+                      Couldn&apos;t start a new investigation
+                    </div>
+                    <div className="text-theme-text-secondary">
+                      {startError}
+                    </div>
+                  </div>
+                  <button
+                    onClick={dismissError}
+                    className="shrink-0 rounded px-1.5 py-0.5 text-xs text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-      {pinned && (
-        <aside
-          className={`w-[400px] shrink-0 overflow-y-auto border-l border-theme-border px-4 py-3 ${busy ? "opacity-70" : ""}`}
-        >
-          <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
-            {busy ? "Verdict · revising…" : "Verdict"}
-          </div>
-          <ResultCard
-            diagnosis={turns[pinnedIdx].diagnosis!}
-            onApply={
-              pinnedIdx === lastRemediationIdx && !stale && !hosted
-                ? requestApply
-                : undefined
-            }
-            onAsk={!busy && canContinue ? askFollowup : undefined}
-            reveal="full"
-          />
-        </aside>
-      )}
+        {pinned && (
+          <aside
+            className={`w-[400px] shrink-0 overflow-y-auto border-l border-theme-border px-4 py-3 ${busy ? "opacity-70" : ""}`}
+          >
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
+              {busy ? "Verdict · revising…" : "Verdict"}
+            </div>
+            <ResultCard
+              diagnosis={turns[pinnedIdx].diagnosis!}
+              onApply={
+                pinnedIdx === lastRemediationIdx && !stale && !hosted
+                  ? requestApply
+                  : undefined
+              }
+              onAsk={!busy && canContinue ? askFollowup : undefined}
+              reveal="full"
+            />
+          </aside>
+        )}
       </div>
 
       {showJump && (
@@ -618,19 +632,19 @@ export function InvestigationView({
       <div
         className={`border-t border-theme-border px-3 py-2.5 ${maximized ? "[&>*]:mx-auto [&>*]:max-w-3xl" : ""}`}
       >
-        {!canContinue ? (
-          <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
-            {run.trigger === "background"
-              ? "Automatic investigation · read-only. Start a new investigation on this resource to continue digging."
-              : "This investigation is read-only."}
-          </div>
-        ) : busy ? (
+        {canStop ? (
           <button
             onClick={stop}
             className="w-full rounded-lg border border-theme-border py-1.5 text-sm text-theme-text-secondary hover:bg-theme-hover"
           >
             Stop
           </button>
+        ) : !canContinue ? (
+          <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
+            {run.trigger === "background"
+              ? "Automatic investigation · read-only. Start a new investigation on this resource to continue digging."
+              : "This investigation is read-only."}
+          </div>
         ) : (
           <div className="flex items-end gap-2">
             <textarea

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -405,6 +405,7 @@ export function AgentControls({
 // or a follow-up, each with its own transcript + result.
 export type Turn = {
   question?: string;
+  actor?: string;
   timeline: TimelineItem[];
   diagnosis: Diagnosis | null;
   error: string | null;
@@ -509,8 +510,15 @@ export function TurnView({
     <div className="space-y-2">
       {turn.question && (
         <div className="flex justify-end">
-          <div className="max-w-[85%] rounded-lg rounded-br-sm bg-accent/10 px-3 py-1.5 text-sm text-theme-text-primary [overflow-wrap:anywhere]">
-            {turn.question}
+          <div className="max-w-[85%]">
+            {turn.actor && (
+              <div className="mb-0.5 text-right text-[10px] text-theme-text-tertiary">
+                {turn.actor}
+              </div>
+            )}
+            <div className="rounded-lg rounded-br-sm bg-accent/10 px-3 py-1.5 text-sm text-theme-text-primary [overflow-wrap:anywhere]">
+              {turn.question}
+            </div>
           </div>
         </div>
       )}

--- a/web/src/components/nav/navigation.test.ts
+++ b/web/src/components/nav/navigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { navigateFromPrimaryRail } from './navigation'
+
+describe('navigateFromPrimaryRail', () => {
+  it('closes an expanded investigation before showing the selected destination', () => {
+    const calls: string[] = []
+
+    navigateFromPrimaryRail(
+      true,
+      () => calls.push('close'),
+      () => calls.push('navigate'),
+    )
+
+    expect(calls).toEqual(['close', 'navigate'])
+  })
+
+  it('keeps a docked investigation open across sidebar navigation', () => {
+    const close = vi.fn()
+    const navigate = vi.fn()
+
+    navigateFromPrimaryRail(false, close, navigate)
+
+    expect(close).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/nav/navigation.ts
+++ b/web/src/components/nav/navigation.ts
@@ -1,0 +1,10 @@
+// Sidebar navigation means “show me that destination.” An expanded investigation
+// obscures it, while a docked investigation intentionally stays alongside it.
+export function navigateFromPrimaryRail(
+  expandedInvestigationOpen: boolean,
+  closeDiagnose: () => void,
+  navigate: () => void,
+) {
+  if (expandedInvestigationOpen) closeDiagnose()
+  navigate()
+}


### PR DESCRIPTION
## Summary

Radar investigations become stable browser state instead of transient panel state. Existing retained runs reopen through `?ai-run=<id>`, survive navigation and reloads, and expose a local `radar_url` in Diagnose/CLI results. When Radar is embedded behind an authorized host, the same UI renders the host's private, organization-shared, and automatic-investigation capabilities.

OSS remains local-first: it gains bookmarkable same-instance URLs, but no copy-link or sharing UI. Cloud collaboration remains entirely server-authorized.

## What changed

### Stable retained-run navigation

- add direct retained-run lookup and URL synchronization for `ai-run`
- preserve the selected run across Radar routes, unrelated query parameters, hashes, Back/Forward, and embedded-router navigation
- render a controlled recovery state when a linked run has expired or been cleared, without repeatedly polling the same missing exact ID
- return `radar_url` from local Diagnose and background/CLI results

### Hosted capability-driven UI

- render copy-link, visibility, ownership, actor attribution, organization history, and automatic-run states only when the host supplies those capabilities
- gate copy-link on a non-empty canonical `radarUrl`, so it is absent in ordinary OSS
- gate sharing controls on `canManageVisibility` and the follow-up composer on `canContinue`
- represent the server's `stopping` state, keep polling while a turn drains, and prevent new starts/follow-ups until it becomes terminal
- let terminal transcript events outrank a lagging `running` summary, without making automatic or genuinely sessionless runs resumable
- keep Stop for a live human turn even before a resumable session exists; automatic runs remain immutable
- disable the composer while the verdict reveal is still finishing so an apparently accepted message cannot be discarded
- remove selected-run actions from the docked History header so it cannot act on a stale transcript
- send the configured host authentication headers on Diagnose API requests

## Behavior by environment

| Behavior | OSS Radar | Radar Cloud |
|---|---|---|
| Retained-run deep link | Same-instance bookmark using `?ai-run=<id>` | Authorized canonical org/cluster/run link |
| Copy investigation link | Not shown | Shown only when Hub supplies `radarUrl` |
| Privacy/organization labels | Not shown | Driven by Hub capabilities |
| Share/unshare | Not available | Creator-only when authorized by Hub |
| Organization history | Not available | Personal and organization sections follow Hub results |
| Automatic-run state | Not synthesized | Organization artifact, explicitly read-only |
| Access boundary | Existing Radar process/server boundary | Enforced by Hub on every read, stream, and mutation |

An OSS URL is not a portable sharing artifact: it works only while the same reachable Radar instance retains that run. This PR adds no OSS identity, permission, cross-instance lookup, or transcript export model.

## Live-tested journeys

| Environment | Journey | Result |
|---|---|---|
| OSS | Open retained history, select a run, reload its `?ai-run=` URL | Exact transcript restored |
| OSS | Navigate to Resources and back with a selected run | Run/query state retained |
| OSS | Navigate from an expanded investigation using the sidebar | Investigation closes and the selected destination is immediately visible |
| OSS | Open a run captured against another cluster | Existing read-only stale-cluster warning shown |
| OSS | Open an unknown run for 10.5s | Controlled unavailable state; no ongoing exact-ID polling |
| OSS | Inspect local retained run at desktop width | No copy button, privacy badge, share control, or organization grouping |
| Cloud | Open/copy/share an owner-private run | Canonical org/cluster/run URL copied; state changes to Organization |
| Cloud | Open the shared run as another org member | Author and transcript shown; follow-up enabled; no visibility control |
| Cloud | Open automatic and sessionless terminal runs | Automatic run read-only with fresh-run escape; sessionless run read-only |
| Cloud | Open a live human run with no session ID | Stop remains available and successfully ends the turn |
| Cloud | Stop while the owning turn drains | UI shows Stopping, keeps polling, and does not offer another start/follow-up |
| Cloud | Receive terminal transcript before summary refresh | Stop disappears immediately; no false read-only flash during verdict reveal |
| Cloud | Open docked History while another run is selected | Header has no stale copy/share/menu actions |
| Cloud | Open an unknown hosted run for 10.5s | One exact GET, then controlled recovery while history polling continues |\n| Cloud | Lose a retained run while its summary still says running | Gone/read-only state; no Stop or follow-up entry point |

## Verification

- frontend suite: 70 files / 583 tests
- `npm run tsc`
- `npm run build`
- repository Go tests/build from the companion QA pass
- OSS and combined Cloud Playwright journeys above at 1280px width
- `git diff --check`
- independent cross-model convergence review: READY

## Dependencies and rollout

This PR is self-contained for OSS bookmark behavior and the hosted component contract. Cloud authorization and durable transcript semantics live in [radar-hub#218](https://github.com/skyhook-dev/radar-hub/pull/218); Fleet handoff and cross-organization bootstrap live in [radar-hub-web#280](https://github.com/skyhook-dev/radar-hub-web/pull/280).

After approval, Cloud rollout requires publishing a new `@skyhook-io/radar-app` version and bumping Hub Web to it. This PR does not publish, tag, deploy, or expand access by itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL/history synchronization, investigation lifecycle gates, and authenticated Diagnose API usage across navigation and cluster switches; sharing UI is capability-gated but org-wide visibility is a sensitive mutation on hosted backends.
> 
> **Overview**
> Investigations are now **bookmarkable browser state** via durable `?ai-run=<id>` links instead of one-shot deep links. The local server adds **`GET /diagnose/runs/{id}`** for runs outside the bounded history list; the diagnose CLI JSON output includes an escaped **`radar_url`**.
> 
> **DiagnoseProvider** keeps the focused run in the URL (with popstate sync and Fleet/embed guards), resolves missing list entries through **`getRun`**, and avoids hammering 404s for cleared runs. **App** navigation and cluster switches preserve `ai-run`; maximized investigations **close before primary-rail navigation** so the destination is visible.
> 
> When the host exposes capabilities, the UI adds **copy-link** (`radarUrl`), **private/organization visibility**, grouped **organization/automatic** history, **actor** labels on turns, and stricter **Stop / follow-up / new investigation** rules for `stopping`, background runs, and lagging summaries. Diagnose API calls send **auth headers**; OSS still has no share/copy UI unless `radarUrl` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d611940d676b27cb8a7a81b37bf4e84f97f1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->