### PR TITLE
feat(gitops): open resource drawer when clicking an app's own root node

### DIFF
--- a/packages/k8s-ui/src/components/gitops/tree/GitOpsTreeGraph.tsx
+++ b/packages/k8s-ui/src/components/gitops/tree/GitOpsTreeGraph.tsx
@@ -582,6 +582,13 @@ const GitOpsResourceNode = memo(function GitOpsResourceNode({ data }: NodeProps<
           // border lift telegraphs "this responds to clicks" without
           // looking like a primary action.
           node.role === 'group' && 'cursor-pointer hover:border-theme-text-tertiary/50 hover:bg-theme-hover',
+          // The root node is this page's own subject, so it deliberately
+          // skips the portal ring/tool-badge above (clicking it can't
+          // "dive into" anything — it's already the page you're on). It's
+          // still clickable — opens the standard resource drawer — so it
+          // gets its own quieter affordance: a hover ring, no ring at rest,
+          // so it doesn't visually compete with real portal children.
+          node.role === 'root' && !data.highlighted && 'cursor-pointer hover:ring-1 hover:ring-theme-text-tertiary/40',
         )}
         style={{ width: dim.width, minHeight: dim.height, borderLeftWidth: 4 }}
       >

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -462,8 +462,17 @@ function GitOpsDetailView({ namespaces, onOpenResource, onOpenSettings }: GitOps
       // The tree's root node is this page's own subject — clicking it must not
       // open a nested copy of the same detail page (which stacks an identical
       // "GitOps / X / X" breadcrumb, and again, ad infinitum). A self-reference
-      // is a no-op; the header already represents this resource.
+      // opens the standard resource drawer instead, matching how every other
+      // resource in Radar responds to a click — the header already represents
+      // this resource, so a full navigation would be redundant, but a raw
+      // metadata/YAML drawer is not.
       if (detailKind === kind && (ref.namespace || '') === (namespace || '') && ref.name === name) {
+        onOpenResource({
+          kind: kindToPluralWithGroup(ref.kind, ref.group ?? ''),
+          namespace: ref.namespace || '',
+          name: ref.name,
+          group: ref.group,
+        })
         return
       }
       const params = new URLSearchParams()


### PR DESCRIPTION
## Summary

The GitOps detail page's Topology tab treats its own root node as a no-op on click — correctly, to avoid navigating to a stacked copy of the same page. But that left the root node without any click affordance at all, while every other resource in the tree opens the standard resource drawer.

A click on the root node now opens the standard resource drawer for that same resource, matching the rest of Radar's click behavior, while still skipping the self-referential navigation.

## Test plan

- [x] Manually verified on a live Application — clicking the root card opens its own drawer instead of doing nothing
- [x] Clicking any child node still navigates as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized GitOps topology UX change; reuses existing resource-drawer flow and does not alter auth, APIs, or child-node navigation.
> 
> **Overview**
> Clicking the **topology root node** on a GitOps detail page no longer does nothing. When the click refers to the same resource as the page (`openResourceFromTree` self-match), it now calls **`onOpenResource`** so Radar opens the **standard resource drawer** (metadata/YAML), while **still avoiding** nested navigation to another copy of the same GitOps detail view.
> 
> In **`GitOpsTreeGraph`**, root nodes get a **quieter click affordance** than GitOps portal children: `cursor-pointer` and a **hover-only** tertiary ring, without the skyhook portal ring at rest, so the subject node reads as clickable but not as “dive into another GitOps page.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5a8e3fd8f0f337d0100fe4d9da0951070cb760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->