### PR TITLE
fix(argocd): give the reachability probe enough budget for .local DNS

### DIFF
--- a/internal/argocd/manager.go
+++ b/internal/argocd/manager.go
@@ -60,6 +60,16 @@ const (
 	probeTimeout       = 15 * time.Second
 	probeRetryInterval = 30 * time.Second
 
+	// probeEndpointTimeout bounds a single reachability probe. On macOS,
+	// resolving any *.local hostname (a common convention for local cluster
+	// Gateway/Ingress hostnames) routes through mDNSResponder, which tries
+	// multicast DNS first and only falls back to /etc/hosts after its own
+	// hardcoded 5s timeout — so a tight probe budget can time out on DNS
+	// resolution alone before the TCP connect even starts, misreporting a
+	// live, reachable server as unreachable. 8s leaves headroom above that
+	// worst case for the actual connect + HTTP round trip.
+	probeEndpointTimeout = 8 * time.Second
+
 	// repoErrorBackoff throttles repo-list refetches after a failure (commonly a
 	// token without `repositories, get`), so insights' 2s poll doesn't hammer
 	// argocd-server. Longer than probeRetryInterval since repo-scope denials are
@@ -1087,7 +1097,7 @@ func (m *Manager) verifyAuth(ctx context.Context, url string, snap probeSnapshot
 // probeEndpoint checks that an Argo CD API server answers at url. A 401/403
 // still proves reachability — auth is verifyAuth's concern.
 func (m *Manager) probeEndpoint(ctx context.Context, url string, snap probeSnapshot) error {
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, probeEndpointTimeout)
 	defer cancel()
 	// Reachability only — send NO token. /api/version answers 200 (public) or 401
 	// either way, so the bearer token is never needed to prove an endpoint is up.


### PR DESCRIPTION
On macOS, resolving any `*.local` hostname (a common convention for local cluster Gateway/Ingress hostnames) routes through `mDNSResponder`, which tries multicast DNS first and only falls back to `/etc/hosts` after its own hardcoded 5s timeout. The Argo CD reachability probe used a 5-second timeout too, so DNS resolution alone could consume the entire budget before the TCP connect even started — misreporting a live, reachable Argo CD server as unreachable.

Bumped `probeEndpoint`'s timeout to 8s, giving headroom above that worst case for the actual connect + HTTP round trip. Named the constant (`probeEndpointTimeout`) next to the existing `probeTimeout`/`probeRetryInterval` instead of a bare literal, with the rationale documented at the definition.

Verified live: an identical Settings save that previously failed after ~5s now succeeds in ~5.0s against a real `*.local` Argo CD endpoint.

## Test plan
- [x] `go test ./internal/argocd/...`
- [x] `go build ./...`
- [x] Live-verified against a real macOS `*.local` DNS resolution delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout tweak for tokenless reachability checks; no auth or data-path changes.
> 
> **Overview**
> Increases the Argo CD **reachability probe** budget from **5s to 8s** by introducing `probeEndpointTimeout` and using it in `probeEndpoint` instead of a hardcoded literal.
> 
> This addresses false **unreachable** results on macOS when the server URL is a `*.local` hostname: **mDNS** resolution can consume the full 5s before TCP/HTTP runs. The constant sits with existing probe tuning (`probeTimeout`, `probeRetryInterval`) and documents that rationale. Discovery and manual URL resolution paths that call `probeEndpoint` inherit the longer budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08c3e2da28d68f298716fc1f9a7c989f98d50cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->