### PR TITLE
fix(capi): use exact API-group matching in CAPI renderer guards

### DIFF
--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -845,3 +845,97 @@ describe('GPU ecosystem status edge cases', () => {
     expect(pool?.text).toBe('Not referenced')
   })
 })
+
+// A foreign group ending in `cluster.x-k8s.io` (e.g. `extension.cluster.x-k8s.io`)
+// used to pass a substring guard and inherit CAPI rendering, status, or the
+// ClusterClass warning. The three switches are independent — the renderer, the
+// status calculation, and the topology-controlled banner — and each one has to
+// use exact-group matching on its own.
+describe('CAPI group-guard collisions — extension.cluster.x-k8s.io', () => {
+  const FOREIGN_GROUP = 'extension.cluster.x-k8s.io/v1'
+
+  it('falls a foreign clusters CRD through to the generic renderer', () => {
+    const html = renderCollidingKind('clusters', FOREIGN_GROUP)
+    expect(html).toContain(COLLISION_PROBE)
+    expect(html).not.toContain('Cluster Not Ready')
+    expect(html).not.toContain('Cluster Paused')
+  })
+
+  it('gives a foreign clusters CRD generic status, not CAPI status', () => {
+    // CAPI's getClusterStatus reads status.phase and status.conditions; the
+    // generic path echoes the phase verbatim without CAPI's tone mapping.
+    const s = getResourceStatus('clusters', {
+      apiVersion: FOREIGN_GROUP,
+      status: { phase: 'Provisioned' },
+    })
+    // The generic getter surfaces the raw phase text.
+    expect(s?.text).toBe('Provisioned')
+  })
+
+  it('renders a foreign machines CRD through the generic renderer', () => {
+    const html = renderKind('machines', {
+      apiVersion: FOREIGN_GROUP,
+      kind: 'Machine',
+      metadata: { name: 'm', namespace: 'default' },
+      spec: { collisionProbe: COLLISION_PROBE },
+      status: {},
+    }, 'default')
+    expect(html).toContain(COLLISION_PROBE)
+    expect(html).not.toContain('Machine Not Ready')
+    expect(html).not.toContain('Infrastructure')
+  })
+
+  it('gives a foreign machines CRD no CAPI status', () => {
+    const s = getResourceStatus('machines', {
+      apiVersion: FOREIGN_GROUP,
+      status: { phase: 'Running' },
+    })
+    // CAPI would map to a coloured badge; the generic path echoes the phase.
+    expect(s?.text).toBe('Running')
+  })
+
+  it('renders a foreign machinesets CRD through the generic renderer', () => {
+    const html = renderKind('machinesets', {
+      apiVersion: FOREIGN_GROUP,
+      kind: 'MachineSet',
+      metadata: { name: 'ms', namespace: 'default' },
+      spec: { collisionProbe: COLLISION_PROBE, replicas: 3 },
+      status: {},
+    }, 'default')
+    expect(html).toContain(COLLISION_PROBE)
+    expect(html).not.toContain('MachineSet Not Ready')
+    expect(html).not.toContain('Machine Template')
+  })
+
+  it('does not warn "Topology-controlled" for a foreign CRD carrying the CAPI ownership label', () => {
+    // The label key is a real CAPI label, but the resource is not from CAPI.
+    // A substring guard would still show the ClusterClass warning.
+    const html = renderKind('foreignkind', {
+      apiVersion: FOREIGN_GROUP,
+      kind: 'ForeignThing',
+      metadata: {
+        name: 'thing',
+        namespace: 'default',
+        labels: { 'topology.cluster.x-k8s.io/owned': '' },
+      },
+      spec: { collisionProbe: COLLISION_PROBE },
+    }, 'default')
+    expect(html).not.toContain('Topology-controlled')
+    expect(html).not.toContain('ClusterClass')
+  })
+
+  it('still shows "Topology-controlled" for a real CAPI resource', () => {
+    const html = renderKind('machines', {
+      apiVersion: 'cluster.x-k8s.io/v1beta1',
+      kind: 'Machine',
+      metadata: {
+        name: 'm',
+        namespace: 'default',
+        labels: { 'topology.cluster.x-k8s.io/owned': '' },
+      },
+      spec: {},
+      status: {},
+    }, 'default')
+    expect(html).toContain('Topology-controlled')
+  })
+})

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -693,6 +693,14 @@ export function ResourceRendererDispatch({
     && !!data?.apiVersion
     && !data.apiVersion.startsWith('batch/')
 
+  // `machines` and `machinesets` are in KNOWN_KINDS, so a foreign CRD sharing
+  // the plural (e.g. `extension.cluster.x-k8s.io/v1`) needs an explicit
+  // fall-through — otherwise the strict group guard on the CAPI render line
+  // matches nothing and the drawer renders blank.
+  const capiCollisionFallthrough =
+    (kind === 'machines' || kind === 'machinesets')
+    && !isApiGroup(data?.apiVersion, 'cluster.x-k8s.io')
+
   const isKnownKind = KNOWN_KINDS.has(kind) || isCrossplaneMR || isCrossplaneClaim || isCrossplaneXR
 
   const PodComp = rendererOverrides?.PodRenderer ?? PodRenderer
@@ -862,15 +870,15 @@ export function ResourceRendererDispatch({
         {kind === 'scheduledbackups' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'poolers' && isApiGroup(data?.apiVersion, CNPG_GROUP) && <CNPGPoolerRenderer data={data} onNavigate={onNavigate} />}
         {/* Cluster API (CAPI) */}
-        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && data?.apiVersion?.includes('cluster.x-k8s.io') && (
+        {'topology.cluster.x-k8s.io/owned' in (data?.metadata?.labels ?? {}) && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && (
           <AlertBanner
             variant="warning"
             title="Topology-controlled — this resource is managed by ClusterClass. Manual changes will be reconciled back."
           />
         )}
-        {kind === 'machines' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIMachineRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'machines' && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && <CAPIMachineRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'machinedeployments' && <CAPIMachineDeploymentRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'machinesets' && data?.apiVersion?.includes('cluster.x-k8s.io') && <CAPIMachineSetRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'machinesets' && isApiGroup(data?.apiVersion, 'cluster.x-k8s.io') && <CAPIMachineSetRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'machinepools' && <CAPIMachinePoolRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'kubeadmcontrolplanes' && <CAPIKubeadmControlPlaneRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'clusterclasses' && <CAPIClusterClassRenderer data={data} />}
@@ -956,7 +964,7 @@ export function ResourceRendererDispatch({
             for known-plural collisions where no apiVersion-gated renderer
             matched (e.g. a Knative Configuration sharing the `configurations`
             plural with Crossplane Configuration). */}
-        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough || groupGatedFallthrough || calicoCollisionFallthrough || nonCoreJobFallthrough) && <GenericRenderer data={data} />}
+        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough || groupGatedFallthrough || calicoCollisionFallthrough || nonCoreJobFallthrough || capiCollisionFallthrough) && <GenericRenderer data={data} />}
 
         {/* Common sections - can be disabled when parent handles them separately */}
         {showCommonSections && (
@@ -1187,7 +1195,7 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
     // Third-party `clusters` CRDs (KubeBlocks, Redis/Valkey) fall through to the
     // generic handling below instead of getting a fabricated PostgreSQL status.
   }
-  if (k === 'machines' && data.apiVersion?.includes('cluster.x-k8s.io')) return getMachineStatus(data)
+  if (k === 'machines' && isApiGroup(data.apiVersion, 'cluster.x-k8s.io')) return getMachineStatus(data)
   if (k === 'machinedeployments') return getMachineDeploymentStatus(data)
   if (k === 'machinesets') return getMachineSetStatus(data)
   if (k === 'machinepools') return getMachinePoolStatus(data)


### PR DESCRIPTION
## Description

Three CAPI renderer guards in [`packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx`](packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx) matched the API group with `apiVersion?.includes(\"cluster.x-k8s.io\")`. That substring test also matches a foreign group whose name ends in the same suffix (e.g. `extension.cluster.x-k8s.io`), so a generic CRD would render through a CAPI renderer, get a fabricated CAPI status, or receive the topology-controlled ClusterClass warning banner.

Replaced the four remaining substring checks with the existing `isApiGroup(..., 'cluster.x-k8s.io')` helper, following the exact-group pattern already used for CAPI `clusters` on line 861 and the CNPG/Velero collision handling.

`machines` and `machinesets` are in `KNOWN_KINDS`, which suppresses the generic renderer. With the strict guard, a foreign CRD sharing those plurals would match neither the CAPI render line nor the generic fall-through and would render a **blank drawer** — the exact trap the Crossplane block documents. Added a `capiCollisionFallthrough` that routes such kinds to `GenericRenderer`, mirroring the existing `groupGatedFallthrough` for `clusters`, `backups`, etc.

Read `docs/INTEGRATION_GUIDE.md` before reviewing renderer-dispatch changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- [x] Added/updated unit tests

Regression coverage in [`ResourceRendererDispatch.test.tsx`](packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx) uses a foreign `extension.cluster.x-k8s.io/v1` CRD and asserts, at all three boundaries the issue calls out, that a substring guard would have failed:

- **Renderer dispatch** for `clusters`, `machines`, `machinesets` — foreign CRD renders through `GenericRenderer`, no CAPI-specific text
- **`getResourceStatus`** for `clusters` and `machines` — foreign CRD gets the generic phase-echo, not the CAPI badge
- **Topology-controlled warning banner** — the `topology.cluster.x-k8s.io/owned` label on a foreign group does not trigger the ClusterClass warning
- Positive check: a real `cluster.x-k8s.io/v1beta1` resource still shows the warning

Test results:
- \`npx vitest run\` in \`packages/k8s-ui\`: **161 files / 3389 tests pass** (1 pre-existing skip)
- \`make tsc\`: green

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings

## Related issues

Fixes #1582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dispatch and status logic for resource detail views; tightens matching so fewer foreign CRDs are mislabeled, with no auth or data-path changes.
> 
> **Overview**
> Fixes **mis-routing** of CRDs whose API group merely *contains* `cluster.x-k8s.io` (e.g. `extension.cluster.x-k8s.io`) through Cluster API UI paths.
> 
> **ResourceRendererDispatch** now gates the topology-controlled ClusterClass banner, `machines` / `machinesets` CAPI renderers, and CAPI machine status on **`isApiGroup(..., 'cluster.x-k8s.io')`** instead of substring `includes`. Foreign `machines` / `machinesets` that share those plurals but are not CAPI are sent to **`GenericRenderer`** via new **`capiCollisionFallthrough`**, avoiding blank drawers after the stricter guards.
> 
> Regression tests cover renderer dispatch, status badges, and the topology banner for `extension.cluster.x-k8s.io`, plus a positive check for real CAPI resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db0a91a27ed8bd8d54daa4402eed6845fa358f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->