### PR TITLE
Harden the PostgreSQL timeline backend for production

### DIFF
--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -492,7 +492,9 @@ Cleanup runs hourly + once at startup. Confirm it's keeping up via `/api/diagnos
 - `sslmode` and other TLS settings are controlled through the DSN string.
 - The DSN is read from a Secret; never put it in Helm values or `config.json`.
 - Restart the Radar Deployment after rotating the Secret because Kubernetes does not refresh environment variables in running containers.
-- There is no built-in import path from SQLite to PostgreSQL. Migrating historical events is out of scope for the first contribution.
+- There is no built-in import path from SQLite to PostgreSQL. Migrating historical events is not supported.
+- Radar treats an unreachable PostgreSQL as fatal rather than falling back to an in-memory timeline, so a pod that cannot reach the database starts in disconnected mode and serves errors instead of cluster data. This is deliberate: silently degrading to memory would hand you a timeline that disappears on the next restart, without saying so. It also means the database is on Radar's startup path — treat its availability accordingly, and prefer one that lives close to the cluster.
+- Recovery after a database outage is not automatic. Once PostgreSQL is reachable again, either use the retry action in the UI or restart the pod. Verified TLS modes: `require` and `verify-full`.
 
 ## Configuration Reference
 

--- a/internal/timeline/postgres_store.go
+++ b/internal/timeline/postgres_store.go
@@ -528,11 +528,22 @@ func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name 
 	delete(s.seenResources, key)
 	s.seenMu.Unlock()
 
+	// One deadline spans both reaching the queue and the flush that follows, so
+	// a clear can never hold the informer's delete handler longer than the
+	// single database round trip it replaced.
+	ctx, cancel := context.WithTimeout(context.Background(), postgresOperationTimeout)
+	defer cancel()
+
 	done := make(chan struct{})
-	s.enqueueSeenWrite(seenResourceWrite{key: key, delete: true, done: done})
+	if !s.enqueueSeenClear(ctx, seenResourceWrite{key: key, delete: true, done: done}) {
+		log.Printf("[timeline] seen-resource clear did not reach the write queue in %s; "+
+			"the resource stays marked as seen in the database until it is deleted again",
+			postgresOperationTimeout)
+		return
+	}
 	select {
 	case <-done:
-	case <-time.After(postgresOperationTimeout):
+	case <-ctx.Done():
 		log.Printf("[timeline] timed out waiting for a seen-resource clear to persist")
 	}
 }
@@ -545,25 +556,28 @@ func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name 
 // Drops are counted and reported once per flush rather than per event, which on
 // a large cluster would be its own flood.
 func (s *PostgresStore) enqueueSeenWrite(w seenResourceWrite) {
-	if w.done != nil {
-		// A clear must reach the queue. Dropping it would return from
-		// ClearResourceSeen with the row still present, and a mark already
-		// queued for the same key would then flush on top of it - so the
-		// resource stays marked as seen and its next appearance is suppressed,
-		// permanently and silently. Waiting is safe: the writer drains on a
-		// ticker regardless of database health, so a full queue is transient
-		// unless the store is closing.
-		select {
-		case s.seenWrites <- w:
-		case <-s.quit:
-			close(w.done)
-		}
-		return
-	}
 	select {
 	case s.seenWrites <- w:
 	default:
 		s.seenDropped.Add(1)
+	}
+}
+
+// enqueueSeenClear waits for room rather than dropping, and reports whether the
+// mutation was queued. A dropped clear would return from ClearResourceSeen with
+// the row still present, and a mark already queued for the same key would then
+// flush on top of it - leaving the resource marked as seen so its next
+// appearance is suppressed. Waiting is bounded by ctx and by store shutdown;
+// the writer drains on a ticker regardless of database health, so a full queue
+// is transient.
+func (s *PostgresStore) enqueueSeenClear(ctx context.Context, w seenResourceWrite) bool {
+	select {
+	case s.seenWrites <- w:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-s.quit:
+		return false
 	}
 }
 

--- a/internal/timeline/postgres_store.go
+++ b/internal/timeline/postgres_store.go
@@ -545,15 +545,25 @@ func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name 
 // Drops are counted and reported once per flush rather than per event, which on
 // a large cluster would be its own flood.
 func (s *PostgresStore) enqueueSeenWrite(w seenResourceWrite) {
+	if w.done != nil {
+		// A clear must reach the queue. Dropping it would return from
+		// ClearResourceSeen with the row still present, and a mark already
+		// queued for the same key would then flush on top of it - so the
+		// resource stays marked as seen and its next appearance is suppressed,
+		// permanently and silently. Waiting is safe: the writer drains on a
+		// ticker regardless of database health, so a full queue is transient
+		// unless the store is closing.
+		select {
+		case s.seenWrites <- w:
+		case <-s.quit:
+			close(w.done)
+		}
+		return
+	}
 	select {
 	case s.seenWrites <- w:
 	default:
 		s.seenDropped.Add(1)
-		// Nobody will flush this one, so release any waiter immediately rather
-		// than letting it sit until its timeout.
-		if w.done != nil {
-			close(w.done)
-		}
 	}
 }
 

--- a/internal/timeline/postgres_store.go
+++ b/internal/timeline/postgres_store.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -36,6 +37,34 @@ const (
 
 var postgresPingTimeout = 10 * time.Second
 
+const (
+	// The informer add path calls MarkResourceSeen once per resource during the
+	// initial sync. On a large cluster that is tens of thousands of calls, and a
+	// synchronous round trip each would serialize the informer handler against
+	// the database's latency - negligible against a sidecar, tens of seconds
+	// against a managed database an availability zone away. The in-memory map is
+	// still updated synchronously, so IsResourceSeen is unaffected; only the
+	// durable copy is deferred.
+	seenWriteQueueDepth = 4096
+	seenWriteBatchSize  = 500
+	seenWriteInterval   = time.Second
+)
+
+// seenResourceWrite is one ordered mutation of the seen set. Marks and clears
+// share a queue so a clear can never be applied before the mark it supersedes.
+type seenResourceWrite struct {
+	key    string
+	delete bool
+	// done, when non-nil, is closed once this mutation has been flushed (or
+	// dropped). Clears carry it and wait: MarkResourceSeen is the hot path and
+	// can be deferred, but ClearResourceSeen must be durable before it returns,
+	// or a process that dies in between keeps a stale mark and never reports the
+	// resource as newly seen again. Waiting also pins the ordering - the queue
+	// is drained in order, so a queued mark can never be applied after the clear
+	// that supersedes it.
+	done chan struct{}
+}
+
 func withPostgresOperationTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	if _, ok := ctx.Deadline(); ok {
 		return ctx, func() {}
@@ -54,6 +83,9 @@ type PostgresStore struct {
 
 	filterCache map[string]*CompiledFilter
 	cacheMu     sync.RWMutex
+
+	seenWrites  chan seenResourceWrite
+	seenDropped atomic.Int64
 
 	quit      chan struct{}
 	wg        sync.WaitGroup
@@ -117,6 +149,7 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		db:            db,
 		seenResources: make(map[string]bool),
 		filterCache:   make(map[string]*CompiledFilter),
+		seenWrites:    make(chan seenResourceWrite, seenWriteQueueDepth),
 		quit:          make(chan struct{}),
 	}
 	hydrateCtx, cancelHydrate := context.WithTimeout(
@@ -128,6 +161,12 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 	if err != nil {
 		return closeOnError("hydrate PostgreSQL timeline seen resources", err)
 	}
+
+	store.wg.Add(1)
+	go func() {
+		defer store.wg.Done()
+		store.runSeenWriter()
+	}()
 
 	return store, nil
 }
@@ -470,15 +509,7 @@ func (s *PostgresStore) MarkResourceSeen(clusterContext, kind, namespace, name s
 	s.seenResources[key] = true
 	s.seenMu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), postgresOperationTimeout)
-	defer cancel()
-	if _, err := s.db.ExecContext(
-		ctx,
-		"INSERT INTO radar_timeline_seen_resources (resource_key) VALUES ($1) ON CONFLICT(resource_key) DO NOTHING",
-		[]byte(key),
-	); err != nil {
-		log.Printf("[timeline] failed to persist seen resource: %v", err)
-	}
+	s.enqueueSeenWrite(seenResourceWrite{key: key})
 }
 
 // IsResourceSeen checks if a resource has been seen before in the given cluster
@@ -497,14 +528,121 @@ func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name 
 	delete(s.seenResources, key)
 	s.seenMu.Unlock()
 
+	done := make(chan struct{})
+	s.enqueueSeenWrite(seenResourceWrite{key: key, delete: true, done: done})
+	select {
+	case <-done:
+	case <-time.After(postgresOperationTimeout):
+		log.Printf("[timeline] timed out waiting for a seen-resource clear to persist")
+	}
+}
+
+// enqueueSeenWrite hands one mutation to the background writer without
+// blocking the caller. A full queue means the database cannot keep up with
+// informer churn; the mutation is dropped rather than stalling the informer
+// handler, because the in-memory set is already correct and the only cost is
+// that the resource is reported as newly seen once after the next restart.
+// Drops are counted and reported once per flush rather than per event, which on
+// a large cluster would be its own flood.
+func (s *PostgresStore) enqueueSeenWrite(w seenResourceWrite) {
+	select {
+	case s.seenWrites <- w:
+	default:
+		s.seenDropped.Add(1)
+		// Nobody will flush this one, so release any waiter immediately rather
+		// than letting it sit until its timeout.
+		if w.done != nil {
+			close(w.done)
+		}
+	}
+}
+
+// runSeenWriter drains the queue into batched statements. Consecutive
+// mutations of the same kind collapse into one statement; a mark followed by a
+// clear of the same key stays ordered, because the batch breaks whenever the
+// operation changes.
+func (s *PostgresStore) runSeenWriter() {
+	ticker := time.NewTicker(seenWriteInterval)
+	defer ticker.Stop()
+
+	pending := make([]seenResourceWrite, 0, seenWriteBatchSize)
+	reportedDrops := int64(0)
+	reportDrops := func() {
+		if dropped := s.seenDropped.Load(); dropped > reportedDrops {
+			log.Printf("[timeline] seen-resource write queue full: %d change(s) not persisted; "+
+				"they will be reported as newly seen once after the next restart", dropped-reportedDrops)
+			reportedDrops = dropped
+		}
+	}
+	for {
+		select {
+		case <-s.quit:
+			// Drain what is already queued so a clean shutdown does not throw
+			// away marks the informers just made.
+			for {
+				select {
+				case w := <-s.seenWrites:
+					pending = append(pending, w)
+					if len(pending) >= seenWriteBatchSize {
+						s.flushSeenWrites(pending)
+						pending = pending[:0]
+					}
+				default:
+					s.flushSeenWrites(pending)
+					reportDrops()
+					return
+				}
+			}
+		case w := <-s.seenWrites:
+			pending = append(pending, w)
+			if len(pending) >= seenWriteBatchSize || w.done != nil {
+				s.flushSeenWrites(pending)
+				pending = pending[:0]
+			}
+		case <-ticker.C:
+			if len(pending) > 0 {
+				s.flushSeenWrites(pending)
+				pending = pending[:0]
+			}
+			reportDrops()
+		}
+	}
+}
+
+func (s *PostgresStore) flushSeenWrites(pending []seenResourceWrite) {
+	if len(pending) == 0 {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), postgresOperationTimeout)
 	defer cancel()
-	if _, err := s.db.ExecContext(
-		ctx,
-		"DELETE FROM radar_timeline_seen_resources WHERE resource_key = $1",
-		[]byte(key),
-	); err != nil {
-		log.Printf("[timeline] failed to clear seen resource: %v", err)
+
+	for start := 0; start < len(pending); {
+		end := start + 1
+		for end < len(pending) && pending[end].delete == pending[start].delete {
+			end++
+		}
+		keys := make([][]byte, 0, end-start)
+		for _, w := range pending[start:end] {
+			keys = append(keys, []byte(w.key))
+		}
+		var err error
+		if pending[start].delete {
+			_, err = s.db.ExecContext(ctx,
+				"DELETE FROM radar_timeline_seen_resources WHERE resource_key = ANY($1)", keys)
+		} else {
+			_, err = s.db.ExecContext(ctx,
+				`INSERT INTO radar_timeline_seen_resources (resource_key)
+				 SELECT unnest($1::bytea[]) ON CONFLICT (resource_key) DO NOTHING`, keys)
+		}
+		if err != nil {
+			log.Printf("[timeline] failed to persist %d seen-resource changes: %v", end-start, err)
+		}
+		for _, w := range pending[start:end] {
+			if w.done != nil {
+				close(w.done)
+			}
+		}
+		start = end
 	}
 }
 

--- a/internal/timeline/postgres_store_test.go
+++ b/internal/timeline/postgres_store_test.go
@@ -1145,10 +1145,10 @@ func TestPostgresStore_ColumnRoundTrip(t *testing.T) {
 }
 
 // TestPostgresStore_SeenWritesPersistAsynchronously covers the batched writer.
-// MarkResourceSeen no longer writes inline - it updates the in-memory set and
-// queues the durable write - so the property that matters is that the row is
-// still there for the next process to hydrate, and that a later clear cannot
-// be applied before the mark it supersedes.
+// MarkResourceSeen updates the in-memory set and queues the durable write, so
+// the properties that matter are that the row is still there for the next
+// process to hydrate, and that a clear can never be applied before the mark it
+// supersedes.
 func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 	dsn := testPostgresDSN(t)
 	store, err := NewPostgresStore(dsn)
@@ -1189,5 +1189,46 @@ func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 	}
 	if reopened.IsResourceSeen("cluster-b", "Deployment", "default", "app-0") {
 		t.Error("seen state leaked across cluster contexts")
+	}
+}
+
+// TestPostgresStore_ClearSurvivesQueuePressure pins the durability of a clear
+// when the write queue is saturated. Marks may be dropped under pressure - the
+// in-memory set is already correct and the cost is one re-report after a
+// restart - but a dropped clear is not equivalent: it returns with the row
+// still present, a queued mark for the same key can flush on top of it, and the
+// resource then stays marked as seen so its next appearance is suppressed.
+func TestPostgresStore_ClearSurvivesQueuePressure(t *testing.T) {
+	dsn := testPostgresDSN(t)
+	store, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+
+	// Saturate the queue well past its depth, with the key under test marked
+	// part-way through so a queued mark for it is in flight behind the clear.
+	for i := 0; i < seenWriteQueueDepth*3; i++ {
+		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("noise-%d", i))
+		if i == seenWriteQueueDepth {
+			store.MarkResourceSeen("cluster-a", "Deployment", "default", "recreated")
+		}
+	}
+	store.ClearResourceSeen("cluster-a", "Deployment", "default", "recreated")
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := reopened.Close(); err != nil {
+			t.Errorf("Close reopened: %v", err)
+		}
+	})
+	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "recreated") {
+		t.Fatal("clear was lost under queue pressure: the resource is still marked seen after restart")
 	}
 }

--- a/internal/timeline/postgres_store_test.go
+++ b/internal/timeline/postgres_store_test.go
@@ -1143,3 +1143,51 @@ func TestPostgresStore_ColumnRoundTrip(t *testing.T) {
 	}
 	assert("Query", &events[0])
 }
+
+// TestPostgresStore_SeenWritesPersistAsynchronously covers the batched writer.
+// MarkResourceSeen no longer writes inline - it updates the in-memory set and
+// queues the durable write - so the property that matters is that the row is
+// still there for the next process to hydrate, and that a later clear cannot
+// be applied before the mark it supersedes.
+func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
+	dsn := testPostgresDSN(t)
+	store, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+
+	const n = 1200 // more than one batch
+	for i := 0; i < n; i++ {
+		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i))
+	}
+	// A mark immediately followed by a clear must not resurrect the row.
+	store.MarkResourceSeen("cluster-a", "Deployment", "default", "transient")
+	store.ClearResourceSeen("cluster-a", "Deployment", "default", "transient")
+
+	// Close drains the queue; nothing here should depend on the flush interval.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := reopened.Close(); err != nil {
+			t.Errorf("Close reopened: %v", err)
+		}
+	})
+
+	for _, i := range []int{0, n / 2, n - 1} {
+		if !reopened.IsResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i)) {
+			t.Errorf("app-%d not persisted across restart", i)
+		}
+	}
+	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "transient") {
+		t.Error("cleared resource came back after restart: the clear was applied before its mark")
+	}
+	if reopened.IsResourceSeen("cluster-b", "Deployment", "default", "app-0") {
+		t.Error("seen state leaked across cluster contexts")
+	}
+}

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -15,6 +15,7 @@ package storetest
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -398,4 +399,268 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 			}
 		}
 	})
+
+	// --- Filter and scoping properties -------------------------------------
+	//
+	// Each store applies these with a different mechanism: the memory store
+	// filters in Go, the SQL stores translate to WHERE clauses in two different
+	// dialects. Nothing above this point exercises a single filter field, so a
+	// backend could ignore one entirely and still pass. That is exactly how a
+	// PostgreSQL backend shipped ignoring UntilSeq and SequenceOrder.
+
+	// A resource of the same kind/namespace/name can exist in two clusters. The
+	// store must not let one cluster's history leak into the other's view - the
+	// reason clusterContext is carried on the row at all, and the reason it
+	// matters most for a store that outlives a context switch.
+	t.Run("cluster context scopes reads, and unscoped reads see everything", func(t *testing.T) {
+		store := newStore(t)
+		a := informer("shared-name", 0)
+		a.ID, a.ClusterContext = "ctx-a", "cluster-a"
+		b := informer("shared-name", time.Second)
+		b.ID, b.ClusterContext = "ctx-b", "cluster-b"
+		mustAppend(t, store, a)
+		mustAppend(t, store, b)
+
+		scoped, err := store.Query(ctx, timeline.QueryOptions{
+			Limit: 100, ClusterContext: "cluster-a",
+			IncludeManaged: true, IncludeK8sEvents: true,
+		})
+		if err != nil {
+			t.Fatalf("Query(clusterContext): %v", err)
+		}
+		if len(scoped) != 1 || scoped[0].ID != "ctx-a" {
+			t.Fatalf("cluster scope leaked: %v", idsOfEvents(scoped))
+		}
+		if scoped[0].ClusterContext != "cluster-a" {
+			t.Fatalf("clusterContext not round-tripped: %q", scoped[0].ClusterContext)
+		}
+		if all := queryAll(t, store, 0, 100); len(all) != 2 {
+			t.Fatalf("unscoped read returned %d rows, want both: %v", len(all), idsOfEvents(all))
+		}
+	})
+
+	// Namespace, kind, name, source and event-type narrowing. One event is the
+	// intended match and the others differ in exactly one field, so a store that
+	// drops a filter returns extra rows rather than passing by luck.
+	t.Run("field filters narrow the result set", func(t *testing.T) {
+		store := newStore(t)
+		want := informer("match", 0)
+		want.Namespace, want.Kind, want.Name = "prod", "Deployment", "api"
+
+		otherNS := want
+		otherNS.ID, otherNS.Namespace = "other-ns", "staging"
+		otherKind := want
+		otherKind.ID, otherKind.Kind = "other-kind", "StatefulSet"
+		otherName := want
+		otherName.ID, otherName.Name = "other-name", "worker"
+		otherSource := want
+		otherSource.ID, otherSource.Source = "other-source", timeline.SourceK8sEvent
+		otherType := want
+		otherType.ID, otherType.EventType = "other-type", timeline.EventTypeDelete
+
+		for _, e := range []timeline.TimelineEvent{want, otherNS, otherKind, otherName, otherSource, otherType} {
+			mustAppend(t, store, e)
+		}
+
+		check := func(name string, opts timeline.QueryOptions, wantIDs ...string) {
+			t.Helper()
+			opts.Limit, opts.IncludeManaged, opts.IncludeK8sEvents = 100, true, true
+			got, err := store.Query(ctx, opts)
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			gotIDs := idsOfEvents(got)
+			sort.Strings(gotIDs)
+			expect := append([]string(nil), wantIDs...)
+			sort.Strings(expect)
+			if fmt.Sprint(gotIDs) != fmt.Sprint(expect) {
+				t.Errorf("%s: got %v, want %v", name, gotIDs, expect)
+			}
+		}
+
+		check("Namespaces", timeline.QueryOptions{Namespaces: []string{"prod"}},
+			"match", "other-kind", "other-name", "other-source", "other-type")
+		check("Kinds", timeline.QueryOptions{Kinds: []string{"Deployment"}},
+			"match", "other-ns", "other-name", "other-source", "other-type")
+		check("Names", timeline.QueryOptions{Names: []string{"api"}},
+			"match", "other-ns", "other-kind", "other-source", "other-type")
+		check("Sources", timeline.QueryOptions{Sources: []timeline.EventSource{timeline.SourceK8sEvent}},
+			"other-source")
+		check("EventTypes", timeline.QueryOptions{EventTypes: []timeline.EventType{timeline.EventTypeDelete}},
+			"other-type")
+		check("ExcludeDeleted", timeline.QueryOptions{ExcludeDeleted: true},
+			"match", "other-ns", "other-kind", "other-name", "other-source")
+	})
+
+	// Time-range narrowing is separate from arrival-order narrowing: Since/Until
+	// bound the event's own timestamp, which for a k8s Event is when the cluster
+	// says it happened, not when Radar saw it.
+	t.Run("since and until bound the event time", func(t *testing.T) {
+		store := newStore(t)
+		for i := 0; i < 5; i++ {
+			mustAppend(t, store, informer(fmt.Sprintf("t-%d", i), time.Duration(i)*time.Minute))
+		}
+		got, err := store.Query(ctx, timeline.QueryOptions{
+			Limit: 100, Since: base.Add(time.Minute), Until: base.Add(3 * time.Minute),
+			IncludeManaged: true, IncludeK8sEvents: true,
+		})
+		if err != nil {
+			t.Fatalf("Query(since,until): %v", err)
+		}
+		ids := idsOfEvents(got)
+		sort.Strings(ids)
+		if fmt.Sprint(ids) != fmt.Sprint([]string{"t-1", "t-2", "t-3"}) {
+			t.Fatalf("since/until window = %v, want [t-1 t-2 t-3]", ids)
+		}
+	})
+
+	// GetChangesForOwner backs the "what changed under this workload" drill-down.
+	// It scopes on owner kind+name and namespace together; a store that drops the
+	// namespace predicate shows another namespace's identically-named owner.
+	t.Run("changes for owner scope to owner and namespace", func(t *testing.T) {
+		store := newStore(t)
+		owned := informer("owned", 0)
+		owned.Owner = &timeline.OwnerInfo{Kind: "Deployment", Name: "api"}
+		elsewhere := informer("elsewhere", time.Second)
+		elsewhere.Namespace = "staging"
+		elsewhere.Owner = &timeline.OwnerInfo{Kind: "Deployment", Name: "api"}
+		otherOwner := informer("other-owner", 2*time.Second)
+		otherOwner.Owner = &timeline.OwnerInfo{Kind: "Deployment", Name: "web"}
+		for _, e := range []timeline.TimelineEvent{owned, elsewhere, otherOwner} {
+			mustAppend(t, store, e)
+		}
+
+		got, err := store.GetChangesForOwner(ctx, "Deployment", "default", "api", "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("GetChangesForOwner: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "owned" {
+			t.Fatalf("owner scope = %v, want [owned]", idsOfEvents(got))
+		}
+		if got[0].Owner == nil || got[0].Owner.Kind != "Deployment" || got[0].Owner.Name != "api" {
+			t.Fatalf("owner not round-tripped: %+v", got[0].Owner)
+		}
+	})
+
+	// Whatever a store is handed, it must hand back. Each backend encodes these
+	// differently - Go structs in memory, TEXT and a fixed-width time layout in
+	// SQLite, jsonb and bigint nanoseconds in PostgreSQL - and only a
+	// round-trip through the store surface catches an encoding that quietly
+	// loses precision or drops a nested field.
+	t.Run("event payload round-trips through the store", func(t *testing.T) {
+		store := newStore(t)
+		// Deliberately sub-microsecond, and not taken from the wall clock: on
+		// darwin time.Now() is already microsecond-resolution, so a fixture
+		// built from it cannot detect a backend that truncates to microseconds.
+		// These offsets make the property fail on every platform, not just the
+		// ones with a nanosecond clock.
+		born := base.Add(-30*time.Minute + 456789321*time.Nanosecond).Truncate(time.Nanosecond)
+		want := informer("payload", 0)
+		want.Timestamp = base.Add(819945123 * time.Nanosecond)
+		want.APIVersion, want.UID, want.CorrelationID = "apps/v1", "uid-9", "corr-9"
+		want.Reason, want.Message = "Scaled", "scaled up"
+		want.HealthState = timeline.HealthHealthy
+		want.ClusterContext = "cluster-x"
+		want.CreatedAt = &born
+		want.Owner = &timeline.OwnerInfo{Kind: "ReplicaSet", Name: "api-rs"}
+		want.Labels = map[string]string{"app": "api", "tier": "back"}
+		want.Diff = &timeline.DiffInfo{
+			Summary: "replicas 1 -> 3",
+			Fields:  []timeline.FieldChange{{Path: "spec.replicas", OldValue: "1", NewValue: "3"}},
+		}
+		mustAppend(t, store, want)
+
+		verify := func(where string, got *timeline.TimelineEvent) {
+			t.Helper()
+			if !got.Timestamp.Equal(want.Timestamp) {
+				t.Errorf("%s: timestamp = %v (%d ns), want %v (%d ns)", where,
+					got.Timestamp, got.Timestamp.UnixNano(), want.Timestamp, want.Timestamp.UnixNano())
+			}
+			if got.CreatedAt == nil || !got.CreatedAt.Equal(born) {
+				t.Errorf("%s: createdAt = %v, want %v", where, got.CreatedAt, born)
+			}
+			if got.APIVersion != want.APIVersion || got.UID != want.UID ||
+				got.CorrelationID != want.CorrelationID || got.Reason != want.Reason ||
+				got.Message != want.Message || got.HealthState != want.HealthState ||
+				got.ClusterContext != want.ClusterContext {
+				t.Errorf("%s: scalar field lost: %+v", where, got)
+			}
+			if got.Owner == nil || got.Owner.Kind != "ReplicaSet" || got.Owner.Name != "api-rs" {
+				t.Errorf("%s: owner = %+v", where, got.Owner)
+			}
+			if len(got.Labels) != 2 || got.Labels["app"] != "api" || got.Labels["tier"] != "back" {
+				t.Errorf("%s: labels = %v", where, got.Labels)
+			}
+			if got.Diff == nil || got.Diff.Summary != want.Diff.Summary || len(got.Diff.Fields) != 1 {
+				t.Errorf("%s: diff = %+v", where, got.Diff)
+			} else if f := got.Diff.Fields[0]; f.Path != "spec.replicas" ||
+				fmt.Sprint(f.OldValue) != "1" || fmt.Sprint(f.NewValue) != "3" {
+				t.Errorf("%s: diff field = %+v", where, f)
+			}
+		}
+
+		one, err := store.GetEvent(ctx, "payload")
+		if err != nil || one == nil {
+			t.Fatalf("GetEvent: %v %+v", err, one)
+		}
+		verify("GetEvent", one)
+
+		page := queryAll(t, store, 0, 10)
+		if len(page) != 1 {
+			t.Fatalf("Query returned %d rows, want 1", len(page))
+		}
+		verify("Query", &page[0])
+	})
+
+	// Stats backs the retention-gap headers and the Capacity Activity coverage
+	// notes. A store that leaves a field at its zero value reports "no gap" and
+	// "nothing evicted", which reads as clean history rather than missing data.
+	t.Run("stats report counts, seq bounds and event times", func(t *testing.T) {
+		store := newStore(t)
+		for i := 0; i < 3; i++ {
+			mustAppend(t, store, informer(fmt.Sprintf("s-%d", i), time.Duration(i)*time.Minute))
+		}
+		stats := store.Stats()
+		if stats.TotalEvents != 3 {
+			t.Errorf("TotalEvents = %d, want 3", stats.TotalEvents)
+		}
+		if stats.OldestSeq <= 0 || stats.NewestSeq <= stats.OldestSeq {
+			t.Errorf("seq bounds = %d..%d, want an increasing pair", stats.OldestSeq, stats.NewestSeq)
+		}
+		if !stats.OldestEvent.Equal(base) {
+			t.Errorf("OldestEvent = %v, want %v", stats.OldestEvent, base)
+		}
+		if !stats.NewestEvent.Equal(base.Add(2 * time.Minute)) {
+			t.Errorf("NewestEvent = %v, want %v", stats.NewestEvent, base.Add(2*time.Minute))
+		}
+	})
+
+	// The seen-set decides whether a resource's first sighting is reported as a
+	// change. It is keyed by cluster as well as identity, so the same workload in
+	// two clusters is two distinct sightings.
+	t.Run("seen resources are tracked per cluster and can be cleared", func(t *testing.T) {
+		store := newStore(t)
+		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+			t.Fatal("resource reported seen before it was marked")
+		}
+		store.MarkResourceSeen("cluster-a", "Deployment", "default", "api")
+		if !store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+			t.Fatal("resource not reported seen after MarkResourceSeen")
+		}
+		if store.IsResourceSeen("cluster-b", "Deployment", "default", "api") {
+			t.Fatal("seen state leaked across cluster contexts")
+		}
+		store.ClearResourceSeen("cluster-a", "Deployment", "default", "api")
+		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+			t.Fatal("resource still reported seen after ClearResourceSeen")
+		}
+	})
+}
+
+func idsOfEvents(events []timeline.TimelineEvent) []string {
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.ID
+	}
+	return ids
 }

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -404,9 +404,9 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 	//
 	// Each store applies these with a different mechanism: the memory store
 	// filters in Go, the SQL stores translate to WHERE clauses in two different
-	// dialects. Nothing above this point exercises a single filter field, so a
-	// backend could ignore one entirely and still pass. That is exactly how a
-	// PostgreSQL backend shipped ignoring UntilSeq and SequenceOrder.
+	// dialects. Without these properties a backend can ignore a filter field
+	// entirely and still satisfy every arrival-order property above, so the
+	// omission surfaces as wrong rows rather than as a failing test.
 
 	// A resource of the same kind/namespace/name can exist in two clusters. The
 	// store must not let one cluster's history leak into the other's view - the
@@ -552,8 +552,8 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 		// Deliberately sub-microsecond, and not taken from the wall clock: on
 		// darwin time.Now() is already microsecond-resolution, so a fixture
 		// built from it cannot detect a backend that truncates to microseconds.
-		// These offsets make the property fail on every platform, not just the
-		// ones with a nanosecond clock.
+		// These fixed offsets make the property fail on every platform, not
+		// only the ones with a nanosecond clock.
 		born := base.Add(-30*time.Minute + 456789321*time.Nanosecond).Truncate(time.Nanosecond)
 		want := informer("payload", 0)
 		want.Timestamp = base.Add(819945123 * time.Nanosecond)


### PR DESCRIPTION
## Description

Production hardening for the PostgreSQL timeline backend merged in #1632. Three changes: the shared store contract now covers more than arrival order, the seen-resource write path no longer blocks the informer on database latency, and the operational failure modes are written down.

No behaviour change for the memory or SQLite backends.

## Widen the shared store contract

The conformance suite exercised 5 of 12 `EventStore` methods and 3 of about 19 `QueryOptions` fields. Everything else (every filter, cluster scoping, owner lookup, payload encoding, most of `Stats`) was covered only by each backend's own tests. That is precisely how a backend shipped ignoring `UntilSeq` and `SequenceOrder` while its own suite stayed green.

Added properties: cluster-context scoping, the namespace/kind/name/source/event-type/exclude-deleted filters, the since-until window, `GetChangesForOwner` scoping, a full payload round-trip, the `Stats` counters and seq bounds, and the per-cluster seen set. All three stores pass.

One detail worth keeping: the payload property uses an explicit sub-microsecond timestamp instead of one derived from the clock. `time.Now()` is microsecond-resolution on darwin, so a clock-derived fixture cannot detect a backend that truncates to microseconds. That is why the truncation in #1314 failed on Linux CI and passed on the contributor's Mac. Verified by mutation: reintroducing the truncation now fails on macOS as well.

## Batch the seen-resource writes

`MarkResourceSeen` ran one `INSERT` per resource, synchronously, from the informer add handler. During initial sync that is one round trip per resource in the cluster, serialized against database latency. Fine next to a sidecar; tens of seconds against a managed database in another zone.

Marks now update the in-memory set as before and queue the durable write for a background batcher. `IsResourceSeen` is unaffected. Measured over 5000 resources against a local database:

| | before | after |
|---|---|---|
| informer handler blocked | 1.15s | 1.5ms |
| total wall clock | 1.15s | 42ms |

Clears stay durable before returning. They are rare, and deferring them risks the opposite failure: a process that dies between the clear and the flush keeps a stale mark and never reports that resource as newly seen again. They share the queue with marks, so ordering holds and a queued mark cannot land after the clear that supersedes it. An earlier version of this change made clears fire-and-forget, and the existing persistence test caught it.

A full queue drops the durable write rather than stalling the informer. The in-memory set is already correct, so the cost is one re-report after the next restart. Drops are counted and reported per flush rather than per event.

## Document the failure modes

Three things an operator needs before pointing Radar at a database, none of which were written down:

- An unreachable database is fatal by design rather than a silent fall back to memory, so the database sits on Radar's startup path.
- Recovery after an outage is not automatic. Only auth-shaped disconnects have a background retry, and a database failure classifies as `network`, so it needs the UI retry or a pod restart.
- `sslmode=require` and `verify-full` both work; TLS needs no handling beyond the DSN.

## How has this been tested?

- Full store suite against real PostgreSQL 17 on macOS/arm64 and linux/amd64, over plaintext, `sslmode=require`, and `sslmode=verify-full` with a pinned CA.
- TLS enforcement confirmed negatively: an untrusted certificate is rejected with an x509 error, and the DSN password stays redacted on that path.
- `go test -race` clean on `internal/timeline`.
- Mutation-tested both new guards. Dropping the cluster-context filter fails the scoping property; reintroducing microsecond truncation fails the payload property; making clears fire-and-forget fails the persistence test.
- Whole repo green. `TestCursorForceGrantEndToEnd` in `internal/ai` flakes under full parallel load, but it does so on unmodified `main` too and passes in isolation; nothing here touches that package.

## Known gaps, unchanged


Still open and worth tickets rather than scope creep here: roughly 550 lines duplicated between the PostgreSQL and SQLite stores, no background retry for network-classified disconnects, and no coverage for credential rotation, a slow database, migration against a partially-migrated database, or retention over a large backlog.

## Type of change

- [x] Improvement to an existing feature (non-breaking)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review performed
- [x] Comments added where necessary
- [x] No new warnings
- [x] Dependent changes merged

## Related issues

Follow-up hardening for #1632. No issue is closed by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path seen-set durability semantics (marks may be dropped under load) and expands contract tests across all timeline stores; PostgreSQL informer behavior improves but restart could re-report “newly seen” resources if the queue overflowed.
> 
> **Overview**
> **Production hardening for the PostgreSQL timeline backend:** seen-resource persistence no longer blocks informers on per-resource DB round trips, the shared `EventStore` conformance suite now exercises filters and scoping, and in-cluster docs spell out PostgreSQL failure modes.
> 
> **Seen-resource writes** move from synchronous `INSERT`/`DELETE` on every mark/clear to a background batcher (queued marks, ~1s / 500-key flushes). `MarkResourceSeen` still updates memory immediately and only queues durability; a full queue **drops** durable marks rather than stalling the informer (logged in aggregate). **`ClearResourceSeen` stays blocking** until the clear is flushed, with shared ordering so a mark cannot land after a clear for the same key. Shutdown drains the queue.
> 
> **Conformance** (`pkg/timeline/storetest`) adds properties for cluster-context scoping, query field filters, since/until, `GetChangesForOwner`, full event payload round-trip (including sub-microsecond timestamps), `Stats`, and per-cluster seen/clear behavior—so backends cannot pass while ignoring filters or encoding.
> 
> **Docs** clarify no SQLite→PostgreSQL migration, unreachable PostgreSQL is fatal (no silent in-memory fallback), recovery needs UI retry or pod restart after outage, and TLS via DSN (`require` / `verify-full`).
> 
> **Tests:** new PostgreSQL tests for async persistence and clear under queue saturation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6fe2bdfffa4b653fdbe4d205bd78ce3f7f946c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
