### PR TITLE
fix(dock): stop log and terminal scrolling from dragging the whole page

### DIFF
--- a/packages/k8s-ui/src/components/dock/BottomDock.tsx
+++ b/packages/k8s-ui/src/components/dock/BottomDock.tsx
@@ -110,7 +110,7 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
 
   return (
     <div
-      className="absolute bottom-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40 overflow-hidden"
+      className="absolute bottom-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40 overflow-hidden overscroll-contain"
       style={{
         height: effectiveHeight,
         left: leftOffset,

--- a/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
@@ -265,7 +265,7 @@ export function LocalTerminalTab({
           </button>
         </div>
       ) : (
-        <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a]" />
+        <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a] [&_.xterm-viewport]:overscroll-contain" />
       )}
       {pasteDialog}
     </div>

--- a/packages/k8s-ui/src/components/dock/TerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/TerminalTab.tsx
@@ -348,7 +348,7 @@ export function TerminalTab({
           )}
         </div>
       ) : (
-        <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a]" />
+        <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a] [&_.xterm-viewport]:overscroll-contain" />
       )}
       {pasteDialog}
     </div>

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -850,7 +850,7 @@ export function LogCore({
                 palette={palette}
               />
             )}
-            className="h-full font-mono text-xs"
+            className="h-full font-mono text-xs overscroll-contain"
           />
           {/* Scroll-to-bottom button */}
           {!atBottom && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -91,6 +91,16 @@ body {
   flex-direction: column;
 }
 
+/* The shell is a fixed-viewport app: the document itself must never scroll or
+   rubber-band, or a wheel gesture that runs past the end of an inner scroller
+   (log pane, terminal) chains out and drags the whole page. Scoped through
+   :has() so it only ever matches Radar's own standalone document — a library
+   consumer's page keeps its own scrolling. */
+body:has(> #radar) {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
 
 /* ============================================
    REACT FLOW CUSTOMIZATIONS


### PR DESCRIPTION
## Problem

Opening pod logs in the bottom dock and scrolling with the mouse dragged the whole app around — the screen moved oddly, as if it scrolled below the app. Reported on the Mac desktop app and in the browser.

## Root cause

Scroll chaining, with nothing to stop it. Three gaps, all confirmed against the running app:

1. **`overscroll-behavior` was set nowhere in the repo.** When the log pane's virtualized scroller (or the xterm viewport) hits its top/bottom, the leftover wheel delta propagates to the nearest scrollable ancestor and on to the document.
2. **`overflow-x-clip` on the content column (`App.tsx:1674`) does not clip vertically.** Measured computed style is `overflow-x: clip`, `overflow-y: visible` — so there is no containment barrier between the log pane and the document.
3. **Nothing pinned the document.** `body { min-height: 100vh }` with no `overflow` rule, and `html` had no rule at all.

On macOS that combination is the elastic-overscroll bounce: past the end of the log buffer the gesture grabs the document and rubber-bands the app. It is a compositor behavior, which is why it hit both the desktop app and the browser.

## Fix

Two independent barriers, so a future scroller that forgets `contain` still can't move the page.

- `web/src/index.css` — `body:has(> #radar) { overflow: hidden; overscroll-behavior: none }`. The `:has()` scope is load-bearing: this file ships as the `@skyhook-io/radar-app` stylesheet (`"./style.css": "./src/index.css"`), so a bare `html, body` rule would reshape a consuming host's document. Host apps have no `#radar`.
- `BottomDock.tsx` — `overscroll-contain` on the dock root, stopping chaining at the dock boundary for every tab type.
- `LogCore.tsx` — `overscroll-contain` on the log scroller. Also covers the resource drawer's inline Logs tab, which renders the same component.
- `TerminalTab.tsx` / `LocalTerminalTab.tsx` — `[&_.xterm-viewport]:overscroll-contain`. xterm creates that element itself at `open()` time, so it is styled from the parent, matching the existing `[&_.xterm-viewport]:!bg-[#0f172a]` on the same line.

## Verification

- Computed styles in the built app: body `hidden` / `none`, dock `contain`, log scroller `contain`, `.xterm-viewport` `contain`.
- 40 hard wheel-ups past the top of a 2000px log buffer: the pane goes 1712 → 0, document `scrollTop` stays 0, header and dock do not move. Normal scrolling inside the pane still works in both directions.
- Regression sweep across Home, Resources, Topology, Events, Helm, Checks, Traffic and Nodes at six viewport sizes down to 900×600 — no view relied on document scroll, nothing clipped by `body { overflow: hidden }`.
- Dock terminal opened against a pod with a shell to confirm the xterm rule applies to the real `.xterm-viewport`.
- `make tsc` clean. Vitest shows 2 failures in `src/api/client.authRedirect.test.ts`, confirmed pre-existing on clean `main`.

## Caveat

Headless Linux Chromium has no elastic overscroll, so what could be verified here is that chaining is now blocked — the mechanism — not the disappearance of the bounce itself. The symptom is macOS-only and needs a confirmation pass there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only scroll/overscroll containment with host-page scoping via `:has(> #radar)`; no auth, data, or API changes.
> 
> **Overview**
> Fixes **scroll chaining** when pod logs or dock terminals hit the top/bottom of their scroll area—especially the macOS rubber-band effect that dragged the whole app.
> 
> **Document-level barrier:** `web/src/index.css` adds `body:has(> #radar) { overflow: hidden; overscroll-behavior: none }` so the standalone Radar shell never scrolls; `:has(> #radar)` keeps library consumers’ pages unchanged.
> 
> **Inner barriers:** Tailwind `overscroll-contain` on the bottom dock root (`BottomDock`), the log `Virtuoso` scroller (`LogCore`), and xterm’s `.xterm-viewport` via `[&_.xterm-viewport]:overscroll-contain` in `TerminalTab` / `LocalTerminalTab`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd59a248ceef2b10b159dc93f2a48c1ab2bcf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->