### PR TITLE
chore: give the root workspace an explicit package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "radar",
       "workspaces": [
         "web",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "radar",
   "private": true,
   "workspaces": [
     "web",


### PR DESCRIPTION
Follow-up to #1601, where this was found. Two lines.

## Problem

The root `package.json` declares no `name`. npm therefore derives the lockfile's root name from the checkout directory and rewrites it on the next install ([npm/cli#8008](https://github.com/npm/cli/issues/8008)). Anyone working from a directory not named `radar` — a git worktree, a second clone, a CI checkout at a different path — regenerates `package-lock.json` with an unrelated one-line rename riding on top of whatever they were actually changing.

Not hypothetical: #1601 was built in a worktree and carried a `radar` → `deps-batch` rename in its lockfile until review caught it.

## Reproduction and proof

From a worktree directory named `lockname`, on `main` at 6d05de38:

```
$ npm install --package-lock-only --ignore-scripts
$ head -2 package-lock.json | tail -1
  "name": "lockname",          # was "radar" — churn, from the directory name alone
```

With this change applied, from that same directory:

```
$ npm install --package-lock-only --ignore-scripts
$ head -2 package-lock.json | tail -1
  "name": "radar",             # stable
```

## Why `radar`

It pins the value npm was already deriving in the canonical checkout, so **no existing lockfile entry changes** — the only lockfile line added is `packages[""].name`, npm recording the now-explicit manifest name. Any other name would rewrite the root entry for no reason. The root stays `private: true` and is never published; the workspaces keep their own names (`@skyhook-io/radar-app`, `@skyhook-io/k8s-ui`), so nothing about publishing or resolution changes.

## Verification

- `npm ci` — clean, and does not re-churn the lockfile
- `npm ls --workspaces --depth=0` — both workspaces resolve; root now reports as `radar@`
- `make tsc` — clean
- `make build` — pass (frontend → embed → Go binary)
- `packages/k8s-ui` → `npm test` — 160 files, 3315 passed, 1 skipped
- `web` → `npm test` — 69 files, 569 passed
- Full Go suite not run locally: no Go source, module, or dependency change here; CI's Backend job covers it
- visual-test: skipped (package metadata only, no rendered surface touched)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Root manifest and lockfile metadata only; no runtime, dependency, or workspace resolution behavior changes.
> 
> **Overview**
> Sets **`"name": "radar"`** on the private root `package.json` so npm no longer infers the lockfile root package name from the checkout directory path.
> 
> That pins `package-lock.json`’s `packages[""].name` to **`radar`** and stops one-line lockfile renames when installs run from worktrees, alternate clones, or CI paths that aren’t named `radar`. Workspace packages keep their existing scoped names; publishing and resolution are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236280c1faae60622f39c6627642559ce3361c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->