### PR TITLE
fix(cost): scope OpenCost data to the caller's namespaces

### DIFF
--- a/internal/opencost/handlers.go
+++ b/internal/opencost/handlers.go
@@ -57,6 +57,7 @@ func handleSummary(w http.ResponseWriter, r *http.Request, resolveCurrency func(
 		r.Context(), client.Prom(), pkgopencost.SummaryOptions{
 			Currency:          currency,
 			AllowedNamespaces: scope.Namespaces,
+			CanReadNodes:      scope.CanReadNodes,
 		})
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/opencost/handlers.go
+++ b/internal/opencost/handlers.go
@@ -16,17 +16,28 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// RegisterRoutes registers OpenCost routes on the given router.
-func RegisterRoutes(r chi.Router, resolveCurrency func() string) {
-	r.Get("/opencost/summary", func(w http.ResponseWriter, r *http.Request) { handleSummary(w, r, resolveCurrency) })
-	r.Get("/opencost/workloads", func(w http.ResponseWriter, r *http.Request) { handleWorkloads(w, r, resolveCurrency) })
-	r.Get("/opencost/trend", func(w http.ResponseWriter, r *http.Request) { handleTrend(w, r, resolveCurrency) })
-	r.Get("/opencost/nodes", func(w http.ResponseWriter, r *http.Request) { handleNodes(w, r, resolveCurrency) })
+// RegisterRoutes registers OpenCost routes on the given router. resolveScope
+// is required: these handlers serve cost data pulled under Radar's own
+// identity, so it is the only thing bounding a response to what the caller may
+// see.
+func RegisterRoutes(r chi.Router, resolveCurrency func() string, resolveScope ScopeResolver) {
+	r.Get("/opencost/summary", func(w http.ResponseWriter, r *http.Request) {
+		handleSummary(w, r, resolveCurrency, resolveScope)
+	})
+	r.Get("/opencost/workloads", func(w http.ResponseWriter, r *http.Request) {
+		handleWorkloads(w, r, resolveCurrency, resolveScope)
+	})
+	r.Get("/opencost/trend", func(w http.ResponseWriter, r *http.Request) {
+		handleTrend(w, r, resolveCurrency, resolveScope)
+	})
+	r.Get("/opencost/nodes", func(w http.ResponseWriter, r *http.Request) {
+		handleNodes(w, r, resolveCurrency, resolveScope)
+	})
 }
 
 // handleSummary returns namespace-level cost summary from OpenCost Prometheus metrics.
-func handleSummary(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
-	scope := scopeFor(r)
+func handleSummary(w http.ResponseWriter, r *http.Request, resolveCurrency func() string, resolveScope ScopeResolver) {
+	scope := resolveScope(r)
 	if scope.Restricted() && len(scope.Namespaces) == 0 {
 		writeJSON(w, http.StatusOK, pkgopencost.CostSummary{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Currency: resolvedCurrency(resolveCurrency)})
 		return
@@ -59,14 +70,14 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 }
 
 // handleWorkloads returns workload-level cost breakdown for a namespace.
-func handleWorkloads(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
+func handleWorkloads(w http.ResponseWriter, r *http.Request, resolveCurrency func() string, resolveScope ScopeResolver) {
 	ns := r.URL.Query().Get("namespace")
 	if ns == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace parameter is required"})
 		return
 	}
 
-	scope := scopeFor(r)
+	scope := resolveScope(r)
 	if !scope.Allows(ns) {
 		writeJSON(w, http.StatusOK, pkgopencost.WorkloadCostResponse{
 			Namespace:  ns,
@@ -141,8 +152,8 @@ func stripReplicaSetSuffix(name string) string {
 }
 
 // handleTrend returns cost trend data over time as a stacked series per namespace.
-func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
-	scope := scopeFor(r)
+func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() string, resolveScope ScopeResolver) {
+	scope := resolveScope(r)
 	if scope.Restricted() && len(scope.Namespaces) == 0 {
 		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Range: r.URL.Query().Get("range"), Currency: resolvedCurrency(resolveCurrency)})
 		return
@@ -166,10 +177,10 @@ func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() 
 }
 
 // handleNodes returns per-node cost breakdown.
-func handleNodes(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
+func handleNodes(w http.ResponseWriter, r *http.Request, resolveCurrency func() string, resolveScope ScopeResolver) {
 	// Node spend is cluster-scoped — there is no namespace slice of it to
 	// hand a restricted caller, so it is all or nothing.
-	if !scopeFor(r).CanReadNodes {
+	if !resolveScope(r).CanReadNodes {
 		writeJSON(w, http.StatusOK, pkgopencost.NodeCostResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Currency: resolvedCurrency(resolveCurrency)})
 		return
 	}

--- a/internal/opencost/handlers.go
+++ b/internal/opencost/handlers.go
@@ -26,6 +26,11 @@ func RegisterRoutes(r chi.Router, resolveCurrency func() string) {
 
 // handleSummary returns namespace-level cost summary from OpenCost Prometheus metrics.
 func handleSummary(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
+	scope := scopeFor(r)
+	if scope.Restricted() && len(scope.Namespaces) == 0 {
+		writeJSON(w, http.StatusOK, pkgopencost.CostSummary{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Currency: resolvedCurrency(resolveCurrency)})
+		return
+	}
 	client := prometheuspkg.GetClient()
 	if client == nil {
 		writeJSON(w, http.StatusOK, pkgopencost.CostSummary{Available: false, Reason: pkgopencost.ReasonNoPrometheus, Currency: resolvedCurrency(resolveCurrency)})
@@ -38,7 +43,10 @@ func handleSummary(w http.ResponseWriter, r *http.Request, resolveCurrency func(
 	}
 	currency := resolvedCurrency(resolveCurrency)
 	resp := pkgopencost.ComputeCostSummaryFromProm(
-		r.Context(), client.Prom(), pkgopencost.SummaryOptions{Currency: currency})
+		r.Context(), client.Prom(), pkgopencost.SummaryOptions{
+			Currency:          currency,
+			AllowedNamespaces: scope.Namespaces,
+		})
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -58,6 +66,18 @@ func handleWorkloads(w http.ResponseWriter, r *http.Request, resolveCurrency fun
 		return
 	}
 
+	scope := scopeFor(r)
+	if !scope.Allows(ns) {
+		writeJSON(w, http.StatusOK, pkgopencost.WorkloadCostResponse{
+			Namespace:  ns,
+			Reason:     pkgopencost.ReasonAccessDenied,
+			Restricted: true,
+			Workloads:  []pkgopencost.WorkloadCost{},
+			Currency:   resolvedCurrency(resolveCurrency),
+		})
+		return
+	}
+
 	client := prometheuspkg.GetClient()
 	if client == nil {
 		writeJSON(w, http.StatusOK, pkgopencost.WorkloadCostResponse{Namespace: ns, Reason: pkgopencost.ReasonNoPrometheus, Currency: resolvedCurrency(resolveCurrency)})
@@ -71,6 +91,7 @@ func handleWorkloads(w http.ResponseWriter, r *http.Request, resolveCurrency fun
 
 	resp := pkgopencost.ComputeWorkloadsFromProm(r.Context(), client.Prom(), ns, BuildPodOwnerLookup(ns))
 	resp.Currency = resolvedCurrency(resolveCurrency)
+	resp.Restricted = scope.Restricted()
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -121,6 +142,11 @@ func stripReplicaSetSuffix(name string) string {
 
 // handleTrend returns cost trend data over time as a stacked series per namespace.
 func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
+	scope := scopeFor(r)
+	if scope.Restricted() && len(scope.Namespaces) == 0 {
+		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Range: r.URL.Query().Get("range"), Currency: resolvedCurrency(resolveCurrency)})
+		return
+	}
 	client := prometheuspkg.GetClient()
 	if client == nil {
 		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: pkgopencost.ReasonNoPrometheus, Currency: resolvedCurrency(resolveCurrency)})
@@ -131,13 +157,22 @@ func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() 
 		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: ConnectionFailureReason(err), Currency: resolvedCurrency(resolveCurrency)})
 		return
 	}
-	resp := pkgopencost.ComputeCostTrendFromProm(r.Context(), client.Prom(), pkgopencost.TrendPromOptions{Range: r.URL.Query().Get("range")})
+	resp := pkgopencost.ComputeCostTrendFromProm(r.Context(), client.Prom(), pkgopencost.TrendPromOptions{
+		Range:             r.URL.Query().Get("range"),
+		AllowedNamespaces: scope.Namespaces,
+	})
 	resp.Currency = resolvedCurrency(resolveCurrency)
 	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleNodes returns per-node cost breakdown.
 func handleNodes(w http.ResponseWriter, r *http.Request, resolveCurrency func() string) {
+	// Node spend is cluster-scoped — there is no namespace slice of it to
+	// hand a restricted caller, so it is all or nothing.
+	if !scopeFor(r).CanReadNodes {
+		writeJSON(w, http.StatusOK, pkgopencost.NodeCostResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Currency: resolvedCurrency(resolveCurrency)})
+		return
+	}
 	client := prometheuspkg.GetClient()
 	if client == nil {
 		writeJSON(w, http.StatusOK, pkgopencost.NodeCostResponse{Available: false, Reason: pkgopencost.ReasonNoPrometheus, Currency: resolvedCurrency(resolveCurrency)})

--- a/internal/opencost/handlers.go
+++ b/internal/opencost/handlers.go
@@ -155,7 +155,7 @@ func stripReplicaSetSuffix(name string) string {
 func handleTrend(w http.ResponseWriter, r *http.Request, resolveCurrency func() string, resolveScope ScopeResolver) {
 	scope := resolveScope(r)
 	if scope.Restricted() && len(scope.Namespaces) == 0 {
-		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Range: r.URL.Query().Get("range"), Currency: resolvedCurrency(resolveCurrency)})
+		writeJSON(w, http.StatusOK, pkgopencost.CostTrendResponse{Available: false, Reason: pkgopencost.ReasonAccessDenied, Restricted: true, Range: pkgopencost.TrendRangeLabel(r.URL.Query().Get("range")), Currency: resolvedCurrency(resolveCurrency)})
 		return
 	}
 	client := prometheuspkg.GetClient()

--- a/internal/opencost/handlers_scope_test.go
+++ b/internal/opencost/handlers_scope_test.go
@@ -67,20 +67,20 @@ func startFakeProm(t *testing.T) {
 		srv.Close()
 		prometheuspkg.Reset()
 		prometheuspkg.Initialize(nil, nil, "")
-		SetScopeResolver(nil)
 	})
 }
 
-func withScope(t *testing.T, scope Scope) {
-	t.Helper()
-	SetScopeResolver(func(*http.Request) Scope { return scope })
-	t.Cleanup(func() { SetScopeResolver(nil) })
+// unrestricted is the scope a no-auth or cluster-admin caller resolves to.
+var unrestricted = Scope{CanReadNodes: true}
+
+func fixedScope(scope Scope) ScopeResolver {
+	return func(*http.Request) Scope { return scope }
 }
 
-func getSummary(t *testing.T) *pkgopencost.CostSummary {
+func getSummary(t *testing.T, scope Scope) *pkgopencost.CostSummary {
 	t.Helper()
 	w := httptest.NewRecorder()
-	handleSummary(w, httptest.NewRequest(http.MethodGet, "/opencost/summary", nil), func() string { return "USD" })
+	handleSummary(w, httptest.NewRequest(http.MethodGet, "/opencost/summary", nil), func() string { return "USD" }, fixedScope(scope))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -101,9 +101,8 @@ func namespaceNames(rows []pkgopencost.NamespaceCost) []string {
 
 func TestSummaryUnrestrictedReturnsEveryNamespace(t *testing.T) {
 	startFakeProm(t)
-	SetScopeResolver(nil)
 
-	got := getSummary(t)
+	got := getSummary(t, unrestricted)
 	if !got.Available {
 		t.Fatalf("Available = false, reason = %q", got.Reason)
 	}
@@ -117,9 +116,8 @@ func TestSummaryUnrestrictedReturnsEveryNamespace(t *testing.T) {
 
 func TestSummaryIsFilteredToTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: false})
 
-	got := getSummary(t)
+	got := getSummary(t, Scope{Namespaces: []string{"team-a"}})
 	if !got.Available {
 		t.Fatalf("Available = false, reason = %q", got.Reason)
 	}
@@ -136,13 +134,8 @@ func TestSummaryIsFilteredToTheUsersNamespaces(t *testing.T) {
 func TestSummaryTotalExcludesNamespacesTheUserCannotSee(t *testing.T) {
 	startFakeProm(t)
 
-	withScope(t, Scope{Namespaces: nil, CanReadNodes: true})
-	clusterTotal := getSummary(t).TotalHourlyCost
-
-	SetScopeResolver(func(*http.Request) Scope {
-		return Scope{Namespaces: []string{"team-a"}, CanReadNodes: false}
-	})
-	restricted := getSummary(t)
+	clusterTotal := getSummary(t, unrestricted).TotalHourlyCost
+	restricted := getSummary(t, Scope{Namespaces: []string{"team-a"}})
 
 	var rowSum float64
 	for _, row := range restricted.Namespaces {
@@ -158,9 +151,8 @@ func TestSummaryTotalExcludesNamespacesTheUserCannotSee(t *testing.T) {
 
 func TestSummaryDeniedWhenUserHasNoNamespaces(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{}})
 
-	got := getSummary(t)
+	got := getSummary(t, Scope{Namespaces: []string{}})
 	if got.Available {
 		t.Error("Available = true, want false")
 	}
@@ -175,10 +167,10 @@ func TestSummaryDeniedWhenUserHasNoNamespaces(t *testing.T) {
 	}
 }
 
-func getWorkloads(t *testing.T, namespace string) *pkgopencost.WorkloadCostResponse {
+func getWorkloads(t *testing.T, scope Scope, namespace string) *pkgopencost.WorkloadCostResponse {
 	t.Helper()
 	w := httptest.NewRecorder()
-	handleWorkloads(w, httptest.NewRequest(http.MethodGet, "/opencost/workloads?namespace="+namespace, nil), func() string { return "USD" })
+	handleWorkloads(w, httptest.NewRequest(http.MethodGet, "/opencost/workloads?namespace="+namespace, nil), func() string { return "USD" }, fixedScope(scope))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -191,9 +183,8 @@ func getWorkloads(t *testing.T, namespace string) *pkgopencost.WorkloadCostRespo
 
 func TestWorkloadsDeniedOutsideTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{"team-a"}})
 
-	got := getWorkloads(t, "team-b")
+	got := getWorkloads(t, Scope{Namespaces: []string{"team-a"}}, "team-b")
 	if got.Available {
 		t.Error("Available = true, want false for a namespace the user cannot see")
 	}
@@ -210,26 +201,24 @@ func TestWorkloadsDeniedOutsideTheUsersNamespaces(t *testing.T) {
 
 func TestWorkloadsServedInsideTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{"team-a"}})
 
-	if got := getWorkloads(t, "team-a"); got.Reason == pkgopencost.ReasonAccessDenied {
+	if got := getWorkloads(t, Scope{Namespaces: []string{"team-a"}}, "team-a"); got.Reason == pkgopencost.ReasonAccessDenied {
 		t.Error("an in-scope namespace must not be denied")
 	}
 }
 
 func TestWorkloadsUnrestrictedIsUnchanged(t *testing.T) {
 	startFakeProm(t)
-	SetScopeResolver(nil)
 
-	if got := getWorkloads(t, "team-b"); got.Reason == pkgopencost.ReasonAccessDenied {
+	if got := getWorkloads(t, unrestricted, "team-b"); got.Reason == pkgopencost.ReasonAccessDenied {
 		t.Error("unrestricted caller must not be denied")
 	}
 }
 
-func getTrend(t *testing.T) *pkgopencost.CostTrendResponse {
+func getTrend(t *testing.T, scope Scope) *pkgopencost.CostTrendResponse {
 	t.Helper()
 	w := httptest.NewRecorder()
-	handleTrend(w, httptest.NewRequest(http.MethodGet, "/opencost/trend?range=24h", nil), func() string { return "USD" })
+	handleTrend(w, httptest.NewRequest(http.MethodGet, "/opencost/trend?range=24h", nil), func() string { return "USD" }, fixedScope(scope))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -243,13 +232,11 @@ func getTrend(t *testing.T) *pkgopencost.CostTrendResponse {
 func TestTrendSeriesFilteredToTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
 
-	SetScopeResolver(nil)
-	if all := getTrend(t); len(all.Series) < 2 {
+	if all := getTrend(t, unrestricted); len(all.Series) < 2 {
 		t.Fatalf("fixture produced %d series, need at least 2 to prove filtering", len(all.Series))
 	}
 
-	withScope(t, Scope{Namespaces: []string{"team-a"}})
-	got := getTrend(t)
+	got := getTrend(t, Scope{Namespaces: []string{"team-a"}})
 	if len(got.Series) != 1 || got.Series[0].Namespace != "team-a" {
 		t.Fatalf("series = %+v, want only team-a", got.Series)
 	}
@@ -260,9 +247,8 @@ func TestTrendSeriesFilteredToTheUsersNamespaces(t *testing.T) {
 
 func TestTrendDeniedWhenUserHasNoNamespaces(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{}})
 
-	got := getTrend(t)
+	got := getTrend(t, Scope{Namespaces: []string{}})
 	if got.Available {
 		t.Error("Available = true, want false")
 	}
@@ -274,10 +260,10 @@ func TestTrendDeniedWhenUserHasNoNamespaces(t *testing.T) {
 	}
 }
 
-func getNodes(t *testing.T) *pkgopencost.NodeCostResponse {
+func getNodes(t *testing.T, scope Scope) *pkgopencost.NodeCostResponse {
 	t.Helper()
 	w := httptest.NewRecorder()
-	handleNodes(w, httptest.NewRequest(http.MethodGet, "/opencost/nodes", nil), func() string { return "USD" })
+	handleNodes(w, httptest.NewRequest(http.MethodGet, "/opencost/nodes", nil), func() string { return "USD" }, fixedScope(scope))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -292,9 +278,8 @@ func getNodes(t *testing.T) *pkgopencost.NodeCostResponse {
 // so a user without `list nodes` gets nothing rather than a partial figure.
 func TestNodesDeniedWithoutNodeReadAccess(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: false})
 
-	got := getNodes(t)
+	got := getNodes(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: false})
 	if got.Available {
 		t.Error("Available = true, want false")
 	}
@@ -308,9 +293,8 @@ func TestNodesDeniedWithoutNodeReadAccess(t *testing.T) {
 
 func TestNodesServedWithNodeReadAccess(t *testing.T) {
 	startFakeProm(t)
-	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: true})
 
-	got := getNodes(t)
+	got := getNodes(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: true})
 	if got.Reason == pkgopencost.ReasonAccessDenied {
 		t.Error("a caller with list-nodes must not be denied")
 	}
@@ -321,9 +305,8 @@ func TestNodesServedWithNodeReadAccess(t *testing.T) {
 
 func TestNodesUnrestrictedIsUnchanged(t *testing.T) {
 	startFakeProm(t)
-	SetScopeResolver(nil)
 
-	got := getNodes(t)
+	got := getNodes(t, unrestricted)
 	if !got.Available || len(got.Nodes) == 0 {
 		t.Errorf("unrestricted caller lost node costs: %+v", got)
 	}

--- a/internal/opencost/handlers_scope_test.go
+++ b/internal/opencost/handlers_scope_test.go
@@ -203,8 +203,8 @@ func TestWorkloadsServedInsideTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
 
 	got := getWorkloads(t, Scope{Namespaces: []string{"team-a"}}, "team-a")
-	if got.Reason == pkgopencost.ReasonAccessDenied {
-		t.Error("an in-scope namespace must not be denied")
+	if !got.Available {
+		t.Errorf("Available = false (reason %q), want true — an in-scope namespace was not served", got.Reason)
 	}
 	if !got.Restricted {
 		t.Error("Restricted = false, want true — the caller is namespace-scoped")
@@ -215,8 +215,11 @@ func TestWorkloadsUnrestrictedIsUnchanged(t *testing.T) {
 	startFakeProm(t)
 
 	got := getWorkloads(t, unrestricted, "team-b")
-	if got.Reason == pkgopencost.ReasonAccessDenied {
-		t.Error("unrestricted caller must not be denied")
+	// Assert Available, not merely "not denied": with Prometheus absent the
+	// response is unavailable/no_prometheus, so a not-denied check alone would
+	// pass without the request ever reaching the compute layer.
+	if !got.Available {
+		t.Errorf("Available = false (reason %q), want true — the unrestricted caller was not served", got.Reason)
 	}
 	if got.Restricted {
 		t.Error("Restricted = true, want false for an unrestricted caller")

--- a/internal/opencost/handlers_scope_test.go
+++ b/internal/opencost/handlers_scope_test.go
@@ -129,8 +129,8 @@ func TestSummaryIsFilteredToTheUsersNamespaces(t *testing.T) {
 	}
 }
 
-// The regression the discussion actually reports: a namespace-scoped user was
-// shown the cluster total. The total must not exceed what their own rows sum to.
+// A restricted total must never exceed the sum of the rows the caller can see.
+// Any excess is cluster spend they are not entitled to.
 func TestSummaryTotalExcludesNamespacesTheUserCannotSee(t *testing.T) {
 	startFakeProm(t)
 

--- a/internal/opencost/handlers_scope_test.go
+++ b/internal/opencost/handlers_scope_test.go
@@ -1,0 +1,330 @@
+package opencost
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
+	pkgopencost "github.com/skyhook-io/radar/pkg/opencost"
+)
+
+// startFakeProm serves cost metrics for team-a, team-b and kube-system so the
+// scope tests can assert on which namespaces survive to the response.
+func startFakeProm(t *testing.T) {
+	t.Helper()
+
+	vector := func(label string, samples map[string]string) string {
+		parts := make([]string, 0, len(samples))
+		for name, value := range samples {
+			parts = append(parts, `{"metric":{"`+label+`":"`+name+`"},"value":[1700000000,"`+value+`"]}`)
+		}
+		return `{"status":"success","data":{"resultType":"vector","result":[` + strings.Join(parts, ",") + `]}}`
+	}
+	matrix := func(samples map[string]string) string {
+		parts := make([]string, 0, len(samples))
+		for ns, value := range samples {
+			parts = append(parts, `{"metric":{"namespace":"`+ns+`"},"values":[[1700000000,"`+value+`"]]}`)
+		}
+		return `{"status":"success","data":{"resultType":"matrix","result":[` + strings.Join(parts, ",") + `]}}`
+	}
+
+	namespaceSamples := map[string]string{"team-a": "3", "team-b": "2", "kube-system": "1"}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = r.ParseForm()
+		query := r.Form.Get("query")
+
+		if query == "up" {
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"prometheus"},"value":[1700000000,"1"]}]}}`))
+			return
+		}
+		if r.URL.Path == "/api/v1/query_range" {
+			_, _ = w.Write([]byte(matrix(namespaceSamples)))
+			return
+		}
+		// Order matters: the per-namespace allocation queries join against the
+		// node cost metrics, so they mention both. Namespace grouping wins.
+		if strings.Contains(query, "by (namespace)") {
+			_, _ = w.Write([]byte(vector("namespace", namespaceSamples)))
+			return
+		}
+		if strings.Contains(query, "node_total_hourly_cost") || strings.Contains(query, "node_cpu_hourly_cost") || strings.Contains(query, "node_ram_hourly_cost") {
+			// Cluster-scoped node series, and the summary's node-total ceiling —
+			// deliberately larger than the sum of the namespace rows.
+			_, _ = w.Write([]byte(vector("node", map[string]string{"node-1": "6", "node-2": "4"})))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+
+	prometheuspkg.Initialize(nil, nil, "test")
+	prometheuspkg.SetManualURL(srv.URL)
+	t.Cleanup(func() {
+		srv.Close()
+		prometheuspkg.Reset()
+		prometheuspkg.Initialize(nil, nil, "")
+		SetScopeResolver(nil)
+	})
+}
+
+func withScope(t *testing.T, scope Scope) {
+	t.Helper()
+	SetScopeResolver(func(*http.Request) Scope { return scope })
+	t.Cleanup(func() { SetScopeResolver(nil) })
+}
+
+func getSummary(t *testing.T) *pkgopencost.CostSummary {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handleSummary(w, httptest.NewRequest(http.MethodGet, "/opencost/summary", nil), func() string { return "USD" })
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body pkgopencost.CostSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	return &body
+}
+
+func namespaceNames(rows []pkgopencost.NamespaceCost) []string {
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.Name)
+	}
+	return names
+}
+
+func TestSummaryUnrestrictedReturnsEveryNamespace(t *testing.T) {
+	startFakeProm(t)
+	SetScopeResolver(nil)
+
+	got := getSummary(t)
+	if !got.Available {
+		t.Fatalf("Available = false, reason = %q", got.Reason)
+	}
+	if len(got.Namespaces) != 3 {
+		t.Errorf("namespaces = %v, want all three", namespaceNames(got.Namespaces))
+	}
+	if got.Restricted {
+		t.Error("Restricted = true, want false for an unrestricted caller")
+	}
+}
+
+func TestSummaryIsFilteredToTheUsersNamespaces(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: false})
+
+	got := getSummary(t)
+	if !got.Available {
+		t.Fatalf("Available = false, reason = %q", got.Reason)
+	}
+	if names := namespaceNames(got.Namespaces); len(names) != 1 || names[0] != "team-a" {
+		t.Fatalf("namespaces = %v, want only [team-a]", names)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true so the UI can label the view")
+	}
+}
+
+// The regression the discussion actually reports: a namespace-scoped user was
+// shown the cluster total. The total must not exceed what their own rows sum to.
+func TestSummaryTotalExcludesNamespacesTheUserCannotSee(t *testing.T) {
+	startFakeProm(t)
+
+	withScope(t, Scope{Namespaces: nil, CanReadNodes: true})
+	clusterTotal := getSummary(t).TotalHourlyCost
+
+	SetScopeResolver(func(*http.Request) Scope {
+		return Scope{Namespaces: []string{"team-a"}, CanReadNodes: false}
+	})
+	restricted := getSummary(t)
+
+	var rowSum float64
+	for _, row := range restricted.Namespaces {
+		rowSum += row.HourlyCost
+	}
+	if restricted.TotalHourlyCost != rowSum {
+		t.Errorf("TotalHourlyCost = %v, want %v (the sum of the visible rows)", restricted.TotalHourlyCost, rowSum)
+	}
+	if restricted.TotalHourlyCost >= clusterTotal {
+		t.Errorf("restricted total %v is not below the cluster total %v — cost is still leaking", restricted.TotalHourlyCost, clusterTotal)
+	}
+}
+
+func TestSummaryDeniedWhenUserHasNoNamespaces(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{}})
+
+	got := getSummary(t)
+	if got.Available {
+		t.Error("Available = true, want false")
+	}
+	if got.Reason != pkgopencost.ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, pkgopencost.ReasonAccessDenied)
+	}
+	if len(got.Namespaces) != 0 {
+		t.Errorf("namespaces = %v, want none", namespaceNames(got.Namespaces))
+	}
+	if got.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", got.Currency)
+	}
+}
+
+func getWorkloads(t *testing.T, namespace string) *pkgopencost.WorkloadCostResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handleWorkloads(w, httptest.NewRequest(http.MethodGet, "/opencost/workloads?namespace="+namespace, nil), func() string { return "USD" })
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body pkgopencost.WorkloadCostResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	return &body
+}
+
+func TestWorkloadsDeniedOutsideTheUsersNamespaces(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{"team-a"}})
+
+	got := getWorkloads(t, "team-b")
+	if got.Available {
+		t.Error("Available = true, want false for a namespace the user cannot see")
+	}
+	if got.Reason != pkgopencost.ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, pkgopencost.ReasonAccessDenied)
+	}
+	if len(got.Workloads) != 0 {
+		t.Errorf("Workloads = %+v, want none", got.Workloads)
+	}
+	if got.Namespace != "team-b" || got.Currency != "USD" {
+		t.Errorf("denied response lost its envelope: %+v", got)
+	}
+}
+
+func TestWorkloadsServedInsideTheUsersNamespaces(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{"team-a"}})
+
+	if got := getWorkloads(t, "team-a"); got.Reason == pkgopencost.ReasonAccessDenied {
+		t.Error("an in-scope namespace must not be denied")
+	}
+}
+
+func TestWorkloadsUnrestrictedIsUnchanged(t *testing.T) {
+	startFakeProm(t)
+	SetScopeResolver(nil)
+
+	if got := getWorkloads(t, "team-b"); got.Reason == pkgopencost.ReasonAccessDenied {
+		t.Error("unrestricted caller must not be denied")
+	}
+}
+
+func getTrend(t *testing.T) *pkgopencost.CostTrendResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handleTrend(w, httptest.NewRequest(http.MethodGet, "/opencost/trend?range=24h", nil), func() string { return "USD" })
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body pkgopencost.CostTrendResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	return &body
+}
+
+func TestTrendSeriesFilteredToTheUsersNamespaces(t *testing.T) {
+	startFakeProm(t)
+
+	SetScopeResolver(nil)
+	if all := getTrend(t); len(all.Series) < 2 {
+		t.Fatalf("fixture produced %d series, need at least 2 to prove filtering", len(all.Series))
+	}
+
+	withScope(t, Scope{Namespaces: []string{"team-a"}})
+	got := getTrend(t)
+	if len(got.Series) != 1 || got.Series[0].Namespace != "team-a" {
+		t.Fatalf("series = %+v, want only team-a", got.Series)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true")
+	}
+}
+
+func TestTrendDeniedWhenUserHasNoNamespaces(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{}})
+
+	got := getTrend(t)
+	if got.Available {
+		t.Error("Available = true, want false")
+	}
+	if got.Reason != pkgopencost.ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, pkgopencost.ReasonAccessDenied)
+	}
+	if len(got.Series) != 0 {
+		t.Errorf("Series = %+v, want none", got.Series)
+	}
+}
+
+func getNodes(t *testing.T) *pkgopencost.NodeCostResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handleNodes(w, httptest.NewRequest(http.MethodGet, "/opencost/nodes", nil), func() string { return "USD" })
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body pkgopencost.NodeCostResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	return &body
+}
+
+// Node cost is cluster-scoped — there is no per-namespace slice of it to show,
+// so a user without `list nodes` gets nothing rather than a partial figure.
+func TestNodesDeniedWithoutNodeReadAccess(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: false})
+
+	got := getNodes(t)
+	if got.Available {
+		t.Error("Available = true, want false")
+	}
+	if got.Reason != pkgopencost.ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, pkgopencost.ReasonAccessDenied)
+	}
+	if len(got.Nodes) != 0 {
+		t.Errorf("Nodes = %+v, want none", got.Nodes)
+	}
+}
+
+func TestNodesServedWithNodeReadAccess(t *testing.T) {
+	startFakeProm(t)
+	withScope(t, Scope{Namespaces: []string{"team-a"}, CanReadNodes: true})
+
+	got := getNodes(t)
+	if got.Reason == pkgopencost.ReasonAccessDenied {
+		t.Error("a caller with list-nodes must not be denied")
+	}
+	if !got.Available || len(got.Nodes) == 0 {
+		t.Errorf("want node costs, got %+v", got)
+	}
+}
+
+func TestNodesUnrestrictedIsUnchanged(t *testing.T) {
+	startFakeProm(t)
+	SetScopeResolver(nil)
+
+	got := getNodes(t)
+	if !got.Available || len(got.Nodes) == 0 {
+		t.Errorf("unrestricted caller lost node costs: %+v", got)
+	}
+}

--- a/internal/opencost/handlers_scope_test.go
+++ b/internal/opencost/handlers_scope_test.go
@@ -202,16 +202,24 @@ func TestWorkloadsDeniedOutsideTheUsersNamespaces(t *testing.T) {
 func TestWorkloadsServedInsideTheUsersNamespaces(t *testing.T) {
 	startFakeProm(t)
 
-	if got := getWorkloads(t, Scope{Namespaces: []string{"team-a"}}, "team-a"); got.Reason == pkgopencost.ReasonAccessDenied {
+	got := getWorkloads(t, Scope{Namespaces: []string{"team-a"}}, "team-a")
+	if got.Reason == pkgopencost.ReasonAccessDenied {
 		t.Error("an in-scope namespace must not be denied")
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true — the caller is namespace-scoped")
 	}
 }
 
 func TestWorkloadsUnrestrictedIsUnchanged(t *testing.T) {
 	startFakeProm(t)
 
-	if got := getWorkloads(t, unrestricted, "team-b"); got.Reason == pkgopencost.ReasonAccessDenied {
+	got := getWorkloads(t, unrestricted, "team-b")
+	if got.Reason == pkgopencost.ReasonAccessDenied {
 		t.Error("unrestricted caller must not be denied")
+	}
+	if got.Restricted {
+		t.Error("Restricted = true, want false for an unrestricted caller")
 	}
 }
 
@@ -257,6 +265,9 @@ func TestTrendDeniedWhenUserHasNoNamespaces(t *testing.T) {
 	}
 	if len(got.Series) != 0 {
 		t.Errorf("Series = %+v, want none", got.Series)
+	}
+	if got.Range != "24h" {
+		t.Errorf("Range = %q, want the normalized 24h the query path would echo", got.Range)
 	}
 }
 

--- a/internal/opencost/handlers_test.go
+++ b/internal/opencost/handlers_test.go
@@ -13,7 +13,7 @@ func TestUnavailableResponsesIncludeCurrency(t *testing.T) {
 	tests := []struct {
 		name    string
 		target  string
-		handler func(http.ResponseWriter, *http.Request, func() string)
+		handler func(http.ResponseWriter, *http.Request, func() string, ScopeResolver)
 	}{
 		{name: "summary", target: "/opencost/summary", handler: handleSummary},
 		{name: "workloads", target: "/opencost/workloads?namespace=default", handler: handleWorkloads},
@@ -24,7 +24,7 @@ func TestUnavailableResponsesIncludeCurrency(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
 			w := httptest.NewRecorder()
-			tt.handler(w, req, func() string { return "GBP" })
+			tt.handler(w, req, func() string { return "GBP" }, fixedScope(unrestricted))
 
 			if w.Code != http.StatusOK {
 				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
@@ -66,7 +66,7 @@ func TestConnectedResponsesIncludeCurrency(t *testing.T) {
 	tests := []struct {
 		name    string
 		target  string
-		handler func(http.ResponseWriter, *http.Request, func() string)
+		handler func(http.ResponseWriter, *http.Request, func() string, ScopeResolver)
 	}{
 		{name: "summary", target: "/opencost/summary", handler: handleSummary},
 		{name: "workloads", target: "/opencost/workloads?namespace=default", handler: handleWorkloads},
@@ -76,7 +76,7 @@ func TestConnectedResponsesIncludeCurrency(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			tt.handler(w, httptest.NewRequest(http.MethodGet, tt.target, nil), func() string { return "GBP" })
+			tt.handler(w, httptest.NewRequest(http.MethodGet, tt.target, nil), func() string { return "GBP" }, fixedScope(unrestricted))
 
 			if w.Code != http.StatusOK {
 				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())

--- a/internal/opencost/scope.go
+++ b/internal/opencost/scope.go
@@ -1,0 +1,62 @@
+package opencost
+
+import (
+	"net/http"
+	"slices"
+	"sync/atomic"
+)
+
+// Scope is what the calling user is allowed to see cost data for. The cost
+// endpoints read OpenCost metrics out of Prometheus under Radar's own
+// identity, so nothing in the query path is bounded by the caller's RBAC —
+// without this, a namespace-restricted user is served cluster-wide spend.
+//
+// Server.getUserNamespaces / Server.canRead are the concrete implementations;
+// passing them via SetScopeResolver avoids an import cycle (server imports
+// opencost, not the other way around).
+type Scope struct {
+	// Namespaces the caller may see. nil means unrestricted; an empty non-nil
+	// slice means no namespace access at all. Mirrors
+	// auth.FilterNamespacesForUser's nil-vs-empty contract, so the no-auth and
+	// cluster-admin paths stay unrestricted by construction.
+	Namespaces []string
+
+	// CanReadNodes gates the cluster-scoped node cost breakdown. Node spend
+	// has no per-namespace slice, so it is a separate grant rather than
+	// something inferred from namespace access.
+	CanReadNodes bool
+}
+
+// Restricted reports whether the caller sees less than the whole cluster.
+func (s Scope) Restricted() bool { return s.Namespaces != nil }
+
+// Allows reports whether namespace is within the caller's scope.
+func (s Scope) Allows(namespace string) bool {
+	return s.Namespaces == nil || slices.Contains(s.Namespaces, namespace)
+}
+
+// ScopeResolver derives the calling user's Scope from their request.
+type ScopeResolver func(r *http.Request) Scope
+
+var scopeResolver atomic.Pointer[ScopeResolver]
+
+// SetScopeResolver installs the request-scoped authorization lookup. Pass nil
+// to clear it (only appropriate for tests and the no-auth local path).
+func SetScopeResolver(fn ScopeResolver) {
+	if fn == nil {
+		scopeResolver.Store(nil)
+		return
+	}
+	scopeResolver.Store(&fn)
+}
+
+// scopeFor consults the installed resolver. With none installed the caller is
+// unrestricted, so the gate stays strictly additive and never locks out the
+// OSS no-auth path.
+func scopeFor(r *http.Request) Scope {
+	resolver := scopeResolver.Load()
+	if resolver == nil {
+		return Scope{CanReadNodes: true}
+	}
+	return (*resolver)(r)
+}

--- a/internal/opencost/scope.go
+++ b/internal/opencost/scope.go
@@ -3,17 +3,12 @@ package opencost
 import (
 	"net/http"
 	"slices"
-	"sync/atomic"
 )
 
 // Scope is what the calling user is allowed to see cost data for. The cost
 // endpoints read OpenCost metrics out of Prometheus under Radar's own
 // identity, so nothing in the query path is bounded by the caller's RBAC —
 // without this, a namespace-restricted user is served cluster-wide spend.
-//
-// Server.getUserNamespaces / Server.canRead are the concrete implementations;
-// passing them via SetScopeResolver avoids an import cycle (server imports
-// opencost, not the other way around).
 type Scope struct {
 	// Namespaces the caller may see. nil means unrestricted; an empty non-nil
 	// slice means no namespace access at all. Mirrors
@@ -36,27 +31,6 @@ func (s Scope) Allows(namespace string) bool {
 }
 
 // ScopeResolver derives the calling user's Scope from their request.
+// Server.openCostScope is the concrete implementation; RegisterRoutes takes it
+// as an argument because server imports opencost, not the other way around.
 type ScopeResolver func(r *http.Request) Scope
-
-var scopeResolver atomic.Pointer[ScopeResolver]
-
-// SetScopeResolver installs the request-scoped authorization lookup. Pass nil
-// to clear it (only appropriate for tests and the no-auth local path).
-func SetScopeResolver(fn ScopeResolver) {
-	if fn == nil {
-		scopeResolver.Store(nil)
-		return
-	}
-	scopeResolver.Store(&fn)
-}
-
-// scopeFor consults the installed resolver. With none installed the caller is
-// unrestricted, so the gate stays strictly additive and never locks out the
-// OSS no-auth path.
-func scopeFor(r *http.Request) Scope {
-	resolver := scopeResolver.Load()
-	if resolver == nil {
-		return Scope{CanReadNodes: true}
-	}
-	return (*resolver)(r)
-}

--- a/internal/opencost/scope_test.go
+++ b/internal/opencost/scope_test.go
@@ -1,59 +1,23 @@
 package opencost
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-)
+import "testing"
 
-func TestScopeForIsUnrestrictedWithoutResolver(t *testing.T) {
-	t.Cleanup(func() { SetScopeResolver(nil) })
-	SetScopeResolver(nil)
-
-	scope := scopeFor(httptest.NewRequest(http.MethodGet, "/opencost/summary", nil))
-	if scope.Namespaces != nil {
-		t.Errorf("Namespaces = %v, want nil (unrestricted)", scope.Namespaces)
+func TestScopeRestricted(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		want       bool
+	}{
+		{name: "nil is unrestricted", namespaces: nil, want: false},
+		{name: "empty non-nil is restricted", namespaces: []string{}, want: true},
+		{name: "populated is restricted", namespaces: []string{"team-a"}, want: true},
 	}
-	if !scope.CanReadNodes {
-		t.Error("CanReadNodes = false, want true without a resolver")
-	}
-	if scope.Restricted() {
-		t.Error("Restricted() = true, want false without a resolver")
-	}
-}
-
-func TestScopeForUsesInstalledResolver(t *testing.T) {
-	t.Cleanup(func() { SetScopeResolver(nil) })
-	SetScopeResolver(func(*http.Request) Scope {
-		return Scope{Namespaces: []string{"team-a"}, CanReadNodes: false}
-	})
-
-	scope := scopeFor(httptest.NewRequest(http.MethodGet, "/opencost/summary", nil))
-	if len(scope.Namespaces) != 1 || scope.Namespaces[0] != "team-a" {
-		t.Errorf("Namespaces = %v, want [team-a]", scope.Namespaces)
-	}
-	if scope.CanReadNodes {
-		t.Error("CanReadNodes = true, want false")
-	}
-	if !scope.Restricted() {
-		t.Error("Restricted() = false, want true")
-	}
-}
-
-// A resolver left installed by one test would silently gate every later test in
-// the package; SetScopeResolver(nil) must actually clear it.
-func TestSetScopeResolverNilClearsPreviousResolver(t *testing.T) {
-	t.Cleanup(func() { SetScopeResolver(nil) })
-	SetScopeResolver(func(*http.Request) Scope { return Scope{Namespaces: []string{}} })
-
-	r := httptest.NewRequest(http.MethodGet, "/opencost/summary", nil)
-	if scopeFor(r).Namespaces == nil {
-		t.Fatal("resolver was not installed")
-	}
-
-	SetScopeResolver(nil)
-	if scopeFor(r).Namespaces != nil {
-		t.Error("scopeFor should be unrestricted after SetScopeResolver(nil)")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (Scope{Namespaces: tt.namespaces}).Restricted(); got != tt.want {
+				t.Errorf("Restricted() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/opencost/scope_test.go
+++ b/internal/opencost/scope_test.go
@@ -1,0 +1,79 @@
+package opencost
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestScopeForIsUnrestrictedWithoutResolver(t *testing.T) {
+	t.Cleanup(func() { SetScopeResolver(nil) })
+	SetScopeResolver(nil)
+
+	scope := scopeFor(httptest.NewRequest(http.MethodGet, "/opencost/summary", nil))
+	if scope.Namespaces != nil {
+		t.Errorf("Namespaces = %v, want nil (unrestricted)", scope.Namespaces)
+	}
+	if !scope.CanReadNodes {
+		t.Error("CanReadNodes = false, want true without a resolver")
+	}
+	if scope.Restricted() {
+		t.Error("Restricted() = true, want false without a resolver")
+	}
+}
+
+func TestScopeForUsesInstalledResolver(t *testing.T) {
+	t.Cleanup(func() { SetScopeResolver(nil) })
+	SetScopeResolver(func(*http.Request) Scope {
+		return Scope{Namespaces: []string{"team-a"}, CanReadNodes: false}
+	})
+
+	scope := scopeFor(httptest.NewRequest(http.MethodGet, "/opencost/summary", nil))
+	if len(scope.Namespaces) != 1 || scope.Namespaces[0] != "team-a" {
+		t.Errorf("Namespaces = %v, want [team-a]", scope.Namespaces)
+	}
+	if scope.CanReadNodes {
+		t.Error("CanReadNodes = true, want false")
+	}
+	if !scope.Restricted() {
+		t.Error("Restricted() = false, want true")
+	}
+}
+
+// A resolver left installed by one test would silently gate every later test in
+// the package; SetScopeResolver(nil) must actually clear it.
+func TestSetScopeResolverNilClearsPreviousResolver(t *testing.T) {
+	t.Cleanup(func() { SetScopeResolver(nil) })
+	SetScopeResolver(func(*http.Request) Scope { return Scope{Namespaces: []string{}} })
+
+	r := httptest.NewRequest(http.MethodGet, "/opencost/summary", nil)
+	if scopeFor(r).Namespaces == nil {
+		t.Fatal("resolver was not installed")
+	}
+
+	SetScopeResolver(nil)
+	if scopeFor(r).Namespaces != nil {
+		t.Error("scopeFor should be unrestricted after SetScopeResolver(nil)")
+	}
+}
+
+func TestScopeAllows(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		ns         string
+		want       bool
+	}{
+		{name: "unrestricted allows anything", namespaces: nil, ns: "team-b", want: true},
+		{name: "in scope", namespaces: []string{"team-a", "team-b"}, ns: "team-b", want: true},
+		{name: "out of scope", namespaces: []string{"team-a"}, ns: "team-b", want: false},
+		{name: "no access at all", namespaces: []string{}, ns: "team-a", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (Scope{Namespaces: tt.namespaces}).Allows(tt.ns); got != tt.want {
+				t.Errorf("Allows(%q) = %v, want %v", tt.ns, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/opencost_scope_test.go
+++ b/internal/server/opencost_scope_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+// The cost handlers key entirely off the nil-vs-empty contract of
+// Scope.Namespaces, so pin what openCostScope produces for each identity.
+func TestOpenCostScope_NoAuthIsUnrestricted(t *testing.T) {
+	s := newAuthServer(auth.Config{Mode: "none"})
+
+	scope := s.openCostScope(httptest.NewRequest("GET", "/opencost/summary", nil))
+	if scope.Namespaces != nil {
+		t.Errorf("Namespaces = %v, want nil (unrestricted)", scope.Namespaces)
+	}
+	if scope.Restricted() {
+		t.Error("Restricted() = true, want false with auth disabled")
+	}
+	if !scope.CanReadNodes {
+		t.Error("CanReadNodes = false, want true with auth disabled")
+	}
+}
+
+func TestOpenCostScope_ClusterAdminIsUnrestricted(t *testing.T) {
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "admin"}
+	s.permCache.Set("admin", nil, &auth.UserPermissions{AllowedNamespaces: nil})
+
+	scope := s.openCostScope(requestWithUser("GET", "/opencost/summary", user))
+	if scope.Namespaces != nil {
+		t.Errorf("Namespaces = %v, want nil (unrestricted)", scope.Namespaces)
+	}
+	if scope.Restricted() {
+		t.Error("Restricted() = true, want false for a cluster admin")
+	}
+}
+
+func TestOpenCostScope_RestrictedUserGetsTheirNamespaces(t *testing.T) {
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "dev"}
+	s.permCache.Set("dev", nil, &auth.UserPermissions{AllowedNamespaces: []string{"team-a", "team-b"}})
+
+	scope := s.openCostScope(requestWithUser("GET", "/opencost/summary", user))
+	if !slices.Equal(scope.Namespaces, []string{"team-a", "team-b"}) {
+		t.Fatalf("Namespaces = %v, want [team-a team-b]", scope.Namespaces)
+	}
+	if !scope.Restricted() {
+		t.Error("Restricted() = false, want true")
+	}
+	if scope.Allows("kube-system") {
+		t.Error("Allows(kube-system) = true for a user restricted to team-a/team-b")
+	}
+	if !scope.Allows("team-a") {
+		t.Error("Allows(team-a) = false for a user granted team-a")
+	}
+}
+
+// A user with an explicitly empty allow-list must come back as empty non-nil,
+// not nil — nil would read as "unrestricted" and serve them the whole cluster.
+func TestOpenCostScope_UserWithNoNamespacesIsDeniedNotUnrestricted(t *testing.T) {
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "nobody"}
+	s.permCache.Set("nobody", nil, &auth.UserPermissions{AllowedNamespaces: []string{}})
+
+	scope := s.openCostScope(requestWithUser("GET", "/opencost/summary", user))
+	if scope.Namespaces == nil {
+		t.Fatal("Namespaces = nil, want an empty non-nil slice (denied, not unrestricted)")
+	}
+	if len(scope.Namespaces) != 0 {
+		t.Errorf("Namespaces = %v, want empty", scope.Namespaces)
+	}
+	if !scope.Restricted() {
+		t.Error("Restricted() = false, want true")
+	}
+}

--- a/internal/server/opencost_workload.go
+++ b/internal/server/opencost_workload.go
@@ -281,3 +281,20 @@ func zeroWorkloadCost(kind, name string) *pkgopencost.WorkloadCost {
 		IdleCost:   0,
 	}
 }
+
+// openCostScope is the authorization ceiling for the cost endpoints in
+// internal/opencost. Those handlers read OpenCost metrics out of Prometheus
+// under Radar's own identity, so nothing in their query path is bounded by the
+// caller's RBAC — this is what keeps a namespace-restricted user off
+// cluster-wide spend.
+//
+// A nil Namespaces means unrestricted (auth disabled or cluster-admin); an
+// empty non-nil slice means no namespace access at all. Node costs are
+// cluster-scoped with no per-namespace slice, so they get their own SAR
+// instead of being inferred from namespace access.
+func (s *Server) openCostScope(r *http.Request) internalopencost.Scope {
+	return internalopencost.Scope{
+		Namespaces:   s.getUserNamespaces(r, nil),
+		CanReadNodes: s.canRead(r, "", "nodes", "", "list"),
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -730,12 +730,11 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			// restricted user off cluster-wide spend. Node costs are cluster-
 			// scoped and get their own SAR rather than inheriting namespace
 			// access.
-			opencost.SetScopeResolver(s.openCostScope)
 			r.Post("/opencost/application", s.handleOpenCostApplication)
 			r.Post("/opencost/application/trend", s.handleOpenCostApplicationTrend)
 			r.Get("/opencost/workload/{kind}/{namespace}/{name}", s.handleOpenCostWorkload)
 			r.Get("/opencost/workload/{kind}/{namespace}/{name}/trend", s.handleOpenCostWorkloadTrend)
-			opencost.RegisterRoutes(r, s.resolvedOpenCostCurrency)
+			opencost.RegisterRoutes(r, s.resolvedOpenCostCurrency, s.openCostScope)
 
 			// FluxCD routes
 			r.Post("/flux/{kind}/{namespace}/{name}/reconcile", s.handleFluxReconcile)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -724,7 +724,13 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			r.Post("/prometheus/rightsizing/scan", s.handleRightsizingScan)
 			prometheuspkg.RegisterRoutes(r)
 
-			// OpenCost routes
+			// OpenCost routes. Cost metrics are read out of Prometheus under
+			// Radar's own identity, so nothing in that query path is bounded by
+			// the caller's RBAC — the scope resolver is what keeps a namespace-
+			// restricted user off cluster-wide spend. Node costs are cluster-
+			// scoped and get their own SAR rather than inheriting namespace
+			// access.
+			opencost.SetScopeResolver(s.openCostScope)
 			r.Post("/opencost/application", s.handleOpenCostApplication)
 			r.Post("/opencost/application/trend", s.handleOpenCostApplicationTrend)
 			r.Get("/opencost/workload/{kind}/{namespace}/{name}", s.handleOpenCostWorkload)

--- a/pkg/opencost/compute.go
+++ b/pkg/opencost/compute.go
@@ -71,6 +71,13 @@ type SummaryOptions struct {
 	// filter rows by their Properties["namespace"] to actually honor the
 	// drill-down scope.
 	NamespaceFilter string
+
+	// AllowedNamespaces is the caller's authorization ceiling: nil means
+	// unrestricted, an empty non-nil slice means no access at all. Distinct
+	// from NamespaceFilter, which is a drill-down the user chose — this one
+	// they cannot widen, so totals are recomputed over the surviving rows
+	// and the response is marked Restricted.
+	AllowedNamespaces []string
 }
 
 // ComputeCostSummary asks OpenCost's REST API for namespace-level allocation
@@ -325,8 +332,13 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 	if opts.Currency == "" {
 		opts.Currency = DefaultCurrency
 	}
+	scope := namespaceScope(opts.AllowedNamespaces)
+	restricted := !scope.unrestricted()
+	if restricted && len(scope) == 0 {
+		return &CostSummary{Available: false, Reason: ReasonAccessDenied, Restricted: true, Currency: opts.Currency}
+	}
 	if client == nil {
-		return &CostSummary{Available: false, Reason: ReasonNoPrometheus, Currency: opts.Currency}
+		return &CostSummary{Available: false, Reason: ReasonNoPrometheus, Restricted: restricted, Currency: opts.Currency}
 	}
 	if opts.Window == "" {
 		opts.Window = "1h"
@@ -340,7 +352,7 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 			`sum by (namespace) (label_replace(rate(opencost_container_cpu_cost_total[1h]), "namespace", "$1", "exported_namespace", "(.+)"))`)
 		if err != nil {
 			log.Printf("[opencost] CPU allocation fallback query also failed: %v", err)
-			return &CostSummary{Available: false, Reason: ReasonQueryError, Currency: opts.Currency}
+			return &CostSummary{Available: false, Reason: ReasonQueryError, Restricted: restricted, Currency: opts.Currency}
 		}
 	}
 
@@ -352,12 +364,12 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 			`sum by (namespace) (label_replace(rate(opencost_container_memory_cost_total[1h]), "namespace", "$1", "exported_namespace", "(.+)"))`)
 		if err != nil {
 			log.Printf("[opencost] memory allocation fallback query also failed: %v", err)
-			return &CostSummary{Available: false, Reason: ReasonQueryError, Currency: opts.Currency}
+			return &CostSummary{Available: false, Reason: ReasonQueryError, Restricted: restricted, Currency: opts.Currency}
 		}
 	}
 
 	if len(cpuResult.Series) == 0 && len(memResult.Series) == 0 {
-		return &CostSummary{Available: false, Reason: ReasonNoMetrics, Currency: opts.Currency}
+		return &CostSummary{Available: false, Reason: ReasonNoMetrics, Restricted: restricted, Currency: opts.Currency}
 	}
 
 	// Usage queries are best-effort: efficiency / idle are derived from them
@@ -385,8 +397,8 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 	storageMap := lastValuePerLabel(storageRes, storageErr, "namespace")
 
 	nsMap := make(map[string]*NamespaceCost)
-	mergeSeriesIntoNamespaceField(cpuResult, nsMap, func(nc *NamespaceCost, v float64) { nc.CPUCost = v })
-	mergeSeriesIntoNamespaceField(memResult, nsMap, func(nc *NamespaceCost, v float64) { nc.MemoryCost = v })
+	mergeSeriesIntoNamespaceField(cpuResult, nsMap, scope, func(nc *NamespaceCost, v float64) { nc.CPUCost = v })
+	mergeSeriesIntoNamespaceField(memResult, nsMap, scope, func(nc *NamespaceCost, v float64) { nc.MemoryCost = v })
 
 	var totalHourlyCost, totalStorageCost, totalUsageCost, totalAllocCost float64
 	namespaces := make([]NamespaceCost, 0, len(nsMap))
@@ -408,9 +420,14 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 		namespaces = append(namespaces, *nc)
 	}
 
-	if nodeResult, err := client.Query(ctx, `sum(`+nodeTotalHourlyCostExpr+`)`); err == nil && len(nodeResult.Series) > 0 && len(nodeResult.Series[0].DataPoints) > 0 {
-		if nodeCost := nodeResult.Series[0].DataPoints[0].Value; nodeCost > totalHourlyCost {
-			totalHourlyCost = nodeCost
+	// The cluster-wide node bill is only a valid floor for the cluster-wide
+	// total. Applying it to a restricted view would hand the caller the very
+	// figure the namespace scope exists to withhold.
+	if !restricted {
+		if nodeResult, err := client.Query(ctx, `sum(`+nodeTotalHourlyCostExpr+`)`); err == nil && len(nodeResult.Series) > 0 && len(nodeResult.Series[0].DataPoints) > 0 {
+			if nodeCost := nodeResult.Series[0].DataPoints[0].Value; nodeCost > totalHourlyCost {
+				totalHourlyCost = nodeCost
+			}
 		}
 	}
 
@@ -436,6 +453,7 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 
 	return &CostSummary{
 		Available:         true,
+		Restricted:        restricted,
 		Currency:          opts.Currency,
 		Window:            opts.Window,
 		TotalHourlyCost:   totalHourlyCost,
@@ -446,13 +464,13 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 	}
 }
 
-func mergeSeriesIntoNamespaceField(result *prom.QueryResult, nsMap map[string]*NamespaceCost, set func(*NamespaceCost, float64)) {
+func mergeSeriesIntoNamespaceField(result *prom.QueryResult, nsMap map[string]*NamespaceCost, scope namespaceScope, set func(*NamespaceCost, float64)) {
 	if result == nil {
 		return
 	}
 	for _, s := range result.Series {
 		ns := s.Labels["namespace"]
-		if ns == "" {
+		if ns == "" || !scope.allows(ns) {
 			continue
 		}
 		nc, ok := nsMap[ns]

--- a/pkg/opencost/compute.go
+++ b/pkg/opencost/compute.go
@@ -95,9 +95,17 @@ type SummaryOptions struct {
 //     Available=false, Reason=ReasonNoMetrics.
 //   - Otherwise Available=true with namespace rows + totals filled in.
 //   - Numbers rounded to 4dp for JSON cleanliness.
+//   - AllowedNamespaces restricts which rows are read at all, so every total
+//     is computed over what the caller may see; an empty non-nil set is
+//     Available=false, Reason=ReasonAccessDenied.
 func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOptions) *CostSummary {
 	if opts.Currency == "" {
 		opts.Currency = DefaultCurrency
+	}
+	scope := namespaceScope(opts.AllowedNamespaces)
+	restricted := !scope.unrestricted()
+	if restricted && len(scope) == 0 {
+		return &CostSummary{Available: false, Reason: ReasonAccessDenied, Restricted: true, Currency: opts.Currency}
 	}
 	if opts.Window == "" {
 		opts.Window = "1h"
@@ -115,10 +123,10 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 	})
 	if err != nil {
 		log.Printf("[opencost] /allocation summary failed: %v", err)
-		return &CostSummary{Available: false, Reason: ReasonQueryError}
+		return &CostSummary{Available: false, Reason: ReasonQueryError, Restricted: restricted, Currency: opts.Currency}
 	}
 	if resp == nil || len(resp.Data) == 0 {
-		return &CostSummary{Available: false, Reason: ReasonNoMetrics}
+		return &CostSummary{Available: false, Reason: ReasonNoMetrics, Restricted: restricted, Currency: opts.Currency}
 	}
 
 	// /allocation returns an array of time windows. For a single bucket we
@@ -137,6 +145,20 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 			if opts.NamespaceFilter != "" {
 				ns, _ := a.Properties["namespace"].(string)
 				if ns != opts.NamespaceFilter {
+					continue
+				}
+			}
+			if restricted {
+				// When aggregating by namespace the row name is the
+				// namespace; other aggregates carry it in Properties. The
+				// synthetic __idle__ row has neither, so it drops out of a
+				// restricted view — unassigned node capacity cannot be
+				// attributed to any one namespace.
+				ns := name
+				if aggregate != "namespace" {
+					ns, _ = a.Properties["namespace"].(string)
+				}
+				if !scope.allows(ns) {
 					continue
 				}
 			}
@@ -171,7 +193,7 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 	}
 
 	if len(combined) == 0 {
-		return &CostSummary{Available: false, Reason: ReasonNoMetrics}
+		return &CostSummary{Available: false, Reason: ReasonNoMetrics, Restricted: restricted, Currency: opts.Currency}
 	}
 
 	namespaces := make([]NamespaceCost, 0, len(combined))
@@ -305,6 +327,7 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 
 	return &CostSummary{
 		Available:         true,
+		Restricted:        restricted,
 		Currency:          opts.Currency,
 		Window:            opts.Window,
 		TotalHourlyCost:   totalHourlyCost,

--- a/pkg/opencost/compute.go
+++ b/pkg/opencost/compute.go
@@ -78,6 +78,12 @@ type SummaryOptions struct {
 	// they cannot widen, so totals are recomputed over the surviving rows
 	// and the response is marked Restricted.
 	AllowedNamespaces []string
+
+	// CanReadNodes gates the node-total floor applied to TotalHourlyCost. That
+	// floor is node data, so it answers to the same grant the per-node
+	// breakdown does — otherwise a caller denied the breakdown is handed its
+	// sum. Fails closed on the zero value.
+	CanReadNodes bool
 }
 
 // ComputeCostSummary asks OpenCost's REST API for namespace-level allocation
@@ -421,9 +427,10 @@ func ComputeCostSummaryFromProm(ctx context.Context, client *prom.Client, opts S
 	}
 
 	// The cluster-wide node bill is only a valid floor for the cluster-wide
-	// total. Applying it to a restricted view would hand the caller the very
-	// figure the namespace scope exists to withhold.
-	if !restricted {
+	// total, and it is node data besides. Applying it to a restricted view, or
+	// to a caller without the node grant, hands over the very figure those
+	// checks exist to withhold.
+	if !restricted && opts.CanReadNodes {
 		if nodeResult, err := client.Query(ctx, `sum(`+nodeTotalHourlyCostExpr+`)`); err == nil && len(nodeResult.Series) > 0 && len(nodeResult.Series[0].DataPoints) > 0 {
 			if nodeCost := nodeResult.Series[0].DataPoints[0].Value; nodeCost > totalHourlyCost {
 				totalHourlyCost = nodeCost

--- a/pkg/opencost/compute_test.go
+++ b/pkg/opencost/compute_test.go
@@ -101,7 +101,7 @@ func TestComputeCostSummary_HappyPath(t *testing.T) {
 		{contains: "node_total_hourly_cost", body: scalarBody(8.0)}, // exceeds sum of namespaces, so it wins
 	})
 
-	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "GBP"})
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "GBP", CanReadNodes: true})
 	if !got.Available {
 		t.Fatalf("summary unavailable: %+v", got)
 	}

--- a/pkg/opencost/scope.go
+++ b/pkg/opencost/scope.go
@@ -1,0 +1,15 @@
+package opencost
+
+import "slices"
+
+// namespaceScope is the set of namespaces a caller may see cost data for.
+// A nil slice means unrestricted; an empty non-nil slice means no access at
+// all. This mirrors auth.FilterNamespacesForUser's nil-vs-empty contract, so
+// the local no-auth and cluster-admin paths stay unrestricted by construction.
+type namespaceScope []string
+
+func (n namespaceScope) unrestricted() bool { return n == nil }
+
+func (n namespaceScope) allows(namespace string) bool {
+	return n == nil || slices.Contains(n, namespace)
+}

--- a/pkg/opencost/scope_test.go
+++ b/pkg/opencost/scope_test.go
@@ -55,7 +55,7 @@ func namespaceRow(t *testing.T, s *CostSummary, name string) NamespaceCost {
 func TestComputeCostSummaryFromProm_UnrestrictedKeepsClusterView(t *testing.T) {
 	client := scriptedProm(t, summaryScopeCases())
 
-	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "USD"})
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "USD", CanReadNodes: true})
 	if !got.Available {
 		t.Fatalf("unavailable: %+v", got)
 	}
@@ -156,6 +156,32 @@ func TestComputeCostSummaryFromProm_AllowedNamespaceWithNoRowsStaysAvailable(t *
 	}
 	if got.TotalHourlyCost != 0 {
 		t.Errorf("TotalHourlyCost = %v, want 0", got.TotalHourlyCost)
+	}
+}
+
+// The node-total floor is node data. A caller denied the per-node breakdown
+// must not receive its sum through the summary's headline total instead.
+func TestComputeCostSummaryFromProm_NodeCeilingNeedsTheNodeGrant(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	withGrant := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "USD", CanReadNodes: true})
+	if withGrant.TotalHourlyCost != 20 {
+		t.Fatalf("TotalHourlyCost = %v, want the 20.0 node bill when the caller may read nodes", withGrant.TotalHourlyCost)
+	}
+
+	withoutGrant := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "USD"})
+	if !withoutGrant.Available {
+		t.Fatalf("unavailable: %+v", withoutGrant)
+	}
+	if len(withoutGrant.Namespaces) != 3 {
+		t.Errorf("got %d namespaces, want all 3 — only the node total is withheld", len(withoutGrant.Namespaces))
+	}
+	var rowSum float64
+	for _, row := range withoutGrant.Namespaces {
+		rowSum += row.HourlyCost
+	}
+	if withoutGrant.TotalHourlyCost != rowSum {
+		t.Errorf("TotalHourlyCost = %v, want %v (the visible rows, not the node bill)", withoutGrant.TotalHourlyCost, rowSum)
 	}
 }
 

--- a/pkg/opencost/scope_test.go
+++ b/pkg/opencost/scope_test.go
@@ -1,0 +1,251 @@
+package opencost
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/prom"
+)
+
+// trendProm serves a matrix response with two data points per namespace.
+func trendProm(t *testing.T, values map[string][]float64) *prom.Client {
+	t.Helper()
+	names := make([]string, 0, len(values))
+	for ns := range values {
+		names = append(names, ns)
+	}
+	sort.Strings(names)
+	series := make([]namespaceSeries, 0, len(names))
+	for _, ns := range names {
+		points := make([]dpoint, 0, len(values[ns]))
+		for i, v := range values[ns] {
+			points = append(points, dpoint{ts: 1700000000 + int64(i)*3600, v: v})
+		}
+		series = append(series, namespaceSeries{ns: ns, points: points})
+	}
+	return rangeProm(t, matrixBody(series))
+}
+
+// summaryScopeCases serves three namespaces plus a node bill that exceeds
+// their sum, so a restricted response that only dropped rows would still leak
+// the cluster figure through the node-total ceiling.
+func summaryScopeCases() []scriptedCase {
+	return []scriptedCase{
+		{contains: "container_cpu_allocation", body: vectorBody(map[string]float64{"team-a": 1.0, "team-b": 2.0, "kube-system": 0.5})},
+		{contains: "container_memory_allocation_bytes", body: vectorBody(map[string]float64{"team-a": 1.5, "team-b": 1.0, "kube-system": 0.5})},
+		{contains: "container_cpu_usage_seconds_total", body: vectorBody(map[string]float64{"team-a": 0.5, "team-b": 1.0, "kube-system": 0.25})},
+		{contains: "container_memory_working_set_bytes", body: vectorBody(map[string]float64{"team-a": 0.75, "team-b": 0.5, "kube-system": 0.25})},
+		{contains: "pv_hourly_cost", body: vectorBody(map[string]float64{"team-a": 0.5})},
+		{contains: "node_total_hourly_cost", body: scalarBody(20.0)},
+	}
+}
+
+func namespaceRow(t *testing.T, s *CostSummary, name string) NamespaceCost {
+	t.Helper()
+	for _, row := range s.Namespaces {
+		if row.Name == name {
+			return row
+		}
+	}
+	t.Fatalf("namespace %q missing from %+v", name, s.Namespaces)
+	return NamespaceCost{}
+}
+
+func TestComputeCostSummaryFromProm_UnrestrictedKeepsClusterView(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{Currency: "USD"})
+	if !got.Available {
+		t.Fatalf("unavailable: %+v", got)
+	}
+	if len(got.Namespaces) != 3 {
+		t.Errorf("got %d namespaces, want 3", len(got.Namespaces))
+	}
+	if got.Restricted {
+		t.Error("Restricted = true, want false")
+	}
+	if got.TotalHourlyCost != 20 {
+		t.Errorf("TotalHourlyCost = %v, want 20 (the node-total ceiling)", got.TotalHourlyCost)
+	}
+}
+
+func TestComputeCostSummaryFromProm_RestrictedDropsOtherNamespaces(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{
+		Currency:          "USD",
+		AllowedNamespaces: []string{"team-a"},
+	})
+	if !got.Available {
+		t.Fatalf("unavailable: %+v", got)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true")
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0].Name != "team-a" {
+		t.Fatalf("namespaces = %+v, want only team-a", got.Namespaces)
+	}
+	row := namespaceRow(t, got, "team-a")
+	if row.HourlyCost != 3.0 { // 1.0 cpu + 1.5 mem + 0.5 storage
+		t.Errorf("team-a HourlyCost = %v, want 3.0", row.HourlyCost)
+	}
+}
+
+// The reported leak: a namespace-scoped user was shown the cluster total. The
+// node-total ceiling is a cluster figure and must not survive the restriction.
+func TestComputeCostSummaryFromProm_RestrictedTotalsCoverOnlyVisibleRows(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{
+		Currency:          "USD",
+		AllowedNamespaces: []string{"team-a"},
+	})
+	if got.TotalHourlyCost != 3.0 {
+		t.Errorf("TotalHourlyCost = %v, want 3.0 (the team-a row, not the 20.0 node bill)", got.TotalHourlyCost)
+	}
+	if got.TotalStorageCost != 0.5 {
+		t.Errorf("TotalStorageCost = %v, want 0.5", got.TotalStorageCost)
+	}
+	// alloc = 1.0 + 1.5 = 2.5, usage = 0.5 + 0.75 = 1.25 → 50% efficient, 1.25 idle.
+	if got.ClusterEfficiency != 50 {
+		t.Errorf("ClusterEfficiency = %v, want 50", got.ClusterEfficiency)
+	}
+	if got.TotalIdleCost != 1.25 {
+		t.Errorf("TotalIdleCost = %v, want 1.25", got.TotalIdleCost)
+	}
+}
+
+func TestComputeCostSummaryFromProm_NoAllowedNamespacesIsDenied(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{
+		Currency:          "GBP",
+		AllowedNamespaces: []string{},
+	})
+	if got.Available {
+		t.Error("Available = true, want false")
+	}
+	if got.Reason != ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, ReasonAccessDenied)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true")
+	}
+	if len(got.Namespaces) != 0 || got.TotalHourlyCost != 0 {
+		t.Errorf("denied summary still carries figures: %+v", got)
+	}
+	if got.Currency != "GBP" {
+		t.Errorf("Currency = %q, want GBP preserved", got.Currency)
+	}
+}
+
+// An in-scope namespace with no cost metrics is a real zero, not an error.
+func TestComputeCostSummaryFromProm_AllowedNamespaceWithNoRowsStaysAvailable(t *testing.T) {
+	client := scriptedProm(t, summaryScopeCases())
+
+	got := ComputeCostSummaryFromProm(context.Background(), client, SummaryOptions{
+		Currency:          "USD",
+		AllowedNamespaces: []string{"team-z"},
+	})
+	if !got.Available {
+		t.Errorf("Available = false (reason %q), want true", got.Reason)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true")
+	}
+	if got.TotalHourlyCost != 0 {
+		t.Errorf("TotalHourlyCost = %v, want 0", got.TotalHourlyCost)
+	}
+}
+
+func TestComputeCostTrendFromProm_RestrictedKeepsOnlyAllowedSeries(t *testing.T) {
+	client := trendProm(t, map[string][]float64{
+		"team-a":      {1, 2},
+		"team-b":      {3, 4},
+		"kube-system": {5, 6},
+	})
+
+	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{
+		AllowedNamespaces: []string{"team-a"},
+	})
+	if !got.Available {
+		t.Fatalf("unavailable: %+v", got)
+	}
+	if len(got.Series) != 1 || got.Series[0].Namespace != "team-a" {
+		t.Fatalf("series = %+v, want only team-a", got.Series)
+	}
+	if !got.Restricted {
+		t.Error("Restricted = false, want true")
+	}
+}
+
+// The "other" bucket aggregates whatever fell outside the top N. For a
+// restricted caller it must aggregate only their own namespaces, or it becomes
+// a second route to the cluster total.
+func TestComputeCostTrendFromProm_RestrictedOtherBucketExcludesHiddenNamespaces(t *testing.T) {
+	series := map[string][]float64{"secret-ns": {1000, 1000}}
+	allowed := make([]string, 0, 10)
+	for i := range 10 {
+		name := string(rune('a'+i)) + "-team"
+		series[name] = []float64{float64(i + 1), float64(i + 1)}
+		allowed = append(allowed, name)
+	}
+	client := trendProm(t, series)
+
+	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{
+		MaxSeries:         8,
+		AllowedNamespaces: allowed,
+	})
+
+	var other *CostTrendSeries
+	for i := range got.Series {
+		if got.Series[i].Namespace == "other" {
+			other = &got.Series[i]
+		}
+		if got.Series[i].Namespace == "secret-ns" {
+			t.Fatal("a namespace outside the caller's scope was returned as its own series")
+		}
+	}
+	if other == nil {
+		t.Fatalf("expected an \"other\" bucket for the 2 allowed namespaces past the top 8; got %d series", len(got.Series))
+	}
+	for _, dp := range other.DataPoints {
+		if dp.Value >= 1000 {
+			t.Errorf("\"other\" bucket value %v includes the out-of-scope namespace", dp.Value)
+		}
+	}
+}
+
+func TestComputeCostTrendFromProm_NoAllowedNamespacesIsDenied(t *testing.T) {
+	client := trendProm(t, map[string][]float64{"team-a": {1, 2}})
+
+	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{
+		Range:             "7d",
+		AllowedNamespaces: []string{},
+	})
+	if got.Available {
+		t.Error("Available = true, want false")
+	}
+	if got.Reason != ReasonAccessDenied {
+		t.Errorf("Reason = %q, want %q", got.Reason, ReasonAccessDenied)
+	}
+	if len(got.Series) != 0 {
+		t.Errorf("Series = %+v, want none", got.Series)
+	}
+	if got.Range != "7d" {
+		t.Errorf("Range = %q, want 7d echoed back", got.Range)
+	}
+}
+
+func TestComputeCostTrendFromProm_UnrestrictedIsUnchanged(t *testing.T) {
+	client := trendProm(t, map[string][]float64{"team-a": {1, 2}, "team-b": {3, 4}})
+
+	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{})
+	if len(got.Series) != 2 {
+		t.Errorf("series = %+v, want both", got.Series)
+	}
+	if got.Restricted {
+		t.Error("Restricted = true, want false")
+	}
+}

--- a/pkg/opencost/scope_test.go
+++ b/pkg/opencost/scope_test.go
@@ -238,6 +238,18 @@ func TestComputeCostTrendFromProm_NoAllowedNamespacesIsDenied(t *testing.T) {
 	}
 }
 
+// A denied answer still has to echo the same normalized label the query path
+// would have produced, so the response contract does not fork by outcome.
+func TestTrendRangeLabelNormalizesUnknownInput(t *testing.T) {
+	for _, tt := range []struct{ in, want string }{
+		{"6h", "6h"}, {"24h", "24h"}, {"7d", "7d"}, {"", "24h"}, {"weird", "24h"},
+	} {
+		if got := TrendRangeLabel(tt.in); got != tt.want {
+			t.Errorf("TrendRangeLabel(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestComputeCostTrendFromProm_UnrestrictedIsUnchanged(t *testing.T) {
 	client := trendProm(t, map[string][]float64{"team-a": {1, 2}, "team-b": {3, 4}})
 

--- a/pkg/opencost/scope_test.go
+++ b/pkg/opencost/scope_test.go
@@ -93,8 +93,8 @@ func TestComputeCostSummaryFromProm_RestrictedDropsOtherNamespaces(t *testing.T)
 	}
 }
 
-// The reported leak: a namespace-scoped user was shown the cluster total. The
-// node-total ceiling is a cluster figure and must not survive the restriction.
+// The node-total ceiling is a cluster figure, so it must not survive a
+// restriction — a restricted total covers only the caller's own rows.
 func TestComputeCostSummaryFromProm_RestrictedTotalsCoverOnlyVisibleRows(t *testing.T) {
 	client := scriptedProm(t, summaryScopeCases())
 

--- a/pkg/opencost/scope_test.go
+++ b/pkg/opencost/scope_test.go
@@ -2,6 +2,7 @@ package opencost
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"testing"
 
@@ -282,6 +283,76 @@ func TestComputeCostTrendFromProm_UnrestrictedIsUnchanged(t *testing.T) {
 	got := ComputeCostTrendFromProm(context.Background(), client, TrendPromOptions{})
 	if len(got.Series) != 2 {
 		t.Errorf("series = %+v, want both", got.Series)
+	}
+	if got.Restricted {
+		t.Error("Restricted = true, want false")
+	}
+}
+
+// The REST path is not reached by Radar's own handlers today, but it shares
+// SummaryOptions with the PromQL path — a caller wiring it up must not get an
+// unscoped answer from a scoped request.
+
+func TestComputeCostSummary_REST_RestrictedTotalsCoverOnlyVisibleRows(t *testing.T) {
+	body := buildAllocationResponse(t, map[string]float64{
+		"team-a":      3.00,
+		"team-b":      5.00,
+		"kube-system": 9.00,
+	})
+	client := fakeOpenCost(t, body)
+
+	got := ComputeCostSummary(context.Background(), client, SummaryOptions{
+		AllowedNamespaces: []string{"team-a"},
+	})
+	if !got.Available || !got.Restricted {
+		t.Fatalf("Available=%v Restricted=%v, want true/true", got.Available, got.Restricted)
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0].Name != "team-a" {
+		t.Fatalf("Namespaces = %+v, want team-a only", got.Namespaces)
+	}
+	if got.TotalHourlyCost != 3.00 {
+		t.Errorf("TotalHourlyCost = %v, want 3 (team-a alone, not the cluster)", got.TotalHourlyCost)
+	}
+}
+
+func TestComputeCostSummary_REST_IdleIsDroppedWhenRestricted(t *testing.T) {
+	// __idle__ is unassigned node capacity. It belongs to no namespace, so a
+	// restricted caller must not be handed it as part of "their" waste.
+	window := map[string]*Allocation{
+		"team-a":   {Name: "team-a", CPUCost: 1.0, RAMCost: 0.5, TotalCost: 1.5, TotalEfficiency: 1},
+		"__idle__": {Name: "__idle__", CPUCost: 8.0, RAMCost: 2.0, TotalCost: 10.0},
+	}
+	body, _ := json.Marshal(AllocationResponse{Code: 200, Data: []map[string]*Allocation{window}})
+	client := fakeOpenCost(t, string(body))
+
+	got := ComputeCostSummary(context.Background(), client, SummaryOptions{
+		AllowedNamespaces: []string{"team-a"},
+	})
+	if got.TotalIdleCost != 0 {
+		t.Errorf("TotalIdleCost = %v, want 0 (cluster idle is not attributable to team-a)", got.TotalIdleCost)
+	}
+}
+
+func TestComputeCostSummary_REST_NoAllowedNamespacesIsDenied(t *testing.T) {
+	client := fakeOpenCost(t, buildAllocationResponse(t, map[string]float64{"team-a": 3.00}))
+
+	got := ComputeCostSummary(context.Background(), client, SummaryOptions{
+		AllowedNamespaces: []string{},
+	})
+	if got.Available || got.Reason != ReasonAccessDenied || !got.Restricted {
+		t.Fatalf("got %+v, want denied", got)
+	}
+	if len(got.Namespaces) != 0 {
+		t.Errorf("Namespaces = %+v, want none", got.Namespaces)
+	}
+}
+
+func TestComputeCostSummary_REST_UnrestrictedIsUnchanged(t *testing.T) {
+	client := fakeOpenCost(t, buildAllocationResponse(t, map[string]float64{"team-a": 3.00, "team-b": 5.00}))
+
+	got := ComputeCostSummary(context.Background(), client, SummaryOptions{})
+	if len(got.Namespaces) != 2 {
+		t.Errorf("Namespaces = %+v, want both", got.Namespaces)
 	}
 	if got.Restricted {
 		t.Error("Restricted = true, want false")

--- a/pkg/opencost/trend_prom.go
+++ b/pkg/opencost/trend_prom.go
@@ -18,6 +18,14 @@ type TrendPromOptions struct {
 	// MaxSeries is the top-N namespaces kept; the rest are aggregated into
 	// a single "other" series. Defaults to 8 when zero.
 	MaxSeries int
+
+	// AllowedNamespaces is the caller's authorization ceiling: nil means
+	// unrestricted, an empty non-nil slice means no access at all. Applied
+	// before the top-N ranking, so a restricted caller's own namespaces are
+	// ranked against each other rather than being collapsed into "other"
+	// (which is itself dropped, since it would aggregate namespaces they
+	// cannot see).
+	AllowedNamespaces []string
 }
 
 // ComputeCostTrendFromProm returns a stacked per-namespace cost trend from
@@ -29,8 +37,13 @@ type TrendPromOptions struct {
 //   - Underlying range query fails → Available=false, Reason=ReasonQueryError.
 //   - No series returned → Available=false, Reason=ReasonNoMetrics.
 func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts TrendPromOptions) *CostTrendResponse {
+	scope := namespaceScope(opts.AllowedNamespaces)
+	restricted := !scope.unrestricted()
+	if restricted && len(scope) == 0 {
+		return &CostTrendResponse{Available: false, Reason: ReasonAccessDenied, Restricted: true, Range: resolveTrendLabel(opts.Range)}
+	}
 	if client == nil {
-		return &CostTrendResponse{Available: false, Reason: ReasonNoPrometheus}
+		return &CostTrendResponse{Available: false, Reason: ReasonNoPrometheus, Restricted: restricted}
 	}
 
 	start, end, step, label := resolveTrendRange(opts.Range)
@@ -48,10 +61,10 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 	result, err := client.QueryRange(ctx, query, start, end, step)
 	if err != nil {
 		log.Printf("[opencost] PromQL trend range query failed (range=%s): %v", label, err)
-		return &CostTrendResponse{Available: false, Reason: ReasonQueryError}
+		return &CostTrendResponse{Available: false, Reason: ReasonQueryError, Restricted: restricted}
 	}
 	if len(result.Series) == 0 {
-		return &CostTrendResponse{Available: false, Reason: ReasonNoMetrics}
+		return &CostTrendResponse{Available: false, Reason: ReasonNoMetrics, Restricted: restricted}
 	}
 
 	type nsRank struct {
@@ -62,7 +75,7 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 	ranks := make([]nsRank, 0, len(result.Series))
 	for i, s := range result.Series {
 		ns := s.Labels["namespace"]
-		if ns == "" {
+		if ns == "" || !scope.allows(ns) {
 			continue
 		}
 		var last float64
@@ -91,7 +104,7 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 	if len(ranks) > maxSeries {
 		otherMap := make(map[int64]float64)
 		for i, s := range result.Series {
-			if topSet[i] {
+			if topSet[i] || !scope.allows(s.Labels["namespace"]) {
 				continue
 			}
 			for _, dp := range s.DataPoints {
@@ -108,7 +121,14 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 		}
 	}
 
-	return &CostTrendResponse{Available: true, Range: label, Series: series}
+	return &CostTrendResponse{Available: true, Restricted: restricted, Range: label, Series: series}
+}
+
+// resolveTrendLabel is resolveTrendRange's label alone, for the early returns
+// that must still echo the requested range without issuing a query.
+func resolveTrendLabel(rangeStr string) string {
+	_, _, _, label := resolveTrendRange(rangeStr)
+	return label
 }
 
 // resolveTrendRange returns the start/end/step/label for the named Range.

--- a/pkg/opencost/trend_prom.go
+++ b/pkg/opencost/trend_prom.go
@@ -40,7 +40,7 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 	scope := namespaceScope(opts.AllowedNamespaces)
 	restricted := !scope.unrestricted()
 	if restricted && len(scope) == 0 {
-		return &CostTrendResponse{Available: false, Reason: ReasonAccessDenied, Restricted: true, Range: resolveTrendLabel(opts.Range)}
+		return &CostTrendResponse{Available: false, Reason: ReasonAccessDenied, Restricted: true, Range: TrendRangeLabel(opts.Range)}
 	}
 	if client == nil {
 		return &CostTrendResponse{Available: false, Reason: ReasonNoPrometheus, Restricted: restricted}
@@ -124,9 +124,10 @@ func ComputeCostTrendFromProm(ctx context.Context, client *prom.Client, opts Tre
 	return &CostTrendResponse{Available: true, Restricted: restricted, Range: label, Series: series}
 }
 
-// resolveTrendLabel is resolveTrendRange's label alone, for the early returns
-// that must still echo the requested range without issuing a query.
-func resolveTrendLabel(rangeStr string) string {
+// TrendRangeLabel is the normalized form of a requested trend range. Callers
+// that answer without issuing a query still have to echo the same label the
+// query path would have returned, or the response contract forks.
+func TrendRangeLabel(rangeStr string) string {
 	_, _, _, label := resolveTrendRange(rangeStr)
 	return label
 }

--- a/pkg/opencost/types.go
+++ b/pkg/opencost/types.go
@@ -13,8 +13,12 @@ const (
 
 // CostSummary is the response for the /api/opencost/summary endpoint.
 type CostSummary struct {
-	Available         bool            `json:"available"`
-	Reason            string          `json:"reason,omitempty"` // Set when available=false: no_prometheus, no_metrics, query_error
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"` // Set when available=false: no_prometheus, no_metrics, query_error
+	// Restricted reports that the caller sees only the namespaces they have
+	// access to. Totals then cover those namespaces alone, so the UI must not
+	// present them as cluster figures.
+	Restricted        bool            `json:"restricted,omitempty"`
 	Currency          string          `json:"currency"`
 	Window            string          `json:"window,omitempty"`
 	TotalHourlyCost   float64         `json:"totalHourlyCost,omitempty"`
@@ -45,11 +49,12 @@ type NamespaceCost struct {
 
 // WorkloadCostResponse is the response for the /api/opencost/workloads endpoint.
 type WorkloadCostResponse struct {
-	Available bool           `json:"available"`
-	Reason    string         `json:"reason,omitempty"`
-	Currency  string         `json:"currency"`
-	Namespace string         `json:"namespace"`
-	Workloads []WorkloadCost `json:"workloads"`
+	Available  bool           `json:"available"`
+	Reason     string         `json:"reason,omitempty"`
+	Restricted bool           `json:"restricted,omitempty"`
+	Currency   string         `json:"currency"`
+	Namespace  string         `json:"namespace"`
+	Workloads  []WorkloadCost `json:"workloads"`
 }
 
 type WorkloadCostDetailResponse struct {
@@ -82,11 +87,12 @@ type WorkloadCost struct {
 
 // CostTrendResponse is the response for the /api/opencost/trend endpoint.
 type CostTrendResponse struct {
-	Available bool              `json:"available"`
-	Reason    string            `json:"reason,omitempty"`
-	Currency  string            `json:"currency"`
-	Range     string            `json:"range"`
-	Series    []CostTrendSeries `json:"series,omitempty"`
+	Available  bool              `json:"available"`
+	Reason     string            `json:"reason,omitempty"`
+	Restricted bool              `json:"restricted,omitempty"`
+	Currency   string            `json:"currency"`
+	Range      string            `json:"range"`
+	Series     []CostTrendSeries `json:"series,omitempty"`
 }
 
 type WorkloadCostTrendResponse struct {
@@ -188,10 +194,11 @@ type CostDataPoint struct {
 
 // NodeCostResponse is the response for the /api/opencost/nodes endpoint.
 type NodeCostResponse struct {
-	Available bool       `json:"available"`
-	Reason    string     `json:"reason,omitempty"`
-	Currency  string     `json:"currency"`
-	Nodes     []NodeCost `json:"nodes,omitempty"`
+	Available  bool       `json:"available"`
+	Reason     string     `json:"reason,omitempty"`
+	Restricted bool       `json:"restricted,omitempty"`
+	Currency   string     `json:"currency"`
+	Nodes      []NodeCost `json:"nodes,omitempty"`
 }
 
 // NodeCost holds per-node cost breakdown.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -890,6 +890,9 @@ export type CostUnavailableReason =
 export interface OpenCostSummary {
   available: boolean;
   reason?: CostUnavailableReason;
+  /** The caller sees only the namespaces they have access to — totals cover
+   *  those namespaces alone and are not cluster figures. */
+  restricted?: boolean;
   currency?: string;
   window?: string;
   totalHourlyCost?: number;
@@ -963,6 +966,7 @@ export interface OpenCostWorkloadCost {
 export interface OpenCostWorkloadResponse {
   available: boolean;
   reason?: CostUnavailableReason;
+  restricted?: boolean;
   currency?: string;
   namespace: string;
   workloads: OpenCostWorkloadCost[];
@@ -1036,6 +1040,7 @@ export interface OpenCostTrendSeries {
 export interface OpenCostTrendResponse {
   available: boolean;
   reason?: CostUnavailableReason;
+  restricted?: boolean;
   currency?: string;
   range: string;
   series?: OpenCostTrendSeries[];
@@ -1238,6 +1243,7 @@ export interface OpenCostNodeCost {
 export interface OpenCostNodeResponse {
   available: boolean;
   reason?: CostUnavailableReason;
+  restricted?: boolean;
   currency?: string;
   nodes?: OpenCostNodeCost[];
 }

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -248,12 +248,7 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
 
         <CostViewTabs />
 
-        {restricted && (
-          <RestrictedCostBanner
-            namespaceCount={namespaces.length}
-            nodesHidden={nodeData?.reason === 'access_denied'}
-          />
-        )}
+        {restricted && <RestrictedCostBanner />}
 
         {/* CPU vs Memory (vs Storage) split bar */}
         <div className="rounded-lg border border-theme-border bg-theme-surface/50 p-4">
@@ -353,6 +348,7 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
         </div>
 
         {/* Node cost table */}
+        {nodeData?.reason === 'access_denied' && <NodeCostsDeniedNote />}
         {nodes.length > 0 && (
           <NodeCostTable
             nodes={nodes}
@@ -500,22 +496,30 @@ function SystemNamespaceCostNote({ namespace }: { namespace: string }) {
   )
 }
 
-function RestrictedCostBanner({
-  namespaceCount,
-  nodesHidden,
-}: {
-  namespaceCount: number
-  nodesHidden: boolean
-}) {
+function RestrictedCostBanner() {
   return (
     <div className="flex items-start gap-2.5 rounded-lg border border-theme-border bg-theme-elevated/40 px-4 py-3">
       <Lock className="mt-0.5 h-4 w-4 shrink-0 text-theme-text-tertiary" />
       <div className="text-xs text-theme-text-secondary">
         <span className="font-medium text-theme-text-primary">Restricted view.</span>{' '}
-        Costs cover only the {namespaceCount === 1 ? 'namespace' : `${namespaceCount} namespaces`}{' '}
-        you have access to. Every figure on this page — including the headline total — is a
-        partial figure, not the cluster total.
-        {nodesHidden && ' Node costs are hidden because they cannot be split per namespace.'}
+        Costs cover only the namespaces you have access to. Every figure on this page — including
+        the headline total — is a partial figure, not the cluster total.
+      </div>
+    </div>
+  )
+}
+
+// Node spend is gated on its own list-nodes grant, so it can be withheld from a
+// caller whose namespace view is otherwise complete. Say so where the table
+// would have been rather than letting it silently vanish.
+function NodeCostsDeniedNote() {
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-theme-border bg-theme-elevated/40 px-4 py-3">
+      <Lock className="mt-0.5 h-4 w-4 shrink-0 text-theme-text-tertiary" />
+      <div className="text-xs text-theme-text-secondary">
+        <span className="font-medium text-theme-text-primary">Node costs hidden.</span>{' '}
+        Per-node pricing is cluster-wide and cannot be split per namespace, so it needs permission
+        to list nodes.
       </div>
     </div>
   )

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -353,6 +353,7 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
           <NodeCostTable
             nodes={nodes}
             currency={nodeCurrency}
+            restricted={restricted}
             onOpenResource={onOpenResource}
           />
         )}
@@ -502,8 +503,8 @@ function RestrictedCostBanner() {
       <Lock className="mt-0.5 h-4 w-4 shrink-0 text-theme-text-tertiary" />
       <div className="text-xs text-theme-text-secondary">
         <span className="font-medium text-theme-text-primary">Restricted view.</span>{' '}
-        Costs cover only the namespaces you have access to. Every figure on this page — including
-        the headline total — is a partial figure, not the cluster total.
+        Costs cover only the namespaces you have access to. Namespace and workload figures —
+        including the headline total — are partial, not cluster totals.
       </div>
     </div>
   )
@@ -533,8 +534,9 @@ function RestrictedCostNotice() {
         <div>
           <p className="text-sm font-medium text-theme-text-primary">Cost data is not available</p>
           <p className="mt-1 text-xs text-theme-text-tertiary">
-            Cost is shown for the namespaces you have access to, and you do not currently have
-            access to any. Ask your cluster administrator for namespace access.
+            Cost is shown for the namespaces you have access to, and no namespace is currently
+            visible to you. If that is unexpected, this can also mean Radar temporarily could not
+            reach the cluster to check your access — retry, then ask your cluster administrator.
           </p>
         </div>
       </div>
@@ -675,10 +677,12 @@ function WorkloadCostRow({
 function NodeCostTable({
   nodes,
   currency,
+  restricted,
   onOpenResource,
 }: {
   nodes: OpenCostNodeCost[]
   currency: string
+  restricted: boolean
   onOpenResource?: (resource: SelectedResource) => void
 }) {
   return (
@@ -692,7 +696,10 @@ function NodeCostTable({
               <span className="text-[10px] text-theme-text-quaternary">current pricing</span>
             </div>
             <p className="text-[11px] text-theme-text-tertiary mt-0.5 ml-6">
-              Per-machine cloud pricing — namespace costs above show how this capacity is allocated
+              Per-machine cloud pricing for the whole cluster
+              {restricted
+                ? ' — the namespace costs above cover only your namespaces, so they account for part of this capacity'
+                : ' — namespace costs above show how this capacity is allocated'}
             </p>
           </div>
           <span className="text-xs text-theme-text-tertiary">{nodes.length} nodes</span>

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -534,9 +534,9 @@ function RestrictedCostNotice() {
         <div>
           <p className="text-sm font-medium text-theme-text-primary">Cost data is not available</p>
           <p className="mt-1 text-xs text-theme-text-tertiary">
-            Cost is shown for the namespaces you have access to, and no namespace is currently
-            visible to you. If that is unexpected, this can also mean Radar temporarily could not
-            reach the cluster to check your access — retry, then ask your cluster administrator.
+            Cost is shown for the namespaces you have access to, and none is currently visible. If
+            that is unexpected, retry — Radar may have been unable to reach the cluster to check
+            your access.
           </p>
         </div>
       </div>

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -19,6 +19,7 @@ import {
   ExternalLink,
   HelpCircle,
   Loader2,
+  Lock,
   Server,
   X,
 } from 'lucide-react'
@@ -113,6 +114,13 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
         </CostOverviewState>
       )
     }
+    if (reason === 'access_denied') {
+      return (
+        <CostOverviewState>
+          <RestrictedCostNotice />
+        </CostOverviewState>
+      )
+    }
     const message =
       reason === 'no_prometheus'
         ? 'Prometheus not found — OpenCost requires Prometheus or VictoriaMetrics'
@@ -152,6 +160,7 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
     )
   }
 
+  const restricted = data.restricted === true
   const hourlyCost = data.totalHourlyCost ?? 0
   const currency = data.currency ?? DEFAULT_COST_CURRENCY
   const namespaces = data.namespaces ?? []
@@ -229,7 +238,9 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
                 </span>
               </div>
               <span className="text-[10px] text-theme-text-quaternary">
-                projected from last 1h average
+                {restricted
+                  ? 'your namespaces only · projected from last 1h average'
+                  : 'projected from last 1h average'}
               </span>
             </div>
           </div>
@@ -237,11 +248,18 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
 
         <CostViewTabs />
 
+        {restricted && (
+          <RestrictedCostBanner
+            namespaceCount={namespaces.length}
+            nodesHidden={nodeData?.reason === 'access_denied'}
+          />
+        )}
+
         {/* CPU vs Memory (vs Storage) split bar */}
         <div className="rounded-lg border border-theme-border bg-theme-surface/50 p-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs font-medium text-theme-text-secondary">
-              Cluster Resource Cost
+              {restricted ? 'Resource Cost' : 'Cluster Resource Cost'}
             </span>
             <div className="flex items-center gap-4 text-xs text-theme-text-tertiary">
               <span className="flex items-center gap-1.5">
@@ -348,6 +366,7 @@ function CostOverview({ onBack, onOpenResource }: CostViewProps) {
           <span>
             {currency} &middot; current rates based on last 1h average &middot;
             *monthly projections assume {COST_HOURS_PER_MONTH} hrs/mo
+            {restricted && <> &middot; limited to your namespaces</>}
             {currency !== DEFAULT_COST_CURRENCY && (
               <> &middot; no conversion</>
             )}
@@ -481,6 +500,44 @@ function SystemNamespaceCostNote({ namespace }: { namespace: string }) {
   )
 }
 
+function RestrictedCostBanner({
+  namespaceCount,
+  nodesHidden,
+}: {
+  namespaceCount: number
+  nodesHidden: boolean
+}) {
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-theme-border bg-theme-elevated/40 px-4 py-3">
+      <Lock className="mt-0.5 h-4 w-4 shrink-0 text-theme-text-tertiary" />
+      <div className="text-xs text-theme-text-secondary">
+        <span className="font-medium text-theme-text-primary">Restricted view.</span>{' '}
+        Costs cover only the {namespaceCount === 1 ? 'namespace' : `${namespaceCount} namespaces`}{' '}
+        you have access to. Every figure on this page — including the headline total — is a
+        partial figure, not the cluster total.
+        {nodesHidden && ' Node costs are hidden because they cannot be split per namespace.'}
+      </div>
+    </div>
+  )
+}
+
+function RestrictedCostNotice() {
+  return (
+    <div className="flex min-h-64 items-center justify-center">
+      <div className="flex max-w-md flex-col items-center gap-3 text-center text-theme-text-secondary">
+        <Lock className="h-8 w-8 text-theme-text-tertiary/40" />
+        <div>
+          <p className="text-sm font-medium text-theme-text-primary">Cost data is not available</p>
+          <p className="mt-1 text-xs text-theme-text-tertiary">
+            Cost is shown for the namespaces you have access to, and you do not currently have
+            access to any. Ask your cluster administrator for namespace access.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function SystemNamespacesCostNote() {
   return (
     <div className="border-b border-theme-border/50 bg-theme-elevated/30 px-4 py-2 text-xs text-theme-text-tertiary">
@@ -516,7 +573,9 @@ function WorkloadRows({
   if (workloads.length === 0) {
     return (
       <div className="px-4 py-3 text-xs text-theme-text-tertiary bg-theme-elevated/30 pl-10">
-        No workload cost data available
+        {data?.reason === 'access_denied'
+          ? 'You do not have access to this namespace'
+          : 'No workload cost data available'}
       </div>
     )
   }

--- a/web/src/components/home/CostCard.tsx
+++ b/web/src/components/home/CostCard.tsx
@@ -88,6 +88,7 @@ function CostCardContent({ data, onNavigate }: { data: OpenCostSummary; onNaviga
         <div className="px-4 py-1.5 border-t border-theme-border/50 flex items-center justify-between">
           <span className="text-[10px] text-theme-text-tertiary">
             {currency} &middot; projected monthly from {data.window ?? '1h'} window
+            {data.restricted && <> &middot; your namespaces only</>}
             {currency !== DEFAULT_COST_CURRENCY && (
               <> &middot; no conversion</>
             )}


### PR DESCRIPTION
Closes the cost data leak reported in discussion #1564 (Linear RAD-429, phase 1).

## The problem

Four cost endpoints had no authorization of any kind. They queried Prometheus under Radar's own ServiceAccount and returned the result verbatim, so a namespace-restricted user saw whole-cluster spend:

| Route | What a restricted user got |
|---|---|
| `GET /api/opencost/summary` | every namespace's cost row + cluster totals |
| `GET /api/opencost/workloads?namespace=X` | workload costs in **any** namespace, just by asking |
| `GET /api/opencost/trend` | per-namespace time series for the whole cluster |
| `GET /api/opencost/nodes` | cluster-scoped node costs |

The seam already existed one block above them in `server.go`: the Prometheus routes install `SetAuthGate` for exactly this reason. The OpenCost routes registered directly below never got the equivalent.

The sibling endpoints in `internal/server` (`/opencost/workload/…`, `/opencost/application`) were already gated through `preflightResourceGet` and are untouched.

## The fix

- **A scope resolved per request** — `internal/opencost.Scope{Namespaces, CanReadNodes}`, threaded into `RegisterRoutes` as a parameter (the local precedent: `resolveCurrency` is already passed the same way). `nil` namespaces means unrestricted, an empty non-nil slice means no access — the same contract `auth.FilterNamespacesForUser` uses, so local no-auth and cluster-admin come out unrestricted by construction.
- **Node costs get their own SubjectAccessReview** on `list nodes` rather than being inferred from namespace access. A user can be namespace-restricted and still legitimately hold that grant, and the reverse is also true.
- **Filtering happens inside the compute layer**, not as a post-pass on the response. Two reasons that both matter: the summary skips the cluster-wide node-total ceiling instead of computing it and undoing it, and the trend filters *before* the top-N ranking (a post-filter would collapse a restricted user's own namespaces into the `other` bucket and then drop it, leaving an empty chart).
- **The node-total floor answers to the node grant.** `ComputeCostSummaryFromProm` raises `TotalHourlyCost` to `sum(node_total_hourly_cost)` when the node bill exceeds the namespace rows. Without this, `/opencost/nodes` would refuse a caller per-node pricing while `/opencost/summary` handed them its sum. Fails closed on the zero value.
- **UI states the restriction.** Per the maintainer reply on the thread, the tab stays visible: a banner when restricted, "your namespaces only" on the headline, "Cluster Resource Cost" retitled to "Resource Cost", the node table stating its own rows are cluster-wide, and a dedicated empty state for a user with no namespace access. `CostCard` on the home dashboard carries the same qualifier since it shows the same figure.

## Not in scope

Phase 2 — cost as an explicit, default-deny Radar permission with the tab hidden — is deliberately not here. It reverses a public commitment on the thread and needs its own design as the first Radar-defined permission in the product. The seams are in place for it: `Scope.CanReadNodes` is the precedent for a second grant on the same resolver, and `/api/capabilities` is the existing per-user channel for hiding a nav entry.

Also unchanged: no `--disable-cost` flag, and cost does not follow the namespace *picker* (a view filter, not the RBAC ceiling — a separate product call).

## One deliberate deviation

Denied requests return **200** with `available:false, reason:"access_denied"`, not 403. Every other unavailability in `internal/opencost/handlers.go` is already carried in the body, the frontend keys off `reason`, and the denied response carries no data. Switching to 403 would fork this file's contract against itself. Flagging it because a reviewer may reasonably prefer the status code.

## Verification

`go build ./...` and `go test ./...` green in both modules; `make tsc` clean. Tests cover unrestricted / restricted / no-access per endpoint, and the `nil`-vs-empty distinction the whole gate rests on — if an empty set were ever read as `nil`, a user with zero access would be served the entire cluster.

Verified end-to-end on a live cluster with a fake OpenCost Prometheus (cluster node bill 60/hr) across five identities:

| user | RBAC | summary | total | nodes | workloads(team-b) | restricted |
|---|---|---|---|---|---|---|
| `kubernetes-admin` | cluster-admin | 3 ns | 60/hr | 2 | served | no |
| `wide-user` | all ns, no `list nodes` | 3 ns | **12.5/hr** | `access_denied` | served | no |
| `node-user` | team-a + `list nodes` | 1 ns | 3.5/hr | 2 | `access_denied` | yes |
| `dev-user` | team-a only | 1 ns | 3.5/hr | `access_denied` | `access_denied` | yes |
| `nobody` | none | `access_denied` | — | `access_denied` | `access_denied` | yes |

Before the fix, `dev-user` was served the 60/hr cluster figure and all three namespace rows.

## Worth its own issue

`/api/prometheus/query` serves arbitrary PromQL to any authenticated caller. That is pre-existing and untouched here, but it means namespace scoping on the cost endpoints is defence in depth rather than a hard boundary for anyone who can reach that endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Authorization and data-boundary changes on cost APIs; incorrect nil-vs-empty namespace handling or total aggregation could still leak cluster spend to restricted users.
> 
> **Overview**
> **OpenCost HTTP handlers** now take a per-request **scope** (`AllowedNamespaces` + `CanReadNodes`) because Prometheus is queried under Radar’s identity, not the user’s. Summary, trend, and workloads filter or deny before/inside compute; **node costs** are all-or-nothing on `list nodes`. Denied cases return **200** with `available: false` and `reason: access_denied`, matching other unavailability paths.
> 
> **Compute layer** (`pkg/opencost`) applies `AllowedNamespaces` when building rows and totals (including REST allocation), sets **`restricted`** on responses, filters trends **before** top-N/`other` bucketing, drops cluster **`__idle__`** for restricted callers, and only applies the **node-total ceiling** when the caller is unrestricted and has the node grant.
> 
> **Server** adds `openCostScope` from user namespace permissions and a nodes SAR; **UI** surfaces restricted views (banner, copy, access-denied empty states, node table note). Types and client TS gain optional `restricted`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8dfba24ad297457bfc9c4af2319c6fd5ff09b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->