### PR TITLE
fix(k8s-ui): use exact CAPI API-group guards

### DIFF
--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -703,6 +703,27 @@ describe('CAPI Machine kind collisions', () => {
       status: { phase: 'provisioned' },
     })?.text).toBe('Provisioned')
   })
+
+  it.each([
+    ['kubeadmcontrolplanes', 'KubeadmControlPlane', 'controlplane.cluster.x-k8s.io/v1beta1'],
+    ['awsmanagedcontrolplanes', 'AWSManagedControlPlane', 'controlplane.cluster.x-k8s.io/v1beta2'],
+    ['awsmanagedmachinepools', 'AWSManagedMachinePool', 'infrastructure.cluster.x-k8s.io/v1beta2'],
+    ['awsmachines', 'AWSMachine', 'infrastructure.cluster.x-k8s.io/v1beta2'],
+  ])('keeps the topology-owned warning for %s', (plural, kind, apiVersion) => {
+    const html = renderKind(plural, {
+      apiVersion,
+      kind,
+      metadata: {
+        name: 'topology-owned',
+        namespace: 'default',
+        labels: { 'topology.cluster.x-k8s.io/owned': '' },
+      },
+      spec: {},
+      status: {},
+    }, 'default')
+
+    expect(html).toContain('Topology-controlled')
+  })
 })
 
 describe('shared plurals — the status path collides too', () => {

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -651,6 +651,60 @@ describe('colliding plurals — near-match API groups', () => {
   })
 })
 
+describe('CAPI Machine kind collisions', () => {
+  const foreignApiVersion = 'extension.cluster.x-k8s.io/v1'
+
+  it.each([
+    ['machines', 'Machine', 'Role'],
+    ['machinesets', 'MachineSet', 'Delete Policy'],
+  ])('routes a foreign %s CRD through the generic renderer only', (plural, kind, capiMarker) => {
+    const html = renderKind(plural, {
+      apiVersion: foreignApiVersion,
+      kind,
+      metadata: {
+        name: 'foreign',
+        namespace: 'default',
+        labels: { 'topology.cluster.x-k8s.io/owned': '' },
+      },
+      spec: { collisionProbe: COLLISION_PROBE },
+      status: { phase: 'provisioned' },
+    }, 'default')
+
+    expect(html).toContain(COLLISION_PROBE)
+    expect(html).not.toContain(capiMarker)
+    expect(html).not.toContain('Topology-controlled')
+    expect(getResourceStatus(plural, {
+      apiVersion: foreignApiVersion,
+      status: { phase: 'provisioned' },
+    })?.text).toBe('provisioned')
+  })
+
+  it.each([
+    ['machines', 'Machine', 'Role'],
+    ['machinesets', 'MachineSet', 'Delete Policy'],
+  ])('keeps exact-group CAPI %s resources on the dedicated path', (plural, kind, capiMarker) => {
+    const html = renderKind(plural, {
+      apiVersion: 'cluster.x-k8s.io/v1beta1',
+      kind,
+      metadata: {
+        name: 'capi',
+        namespace: 'default',
+        labels: { 'topology.cluster.x-k8s.io/owned': '' },
+      },
+      spec: { collisionProbe: COLLISION_PROBE },
+      status: { phase: 'provisioned' },
+    }, 'default')
+
+    expect(html).toContain(capiMarker)
+    expect(html).toContain('Topology-controlled')
+    expect(html).not.toContain(COLLISION_PROBE)
+    expect(getResourceStatus(plural, {
+      apiVersion: 'cluster.x-k8s.io/v1beta1',
+      status: { phase: 'provisioned' },
+    })?.text).toBe('Provisioned')
+  })
+})
+
 describe('shared plurals — the status path collides too', () => {
   // The renderer and the status badge are two separate switches over the same
   // plural, and fixing one leaves the other reading a foreign CRD's conditions

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -658,11 +658,13 @@ export function ResourceRendererDispatch({
   // them, and `subscriptions` is Knative's as well. Adding a kind to KNOWN_KINDS
   // with a positively-gated render line and forgetting this list is what makes a
   // foreign CRD render a BLANK drawer rather than the generic one.
+  // CAPI's `machines` and `machinesets` need the same protection because another
+  // API group can publish either plural without inheriting CAPI presentation.
   const isGroupGatedKind =
     kind === 'clusters' || kind === 'backups' || kind === 'scheduledbackups' || kind === 'poolers'
     || kind === 'objectstores' || kind === 'databases' || kind === 'publications'
     || kind === 'subscriptions' || kind === 'imagecatalogs' || kind === 'clusterimagecatalogs'
-    || kind === 'policies' || kind === 'rollouts'
+    || kind === 'policies' || kind === 'rollouts' || kind === 'machines' || kind === 'machinesets'
   const isCNPGApiVersion = isApiGroup(data?.apiVersion, CNPG_GROUP)
   const groupGatedMatched =
     (kind === 'clusters' && (isCNPGApiVersion || isApiGroup(data?.apiVersion, 'cluster.x-k8s.io')))
@@ -675,6 +677,8 @@ export function ResourceRendererDispatch({
       && (isCNPGApiVersion || isApiGroup(data?.apiVersion, 'messaging.knative.dev')))
     || (kind === 'policies' && isApiGroup(data?.apiVersion, 'kyverno.io'))
     || (kind === 'rollouts' && isArgoRolloutResource(data))
+    || ((kind === 'machines' || kind === 'machinesets')
+      && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io'))
   const groupGatedFallthrough = isGroupGatedKind && !groupGatedMatched
 
   const calicoApiVersionMatched = isCalicoApiVersion(data?.apiVersion)
@@ -862,15 +866,15 @@ export function ResourceRendererDispatch({
         {kind === 'scheduledbackups' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'poolers' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
-        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && data?.apiVersion?.includes('cluster.x-k8s.io') && (
+        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && (
           <AlertBanner
             variant="warning"
             title="Topology-controlled — this resource is managed by ClusterClass. Manual changes will be reconciled back."
           />
         )}
-        {kind === 'machines' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIMachineRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'machines' && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && <CAPIMachineRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'machinedeployments' && <CAPIMachineDeploymentRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'machinesets' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIMachineSetRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'machinesets' && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && <CAPIMachineSetRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'machinepools' && <CAPIMachinePoolRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'kubeadmcontrolplanes' && <CAPIKubeadmControlPlaneRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusterclasses' && <CAPIClusterClassRenderer data={data} />}
@@ -1187,9 +1191,9 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
     // Third-party `clusters` CRDs (KubeBlocks, Redis/Valkey) fall through to the
     // generic handling below instead of getting a fabricated PostgreSQL status.
   }
-  if (k === 'machines' && data.apiVersion?.includes('cluster.x-k8s.io')) return getMachineStatus(data)
+  if (k === 'machines' && isApiGroup(data.apiVersion, 'cluster.x-k8s.io')) return getMachineStatus(data)
   if (k === 'machinedeployments') return getMachineDeploymentStatus(data)
-  if (k === 'machinesets') return getMachineSetStatus(data)
+  if (k === 'machinesets' && isApiGroup(data.apiVersion, 'cluster.x-k8s.io')) return getMachineSetStatus(data)
   if (k === 'machinepools') return getMachinePoolStatus(data)
   if (k === 'kubeadmcontrolplanes') return getKCPStatus(data)
   if (k === 'clusterclasses') return getClusterClassStatus(data)

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -503,6 +503,20 @@ const KNOWN_KINDS = new Set([
   'functions', 'configurations',
 ])
 
+// Cluster topology owns resources across the core, bootstrap, control-plane,
+// and infrastructure contracts. Keep this explicit: a suffix/substring match
+// would also accept unrelated groups such as extension.cluster.x-k8s.io.
+const CAPI_TOPOLOGY_GROUPS = [
+  'cluster.x-k8s.io',
+  'bootstrap.cluster.x-k8s.io',
+  'controlplane.cluster.x-k8s.io',
+  'infrastructure.cluster.x-k8s.io',
+] as const
+
+function isCAPITopologyGroup(apiVersion?: string): boolean {
+  return CAPI_TOPOLOGY_GROUPS.some(group => isApiGroup(apiVersion, group))
+}
+
 // ============================================================================
 // RESOURCE CONTENT - Delegates to specific renderers
 // ============================================================================
@@ -866,7 +880,7 @@ export function ResourceRendererDispatch({
         {kind === 'scheduledbackups' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'poolers' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
-        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && (
+        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && isCAPITopologyGroup(data?.apiVersion) && (
           <AlertBanner
             variant="warning"
             title="Topology-controlled — this resource is managed by ClusterClass. Manual changes will be reconciled back."


### PR DESCRIPTION
## Summary

- replace substring-based CAPI API-group checks with exact `isApiGroup()` matching
- cover Machine and MachineSet renderer dispatch and status calculation
- prevent foreign CRDs from receiving the topology-controlled warning
- preserve GenericRenderer fall-through for colliding foreign CRDs

## Testing

- `npm test --workspace @skyhook-io/k8s-ui -- src/components/shared/ResourceRendererDispatch.test.tsx`
  - 92 tests passed
- `npm test --workspace @skyhook-io/k8s-ui`
  - 160 test files passed
  - 3319 tests passed, 1 skipped
- `git diff --check`

Fixes #1582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only routing and status labeling in the k8s resource drawer; no cluster mutation or auth changes.
> 
> **Overview**
> **CAPI resource dispatch** no longer treats any `apiVersion` containing `cluster.x-k8s.io` as Cluster API. **Machine** and **MachineSet** renderers and status badges now require the exact **`cluster.x-k8s.io`** group via `isApiGroup()`, and **`machines` / `machinesets`** join the group-gated collision list so foreign CRDs (e.g. `extension.cluster.x-k8s.io`) fall through to **GenericRenderer** instead of a blank or CAPI-specific UI.
> 
> The **topology-controlled** warning is limited to an explicit allowlist of CAPI contract groups (core, bootstrap, control-plane, infrastructure) through **`isCAPITopologyGroup()`**, so unrelated groups with similar names do not show **Topology-controlled** or CAPI status formatting.
> 
> Tests lock in foreign vs exact-group behavior for machines/machinesets and that topology-owned labels still warn on infrastructure/control-plane resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0b258f97dd7a81a159c37a92f1211bfe472477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->