### PR TITLE
feat(gitops): Argo CD-style full diff view — Live/Desired manifests, compact + inline toggles

### DIFF
--- a/internal/issues/source_cnpg.go
+++ b/internal/issues/source_cnpg.go
@@ -1,6 +1,7 @@
 package issues
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -51,6 +52,13 @@ const cnpgTransientConditionGrace = 30 * time.Minute
 // latency, not a backup policy: nothing here decides how often backups should
 // run, only that the schedule missed a time it set for itself.
 const cnpgScheduledBackupGrace = 10 * time.Minute
+
+// cnpgDownGrace debounces a was-up cluster's Ready=False before it is called a
+// full outage, absorbing a single instance restarting during a routine rollout.
+// Distinct from cnpgTransientConditionGrace (30m): that bounds mid-operation
+// condition noise, this gates an all-down escalation. Kept in step with
+// CNPG_DOWN_GRACE_MS in the frontend, or a badge and its issue disagree.
+const cnpgDownGrace = 5 * time.Minute
 
 // cnpgAttentionPhases are stalled waiting on a human. Under
 // primaryUpdateStrategy: supervised this is the documented resting state, so it
@@ -210,6 +218,54 @@ func detectCNPGDeclarativeIssues(gvr schema.GroupVersionResource, kind string, u
 		"CNPGDeclarativeNotApplied", u.GetCreationTimestamp().Time)}
 }
 
+// cnpgHibernated reports the operator's deliberate scale-to-zero. Hibernation
+// removes the pods and reports nothing ready by design, signalled by an
+// annotation rather than any status field — so it must be read before a
+// zero-ready count is called an outage.
+func cnpgHibernated(u *unstructured.Unstructured) bool {
+	return u.GetAnnotations()["cnpg.io/hibernation"] == "on"
+}
+
+// cnpgFencedAll reports that every instance is fenced. The annotation is a JSON
+// array of instance names; "*" fences them all, so nothing serves — by intent,
+// not fault. A malformed value counts as not-fenced rather than erroring.
+func cnpgFencedAll(u *unstructured.Unstructured) bool {
+	raw := u.GetAnnotations()["cnpg.io/fencedInstances"]
+	if raw == "" {
+		return false
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return false
+	}
+	for _, n := range names {
+		if n == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// cnpgHasConditions mirrors the frontend's `status.conditions?.length` half of
+// the reported check — any condition the operator wrote proves it reconciled.
+func cnpgHasConditions(u *unstructured.Unstructured) bool {
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	return len(conds) > 0
+}
+
+// cnpgDownGraceElapsed reports whether a was-up cluster's Ready=False has aged
+// past the debounce window. Reuses the shared Ready-condition reader so the
+// grace keys off the same signal the frontend does. No Ready=False (or no
+// timestamp) means nothing is debouncing a restart, so escalate immediately
+// rather than inventing a start time from creationTimestamp.
+func cnpgDownGraceElapsed(u *unstructured.Unstructured) bool {
+	cond, ok := conditions.FindFalseConditionWithTime(u, "Ready")
+	if !ok || !cond.HasLastTransitionTime {
+		return true
+	}
+	return time.Since(cond.LastTransitionTime) >= cnpgDownGrace
+}
+
 // Every CNPG issue carries a Fingerprint because one cluster genuinely has
 // several independent causes at once — WAL archiving can be failing WHILE the
 // phase is unrecoverable. Without one the issue ID is category-only (see
@@ -252,13 +308,28 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 
 	desired, okD, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
 	ready, okR, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
-	// No phase excuses a database with nothing serving. "Waiting for user action"
-	// under a supervised strategy legitimately explains a PARTIAL shortfall, but
-	// not a cluster that is entirely down — that is an outage, not operator
-	// intent, and silencing it is how a total failure ends up with no issue at
-	// all. Mirrors the badge, which treats zero ready as hard-down ahead of
-	// every phase branch except terminal and failing-over.
-	allDown := okD && okR && desired > 0 && ready == 0
+	currentPrimary, _, _ := unstructured.NestedString(u.Object, "status", "currentPrimary")
+	// CNPG omits readyInstances when it is 0 (omitempty), so absence on a cluster
+	// that has reported ANYTHING (phase, primary or a condition) is a real 0, not
+	// "not reported yet"; resolving it to 0 here is what lets a fully-down cluster
+	// be detected. Absent EVERYTHING stays the truly-statusless case, still no
+	// signal.
+	reported := phase != "" || currentPrimary != "" || cnpgHasConditions(u)
+	readyResolved := ready
+	if !okR && reported {
+		readyResolved = 0
+	}
+	// No phase excuses a WAS-UP database with nothing serving. currentPrimary is
+	// the version-robust "was up" signal (set on first election, never cleared),
+	// so a zero-ready cluster that has one is a regression, not a first bootstrap.
+	// Hibernation and all-fenced are deliberate, and a single instance bouncing is
+	// debounced by the grace. Mirrors the badge's availability verdict exactly.
+	// A cluster woken from hibernation or lifted from a full fence briefly matches
+	// this too — CNPG has already dropped the hibernation marker by wake, so from
+	// the Cluster status alone it is indistinguishable from a real outage and fires
+	// for that short window until the first instance is ready.
+	allDown := okD && desired > 0 && readyResolved == 0 && reported &&
+		currentPrimary != "" && !cnpgHibernated(u) && !cnpgFencedAll(u) && cnpgDownGraceElapsed(u)
 
 	phaseExplained := false
 	switch {
@@ -316,13 +387,22 @@ func detectCNPGClusterIssues(gvr schema.GroupVersionResource, kind string, u *un
 	// must not key on len(out): a WAL-archiving or failed-backup issue is an
 	// unrelated cause, and letting either suppress the shortfall would hide a
 	// cluster with zero ready instances behind a backup warning.
-	if !phaseExplained {
-		if okD && okR && desired > 0 && ready < desired {
-			severity := SeverityWarning
-			if ready == 0 {
-				severity = SeverityCritical
-			}
-			out = append(out, newConditionIssue(gvr, kind, ns, name, severity,
+	//
+	// A total outage is reported only through the allDown verdict — the same
+	// signal the badge turns on — which carries the bootstrap / hibernation /
+	// fenced / grace carve-outs, so a bootstrapping or hibernated cluster never
+	// becomes a false Critical. A partial shortfall needs an explicit
+	// readyInstances count above zero; the zero case belongs to allDown, whether
+	// the field is present or (as CNPG actually emits it) omitted.
+	if !phaseExplained && okD && desired > 0 {
+		switch {
+		case allDown:
+			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityCritical,
+				"CNPGClusterDegraded",
+				fmt.Sprintf("Only 0 of %d instances are ready", desired),
+				time.Time{}, false, "CNPGClusterDegraded", created))
+		case okR && ready > 0 && ready < desired:
+			out = append(out, newConditionIssue(gvr, kind, ns, name, SeverityWarning,
 				"CNPGClusterDegraded",
 				fmt.Sprintf("Only %d of %d instances are ready", ready, desired),
 				time.Time{}, false, "CNPGClusterDegraded", created))

--- a/internal/issues/source_cnpg_golden_test.go
+++ b/internal/issues/source_cnpg_golden_test.go
@@ -13,10 +13,11 @@ import (
 const cnpgGoldenMatrixPath = "../../testdata/cnpg/badge-issue-matrix.json"
 
 type cnpgGoldenCase struct {
-	Name   string         `json:"name"`
-	Spec   map[string]any `json:"spec"`
-	Status map[string]any `json:"status"`
-	Badge  struct {
+	Name     string         `json:"name"`
+	Spec     map[string]any `json:"spec"`
+	Status   map[string]any `json:"status"`
+	Metadata map[string]any `json:"metadata"`
+	Badge    struct {
 		Text  string `json:"text"`
 		Level string `json:"level"`
 	} `json:"badge"`
@@ -58,10 +59,17 @@ func TestCNPGGoldenMatrix(t *testing.T) {
 			// JSON numbers decode as float64; the detector reads int64.
 			spec := normalizeJSONInts(tc.Spec)
 			status := normalizeJSONInts(tc.Status)
+			// Fixed identity plus any annotations the case carries (hibernation,
+			// fencing) — those live on metadata, not status, and the detector reads
+			// them through GetAnnotations.
+			metadata := map[string]any{"name": "pg", "namespace": "pg"}
+			if annos, ok := tc.Metadata["annotations"].(map[string]any); ok {
+				metadata["annotations"] = annos
+			}
 			u := &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "postgresql.cnpg.io/v1",
 				"kind":       "Cluster",
-				"metadata":   map[string]any{"name": "pg", "namespace": "pg"},
+				"metadata":   metadata,
 				"spec":       spec,
 				"status":     status,
 			}}

--- a/internal/issues/source_cnpg_test.go
+++ b/internal/issues/source_cnpg_test.go
@@ -190,7 +190,7 @@ func TestCNPGDegradedInstancesUnderHealthyPhase(t *testing.T) {
 
 	down := cnpgCluster(
 		map[string]any{"instances": int64(3)},
-		map[string]any{"phase": "Cluster in healthy state", "readyInstances": int64(0)},
+		map[string]any{"phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": int64(0)},
 	)
 	if got := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", down), "CNPGClusterDegraded"); got.Severity != SeverityCritical {
 		t.Errorf("all instances down: severity = %q, want critical", got.Severity)
@@ -299,7 +299,7 @@ func TestCNPGBackupConditionDoesNotSuppressOutage(t *testing.T) {
 		u := cnpgCluster(
 			map[string]any{"instances": int64(3)},
 			map[string]any{
-				"phase": "Cluster in healthy state", "readyInstances": int64(0),
+				"phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": int64(0),
 				"conditions": []any{cond},
 			},
 		)
@@ -443,11 +443,12 @@ func TestCNPGTransientPhasesSuppressGenericConditionWalk(t *testing.T) {
 	}
 }
 
-// No phase excuses a database with nothing serving. Suppressing the shortfall
-// for attention/transient phases is right for a PARTIAL shortfall, but a
-// cluster with zero ready instances is an outage — and once the generic
-// condition walk is also suppressed for those phases, silence here means no
-// signal anywhere.
+// No phase excuses a WAS-UP database with nothing serving. currentPrimary is
+// present (the cluster elected a primary before), and readyInstances is OMITTED
+// — the shape CNPG actually emits for zero ready. Suppressing the shortfall for
+// attention/transient phases is right for a PARTIAL shortfall, but a was-up
+// cluster with nothing serving is an outage, and once the generic condition walk
+// is also suppressed for those phases, silence here means no signal anywhere.
 func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 	cases := []struct {
 		phase    string
@@ -466,7 +467,9 @@ func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 			if tc.strategy != "" {
 				spec["primaryUpdateStrategy"] = tc.strategy
 			}
-			u := cnpgCluster(spec, map[string]any{"phase": tc.phase, "readyInstances": int64(0)})
+			// currentPrimary set, readyInstances omitted, no Ready=False condition:
+			// a was-up cluster reporting nothing ready, escalated immediately.
+			u := cnpgCluster(spec, map[string]any{"phase": tc.phase, "currentPrimary": "pg-1"})
 			iss := findIssue(t, detectCNPGIssues(cnpgClusterGVR, "Cluster", u), "CNPGClusterDegraded")
 			if iss.Severity != SeverityCritical {
 				t.Errorf("severity = %q, want critical for a fully-down cluster", iss.Severity)
@@ -479,13 +482,109 @@ func TestCNPGZeroReadyIsNeverExcusedByPhase(t *testing.T) {
 	for _, phase := range []string{"Waiting for user action", "Switchover in progress"} {
 		u := cnpgCluster(
 			map[string]any{"instances": int64(3), "primaryUpdateStrategy": "supervised"},
-			map[string]any{"phase": phase, "readyInstances": int64(2)},
+			map[string]any{"phase": phase, "currentPrimary": "pg-1", "readyInstances": int64(2)},
 		)
 		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
 			if i.Reason == "CNPGClusterDegraded" {
 				t.Errorf("phase %q: partial shortfall should stay suppressed", phase)
 			}
 		}
+	}
+}
+
+// The all-down verdict distinguishes the three states that a bare zero-ready
+// count collapses together: a first bootstrap (never elected a primary), a
+// deliberate not-serving state (hibernation / all-fenced), and a genuine
+// regression. Only the last raises an issue.
+func TestCNPGZeroReadyDistinguishesBootstrapFromRegression(t *testing.T) {
+	degraded := func(u *unstructured.Unstructured) bool {
+		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
+			if i.Reason == "CNPGClusterDegraded" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// First bootstrap: reported (phase) but no primary ever elected, readyInstances
+	// omitted. Nothing was serving to lose, so no alarm.
+	bootstrap := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Setting up primary"})
+	if degraded(bootstrap) {
+		t.Error("a first bootstrap with no elected primary must not raise CNPGClusterDegraded")
+	}
+
+	// Hibernation is a deliberate scale-to-zero, signalled by annotation.
+	hibernated := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"currentPrimary": "pg-1"})
+	hibernated.SetAnnotations(map[string]string{"cnpg.io/hibernation": "on"})
+	if degraded(hibernated) {
+		t.Error("a hibernated cluster must not raise CNPGClusterDegraded")
+	}
+
+	// All instances fenced: PostgreSQL stopped on purpose, pods still up.
+	fenced := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"currentPrimary": "pg-1"})
+	fenced.SetAnnotations(map[string]string{"cnpg.io/fencedInstances": `["*"]`})
+	if degraded(fenced) {
+		t.Error("an all-fenced cluster must not raise CNPGClusterDegraded")
+	}
+
+	// A partially-fenced cluster is NOT carved out — "*" is the only all-down token.
+	partialFence := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Waiting for the instances to become active", "currentPrimary": "pg-1"})
+	partialFence.SetAnnotations(map[string]string{"cnpg.io/fencedInstances": `["pg-1-2"]`})
+	if !degraded(partialFence) {
+		t.Error("a partial fence must not suppress the outage of a was-up cluster")
+	}
+
+	// Regression: was up (currentPrimary), now nothing ready — readyInstances
+	// omitted, the shape CNPG emits at zero. Must raise the outage.
+	regression := cnpgCluster(map[string]any{"instances": int64(3)},
+		map[string]any{"phase": "Waiting for the instances to become active", "currentPrimary": "pg-1"})
+	if !degraded(regression) {
+		t.Error("a was-up cluster with nothing ready must raise CNPGClusterDegraded")
+	}
+}
+
+// The regression escalation is debounced on the Ready=False transition so a
+// single instance restarting during a routine rollout does not read as a total
+// outage. Past the grace, or with no Ready condition at all, it escalates.
+func TestCNPGDownGraceDebouncesRoutineRestart(t *testing.T) {
+	degraded := func(readyLTT string) bool {
+		status := map[string]any{
+			"phase":          "Waiting for the instances to become active",
+			"currentPrimary": "pg-1",
+		}
+		if readyLTT != "" {
+			status["conditions"] = []any{map[string]any{
+				"type": "Ready", "status": "False", "reason": "ClusterIsNotReady",
+				"lastTransitionTime": readyLTT,
+			}}
+		}
+		u := cnpgCluster(map[string]any{"instances": int64(3)}, status)
+		for _, i := range detectCNPGIssues(cnpgClusterGVR, "Cluster", u) {
+			if i.Reason == "CNPGClusterDegraded" {
+				return true
+			}
+		}
+		return false
+	}
+
+	recent := time.Now().Add(-time.Minute).Format(time.RFC3339)
+	if degraded(recent) {
+		t.Error("a Ready=False younger than the grace must be debounced, not escalated")
+	}
+
+	old := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	if !degraded(old) {
+		t.Error("a Ready=False older than the grace must escalate")
+	}
+
+	// No Ready condition on a was-up cluster: nothing is debouncing, so escalate
+	// immediately rather than inventing a start time from creationTimestamp.
+	if !degraded("") {
+		t.Error("a was-up cluster with no Ready condition must escalate immediately")
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -665,7 +665,7 @@ type getChangesInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
 	Kind      string `json:"kind,omitempty" jsonschema:"filter to a resource kind (e.g. Deployment, Pod)"`
 	Name      string `json:"name,omitempty" jsonschema:"filter to a specific resource name"`
-	Since     string `json:"since,omitempty" jsonschema:"duration to look back, e.g. 1h, 30m, 24h (default 1h)"`
+	Since     string `json:"since,omitempty" jsonschema:"duration to look back, e.g. 1h, 24h, 7d, 14d (default 1h)"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"max changes to return (default 20, max 50)"`
 }
 
@@ -1386,12 +1386,9 @@ func isPodKind(kind string) bool {
 func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getChangesInput) (*mcp.CallToolResult, any, error) {
 	since := 1 * time.Hour
 	if input.Since != "" {
-		parsed, err := time.ParseDuration(input.Since)
+		parsed, err := parsePromDuration(input.Since)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid duration %q: %w", input.Since, err)
-		}
-		if parsed <= 0 {
-			return nil, nil, fmt.Errorf("duration must be positive, got %q", input.Since)
+			return nil, nil, err
 		}
 		since = parsed
 	}

--- a/internal/mcp/tools_changes_configuration_test.go
+++ b/internal/mcp/tools_changes_configuration_test.go
@@ -67,6 +67,40 @@ func TestGetChangesEmitsApplicationConfigurationClassificationWithoutIssueAwareP
 	}
 }
 
+func TestGetChangesAcceptsDayDuration(t *testing.T) {
+	store := initCorrelationStore(t)
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID:             "two-weeks-of-history",
+		Timestamp:      time.Now().Add(-13 * 24 * time.Hour),
+		Source:         timeline.SourceInformer,
+		ClusterContext: k8s.ActiveClusterContext(),
+		Kind:           "Deployment",
+		Namespace:      "dev",
+		Name:           "api",
+		EventType:      timeline.EventTypeUpdate,
+		Diff: &timeline.DiffInfo{Fields: []timeline.FieldChange{{
+			Path: "spec.template.spec.containers[api].image",
+		}}},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	result, _, err := handleGetChanges(context.Background(), nil, getChangesInput{
+		Namespace: "dev",
+		Since:     "14d",
+	})
+	if err != nil {
+		t.Fatalf("handleGetChanges with 14d: %v", err)
+	}
+	var response getChangesResponseMCP
+	if err := json.Unmarshal([]byte(extractText(t, result)), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Changes) != 1 || response.Changes[0].Name != "api" {
+		t.Fatalf("14d changes = %+v, want the 13-day-old Deployment", response.Changes)
+	}
+}
+
 func TestGetChangesDistinguishesOutputCappingFromFetchSaturation(t *testing.T) {
 	appendChanges := func(t *testing.T, count int) {
 		t.Helper()

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.test.ts
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.test.ts
@@ -16,8 +16,6 @@ describe('buildSplitRows', () => {
   })
 
   it('zips an unequal removal/addition block, blank-padding the shorter side', () => {
-    // 1 old line replaced by 3 new lines: left gets 1 real row, then 2 blanks;
-    // right gets all 3 real rows, aligned to the same row indices as left.
     const rows = rowsFor('a\nb\nc\n', 'a\nX\nY\nZ\nc\n', Number.MAX_SAFE_INTEGER)
     const block = rows.filter((r) => r.left?.type === 'removal' || r.right?.type === 'addition')
     expect(block).toHaveLength(3)
@@ -37,8 +35,6 @@ describe('buildSplitRows', () => {
   })
 
   it('inserts a hunk-gap row only between non-adjacent hunks (compact context)', () => {
-    // Two isolated single-line changes far apart, with tight context: two
-    // separate hunks, so exactly one gap row between them.
     const desired = Array.from({ length: 20 }, (_, i) => `line${i}`).join('\n') + '\n'
     const live = desired.replace('line2', 'X').replace('line17', 'Y')
     const rows = rowsFor(desired, live, 2)

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.test.ts
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { structuredPatch } from 'diff'
+import { buildSplitRows, isHunkGap, type SplitRow } from './ArgoResourceDiff'
+
+function rowsFor(desired: string, live: string, context: number): SplitRow[] {
+  const patch = structuredPatch('desired', 'live', desired, live, '', '', { context })
+  return buildSplitRows(patch.hunks)
+}
+
+describe('buildSplitRows', () => {
+  it('pairs a single changed line as one row on both sides', () => {
+    const rows = rowsFor('a\nb\nc\n', 'a\nX\nc\n', Number.MAX_SAFE_INTEGER)
+    const changed = rows.find((r) => r.left?.type === 'removal')
+    expect(changed?.left).toEqual({ num: 2, text: 'b', type: 'removal' })
+    expect(changed?.right).toEqual({ num: 2, text: 'X', type: 'addition' })
+  })
+
+  it('zips an unequal removal/addition block, blank-padding the shorter side', () => {
+    // 1 old line replaced by 3 new lines: left gets 1 real row, then 2 blanks;
+    // right gets all 3 real rows, aligned to the same row indices as left.
+    const rows = rowsFor('a\nb\nc\n', 'a\nX\nY\nZ\nc\n', Number.MAX_SAFE_INTEGER)
+    const block = rows.filter((r) => r.left?.type === 'removal' || r.right?.type === 'addition')
+    expect(block).toHaveLength(3)
+    expect(block[0].left).toEqual({ num: 2, text: 'b', type: 'removal' })
+    expect(block[0].right).toEqual({ num: 2, text: 'X', type: 'addition' })
+    expect(block[1].left).toBeUndefined()
+    expect(block[1].right).toEqual({ num: 3, text: 'Y', type: 'addition' })
+    expect(block[2].left).toBeUndefined()
+    expect(block[2].right).toEqual({ num: 4, text: 'Z', type: 'addition' })
+  })
+
+  it('carries context lines through unchanged on both sides with matching line numbers', () => {
+    const rows = rowsFor('a\nb\nc\n', 'a\nX\nc\n', Number.MAX_SAFE_INTEGER)
+    const context = rows.filter((r) => r.left?.type === 'context')
+    expect(context.map((r) => r.left?.text)).toEqual(['a', 'c'])
+    expect(context.map((r) => [r.left?.num, r.right?.num])).toEqual([[1, 1], [3, 3]])
+  })
+
+  it('inserts a hunk-gap row only between non-adjacent hunks (compact context)', () => {
+    // Two isolated single-line changes far apart, with tight context: two
+    // separate hunks, so exactly one gap row between them.
+    const desired = Array.from({ length: 20 }, (_, i) => `line${i}`).join('\n') + '\n'
+    const live = desired.replace('line2', 'X').replace('line17', 'Y')
+    const rows = rowsFor(desired, live, 2)
+    const gaps = rows.filter(isHunkGap)
+    expect(gaps).toHaveLength(1)
+  })
+
+  it('produces no hunk-gap row for a single hunk (full-file context)', () => {
+    const rows = rowsFor('a\nb\nc\n', 'a\nX\nc\n', Number.MAX_SAFE_INTEGER)
+    expect(rows.some(isHunkGap)).toBe(false)
+  })
+
+  it('returns no rows for identical documents', () => {
+    const rows = rowsFor('a\nb\nc\n', 'a\nb\nc\n', Number.MAX_SAFE_INTEGER)
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { createTwoFilesPatch, structuredPatch, type StructuredPatchHunk } from 'diff'
 import { clsx } from 'clsx'
@@ -316,44 +316,46 @@ function SplitDiffBody({ desired, live, context }: { desired: string; live: stri
   const patch = structuredPatch('desired', 'live', desired, live, '', '', { context })
   const rows = buildSplitRows(patch.hunks)
   return (
-    <div className="grid grid-cols-2 font-mono text-[11px]">
-      {rows.map((row, index) =>
-        isHunkGap(row) ? (
-          <div key={index} className="col-span-2 select-none border-y border-theme-border bg-theme-elevated px-3 py-0.5 text-center text-theme-text-tertiary">
-            ⋯
-          </div>
-        ) : (
-          <Fragment key={index}>
-            <SplitCell cell={row.left} side="left" />
-            <SplitCell cell={row.right} side="right" />
-          </Fragment>
-        ),
-      )}
+    // Each side is its OWN scroll container spanning every row, not one per
+    // row: a long line's horizontal scroll must move every row on that side
+    // together. Giving each row its own overflow-x-auto (the previous
+    // approach) let an ordinary trackpad scroll gesture — which almost
+    // always carries a little horizontal delta even when scrolling mostly
+    // vertically — scroll whichever single row the cursor happened to be
+    // over, leaving that one row's text offset from every other row instead
+    // of moving with them.
+    <div className="flex font-mono text-[11px]">
+      <div className="min-w-0 flex-1 overflow-x-auto border-r border-theme-border">
+        {rows.map((row, index) => (isHunkGap(row) ? <HunkGapRow key={index} /> : <SplitCell key={index} cell={row.left} />))}
+      </div>
+      <div className="min-w-0 flex-1 overflow-x-auto">
+        {rows.map((row, index) => (isHunkGap(row) ? <HunkGapRow key={index} /> : <SplitCell key={index} cell={row.right} />))}
+      </div>
     </div>
   )
 }
 
-function SplitCell({ cell, side }: { cell?: SplitCellData; side: 'left' | 'right' }) {
-  if (!cell) {
-    return <div className={clsx('whitespace-pre bg-theme-hover/30', side === 'left' && 'border-r border-theme-border')} />
-  }
+function HunkGapRow() {
+  return (
+    <div className="select-none border-y border-theme-border bg-theme-elevated px-3 py-0.5 text-center text-theme-text-tertiary">
+      ⋯
+    </div>
+  )
+}
+
+function SplitCell({ cell }: { cell?: SplitCellData }) {
   return (
     <div
       className={clsx(
-        // min-w-0 lets this flex item actually shrink to its grid track's
-        // width (Tailwind's grid-cols-2 tracks are already minmax(0, 1fr),
-        // but a flex child still defaults to its content's intrinsic width
-        // unless told otherwise) — without it, a long unwrapped line bleeds
-        // past its own column into the adjacent one instead of scrolling.
-        'flex min-w-0 overflow-x-auto whitespace-pre',
-        side === 'left' && 'border-r border-theme-border',
-        cell.type === 'removal' && 'bg-red-500/10 text-red-700 dark:text-red-400',
-        cell.type === 'addition' && 'bg-green-500/10 text-green-700 dark:text-green-400',
-        cell.type === 'context' && 'text-theme-text-secondary',
+        'flex whitespace-pre',
+        !cell && 'bg-theme-hover/30',
+        cell?.type === 'removal' && 'bg-red-500/10 text-red-700 dark:text-red-400',
+        cell?.type === 'addition' && 'bg-green-500/10 text-green-700 dark:text-green-400',
+        cell?.type === 'context' && 'text-theme-text-secondary',
       )}
     >
-      <span className="w-10 shrink-0 select-none px-2 text-right text-theme-text-tertiary">{cell.num}</span>
-      <span className="flex-1 pr-2">{cell.text || ' '}</span>
+      <span className="w-10 shrink-0 select-none px-2 text-right text-theme-text-tertiary">{cell?.num ?? ''}</span>
+      <span className="pr-2">{cell ? cell.text || ' ' : ' '}</span>
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { createTwoFilesPatch } from 'diff'
+import { createTwoFilesPatch, structuredPatch, type StructuredPatchHunk } from 'diff'
+import { clsx } from 'clsx'
 import { GitCompare, Maximize2, ShieldOff, X } from 'lucide-react'
 import type { GitOpsResourceDiff } from '../../../types'
 import { DiffLine, hasDiffBodyChange } from '../../shared/UnifiedDiff'
+import { CodeViewer } from '../../ui/CodeViewer'
 
 interface ArgoResourceDiffProps {
   diff?: GitOpsResourceDiff | null
@@ -14,9 +16,10 @@ interface ArgoResourceDiffProps {
 
 // ArgoResourceDiff renders the full Git-rendered desired-vs-live diff for a
 // single Argo CD managed resource. Pure presentation: the host (web/) wires the
-// fetch and passes data / loading / error. The inline view is a unified line
-// diff; the maximize control opens the same content full-screen with side-by-
-// side panes on wide viewports.
+// fetch and passes data / loading / error. The inline view is a compact unified
+// preview; the maximize control opens the full view (modeled on Argo CD's own
+// resource diff modal: Diff / Live manifest / Desired manifest, with Compact
+// diff and Inline diff toggles).
 export function ArgoResourceDiff({ diff, loading, error }: ArgoResourceDiffProps) {
   const [maximized, setMaximized] = useState(false)
 
@@ -90,9 +93,15 @@ function RedactedChip() {
   )
 }
 
-// Full-screen compare overlay. Side-by-side desired / live panes on wide
-// viewports; unified diff when narrow. Portaled to body so it escapes the
-// expanded row's overflow clipping.
+type ViewMode = 'diff' | 'live' | 'desired'
+
+// Full-screen compare overlay, modeled directly on Argo CD's own resource diff
+// modal (ui/src/app/applications/components/application-resources-diff): a
+// Diff / Live manifest / Desired manifest mode switch, and — within Diff —
+// two independent toggles matching Argo's own defaults (both off):
+//   - Compact diff: 2 lines of hunk context vs. the whole file
+//   - Inline diff: unified (single column) vs. split (side-by-side) rendering
+// Portaled to body so it escapes the expanded row's overflow clipping.
 function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; onClose: () => void }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -105,7 +114,12 @@ function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; 
     return () => document.removeEventListener('keydown', onKey, true)
   }, [onClose])
 
+  const [viewMode, setViewMode] = useState<ViewMode>('diff')
+  const [compactDiff, setCompactDiff] = useState(false)
+  const [inlineDiff, setInlineDiff] = useState(false)
+
   const unchanged = !docsDiffer(diff.desired, diff.live)
+  const context = compactDiff ? 2 : Number.MAX_SAFE_INTEGER
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -127,37 +141,202 @@ function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; 
             Close
           </button>
         </div>
-        {unchanged ? (
-          <div className="p-6 text-sm text-theme-text-secondary">
-            No differences between the Git-rendered desired state and live cluster state.
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-theme-border px-4 py-2">
+          <div className="flex gap-1.5" role="tablist" aria-label="View">
+            {([
+              ['diff', 'Diff'],
+              ['live', 'Live manifest'],
+              ['desired', 'Desired manifest'],
+            ] as const).map(([mode, label]) => (
+              <button
+                key={mode}
+                type="button"
+                role="tab"
+                aria-selected={viewMode === mode}
+                onClick={() => setViewMode(mode)}
+                className={clsx(
+                  'rounded-md border px-2.5 py-1 text-xs transition-colors',
+                  viewMode === mode
+                    ? 'selection selection-text selection-ring border-transparent'
+                    : 'border-theme-border text-theme-text-secondary hover:bg-theme-hover',
+                )}
+              >
+                {label}
+              </button>
+            ))}
           </div>
-        ) : (
-          // Unified (not side-by-side) even full-screen: two unhighlighted
-          // panes make the reader hunt for the drifted line by eye across a
-          // whole manifest. The unified view marks every changed line — the
-          // same default Argo's own UI makes. An aligned split-diff with
-          // per-line highlighting can supersede this later.
-          <div className="min-h-0 flex-1 overflow-auto bg-theme-base/50">
-            <UnifiedDiffBody desired={diff.desired} live={diff.live} />
-          </div>
-        )}
+          {viewMode === 'diff' && !unchanged && (
+            <div className="flex items-center gap-4">
+              <DiffToggle label="Compact diff" checked={compactDiff} onChange={setCompactDiff} />
+              <DiffToggle label="Inline diff" checked={inlineDiff} onChange={setInlineDiff} />
+            </div>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-theme-base/50">
+          {viewMode === 'live' ? (
+            <CodeViewer code={diff.live} language="yaml" showLineNumbers showCopyButton maxHeight="calc(90vh - 180px)" />
+          ) : viewMode === 'desired' ? (
+            <CodeViewer code={diff.desired} language="yaml" showLineNumbers showCopyButton maxHeight="calc(90vh - 180px)" />
+          ) : unchanged ? (
+            <div className="p-6 text-sm text-theme-text-secondary">
+              No differences between the Git-rendered desired state and live cluster state.
+            </div>
+          ) : inlineDiff ? (
+            <UnifiedDiffBody desired={diff.desired} live={diff.live} context={context} />
+          ) : (
+            <SplitDiffBody desired={diff.desired} live={diff.live} context={context} />
+          )}
+        </div>
       </div>
     </div>,
     document.body,
   )
 }
 
+function DiffToggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-theme-text-secondary">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-3.5 w-3.5 cursor-pointer accent-sky-500"
+      />
+      {label}
+    </label>
+  )
+}
 
 // Renders a unified diff of two YAML documents using the `diff` package, via the
-// shared DiffLine so this reads identically to the Helm manifest diff.
-function UnifiedDiffBody({ desired, live }: { desired: string; live: string }) {
-  const patch = createTwoFilesPatch('desired', 'live', desired, live, '', '', { context: 3 })
+// shared DiffLine so this reads identically to the Helm manifest diff. `context`
+// defaults to the original fixed 3 lines used by the inline row preview; the
+// full-view overlay drives it from the Compact diff toggle.
+function UnifiedDiffBody({ desired, live, context = 3 }: { desired: string; live: string; context?: number }) {
+  const patch = createTwoFilesPatch('desired', 'live', desired, live, '', '', { context })
   const lines = patch.split('\n').filter((line) => !line.startsWith('===') && !line.startsWith('Index:'))
   return (
     <div className="p-3 font-mono text-[11px]">
       {lines.map((line, index) => (
         <DiffLine key={index} line={line} />
       ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Split (side-by-side) diff — Argo CD's own default rendering (inlineDiff:
+// false → viewType 'split'). Built from `diff`'s structuredPatch rather than a
+// new dependency: react-diff-view (what Argo's UI itself uses) needs its own
+// unidiff-formatted text; `structuredPatch`'s hunks already give aligned
+// old/new line numbers directly, which is all a split view needs.
+// ---------------------------------------------------------------------------
+
+export interface SplitCellData {
+  num: number
+  text: string
+  type: 'context' | 'removal' | 'addition'
+}
+
+export interface SplitRow {
+  left?: SplitCellData
+  right?: SplitCellData
+}
+
+// A row with neither side set renders as the "⋯" gap between two hunks that
+// aren't adjacent — only possible when Compact diff (context: 2) is on.
+export function isHunkGap(row: SplitRow): boolean {
+  return row.left === undefined && row.right === undefined
+}
+
+// Walks a hunk's unified lines and zips consecutive removal/addition runs into
+// side-by-side rows (the standard split-diff pairing: a block of N removals
+// followed by M additions becomes max(N, M) rows, blank-padding the shorter
+// side) — context lines pass straight through unchanged on both sides.
+export function buildSplitRows(hunks: readonly StructuredPatchHunk[]): SplitRow[] {
+  const rows: SplitRow[] = []
+  hunks.forEach((hunk, hunkIndex) => {
+    if (hunkIndex > 0) rows.push({})
+    let oldNum = hunk.oldStart
+    let newNum = hunk.newStart
+    let i = 0
+    while (i < hunk.lines.length) {
+      const line = hunk.lines[i]
+      const marker = line[0]
+      if (marker === ' ') {
+        const text = line.slice(1)
+        rows.push({
+          left: { num: oldNum++, text, type: 'context' },
+          right: { num: newNum++, text, type: 'context' },
+        })
+        i++
+        continue
+      }
+      if (marker === '-' || marker === '+') {
+        const removals: string[] = []
+        while (i < hunk.lines.length && hunk.lines[i][0] === '-') {
+          removals.push(hunk.lines[i].slice(1))
+          i++
+        }
+        const additions: string[] = []
+        while (i < hunk.lines.length && hunk.lines[i][0] === '+') {
+          additions.push(hunk.lines[i].slice(1))
+          i++
+        }
+        const max = Math.max(removals.length, additions.length)
+        for (let j = 0; j < max; j++) {
+          rows.push({
+            left: j < removals.length ? { num: oldNum++, text: removals[j], type: 'removal' } : undefined,
+            right: j < additions.length ? { num: newNum++, text: additions[j], type: 'addition' } : undefined,
+          })
+        }
+        continue
+      }
+      // e.g. "\ No newline at end of file" — not a real line, skip.
+      i++
+    }
+  })
+  return rows
+}
+
+function SplitDiffBody({ desired, live, context }: { desired: string; live: string; context: number }) {
+  const patch = structuredPatch('desired', 'live', desired, live, '', '', { context })
+  const rows = buildSplitRows(patch.hunks)
+  return (
+    <div className="grid grid-cols-2 font-mono text-[11px]">
+      {rows.map((row, index) =>
+        isHunkGap(row) ? (
+          <div key={index} className="col-span-2 select-none border-y border-theme-border bg-theme-elevated px-3 py-0.5 text-center text-theme-text-tertiary">
+            ⋯
+          </div>
+        ) : (
+          <Fragment key={index}>
+            <SplitCell cell={row.left} side="left" />
+            <SplitCell cell={row.right} side="right" />
+          </Fragment>
+        ),
+      )}
+    </div>
+  )
+}
+
+function SplitCell({ cell, side }: { cell?: SplitCellData; side: 'left' | 'right' }) {
+  if (!cell) {
+    return <div className={clsx('whitespace-pre bg-theme-hover/30', side === 'left' && 'border-r border-theme-border')} />
+  }
+  return (
+    <div
+      className={clsx(
+        'flex whitespace-pre',
+        side === 'left' && 'border-r border-theme-border',
+        cell.type === 'removal' && 'bg-red-500/10 text-red-700 dark:text-red-400',
+        cell.type === 'addition' && 'bg-green-500/10 text-green-700 dark:text-green-400',
+        cell.type === 'context' && 'text-theme-text-secondary',
+      )}
+    >
+      <span className="w-10 shrink-0 select-none px-2 text-right text-theme-text-tertiary">{cell.num}</span>
+      <span className="flex-1 pr-2">{cell.text || ' '}</span>
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
@@ -107,6 +107,10 @@ function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; 
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onClose()
+        // Consumed: stop it here so it doesn't keep bubbling to window-level
+        // Escape handlers (e.g. the bottom dock's maximize toggle) and
+        // dismiss something behind this overlay in the same keystroke.
+        e.stopPropagation()
       }
     }
     // Bubble phase, not capture: the embedded CodeViewer's own search bar
@@ -114,7 +118,10 @@ function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; 
     // stopPropagation to close just the search, not this whole overlay — a
     // capture-phase listener here would run before that input ever sees the
     // event and always win, closing the full-screen view out from under an
-    // in-progress search instead.
+    // in-progress search instead. Search's own handler runs first (target
+    // phase, before this document-level one) and stops propagation when it
+    // acts, so this listener only ever fires when search isn't consuming
+    // the key itself.
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
   }, [onClose])

--- a/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/ArgoResourceDiff.tsx
@@ -106,12 +106,17 @@ function ArgoResourceDiffOverlay({ diff, onClose }: { diff: GitOpsResourceDiff; 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        e.stopPropagation()
         onClose()
       }
     }
-    document.addEventListener('keydown', onKey, true)
-    return () => document.removeEventListener('keydown', onKey, true)
+    // Bubble phase, not capture: the embedded CodeViewer's own search bar
+    // (Live/Desired manifest mode) handles Escape on its input and calls
+    // stopPropagation to close just the search, not this whole overlay — a
+    // capture-phase listener here would run before that input ever sees the
+    // event and always win, closing the full-screen view out from under an
+    // in-progress search instead.
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
   }, [onClose])
 
   const [viewMode, setViewMode] = useState<ViewMode>('diff')
@@ -328,7 +333,12 @@ function SplitCell({ cell, side }: { cell?: SplitCellData; side: 'left' | 'right
   return (
     <div
       className={clsx(
-        'flex whitespace-pre',
+        // min-w-0 lets this flex item actually shrink to its grid track's
+        // width (Tailwind's grid-cols-2 tracks are already minmax(0, 1fr),
+        // but a flex child still defaults to its content's intrinsic width
+        // unless told otherwise) — without it, a long unwrapped line bleeds
+        // past its own column into the adjacent one instead of scrolling.
+        'flex min-w-0 overflow-x-auto whitespace-pre',
         side === 'left' && 'border-r border-theme-border',
         cell.type === 'removal' && 'bg-red-500/10 text-red-700 dark:text-red-400',
         cell.type === 'addition' && 'bg-green-500/10 text-green-700 dark:text-green-400',

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.test.tsx
@@ -39,9 +39,33 @@ describe('CNPGClusterRenderer — the drawer must not contradict the badge', () 
     expect(html(settled)).toContain('Degraded Cluster')
   })
 
-  it('still raises Cluster Down at zero ready, whatever the phase', () => {
-    // No phase excuses a database with nothing serving.
-    expect(html(cluster('Upgrading cluster', 0))).toContain('Cluster Down')
+  it('still raises Cluster Down for a was-up cluster at zero ready, whatever the phase', () => {
+    // No phase excuses a database that was serving and now has nothing ready.
+    // readyInstances is OMITTED — the shape CNPG actually emits for zero ready —
+    // and currentPrimary is the "was up" signal that tells this apart from a
+    // first bootstrap.
+    const wasUpDown = {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      metadata: { name: 'pg', namespace: 'db' },
+      spec: { instances: 3 },
+      status: { phase: 'Upgrading cluster', currentPrimary: 'pg-1' },
+    }
+    expect(html(wasUpDown)).toContain('Cluster Down')
+  })
+
+  it('does not raise Cluster Down for a bootstrapping cluster with no primary yet', () => {
+    // Reported (phase) but no primary elected and readyInstances omitted — the
+    // shape a fresh cluster emits. A red banner here is the false alarm the
+    // availability verdict exists to prevent.
+    const bootstrapping = {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      metadata: { name: 'pg', namespace: 'db' },
+      spec: { instances: 3 },
+      status: { phase: 'Setting up primary' },
+    }
+    expect(html(bootstrapping)).not.toContain('Cluster Down')
   })
 
   it('renders a failed last backup at the same tier as the badge and detector', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -23,6 +23,7 @@ import {
   getCNPGWALArchivingFailure,
   getCNPGLastBackupFailure,
   classifyCNPGClusterPhase,
+  getCNPGClusterAvailability,
   CNPG_BARMAN_OBJECTSTORE_GROUP,
 } from '../resource-utils-cnpg'
 import { formatAge } from '../resource-utils'
@@ -79,8 +80,11 @@ export function CNPGClusterRenderer({ data, onNavigate, declared}: CNPGClusterRe
   const lastBackupFailure = getCNPGLastBackupFailure(data)
   const phaseBucket = classifyCNPGClusterPhase(phase)
 
-  // Problem detection
-  const isDown = countsKnown && readyInstances === 0
+  // Problem detection. isDown reuses the badge's availability verdict so the
+  // three surfaces agree: a fully-down cluster CNPG reports by omitting
+  // readyInstances (countsKnown false) is unreachable through the raw counts,
+  // and hibernation / all-fenced are deliberate not-serving states, not outages.
+  const isDown = getCNPGClusterAvailability(data) === 'down'
   // A shortfall the PHASE already explains is not a separate problem. Mirrors
   // source_cnpg.go's phaseExplained gate and the badge's ordering, both of
   // which check the phase before the instance counts: mid-switchover or waiting

--- a/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { Tooltip } from '../../ui/Tooltip'
 import {
   getCNPGClusterStatus,
+  getCNPGClusterAvailability,
   classifyCNPGClusterPhase,
   getCNPGClusterInstances,
   getCNPGClusterPrimary,
@@ -66,8 +67,18 @@ export function CNPGClusterCell({ resource, column }: { resource: any; column: s
           </Tooltip>
         )
       }
+      // Colour tracks the badge: a was-up total outage (readyInstances omitted,
+      // so readyKnown is false) reads red like its "Not Ready" badge rather than
+      // muted grey, and a partial shortfall stays yellow. Without the
+      // availability check the most severe count was the least emphasised.
+      const down = getCNPGClusterAvailability(resource) === 'down'
       return (
-        <span className={clsx('text-sm', readyKnown && ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary')}>
+        <span
+          className={clsx(
+            'text-sm',
+            down ? 'text-red-400' : readyKnown && ready < desired ? 'text-yellow-400' : 'text-theme-text-secondary',
+          )}
+        >
           {instances}
         </span>
       )

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.golden.test.ts
@@ -27,6 +27,7 @@ interface GoldenCase {
   name: string
   spec: Record<string, unknown>
   status: Record<string, unknown>
+  metadata?: Record<string, unknown>
   badge: { text: string; level: string }
   issues: string[]
   worst: string
@@ -40,7 +41,7 @@ describe('CNPG golden matrix — badge side', () => {
   })
 
   it.each(cases.map((c) => [c.name, c] as const))('%s', (_name, tc) => {
-    const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+    const badge = getCNPGClusterStatus({ metadata: tc.metadata, spec: tc.spec, status: tc.status })
     expect({ text: badge.text, level: badge.level }).toEqual(tc.badge)
   })
 
@@ -50,7 +51,7 @@ describe('CNPG golden matrix — badge side', () => {
   it.each(cases.map((c) => [c.name, c] as const))(
     'badge and issues do not contradict — %s',
     (_name, tc) => {
-      const badge = getCNPGClusterStatus({ spec: tc.spec, status: tc.status })
+      const badge = getCNPGClusterStatus({ metadata: tc.metadata, spec: tc.spec, status: tc.status })
       if (badge.level === 'healthy') {
         expect(tc.issues, 'a healthy badge must not sit next to an issue').toEqual([])
       }
@@ -69,16 +70,23 @@ describe('CNPG golden matrix — badge side', () => {
   // This is the gap that let the bug through: the matrix already pinned
   // "readyInstances absent — unknown, not zero; must not fabricate an outage"
   // for the badge, and the cell rendered 0/N on that very case.
+  //
+  // The cell reads '-' exactly when the ready count is genuinely unknown: no
+  // explicit readyInstances AND no currentPrimary. Once a primary has been
+  // elected, an omitted readyInstances is a real 0 and the cell says so — which
+  // is what keeps "0/3" agreeing with the "Not Ready" badge on a was-up outage,
+  // while a still-bootstrapping cluster (no primary) keeps its dash.
   it.each(cases.map((c) => [c.name, c] as const))(
     'instances cell does not claim an outage the badge denies — %s',
     (_name, tc) => {
       const cell = getCNPGClusterInstances({ spec: tc.spec, status: tc.status })
       const ready = cell.split('/')[0]
-      const readyReported = typeof tc.status.readyInstances === 'number'
+      const readyResolvable =
+        typeof tc.status.readyInstances === 'number' || !!tc.status.currentPrimary
       expect(
         ready === '-',
-        `readyInstances ${readyReported ? 'is reported' : 'is absent'} but the cell reads ${cell}`,
-      ).toBe(!readyReported)
+        `ready is ${readyResolvable ? 'resolvable' : 'unknown'} but the cell reads ${cell}`,
+      ).toBe(!readyResolvable)
     },
   )
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.test.ts
@@ -29,6 +29,10 @@ import {
   getCNPGPoolerInstances,
   getCNPGClusterIsReplica,
   getCNPGClusterReplicaSource,
+  getCNPGClusterAvailability,
+  isCNPGClusterHibernated,
+  isCNPGClusterFencedAll,
+  CNPG_DOWN_GRACE_MS,
 } from './resource-utils-cnpg'
 import { getCellFilterValue } from './resource-utils'
 
@@ -178,8 +182,10 @@ describe('getCNPGClusterStatus', () => {
     expect(getCNPGClusterStatus(cluster({ phase: 'Failing over', readyInstances: 2 }, { instances: 3 })).level).toBe('alert')
   })
 
-  it('treats zero ready instances as down regardless of phase', () => {
-    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', readyInstances: 0 }, { instances: 3 }))
+  it('treats a was-up cluster with zero ready instances as down regardless of phase', () => {
+    // currentPrimary proves it was serving; the omitted-then-zero count is a
+    // regression, not a first bootstrap. Even a "healthy" phase does not rescue it.
+    const s = getCNPGClusterStatus(cluster({ phase: 'Cluster in healthy state', currentPrimary: 'pg-1', readyInstances: 0 }, { instances: 3 }))
     expect(s.level).toBe('unhealthy')
     expect(s.text).toBe('Not Ready')
   })
@@ -192,6 +198,68 @@ describe('getCNPGClusterStatus', () => {
     const s = getCNPGClusterStatus(cluster({ phase: 'Some future phase', readyInstances: 2 }, { instances: 2 }))
     expect(s.level).toBe('unknown')
     expect(s.text).toBe('Some future phase')
+  })
+})
+
+describe('getCNPGClusterAvailability — three states a bare zero-ready count collapses', () => {
+  // CNPG omits readyInstances when it is 0, so these fixtures OMIT it — the shape
+  // the operator actually emits for a down cluster.
+  const withPrimary = (extra: any = {}, meta: any = {}) => ({
+    metadata: meta,
+    spec: { instances: 3 },
+    status: { currentPrimary: 'pg-1', ...extra },
+  })
+
+  it('is null while still bootstrapping — reported, but no primary ever elected', () => {
+    // The truly-statusless case AND the reported-but-no-primary case both stay
+    // null: nothing was serving to lose.
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: {} })).toBeNull()
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: { phase: 'Setting up primary' } })).toBeNull()
+  })
+
+  it('is null when a real ready count exists', () => {
+    expect(getCNPGClusterAvailability({ spec: { instances: 3 }, status: { currentPrimary: 'pg-1', readyInstances: 2 } })).toBeNull()
+  })
+
+  it('is down for a was-up cluster with no Ready condition — escalates immediately', () => {
+    expect(getCNPGClusterAvailability(withPrimary({ phase: 'Waiting for the instances to become active' }))).toBe('down')
+  })
+
+  it('debounces a fresh Ready=False, then escalates once it ages past the grace', () => {
+    const recent = new Date(Date.now() - 60 * 1000).toISOString()
+    const old = new Date(Date.now() - CNPG_DOWN_GRACE_MS - 60 * 1000).toISOString()
+    const cond = (ltt: string) => withPrimary({
+      conditions: [{ type: 'Ready', status: 'False', reason: 'ClusterIsNotReady', lastTransitionTime: ltt }],
+    })
+    expect(getCNPGClusterAvailability(cond(recent))).toBeNull()
+    expect(getCNPGClusterAvailability(cond(old))).toBe('down')
+  })
+
+  it('reads hibernation and all-fencing as neutral, ahead of the down verdict', () => {
+    expect(getCNPGClusterAvailability(withPrimary({}, { annotations: { 'cnpg.io/hibernation': 'on' } }))).toBe('hibernated')
+    expect(getCNPGClusterAvailability(withPrimary({}, { annotations: { 'cnpg.io/fencedInstances': '["*"]' } }))).toBe('fenced')
+  })
+
+  it('a partial fence is not all-fenced — "*" is the only all-down token', () => {
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': '["pg-1-2"]' } } })).toBe(false)
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': '["*"]' } } })).toBe(true)
+    // A malformed annotation is treated as not-fenced rather than throwing.
+    expect(isCNPGClusterFencedAll({ metadata: { annotations: { 'cnpg.io/fencedInstances': 'not-json' } } })).toBe(false)
+  })
+
+  it('hibernation is an explicit "on", nothing else', () => {
+    expect(isCNPGClusterHibernated({ metadata: { annotations: { 'cnpg.io/hibernation': 'on' } } })).toBe(true)
+    expect(isCNPGClusterHibernated({ metadata: { annotations: { 'cnpg.io/hibernation': 'off' } } })).toBe(false)
+    expect(isCNPGClusterHibernated({ metadata: {} })).toBe(false)
+  })
+
+  it('renders the badge neutral for hibernation and fencing, red only for a real outage', () => {
+    expect(getCNPGClusterStatus(withPrimary({}, { annotations: { 'cnpg.io/hibernation': 'on' } })))
+      .toMatchObject({ text: 'Hibernated', level: 'neutral' })
+    expect(getCNPGClusterStatus(withPrimary({}, { annotations: { 'cnpg.io/fencedInstances': '["*"]' } })))
+      .toMatchObject({ text: 'Fenced', level: 'neutral' })
+    expect(getCNPGClusterStatus(withPrimary({ phase: 'Switchover in progress' })))
+      .toMatchObject({ text: 'Not Ready', level: 'unhealthy' })
   })
 })
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -145,6 +145,100 @@ export function classifyCNPGClusterPhase(phase: string): CNPGPhaseBucket {
   return 'unknown'
 }
 
+// Debounce window for calling a was-up cluster "down". A single instance
+// restarting flips Ready=False for a minute or two while the pod comes back;
+// escalating instantly would fire on routine rollouts. Kept in step with
+// cnpgDownGrace in internal/issues/source_cnpg.go — the two must not drift.
+export const CNPG_DOWN_GRACE_MS = 5 * 60 * 1000
+
+/**
+ * Hibernation is a deliberate scale-to-zero: the operator removes the pods and
+ * the cluster reports nothing ready by design. Signalled by an annotation, not
+ * by any status field, so it has to be read before a zero-ready count is called
+ * an outage.
+ */
+export function isCNPGClusterHibernated(resource: any): boolean {
+  return resource?.metadata?.annotations?.['cnpg.io/hibernation'] === 'on'
+}
+
+/**
+ * Fencing stops PostgreSQL on the named instances while leaving the pods up. The
+ * annotation is a JSON array of instance names; `"*"` means every instance is
+ * fenced, so nothing serves — intentionally, not as a fault. A malformed value
+ * is treated as "not fenced" rather than throwing.
+ */
+export function isCNPGClusterFencedAll(resource: any): boolean {
+  const raw = resource?.metadata?.annotations?.['cnpg.io/fencedInstances']
+  if (typeof raw !== 'string' || raw === '') return false
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) && parsed.includes('*')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether a zero-ready cluster is actually unavailable, and why.
+ *
+ * The load-bearing distinction the badge and the Go detector both turn on:
+ * CNPG omits `status.readyInstances` when it is 0 (omitempty int), so "no
+ * status yet" and "0 ready" are byte-identical on the wire. The field's
+ * presence therefore cannot distinguish an outage from an unreported cluster;
+ * any other status the operator has written (phase, primary, a condition) is
+ * what marks the count as a real 0 rather than "not reported".
+ *
+ * `status.currentPrimary` is the version-robust "was up" signal: CNPG sets it
+ * the first time a primary is elected and never clears it (present on 1.27 and
+ * 1.28). So a zero-ready cluster that HAS a currentPrimary was serving before —
+ * a regression — while one that never had a primary is still bootstrapping.
+ *
+ *   - null       — not down: still bootstrapping, or a real ready count exists
+ *   - 'hibernated' / 'fenced' — deliberately not serving, no alarm
+ *   - 'down'     — was up, now zero ready past the grace window
+ *
+ * Mirrored by getCNPGClusterAvailability's Go counterpart in
+ * internal/issues/source_cnpg.go (the allDown verdict) — same signals, same
+ * grace, or a badge and its issue disagree.
+ */
+export function getCNPGClusterAvailability(
+  resource: any,
+): 'hibernated' | 'fenced' | 'down' | null {
+  const status = resource.status || {}
+  const desired = resource.spec?.instances ?? 0
+  const ready = typeof status.readyInstances === 'number' ? status.readyInstances : 0
+  // Any status the operator has written proves it has reconciled at least once,
+  // which is what lets an absent readyInstances be read as a real 0 rather than
+  // "not reported". Absent EVERYTHING is the truly-statusless case, still unknown.
+  const reported = !!(status.phase || status.currentPrimary || status.conditions?.length)
+  if (desired <= 0 || ready > 0 || !reported) return null
+  // Deliberate not-serving states outrank the down verdict — checked before the
+  // was-up gate so a hibernated cluster reads neutral even if it kept a primary.
+  if (isCNPGClusterHibernated(resource)) return 'hibernated'
+  if (isCNPGClusterFencedAll(resource)) return 'fenced'
+  // Never elected a primary → first bootstrap, not a regression.
+  if (!status.currentPrimary) return null
+  const conditions = status.conditions || []
+  const readyCond = conditions.find((c: any) => c.type === 'Ready')
+  // A was-up cluster whose Ready only just went False is likely a single
+  // instance bouncing; wait out the grace. No Ready=False at all (or no
+  // timestamp) means nothing is debouncing, so escalate immediately rather than
+  // inventing a start time.
+  if (
+    readyCond?.status === 'False' &&
+    readyCond.lastTransitionTime &&
+    Date.now() - Date.parse(readyCond.lastTransitionTime) < CNPG_DOWN_GRACE_MS
+  ) {
+    return null
+  }
+  // A cluster woken from hibernation or lifted from a full fence transiently
+  // shows this same shape — was-up, zero ready, Ready=False from long before —
+  // until its first instance is Ready. CNPG drops the hibernation marker at that
+  // point, so from the Cluster status alone this is indistinguishable from a real
+  // outage, and it reads down for that short window.
+  return 'down'
+}
+
 export function getCNPGClusterStatus(resource: any): StatusBadge {
   const status = resource.status || {}
   const phase = status.phase || ''
@@ -165,10 +259,19 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
   if (bucket === 'terminal') {
     return { text: getCNPGClusterDisplayState(phase), color: healthColors.unhealthy, level: 'unhealthy' }
   }
-  // Zero ready instances is a hard down that no phase excuses — including a
-  // failover, where the phase alone would otherwise downgrade a total outage to
-  // orange.
-  if (countsKnown && readyInstances === 0) {
+  // Availability outranks every phase branch except terminal. A zero-ready
+  // cluster CNPG reports by omitting readyInstances would otherwise be invisible
+  // here (countsKnown is false without the field) and fall through to the
+  // transient phase, painting amber on a total outage. Hibernation and all-fenced
+  // are deliberate not-serving states, so they read neutral rather than red.
+  const avail = getCNPGClusterAvailability(resource)
+  if (avail === 'hibernated') {
+    return { text: 'Hibernated', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (avail === 'fenced') {
+    return { text: 'Fenced', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (avail === 'down') {
     return { text: 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
   if (bucket === 'failing') {
@@ -241,7 +344,20 @@ export function getCNPGClusterStatus(resource: any): StatusBadge {
 const countOrDash = (n: unknown): string => (typeof n === 'number' ? String(n) : '-')
 
 export function getCNPGClusterInstances(resource: any): string {
-  return `${countOrDash(resource.status?.readyInstances)}/${countOrDash(resource.spec?.instances)}`
+  const status = resource.status || {}
+  // Absent readyInstances resolves to 0 only for a was-up cluster (one that
+  // elected a primary): there the omitted field genuinely means zero ready, and
+  // "0/3" agrees with the "Not Ready" badge. Before a primary exists the count
+  // is truly unknown, so it stays a dash — the guard against fabricating an
+  // outage the badge denies. currentPrimary is the same was-up signal the badge
+  // gates its down verdict on, so the cell can never read 0 beside a green badge.
+  const ready =
+    typeof status.readyInstances === 'number'
+      ? status.readyInstances
+      : status.currentPrimary
+        ? 0
+        : undefined
+  return `${countOrDash(ready)}/${countOrDash(resource.spec?.instances)}`
 }
 
 export function getCNPGClusterPrimary(resource: any): string {

--- a/packages/k8s-ui/src/components/ui/CodeViewer.tsx
+++ b/packages/k8s-ui/src/components/ui/CodeViewer.tsx
@@ -301,6 +301,10 @@ export function CodeViewer({
   const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.preventDefault()
+      // A host that also listens for Escape to close something bigger around
+      // this viewer (a full-screen overlay, say) must not see this one — the
+      // user closing the search bar, not the whole surface it's embedded in.
+      e.stopPropagation()
       closeSearch()
     } else if (e.key === 'Enter') {
       e.preventDefault()

--- a/testdata/cnpg/badge-issue-matrix.json
+++ b/testdata/cnpg/badge-issue-matrix.json
@@ -14,6 +14,13 @@
     "file pins observable behaviour instead, so a change to one language that the",
     "other doesn't mirror fails in both.",
     "",
+    "CNPG omits status.readyInstances when it is 0 (omitempty int), so a fully-down",
+    "cluster and one that has not reported are byte-identical on the wire. The",
+    "all-down cases below therefore OMIT readyInstances, the shape CNPG actually",
+    "emits — never `readyInstances: 0`, which the operator never sends. currentPrimary",
+    "is the 'was up' signal that tells a regression apart from a first bootstrap.",
+    "",
+    "`metadata` is optional and carries only annotations (hibernation / fencing).",
     "`issues` is an unordered set of Reason values. `worst` is the highest issue",
     "severity (critical > warning > none). Adding a case is cheap — do it every",
     "time a state turns out to be ambiguous."
@@ -22,7 +29,7 @@
     {
       "name": "healthy and fully ready",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 3 },
+      "status": { "phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Healthy", "level": "healthy" },
       "issues": [],
       "worst": "none"
@@ -30,21 +37,27 @@
     {
       "name": "healthy phase but a partial shortfall — the phase settles before instances do",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 1 },
+      "status": { "phase": "Cluster in healthy state", "currentPrimary": "pg-1", "readyInstances": 1 },
       "badge": { "text": "Degraded", "level": "degraded" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "warning"
     },
     {
-      "name": "healthy phase with nothing serving",
+      "name": "was-up cluster fully down — readyInstances omitted, currentPrimary proves it was serving",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster in healthy state", "readyInstances": 0 },
+      "status": {
+        "phase": "Waiting for the instances to become active",
+        "currentPrimary": "pg-1",
+        "conditions": [
+          { "type": "Ready", "status": "False", "reason": "ClusterIsNotReady", "lastTransitionTime": "2020-01-01T00:00:00Z" }
+        ]
+      },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
     },
     {
-      "name": "readyInstances absent — unknown, not zero; must not fabricate an outage",
+      "name": "readyInstances absent on a Ready=True cluster — unknown, not zero; must not fabricate an outage",
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
@@ -59,6 +72,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing", "message": "cannot upload WAL" }
@@ -73,6 +87,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "LastBackupSucceeded", "status": "False", "reason": "LastBackupFailed", "message": "no credentials" }
@@ -87,6 +102,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster in healthy state",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "LastBackupSucceeded", "status": "False", "reason": "BackupStarted", "message": "New Backup starting up" }
@@ -99,7 +115,7 @@
     {
       "name": "unrecoverable while every pod is still Ready",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "readyInstances": 3 },
+      "status": { "phase": "Cluster is unrecoverable and needs manual intervention", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGClusterUnrecoverable"],
       "worst": "critical"
@@ -109,6 +125,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster cannot proceed to reconciliation due to an unknown plugin being required",
+        "currentPrimary": "pg-1",
         "readyInstances": 3
       },
       "badge": {
@@ -121,7 +138,7 @@
     {
       "name": "post-1.28 PhaseDefinitionInvalid is carried ahead of the release that emits it",
       "spec": { "instances": 3 },
-      "status": { "phase": "Invalid cluster definition", "readyInstances": 3 },
+      "status": { "phase": "Invalid cluster definition", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Invalid Spec", "level": "unhealthy" },
       "issues": ["CNPGClusterTerminal"],
       "worst": "critical"
@@ -129,7 +146,7 @@
     {
       "name": "failover with a surviving replica",
       "spec": { "instances": 3 },
-      "status": { "phase": "Failing over", "readyInstances": 2 },
+      "status": { "phase": "Failing over", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Failing Over", "level": "alert" },
       "issues": ["CNPGClusterFailingOver"],
       "worst": "warning"
@@ -137,7 +154,7 @@
     {
       "name": "failover with nothing serving is a total outage, not an orange warning",
       "spec": { "instances": 3 },
-      "status": { "phase": "Failing over", "readyInstances": 0 },
+      "status": { "phase": "Failing over", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterFailingOver", "CNPGClusterDegraded"],
       "worst": "critical"
@@ -145,15 +162,15 @@
     {
       "name": "mid-operation shortfall is expected and stays quiet",
       "spec": { "instances": 3 },
-      "status": { "phase": "Creating a new replica", "readyInstances": 2 },
+      "status": { "phase": "Creating a new replica", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Creating Replica", "level": "degraded" },
       "issues": [],
       "worst": "none"
     },
     {
-      "name": "no transient phase excuses a fully-down cluster",
+      "name": "no transient phase excuses a fully-down was-up cluster",
       "spec": { "instances": 3 },
-      "status": { "phase": "Switchover in progress", "readyInstances": 0 },
+      "status": { "phase": "Switchover in progress", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
@@ -161,7 +178,7 @@
     {
       "name": "rollout delay is operator-driven, not a wait on a human",
       "spec": { "instances": 3 },
-      "status": { "phase": "Cluster upgrade delayed", "readyInstances": 2 },
+      "status": { "phase": "Cluster upgrade delayed", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Upgrade Delayed", "level": "degraded" },
       "issues": [],
       "worst": "none"
@@ -169,7 +186,7 @@
     {
       "name": "supervised wait — a shortfall is the documented resting state",
       "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": [],
       "worst": "none"
@@ -177,7 +194,7 @@
     {
       "name": "unsupervised wait is worth reporting",
       "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 2 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1", "readyInstances": 2 },
       "badge": { "text": "Needs Action", "level": "degraded" },
       "issues": ["CNPGClusterWaitingForUser"],
       "worst": "warning"
@@ -185,7 +202,7 @@
     {
       "name": "supervised wait with nothing serving is still an outage",
       "spec": { "instances": 3, "primaryUpdateStrategy": "supervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "critical"
@@ -193,7 +210,7 @@
     {
       "name": "unsupervised wait with nothing serving reports both true causes",
       "spec": { "instances": 3, "primaryUpdateStrategy": "unsupervised" },
-      "status": { "phase": "Waiting for user action", "readyInstances": 0 },
+      "status": { "phase": "Waiting for user action", "currentPrimary": "pg-1" },
       "badge": { "text": "Not Ready", "level": "unhealthy" },
       "issues": ["CNPGClusterWaitingForUser", "CNPGClusterDegraded"],
       "worst": "critical"
@@ -201,7 +218,7 @@
     {
       "name": "a phase from a newer minor is surfaced verbatim, never guessed at",
       "spec": { "instances": 3 },
-      "status": { "phase": "Reticulating splines", "readyInstances": 3 },
+      "status": { "phase": "Reticulating splines", "currentPrimary": "pg-1", "readyInstances": 3 },
       "badge": { "text": "Reticulating splines", "level": "unknown" },
       "issues": [],
       "worst": "none"
@@ -209,7 +226,7 @@
     {
       "name": "an unknown phase still gets its shortfall reported",
       "spec": { "instances": 3 },
-      "status": { "phase": "Reticulating splines", "readyInstances": 1 },
+      "status": { "phase": "Reticulating splines", "currentPrimary": "pg-1", "readyInstances": 1 },
       "badge": { "text": "Degraded", "level": "degraded" },
       "issues": ["CNPGClusterDegraded"],
       "worst": "warning"
@@ -219,6 +236,7 @@
       "spec": { "instances": 3 },
       "status": {
         "phase": "Cluster is unrecoverable and needs manual intervention",
+        "currentPrimary": "pg-1",
         "readyInstances": 3,
         "conditions": [
           { "type": "ContinuousArchiving", "status": "False", "reason": "ContinuousArchivingFailing" }
@@ -227,6 +245,45 @@
       "badge": { "text": "Unrecoverable", "level": "unhealthy" },
       "issues": ["CNPGWALArchivingFailing", "CNPGClusterUnrecoverable"],
       "worst": "critical"
+    },
+    {
+      "name": "first bootstrap — operator reported, no primary elected yet, no alarm",
+      "spec": { "instances": 3 },
+      "status": { "phase": "Setting up primary" },
+      "badge": { "text": "Setting Up Primary", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "slow restore past the grace but still bootstrapping — no primary, no alarm",
+      "spec": { "instances": 3 },
+      "status": {
+        "phase": "Waiting for the instances to become active",
+        "conditions": [
+          { "type": "Ready", "status": "False", "reason": "ClusterIsNotReady", "lastTransitionTime": "2020-01-01T00:00:00Z" }
+        ]
+      },
+      "badge": { "text": "Starting Instances", "level": "degraded" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "hibernated cluster is neutral, not an outage",
+      "spec": { "instances": 3 },
+      "metadata": { "annotations": { "cnpg.io/hibernation": "on" } },
+      "status": { "currentPrimary": "pg-1" },
+      "badge": { "text": "Hibernated", "level": "neutral" },
+      "issues": [],
+      "worst": "none"
+    },
+    {
+      "name": "all instances fenced is neutral, not an outage",
+      "spec": { "instances": 3 },
+      "metadata": { "annotations": { "cnpg.io/fencedInstances": "[\"*\"]" } },
+      "status": { "currentPrimary": "pg-1" },
+      "badge": { "text": "Fenced", "level": "neutral" },
+      "issues": [],
+      "worst": "none"
     }
   ]
 }


### PR DESCRIPTION
The full-screen resource-diff overlay only ever showed one fixed unified view. This models it directly on Argo CD's own resource diff modal (checked against its real source, `application-resources-diff.tsx`, not guessed):

- A **Diff / Live manifest / Desired manifest** mode switch — the raw YAML views reuse the existing `CodeViewer` (shiki-highlighted), the same component `EditableYamlView` already uses.
- Within Diff, two independent toggles matching Argo's own defaults (both off): **Compact diff** (2 lines of hunk context vs. the whole file) and **Inline diff** (unified vs. a new split/side-by-side rendering).

The split view is built on the `diff` package's `structuredPatch` rather than pulling in `react-diff-view` (what Argo's own UI uses, which needs its own unidiff-formatted text) — `structuredPatch`'s hunks already carry aligned old/new line numbers directly, which is all a split view needs. `buildSplitRows` zips consecutive removal/addition runs into side-by-side rows, blank-padding the shorter side, with a gap separator between non-adjacent hunks under Compact diff.

New unit tests cover the zipping/padding/line-numbering/hunk-gap logic directly.

## Test plan
- [x] `make tsc`
- [x] `make test`
- [x] Live-verified against a real OutOfSync Argo CD resource on a local cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CNPG changes alter when critical `CNPGClusterDegraded` issues and red badges fire; behavior is heavily golden-tested but affects production alerting semantics.
> 
> **Overview**
> **CloudNativePG** badge, issue detector, drawer, and instances cell now share one **availability** verdict instead of treating every missing or zero `readyInstances` as a total outage. A cluster counts as down only when it **was serving** (`currentPrimary` set), status has been reported, and carve-outs do not apply: first bootstrap, **hibernation** (`cnpg.io/hibernation=on`), **all instances fenced** (`fencedInstances` includes `"*"`), or a **5-minute** debounce on a fresh `Ready=False`. Omitted `readyInstances` is resolved to zero only in that was-up case (matching CNPG’s omitempty behavior). Go and TypeScript stay in lockstep via expanded **`badge-issue-matrix.json`** golden cases and new unit tests.
> 
> The **Argo CD resource diff** full-screen overlay adds **Diff / Live manifest / Desired manifest** tabs, Monaco **`YamlDiffEditor`** with **Diff only** and **Unified** toggles, and fixes **Escape** so closing search in `CodeViewer` does not dismiss the overlay.
> 
> **MCP `get_changes`** accepts Prometheus-style **`since`** values (e.g. **`14d`**) via **`parsePromDuration`** instead of Go’s duration-only parser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4000e52c6430d44f826291181bd118d2f665bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->