### PR TITLE
fix(k8s): retry non-auth disconnects for deployments with no browser attached

### DIFF
--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -494,7 +494,7 @@ Cleanup runs hourly + once at startup. Confirm it's keeping up via `/api/diagnos
 - Restart the Radar Deployment after rotating the Secret because Kubernetes does not refresh environment variables in running containers.
 - There is no built-in import path from SQLite to PostgreSQL. Migrating historical events is not supported.
 - Radar treats an unreachable PostgreSQL as fatal rather than falling back to an in-memory timeline, so a pod that cannot reach the database starts in disconnected mode and serves errors instead of cluster data. This is deliberate: silently degrading to memory would hand you a timeline that disappears on the next restart, without saying so. It also means the database is on Radar's startup path — treat its availability accordingly, and prefer one that lives close to the cluster.
-- Recovery after a database outage is not automatic. Once PostgreSQL is reachable again, either use the retry action in the UI or restart the pod. Verified TLS modes: `require` and `verify-full`.
+- Recovery after a database outage is automatic. An open browser tab retries on its own within a minute, and the server keeps its own slower backoff for deployments with no tab attached, so a pod reconnects once PostgreSQL is reachable again. The retry action in the UI forces an immediate attempt. Verified TLS modes: `require` and `verify-full`.
 
 ## Configuration Reference
 

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -68,12 +68,19 @@ func SetConnectionStatus(status ConnectionStatus) {
 	switch status.State {
 	case StateConnected:
 		runtimeAuthRecoveryOwed.Store(false)
+		runtimeNetworkRecoveryOwed.Store(false)
 		resetInconclusiveStreak()
 	case StateDisconnected:
 		if isAuthClassification(status.ErrorType) {
 			runtimeAuthRecoveryOwed.Store(true)
+		} else {
+			// Non-auth disconnects: a browser retries these itself, but a
+			// deployment with no tab attached has nothing that would, so the
+			// server keeps its own backoff as the floor. This debt is not
+			// published to the browser, which keeps its faster retry.
+			runtimeNetworkRecoveryOwed.Store(true)
 		}
-		if runtimeAuthRecoveryOwed.Load() {
+		if runtimeRecoveryOwed() {
 			startRuntimeAuthRecovery()
 		}
 	}

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -71,15 +71,7 @@ func SetConnectionStatus(status ConnectionStatus) {
 		runtimeNetworkRecoveryOwed.Store(false)
 		resetInconclusiveStreak()
 	case StateDisconnected:
-		if isAuthClassification(status.ErrorType) {
-			runtimeAuthRecoveryOwed.Store(true)
-		} else {
-			// Non-auth disconnects: a browser retries these itself, but a
-			// deployment with no tab attached has nothing that would, so the
-			// server keeps its own backoff as the floor. This debt is not
-			// published to the browser, which keeps its faster retry.
-			runtimeNetworkRecoveryOwed.Store(true)
-		}
+		armRecoveryDebt(status.ErrorType)
 		if runtimeRecoveryOwed() {
 			startRuntimeAuthRecovery()
 		}

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -98,10 +98,12 @@ func runRuntimeAuthRecovery() {
 			runtimeAuthRecoveryOwed.Store(false)
 			runtimeNetworkRecoveryOwed.Store(false)
 			// A disconnect publishing between the read above and these stores
-			// set a debt that has just been erased, and its own start call only
-			// nudged because this worker was still active. Re-read so that
-			// episode keeps a worker instead of being stranded.
-			if GetConnectionStatus().State != StateConnected {
+			// has just had its debt erased, and its own start call only nudged
+			// because this worker was still marked active. Re-arm from the
+			// current status so the episode keeps a worker; clearing and
+			// looping alone would fall straight back out at the debt check.
+			if current := GetConnectionStatus(); current.State != StateConnected {
+				armRecoveryDebt(current.ErrorType)
 				continue
 			}
 			return
@@ -231,4 +233,18 @@ func setRuntimeAuthReconnect(fn func(string, uint64) error) {
 // and in whether the browser is told to stand down.
 func runtimeRecoveryOwed() bool {
 	return runtimeAuthRecoveryOwed.Load() || runtimeNetworkRecoveryOwed.Load()
+}
+
+// armRecoveryDebt records which reconnect loop a disconnect owes, from its
+// classification. Auth-shaped failures take the published debt, which also
+// tells the browser to stand down so two retriers do not race the same exec
+// credential plugin. Everything else takes the unpublished one: a browser
+// retries those itself and faster, so this is only the floor for deployments
+// with no tab attached.
+func armRecoveryDebt(errorType string) {
+	if isAuthClassification(errorType) {
+		runtimeAuthRecoveryOwed.Store(true)
+		return
+	}
+	runtimeNetworkRecoveryOwed.Store(true)
 }

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -97,6 +97,13 @@ func runRuntimeAuthRecovery() {
 			// guard against direct status writes that bypass it.
 			runtimeAuthRecoveryOwed.Store(false)
 			runtimeNetworkRecoveryOwed.Store(false)
+			// A disconnect publishing between the read above and these stores
+			// set a debt that has just been erased, and its own start call only
+			// nudged because this worker was still active. Re-read so that
+			// episode keeps a worker instead of being stranded.
+			if GetConnectionStatus().State != StateConnected {
+				continue
+			}
 			return
 		}
 		if status.State == StateConnecting || activeContextOperations.Load() != 0 {

--- a/internal/k8s/runtime_auth_recovery.go
+++ b/internal/k8s/runtime_auth_recovery.go
@@ -32,6 +32,15 @@ var (
 	// only reconnect path headless deployments have. Set on any auth-shaped
 	// disconnect, cleared only by a successful connect.
 	runtimeAuthRecoveryOwed atomic.Bool
+	// Recovery debt for non-auth disconnects. Browser sessions already retry
+	// these themselves on a 10s-60s backoff, so this exists for deployments
+	// with no tab attached - MCP-only or API-only - where otherwise nothing
+	// would ever retry and the process stays wedged until a human calls the
+	// API. Kept separate from the auth debt because that one is published to
+	// the browser as authRecoveryOwed to make it stand down; publishing this
+	// one would replace the browser's faster retry with the server's slower
+	// backoff for no gain.
+	runtimeNetworkRecoveryOwed atomic.Bool
 	// Wakes a sleeping worker so a new auth-loss episode isn't stuck waiting
 	// out the previous episode's backoff — worst case the 30min hung-plugin
 	// interval.
@@ -63,7 +72,7 @@ func runRuntimeAuthRecovery() {
 		runtimeAuthRecoveryActive.Store(false)
 		// A demotion racing this exit saw the active flag still true and only
 		// nudged; re-check so its episode isn't stranded without a worker.
-		if runtimeAuthRecoveryStillOwed() {
+		if runtimeRecoveryStillOwed() {
 			startRuntimeAuthRecovery()
 		}
 	}()
@@ -79,7 +88,7 @@ func runRuntimeAuthRecovery() {
 			// the previous episode's backoff.
 			interval = initialInterval
 		}
-		if !runtimeAuthRecoveryOwed.Load() {
+		if !runtimeRecoveryOwed() {
 			return
 		}
 		status := GetConnectionStatus()
@@ -87,6 +96,7 @@ func runRuntimeAuthRecovery() {
 			// The publish-side hook clears the debt on connect; this is a
 			// guard against direct status writes that bypass it.
 			runtimeAuthRecoveryOwed.Store(false)
+			runtimeNetworkRecoveryOwed.Store(false)
 			return
 		}
 		if status.State == StateConnecting || activeContextOperations.Load() != 0 {
@@ -141,8 +151,8 @@ func runRuntimeAuthRecovery() {
 	}
 }
 
-func runtimeAuthRecoveryStillOwed() bool {
-	return runtimeAuthRecoveryOwed.Load() && GetConnectionStatus().State != StateConnected
+func runtimeRecoveryStillOwed() bool {
+	return runtimeRecoveryOwed() && GetConnectionStatus().State != StateConnected
 }
 
 // RuntimeAuthRecoveryOwed reports whether the server-side reconnect loop owns
@@ -207,4 +217,11 @@ func setRuntimeAuthReconnect(fn func(string, uint64) error) {
 	runtimeAuthChecksMu.Lock()
 	defer runtimeAuthChecksMu.Unlock()
 	runtimeAuthReconnect = fn
+}
+
+// runtimeRecoveryOwed reports whether any recovery debt is outstanding, of
+// either shape. One worker serves both: they differ only in what starts them
+// and in whether the browser is told to stand down.
+func runtimeRecoveryOwed() bool {
+	return runtimeAuthRecoveryOwed.Load() || runtimeNetworkRecoveryOwed.Load()
 }

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1614,7 +1614,8 @@ func TestRuntimeRecoveryReconnectsAfterNetworkDisconnect(t *testing.T) {
 
 	var probes atomic.Int32
 	setRuntimeAuthProbe(func(context.Context) error {
-		// Unreachable for the first few passes, then the cluster comes back.
+		// Fails a few times first so the assertion below proves the loop keeps
+		// probing on its backoff, rather than passing on a single lucky probe.
 		if probes.Add(1) < 3 {
 			return errors.New("dial tcp 10.0.0.1:6443: connect: connection refused")
 		}

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1670,3 +1670,35 @@ func TestNetworkRecoveryDebtIsNotPublishedToTheBrowser(t *testing.T) {
 		t.Fatal("an auth disconnect no longer reports authRecoveryOwed")
 	}
 }
+
+// armRecoveryDebt is the single definition of which loop a disconnect owes, used
+// both when a status is published and when the worker re-arms after racing a
+// clear. Auth-shaped failures must take the published debt, because that is what
+// tells the browser to stand down; everything else must take the unpublished one,
+// or a browser session would be dropped onto the server's much slower backoff.
+func TestArmRecoveryDebtRoutesByClassification(t *testing.T) {
+	for _, tc := range []struct {
+		errorType   string
+		wantAuth    bool
+		wantNetwork bool
+	}{
+		{"auth", true, false},
+		{"auth-rejected", true, false},
+		{"auth-plugin-stuck", true, false},
+		{"network", false, true},
+		{"timeout", false, true},
+		{"", false, true},
+	} {
+		t.Run(tc.errorType, func(t *testing.T) {
+			ResetTestState()
+			t.Cleanup(ResetTestState)
+			armRecoveryDebt(tc.errorType)
+			if got := runtimeAuthRecoveryOwed.Load(); got != tc.wantAuth {
+				t.Errorf("auth debt = %v, want %v", got, tc.wantAuth)
+			}
+			if got := runtimeNetworkRecoveryOwed.Load(); got != tc.wantNetwork {
+				t.Errorf("network debt = %v, want %v", got, tc.wantNetwork)
+			}
+		})
+	}
+}

--- a/internal/k8s/runtime_auth_test.go
+++ b/internal/k8s/runtime_auth_test.go
@@ -1603,3 +1603,69 @@ func TestRuntimeAuthExecCredentialExpiry(t *testing.T) {
 		t.Fatalf("second connection status = %+v, want disconnected auth", status)
 	}
 }
+
+// A non-auth disconnect must also leave a reconnect loop running. A browser
+// retries these itself, but a deployment with no tab attached (MCP-only,
+// API-only) has nothing that would, so the server is the floor.
+func TestRuntimeRecoveryReconnectsAfterNetworkDisconnect(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(2*time.Millisecond, 4*time.Millisecond)
+
+	var probes atomic.Int32
+	setRuntimeAuthProbe(func(context.Context) error {
+		// Unreachable for the first few passes, then the cluster comes back.
+		if probes.Add(1) < 3 {
+			return errors.New("dial tcp 10.0.0.1:6443: connect: connection refused")
+		}
+		return nil
+	})
+	var reconnects atomic.Int32
+	setRuntimeAuthReconnect(func(string, uint64) error {
+		reconnects.Add(1)
+		return nil
+	})
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "network",
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for reconnects.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("server never retried a network-shaped disconnect; a headless deployment would stay wedged")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// The browser suppresses its own retry while the server owns recovery, so the
+// network debt must stay invisible to it: publishing it would replace the
+// browser's 10s-60s retry with the server's much slower backoff.
+func TestNetworkRecoveryDebtIsNotPublishedToTheBrowser(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+	setRuntimeAuthRecoveryIntervalsForTest(time.Hour, time.Hour)
+	setRuntimeAuthProbe(func(context.Context) error { return errors.New("unreachable") })
+	setRuntimeAuthReconnect(func(string, uint64) error { return nil })
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "network",
+	})
+	if RuntimeAuthRecoveryOwed() {
+		t.Fatal("a network disconnect reported authRecoveryOwed; the browser would stand down and retry far more slowly")
+	}
+
+	SetConnectionStatus(ConnectionStatus{
+		State:     StateDisconnected,
+		Context:   "recovery-context",
+		ErrorType: "auth",
+	})
+	if !RuntimeAuthRecoveryOwed() {
+		t.Fatal("an auth disconnect no longer reports authRecoveryOwed")
+	}
+}

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -332,6 +332,7 @@ func ResetTestState() {
 	// no worker alive, drain instead — a stray token would give the next
 	// test's worker a spurious immediate tick.
 	runtimeAuthRecoveryOwed.Store(false)
+	runtimeNetworkRecoveryOwed.Store(false)
 	if runtimeAuthRecoveryActive.Load() {
 		select {
 		case runtimeAuthRecoveryNudge <- struct{}{}:


### PR DESCRIPTION
## Description

A disconnect left a reconnect loop running only when it was auth-shaped. Browsers retry every other kind themselves on a 10s to 60s backoff, so any open tab covered it. A deployment with no tab attached, MCP-only or API-only, had nothing that would retry: a transient loss of the apiserver, or of an external timeline database, wedged the process until a human called the API.

The existing loop already does the right thing, probe on a backoff and reconnect when the probe succeeds. Only the gate that starts it was auth-specific. Non-auth disconnects now arm it too, through a separate debt flag.

## Why the debt flag is separate

The auth debt is published to the browser as `authRecoveryOwed`, which makes the browser stand down so two retriers do not fight over the same exec credential plugin. The browser's own retry is much faster than this loop's backoff. Publishing the network debt the same way would replace a 10s to 60s retry with a 30s to 5min one for every browser session, which is a regression for the common case. So the network debt stays invisible to the browser, and a tab keeps winning the race whenever one is open. The server is the floor, not the owner.

## Also in this change

`docs/in-cluster.md` claimed recovery after a database outage was not automatic and told operators to use the retry action or restart the pod. That was drawn from an observation made with curl and no browser attached, and it is wrong for the common case. Corrected to describe both paths.

## How has this been tested?

- [x] Added/updated unit tests
- A non-auth disconnect now arms the loop and reconnects once the probe recovers.
- `authRecoveryOwed` stays false for a network disconnect and true for an auth one, so the browser's behaviour is unchanged.
- Both tests were mutation-checked: removing the new gate fails the first one.
- `internal/k8s` run three times, with `-count=2` to catch global-state leakage between tests, and under `-race`. All clean.
- Whole repo green. `TestCursorForceGrantEndToEnd` in `internal/ai` flakes under full parallel load and passes in isolation; it does the same on unmodified `main` and nothing here touches that package.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Follow-up to #1636. No issue is closed by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection recovery when disconnected from the cluster; behavior for browser sessions is intentionally unchanged, but headless auto-reconnect timing and race handling around debt clearing affect production uptime paths.
> 
> **Overview**
> **Non-auth disconnects** (network, timeout, etc.) now start the same server-side reconnect worker that already handled auth failures, so MCP-only or API-only deployments are not left wedged until someone hits retry manually. Browsers still own fast retry for those cases when a tab is open.
> 
> Recovery is tracked with a separate **`runtimeNetworkRecoveryOwed`** flag from auth debt. Auth debt still drives **`authRecoveryOwed`** so the browser stands down and does not fight exec-credential plugins; network debt stays unpublished so open tabs keep their 10s–60s backoff instead of the server’s slower one. **`armRecoveryDebt`** is the single gate that picks which flag to set from **`ErrorType`**, and the worker treats either debt as “still owed.”
> 
> **Docs:** `in-cluster.md` now says PostgreSQL/cluster recovery is automatic (browser retry within ~1 minute plus a slower server backoff when no tab is attached), instead of requiring manual retry or pod restart.
> 
> **Tests** cover network reconnect, that network debt does not surface as **`authRecoveryOwed`**, and classification routing in **`armRecoveryDebt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f033060b728b8ab4b0f68d0c48d629505ec41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->