### PR TITLE
fix(topology): expose all declared Service ports not just the first

### DIFF
--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.test.ts
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.test.ts
@@ -9,6 +9,15 @@ describe('baseSubtitle', () => {
     expect(baseSubtitle('ServiceMonitor', { endpointCount: 1 })).toBe('1 scrape endpoint')
   })
 
+  it('describes a Service by its first port, capping additional ports to a count', () => {
+    expect(baseSubtitle('Service', { type: 'ClusterIP', ports: [] })).toBe('ClusterIP')
+    expect(baseSubtitle('Service', { type: 'ClusterIP', ports: [{ port: 80 }] })).toBe('ClusterIP :80')
+    expect(baseSubtitle('Service', {
+      type: 'ClusterIP',
+      ports: [{ port: 80 }, { port: 443 }, { port: 9153 }],
+    })).toBe('ClusterIP :80 +2 more')
+  })
+
   it('describes a Calico staged deletion as a removal, not as selecting everything', () => {
     // A staged deletion carries no selector, because the Calico API forbids one.
     // Falling through to the empty-selector default would label the broadest

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -168,6 +168,34 @@ function getIssueTooltip(issue: string | undefined): React.ReactNode {
   );
 }
 
+// Full port list for the Service subtitle's hover affordance — the subtitle
+// itself only ever shows the first port + a count, so this is the only place
+// a multi-port Service's other ports are visible without opening the detail
+// page. Formatting (hide targetPort when it matches port) mirrors
+// ServicePortCards in ServiceRenderer.tsx so a Service's ports read the same
+// whether glanced at in the graph or opened in the full resource view.
+function servicePortsTooltip(ports: ServicePortEntry[]): React.ReactNode | null {
+  if (ports.length < 2) return null;
+  return (
+    <div className="max-w-xs space-y-0.5">
+      {ports.map((p, i) => {
+        const target =
+          p.targetPort != null && p.targetPort !== String(p.port)
+            ? ` → ${p.targetPort}`
+            : "";
+        const proto = p.appProtocol || p.protocol;
+        return (
+          <div key={i} className="text-[11px]">
+            {p.name && <span className="text-theme-text-tertiary">{p.name} </span>}
+            <span className="font-medium">{p.port}{target}</span>
+            {proto && <span className="text-theme-text-tertiary"> ({proto})</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // Default dimensions for unknown CRD kinds
 export const DEFAULT_NODE_DIMENSIONS = { width: 260, height: 84 };
 
@@ -322,6 +350,16 @@ const SUMMARY_POD_KINDS = new Set<NodeKind>([
   "Service",
 ]);
 
+// Shape of one entry in a Service node's nodeData.ports (pkg/topology/builder.go's
+// serviceTopologyPorts). name/appProtocol are omitted server-side when unset.
+export interface ServicePortEntry {
+  name?: string;
+  port: number;
+  targetPort?: string;
+  protocol?: string;
+  appProtocol?: string;
+}
+
 export function baseSubtitle(kind: NodeKind, nodeData: Record<string, unknown>): string {
   if (nodeData.deploymentMembership === 'source-only') {
     return `Declared by ${nodeData.deploymentSourceLabel ?? 'deployment source'}`
@@ -369,8 +407,10 @@ export function baseSubtitle(kind: NodeKind, nodeData: Record<string, unknown>):
       return (nodeData.phase as string) || "Unknown";
     case "Service": {
       const svcType = (nodeData.type as string) || "ClusterIP";
-      const port = nodeData.port;
-      return port ? `${svcType} :${port}` : svcType;
+      const ports = (nodeData.ports as ServicePortEntry[] | undefined) || [];
+      if (ports.length === 0) return svcType;
+      const more = ports.length > 1 ? ` +${ports.length - 1} more` : "";
+      return `${svcType} :${ports[0].port}${more}`;
     }
     case "CalicoNetworkPolicy":
     case "CalicoGlobalNetworkPolicy":
@@ -513,6 +553,9 @@ export const K8sResourceNode = memo(function K8sResourceNode({
   const { ownerColorIndex } = ownershipOf(nodeData)
   const hue = ownerColorIndex !== null ? workloadHue(ownerColorIndex) : undefined
   const subtitle = getSubtitle(kind, nodeData)
+  const portsTooltip = kind === 'Service'
+    ? servicePortsTooltip((nodeData.ports as ServicePortEntry[] | undefined) || [])
+    : null
   const isInternet = kind === 'Internet'
   const isPodGroup = kind === 'PodGroup'
   const isSmallNode = kind === 'ConfigMap' || kind === 'Secret' || kind === 'ServiceAccount' || kind === 'SealedSecret' || kind === 'ServiceMonitor' || kind === 'PodMonitor' || kind === 'HorizontalPodAutoscaler'
@@ -730,9 +773,17 @@ export const K8sResourceNode = memo(function K8sResourceNode({
 
           {/* Subtitle */}
           {subtitle && (
-            <div className="text-xs text-theme-text-secondary truncate mt-0.5">
-              {subtitle}
-            </div>
+            portsTooltip ? (
+              <Tooltip content={portsTooltip} position="bottom" wrapperClassName="max-w-full mt-0.5">
+                <div className="text-xs text-theme-text-secondary truncate cursor-help">
+                  {subtitle}
+                </div>
+              </Tooltip>
+            ) : (
+              <div className="text-xs text-theme-text-secondary truncate mt-0.5">
+                {subtitle}
+              </div>
+            )
           )}
         </div>
       </div>

--- a/pkg/gitops/tree/graph.go
+++ b/pkg/gitops/tree/graph.go
@@ -139,8 +139,12 @@ func infoFromTopology(n topology.Node) []InfoItem {
 		}
 	case "Service":
 		if typ, ok := n.Data["type"].(string); ok && typ != "" {
-			if port, ok := n.Data["port"]; ok {
-				return []InfoItem{{Name: "Service", Value: fmt.Sprintf("%s :%v", typ, port)}}
+			if ports, ok := n.Data["ports"].([]map[string]any); ok && len(ports) > 0 {
+				value := fmt.Sprintf("%s :%v", typ, ports[0]["port"])
+				if len(ports) > 1 {
+					value = fmt.Sprintf("%s +%d more", value, len(ports)-1)
+				}
+				return []InfoItem{{Name: "Service", Value: value}}
 			}
 			return []InfoItem{{Name: "Service", Value: typ}}
 		}

--- a/pkg/gitops/tree/graph_test.go
+++ b/pkg/gitops/tree/graph_test.go
@@ -73,6 +73,33 @@ func TestRolloutTopologyInfoAndPriority(t *testing.T) {
 	}
 }
 
+func TestServiceTopologyInfoShowsAllPorts(t *testing.T) {
+	info := infoFromTopology(topology.Node{
+		Kind: topology.KindService,
+		Data: map[string]any{
+			"type": "ClusterIP",
+			"ports": []map[string]any{
+				{"name": "http", "port": int32(80), "protocol": "TCP"},
+				{"name": "https", "port": int32(443), "protocol": "TCP"},
+			},
+		},
+	})
+	if len(info) != 1 || info[0].Name != "Service" || info[0].Value != "ClusterIP :80 +1 more" {
+		t.Fatalf("service info = %#v, want Service \"ClusterIP :80 +1 more\"", info)
+	}
+
+	singlePort := infoFromTopology(topology.Node{
+		Kind: topology.KindService,
+		Data: map[string]any{
+			"type":  "ClusterIP",
+			"ports": []map[string]any{{"port": int32(80), "protocol": "TCP"}},
+		},
+	})
+	if len(singlePort) != 1 || singlePort[0].Value != "ClusterIP :80" {
+		t.Fatalf("single-port service info = %#v, want Service \"ClusterIP :80\"", singlePort)
+	}
+}
+
 func TestSummarize_ExcludesRootAndGroupFromDegraded(t *testing.T) {
 	nodes := []Node{
 		{Role: RoleRoot, Ref: ResourceRef{Kind: "Application", Name: "app"}, Health: "Degraded", Sync: "OutOfSync"}, // the app itself — must NOT count

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -3009,11 +3009,6 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		svcID := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
 		serviceIDs[svc.Namespace+"/"+svc.Name] = svcID
 
-		var port int32
-		if len(svc.Spec.Ports) > 0 {
-			port = svc.Spec.Ports[0].Port
-		}
-
 		nodes = append(nodes, Node{
 			ID:     svcID,
 			Kind:   KindService,
@@ -3023,7 +3018,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				"namespace": svc.Namespace,
 				"type":      string(svc.Spec.Type),
 				"clusterIP": svc.Spec.ClusterIP,
-				"port":      port,
+				"ports":     serviceTopologyPorts(svc.Spec.Ports),
 				"labels":    svc.Labels,
 			},
 		})
@@ -7018,11 +7013,6 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		svcID := fmt.Sprintf("service/%s/%s", svc.Namespace, svc.Name)
 		serviceIDs[svcKey] = svcID
 
-		var port int32
-		if len(svc.Spec.Ports) > 0 {
-			port = svc.Spec.Ports[0].Port
-		}
-
 		nodes = append(nodes, Node{
 			ID:     svcID,
 			Kind:   KindService,
@@ -7032,7 +7022,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"namespace": svc.Namespace,
 				"type":      string(svc.Spec.Type),
 				"clusterIP": svc.Spec.ClusterIP,
-				"port":      port,
+				"ports":     serviceTopologyPorts(svc.Spec.Ports),
 				"labels":    svc.Labels,
 			},
 		})
@@ -7578,6 +7568,31 @@ func getFluxReadyStatus(status map[string]any) (string, HealthStatus) {
 		}
 	}
 	return "Unknown", StatusUnknown
+}
+
+// serviceTopologyPorts serializes every declared Service port for the topology
+// node's Data map — spec.ports[0] alone misrepresents multi-port Services
+// (e.g. a Service exposing both :80 and :443 looked like it only had :80).
+func serviceTopologyPorts(svcPorts []corev1.ServicePort) []map[string]any {
+	ports := make([]map[string]any, 0, len(svcPorts))
+	for _, p := range svcPorts {
+		port := map[string]any{
+			"port":       p.Port,
+			"targetPort": p.TargetPort.String(),
+			"protocol":   string(p.Protocol),
+		}
+		// Name is truly optional (valid to omit with a single port); Port,
+		// TargetPort and Protocol are always populated by apiserver defaulting
+		// by the time an informer sees them, so those stay unconditional.
+		if p.Name != "" {
+			port["name"] = p.Name
+		}
+		if p.AppProtocol != nil {
+			port["appProtocol"] = *p.AppProtocol
+		}
+		ports = append(ports, port)
+	}
+	return ports
 }
 
 func matchesSelector(labels, selector map[string]string) bool {

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	k8score "github.com/skyhook-io/radar/pkg/k8score"
 )
@@ -463,6 +464,202 @@ func TestBuildResourcesTopology_ServiceOnlyExposesActiveJobs(t *testing.T) {
 	}
 	if targets["cronjob/prod/scheduled"] {
 		t.Fatalf("CronJob template must not appear as a current Service backend; targets=%v", targets)
+	}
+}
+
+func TestBuildResourcesTopology_ServiceExposesAllPorts(t *testing.T) {
+	provider := &mockProvider{
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						Port:       80,
+						TargetPort: intstr.FromInt32(8080),
+						Protocol:   corev1.ProtocolTCP,
+					},
+					{
+						Name:       "https",
+						Port:       443,
+						TargetPort: intstr.FromString("https"),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		}},
+	}
+
+	topo, err := NewBuilder(provider).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	var serviceNode *Node
+	for i := range topo.Nodes {
+		if topo.Nodes[i].Kind == KindService {
+			serviceNode = &topo.Nodes[i]
+			break
+		}
+	}
+	if serviceNode == nil {
+		t.Fatal("expected Service node")
+	}
+
+	ports, ok := serviceNode.Data["ports"]
+	if !ok {
+		t.Fatal("expected Service node to expose ports")
+	}
+
+	got, ok := ports.([]map[string]any)
+	if !ok {
+		t.Fatalf("ports has type %T, want []map[string]any", ports)
+	}
+
+	want := []map[string]any{
+		{
+			"name":       "http",
+			"port":       int32(80),
+			"targetPort": "8080",
+			"protocol":   "TCP",
+		},
+		{
+			"name":       "https",
+			"port":       int32(443),
+			"targetPort": "https",
+			"protocol":   "TCP",
+		},
+	}
+
+	if !slices.EqualFunc(got, want, func(a, b map[string]any) bool {
+		return fmt.Sprint(a) == fmt.Sprint(b)
+	}) {
+		t.Fatalf("ports = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildTrafficTopology_ServiceExposesAllPorts(t *testing.T) {
+	provider := &mockProvider{
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+			Spec: corev1.ServiceSpec{
+				Type:     corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{"app": "web"},
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						Port:       80,
+						TargetPort: intstr.FromInt32(8080),
+						Protocol:   corev1.ProtocolTCP,
+					},
+					{
+						Name:       "https",
+						Port:       443,
+						TargetPort: intstr.FromString("https"),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		}},
+		pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "web-0",
+				Namespace: "prod",
+				Labels:    map[string]string{"app": "web"},
+			},
+		}},
+	}
+
+	opts := DefaultBuildOptions()
+	opts.ViewMode = ViewModeTraffic
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	serviceNode := findNode(topo, "service/prod/web")
+	if serviceNode == nil {
+		t.Fatal("expected Service node")
+	}
+
+	ports, ok := serviceNode.Data["ports"]
+	if !ok {
+		t.Fatal("expected Service node to expose ports")
+	}
+
+	got, ok := ports.([]map[string]any)
+	if !ok {
+		t.Fatalf("ports has type %T, want []map[string]any", ports)
+	}
+
+	want := []map[string]any{
+		{
+			"name":       "http",
+			"port":       int32(80),
+			"targetPort": "8080",
+			"protocol":   "TCP",
+		},
+		{
+			"name":       "https",
+			"port":       int32(443),
+			"targetPort": "https",
+			"protocol":   "TCP",
+		},
+	}
+
+	if !slices.EqualFunc(got, want, func(a, b map[string]any) bool {
+		return fmt.Sprint(a) == fmt.Sprint(b)
+	}) {
+		t.Fatalf("ports = %#v, want %#v", got, want)
+	}
+}
+
+func TestServiceTopologyPorts(t *testing.T) {
+	httpProto := "kubernetes.io/h2c"
+
+	got := serviceTopologyPorts([]corev1.ServicePort{
+		{
+			Name:        "http",
+			Port:        80,
+			TargetPort:  intstr.FromInt32(8080),
+			Protocol:    corev1.ProtocolTCP,
+			AppProtocol: &httpProto,
+		},
+		{
+			// Unnamed: valid and common when a Service declares only one port.
+			Port:       9090,
+			TargetPort: intstr.FromInt32(9090),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	})
+
+	want := []map[string]any{
+		{
+			"name":        "http",
+			"port":        int32(80),
+			"targetPort":  "8080",
+			"protocol":    "TCP",
+			"appProtocol": "kubernetes.io/h2c",
+		},
+		{
+			"port":       int32(9090),
+			"targetPort": "9090",
+			"protocol":   "TCP",
+		},
+	}
+
+	if !slices.EqualFunc(got, want, func(a, b map[string]any) bool {
+		return fmt.Sprint(a) == fmt.Sprint(b)
+	}) {
+		t.Fatalf("serviceTopologyPorts = %#v, want %#v", got, want)
+	}
+
+	if _, ok := got[1]["name"]; ok {
+		t.Fatalf("expected no name key for an unnamed port, got %#v", got[1])
+	}
+	if _, ok := got[1]["appProtocol"]; ok {
+		t.Fatalf("expected no appProtocol key when unset, got %#v", got[1])
 	}
 }
 


### PR DESCRIPTION
## Problem

Topology Service nodes displayed only `spec.ports[0]` — both the resources
and traffic topology builders (`pkg/topology/builder.go`) serialized a
single port, so a Service exposing e.g. `http:80` and `https:443` looked
like it only had `:80`. The GitOps resource tree's Service info line had
the same problem, reading the same trimmed field.

## Fix

- `pkg/topology/builder.go`: both builders now serialize every declared
  port via a shared `serviceTopologyPorts` helper into `Data["ports"]`
  (name, port, targetPort, protocol, appProtocol) instead of a single
  `Data["port"]`. `name`/`appProtocol` are omitted when unset — Port,
  TargetPort, and Protocol are always populated by apiserver defaulting
  by the time an informer sees them, so those stay unconditional.
- `pkg/gitops/tree/graph.go`: the GitOps tree's Service info line
  (`"ClusterIP :80"`) read the same removed `Data["port"]` field and
  silently dropped the port entirely once it was gone. Updated to the
  new `Data["ports"]` shape with the same first-port-plus-count summary.
- `packages/k8s-ui/.../K8sResourceNode.tsx`: the topology graph node
  subtitle now shows `ClusterIP :80` unchanged for a single port,
  `ClusterIP :80 +1 more` for multiple, and the full list on hover
  (reusing the existing `Tooltip` already used elsewhere in this file).
  Formatting (hiding `targetPort` when it matches `port`) mirrors
  `ServicePortCards` on the resource detail page, so a Service reads the
  same whether glanced at in the graph or opened in full.

## Tests

- `pkg/topology/builder_test.go`: pipeline coverage for both the
  resources and traffic builders exposing all ports, plus a focused unit
  test for the port-transform edge cases (unnamed port, `appProtocol`).
- `pkg/gitops/tree/graph_test.go`: new coverage for the Service info line
  (single- and multi-port) — previously only `Rollout` was covered here.
- `packages/k8s-ui/.../K8sResourceNode.test.ts`: subtitle test for
  0/1/many ports.
- Verified live against a real cluster (`kube-dns`, 3 ports) and the
  `podinfo` Flux fixture (`scripts/gitops-demo`, 2 ports) — both the
  topology graph and the GitOps tree API now report every declared port.

Fixes #1604.

## Related

While verifying the GitOps tree fix, found its Service info line is
actually unreachable in the UI today for an unrelated, pre-existing
reason (health/sync status always wins over the info line, and Service
nodes always carry a health status). Filed as #1629 — not fixed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and topology payload shape change for Services only; backward-incompatible removal of `Data["port"]` but scoped to UI/GitOps summaries with test coverage.
> 
> **Overview**
> **Service topology nodes** no longer serialize only `spec.ports[0]`. Both resource and traffic builders now populate `Data["ports"]` via `serviceTopologyPorts` (port, targetPort, protocol, optional name/appProtocol), replacing the single `Data["port"]` field.
> 
> **GitOps tree** Service info lines use the same `ports` array and show `ClusterIP :80` or `ClusterIP :80 +N more` when multiple ports exist.
> 
> **Topology graph UI** (`K8sResourceNode`) subtitles follow that first-port-plus-count pattern; multi-port Services get a hover tooltip listing every port (aligned with `ServicePortCards` formatting). Tests cover builder serialization, GitOps info, and subtitle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728707df3aaba852da3ef5c87590814203d450b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->