### PR TITLE
fix(cnpg): detect a fully-down cluster instead of showing it as starting

### DIFF
--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -309,11 +309,11 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
 	ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
 	currentPrimary, _, _ := unstructured.NestedString(u.Object, "status", "currentPrimary")
-	// CNPG omits readyInstances when it is 0, so absence on a cluster that has
-	// reported ANYTHING (phase, primary or a condition) is a real 0, not "not
-	// reported yet". Resolving it here is what makes a fully-down cluster
-	// reachable at all — the old okR gate left it byte-identical to a statusless
-	// one. Absent EVERYTHING stays the truly-statusless case, still no signal.
+	// CNPG omits readyInstances when it is 0 (omitempty), so absence on a cluster
+	// that has reported ANYTHING (phase, primary or a condition) is a real 0, not
+	// "not reported yet"; resolving it to 0 here is what lets a fully-down cluster
+	// be detected. Absent EVERYTHING stays the truly-statusless case, still no
+	// signal.
 	reported := phase != "" || currentPrimary != "" || cnpgHasConditions(u)
 	readyResolved := ready
 	if !okR && reported {

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -1,6 +1,7 @@
 package issues
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -51,6 +52,13 @@ const cnpgTransientConditionGrace = 30 * time.Minute
 // latency, not a backup policy: nothing here decides how often backups should
 // run, only that the schedule missed a time it set for itself.
 const cnpgScheduledBackupGrace = 10 * time.Minute
+
+// cnpgDownGrace debounces a was-up cluster's Ready=False before it is called a
+// full outage, absorbing a single instance restarting during a routine rollout.
+// Distinct from cnpgTransientConditionGrace (30m): that bounds mid-operation
+// condition noise, this gates an all-down escalation. Kept in step with
+// CNPG_DOWN_GRACE_MS in the frontend, or a badge and its issue disagree.
+const cnpgDownGrace = 5 * time.Minute
 
 // cnpgAttentionPhases are stalled waiting on a human. Under
 // primaryUpdateStrategy: supervised this is the documented resting state, so it
@@ -210,6 +218,54 @@ func detectCNPGDeclarativeIssues(gvr schema.GroupVersionResource, kind string, u
 		"CNPGDeclarativeNotApplied", u.GetCreationTimestamp().Time)}
 }
 
+// cnpgHibernated reports the operator's deliberate scale-to-zero. Hibernation
+// removes the pods and reports nothing ready by design, signalled by an
+// annotation rather than any status field — so it must be read before a
+// zero-ready count is called an outage.
+func cnpgHibernated(u *unstructured.Unstructured) bool {
+	return u.GetAnnotations()["cnpg.io/hibernation"] == "on"
+}
+
+// cnpgFencedAll reports that every instance is fenced. The annotation is a JSON
+// array of instance names; "*" fences them all, so nothing serves — by intent,
+// not fault. A malformed value counts as not-fenced rather than erroring.
+func cnpgFencedAll(u *unstructured.Unstructured) bool {
+	raw := u.GetAnnotations()["cnpg.io/fencedInstances"]
+	if raw == "" {
+		return false
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return false
+	}
+	for _, n := range names {
+		if n == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// cnpgHasConditions mirrors the frontend's `status.conditions?.length` half of
+// the reported check — any condition the operator wrote proves it reconciled.
+func cnpgHasConditions(u *unstructured.Unstructured) bool {
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	return len(conds) > 0
+}
+
+// cnpgDownGraceElapsed reports whether a was-up cluster's Ready=False has aged
+// past the debounce window. Reuses the shared Ready-condition reader so the
+// grace keys off the same signal the frontend does. No Ready=False (or no
+// timestamp) means nothing is debouncing a restart, so escalate immediately
+// rather than inventing a start time from creationTimestamp.
+func cnpgDownGraceElapsed(u *unstructured.Unstructured) bool {
+	cond, ok := conditions.FindFalseConditionWithTime(u, "Ready")
+	if !ok || !cond.HasLastTransitionTime {
+		return true
+	}
+	return time.Since(cond.LastTransitionTime) >= cnpgDownGrace
+}
+
 // Every CNPG issue carries a Fingerprint because one cluster genuinely has
 // several independent causes at once — WAL archiving can be failing WHILE the
 // phase is unrecoverable. Without one the issue ID is category-only (see
@@ -252,13 +308,24 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 
 	desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
 	ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
-	// No phase excuses a database with nothing serving. "Waiting for user action"
-	// under a supervised strategy legitimately explains a PARTIAL shortfall, but
-	// not a cluster that is entirely down — that is an outage, not operator
-	// intent, and silencing it is how a total failure ends up with no issue at
-	// all. Mirrors the badge, which treats zero ready as hard-down ahead of
-	// every phase branch except terminal and failing-over.
-	allDown := okD && okR && desired > 0 && ready == 0
+	currentPrimary, _, _ := unstructured.NestedString(u.Object, "status", "currentPrimary")
+	// CNPG omits readyInstances when it is 0, so absence on a cluster that has
+	// reported ANYTHING (phase, primary or a condition) is a real 0, not "not
+	// reported yet". Resolving it here is what makes a fully-down cluster
+	// reachable at all — the old okR gate left it byte-identical to a statusless
+	// one. Absent EVERYTHING stays the truly-statusless case, still no signal.
+	reported := phase != "" || currentPrimary != "" || cnpgHasConditions(u)
+	readyResolved := ready
+	if !okR && reported {
+		readyResolved = 0
+	}
+	// No phase excuses a WAS-UP database with nothing serving. currentPrimary is
+	// the version-robust "was up" signal (set on first election, never cleared),
+	// so a zero-ready cluster that has one is a regression, not a first bootstrap.
+	// Hibernation and all-fenced are deliberate, and a single instance bouncing is
+	// debounced by the grace. Mirrors the badge's availability verdict exactly.
+	allDown := okD && desired > 0 && readyResolved == 0 && reported &&
+		currentPrimary != "" && !cnpgHibernated(u) && !cnpgFencedAll(u) && cnpgDownGraceElapsed(u)
 
 	phaseExplained := false
 	switch {
@@ -316,13 +383,22 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	// must not key on len(out): a WAL-archiving or failed-backup issue is an
 	// unrelated cause, and letting either suppress the shortfall would hide a
 	// cluster with zero ready instances behind a backup warning.
-	if !phaseExplained {
-		if okD && okR && desired > 0 && ready < desired {
-			severity := SeverityWarning
-			if ready == 0 {
-				severity = SeverityCritical
-			}
-			out = append(out, newConditionIssue(gvr, kind, ns, name, severity,
+	//
+	// A total outage is reported only through the allDown verdict — the same
+	// signal the badge turns on — which carries the bootstrap / hibernation /
+	// fenced / grace carve-outs, so a bootstrapping or hibernated cluster never
+	// becomes a false Critical. A partial shortfall needs an explicit
+	// readyInstances count above zero; the zero case belongs to allDown, whether
+	// the field is present or (as CNPG actually emits it) omitted.
+	if !phaseExplained && okD && desired > 0 {
+		switch {
+		case allDown:
+			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityCritical,
+				"CNPGClusterDegraded",
+				fmt.Sprintf("Only 0 of %d instances are ready", desired),
+				time.Time{}, false, "CNPGClusterDegraded", created))
+		case okR && ready > 0 && ready < desired:
+			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 				"CNPGClusterDegraded",
 				fmt.Sprintf("Only %d of %d instances are ready", ready, desired),
 				time.Time{}, false, "CNPGClusterDegraded", created))

--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -324,6 +324,10 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	// so a zero-ready cluster that has one is a regression, not a first bootstrap.
 	// Hibernation and all-fenced are deliberate, and a single instance bouncing is
 	// debounced by the grace. Mirrors the badge's availability verdict exactly.
+	// A cluster woken from hibernation or lifted from a full fence briefly matches
+	// this too — CNPG has already dropped the hibernation marker by wake, so from
+	// the Cluster status alone it is indistinguishable from a real outage and fires
+	// for that short window until the first instance is ready.
 	allDown := okD && desired > 0 && readyResolved == 0 && reported &&
 		currentPrimary != "" && !cnpgHibernated(u) && !cnpgFencedAll(u) && cnpgDownGraceElapsed(u)
 

--- a/internal/issues/source_cnpg_golden_test.go
+++ b/internal/issues/source_cnpg_golden_test.go
@@ -13,10 +13,11 @@ import (
 const cnpgGoldenMatrixPath = "../../testdata/cnpg/badge-issue-matrix.json"
 
 type cnpgGoldenCase struct {
-	Name   string         `json:"name"`
-	Spec   map[string]any `json:"spec"`
-	Status map[string]any `json:"status"`
-	Badge  struct {
+	Name     string         `json:"name"`
+	Spec     map[string]any `json:"spec"`
+	Status   map[string]any `json:"status"`
+	Metadata map[string]any `json:"metadata"`
+	Badge    struct {
 		Text  string `json:"text"`
 		Level string `json:"level"`
 	} `json:"badge"`
@@ -58,10 +59,17 @@ func TestCNPGGoldenMatrix(t *testing.T) {
 			// JSON numbers decode as float64; the detector reads int64.
 			spec := normalizeJSONInts(tc.Spec)
 			status := normalizeJSONInts(tc.Status)
+			// Fixed identity plus any annotations the case carries (hibernation,
+			// fencing) — those live on metadata, not status, and the detector reads
+			// them through GetAnnotations.
+			metadata := map[string]any{"name": "pg", "namespace": "pg"}
+			if annos, ok := tc.Metadata["annotations"].(map[string]any); ok {
+				metadata["annotations"] = annos
+			}
 			u := &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "postgresql.cnpg.io/v1",
 				"kind":       "Cluster",
-				"metadata":   map[string]any{"name": "pg", "namespace": "pg"},
+				"metadata":   metadata,
 				"spec":       spec,
 				"status":     status,
 			}}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -538,8 +538,8 @@ func TestCNPGZeroReadyDistinguishesBootstrapFromRegression(t *testing.T) {
 		t.Error("a partial fence must not suppress the outage of a was-up cluster")
 	}
 
-	// Regression: was up (currentPrimary), now nothing ready. This is the case the
-	// old readyInstances-presence gate made unreachable.
+	// Regression: was up (currentPrimary), now nothing ready — readyInstances
+	// omitted, the shape CNPG emits at zero. Must raise the outage.
 	regression := cnpgCluster(map[string]any{"instances": int64(3)},
 		map[string]any{"phase": "Waiting for the instances to become active", "currentPrimary": "pg-1"})
 	if !degraded(regression) {

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -190,7 +190,7 @@ func TestCNPGDegradedInstancesUnderHealthyPhase(t *testing.T) {
 
 	down := cnpgCluster(
 		map[string]any{"instances": int64(3)},
-		map[string]any{"phase": "Cluster in healthy state", "readyInstances": int64(0)},
+		map[string]any{"phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": int64(0)},
 	)
 	if got := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", down), "CNPGClusterDegraded"); got.Severity != SeverityCritical {
 		t.Errorf("all instances down: severity = %q, want critical", got.Severity)
@@ -299,7 +299,7 @@ func TestCNPGBackupConditionDoesNotSuppressOutage(t *testing.T) {
 		u := cnpgCluster(
 			map[string]any{"instances": int64(3)},
 			map[string]any{
-				"phase": "Cluster in healthy state", "readyInstances": int64(0),
+				"phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": int64(0),
 				"conditions": []any{cond},
 			},
 		)
@@ -443,11 +443,12 @@ func TestCNPGTransientPhasesSuppressGenericConditionWalk(t *testing.T) {
 	}
 }
 
-// No phase excuses a database with nothing serving. Suppressing the shortfall
-// for attention/transient phases is right for a PARTIAL shortfall, but a
-// cluster with zero ready instances is an outage — and once the generic
-// condition walk is also suppressed for those phases, silence here means no
-// signal anywhere.
+// No phase excuses a WAS-UP database with nothing serving. currentPrimary is
+// present (the cluster elected a primary before), and readyInstances is OMITTED
+// — the shape CNPG actually emits for zero ready. Suppressing the shortfall for
+// attention/transient phases is right for a PARTIAL shortfall, but a was-up
+// cluster with nothing serving is an outage, and once the generic condition walk
+// is also suppressed for those phases, silence here means no signal anywhere.
 func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 	cases := []struct {
 		phase    string
@@ -466,7 +467,9 @@ func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 			if tc.strategy != "" {
 				spec["primaryUpdateStrategy"] = tc.strategy
 			}
-			u := cnpgCluster(spec, map[string]any{"phase": tc.phase, "readyInstances": int64(0)})
+			// currentPrimary set, readyInstances omitted, no Ready=False condition:
+			// a was-up cluster reporting nothing ready, escalated immediately.
+			u := cnpgCluster(spec, map[string]any{"phase": tc.phase, "currentPrimary": "pg-1"})
 			iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGClusterDegraded")
 			if iss.Severity != SeverityCritical {
 				t.Errorf("severity = %q, want critical for a fully-down cluster", iss.Severity)
@@ -479,13 +482,109 @@ func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 	for _, phase := range []string{"Waiting for user action", "Switchover in progress"} {
 		u := cnpgCluster(
 			map[string]any{"instances": int64(3), "primaryUpdateStrategy": "supervised"},
-			map[string]any{"phase": phase, "readyInstances": int64(2)},
+			map[string]any{"phase": phase, "currentPrimary": "pg-1", "readyInstances": int64(2)},
 		)
 		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
 			if i.Reason == "CNPGClusterDegraded" {
 				t.Errorf("phase %q: partial shortfall should stay suppressed", phase)
 			}
 		}
+	}
+}
+
+// The all-down verdict distinguishes the three states that a bare zero-ready
+// count collapses together: a first bootstrap (never elected a primary), a
+// deliberate not-serving state (hibernation / all-fenced), and a genuine
+// regression. Only the last raises an issue.
+func TestCNPGZeroReadyDistinguishesBootstrapFromRegression(t *testing.T) {
+	degraded := func(u *unstructured.Unstructured) bool {
+		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
+			if i.Reason == "CNPGClusterDegraded" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// First bootstrap: reported (phase) but no primary ever elected, readyInstances
+	// omitted. Nothing was serving to lose, so no alarm.
+	bootstrap := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Setting up primary"})
+	if degraded(bootstrap) {
+		t.Error("a first bootstrap with no elected primary must not raise CNPGClusterDegraded")
+	}
+
+	// Hibernation is a deliberate scale-to-zero, signalled by annotation.
+	hibernated := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"currentPrimary": "pg-1"})
+	hibernated.SetAnnotations(map[string]string{"cnpg.io/hibernation": "on"})
+	if degraded(hibernated) {
+		t.Error("a hibernated cluster must not raise CNPGClusterDegraded")
+	}
+
+	// All instances fenced: PostgreSQL stopped on purpose, pods still up.
+	fenced := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"currentPrimary": "pg-1"})
+	fenced.SetAnnotations(map[string]string{"cnpg.io/fencedInstances": `["*"]`})
+	if degraded(fenced) {
+		t.Error("an all-fenced cluster must not raise CNPGClusterDegraded")
+	}
+
+	// A partially-fenced cluster is NOT carved out — "*" is the only all-down token.
+	partialFence := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Waiting for the instances to become active", "currentPrimary": "pg-1"})
+	partialFence.SetAnnotations(map[string]string{"cnpg.io/fencedInstances": `["pg-1-2"]`})
+	if !degraded(partialFence) {
+		t.Error("a partial fence must not suppress the outage of a was-up cluster")
+	}
+
+	// Regression: was up (currentPrimary), now nothing ready. This is the case the
+	// old readyInstances-presence gate made unreachable.
+	regression := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Waiting for the instances to become active", "currentPrimary": "pg-1"})
+	if !degraded(regression) {
+		t.Error("a was-up cluster with nothing ready must raise CNPGClusterDegraded")
+	}
+}
+
+// The regression escalation is debounced on the Ready=False transition so a
+// single instance restarting during a routine rollout does not read as a total
+// outage. Past the grace, or with no Ready condition at all, it escalates.
+func TestCNPGDownGraceDebouncesRoutineRestart(t *testing.T) {
+	degraded := func(readyLTT string) bool {
+		status := map[string]any{
+			"phase":          "Waiting for the instances to become active",
+			"currentPrimary": "pg-1",
+		}
+		if readyLTT != "" {
+			status["conditions"] = []any{map[string]any{
+				"type": "Ready", "status": "False", "reason": "ClusterIsNotReady",
+				"lastTransitionTime": readyLTT,
+			}}
+		}
+		u := cnpgCluster(map[string]any{"instances": int64(3)}, status)
+		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
+			if i.Reason == "CNPGClusterDegraded" {
+				return true
+			}
+		}
+		return false
+	}
+
+	recent := time.Now().Add(-time.Minute).Format(time.RFC3339)
+	if degraded(recent) {
+		t.Error("a Ready=False younger than the grace must be debounced, not escalated")
+	}
+
+	old := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	if !degraded(old) {
+		t.Error("a Ready=False older than the grace must escalate")
+	}
+
+	// No Ready condition on a was-up cluster: nothing is debouncing, so escalate
+	// immediately rather than inventing a start time from creationTimestamp.
+	if !degraded("") {
+		t.Error("a was-up cluster with no Ready condition must escalate immediately")
 	}
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -43,7 +43,7 @@ describe('CNPGClusterRenderer — the drawer must not contradict the badge', () 
     // No phase excuses a database that was serving and now has nothing ready.
     // readyInstances is OMITTED — the shape CNPG actually emits for zero ready —
     // and currentPrimary is the "was up" signal that tells this apart from a
-    // first bootstrap. This is the exact case the old presence gate missed.
+    // first bootstrap.
     const wasUpDown = {
       apiVersion: 'postgresql.cnpg.io/v1',
       kind: 'Cluster',

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -39,9 +39,33 @@ describe('CNPGClusterRenderer — the drawer must not contradict the badge', () 
     expect(html(settled)).toContain('Degraded Cluster')
   })
 
-  it('still raises Cluster Down at zero ready, whatever the phase', () => {
-    // No phase excuses a database with nothing serving.
-    expect(html(cluster('Upgrading cluster', 0))).toContain('Cluster Down')
+  it('still raises Cluster Down for a was-up cluster at zero ready, whatever the phase', () => {
+    // No phase excuses a database that was serving and now has nothing ready.
+    // readyInstances is OMITTED — the shape CNPG actually emits for zero ready —
+    // and currentPrimary is the "was up" signal that tells this apart from a
+    // first bootstrap. This is the exact case the old presence gate missed.
+    const wasUpDown = {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      metadata: { name: 'pg', namespace: 'db' },
+      spec: { instances: 3 },
+      status: { phase: 'Upgrading cluster', currentPrimary: 'pg-1' },
+    }
+    expect(html(wasUpDown)).toContain('Cluster Down')
+  })
+
+  it('does not raise Cluster Down for a bootstrapping cluster with no primary yet', () => {
+    // Reported (phase) but no primary elected and readyInstances omitted — the
+    // shape a fresh cluster emits. A red banner here is the false alarm the
+    // availability verdict exists to prevent.
+    const bootstrapping = {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      metadata: { name: 'pg', namespace: 'db' },
+      spec: { instances: 3 },
+      status: { phase: 'Setting up primary' },
+    }
+    expect(html(bootstrapping)).not.toContain('Cluster Down')
   })
 
   it('renders a failed last backup at the same tier as the badge and detector', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -23,6 +23,7 @@ import {
   getCNPGWALArchivingFailure,
   getCNPGLastBackupFailure,
   classifyCNPGClusterPhase,
+  getCNPGClusterAvailability,
   CNPG_BARMAN_OBJECTSTORE_GROUP,
 } from '../resource-utils-cnpg'
 import { formatAge } from '../resource-utils'
@@ -79,8 +80,11 @@ export function CNPGClusterRenderer({ data, onNavigate, declared}: CNPGClusterRe
   const lastBackupFailure = getCNPGLastBackupFailure(data)
   const phaseBucket = classifyCNPGClusterPhase(phase)
 
-  // Problem detection
-  const isDown = countsKnown && readyInstances === 0
+  // Problem detection. isDown reuses the badge's availability verdict so the
+  // three surfaces agree: a fully-down cluster CNPG reports by omitting
+  // readyInstances (countsKnown false) is unreachable through the raw counts,
+  // and hibernation / all-fenced are deliberate not-serving states, not outages.
+  const isDown = getCNPGClusterAvailability(data) === 'down'
   // A shortfall the PHASE already explains is not a separate problem. Mirrors
   // source_cnpg.go's phaseExplained gate and the badge's ordering, both of
   // which check the phase before the instance counts: mid-switchover or waiting

--- a/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { Tooltip } from '../../ui/Tooltip'
 import {
   getCNPGClusterStatus,
+  getCNPGClusterAvailability,
   classifyCNPGClusterPhase,
   getCNPGClusterInstances,
   getCNPGClusterPrimary,
@@ -66,8 +67,18 @@ export function CNPGClusterCell({ resource, column }: { resource: any; column: s
           </Tooltip>
         )
       }
+      // Colour tracks the badge: a was-up total outage (readyInstances omitted,
+      // so readyKnown is false) reads red like its "Not Ready" badge rather than
+      // muted grey, and a partial shortfall stays yellow. Without the
+      // availability check the most severe count was the least emphasised.
+      const down = getCNPGClusterAvailability(resource) === 'down'
       return (
-        <span className={clsx('text-sm', readyKnown && ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary')}>
+        <span
+          className={clsx(
+            'text-sm',
+            down ? 'text-red-400' : readyKnown && ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary',
+          )}
+        >
           {instances}
         </span>
       )

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
@@ -27,6 +27,7 @@ interface GoldenCase {
   name: string
   spec: Record<string, unknown>
   status: Record<string, unknown>
+  metadata?: Record<string, unknown>
   badge: { text: string; level: string }
   issues: string[]
   worst: string
@@ -40,7 +41,7 @@ describe('CNPG golden matrix — badge side', () => {
   })
 
   it.each(cases.map((c) => [c.name, c] as const))('%s', (_name, tc) => {
-    const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+    const badge = getCNPGClusterStatus({ metadata: tc.metadata, spec: tc.spec, status: tc.status })
     expect({ text: badge.text, level: badge.level }).toEqual(tc.badge)
   })
 
@@ -50,7 +51,7 @@ describe('CNPG golden matrix — badge side', () => {
   it.each(cases.map((c) => [c.name, c] as const))(
     'badge and issues do not contradict — %s',
     (_name, tc) => {
-      const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+      const badge = getCNPGClusterStatus({ metadata: tc.metadata, spec: tc.spec, status: tc.status })
       if (badge.level === 'healthy') {
         expect(tc.issues, 'a healthy badge must not sit next to an issue').toEqual([])
       }
@@ -69,16 +70,23 @@ describe('CNPG golden matrix — badge side', () => {
   // This is the gap that let the bug through: the matrix already pinned
   // "readyInstances absent — unknown, not zero; must not fabricate an outage"
   // for the badge, and the cell rendered 0/N on that very case.
+  //
+  // The cell reads '-' exactly when the ready count is genuinely unknown: no
+  // explicit readyInstances AND no currentPrimary. Once a primary has been
+  // elected, an omitted readyInstances is a real 0 and the cell says so — which
+  // is what keeps "0/3" agreeing with the "Not Ready" badge on a was-up outage,
+  // while a still-bootstrapping cluster (no primary) keeps its dash.
   it.each(cases.map((c) => [c.name, c] as const))(
     'instances cell does not claim an outage the badge denies — %s',
     (_name, tc) => {
       const cell = getCNPGClusterInstances({ spec: tc.spec, status: tc.status })
       const ready = cell.split('/')[0]
-      const readyReported = typeof tc.status.readyInstances === 'number'
+      const readyResolvable =
+        typeof tc.status.readyInstances === 'number' || !!tc.status.currentPrimary
       expect(
         ready === '-',
-        `readyInstances ${readyReported ? 'is reported' : 'is absent'} but the cell reads ${cell}`,
-      ).toBe(!readyReported)
+        `ready is ${readyResolvable ? 'resolvable' : 'unknown'} but the cell reads ${cell}`,
+      ).toBe(!readyResolvable)
     },
   )
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -29,6 +29,10 @@ import {
   getCNPGPoolerInstances,
   getCNPGClusterIsReplica,
   getCNPGClusterReplicaSource,
+  getCNPGClusterAvailability,
+  isCNPGClusterHibernated,
+  isCNPGClusterFencedAll,
+  CNPG_DOWN_GRACE_MS,
 } from './resource-utils-cnpg'
 import { getCellFilterValue } from './resource-utils'
 
@@ -178,8 +182,10 @@ describe('getCNPGClusterStatus', () => {
     expect(getCNPGClusterStatus(cluster({ phase: 'Failing over', readyInstances: 2 }, { instances: 3 })).level).toBe('alert')
   })
 
-  it('treats zero ready instances as down regardless of phase', () => {
-    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 0 }, { instances: 3 }))
+  it('treats a was-up cluster with zero ready instances as down regardless of phase', () => {
+    // currentPrimary proves it was serving; the omitted-then-zero count is a
+    // regression, not a first bootstrap. Even a "healthy" phase does not rescue it.
+    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', currentPrimary: 'pg-1', readyInstances: 0 }, { instances: 3 }))
     expect(s.level).toBe('unhealthy')
     expect(s.text).toBe('Not Ready')
   })
@@ -192,6 +198,68 @@ describe('getCNPGClusterStatus', () => {
     const s = getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 2 }, { instances: 2 }))
     expect(s.level).toBe('unknown')
     expect(s.text).toBe('Some future phase')
+  })
+})
+
+describe('getCNPGClusterAvailability — three states a bare zero-ready count collapses', () => {
+  // CNPG omits readyInstances when it is 0, so these fixtures OMIT it — the shape
+  // the operator actually emits for a down cluster.
+  const withPrimary = (extra: any = {}, meta: any = {}) => ({
+    metadata: meta,
+    spec: { instances: 3 },
+    status: { currentPrimary: 'pg-1', ...extra },
+  })
+
+  it('is null while still bootstrapping — reported, but no primary ever elected', () => {
+    // The truly-statusless case AND the reported-but-no-primary case both stay
+    // null: nothing was serving to lose.
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: {} })).toBeNull()
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: { phase: 'Setting up primary' } })).toBeNull()
+  })
+
+  it('is null when a real ready count exists', () => {
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: { currentPrimary: 'pg-1', readyInstances: 2 } })).toBeNull()
+  })
+
+  it('is down for a was-up cluster with no Ready condition — escalates immediately', () => {
+    expect(getCNPGClusterAvailability(withPrimary({ phase: 'Waiting for the instances to become active' }))).toBe('down')
+  })
+
+  it('debounces a fresh Ready=False, then escalates once it ages past the grace', () => {
+    const recent = new Date(Date.now() - 60 * 1000).toISOString()
+    const old = new Date(Date.now() - CNPG_DOWN_GRACE_MS - 60 * 1000).toISOString()
+    const cond = (ltt: string) => withPrimary({
+      conditions: [{ type: 'Ready', status: 'False', reason: 'ClusterIsNotReady', lastTransitionTime: ltt }],
+    })
+    expect(getCNPGClusterAvailability(cond(recent))).toBeNull()
+    expect(getCNPGClusterAvailability(cond(old))).toBe('down')
+  })
+
+  it('reads hibernation and all-fencing as neutral, ahead of the down verdict', () => {
+    expect(getCNPGClusterAvailability(withPrimary({}, { annotations: { 'cnpg.io/hibernation': 'on' } }))).toBe('hibernated')
+    expect(getCNPGClusterAvailability(withPrimary({}, { annotations: { 'cnpg.io/fencedInstances': '["*"]' } }))).toBe('fenced')
+  })
+
+  it('a partial fence is not all-fenced — "*" is the only all-down token', () => {
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': '["pg-1-2"]' } } })).toBe(false)
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': '["*"]' } } })).toBe(true)
+    // A malformed annotation is treated as not-fenced rather than throwing.
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': 'not-json' } } })).toBe(false)
+  })
+
+  it('hibernation is an explicit "on", nothing else', () => {
+    expect(isCNPGClusterHibernated({ metadata: { annotations: { 'cnpg.io/hibernation': 'on' } } })).toBe(true)
+    expect(isCNPGClusterHibernated({ metadata: { annotations: { 'cnpg.io/hibernation': 'off' } } })).toBe(false)
+    expect(isCNPGClusterHibernated({ metadata: {} })).toBe(false)
+  })
+
+  it('renders the badge neutral for hibernation and fencing, red only for a real outage', () => {
+    expect(getCNPGClusterStatus(withPrimary({}, { annotations: { 'cnpg.io/hibernation': 'on' } })))
+      .toMatchObject({ text: 'Hibernated', level: 'neutral' })
+    expect(getCNPGClusterStatus(withPrimary({}, { annotations: { 'cnpg.io/fencedInstances': '["*"]' } })))
+      .toMatchObject({ text: 'Fenced', level: 'neutral' })
+    expect(getCNPGClusterStatus(withPrimary({ phase: 'Switchover in progress' })))
+      .toMatchObject({ text: 'Not Ready', level: 'unhealthy' })
   })
 })
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -183,9 +183,10 @@ export function isCNPGClusterFencedAll(resource: any): boolean {
  *
  * The load-bearing distinction the badge and the Go detector both turn on:
  * CNPG omits `status.readyInstances` when it is 0 (omitempty int), so "no
- * status yet" and "0 ready" are byte-identical on the wire. Gating an outage on
- * the field's PRESENCE therefore made a fully-down cluster unreachable — it
- * looked exactly like one that had not reported.
+ * status yet" and "0 ready" are byte-identical on the wire. The field's
+ * presence therefore cannot distinguish an outage from an unreported cluster;
+ * any other status the operator has written (phase, primary, a condition) is
+ * what marks the count as a real 0 rather than "not reported".
  *
  * `status.currentPrimary` is the version-robust "was up" signal: CNPG sets it
  * the first time a primary is elected and never clears it (present on 1.27 and

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -145,6 +145,94 @@ export function classifyCNPGClusterPhase(phase: string): CNPGPhaseBucket {
   return 'unknown'
 }
 
+// Debounce window for calling a was-up cluster "down". A single instance
+// restarting flips Ready=False for a minute or two while the pod comes back;
+// escalating instantly would fire on routine rollouts. Kept in step with
+// cnpgDownGrace in internal/issues/source_cnpg.go — the two must not drift.
+export const CNPG_DOWN_GRACE_MS = 5 * 60 * 1000
+
+/**
+ * Hibernation is a deliberate scale-to-zero: the operator removes the pods and
+ * the cluster reports nothing ready by design. Signalled by an annotation, not
+ * by any status field, so it has to be read before a zero-ready count is called
+ * an outage.
+ */
+export function isCNPGClusterHibernated(resource: any): boolean {
+  return resource?.metadata?.annotations?.['cnpg.io/hibernation'] === 'on'
+}
+
+/**
+ * Fencing stops PostgreSQL on the named instances while leaving the pods up. The
+ * annotation is a JSON array of instance names; `"*"` means every instance is
+ * fenced, so nothing serves — intentionally, not as a fault. A malformed value
+ * is treated as "not fenced" rather than throwing.
+ */
+export function isCNPGClusterFencedAll(resource: any): boolean {
+  const raw = resource?.metadata?.annotations?.['cnpg.io/fencedInstances']
+  if (typeof raw !== 'string' || raw === '') return false
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) && parsed.includes('*')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether a zero-ready cluster is actually unavailable, and why.
+ *
+ * The load-bearing distinction the badge and the Go detector both turn on:
+ * CNPG omits `status.readyInstances` when it is 0 (omitempty int), so "no
+ * status yet" and "0 ready" are byte-identical on the wire. Gating an outage on
+ * the field's PRESENCE therefore made a fully-down cluster unreachable — it
+ * looked exactly like one that had not reported.
+ *
+ * `status.currentPrimary` is the version-robust "was up" signal: CNPG sets it
+ * the first time a primary is elected and never clears it (present on 1.27 and
+ * 1.28). So a zero-ready cluster that HAS a currentPrimary was serving before —
+ * a regression — while one that never had a primary is still bootstrapping.
+ *
+ *   - null       — not down: still bootstrapping, or a real ready count exists
+ *   - 'hibernated' / 'fenced' — deliberately not serving, no alarm
+ *   - 'down'     — was up, now zero ready past the grace window
+ *
+ * Mirrored by getCNPGClusterAvailability's Go counterpart in
+ * internal/issues/source_cnpg.go (the allDown verdict) — same signals, same
+ * grace, or a badge and its issue disagree.
+ */
+export function getCNPGClusterAvailability(
+  resource: any,
+): 'hibernated' | 'fenced' | 'down' | null {
+  const status = resource.status || {}
+  const desired = resource.spec?.instances ?? 0
+  const ready = typeof status.readyInstances === 'number' ? status.readyInstances : 0
+  // Any status the operator has written proves it has reconciled at least once,
+  // which is what lets an absent readyInstances be read as a real 0 rather than
+  // "not reported". Absent EVERYTHING is the truly-statusless case, still unknown.
+  const reported = !!(status.phase || status.currentPrimary || status.conditions?.length)
+  if (desired <= 0 || ready > 0 || !reported) return null
+  // Deliberate not-serving states outrank the down verdict — checked before the
+  // was-up gate so a hibernated cluster reads neutral even if it kept a primary.
+  if (isCNPGClusterHibernated(resource)) return 'hibernated'
+  if (isCNPGClusterFencedAll(resource)) return 'fenced'
+  // Never elected a primary → first bootstrap, not a regression.
+  if (!status.currentPrimary) return null
+  const conditions = status.conditions || []
+  const readyCond = conditions.find((c: any) => c.type === 'Ready')
+  // A was-up cluster whose Ready only just went False is likely a single
+  // instance bouncing; wait out the grace. No Ready=False at all (or no
+  // timestamp) means nothing is debouncing, so escalate immediately rather than
+  // inventing a start time.
+  if (
+    readyCond?.status === 'False' &&
+    readyCond.lastTransitionTime &&
+    Date.now() - Date.parse(readyCond.lastTransitionTime) < CNPG_DOWN_GRACE_MS
+  ) {
+    return null
+  }
+  return 'down'
+}
+
 export function getCNPGClusterStatus(resource: any): StatusBadge {
   const status = resource.status || {}
   const phase = status.phase || ''
@@ -165,10 +253,19 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   if (bucket === 'terminal') {
     return { text: getCNPGClusterDisplayState(phase), color: healthColors.unhealthy, level: 'unhealthy' }
   }
-  // Zero ready instances is a hard down that no phase excuses — including a
-  // failover, where the phase alone would otherwise downgrade a total outage to
-  // orange.
-  if (countsKnown && readyInstances === 0) {
+  // Availability outranks every phase branch except terminal. A zero-ready
+  // cluster CNPG reports by omitting readyInstances would otherwise be invisible
+  // here (countsKnown is false without the field) and fall through to the
+  // transient phase, painting amber on a total outage. Hibernation and all-fenced
+  // are deliberate not-serving states, so they read neutral rather than red.
+  const avail = getCNPGClusterAvailability(resource)
+  if (avail === 'hibernated') {
+    return { text: 'Hibernated', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (avail === 'fenced') {
+    return { text: 'Fenced', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (avail === 'down') {
     return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
   if (bucket === 'failing') {
@@ -241,7 +338,20 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
 const countOrDash = (n: unknown): string => (typeof n === 'number' ? String(n) : '-')
 
 export function getCNPGClusterInstances(resource: any): string {
-  return `${countOrDash(resource.status?.readyInstances)}/${countOrDash(resource.spec?.instances)}`
+  const status = resource.status || {}
+  // Absent readyInstances resolves to 0 only for a was-up cluster (one that
+  // elected a primary): there the omitted field genuinely means zero ready, and
+  // "0/3" agrees with the "Not Ready" badge. Before a primary exists the count
+  // is truly unknown, so it stays a dash — the guard against fabricating an
+  // outage the badge denies. currentPrimary is the same was-up signal the badge
+  // gates its down verdict on, so the cell can never read 0 beside a green badge.
+  const ready =
+    typeof status.readyInstances === 'number'
+      ? status.readyInstances
+      : status.currentPrimary
+        ? 0
+        : undefined
+  return `${countOrDash(ready)}/${countOrDash(resource.spec?.instances)}`
 }
 
 export function getCNPGClusterPrimary(resource: any): string {

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -231,6 +231,11 @@ export function getCNPGClusterAvailability(
   ) {
     return null
   }
+  // A cluster woken from hibernation or lifted from a full fence transiently
+  // shows this same shape — was-up, zero ready, Ready=False from long before —
+  // until its first instance is Ready. CNPG drops the hibernation marker at that
+  // point, so from the Cluster status alone this is indistinguishable from a real
+  // outage, and it reads down for that short window.
   return 'down'
 }
 

--- a/testdata/cnpg/badge-issue-matrix.json
+++ b/testdata/cnpg/badge-issue-matrix.json
@@ -14,6 +14,13 @@
     "file pins observable behaviour instead, so a change to one language that the",
     "other doesn't mirror fails in both.",
     "",
+    "CNPG omits status.readyInstances when it is 0 (omitempty int), so a fully-down",
+    "cluster and one that has not reported are byte-identical on the wire. The",
+    "all-down cases below therefore OMIT readyInstances, the shape CNPG actually",
+    "emits — never `readyInstances: 0`, which the operator never sends. currentPrimary",
+    "is the 'was up' signal that tells a regression apart from a first bootstrap.",
+    "",
+    "`metadata` is optional and carries only annotations (hibernation / fencing).",
     "`issues` is an unordered set of Reason values. `worst` is the highest issue",
     "severity (critical > warning > none). Adding a case is cheap — do it every",
     "time a state turns out to be ambiguous."
@@ -22,7 +29,7 @@
     {
       "name": "healthy and fully ready",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 3 },
+      "status": { "phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Healthy", "level": "healthy" },
       "issues": [],
       "worst": "none"
@@ -30,21 +37,27 @@
     {
       "name": "healthy phase but a partial shortfall — the phase settles before instances do",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 1 },
+      "status": { "phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": 1 },
       "badge": { "text": "Degraded", "level": "degraded" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "warning"
     },
     {
-      "name": "healthy phase with nothing serving",
+      "name": "was-up cluster fully down — readyInstances omitted, currentPrimary proves it was serving",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 0 },
+      "status": {
+        "phase": "Waiting for the instances to become active",
+        "currentPrimary": "pg-1",
+        "conditions": [
+          { "type": "Ready", "status": "False", "reason": "ClusterIsNotReady", "lastTransitionTime": "2020-01-01T00:00:00Z" }
+        ]
+      },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
     },
     {
-      "name": "readyInstances absent — unknown, not zero; must not fabricate an outage",
+      "name": "readyInstances absent on a Ready=True cluster — unknown, not zero; must not fabricate an outage",
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
@@ -59,6 +72,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing", "message": "cannot upload WAL" }
@@ -73,6 +87,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "LastBackupSucceeded", "status": "False", "reason": "LastBackupFailed", "message": "no credentials" }
@@ -87,6 +102,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "LastBackupSucceeded", "status": "False", "reason": "BackupStarted", "message": "New Backup starting up" }
@@ -99,7 +115,7 @@
     {
       "name": "unrecoverable while every pod is still Ready",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "readyInstances": 3 },
+      "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGClusterUnrecoverable"],
       "worst": "critical"
@@ -109,6 +125,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster cannot proceed to reconciliation due to an unknown plugin being required",
+        "currentPrimary": "pg-1",
         "readyInstances": 3
       },
       "badge": {
@@ -121,7 +138,7 @@
     {
       "name": "post-1.28 PhaseDefinitionInvalid is carried ahead of the release that emits it",
       "spec": { "instances": 3 },
-      "status": { "phase": "Invalid cluster definition", "readyInstances": 3 },
+      "status": { "phase": "Invalid cluster definition", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Invalid Spec", "level": "unhealthy" },
       "issues": ["CNPGClusterTerminal"],
       "worst": "critical"
@@ -129,7 +146,7 @@
     {
       "name": "failover with a surviving replica",
       "spec": { "instances": 3 },
-      "status": { "phase": "Failing over", "readyInstances": 2 },
+      "status": { "phase": "Failing over", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Failing Over", "level": "alert" },
       "issues": ["CNPGClusterFailingOver"],
       "worst": "warning"
@@ -137,7 +154,7 @@
     {
       "name": "failover with nothing serving is a total outage, not an orange warning",
       "spec": { "instances": 3 },
-      "status": { "phase": "Failing over", "readyInstances": 0 },
+      "status": { "phase": "Failing over", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterFailingOver", "CNPGClusterDegraded"],
       "worst": "critical"
@@ -145,15 +162,15 @@
     {
       "name": "mid-operation shortfall is expected and stays quiet",
       "spec": { "instances": 3 },
-      "status": { "phase": "Creating a new replica", "readyInstances": 2 },
+      "status": { "phase": "Creating a new replica", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Creating Replica", "level": "degraded" },
       "issues": [],
       "worst": "none"
     },
     {
-      "name": "no transient phase excuses a fully-down cluster",
+      "name": "no transient phase excuses a fully-down was-up cluster",
       "spec": { "instances": 3 },
-      "status": { "phase": "Switchover in progress", "readyInstances": 0 },
+      "status": { "phase": "Switchover in progress", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
@@ -161,7 +178,7 @@
     {
       "name": "rollout delay is operator-driven, not a wait on a human",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster upgrade delayed", "readyInstances": 2 },
+      "status": { "phase": "Cluster upgrade delayed", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Upgrade Delayed", "level": "degraded" },
       "issues": [],
       "worst": "none"
@@ -169,7 +186,7 @@
     {
       "name": "supervised wait — a shortfall is the documented resting state",
       "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": [],
       "worst": "none"
@@ -177,7 +194,7 @@
     {
       "name": "unsupervised wait is worth reporting",
       "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": ["CNPGClusterWaitingForUser"],
       "worst": "warning"
@@ -185,7 +202,7 @@
     {
       "name": "supervised wait with nothing serving is still an outage",
       "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
@@ -193,7 +210,7 @@
     {
       "name": "unsupervised wait with nothing serving reports both true causes",
       "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterWaitingForUser", "CNPGClusterDegraded"],
       "worst": "critical"
@@ -201,7 +218,7 @@
     {
       "name": "a phase from a newer minor is surfaced verbatim, never guessed at",
       "spec": { "instances": 3 },
-      "status": { "phase": "Reticulating splines", "readyInstances": 3 },
+      "status": { "phase": "Reticulating splines", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Reticulating splines", "level": "unknown" },
       "issues": [],
       "worst": "none"
@@ -209,7 +226,7 @@
     {
       "name": "an unknown phase still gets its shortfall reported",
       "spec": { "instances": 3 },
-      "status": { "phase": "Reticulating splines", "readyInstances": 1 },
+      "status": { "phase": "Reticulating splines", "currentPrimary": "pg-1", "readyInstances": 1 },
       "badge": { "text": "Degraded", "level": "degraded" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "warning"
@@ -219,6 +236,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster is unrecoverable and needs manual intervention",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing" }
@@ -227,6 +245,45 @@
       "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGWALArchivingFailing", "CNPGClusterUnrecoverable"],
       "worst": "critical"
+    },
+    {
+      "name": "first bootstrap — operator reported, no primary elected yet, no alarm",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Setting up primary" },
+      "badge": { "text": "Setting Up Primary", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "slow restore past the grace but still bootstrapping — no primary, no alarm",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Waiting for the instances to become active",
+        "conditions": [
+          { "type": "Ready", "status": "False", "reason": "ClusterIsNotReady", "lastTransitionTime": "2020-01-01T00:00:00Z" }
+        ]
+      },
+      "badge": { "text": "Starting Instances", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "hibernated cluster is neutral, not an outage",
+      "spec": { "instances": 3 },
+      "metadata": { "annotations": { "cnpg.io/hibernation": "on" } },
+      "status": { "currentPrimary": "pg-1" },
+      "badge": { "text": "Hibernated", "level": "neutral" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "all instances fenced is neutral, not an outage",
+      "spec": { "instances": 3 },
+      "metadata": { "annotations": { "cnpg.io/fencedInstances": "[\"*\"]" } },
+      "status": { "currentPrimary": "pg-1" },
+      "badge": { "text": "Fenced", "level": "neutral" },
+      "issues": [],
+      "worst": "none"
     }
   ]
 }


### PR DESCRIPTION
## Problem

CNPG omits `status.readyInstances` when it is 0 (`omitempty` int), so a cluster with **zero ready instances serializes identically to one whose status was never written** — the field is simply absent in both. Radar's badge (`getCNPGClusterStatus`) and the Go issue detector (`detectCNPGClusterIssues`) both gated the all-down path on the field being *present*, so a fully-down cluster never reached it: it fell through to the transient-phase branch, showed amber "Starting Instances" forever, and raised no issue. A dead database, silent.

(The existing "all-down" tests hid this by fabricating `readyInstances: 0`, a shape CNPG never emits.)

## Fix

Distinguish the cases the absent field collapses together, using `status.currentPrimary` (CNPG sets it on first primary election and never clears it — the version-robust "was up" signal, present on 1.27/1.28):

- **No status yet** → Unknown (unchanged — absence is still not zero)
- **Reported, 0 ready, no primary elected** → first bootstrap → amber, no alarm
- **Reported, 0 ready, primary present** → was up and now down → red badge + **Critical** issue
- **Hibernated / fully-fenced** (`cnpg.io/hibernation`, `cnpg.io/fencedInstances: ["*"]`) → intentionally 0 ready → neutral, no alarm

A **5-minute grace** on the `Ready=False` transition absorbs a routine single-instance restart before alarming — the same on-read, stateless grace mechanism CNPG's existing timers already use (`conditions.FindFalseConditionWithTime`). It escalates immediately if there is no `Ready` condition to time from.

One shared availability read drives the **badge, drawer banner, row count, and cell colour**, and the **Go detector mirrors it field-for-field**, so all surfaces agree. Golden fixtures now use the real *omitted*-ready wire shape rather than a fabricated zero.

## Tests

Rewrote the shared `testdata/cnpg/badge-issue-matrix.json` to realistic omitted-ready shapes and added: was-up fully down (→ red + Critical), first bootstrap (→ amber, no issue), slow restore past grace (→ amber), hibernated, all-fenced, plus the unchanged healthy / partial / status-never-written cases. The was-up-down / hibernated / fenced cases fail against the pre-fix code. Full k8s-ui suite and `go test ./internal/issues/...` pass.

## Two known, non-blocking edges

1. A 1-instance, was-up cluster whose only pod is restarting *within* the grace while its phase still lags at "healthy" can briefly show `0/1` next to a green "Healthy" badge. Narrow, self-heals in ≤5 min, not a false page or a silent outage.
2. The cell colour branch has no dedicated unit test (brittle class-name assertion avoided); the underlying `getCNPGClusterAvailability` is thoroughly covered.

Ticket: RAD-403 (Velero/CNPG/Kyverno review).

https://claude.ai/code/session_01KxZ3xt2G4KpexrKSoXQ91S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CNPG health and alerting semantics across UI and the issue detector; incorrect parity could cause missed outages or false criticals, though behavior is heavily pinned by the shared golden matrix.
> 
> **Overview**
> Fixes **false “starting” and silent outages** when CloudNativePG omits `status.readyInstances` at zero — the same wire shape as “status not written yet.”
> 
> **Shared availability logic** (`getCNPGClusterAvailability` in the UI, mirrored in `detectCNPGClusterIssues`) now treats omitted ready as **0 only after the operator has reported** (phase, `currentPrimary`, or conditions), uses **`currentPrimary` as “was up”** to separate first bootstrap from regression, and applies carve-outs for **hibernation** and **all-instance fencing** plus a **5-minute `Ready=False` grace** (kept in sync with `cnpgDownGrace` / `CNPG_DOWN_GRACE_MS`).
> 
> **Surfaces aligned:** list badge, instances cell (including red styling), cluster drawer “down” banner, and Go **`CNPGClusterDegraded` Critical** for total outage; partial shortfalls still need an explicit ready count above zero.
> 
> **Tests:** shared `badge-issue-matrix.json` uses realistic omitted-ready fixtures and optional `metadata.annotations`; Go golden tests and TS golden/unit tests extended for bootstrap, hibernated, fenced, grace, and was-up-down cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7b2eae930c3201db136f7e6c5d62dc3b763aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->