### PR TITLE
feat(contexts): open clusters in isolated browser tabs

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -101,6 +102,8 @@ func main() {
 	contextName := flag.String("context", "", "Initial kubeconfig context (used for isolated browser tabs)")
 	contextSource := flag.String("context-source", "", "Source kubeconfig file for --context (used for isolated browser tabs)")
 	contextInFile := flag.String("context-in-file", "", "Original context name inside --context-source (used for isolated browser tabs)")
+	contextTabs := flag.Bool("context-tabs", true, "Allow opening kubeconfig contexts in isolated browser tabs")
+	contextTabReadyFile := flag.String("context-tab-ready-file", "", "Write the bound port here when an isolated context tab is ready")
 	namespace := flag.String("namespace", fileCfg.Namespace, "Initial namespace filter (empty = all namespaces)")
 	namespaces := flag.String("namespaces", fileCfg.NamespacesFlag(), "Initial namespace filters as a comma-separated list (e.g. ns1,ns2,ns3). Use this when you can list resources in specific namespaces but cannot list namespaces cluster-wide.")
 	port := flag.Int("port", fileCfg.PortOr(9280), "Server port")
@@ -262,6 +265,9 @@ func main() {
 	if normalizedBasePath != "" && (*cloudURL != "" || cloud.Mode()) {
 		log.Fatalf("--base-path is not supported in Radar Cloud mode (--cloud-url / RADAR_CLOUD_MODE): Radar Cloud owns the URL path")
 	}
+	if err := validateContextRefFlags(*contextName, *contextSource, *contextInFile); err != nil {
+		log.Fatalf("%v", err)
+	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {
 		log.Fatalf("Invalid --timeline-max-size %q: %v", *timelineMaxSize, err)
@@ -336,7 +342,7 @@ func main() {
 	cfg := app.AppConfig{
 		Kubeconfig:               resolvedKubeconfig,
 		KubeconfigDirs:           resolvedKubeconfigDirs,
-		ContextTabs:              true,
+		ContextTabs:              *contextTabs,
 		PreferredContext:         k8s.ContextRef{Name: *contextName, SourceFile: *contextSource, InFileName: *contextInFile},
 		Namespace:                resolvedNamespace,
 		Namespaces:               resolvedNamespaces,
@@ -426,7 +432,7 @@ func main() {
 		log.Printf("MCP catalog-only mode enabled: skipping Kubernetes initialization")
 		cfg.NoBrowser = true
 		srv := app.CreateServer(cfg)
-		_, rootCancel := startServer(srv, startupStart)
+		_, rootCancel := startServer(srv, startupStart, "")
 		defer rootCancel()
 		select {}
 	}
@@ -474,7 +480,7 @@ func main() {
 	srv := app.CreateServer(cfg)
 	k8s.LogTiming(" Server created: %v", time.Since(t))
 
-	rootCtx, rootCancel := startServer(srv, startupStart)
+	rootCtx, rootCancel := startServer(srv, startupStart, *contextTabReadyFile)
 	defer rootCancel()
 
 	// Open browser — server is confirmed ready to accept connections
@@ -549,7 +555,7 @@ func main() {
 	select {}
 }
 
-func startServer(srv *server.Server, startupStart time.Time) (context.Context, context.CancelFunc) {
+func startServer(srv *server.Server, startupStart time.Time, contextTabReadyFile string) (context.Context, context.CancelFunc) {
 	// Root context cancelled on SIGINT/SIGTERM. Long-running background
 	// workers (cloud tunnel, etc.) observe this to shut down cleanly before
 	// the process exits.
@@ -582,8 +588,38 @@ func startServer(srv *server.Server, startupStart time.Time) (context.Context, c
 
 	// Write port file so MCP clients can discover the running server
 	app.WriteMCPPortFile(srv.ActualPort(), srv.BasePath())
+	if contextTabReadyFile != "" {
+		if err := writeContextTabReadyFile(contextTabReadyFile, srv.ActualPort()); err != nil {
+			log.Fatalf("Failed to write context-tab readiness file: %v", err)
+		}
+	}
 
 	return rootCtx, rootCancel
+}
+
+func writeContextTabReadyFile(path string, port int) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(port)+"\n"), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func validateContextRefFlags(name, source, inFileName string) error {
+	provided := 0
+	for _, value := range []string{name, source, inFileName} {
+		if value != "" {
+			provided++
+		}
+	}
+	if provided != 0 && provided != 3 {
+		return errors.New("--context, --context-source, and --context-in-file must be provided together")
+	}
+	return nil
 }
 
 func parseCSV(s string) []string {

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -98,6 +98,9 @@ func main() {
 	// Parse flags (defaults come from config file, falling back to hardcoded values)
 	kubeconfig := flag.String("kubeconfig", fileCfg.Kubeconfig, "Path to primary kubeconfig file (default: ~/.kube/config)")
 	kubeconfigDir := flag.String("kubeconfig-dir", fileCfg.KubeconfigDirsFlag(), "Comma-separated directories containing additional kubeconfig files")
+	contextName := flag.String("context", "", "Initial kubeconfig context (used for isolated browser tabs)")
+	contextSource := flag.String("context-source", "", "Source kubeconfig file for --context (used for isolated browser tabs)")
+	contextInFile := flag.String("context-in-file", "", "Original context name inside --context-source (used for isolated browser tabs)")
 	namespace := flag.String("namespace", fileCfg.Namespace, "Initial namespace filter (empty = all namespaces)")
 	namespaces := flag.String("namespaces", fileCfg.NamespacesFlag(), "Initial namespace filters as a comma-separated list (e.g. ns1,ns2,ns3). Use this when you can list resources in specific namespaces but cannot list namespaces cluster-wide.")
 	port := flag.Int("port", fileCfg.PortOr(9280), "Server port")
@@ -333,6 +336,8 @@ func main() {
 	cfg := app.AppConfig{
 		Kubeconfig:               resolvedKubeconfig,
 		KubeconfigDirs:           resolvedKubeconfigDirs,
+		ContextTabs:              true,
+		PreferredContext:         k8s.ContextRef{Name: *contextName, SourceFile: *contextSource, InFileName: *contextInFile},
 		Namespace:                resolvedNamespace,
 		Namespaces:               resolvedNamespaces,
 		Port:                     *port,

--- a/cmd/explorer/main_test.go
+++ b/cmd/explorer/main_test.go
@@ -1,9 +1,50 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
+
+func TestValidateContextRefFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		context    string
+		source     string
+		inFileName string
+		wantErr    bool
+	}{
+		{name: "none", wantErr: false},
+		{name: "complete", context: "prod", source: "/tmp/config", inFileName: "prod", wantErr: false},
+		{name: "context only", context: "prod", wantErr: true},
+		{name: "source only", source: "/tmp/config", wantErr: true},
+		{name: "missing in-file name", context: "prod", source: "/tmp/config", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContextRefFlags(tt.context, tt.source, tt.inFileName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateContextRefFlags() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWriteContextTabReadyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready")
+	if err := writeContextTabReadyFile(path, 43127); err != nil {
+		t.Fatalf("writeContextTabReadyFile() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read readiness file: %v", err)
+	}
+	if got := string(data); got != "43127\n" {
+		t.Fatalf("readiness file = %q, want %q", got, "43127\\n")
+	}
+}
 
 func TestHeaderFlagSet(t *testing.T) {
 	cases := []struct {

--- a/docs/context-tabs.md
+++ b/docs/context-tabs.md
@@ -1,0 +1,20 @@
+# Isolated context tabs
+
+Radar's standalone local binary can open another kubeconfig context in a new
+browser tab without changing the cluster used by the current tab.
+
+Open the context switcher and choose the new-tab icon on any non-current
+context row. Radar starts a sibling process on a loopback port with that
+context's kubeconfig source. The sibling has its own Kubernetes clients,
+informers, caches, SSE stream, and integration state, so switching the parent
+tab no longer retargets the new tab.
+
+This feature is deliberately limited to unauthenticated standalone Radar on a
+loopback listener. It is disabled for shared listeners, OIDC/proxy-auth
+deployments, Cloud/in-cluster mode, and in-cluster Radar, where a separate
+process cannot safely inherit the deployment's authentication or tunnel
+session. The existing **Switch context** action remains available for changing
+the current tab.
+
+Child processes are tracked by the parent and terminated when the parent Radar
+process shuts down.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -36,6 +36,13 @@ var clusterConnectionProbe = k8s.TestClusterConnection
 type AppConfig struct {
 	Kubeconfig     string
 	KubeconfigDirs []string
+	// ContextTabs enables the Explorer-only isolated browser-tab launcher.
+	// Other entrypoints may share CreateServer but do not accept Explorer's
+	// child-process flags.
+	ContextTabs bool
+	// PreferredContext selects the context for this process. It is used by
+	// isolated browser tabs so each tab can run its own Radar backend.
+	PreferredContext k8s.ContextRef
 	// Zero value is the deliberate one: an entrypoint that never sets this
 	// starts on the kubeconfig's current-context. Only cmd/desktop opts in.
 	RestoreLastDesktopContext bool
@@ -119,7 +126,11 @@ func validateNamespaceFanout(namespaces []string, ctxNs string, maxCandidates in
 
 // InitializeK8s creates and configures the Kubernetes client.
 func InitializeK8s(cfg AppConfig) error {
-	preferredContext, err := startupContextPreference(cfg)
+	preferredContext := cfg.PreferredContext
+	var err error
+	if preferredContext.Empty() {
+		preferredContext, err = startupContextPreference(cfg)
+	}
 	if err != nil {
 		log.Printf("[context] failed to read the remembered Desktop context: %v", err)
 		errorlog.Record("k8s-init", "warning",
@@ -376,6 +387,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 
 	serverCfg := server.Config{
 		Port:             cfg.Port,
+		ContextTabs:      cfg.ContextTabs,
 		ListenAddress:    cfg.ListenAddress,
 		BasePath:         cfg.BasePath,
 		StartupLog:       true,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -2164,6 +2164,7 @@ func GetContextSource(name string) (sourceFile, inFileName string, ok bool) {
 		return entry.SourceFile, entry.InFileName, true
 	}
 	path := kubeconfigPath
+	activeName := contextName
 	registryBacked := contextRegistry != nil
 	clientMu.RUnlock()
 	if !registryBacked && path != "" {
@@ -2175,9 +2176,9 @@ func GetContextSource(name string) (sourceFile, inFileName string, ok bool) {
 				return path, name, true
 			}
 		}
-		// Preserve the historical current-context fallback when the source
-		// cannot be reread; startup already validated this binding.
-		if name == contextName {
+		// The active context remains usable when the source cannot be reread
+		// because startup already validated this binding.
+		if name == activeName {
 			return path, name, true
 		}
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -2151,19 +2151,35 @@ func findQualifiedNameForPath(registry map[string]contextEntry, file, inFileName
 
 // GetContextSource resolves a switcher-visible context name to its isolated
 // kubeconfig file and original in-file context name. Registry-backed loading
-// can resolve any visible name; direct single-file loading can resolve only the
-// active name because no registry is maintained in that mode.
+// can resolve any visible name; direct single-file loading resolves every
+// context from its one source file.
 func GetContextSource(name string) (sourceFile, inFileName string, ok bool) {
 	clientMu.RLock()
-	defer clientMu.RUnlock()
 	if name == contextName && activeSourceFile != "" && activeSourceName != "" {
+		clientMu.RUnlock()
 		return activeSourceFile, activeSourceName, true
 	}
 	if entry, found := contextRegistry[name]; found {
+		clientMu.RUnlock()
 		return entry.SourceFile, entry.InFileName, true
 	}
-	if contextRegistry == nil && kubeconfigPath != "" && name == contextName {
-		return kubeconfigPath, name, true
+	path := kubeconfigPath
+	registryBacked := contextRegistry != nil
+	clientMu.RUnlock()
+	if !registryBacked && path != "" {
+		// Read outside clientMu so a slow filesystem cannot block client state
+		// transitions. This is only a local kubeconfig metadata lookup.
+		cfg, err := clientcmd.LoadFromFile(path)
+		if err == nil {
+			if _, exists := cfg.Contexts[name]; exists {
+				return path, name, true
+			}
+		}
+		// Preserve the historical current-context fallback when the source
+		// cannot be reread; startup already validated this binding.
+		if name == contextName {
+			return path, name, true
+		}
 	}
 	return "", "", false
 }

--- a/internal/k8s/cluster_detection.go
+++ b/internal/k8s/cluster_detection.go
@@ -53,6 +53,7 @@ type ClusterInfo struct {
 	NamespaceCount     int    `json:"namespaceCount"`
 	InCluster          bool   `json:"inCluster"`                    // true when running inside a K8s cluster
 	CRDDiscoveryStatus string `json:"crdDiscoveryStatus,omitempty"` // idle, discovering, ready
+	ContextTabsEnabled bool   `json:"contextTabsEnabled"`
 }
 
 // GetClusterInfo returns detected cluster information

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -500,6 +500,53 @@ func TestGetContextSourceDirectModeResolvesNonCurrentContext(t *testing.T) {
 	}
 }
 
+func TestGetContextSourceDirectModeConcurrentContextChange(t *testing.T) {
+	dir := t.TempDir()
+	path := writeKubeconfig(t, dir, "config", "prod", []kubeEntry{
+		{ctxName: "prod", userName: "u1", clusterName: "c1"},
+	})
+
+	clientMu.Lock()
+	prevRegistry := contextRegistry
+	prevPath := kubeconfigPath
+	prevName := contextName
+	prevActiveFile := activeSourceFile
+	prevActiveName := activeSourceName
+	contextRegistry = nil
+	kubeconfigPath = path
+	contextName = "prod"
+	activeSourceFile = ""
+	activeSourceName = ""
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextRegistry = prevRegistry
+		kubeconfigPath = prevPath
+		contextName = prevName
+		activeSourceFile = prevActiveFile
+		activeSourceName = prevActiveName
+		clientMu.Unlock()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			clientMu.Lock()
+			if i%2 == 0 {
+				contextName = "prod"
+			} else {
+				contextName = "other"
+			}
+			clientMu.Unlock()
+		}
+	}()
+	for i := 0; i < 100; i++ {
+		GetContextSource("missing")
+	}
+	<-done
+}
+
 func TestActiveContextSourceSurvivesRegistryRefresh(t *testing.T) {
 	dir := t.TempDir()
 	primary := writeKubeconfig(t, dir, "primary.yaml", "primary", []kubeEntry{

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -465,6 +465,41 @@ func TestGetContextSourceDirectModeUsesResolvedPath(t *testing.T) {
 	}
 }
 
+func TestGetContextSourceDirectModeResolvesNonCurrentContext(t *testing.T) {
+	dir := t.TempDir()
+	path := writeKubeconfig(t, dir, "config", "prod", []kubeEntry{
+		{ctxName: "prod", userName: "u1", clusterName: "c1"},
+		{ctxName: "jp", userName: "u2", clusterName: "c2"},
+	})
+
+	clientMu.Lock()
+	prevRegistry := contextRegistry
+	prevPath := kubeconfigPath
+	prevName := contextName
+	prevActiveFile := activeSourceFile
+	prevActiveName := activeSourceName
+	contextRegistry = nil
+	kubeconfigPath = path
+	contextName = "prod"
+	activeSourceFile = ""
+	activeSourceName = ""
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextRegistry = prevRegistry
+		kubeconfigPath = prevPath
+		contextName = prevName
+		activeSourceFile = prevActiveFile
+		activeSourceName = prevActiveName
+		clientMu.Unlock()
+	})
+
+	sourceFile, inFileName, ok := GetContextSource("jp")
+	if !ok || sourceFile != path || inFileName != "jp" {
+		t.Fatalf("context source = (%q, %q, %t)", sourceFile, inFileName, ok)
+	}
+}
+
 func TestActiveContextSourceSurvivesRegistryRefresh(t *testing.T) {
 	dir := t.TempDir()
 	primary := writeKubeconfig(t, dir, "primary.yaml", "primary", []kubeEntry{

--- a/internal/server/context_tabs_test.go
+++ b/internal/server/context_tabs_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestWaitForLocalListenerReady(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("close listener: %v", err)
+		}
+	})
+
+	if err := waitForLocalListener(t.Context(), listener.Addr().String(), time.Second); err != nil {
+		t.Fatalf("waitForLocalListener() error = %v", err)
+	}
+}
+
+func TestWaitForLocalListenerCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := waitForLocalListener(ctx, "127.0.0.1:1", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForLocalListener() error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/server/context_tabs_test.go
+++ b/internal/server/context_tabs_test.go
@@ -3,37 +3,71 @@ package server
 import (
 	"context"
 	"errors"
-	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
-func TestWaitForLocalListenerReady(t *testing.T) {
-	t.Parallel()
+func TestHandleOpenContextTabRejectsCrossOriginRequest(t *testing.T) {
+	srv := &Server{contextTabs: true}
+	req := httptest.NewRequest(http.MethodPost, "/api/contexts/prod/tab", nil)
+	req.Header.Set("Origin", "https://example.com")
+	response := httptest.NewRecorder()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := listener.Close(); err != nil {
-			t.Errorf("close listener: %v", err)
-		}
-	})
+	srv.handleOpenContextTab(response, req)
 
-	if err := waitForLocalListener(t.Context(), listener.Addr().String(), time.Second); err != nil {
-		t.Fatalf("waitForLocalListener() error = %v", err)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
 	}
 }
 
-func TestWaitForLocalListenerCanceled(t *testing.T) {
-	t.Parallel()
+func TestWaitForContextTabReady(t *testing.T) {
+	t.Run("reads published port", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ready")
+		if err := os.WriteFile(path, []byte("43127\n"), 0o600); err != nil {
+			t.Fatalf("write readiness file: %v", err)
+		}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+		port, err := waitForContextTabReady(t.Context(), path, make(chan struct{}), time.Second)
+		if err != nil {
+			t.Fatalf("waitForContextTabReady() error = %v", err)
+		}
+		if port != 43127 {
+			t.Fatalf("port = %d, want 43127", port)
+		}
+	})
 
-	err := waitForLocalListener(ctx, "127.0.0.1:1", time.Second)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("waitForLocalListener() error = %v, want context.Canceled", err)
-	}
+	t.Run("rejects invalid port", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ready")
+		if err := os.WriteFile(path, []byte("70000\n"), 0o600); err != nil {
+			t.Fatalf("write readiness file: %v", err)
+		}
+
+		_, err := waitForContextTabReady(t.Context(), path, make(chan struct{}), time.Second)
+		if err == nil {
+			t.Fatal("waitForContextTabReady() error = nil, want invalid port error")
+		}
+	})
+
+	t.Run("reports process exit", func(t *testing.T) {
+		done := make(chan struct{})
+		close(done)
+		_, err := waitForContextTabReady(t.Context(), filepath.Join(t.TempDir(), "missing"), done, time.Second)
+		if err == nil {
+			t.Fatal("waitForContextTabReady() error = nil, want process exit error")
+		}
+	})
+
+	t.Run("reports cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err := waitForContextTabReady(ctx, filepath.Join(t.TempDir(), "missing"), make(chan struct{}), time.Second)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForContextTabReady() error = %v, want context.Canceled", err)
+		}
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	pathpkg "path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"slices"
@@ -166,6 +167,7 @@ type Server struct {
 	aiRuns              *ai.RunManager
 	contextTabsMu       sync.Mutex
 	contextTabProcesses []*exec.Cmd
+	contextTabsStopping bool
 }
 
 // Config holds server configuration
@@ -1199,13 +1201,15 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) Stop() {
 	StopAllLocalTermSessions()
 	s.contextTabsMu.Lock()
-	for _, cmd := range s.contextTabProcesses {
+	s.contextTabsStopping = true
+	processes := s.contextTabProcesses
+	s.contextTabProcesses = nil
+	s.contextTabsMu.Unlock()
+	for _, cmd := range processes {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
 	}
-	s.contextTabProcesses = nil
-	s.contextTabsMu.Unlock()
 	if s.aiRuns != nil {
 		s.aiRuns.Shutdown() // cancel investigations so agent children don't outlive us
 	}
@@ -1282,6 +1286,7 @@ func (s *Server) handleClusterInfo(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	info.ContextTabsEnabled = s.contextTabsEnabled()
 	s.writeJSON(w, info)
 }
 
@@ -4480,6 +4485,7 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	info.ContextTabsEnabled = s.contextTabsEnabled()
 	s.writeJSON(w, info)
 }
 
@@ -4489,6 +4495,10 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 // informer caches, SSE streams, and integration state without making a global
 // context switch visible to existing tabs.
 func (s *Server) handleOpenContextTab(w http.ResponseWriter, r *http.Request) {
+	if !localOriginOK(r) {
+		s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
+		return
+	}
 	if !s.contextTabsEnabled() {
 		s.writeError(w, http.StatusNotImplemented, "isolated context tabs are available only in standalone local mode")
 		return
@@ -4518,41 +4528,63 @@ func (s *Server) handleOpenContextTab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	runtimeDir, err := os.MkdirTemp("", "radar-context-tab-")
 	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, "could not allocate a local context-tab port")
+		log.Printf("[context-tab] Failed to create runtime directory %s/%s: %v", name, source, err)
+		s.writeError(w, http.StatusInternalServerError, "could not create isolated context-tab state")
 		return
 	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	if err := ln.Close(); err != nil {
-		s.writeError(w, http.StatusInternalServerError, "could not release the local context-tab port")
-		return
-	}
+	cleanupRuntimeDir := true
+	defer func() {
+		if cleanupRuntimeDir {
+			_ = os.RemoveAll(runtimeDir)
+		}
+	}()
+	readyFile := filepath.Join(runtimeDir, "ready")
 
 	executable, err := os.Executable()
 	if err != nil {
+		log.Printf("[context-tab] Failed to locate executable %s/%s: %v", name, source, err)
 		s.writeError(w, http.StatusInternalServerError, "could not locate the Radar executable")
 		return
 	}
 	args := []string{
-		"--no-browser", "--no-mcp", "--port", strconv.Itoa(port),
+		"--no-browser", "--no-mcp", "--port", "0",
 		"--listen-address", "127.0.0.1",
+		"--context-tabs=false",
+		"--context-tab-ready-file", readyFile,
 		"--kubeconfig", source,
 		"--context", ref.Name,
 		"--context-source", ref.SourceFile,
 		"--context-in-file", ref.InFileName,
 	}
+	if s.basePath != "" {
+		args = append(args, "--base-path", s.basePath)
+	}
 	cmd := exec.Command(executable, args...)
+	cmd.Env = append(os.Environ(), "RADAR_SETTINGS_PATH="+filepath.Join(runtimeDir, "settings.json"))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
+		log.Printf("[context-tab] Failed to start process %s/%s: %v", name, source, err)
 		s.writeError(w, http.StatusInternalServerError, "could not start the isolated context tab")
 		return
 	}
 
 	s.contextTabsMu.Lock()
+	if s.contextTabsStopping {
+		s.contextTabsMu.Unlock()
+		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			log.Printf("[context-tab] Failed to stop process %s/%s: %v", name, source, err)
+		}
+		_ = cmd.Wait()
+		s.writeError(w, http.StatusServiceUnavailable, "server is shutting down")
+		return
+	}
 	s.contextTabProcesses = append(s.contextTabProcesses, cmd)
 	s.contextTabsMu.Unlock()
+	cleanupRuntimeDir = false
+	cmdDone := make(chan struct{})
 	go func() {
 		_ = cmd.Wait()
 		s.contextTabsMu.Lock()
@@ -4563,14 +4595,16 @@ func (s *Server) handleOpenContextTab(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		s.contextTabsMu.Unlock()
+		_ = os.RemoveAll(runtimeDir)
+		close(cmdDone)
 	}()
 
-	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
-	if err := waitForLocalListener(r.Context(), address, 5*time.Second); err != nil {
+	port, err := waitForContextTabReady(r.Context(), readyFile, cmdDone, 5*time.Second)
+	if err != nil {
 		if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
-			log.Printf("[context-tab] failed to stop an unready child process: %v", killErr)
+			log.Printf("[context-tab] Failed to stop unready process %s/%s: %v", name, source, killErr)
 		}
-		log.Printf("[context-tab] child process did not become ready: %v", err)
+		log.Printf("[context-tab] Failed to await readiness %s/%s: %v", name, source, err)
 		s.writeError(w, http.StatusInternalServerError, "isolated context tab did not become ready")
 		return
 	}
@@ -4582,31 +4616,44 @@ func (s *Server) handleOpenContextTab(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func waitForLocalListener(ctx context.Context, address string, timeout time.Duration) error {
+func waitForContextTabReady(ctx context.Context, path string, processDone <-chan struct{}, timeout time.Duration) (int, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		data, err := os.ReadFile(path)
 		if err == nil {
-			if err := conn.Close(); err != nil {
-				return fmt.Errorf("close context-tab readiness connection: %w", err)
+			value := strings.TrimSpace(string(data))
+			port, parseErr := strconv.Atoi(value)
+			if parseErr != nil {
+				return 0, fmt.Errorf("parse context-tab readiness port %q: %w", value, parseErr)
 			}
-			return nil
+			if port < 1 || port > 65535 {
+				return 0, fmt.Errorf("context-tab readiness port %d is outside the valid range", port)
+			}
+			return port, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return 0, fmt.Errorf("read context-tab readiness file: %w", err)
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("wait for context-tab listener: %w", ctx.Err())
+			return 0, fmt.Errorf("wait for context-tab readiness: %w", ctx.Err())
+		case <-processDone:
+			return 0, errors.New("context-tab process exited before becoming ready")
 		case <-ticker.C:
 		}
 	}
 }
 
 func (s *Server) contextTabsEnabled() bool {
-	return s.contextTabs && !s.authConfig.Enabled() && !k8s.IsInCluster() && !cloud.Mode() && !s.sharedListener()
+	s.contextTabsMu.Lock()
+	stopping := s.contextTabsStopping
+	s.contextTabsMu.Unlock()
+	return s.contextTabs && !stopping && !s.authConfig.Enabled() && !k8s.IsInCluster() && !cloud.Mode() && !s.sharedListener()
 }
 
 // Connection status handlers (for graceful startup)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"net/url"
+	"os"
+	"os/exec"
 	pathpkg "path"
 	"reflect"
 	"runtime"
@@ -97,6 +99,7 @@ type Server struct {
 	newExecutor     func(*rest.Config, *url.URL) (remotecommand.Executor, error)
 	cloudConnectCfg CloudConnectConfig
 	cloudInstall    *cloudInstallManager
+	contextTabs     bool
 	// nsPreferences holds each user's active-namespace pick from the in-app
 	// switcher. Key shape: "<username>\x00<contextName>" when auth is enabled,
 	// "\x00<contextName>" when auth is disabled. Cleared on context switch
@@ -160,7 +163,9 @@ type Server struct {
 	aiDiagnoser *ai.Diagnoser
 	// aiRuns owns investigations as durable server-side jobs (survive panel close
 	// / navigation / refresh). nil exactly when aiDiagnoser is.
-	aiRuns *ai.RunManager
+	aiRuns              *ai.RunManager
+	contextTabsMu       sync.Mutex
+	contextTabProcesses []*exec.Cmd
 }
 
 // Config holds server configuration
@@ -182,6 +187,10 @@ type Config struct {
 	AuthConfig         auth.Config    // Authentication configuration
 	AIHistoryDB        string         // AI run-history SQLite path ("" = memory-only runs)
 	CloudConnect       CloudConnectConfig
+	// ContextTabs enables the standalone local implementation of multi-cluster
+	// browser tabs. Each additional tab is backed by a separate Radar process,
+	// which keeps the existing singleton-based K8s subsystems isolated.
+	ContextTabs bool
 }
 
 // New creates a new server instance
@@ -215,6 +224,7 @@ func New(cfg Config) *Server {
 		currencyManaged:       cfg.OpenCostManaged,
 		authConfig:            cfg.AuthConfig,
 		cloudConnectCfg:       cfg.CloudConnect,
+		contextTabs:           cfg.ContextTabs,
 		topoMemo:              topology.NewMemoizer(5 * time.Second),
 		rbacMemo:              rbac.NewMemoizer(5 * time.Second),
 		capacityIssueMemo:     newCapacityIssueMemo(5 * time.Second),
@@ -783,6 +793,7 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			// Context routes
 			r.Get("/contexts", s.handleListContexts)
 			r.Post("/contexts/{name}", s.handleSwitchContext)
+			r.Post("/contexts/{name}/tab", s.handleOpenContextTab)
 
 			// Active namespace switcher (k9s :ns equivalent for the
 			// namespace-scoped path; informational filter for cluster-wide users)
@@ -1187,6 +1198,14 @@ func (s *Server) Handler() http.Handler {
 // Stop gracefully stops the server and releases the listening port.
 func (s *Server) Stop() {
 	StopAllLocalTermSessions()
+	s.contextTabsMu.Lock()
+	for _, cmd := range s.contextTabProcesses {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
+	s.contextTabProcesses = nil
+	s.contextTabsMu.Unlock()
 	if s.aiRuns != nil {
 		s.aiRuns.Shutdown() // cancel investigations so agent children don't outlive us
 	}
@@ -4462,6 +4481,132 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, info)
+}
+
+// handleOpenContextTab starts an isolated local Radar process for a context
+// and returns its URL. Radar's K8s layer intentionally remains singleton-based
+// within one process; process isolation gives browser tabs independent clients,
+// informer caches, SSE streams, and integration state without making a global
+// context switch visible to existing tabs.
+func (s *Server) handleOpenContextTab(w http.ResponseWriter, r *http.Request) {
+	if !s.contextTabsEnabled() {
+		s.writeError(w, http.StatusNotImplemented, "isolated context tabs are available only in standalone local mode")
+		return
+	}
+
+	name, err := url.PathUnescape(chi.URLParam(r, "name"))
+	if err != nil || name == "" {
+		s.writeError(w, http.StatusBadRequest, "invalid context name encoding")
+		return
+	}
+	if name == k8s.GetContextName() {
+		s.writeError(w, http.StatusBadRequest, "context is already open in this tab")
+		return
+	}
+
+	ref := k8s.ContextSourceFor(name)
+	if ref.Empty() {
+		s.writeError(w, http.StatusBadRequest, "context source is unavailable; refresh the context list and try again")
+		return
+	}
+	source := ref.SourceFile
+	if source == "" {
+		source = k8s.GetKubeconfigPath()
+	}
+	if source == "" {
+		s.writeError(w, http.StatusBadRequest, "kubeconfig source is unavailable")
+		return
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "could not allocate a local context-tab port")
+		return
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "could not release the local context-tab port")
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "could not locate the Radar executable")
+		return
+	}
+	args := []string{
+		"--no-browser", "--no-mcp", "--port", strconv.Itoa(port),
+		"--listen-address", "127.0.0.1",
+		"--kubeconfig", source,
+		"--context", ref.Name,
+		"--context-source", ref.SourceFile,
+		"--context-in-file", ref.InFileName,
+	}
+	cmd := exec.Command(executable, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "could not start the isolated context tab")
+		return
+	}
+
+	s.contextTabsMu.Lock()
+	s.contextTabProcesses = append(s.contextTabProcesses, cmd)
+	s.contextTabsMu.Unlock()
+	go func() {
+		_ = cmd.Wait()
+		s.contextTabsMu.Lock()
+		for i, candidate := range s.contextTabProcesses {
+			if candidate == cmd {
+				s.contextTabProcesses = append(s.contextTabProcesses[:i], s.contextTabProcesses[i+1:]...)
+				break
+			}
+		}
+		s.contextTabsMu.Unlock()
+	}()
+
+	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	if err := waitForLocalListener(r.Context(), address, 5*time.Second); err != nil {
+		if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			log.Printf("[context-tab] failed to stop an unready child process: %v", killErr)
+		}
+		log.Printf("[context-tab] child process did not become ready: %v", err)
+		s.writeError(w, http.StatusInternalServerError, "isolated context tab did not become ready")
+		return
+	}
+
+	s.writeJSON(w, map[string]any{
+		"context": name,
+		"port":    port,
+		"url":     "http://127.0.0.1:" + strconv.Itoa(port) + s.basePath,
+	})
+}
+
+func waitForLocalListener(ctx context.Context, address string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		if err == nil {
+			if err := conn.Close(); err != nil {
+				return fmt.Errorf("close context-tab readiness connection: %w", err)
+			}
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for context-tab listener: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Server) contextTabsEnabled() bool {
+	return s.contextTabs && !s.authConfig.Enabled() && !k8s.IsInCluster() && !cloud.Mode() && !s.sharedListener()
 }
 
 // Connection status handlers (for graceful startup)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -75,8 +75,14 @@ type LastContext struct {
 // overwriting each other's changes.
 var mu sync.Mutex
 
-// Path returns the settings file path (~/.radar/settings.json).
+const pathEnv = "RADAR_SETTINGS_PATH"
+
+// Path returns the settings file path. Isolated child processes can override
+// the default ~/.radar/settings.json location through RADAR_SETTINGS_PATH.
 func Path() string {
+	if path := os.Getenv(pathEnv); path != "" {
+		return path
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Printf("[settings] Cannot determine home directory: %v (settings will not be persisted)", err)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -10,6 +10,15 @@ import (
 	"testing"
 )
 
+func TestPathUsesEnvironmentOverride(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "child-settings.json")
+	t.Setenv(pathEnv, want)
+
+	if got := Path(); got != want {
+		t.Fatalf("Path() = %q, want %q", got, want)
+	}
+}
+
 func TestLoadMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   useImperativeHandle,
 } from 'react'
-import { ChevronDown, Check, FolderOpen, Loader2, Search, Server, X } from 'lucide-react'
+import { ChevronDown, Check, ExternalLink, FolderOpen, Loader2, Search, Server, X } from 'lucide-react'
 import { ClusterName } from '../ui/ClusterName'
 import { Input } from '../ui/Input'
 import { MiddleEllipsis } from '../ui/MiddleEllipsis'
@@ -54,6 +54,8 @@ export interface ClusterSwitcherProps {
   currentSourceLabel?: string
   items: ClusterSwitcherItem[]
   onSelect?: (item: ClusterSwitcherItem) => void
+  /** Optional secondary action rendered on each selectable row. */
+  onOpenInNewTab?: (item: ClusterSwitcherItem) => void
   searchable?: boolean
   showGroupHeaders?: boolean
   showCurrentBullet?: boolean
@@ -89,6 +91,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
   currentSourceLabel,
   items,
   onSelect,
+  onOpenInNewTab,
   searchable = true,
   showGroupHeaders = true,
   showCurrentBullet = true,
@@ -331,91 +334,108 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
                     const idx = indexById.get(item.id) ?? -1
                     const isCurrent = item.id === currentId
                     return (
-                      <button
-                        type="button"
+                      <div
                         key={item.id}
                         data-highlighted={idx === highlightedIndex}
-                        onClick={() => select(item)}
                         onMouseEnter={() => setHighlightedIndex(idx)}
-                        disabled={isCurrent || item.disabled}
-                        title={item.title}
                         className={`
-                          w-full flex items-center gap-2 px-3 py-2 text-left transition-colors
+                          group relative flex w-full items-stretch transition-colors
                           ${isCurrent
                             ? 'selection'
                             : idx === highlightedIndex
                               ? 'bg-theme-hover cursor-pointer'
                               : 'hover:bg-theme-hover cursor-pointer'}
-                          disabled:opacity-50
                         `}
                       >
-                        <div className="shrink-0 w-4 h-4 flex items-center justify-center">
-                          {isCurrent ? (
-                            <Check className="w-3.5 h-3.5 selection-text" />
-                          ) : showCurrentBullet ? (
-                            <div className="w-1.5 h-1.5 rounded-full bg-theme-text-tertiary/30" />
-                          ) : null}
-                        </div>
-                        {item.status && (
-                          <span className="shrink-0">
-                            <StatusDot tone={item.status} />
-                          </span>
-                        )}
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-1.5">
-                            {/* No tooltip on row names — each row already
-                                renders the raw context inline below the
-                                name (item.secondary), so the hover tooltip
-                                would just repeat what's already visible. */}
-                            <ClusterName
-                              name={item.name}
-                              noTooltip
-                              className={`text-sm font-medium flex-1 ${
-                                isCurrent
-                                  ? 'selection-text'
-                                  : item.disabled
-                                    ? 'text-theme-text-tertiary'
-                                    : 'text-theme-text-primary'
-                              }`}
-                            />
-                            {item.nameQualifier && (
-                              <span
-                                className="shrink-0 max-w-[120px] truncate text-xs font-normal text-theme-text-tertiary"
-                                title={item.nameQualifier}
+                        <button
+                          type="button"
+                          onClick={() => select(item)}
+                          disabled={isCurrent || item.disabled}
+                          title={item.title}
+                          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left disabled:opacity-50"
+                        >
+                          <div className="shrink-0 w-4 h-4 flex items-center justify-center">
+                            {isCurrent ? (
+                              <Check className="w-3.5 h-3.5 selection-text" />
+                            ) : showCurrentBullet ? (
+                              <div className="w-1.5 h-1.5 rounded-full bg-theme-text-tertiary/30" />
+                            ) : null}
+                          </div>
+                          {item.status && (
+                            <span className="shrink-0">
+                              <StatusDot tone={item.status} />
+                            </span>
+                          )}
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              {/* No tooltip on row names — each row already
+                                  renders the raw context inline below the
+                                  name (item.secondary), so the hover tooltip
+                                  would just repeat what's already visible. */}
+                              <ClusterName
+                                name={item.name}
+                                noTooltip
+                                className={`text-sm font-medium flex-1 ${
+                                  isCurrent
+                                    ? 'selection-text'
+                                    : item.disabled
+                                      ? 'text-theme-text-tertiary'
+                                      : 'text-theme-text-primary'
+                                }`}
+                              />
+                              {item.nameQualifier && (
+                                <span
+                                  className="shrink-0 max-w-[120px] truncate text-xs font-normal text-theme-text-tertiary"
+                                  title={item.nameQualifier}
+                                >
+                                  {item.nameQualifier}
+                                </span>
+                              )}
+                              {item.badge && (
+                                <span className="shrink-0 text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
+                                  {item.badge}
+                                </span>
+                              )}
+                            </div>
+                            {item.sourceLabel && (
+                              // Source chip lives on its own line under the
+                              // name so long folder paths get the full row
+                              // width to render via MiddleEllipsis. Inline
+                              // would steal width from the name and force
+                              // both to truncate.
+                              <div
+                                className="flex items-center gap-0.5 text-[10px] text-theme-text-tertiary opacity-80 mt-0.5"
+                                title={`From kubeconfig: ${item.sourceLabel}`}
                               >
-                                {item.nameQualifier}
-                              </span>
+                                <FolderOpen className="w-2.5 h-2.5 shrink-0" />
+                                <MiddleEllipsis text={item.sourceLabel} className="font-mono" />
+                              </div>
                             )}
-                            {item.badge && (
-                              <span className="shrink-0 text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
-                                {item.badge}
-                              </span>
+                            {item.secondary && (
+                              <div
+                                className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5"
+                                title={item.secondary}
+                              >
+                                {item.secondary}
+                              </div>
                             )}
                           </div>
-                          {item.sourceLabel && (
-                            // Source chip lives on its own line under the
-                            // name so long folder paths get the full row
-                            // width to render via MiddleEllipsis. Inline
-                            // would steal width from the name and force
-                            // both to truncate.
-                            <div
-                              className="flex items-center gap-0.5 text-[10px] text-theme-text-tertiary opacity-80 mt-0.5"
-                              title={`From kubeconfig: ${item.sourceLabel}`}
-                            >
-                              <FolderOpen className="w-2.5 h-2.5 shrink-0" />
-                              <MiddleEllipsis text={item.sourceLabel} className="font-mono" />
-                            </div>
-                          )}
-                          {item.secondary && (
-                            <div
-                              className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5"
-                              title={item.secondary}
-                            >
-                              {item.secondary}
-                            </div>
-                          )}
-                        </div>
-                      </button>
+                        </button>
+                        {onOpenInNewTab && !isCurrent && !item.disabled && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setIsOpen(false)
+                              onOpenInNewTab(item)
+                            }}
+                            className="mr-2 my-2 flex h-7 w-7 shrink-0 items-center justify-center rounded text-theme-text-tertiary opacity-70 transition-colors hover:bg-theme-elevated hover:text-theme-text-primary hover:opacity-100 focus-visible:opacity-100"
+                            title={`Open ${item.name} in a new tab`}
+                            aria-label={`Open ${item.name} in a new tab`}
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
                     )
                   })}
                 </div>

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -500,6 +500,7 @@ export interface ClusterInfo {
   podCount: number
   namespaceCount: number
   inCluster: boolean
+  contextTabsEnabled: boolean
   crdDiscoveryStatus?: 'idle' | 'discovering' | 'ready'
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6097,6 +6097,36 @@ export async function fetchSessionCounts(): Promise<SessionCounts> {
   return fetchJSON("/sessions");
 }
 
+export interface ContextTabResponse {
+  context: string;
+  port: number;
+  url: string;
+}
+
+// Ask the standalone backend to start an isolated Radar process for a
+// different kubeconfig context. The returned URL is intentionally local-only;
+// authenticated and in-cluster deployments report a clear 501 instead.
+export async function openContextTab(name: string): Promise<ContextTabResponse> {
+  const response = await apiFetch(
+    `${getApiBase()}/contexts/${encodeURIComponent(name)}/tab`,
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    let message = body.trim();
+    try {
+      const error = JSON.parse(body) as { error?: string };
+      if (error.error) message = error.error;
+    } catch {
+      // Some failures (including a stale backend without this route) are
+      // emitted as text/plain. Preserve that response instead of replacing
+      // the useful error with "Unknown error".
+    }
+    throw new Error(message || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
 // Context switch timeout in milliseconds (should be longer than backend timeout)
 const CONTEXT_SWITCH_TIMEOUT = 45000; // 45 seconds
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6108,7 +6108,7 @@ export interface ContextTabResponse {
 // authenticated and in-cluster deployments report a clear 501 instead.
 export async function openContextTab(name: string): Promise<ContextTabResponse> {
   const response = await apiFetch(
-    `${getApiBase()}/contexts/${encodeURIComponent(name)}/tab`,
+    apiUrl(`/contexts/${encodeURIComponent(name)}/tab`),
     { method: "POST" },
   );
   if (!response.ok) {

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -5,7 +5,7 @@ import {
   type ClusterSwitcherItem,
   pluralize,
 } from '@skyhook-io/k8s-ui'
-import { useContexts, useSwitchContext, useClusterInfo, fetchSessionCounts, type SessionCounts } from '../api/client'
+import { useContexts, useSwitchContext, useClusterInfo, fetchSessionCounts, openContextTab, type SessionCounts } from '../api/client'
 import { useContextSwitch } from '../context/ContextSwitchContext'
 import { useToast } from '../components/ui/Toast'
 import { useDock } from '../components/dock'
@@ -166,6 +166,30 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
     setSessionCounts(null)
   }
 
+  const handleOpenTab = async (parsed: ParsedContext) => {
+    // Reserve the tab synchronously from the click gesture; waiting for the
+    // backend response before calling window.open would trigger popup
+    // blockers in browsers that require a direct user action.
+    // Do not pass `noopener` to window.open here. Browsers are allowed to
+    // return null for that feature even when the popup was opened, which
+    // makes a permitted popup look blocked to the caller. Detach the opener
+    // after reserving the tab instead.
+    const tab = window.open('about:blank', '_blank')
+    if (!tab) {
+      showError('Could not open context tab', 'Allow pop-ups for Radar and try again.')
+      return
+    }
+    tab.opener = null
+    try {
+      const result = await openContextTab(parsed.context.name)
+      tab.location.href = result.url
+    } catch (error) {
+      tab.close()
+      const message = error instanceof Error ? error.message : 'Could not open an isolated context tab'
+      showError('Could not open context tab', message)
+    }
+  }
+
   // In-cluster mode renders a static badge instead of a switcher (only one
   // synthetic context, no kubeconfig to choose from).
   const isInClusterMode = contexts?.length === 1 && contexts[0].name === 'in-cluster'
@@ -209,6 +233,10 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
         disabled={contextsLoading}
         searchable={items.length > 1}
         showGroupHeaders={hasMultipleAccounts}
+        onOpenInNewTab={item => {
+          const parsed = parsedById.get(item.id)
+          if (parsed) void handleOpenTab(parsed)
+        }}
         errorSlot={
           switchContext.isError ? (
             <span className="text-xs text-red-400">{switchContext.error?.message}</span>

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -233,10 +233,10 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
         disabled={contextsLoading}
         searchable={items.length > 1}
         showGroupHeaders={hasMultipleAccounts}
-        onOpenInNewTab={item => {
+        onOpenInNewTab={clusterInfo?.contextTabsEnabled ? item => {
           const parsed = parsedById.get(item.id)
           if (parsed) void handleOpenTab(parsed)
-        }}
+        } : undefined}
         errorSlot={
           switchContext.isError ? (
             <span className="text-xs text-red-400">{switchContext.error?.message}</span>


### PR DESCRIPTION
## Description

Allow standalone local Radar users to open another kubeconfig context in an isolated browser tab without retargeting the current tab.

- launch a loopback-only sibling Radar process with independent Kubernetes clients, informers, caches, SSE streams, and integration state
- preserve the exact kubeconfig source and in-file context identity, including direct single-file configurations
- add an accessible new-tab action to each non-current row in the shared cluster workspace switcher
- wait for the sibling listener before returning its URL, track child processes, and stop them with the parent
- surface plain-text API failures instead of replacing them with `Unknown error`
- document the standalone-only security and deployment boundaries

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How has this been tested?

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [x] Added/updated unit tests

Validation performed:

- `make build`
- `cd web && npm run tsc`
- `go test ./internal/server -run 'TestWaitForLocalListener' -count=1`
- real-cluster API and browser smoke test
- Playwright at 1920x1080 and 1280x800; the per-row action opened a healthy isolated tab with no console errors

The full `go test ./...` run passes all changed packages but the existing `internal/ai` `TestCursorForceGrantEndToEnd` probe times out when run in the concurrent full suite; it passes in isolation. `make lint` reports existing copylock warnings in `internal/server/exec_origin_test.go` and `internal/server/localterm_disable_test.go` because their table cases copy `Server` values containing `vitalsMetricsMemo`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The feature spawns local child processes with kubeconfig credentials and opens new loopback listeners, but it is restricted to unauthenticated standalone mode with same-origin checks on the launch API.
> 
> **Overview**
> **Standalone local Radar** can open another kubeconfig context in a **new browser tab** without switching the current tab’s cluster. The UI adds a per-row **open in new tab** action on the cluster switcher when `contextTabsEnabled` is true.
> 
> The backend implements this by **`POST /api/contexts/{name}/tab`**, which starts a **loopback sibling `radar` process** (own K8s clients, caches, SSE) with CLI flags `--context`, `--context-source`, `--context-in-file`, waits on a **readiness file** for the bound port, returns a local URL, and **tracks/kills child processes** on parent shutdown. Explorer gains matching flags plus validation that the three context-ref flags are **all-or-nothing**; child tabs use **`RADAR_SETTINGS_PATH`** for isolated settings.
> 
> **Capability gating** disables context tabs for auth, Cloud, in-cluster, and shared listeners; cluster info exposes `contextTabsEnabled`. **`GetContextSource`** in single-file kubeconfig mode now resolves **non-current** contexts (with tests). Docs added in `docs/context-tabs.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2f6d08054a0afcf298a9b6c615e857f4482895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->