### PR TITLE
fix(drawer): stop collapsed sections adding phantom scroll space

### DIFF
--- a/packages/k8s-ui/src/components/ui/Collapse.tsx
+++ b/packages/k8s-ui/src/components/ui/Collapse.tsx
@@ -40,7 +40,15 @@ export function Collapse({
       className={clsx('grid transition-[grid-template-rows] duration-200 ease-out', className)}
       style={{ gridTemplateRows: open ? '1fr' : '0fr' }}
     >
-      <div className="overflow-hidden" inert={!open || undefined}>{render ? children : null}</div>
+      {/* `relative` is load-bearing. Collapsed content is still laid out at full
+          height and only clipped by `overflow-hidden` — but an absolutely-positioned
+          descendant (Tailwind's `sr-only` is position:absolute) resolves its
+          containing block ABOVE this wrapper, so the clip doesn't apply to it. It
+          then sits at its static position, hundreds of px below a collapsed section,
+          and extends the enclosing scroll container's scrollable overflow: the drawer
+          scrolls past its own content into blank space. Anchoring here puts those
+          boxes back inside the clip, so a collapsed section contributes nothing. */}
+      <div className="relative overflow-hidden" inert={!open || undefined}>{render ? children : null}</div>
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -101,7 +101,8 @@ export function Section({ title, icon: Icon, children, defaultExpanded = true, c
         className="grid transition-[grid-template-rows] duration-200 ease-out"
         style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
       >
-        <div className="overflow-hidden">
+        {/* `relative` is load-bearing — see the note in ui/Collapse.tsx. */}
+        <div className="relative overflow-hidden">
           <div className={contentClassName ?? 'pl-6'}>{children}</div>
         </div>
       </div>
@@ -131,7 +132,8 @@ export function ExpandableSection({ title, children, defaultExpanded = true }: E
         className="grid transition-[grid-template-rows] duration-200 ease-out"
         style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
       >
-        <div className="overflow-hidden">
+        {/* `relative` is load-bearing — see the note in ui/Collapse.tsx. */}
+        <div className="relative overflow-hidden">
           <div className="ml-5">{children}</div>
         </div>
       </div>

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -880,8 +880,15 @@ export function WorkloadView({
         {/* Success animation overlay */}
         {saveSuccess && <SaveSuccessAnimation />}
 
-        {/* Content — viewTransitionName scopes View Transitions API cross-fade to this element */}
-        <div className="flex-1 overflow-y-auto" style={{ viewTransitionName: 'drawer-content' }}>
+        {/* Content — viewTransitionName scopes View Transitions API cross-fade to this element.
+            `relative` is the backstop for absolutely-positioned descendants (Tailwind's
+            `sr-only` is position:absolute). The drawer frame keeps overflow visible at idle so
+            popovers aren't clipped, and the app's content column clips only horizontally, so one
+            that resolves its containing block above this scroller escapes into the DOCUMENT's
+            scrollable overflow — a second, page-level scrollbar. Anchoring here confines the
+            damage to this scroll body; ui/Collapse.tsx keeps them from escaping in the first
+            place. */}
+        <div className="relative flex-1 overflow-y-auto" style={{ viewTransitionName: 'drawer-content' }}>
           {!resource ? (
             // Fill the drawer body so the loading logo centers in it, not in a
             // 128px box pinned to the top (matches the splash/PaneLoader centering).


### PR DESCRIPTION
## The bug

Opening the resource drawer for some Pods gave the app a **second, page-level scrollbar** ending in blank space. Fixing that surfaced a second symptom: with a section collapsed, the drawer's own scroller ran past the end of its content into dead space, which filled in when the section was expanded.

`argocd-server` (48 env vars) reproduced it; `cert-manager` (1 env var) did not.

## Root cause

Collapsible content is **clipped, not removed** — it stays laid out at full height behind the wrapper's `overflow-hidden`. That clip does not apply to an absolutely-positioned descendant whose containing block resolves *above* the wrapper.

Tailwind's `sr-only` is `position: absolute`. The env-var table renders one per row to give the icon-only source badge an accessible name (every icon is `aria-hidden`, so it's the button's only name). With 48 rows, 48 boxes sat at their static positions hundreds of px below a collapsed section and inflated whatever scroll container *did* contain them:

- containing block above the drawer's scroller → the **document** grew → page-level scrollbar
- containing block = the scroller → the **drawer** grew → dead space at the end

## Fix

Make each clipping wrapper a containing block, so collapsed content contributes nothing:

- `Collapse` — carries the full explanation
- `Section` / `ExpandableSection`

Plus `relative` on the drawer's scroll body as a backstop. The drawer frame deliberately keeps `overflow: visible` at idle so popovers aren't clipped, and the app's content column clips only horizontally — so an escape there reaches the document and breaks the app chrome. Anchoring confines it to the drawer.

`sr-only` is a real accessibility affordance, not dead markup, so it is contained rather than deleted.

## Verification

Measured on `argocd/argocd-server` (48 env vars) at 1920x1080:

| state | phantom scroll before | after |
|---|---|---|
| page overflow, standalone Radar | 1579px | 0px |
| dead space in drawer, section collapsed | 128px | 0px |
| escaping `sr-only` boxes | 48 | 0 |

Scrolling to the end now lands exactly on the content bottom.

### Radar Hub

The bug reproduced there too — the cluster view grew past `100dvh` and pushed the host chrome. Verified against `radar-hub-web` with both packages symlinked into this tree, using the hub's own compiled CSS and its embedded geometry (`embedded: true, chrome: 'none'` → no Radar header, drawer `top: 0`):

| state | page overflow before | after |
|---|---|---|
| all expanded | 1243px | 0px |
| all collapsed | 962px | 0px |
| mixed | — | 0px |

`tsc -b` shows no delta (3 pre-existing errors, identical with the fix stashed — they're a `file:`-link artifact: duplicate `@types/react` / `lucide-react`). `vite build` succeeds and the hub bundle emits `.relative{position:relative}`. Hub suite: 24 files / 384 tests pass.

## Checks

`make tsc` clean. k8s-ui suite: 161 files / 3382 tests pass, 1 skipped.

## Notes for review

- Four hand-rolled copies of the same grid-collapse pattern exist (`ReachabilityView` ×2, `ChecksView` ×2, `AuditAlerts`, `ResourcesSidebar`). None currently renders `sr-only` inside, so none is defective today — left untouched rather than churning unverifiable surfaces.
- `HelmReleaseDrawer` has the same shape but its root is `position: fixed`, which already establishes a containing block, so it is not exposed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only positioning on existing collapse/scroll wrappers; low regression risk aside from rare stacking/containing-block edge cases around popovers.
> 
> **Overview**
> Fixes **phantom scroll** in the resource drawer (and page-level overflow when `sr-only` escapes the drawer): collapsed grid-collapse sections still lay out children at full height, and Tailwind **`sr-only`** (`position: absolute`) was not clipped when its containing block sat above the `overflow-hidden` wrapper—e.g. many env-var rows in `ContainerEnvironmentSection`.
> 
> Adds **`relative`** on collapse clip wrappers in **`Collapse`**, drawer **`Section`** / **`ExpandableSection`**, and on the drawer scroll body in **`WorkloadView`** so absolutely positioned descendants stay inside the clip (or at least inside the drawer scroller). Accessibility labels are retained; only layout containment changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c7bdc91b8dce4bc48f08c1636753527298becd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

fix: #1616
