### PR TITLE
fix(gitops): read Argo row actions and ApplicationSet status by kind

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -1370,7 +1370,13 @@ function buildRowActionItems(
   const suspendedReason = 'Cannot sync while suspended. Resume first.'
   const items: RowActionItem[] = []
 
-  if (row.tool === 'argo') {
+  // Gate on the kind, not the tool. Every action below posts to
+  // /argo/applications/{namespace}/{name}, which resolves the name against the
+  // Application GVR - so offering them on any other argoproj.io kind either
+  // 404s or, when an Application happens to share the name, mutates that
+  // unrelated Application instead. The detail page gates the same actions the
+  // same way.
+  if (row.kindName === 'applications') {
     const operationInProgress = isArgoOperationInProgress(row.raw)
     items.push({
       key: 'sync',
@@ -1445,6 +1451,7 @@ function buildRowActionItems(
   }
 
   // Flux (Kustomization / HelmRelease)
+  if (row.tool !== 'flux') return items
   items.push({
     key: 'reconcile',
     label: 'Reconcile',

--- a/packages/k8s-ui/src/components/gitops/detail-helpers.test.ts
+++ b/packages/k8s-ui/src/components/gitops/detail-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from 'vitest'
 import {
   formatGitOpsDestination,
   formatGitOpsSourceUrl,
+  getGitOpsResourceStatus,
   getGitOpsTool,
   parseArgoRollbackID,
 } from './detail-helpers'
@@ -93,5 +94,58 @@ describe('getGitOpsTool', () => {
   // Unknown kinds default to flux (matches the OSS fall-through).
   test('unknown kind defaults to flux', () => {
     expect(getGitOpsTool('somecustomresource', 'unknown.io')).toBe('flux')
+  })
+})
+
+describe('getGitOpsResourceStatus - ApplicationSet', () => {
+  // An ApplicationSet reports through ErrorOccurred / ParametersGenerated /
+  // ResourcesUpToDate and never sets Ready. Routed to the Flux reader - which
+  // looks for Ready - every one of these cases collapses to Unknown, and a
+  // generator that is failing outright reads exactly like a healthy one.
+  const appSet = (conditions: Array<Record<string, string>>) => ({
+    status: { conditions },
+  })
+
+  test('a failed generator is Degraded, not Unknown', () => {
+    const status = getGitOpsResourceStatus('applicationsets', appSet([
+      { type: 'ErrorOccurred', status: 'True', message: 'error generating params from git' },
+      { type: 'ResourcesUpToDate', status: 'False', reason: 'ErrorOccurred' },
+    ]))
+    expect(status?.health).toBe('Degraded')
+    expect(status?.message).toBe('error generating params from git')
+  })
+
+  test('a generator that produced its Applications is Healthy', () => {
+    const status = getGitOpsResourceStatus('applicationsets', appSet([
+      { type: 'ResourcesUpToDate', status: 'True', reason: 'ApplicationSetUpToDate' },
+      { type: 'ParametersGenerated', status: 'True', reason: 'ParametersGenerated' },
+    ]))
+    expect(status?.health).toBe('Healthy')
+  })
+
+  test('no conditions yet is Unknown', () => {
+    expect(getGitOpsResourceStatus('applicationsets', appSet([]))?.health).toBe('Unknown')
+  })
+
+  // Sync answers "is the declared state applied". An ApplicationSet applies
+  // nothing - it generates Applications, each of which carries its own sync.
+  // Unknown is the honest answer in every case, including the healthy one.
+  test('sync stays Unknown regardless of health', () => {
+    expect(getGitOpsResourceStatus('applicationsets', appSet([
+      { type: 'ResourcesUpToDate', status: 'True' },
+    ]))?.sync).toBe('Unknown')
+    expect(getGitOpsResourceStatus('applicationsets', appSet([
+      { type: 'ErrorOccurred', status: 'True', message: 'boom' },
+    ]))?.sync).toBe('Unknown')
+  })
+
+  // ErrorOccurred=False is the steady state of a working generator; only
+  // status 'True' means a fault.
+  test('ErrorOccurred=False does not count as a fault', () => {
+    const status = getGitOpsResourceStatus('applicationsets', appSet([
+      { type: 'ErrorOccurred', status: 'False' },
+      { type: 'ResourcesUpToDate', status: 'True' },
+    ]))
+    expect(status?.health).toBe('Healthy')
   })
 })

--- a/packages/k8s-ui/src/components/gitops/detail-helpers.ts
+++ b/packages/k8s-ui/src/components/gitops/detail-helpers.ts
@@ -1,4 +1,4 @@
-import { argoStatusToGitOpsStatus, fluxConditionsToGitOpsStatus, type FluxCondition, type GitOpsStatus } from '../../types/gitops'
+import { argoApplicationSetConditionsToGitOpsStatus, argoStatusToGitOpsStatus, fluxConditionsToGitOpsStatus, type FluxCondition, type GitOpsStatus } from '../../types/gitops'
 import { formatCompactAge } from '../../utils/format'
 
 // =============================================================================
@@ -91,13 +91,23 @@ export function describeGitOpsTerminating(summary?: {
   }
 }
 
-// getGitOpsResourceStatus dispatches sync/health extraction by tool. Argo
-// reads from .status (rich operationState + sync state); Flux reads from
+// getGitOpsResourceStatus dispatches sync/health extraction by kind. Argo
+// Applications read from .status (rich operationState + sync state); Argo
+// ApplicationSets read their own generator conditions; Flux kinds read
 // .status.conditions + .spec.suspend. Returns null if the resource has
 // no recognizable status (e.g. just-created, status not yet populated).
 export function getGitOpsResourceStatus(kind: string, resource: any): GitOpsStatus | null {
   if (kind === 'applications') {
     return argoStatusToGitOpsStatus(resource?.status ?? {})
+  }
+  // ApplicationSets carry Argo's generator conditions, not Flux's. Without
+  // this they fall through to the Flux reader below, which looks for Ready /
+  // Reconciling / Stalled, finds none, and reports a failing generator as
+  // Unknown.
+  if (kind === 'applicationsets') {
+    return argoApplicationSetConditionsToGitOpsStatus(
+      (resource?.status?.conditions ?? []) as FluxCondition[]
+    )
   }
   const conditions = (resource?.status?.conditions ?? []) as FluxCondition[]
   return fluxConditionsToGitOpsStatus(conditions, resource?.spec?.suspend === true, {

--- a/packages/k8s-ui/src/components/ui/RowActionMenu.tsx
+++ b/packages/k8s-ui/src/components/ui/RowActionMenu.tsx
@@ -67,6 +67,10 @@ export function RowActionMenu({ items, ariaLabel = 'Row actions', compact = true
   const triggerSize = compact ? 'p-1' : 'p-1.5'
   const iconSize = compact ? 'h-4 w-4' : 'h-5 w-5'
 
+  // A trigger that opens an empty menu is a dead end - render nothing and let
+  // the cell collapse instead.
+  if (items.length === 0) return null
+
   return (
     <div ref={ref} className="relative inline-block">
       <button

--- a/packages/k8s-ui/src/types/gitops.ts
+++ b/packages/k8s-ui/src/types/gitops.ts
@@ -359,6 +359,57 @@ export function argoStatusToGitOpsStatus(status: ArgoAppStatus): GitOpsStatus {
   }
 }
 
+/**
+ * Maps an Argo CD ApplicationSet's conditions to a GitOpsStatus.
+ *
+ * An ApplicationSet generates Applications; it does not apply declared state
+ * to a cluster itself. Sync answers "is the declared state applied", so there
+ * is no honest sync value here and it stays Unknown - the generated
+ * Applications each carry their own.
+ *
+ * Health answers whether the generator is doing its job, which its conditions
+ * do report, in a vocabulary of their own (ErrorOccurred / ParametersGenerated
+ * / ResourcesUpToDate - never Ready):
+ * - ErrorOccurred=True      → Degraded, carrying the controller's message
+ * - ResourcesUpToDate=True  → Healthy
+ * - neither                 → Unknown (status not populated yet)
+ *
+ * The Resources view renders the same three conditions through
+ * getArgoApplicationSetStatus for its own badge vocabulary. The two read the
+ * same signals and must agree on which condition wins.
+ */
+export function argoApplicationSetConditionsToGitOpsStatus(
+  conditions: FluxCondition[]
+): GitOpsStatus {
+  const error = conditions.find(c => c.type === 'ErrorOccurred' && c.status === 'True')
+  if (error) {
+    return {
+      sync: 'Unknown',
+      health: 'Degraded',
+      message: error.message || 'Generation failed',
+      lastSyncTime: error.lastTransitionTime,
+      suspended: false,
+    }
+  }
+
+  const upToDate = conditions.find(c => c.type === 'ResourcesUpToDate')
+  if (upToDate?.status === 'True') {
+    return {
+      sync: 'Unknown',
+      health: 'Healthy',
+      lastSyncTime: upToDate.lastTransitionTime,
+      suspended: false,
+    }
+  }
+
+  return {
+    sync: 'Unknown',
+    health: 'Unknown',
+    message: 'Status cannot be determined',
+    suspended: false,
+  }
+}
+
 // ============================================================================
 // INVENTORY PARSERS
 // ============================================================================


### PR DESCRIPTION
## Summary

Two places in the GitOps fleet code treat "this row is an Argo object" as "this row is an Argo Application". That holds today only because Applications are the only Argo kind that becomes a row. It stops holding the moment a second one does, and #1609 adds ApplicationSets.

### Row actions were gated on the tool, not the kind

`buildRowActionItems` offered Sync / Refresh / Hard refresh / Suspend to any row with `tool === 'argo'`. All four post to `/argo/applications/{namespace}/{name}`, and the handler resolves that name against the Application GVR.

So on a non-Application Argo row those buttons either 404, or — when an Application happens to share the name, which Kubernetes permits since they are different resource types — quietly mutate that unrelated Application and report success.

Gated on `kindName === 'applications'` instead, which is how the detail page already gates the same actions (`isArgoApp`). `RowActionMenu` now renders nothing for an empty item list, so a kind with no actions gets no dead three-dot trigger.

### ApplicationSet status went through the Flux condition reader

`getGitOpsResourceStatus` special-cased `applications` and sent everything else to `fluxConditionsToGitOpsStatus`, which looks for `Ready` / `Reconciling` / `Stalled`.

An ApplicationSet reports through `ErrorOccurred` / `ParametersGenerated` / `ResourcesUpToDate` and never sets `Ready`, so every ApplicationSet bottomed out at Unknown — a generator failing outright read exactly like a healthy one. This is live today on the ApplicationSet detail page, independent of #1609.

Added a reader for those conditions. Sync stays Unknown in all cases: Sync answers "is the declared state applied", and an ApplicationSet applies nothing — it generates Applications, each carrying its own sync state.

## Test plan

- 6 unit tests on the new mapper covering failed / healthy / no-status, that Sync stays Unknown either way, and that `ErrorOccurred=False` is not treated as a fault
- `packages/k8s-ui`: 3387 passed
- `web`: 569 passed, `tsc` clean, lint 0 errors
- Verified against a live `kind` cluster (Argo CD 2.13.2, the `scripts/gitops-demo.sh` fixtures plus an ApplicationSet with an unreachable git generator), built with #1609 merged on top:
  - before: both ApplicationSets Unknown/Unknown; Suspend on one of them suspended a same-named Application and returned 200
  - after: the failing generator reads Degraded and sorts to the top, the healthy one reads Healthy, Sync stays Unknown, and neither row offers an action menu

The action gate is a no-op on `main` as it stands, since Applications are the only Argo rows today. The status reader is not — it fixes the ApplicationSet detail page now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitOps row mutations are offered (prevents mistaken Application API calls on non-Application Argo rows) and how ApplicationSet status is shown in detail/list surfaces; UI-only but affects operator triage and action safety.
> 
> **Overview**
> **GitOps fleet table** now limits Argo **Sync / Refresh / Suspend** (and related) actions to rows with `kindName === 'applications'`, matching the detail page. Other Argo kinds (e.g. ApplicationSets) no longer get menus that POST to `/argo/applications/...` and could 404 or hit a same-named Application. Flux reconcile actions are explicitly limited to `tool === 'flux'`. **`RowActionMenu`** renders nothing when there are no items, so rows without actions do not show a useless ⋮ control.
> 
> **ApplicationSet health/sync** is no longer derived via the Flux `Ready` condition path. **`getGitOpsResourceStatus`** routes `applicationsets` through a new **`argoApplicationSetConditionsToGitOpsStatus`** mapper (`ErrorOccurred`, `ResourcesUpToDate`, etc.): failed generators show **Degraded** with the controller message, healthy generators **Healthy**, and **sync stays Unknown** because ApplicationSets do not apply cluster state themselves. Unit tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d9fa5ad540d49f3a60541ead0453fb4077152e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->