### PR TITLE
Accept day durations in get_changes

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -664,7 +664,7 @@ type getChangesInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
 	Kind      string `json:"kind,omitempty" jsonschema:"filter to a resource kind (e.g. Deployment, Pod)"`
 	Name      string `json:"name,omitempty" jsonschema:"filter to a specific resource name"`
-	Since     string `json:"since,omitempty" jsonschema:"duration to look back, e.g. 1h, 30m, 24h (default 1h)"`
+	Since     string `json:"since,omitempty" jsonschema:"duration to look back, e.g. 1h, 24h, 7d, 14d (default 1h)"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"max changes to return (default 20, max 50)"`
 }
 
@@ -1384,12 +1384,9 @@ func isPodKind(kind string) bool {
 func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getChangesInput) (*mcp.CallToolResult, any, error) {
 	since := 1 * time.Hour
 	if input.Since != "" {
-		parsed, err := time.ParseDuration(input.Since)
+		parsed, err := parsePromDuration(input.Since)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid duration %q: %w", input.Since, err)
-		}
-		if parsed <= 0 {
-			return nil, nil, fmt.Errorf("duration must be positive, got %q", input.Since)
+			return nil, nil, err
 		}
 		since = parsed
 	}

--- a/internal/mcp/tools_changes_configuration_test.go
+++ b/internal/mcp/tools_changes_configuration_test.go
@@ -67,6 +67,40 @@ func TestGetChangesEmitsApplicationConfigurationClassificationWithoutIssueAwareP
 	}
 }
 
+func TestGetChangesAcceptsDayDuration(t *testing.T) {
+	store := initCorrelationStore(t)
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID:             "two-weeks-of-history",
+		Timestamp:      time.Now().Add(-13 * 24 * time.Hour),
+		Source:         timeline.SourceInformer,
+		ClusterContext: k8s.ActiveClusterContext(),
+		Kind:           "Deployment",
+		Namespace:      "dev",
+		Name:           "api",
+		EventType:      timeline.EventTypeUpdate,
+		Diff: &timeline.DiffInfo{Fields: []timeline.FieldChange{{
+			Path: "spec.template.spec.containers[api].image",
+		}}},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	result, _, err := handleGetChanges(context.Background(), nil, getChangesInput{
+		Namespace: "dev",
+		Since:     "14d",
+	})
+	if err != nil {
+		t.Fatalf("handleGetChanges with 14d: %v", err)
+	}
+	var response getChangesResponseMCP
+	if err := json.Unmarshal([]byte(extractText(t, result)), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Changes) != 1 || response.Changes[0].Name != "api" {
+		t.Fatalf("14d changes = %+v, want the 13-day-old Deployment", response.Changes)
+	}
+}
+
 func TestGetChangesDistinguishesOutputCappingFromFetchSaturation(t *testing.T) {
 	appendChanges := func(t *testing.T, count int) {
 		t.Helper()


### PR DESCRIPTION
## Summary

Fix `get_changes` rejecting day-based history windows such as `since: "14d"`.

Radar can retain changes for weeks or longer, so an operator should be able to query that retained window using normal duration syntax. The tool now uses the same Prometheus-compatible duration parser as metrics queries.

## What changed

- accept day, week, compound, and fractional-day duration forms supported by the existing parser (for example `14d`, `2w`, `1d12h`)
- preserve positive-duration validation and clear invalid-input errors
- advertise day examples in the MCP schema
- add a regression test that retrieves a 13-day-old change using `since: "14d"`

## Scope

This changes only the `get_changes` request parser. It does not alter timeline retention, storage, result limits, or access control.

## Verification

- `gofmt`
- `git diff --check`
- Local Go test compilation is blocked by the workstation's temporary filesystem (301 MiB free; compiler reports `no space left on device`). CI is pending and is the authoritative full test run for this isolated Go change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated change to get_changes since parsing with no auth, retention, or data-path modifications; behavior aligns with an existing shared duration parser used elsewhere in MCP.
> 
> **Overview**
> Fixes **`get_changes`** rejecting multi-day history windows such as **`since: "14d"`**, which operators need when Radar retains changes for weeks.
> 
> The handler now parses **`since`** with **`parsePromDuration`** (same Prometheus-style parser as **`query_prometheus`**), so day/week and compound forms like **`7d`**, **`14d`**, **`2w`**, and **`1d12h`** work instead of only Go’s hour/minute durations. Invalid inputs still fail with clear errors; the MCP input schema examples were updated to advertise day-based values.
> 
> A regression test confirms a change from ~13 days ago is returned when **`since: "14d"`**. Scope is limited to request parsing—timeline retention, ranking, limits, and RBAC are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f980f2d2d585a2667d935c172dc12bdaf204ff91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->