### PR TITLE
fix(gitops): make ApplicationSet rows report what they actually are

### DIFF
--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -20,7 +20,7 @@ The hard part of GitOps tooling isn't sync — it's diagnosis. Radar surfaces dr
 
 Open the **GitOps** tab in the sidebar. Argo + Flux rows mix in the same table or tile view with resolved source URLs (`github.com/owner/repo`) for both ecosystems — not the CRD-internal source name.
 
-- **Filters**: Sync, Health, Project, Namespace, Labels, Automation (auto-sync / manual / suspended), Lifecycle (active / terminating)
+- **Filters**: Sync, Health, Project, Namespace, Labels, Automation (auto-sync / manual / suspended), Lifecycle (active / terminating), Kind (Applications / ApplicationSets — Argo only, shown once a cluster has ApplicationSets)
 - **Modes**: Applications / Sources / Projects / Alerts
 - **Default sort**: smart-tiered by urgency — Failed > Terminating > Degraded > Missing > OutOfSync > Suspended > Progressing > Synced
 

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -292,12 +292,9 @@ const GITOPS_FILTER_SCHEMA = defineFilterSchema({
   automation: { param: 'automation', type: 'set' },
   labels: { param: 'labels', type: 'set' },
   lifecycle: { param: 'lifecycle', type: 'single', default: 'all' },
-  // Values are Argo kind names ('Application' | 'ApplicationSet'). Empty set =
-  // no restriction (both shown, plus every Flux kind — this filter never
-  // touches those). Non-empty narrows to just the selected Argo kind(s); it's
-  // deliberately not a general "kind" facet across every GitOps kind — the
-  // Application-vs-ApplicationSet distinction is the whole ask, and widening
-  // this to a full multi-tool kind picker would add scope nobody asked for.
+  // Argo kind names ('Application' | 'ApplicationSet'). An empty set places no
+  // restriction: both are shown, as is every Flux kind, which this filter never
+  // narrows. A non-empty set selects among the Argo kinds only.
   kind: { param: 'kind', type: 'set' },
 })
 
@@ -424,11 +421,14 @@ export function GitOpsTableView({
   )
   const syncCounts = useMemo(() => countMap(allRows.map((row) => row.sync)), [allRows])
   const healthCounts = useMemo(() => countMap(allRows.map((row) => row.health)), [allRows])
-  const automationCounts = useMemo(() => ({
-    auto: allRows.filter((row) => row.autoSync).length,
-    manual: allRows.filter((row) => !row.autoSync).length,
-    suspended: allRows.filter((row) => row.suspended).length,
-  }), [allRows])
+  const automationCounts = useMemo(() => {
+    const policyRows = allRows.filter(hasSyncPolicy)
+    return {
+      auto: policyRows.filter((row) => row.autoSync).length,
+      manual: policyRows.filter((row) => !row.autoSync).length,
+      suspended: policyRows.filter((row) => row.suspended).length,
+    }
+  }, [allRows])
   const kindCounts = useMemo(() => ({
     Application: allRows.filter((row) => row.kind === 'Application').length,
     ApplicationSet: allRows.filter((row) => row.kind === 'ApplicationSet').length,
@@ -474,11 +474,11 @@ export function GitOpsTableView({
       if (projectFilters.size > 0 && !projectFilters.has(row.project || '(none)')) return false
       if (namespaceFilters.size > 0 && !namespaceFilters.has(row.namespace || '(cluster)')) return false
       if (activeLabels.length > 0 && !activeLabels.every(({ key, value }) => row.labels[key] === value)) return false
-      if (automationFilters.size > 0 && !(
+      if (automationFilters.size > 0 && (!hasSyncPolicy(row) || !(
         (automationFilters.has('auto') && row.autoSync) ||
         (automationFilters.has('manual') && !row.autoSync) ||
         (automationFilters.has('suspended') && row.suspended)
-      )) return false
+      ))) return false
       if (lifecycleFilter === 'terminating' && !row.terminating) return false
       if (lifecycleFilter === 'active' && row.terminating) return false
       // Only constrains Argo Application/ApplicationSet rows — Flux kinds
@@ -522,6 +522,7 @@ export function GitOpsTableView({
       namespaceFilters.size === 0 &&
       labelFilters.size === 0 &&
       automationFilters.size === 0 &&
+      kindFilters.size === 0 &&
       lifecycleFilter === 'all' &&
       (!destinationFilter || destinationFilter === 'all'),
     [
@@ -532,6 +533,7 @@ export function GitOpsTableView({
       namespaceFilters,
       labelFilters,
       automationFilters,
+      kindFilters,
       lifecycleFilter,
       destinationFilter,
     ],
@@ -968,7 +970,11 @@ function GitOpsFilterSidebar({
           <GitOpsFacetButton label="Unknown" count={healthCounts.get('Unknown') ?? 0} active={healthFilters.has('Unknown')} onClick={() => onToggleHealth('Unknown')} />
         </GitOpsFilterSection>
 
-        {kindCounts.ApplicationSet > 0 && (
+        {/* Stays rendered while a kind filter is set even if this scope has no
+            ApplicationSets - otherwise the facet vanishes while still hiding
+            every Application, leaving an empty table with nothing on screen to
+            explain it or switch it off. */}
+        {(kindCounts.ApplicationSet > 0 || kindFilters.size > 0) && (
           <GitOpsFilterSection icon={Layers} title="Kind">
             <GitOpsFacetButton label="Applications" count={kindCounts.Application} active={kindFilters.has('Application')} onClick={() => onToggleKind('Application')} />
             <GitOpsFacetButton label="ApplicationSets" count={kindCounts.ApplicationSet} active={kindFilters.has('ApplicationSet')} onClick={() => onToggleKind('ApplicationSet')} />
@@ -1362,7 +1368,7 @@ function GitOpsTable({
               {showDestination && (
                 <TableCell>
                   <DestinationCell row={row} onDestinationClick={onDestinationClick} destinationHrefFor={destinationHrefFor} />
-                  <div className="truncate text-xs text-theme-text-tertiary">{row.destinationNamespace || row.namespace || '-'}</div>
+                  <div className="truncate text-xs text-theme-text-tertiary">{destinationNamespaceLabel(row) || '-'}</div>
                 </TableCell>
               )}
               <TableCell>
@@ -1563,7 +1569,7 @@ function GitOpsTile({
   const lastSyncRaw = row.lastSync || row.createdAt
   const recencyClass = recencyTone(lastSyncRaw)
   const dest = row.destination ? compactClusterURL(row.destination) : ''
-  const ns = row.destinationNamespace || row.namespace
+  const ns = destinationNamespaceLabel(row)
   const tileClass = clsx(
     'group relative flex min-w-0 flex-col overflow-hidden rounded-md border border-theme-border bg-theme-surface text-left shadow-theme-sm transition-all hover:border-theme-text-tertiary/40 hover:shadow-theme-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-text-primary/20',
     row.terminating && 'opacity-80',
@@ -1774,6 +1780,25 @@ export function summarizeGitOpsRows(rows: GitOpsRow[]) {
   )
 }
 
+// hasSyncPolicy answers whether the Automation (sync policy) facet means
+// anything for a row. An ApplicationSet never syncs - it generates
+// Applications, and the policy on its template belongs to those. Counting it
+// as Manual would answer "what is not auto-syncing" with objects that were
+// never going to sync in the first place.
+// destinationNamespaceLabel resolves what to show under a row's destination.
+// Falling back to the row's own namespace suits a resource that lives beside
+// what it deploys. An ApplicationSet sits in the controller namespace and
+// generates Applications that land somewhere else, so that fallback would name
+// a namespace it never deploys to.
+export function destinationNamespaceLabel(row: GitOpsRow): string {
+  if (row.destinationNamespace) return row.destinationNamespace
+  return row.kind === 'ApplicationSet' ? '' : row.namespace
+}
+
+export function hasSyncPolicy(row: GitOpsRow): boolean {
+  return row.kind !== 'ApplicationSet'
+}
+
 // Natural direction per column, used the first time a column is clicked: the
 // urgency-ordered facets default ascending (most-urgent first); recency defaults
 // to newest-first.
@@ -1979,16 +2004,47 @@ export function normalizeArgoApplication(resource: any): GitOpsRow {
 // getGitOpsResourceStatus fallback below correctly bottoms out at
 // Unknown/Unknown rather than us inventing a fleet-health rollup from
 // generator-run conditions that don't mean what a Synced/Healthy chip implies.
+// An ApplicationSet's template fields may carry generator placeholders
+// ({{path}}, {{cluster.name}}, …) that only resolve per generated Application.
+// Rendering the raw placeholder is worse than rendering nothing, so a value is
+// only surfaced when it is literal.
+function resolvedTemplateValue(value: unknown): string {
+  if (typeof value !== 'string' || value.includes('{{')) return ''
+  return value
+}
+
 export function normalizeArgoApplicationSet(resource: any): GitOpsRow {
   const status = getGitOpsResourceStatus('applicationsets', resource)
   const templateSpec = resource.spec?.template?.spec ?? {}
-  const dest = templateSpec.destination?.server ?? templateSpec.destination?.name ?? ''
-  // Best-effort source summary from the first generator that carries one.
-  // ApplicationSets can combine multiple generators (list, cluster, git,
-  // matrix, …) with no single "the" source, so this is a hint for the Source
-  // column, not a claim of completeness — blank is the honest answer for
-  // generators (List, Cluster, SCM Provider, …) that don't reference a repo.
+  // Destination is templated as often as the source is ({{server}},
+  // {{cluster.name}}), and a cluster generator templates it by definition.
+  const dest = resolvedTemplateValue(templateSpec.destination?.server)
+    || resolvedTemplateValue(templateSpec.destination?.name)
+  // The source the generated Applications deploy from lives on the template.
+  // A git generator's repo is a different thing - it is scanned to produce
+  // parameters and is often not a deployment source at all - so it is only a
+  // fallback for templates that carry no literal source of their own.
+  const templateSource = templateSpec.source ?? {}
   const gitGenerator = (resource.spec?.generators ?? []).find((g: any) => g?.git)?.git
+  // Repo, revision and path are taken from one place or the other, never
+  // mixed. A template repo paired with a generator's path would name a tree
+  // that exists in neither, which reads as a real location and is not one.
+  //
+  // The branch turns on whether the template declares a source at all, not on
+  // whether that source resolved. A template whose repoURL is itself a
+  // placeholder still means "the generated Applications deploy from here", so
+  // falling back would present the generator's own tree as the deployed one.
+  // Multi-source templates take the same branch and render blank, matching
+  // what the rest of the view does with spec.sources.
+  const fromTemplate = templateSpec.source != null || Array.isArray(templateSpec.sources)
+  const repository = fromTemplate ? resolvedTemplateValue(templateSource.repoURL) : (gitGenerator?.repoURL ?? '')
+  const targetRevision = fromTemplate
+    ? resolvedTemplateValue(templateSource.targetRevision)
+    : (gitGenerator?.revision ?? '')
+  const path = fromTemplate
+    ? resolvedTemplateValue(templateSource.path)
+    : (resolvedTemplateValue(gitGenerator?.directories?.[0]?.path)
+      || resolvedTemplateValue(gitGenerator?.files?.[0]?.path))
   return {
     id: `argo/applicationsets/${resource.metadata?.namespace ?? ''}/${resource.metadata?.name ?? ''}`,
     mode: 'applications',
@@ -1998,25 +2054,30 @@ export function normalizeArgoApplicationSet(resource: any): GitOpsRow {
     group: 'argoproj.io',
     name: resource.metadata?.name ?? '',
     namespace: resource.metadata?.namespace ?? '',
-    // ApplicationSets aren't scoped to a project themselves — the project
-    // lives on each generated Application (via the template), which can
-    // itself vary per generated app. Leaving this blank (rather than
-    // guessing from the template) keeps the Project filter honest.
-    project: '',
+    // The project every generated Application lands in, when the template
+    // names one literally. A templated project varies per generated app, so
+    // it resolves to blank rather than to a placeholder.
+    project: resolvedTemplateValue(templateSpec.project),
     labels: (resource.metadata?.labels ?? {}) as Record<string, string>,
     sync: status?.sync ?? 'Unknown',
     health: status?.health ?? 'Unknown',
     reconciling: status?.reconciling,
     reconcilingSince: status?.reconcilingSince,
     suspended: false,
-    repository: gitGenerator?.repoURL ?? '',
-    targetRevision: gitGenerator?.revision ?? '',
-    path: gitGenerator?.directories?.[0]?.path ?? gitGenerator?.files?.[0]?.path ?? '',
-    chart: '',
+    repository,
+    targetRevision,
+    path,
+    chart: fromTemplate ? resolvedTemplateValue(templateSource.chart) : '',
     destination: dest,
-    destinationNamespace: templateSpec.destination?.namespace ?? '',
+    destinationNamespace: resolvedTemplateValue(templateSpec.destination?.namespace),
     createdAt: resource.metadata?.creationTimestamp ?? '',
-    lastSync: '',
+    // When the generator last ran, taken from the condition that reported it.
+    // Left empty the Last Sync column falls back to the creation timestamp,
+    // which dates the object rather than any activity on it.
+    lastSync: status?.lastSyncTime ?? '',
+    // An ApplicationSet has no sync policy of its own; the template's policy
+    // belongs to the Applications it generates. Automation counts and the
+    // sync-policy filter skip this kind rather than read this field.
     autoSync: false,
     terminating: isTerminating(resource),
     terminationStartedAt: terminationStartedAt(resource),

--- a/packages/k8s-ui/src/components/gitops/applicationset-row.test.ts
+++ b/packages/k8s-ui/src/components/gitops/applicationset-row.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect } from 'vitest'
+
+import { destinationNamespaceLabel, hasSyncPolicy, normalizeArgoApplicationSet, normalizeArgoApplication } from './GitOpsTableView'
+
+// Mirrors scripts/gitops-demo/05-argo-applicationset.yaml: a list generator,
+// so nothing about the deployed source is discoverable from the generator.
+const listGeneratorSet = {
+  metadata: { name: 'radar-demo-set', namespace: 'argocd', creationTimestamp: '2026-01-01T00:00:00Z' },
+  spec: {
+    generators: [{ list: { elements: [{ name: 'vanilla', path: 'guestbook' }] } }],
+    template: {
+      spec: {
+        project: 'radar-demo',
+        source: { repoURL: 'https://github.com/argoproj/argocd-example-apps', targetRevision: 'HEAD', path: '{{path}}' },
+        destination: { server: 'https://kubernetes.default.svc', namespace: 'demo-set' },
+        syncPolicy: { automated: { prune: true, selfHeal: true } },
+      },
+    },
+  },
+  status: { conditions: [{ type: 'ResourcesUpToDate', status: 'True' }] },
+}
+
+describe('normalizeArgoApplicationSet source and project', () => {
+  // The source the generated Applications deploy from lives on the template.
+  // List, cluster and SCM generators carry no repo at all, so the template is
+  // the only place it can come from for those.
+  test('reads the repo from the template, not the generator', () => {
+    const row = normalizeArgoApplicationSet(listGeneratorSet)
+    expect(row.repository).toBe('https://github.com/argoproj/argocd-example-apps')
+    expect(row.targetRevision).toBe('HEAD')
+  })
+
+  // A templated value only resolves per generated Application, so the literal
+  // "{{path}}" would be noise in the Source column.
+  test('blanks a templated path rather than printing the placeholder', () => {
+    expect(normalizeArgoApplicationSet(listGeneratorSet).path).toBe('')
+  })
+
+  test('reads a literal project from the template', () => {
+    expect(normalizeArgoApplicationSet(listGeneratorSet).project).toBe('radar-demo')
+  })
+
+  test('blanks a templated project', () => {
+    const templated = structuredClone(listGeneratorSet)
+    templated.spec.template.spec.project = '{{cluster.name}}'
+    expect(normalizeArgoApplicationSet(templated).project).toBe('')
+  })
+
+  // A git generator's repo is scanned for parameters, not necessarily deployed
+  // from. It stays available for templates that carry no literal source.
+  test('falls back to the git generator when the template has no source', () => {
+    const gitGen: any = structuredClone(listGeneratorSet)
+    delete gitGen.spec.template.spec.source
+    gitGen.spec.generators = [{ git: { repoURL: 'https://github.com/org/infra', revision: 'main', directories: [{ path: 'apps/prod' }] } }]
+    const row = normalizeArgoApplicationSet(gitGen)
+    expect(row.repository).toBe('https://github.com/org/infra')
+    expect(row.targetRevision).toBe('main')
+    expect(row.path).toBe('apps/prod')
+  })
+
+  // A glob is how git-generator directories are normally written, and it is a
+  // real literal - not a per-app placeholder - so it survives.
+  test('keeps a directory glob from the git generator', () => {
+    const gitGen: any = structuredClone(listGeneratorSet)
+    delete gitGen.spec.template.spec.source
+    gitGen.spec.generators = [{ git: { repoURL: 'https://github.com/org/infra', directories: [{ path: 'apps/*' }] } }]
+    expect(normalizeArgoApplicationSet(gitGen).path).toBe('apps/*')
+  })
+
+  test('a set with neither template source nor git generator stays blank', () => {
+    const bare: any = structuredClone(listGeneratorSet)
+    delete bare.spec.template.spec.source
+    const row = normalizeArgoApplicationSet(bare)
+    expect(row.repository).toBe('')
+    expect(row.path).toBe('')
+  })
+})
+
+describe('hasSyncPolicy', () => {
+  // The Automation facet answers "what is not auto-syncing". An ApplicationSet
+  // never syncs, so counting it as Manual puts objects in that answer that
+  // were never going to sync.
+  test('an ApplicationSet has no sync policy of its own', () => {
+    expect(hasSyncPolicy(normalizeArgoApplicationSet(listGeneratorSet))).toBe(false)
+  })
+
+  test('an Application does', () => {
+    const app = normalizeArgoApplication({
+      metadata: { name: 'guestbook', namespace: 'argocd' },
+      spec: { project: 'default', source: {}, destination: {}, syncPolicy: { automated: {} } },
+      status: {},
+    })
+    expect(hasSyncPolicy(app)).toBe(true)
+  })
+})
+
+describe('normalizeArgoApplicationSet destination', () => {
+  // A cluster generator templates the destination by definition. Rendering
+  // "{{server}}" in the Destination column is the same class of noise as a
+  // templated path, and the table shows a dash for an empty destination.
+  test('blanks a templated destination server', () => {
+    const clusterGen = structuredClone(listGeneratorSet)
+    clusterGen.spec.template.spec.destination = { server: '{{server}}', namespace: 'demo-set' } as any
+    const row = normalizeArgoApplicationSet(clusterGen)
+    expect(row.destination).toBe('')
+    expect(row.destinationNamespace).toBe('demo-set')
+  })
+
+  test('keeps a literal destination server', () => {
+    expect(normalizeArgoApplicationSet(listGeneratorSet).destination).toBe('https://kubernetes.default.svc')
+  })
+
+  test('blanks a templated destination namespace', () => {
+    const templatedNs = structuredClone(listGeneratorSet)
+    templatedNs.spec.template.spec.destination = { server: 'https://kubernetes.default.svc', namespace: '{{ns}}' } as any
+    expect(normalizeArgoApplicationSet(templatedNs).destinationNamespace).toBe('')
+  })
+})
+
+describe('normalizeArgoApplicationSet last activity', () => {
+  // The Last Sync column falls back to the creation timestamp when this is
+  // empty, which would date the object rather than report activity on it.
+  test('carries the condition transition time, not the creation time', () => {
+    const withTime = structuredClone(listGeneratorSet)
+    withTime.metadata.creationTimestamp = '2026-01-01T00:00:00Z'
+    withTime.status.conditions = [
+      { type: 'ResourcesUpToDate', status: 'True', lastTransitionTime: '2026-06-15T09:30:00Z' },
+    ] as any
+    expect(normalizeArgoApplicationSet(withTime).lastSync).toBe('2026-06-15T09:30:00Z')
+  })
+
+  test('a failing generator reports when it failed', () => {
+    const failed = structuredClone(listGeneratorSet)
+    failed.status.conditions = [
+      { type: 'ErrorOccurred', status: 'True', message: 'boom', lastTransitionTime: '2026-06-15T10:00:00Z' },
+    ] as any
+    expect(normalizeArgoApplicationSet(failed).lastSync).toBe('2026-06-15T10:00:00Z')
+  })
+})
+
+describe('source is taken from one place, never mixed', () => {
+  // A template repo paired with a git generator's path would name a tree that
+  // exists in neither the generated Application nor the generator.
+  test('a literal template repo does not borrow the generator path', () => {
+    const mixed: any = structuredClone(listGeneratorSet)
+    mixed.spec.template.spec.source = { repoURL: 'https://github.com/org/deploy', path: '{{path}}' }
+    mixed.spec.generators = [{ git: { repoURL: 'https://github.com/org/config', revision: 'main', directories: [{ path: 'apps/*' }] } }]
+    const row = normalizeArgoApplicationSet(mixed)
+    expect(row.repository).toBe('https://github.com/org/deploy')
+    expect(row.path).toBe('')
+    expect(row.targetRevision).toBe('')
+  })
+
+  test('with no literal template repo the generator supplies all three', () => {
+    const gen: any = structuredClone(listGeneratorSet)
+    delete gen.spec.template.spec.source
+    gen.spec.generators = [{ git: { repoURL: 'https://github.com/org/config', revision: 'main', directories: [{ path: 'apps/*' }] } }]
+    const row = normalizeArgoApplicationSet(gen)
+    expect(row.repository).toBe('https://github.com/org/config')
+    expect(row.targetRevision).toBe('main')
+    expect(row.path).toBe('apps/*')
+  })
+})
+
+describe('destinationNamespaceLabel', () => {
+  // An ApplicationSet lives in the controller namespace and deploys elsewhere,
+  // so naming its own namespace as the destination would be a real-looking
+  // value that is simply wrong.
+  test('an ApplicationSet with a templated namespace resolves to nothing', () => {
+    const templatedNs: any = structuredClone(listGeneratorSet)
+    templatedNs.spec.template.spec.destination = { server: 'https://kubernetes.default.svc', namespace: '{{ns}}' }
+    expect(destinationNamespaceLabel(normalizeArgoApplicationSet(templatedNs))).toBe('')
+  })
+
+  test('a literal namespace is used as-is', () => {
+    expect(destinationNamespaceLabel(normalizeArgoApplicationSet(listGeneratorSet))).toBe('demo-set')
+  })
+
+  test('an Application still falls back to its own namespace', () => {
+    const app = normalizeArgoApplication({
+      metadata: { name: 'guestbook', namespace: 'argocd' },
+      spec: { project: 'default', source: {}, destination: {} },
+      status: {},
+    })
+    expect(destinationNamespaceLabel(app)).toBe('argocd')
+  })
+})
+
+describe('a declared template source claims the row even when unresolved', () => {
+  // A templated repoURL still means "the generated Applications deploy from
+  // here". Falling back would present the generator's own tree as the
+  // deployed one.
+  test('a fully templated template source does not fall back to the generator', () => {
+    const templatedRepo: any = structuredClone(listGeneratorSet)
+    templatedRepo.spec.template.spec.source = { repoURL: '{{url}}', targetRevision: '{{rev}}', path: '{{path}}' }
+    templatedRepo.spec.generators = [{ git: { repoURL: 'https://github.com/org/config', revision: 'main', directories: [{ path: 'apps/*' }] } }]
+    const row = normalizeArgoApplicationSet(templatedRepo)
+    expect(row.repository).toBe('')
+    expect(row.targetRevision).toBe('')
+    expect(row.path).toBe('')
+  })
+
+  // Multi-source is unrendered across this view, so a sources-only template
+  // reads blank rather than borrowing the generator.
+  test('a multi-source template does not fall back to the generator', () => {
+    const multi: any = structuredClone(listGeneratorSet)
+    delete multi.spec.template.spec.source
+    multi.spec.template.spec.sources = [{ repoURL: 'https://github.com/org/a', path: 'x' }]
+    multi.spec.generators = [{ git: { repoURL: 'https://github.com/org/config', directories: [{ path: 'apps/*' }] } }]
+    const row = normalizeArgoApplicationSet(multi)
+    expect(row.repository).toBe('')
+    expect(row.path).toBe('')
+  })
+})

--- a/pkg/gitops/insights/insights.go
+++ b/pkg/gitops/insights/insights.go
@@ -477,6 +477,14 @@ func buildSummary(root *unstructured.Unstructured, tool string) Summary {
 // describeArgoAutoSync formats spec.syncPolicy.automated into a chip label.
 // Empty when the field can't be read; "Manual" when automated is absent.
 func describeArgoAutoSync(root *unstructured.Unstructured) string {
+	// An ApplicationSet has no sync policy of its own. Its spec.syncPolicy
+	// governs how generated Applications are created and deleted, not how
+	// anything syncs, so it never carries `automated` - reading it here would
+	// report every ApplicationSet as "Manual". The policy that does decide
+	// auto-sync lives on spec.template.spec and belongs to what it generates.
+	if root.GetKind() == "ApplicationSet" {
+		return ""
+	}
 	automated, found, _ := unstructured.NestedMap(root.Object, "spec", "syncPolicy", "automated")
 	if !found {
 		return "Manual"

--- a/pkg/gitops/insights/insights_test.go
+++ b/pkg/gitops/insights/insights_test.go
@@ -237,6 +237,49 @@ func TestDescribeArgoAutoSync(t *testing.T) {
 	}
 }
 
+// An ApplicationSet's spec.syncPolicy controls how generated Applications are
+// created and deleted; it never carries `automated`. Read as an Application's
+// policy it yields "Manual" for every ApplicationSet, which the detail header
+// and the rollback gating both consume as a real sync mode.
+func TestDescribeArgoAutoSyncApplicationSet(t *testing.T) {
+	cases := []struct {
+		name string
+		spec map[string]any
+	}{
+		{name: "no syncPolicy", spec: map[string]any{}},
+		{name: "applicationsSync policy is not a sync mode", spec: map[string]any{
+			"syncPolicy": map[string]any{"applicationsSync": "create-update"},
+		}},
+		{name: "template automated belongs to generated apps, not the set", spec: map[string]any{
+			"template": map[string]any{"spec": map[string]any{
+				"syncPolicy": map[string]any{"automated": map[string]any{"prune": true}},
+			}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := &unstructured.Unstructured{Object: map[string]any{
+				"kind": "ApplicationSet",
+				"spec": tc.spec,
+			}}
+			if got := describeArgoAutoSync(root); got != "" {
+				t.Fatalf("describeArgoAutoSync = %q, want empty for an ApplicationSet", got)
+			}
+		})
+	}
+}
+
+// An Application with the same shape must keep reporting its real mode.
+func TestDescribeArgoAutoSyncApplicationUnaffected(t *testing.T) {
+	root := &unstructured.Unstructured{Object: map[string]any{
+		"kind": "Application",
+		"spec": map[string]any{"syncPolicy": map[string]any{"automated": map[string]any{"prune": true}}},
+	}}
+	if got := describeArgoAutoSync(root); got != "Auto · prune" {
+		t.Fatalf("describeArgoAutoSync = %q, want %q", got, "Auto · prune")
+	}
+}
+
 // argoResourceChanges' syncResult-status gating decides whether a per-resource
 // failure message surfaces in the UI as a red SyncError. Pin the contract so
 // a future refactor that simplifies the status check (e.g. `if status != ""`)

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -569,12 +569,19 @@ function GitOpsDetailView({ namespaces, onOpenResource, onOpenSettings }: GitOps
   // The bulk of the JSX is now in <GitOpsDetailLayout>; this wrapper does
   // the OSS-specific things the layout can't (call OSS-side data hooks,
   // open OSS dialogs, talk to OSS Toast, hit OSS keyboard registry).
+  const isApplicationSet = kind === 'applicationsets'
   const detail: GitOpsDetailMetadata = {
     project: detailRow?.project,
     repository: detailRow?.repository ? formatGitOpsSourceUrl(detailRow.repository) : undefined,
     path: detailRow?.path || undefined,
     chart: detailRow?.chart || undefined,
-    destination: formatGitOpsDestination(detailRow?.destination, detailRow?.destinationNamespace),
+    // An empty destination means "in-cluster" for an Application - that is
+    // Argo's default when the field is unset. For an ApplicationSet it means
+    // the template's destination was a generator placeholder, which is not the
+    // same claim, so the server half is dropped rather than asserted.
+    destination: isApplicationSet && !detailRow?.destination
+      ? (detailRow?.destinationNamespace ? `Namespace: ${detailRow.destinationNamespace}` : '')
+      : formatGitOpsDestination(detailRow?.destination, detailRow?.destinationNamespace),
     autoSyncMode: insightsQ.data?.summary?.autoSyncMode,
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1609. Several fields still described an ApplicationSet using values that only mean something for an Application. Verified against a live `kind` cluster running Argo CD 2.13.2.

### Source, project and destination

These were read from a git generator, or left blank. A git generator's repo is scanned to produce parameters and is often not a deployment source at all; what the generated Applications deploy is on `spec.template.spec`. The template is now read first, with the generator kept as a fallback only for templates that declare no source of their own.

Repo, revision and path resolve as a unit rather than independently. Mixing a literal template repo with a generator's path names a tree that exists in neither, which reads as a real location and is not one. The branch turns on whether the template *declares* a source, not on whether that source *resolved*, so a template whose `repoURL` is itself a placeholder still claims the row and renders blank.

Template values can carry per-app placeholders (`{{path}}`, `{{server}}`), so a value is surfaced only when it is literal. Rendering the raw placeholder is worse than rendering nothing, and the table already shows a dash for an empty destination.

The destination namespace no longer falls back to the row's own namespace for an ApplicationSet. That fallback suits a resource sitting beside what it deploys; an ApplicationSet sits in the controller namespace and generates Applications that land elsewhere, so it named a namespace the object never deploys to.

### Last Sync

Empty, so the column fell through to the creation timestamp and dated the object rather than reporting activity on it. It now carries the transition time of the condition the status was read from.

### Sync policy

The Automation facet counted every ApplicationSet as Manual, answering "what is not auto-syncing" with objects that never sync. The kind is now skipped in the counts and the predicate.

`describeArgoAutoSync` had the same problem server-side. An ApplicationSet's `spec.syncPolicy` governs how generated Applications are created and deleted and never carries `automated`, so it reported `Manual` to the detail header, the insights summary and the rollback gating alike. Fixed there rather than at one call site, since all three read the same field.

### Kind facet

The section rendered only while ApplicationSets were present, but the filter applied regardless. Scoping to a namespace without any hid every Application and left an empty table with no facet on screen to explain it or switch it off. The section now stays while a `kind` filter is set. `noOtherFiltersActive` did not account for the filter either, so the Total tile still read as unfiltered.

### Destination on the detail page

An empty destination means in-cluster for an Application, which is Argo's default when the field is unset. For an ApplicationSet it means the template's destination was a generator placeholder, so the header no longer makes that claim.

## Test plan

- 21 unit tests on the normalizer: template vs generator precedence, source resolved as a unit, declared-but-templated sources, placeholder blanking, literal globs, condition timestamps, the sync-policy predicate and the destination-namespace label
- 2 Go tests on `describeArgoAutoSync` covering ApplicationSet shapes and pinning that Applications are unaffected
- `packages/k8s-ui` 3408 passed, `web` 569 passed, `tsc` clean, lint 0 errors, `pkg` and backend suites pass
- Live cluster with eight ApplicationSets covering list, cluster, matrix, mixed-source, templated-fields, templated-repo, templated-namespace and failing-git generators:
  - source, project and path resolve from the template; no `{{...}}` renders anywhere
  - a template that declares a source never borrows the generator's repo or path
  - a cluster generator's `{{server}}` destination shows as a namespace rather than a false "in-cluster"
  - a templated destination namespace shows nothing rather than the controller namespace
  - Last Sync reports condition times, not creation age
  - Automation counts cover only the Applications
  - the Kind section stays visible and unsettable when scoped to a namespace with no ApplicationSets
  - Applications and Flux resources are unchanged: counts, filters, row actions and detail header all as before

## Not included

Multi-source (`spec.sources`) is unrendered for Applications too, so a sources-only ApplicationSet template reads blank rather than being handled ahead of the rest of the view.

"Total Applications" counts every row, which has always included Flux Kustomizations and HelmReleases. The label predates this and is a naming decision rather than a bug here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and normalization fixes for ApplicationSet rows with broad test coverage; Argo Applications and Flux behavior are intentionally unchanged.
> 
> **Overview**
> **ApplicationSet fleet rows** now derive source, project, destination, and “last activity” from `spec.template.spec` (with git-generator fallback only when the template declares no source), resolve repo/revision/path as a single unit, and hide `{{…}}` placeholders instead of showing misleading literals.
> 
> **Automation and detail metadata** stop treating ApplicationSets like syncable Applications: `hasSyncPolicy` excludes them from Automation counts/filters, `destinationNamespaceLabel` avoids wrongly using the controller namespace, the **Kind** facet stays visible while a kind filter is active (and **Total** respects that filter), and `describeArgoAutoSync` returns empty for ApplicationSets so the detail header/insights no longer show **Manual**.
> 
> **ApplicationSet detail** no longer implies in-cluster when the template destination server is empty; namespace-only display is used when appropriate. Docs note the Argo-only **Kind** filter. Covered by new Vitest and Go tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e8fa1996b63cb666416a82e1d2e0b76a55fedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->