### PR TITLE
fix(execution): show cleanup TTL for job templates

### DIFF
--- a/web/src/components/execution/BatchExecutionView.render.test.tsx
+++ b/web/src/components/execution/BatchExecutionView.render.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { BatchExecutionFullscreen } from './BatchExecutionView'
+
+vi.mock('../../api/client', () => ({
+  useResource: () => ({}),
+  useWorkloadPods: () => ({}),
+  useWorkloadRuns: () => ({ data: { runs: [] } }),
+}))
+
+describe.each(['Job', 'CronJob', 'ScaledJob'])('%s cleanup retention display', (kind) => {
+  function render(ttlSecondsAfterFinished?: number) {
+    const jobSpec = { ttlSecondsAfterFinished, activeDeadlineSeconds: 60 }
+    const spec = kind === 'CronJob'
+      ? { jobTemplate: { spec: jobSpec } }
+      : kind === 'ScaledJob'
+        ? { jobTargetRef: jobSpec }
+        : jobSpec
+    return renderToStaticMarkup(
+      <BatchExecutionFullscreen kind={kind} apiKind={`${kind.toLowerCase()}s`} namespace="default" name="example" resource={{ spec }} />,
+    )
+  }
+
+  it.each([0, 300])('shows a configured TTL of %i seconds exactly once alongside the definition', (ttl) => {
+    const html = render(ttl)
+    expect(html.match(/TTL after finish/g)).toHaveLength(1)
+    expect(html).toContain(`>${ttl}s<`)
+    expect(html).toContain('>Deadline<')
+    expect(html).toContain('>60s<')
+  })
+
+  it('omits TTL when cleanup retention is unconfigured', () => {
+    expect(render()).not.toContain('TTL after finish')
+  })
+})

--- a/web/src/components/execution/BatchExecutionView.tsx
+++ b/web/src/components/execution/BatchExecutionView.tsx
@@ -475,9 +475,7 @@ function sourceFacts(kind: string, resource: any, runs: WorkloadRun[]) {
       progress: latest?.progress,
       duration: latest ? formatRunDuration(latest) : '',
       work: latest ? workCount(latest) : '',
-      facts: [
-        ['TTL after finish', spec.ttlSecondsAfterFinished != null ? `${spec.ttlSecondsAfterFinished}s` : 'None'],
-      ],
+      facts: [],
       definition,
     }
   }
@@ -544,6 +542,7 @@ function ExecutionDefinitionDetails({ summary, namespace, compact = false }: { s
             <DefinitionFact label="Service account" value={summary.serviceAccount} mono />
             {summary.configMaps.length > 0 && <DefinitionFact label="ConfigMaps" value={summary.configMaps.join(', ')} mono />}
             {summary.secrets.length > 0 && <DefinitionFact label="Secrets" value={summary.secrets.join(', ')} mono />}
+            {summary.ttlAfterFinished && <DefinitionFact label="TTL after finish" value={summary.ttlAfterFinished} />}
           </>
         )}
       </div>

--- a/web/src/components/execution/execution-definition.test.ts
+++ b/web/src/components/execution/execution-definition.test.ts
@@ -48,6 +48,25 @@ describe('executionDefinitionSummary', () => {
     })
   })
 
+  describe.each(['Job', 'CronJob', 'ScaledJob'])('%s retention', (kind) => {
+    function resource(jobSpec: Record<string, unknown>) {
+      if (kind === 'CronJob') return { spec: { jobTemplate: { spec: jobSpec } } }
+      if (kind === 'ScaledJob') return { spec: { jobTargetRef: jobSpec } }
+      return { spec: jobSpec }
+    }
+
+    it.each([0, 300])('keeps a configured TTL of %i seconds separate from the execution deadline', (ttl) => {
+      expect(executionDefinitionSummary(kind, resource({
+        ttlSecondsAfterFinished: ttl,
+        activeDeadlineSeconds: 60,
+      }))).toMatchObject({ ttlAfterFinished: `${ttl}s`, deadline: '60s' })
+    })
+
+    it('does not invent a TTL when cleanup retention is unconfigured', () => {
+      expect(executionDefinitionSummary(kind, resource({}))).not.toHaveProperty('ttlAfterFinished')
+    })
+  })
+
   it('explains Argo DAG shape, executable templates, policy, and dependencies', () => {
     const summary = executionDefinitionSummary('WorkflowTemplate', {
       spec: {

--- a/web/src/components/execution/execution-definition.ts
+++ b/web/src/components/execution/execution-definition.ts
@@ -19,6 +19,7 @@ export interface ExecutionDefinitionSummary {
   serviceAccount: string
   retry: string
   deadline?: string
+  ttlAfterFinished?: string
   parallelism?: string
 }
 
@@ -79,6 +80,7 @@ function kubernetesJobSummary(jobSpec: any): ExecutionDefinitionSummary {
     serviceAccount: podSpec.serviceAccountName || 'default',
     retry: `Backoff limit ${jobSpec.backoffLimit ?? 6} · restart ${podSpec.restartPolicy || 'Never'}`,
     ...(jobSpec.activeDeadlineSeconds != null ? { deadline: `${jobSpec.activeDeadlineSeconds}s` } : {}),
+    ...(jobSpec.ttlSecondsAfterFinished != null ? { ttlAfterFinished: `${jobSpec.ttlSecondsAfterFinished}s` } : {}),
     parallelism: `${parallelism} parallel · ${completions} ${completions === 1 ? 'completion' : 'completions'} · ${completionMode}`,
   }
 }


### PR DESCRIPTION
## Description

Show configured TTL-after-finish in the shared execution definition for Job, CronJob, and ScaledJob. CronJob reads the embedded job template and ScaledJob reads its job target. Cleanup retention stays separate from the execution deadline, and the standalone Job fact is removed to avoid displaying TTL twice.

A configured value of zero is displayed as `0s`; an absent value is omitted.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- 55 execution tests pass, including summary and rendered-component regressions for all three resource shapes with positive, zero, and unconfigured TTL values. The six configured-TTL summary cases failed before the fix.
- Web TypeScript 7 typecheck passes.
- Production frontend build passes, with existing chunk-size and mixed-import warnings.
- Targeted ESLint passes with no errors; 59 existing `no-explicit-any` warnings remain in the two implementation files.

The rendering tests use mocked resource hooks. No live Kubernetes cluster was used.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #1599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in execution UI with no API or cluster behavior impact; covered by new unit and render tests.
> 
> **Overview**
> Fixes missing or duplicated **TTL after finish** in the batch execution UI for **Job**, **CronJob**, and **ScaledJob**.
> 
> `executionDefinitionSummary` now surfaces `ttlSecondsAfterFinished` as `ttlAfterFinished` in the shared job definition summary (CronJob from `jobTemplate.spec`, ScaledJob from `jobTargetRef`), alongside the existing **Deadline** field. Configured values render as seconds (including **`0s`**); unset TTL is omitted instead of showing “None”. The standalone Job-only fact row for TTL is removed so the label appears **once** in the “What it runs” definition block.
> 
> Unit tests cover summary parsing for all three kinds and static render regressions that TTL appears exactly once next to the deadline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081a0097e801bbd06ca84d49ea1e5ec21b168f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->