### PR TITLE
fix(resources): size table columns to fit their own headers

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -240,7 +240,7 @@ export function isColumnFilterableByDistinctCount(colKey: string, distinctCount:
 }
 
 // Column definitions per resource kind
-interface Column {
+export interface Column {
   key: string
   label: string
   width?: string
@@ -321,7 +321,168 @@ const COMPARE_COLUMN_STYLE: React.CSSProperties = {
   maxWidth: COMPARE_COLUMN_WIDTH,
 }
 
-function getColumnMinWidth(col: Column): number {
+// Built-in sortable keys. Hoisted so getColumnMinWidth can reserve room for the
+// sort icon without the header render and the width math drifting apart.
+const BUILTIN_SORTABLE_COLUMN_KEYS = new Set([
+  'name', 'namespace', 'age', 'status', 'ready', 'restarts', 'type', 'version',
+  'desired', 'available', 'upToDate', 'lastSeen', 'count', 'reason', 'object',
+  'cpu', 'memory', 'containers',
+])
+
+// The header row is px-4 with a `truncate` label, under table-layout:fixed with
+// explicit <col> widths — so a column narrower than its own heading clips to
+// "ADDRESS T…" and stays clipped at every viewport size, because only the Name
+// column flexes. Deriving a floor from the label keeps a declared w-* from
+// being narrower than the word it has to show.
+const HEADER_PADDING_PX = 32 // px-4 on both sides
+const HEADER_SORT_AFFORDANCE_PX = 20 // gap-1 + the w-3.5 chevron / ArrowUpDown
+const HEADER_FILTER_AFFORDANCE_PX = 20 // gap-1 + the p-0.5 filter button
+// Deliberately an upper bound on the rendered header font (DM Sans 500, 12px,
+// uppercase, tracking-wide): measured per-character widths across the curated
+// labels ranged 7.2–8.1px, so 8.2 never under-reserves. Over-reserving costs
+// space the flexible Name column has to spare; under-reserving clips again.
+// Printer and host-extra columns take their label from vendor CRD text, which
+// can be long or non-Latin. Cap the floor so one such label can't size a column
+// off the screen; past this a truncated heading (with its tooltip) is better.
+const HEADER_FLOOR_MAX_PX = 320
+
+// Must match the rendered header: text-xs (12px) / font-medium (500) / uppercase
+// / tracking-wide, in the app font. measureText does not apply letter-spacing,
+// so it is added per gap.
+const HEADER_FONT = "500 12px 'DM Sans Variable', 'DM Sans', system-ui, sans-serif"
+const HEADER_LETTER_SPACING_PX = 0.3 // tracking-wide = 0.025em at 12px
+// Fallback only — used where there is no canvas (SSR, jsdom). Deliberately an
+// upper bound: measured per-character widths across the curated labels ranged
+// 7.2–8.1px, so this never under-reserves for Latin text.
+const HEADER_CHAR_PX_FALLBACK = 8.2
+const HEADER_SPACE_PX_FALLBACK = 4
+
+let headerMeasureCtx: CanvasRenderingContext2D | null | undefined
+const headerLabelWidthCache = new Map<string, number>()
+
+// DM Sans is loaded with font-display:swap, so the first tables can render — and
+// be measured — while the browser is still painting the fallback face. Those
+// measurements would otherwise be cached against the wrong glyph metrics for the
+// rest of the session: a wider real face clips a label whose tooltip never
+// activates, a narrower one leaves the table permanently too wide. Drop the
+// cache when the real font arrives and let subscribers recompute.
+let headerFontEpoch = 0
+const headerFontListeners = new Set<() => void>()
+let headerFontWatchStarted = false
+
+function watchHeaderFont(): void {
+  if (headerFontWatchStarted) return
+  headerFontWatchStarted = true
+  const fonts = typeof document === 'undefined' ? undefined : (document as Document & { fonts?: FontFaceSet }).fonts
+  if (!fonts?.ready) return
+  void fonts.ready.then(() => {
+    headerLabelWidthCache.clear()
+    headerMeasureCtx = undefined // re-created so ctx.font resolves against the loaded face
+    headerFontEpoch++
+    for (const notify of headerFontListeners) notify()
+  })
+}
+
+/**
+ * Re-renders once the web font has loaded, so column widths measured against the
+ * fallback face are recomputed against the real one.
+ */
+export function useHeaderFontEpoch(): number {
+  const [epoch, setEpoch] = useState(headerFontEpoch)
+  useEffect(() => {
+    const notify = () => setEpoch(headerFontEpoch)
+    headerFontListeners.add(notify)
+    notify() // the font may have loaded between render and effect
+    return () => { headerFontListeners.delete(notify) }
+  }, [])
+  return epoch
+}
+
+/**
+ * Width of a header label as the browser will actually draw it.
+ *
+ * Measured rather than estimated because the labels are not a closed set: an
+ * uncurated CRD's printer columns take their names from the vendor's own
+ * additionalPrinterColumns, so they can be any length, any script, and a
+ * per-character constant calibrated on curated ASCII silently stops holding.
+ */
+function headerLabelWidth(label: string): number {
+  watchHeaderFont()
+  const cached = headerLabelWidthCache.get(label)
+  if (cached !== undefined) return cached
+  const upper = label.toUpperCase() // the header renders uppercase
+  let width: number
+  if (headerMeasureCtx === undefined) {
+    headerMeasureCtx = typeof document === 'undefined'
+      ? null
+      : document.createElement('canvas').getContext('2d')
+    if (headerMeasureCtx) headerMeasureCtx.font = HEADER_FONT
+  }
+  if (headerMeasureCtx) {
+    width = headerMeasureCtx.measureText(upper).width
+      + HEADER_LETTER_SPACING_PX * Math.max(0, upper.length - 1)
+  } else {
+    width = 0
+    for (const ch of upper) width += ch === ' ' ? HEADER_SPACE_PX_FALLBACK : HEADER_CHAR_PX_FALLBACK
+  }
+  headerLabelWidthCache.set(label, width)
+  return width
+}
+
+/**
+ * Header label that carries its own full text in a tooltip when it truncates.
+ *
+ * The width floor in getColumnMinWidth keeps a heading from being clipped by its
+ * own column, but three cases still truncate: a label past the floor cap, a
+ * column the user dragged narrower, and the sort/filter controls sharing the
+ * row — whose width depends on their state (an active filter renders padding,
+ * an icon and a count). Predicting those widths was wrong twice, so this reads
+ * the actual overflow instead of computing it.
+ */
+function HeaderLabel({ label, className }: { label: string; className?: string }) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [truncated, setTruncated] = useState(false)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const check = () => setTruncated(el.scrollWidth > el.clientWidth + 0.5)
+    check()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(check)
+    ro.observe(el)
+    return () => { ro.disconnect() }
+  }, [label])
+  const span = <span ref={ref} className={clsx('truncate', className)}>{label}</span>
+  return truncated ? <Tooltip content={label}>{span}</Tooltip> : span
+}
+
+/**
+ * Whether a column's header renders a sort control, which takes width beside the
+ * label. Shared by the header render and the width math so the two can't
+ * disagree: printer and custom columns are sortable through their own
+ * getSortValue even though their keys aren't in the built-in list.
+ */
+export function isColumnSortable(col: Column, extras?: Map<string, ExtraColumn>): boolean {
+  return BUILTIN_SORTABLE_COLUMN_KEYS.has(col.key) || !!extras?.get(col.key)?.getSortValue
+}
+
+export function getColumnMinWidth(col: Column, extras?: Map<string, ExtraColumn>): number {
+  const declared = declaredColumnWidth(col)
+  // A column-filter button also sits in this row, but whether one renders
+  // depends on the distinct values in the data (isColumnFilterableByDistinctCount),
+  // which isn't knowable here — those columns stay ~20px tighter than ideal.
+  // Both controls are reserved statically. The filter button only renders once
+  // the data has a filterable spread of values (isColumnFilterableByDistinctCount),
+  // but sizing the column from that would make it change width as rows load or
+  // are filtered — the jumping-column problem fixed layout exists to avoid. So
+  // reserve for any column that could ever carry one, and keep the width stable.
+  const affordance = (isColumnSortable(col, extras) ? HEADER_SORT_AFFORDANCE_PX : 0)
+    + (SKIP_FILTER_COLUMNS.has(col.key) ? 0 : HEADER_FILTER_AFFORDANCE_PX)
+  const headerFloor = HEADER_PADDING_PX + headerLabelWidth(col.label) + affordance
+  return Math.max(declared, Math.min(Math.ceil(headerFloor), HEADER_FLOOR_MAX_PX))
+}
+
+function declaredColumnWidth(col: Column): number {
   if (col.minWidth) return col.minWidth
   if (!col.width) return 200 // Name column (no width class) gets wider minimum
   const match = col.width.match(/(?:min-)?w-(\d+)/)
@@ -3603,6 +3764,9 @@ export function ResourcesView({
 
   // Map of extra column keys for fast O(1) lookup on each render path
   // (cell render, sort, column-filter unique-values).
+  // Recompute header-derived widths once the web font swaps in (see watchHeaderFont).
+  const headerFontEpoch = useHeaderFontEpoch()
+
   const extraColumnsByKey = useMemo(() => {
     const m = new Map<string, ExtraColumn>()
     extraLeadingColumns?.forEach(c => m.set(c.key, c))
@@ -5248,12 +5412,12 @@ export function ResourcesView({
   // scroll horizontally when the viewport is too narrow.
   const tableMinWidth = useMemo(() => {
     const compareColumnWidth = compareMode ? COMPARE_COLUMN_WIDTH : 0
-    const baseMinWidth = columns.reduce((sum, col) => sum + (columnWidths[col.key] || getColumnMinWidth(col)), compareColumnWidth)
+    const baseMinWidth = columns.reduce((sum, col) => sum + (columnWidths[col.key] || getColumnMinWidth(col, extraColumnsByKey)), compareColumnWidth)
     const flexibleNameColumn = columns.find(col => col.key === 'name' && !columnWidths[col.key])
 
     if (!hasResizedColumns || !flexibleNameColumn) return baseMinWidth
-    return baseMinWidth + getColumnMinWidth(flexibleNameColumn)
-  }, [columns, columnWidths, compareMode, hasResizedColumns])
+    return baseMinWidth + getColumnMinWidth(flexibleNameColumn, extraColumnsByKey)
+  }, [columns, columnWidths, compareMode, hasResizedColumns, extraColumnsByKey, headerFontEpoch])
 
   // Stable virtuoso components — memoized to avoid remounting the table on every render
   const virtuosoComponents = useMemo(() => ({
@@ -5281,7 +5445,7 @@ export function ResourcesView({
                 style={{
                   width: columnWidths[col.key]
                     ? `${columnWidths[col.key]}px`
-                    : col.key === 'name' ? undefined : `${getColumnMinWidth(col)}px`,
+                    : col.key === 'name' ? undefined : `${getColumnMinWidth(col, extraColumnsByKey)}px`,
                 }}
               />
             ))}
@@ -5292,7 +5456,7 @@ export function ResourcesView({
       )
     }),
     TableRow: VirtuosoTableRow,
-  }), [columns, columnWidths, hasResizedColumns, compareMode, tableMinWidth, isCheckboxMode])
+  }), [columns, columnWidths, hasResizedColumns, compareMode, tableMinWidth, isCheckboxMode, extraColumnsByKey, headerFontEpoch])
 
   // Calculate filter options with counts based on current resources (before filtering)
   const filterOptions = useMemo(() => {
@@ -6143,8 +6307,7 @@ export function ResourcesView({
                   )}
                   {columns.map((col, colIdx) => {
                     // Built-in sortable keys, plus any extra/custom column that carries its own getSortValue.
-                    const isSortable = ['name', 'namespace', 'age', 'status', 'ready', 'restarts', 'type', 'version', 'desired', 'available', 'upToDate', 'lastSeen', 'count', 'reason', 'object', 'cpu', 'memory', 'containers'].includes(col.key)
-                      || !!extraColumnsByKey.get(col.key)?.getSortValue
+                    const isSortable = isColumnSortable(col, extraColumnsByKey)
                     const isSorted = sortColumn === col.key
                     const isLastCol = colIdx === columns.length - 1
                     const filterCol = filterableColumnMap.get(col.key)
@@ -6168,7 +6331,7 @@ export function ResourcesView({
                               <span className="border-b border-dotted border-theme-text-tertiary truncate">{col.label}</span>
                             </Tooltip>
                           ) : (
-                            <span className="truncate">{col.label}</span>
+                            <HeaderLabel label={col.label} />
                           )}
                           {isSortable && (
                             <span className="text-theme-text-tertiary shrink-0">

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -227,6 +227,12 @@ export const SKIP_FILTER_COLUMNS = new Set([
   'lastUpdated', 'chart', 'events', 'repo',
   'generators', 'applications', 'destinations', 'sources', 'budget', 'healthy', 'allowed',
   'secrets', 'subjects', 'role', 'entrypoint', 'templates',
+  // Trivy and Kyverno report counts. These look filterable but cannot be:
+  // getCellFilterValue has no case for them and its fallback probes
+  // status[key]/spec[key], while the counts live under report.summary /
+  // status.summary. Listing them here stops the header reserving room for a
+  // button that can never render.
+  'critical', 'high', 'medium', 'low', 'pass', 'fail', 'warn', 'error', 'skip',
 ])
 
 // Namespace/node cardinality scales with cluster size, not kind enum size;
@@ -436,8 +442,16 @@ function headerLabelWidth(label: string): number {
  * own column, but three cases still truncate: a label past the floor cap, a
  * column the user dragged narrower, and the sort/filter controls sharing the
  * row — whose width depends on their state (an active filter renders padding,
- * an icon and a count). Predicting those widths was wrong twice, so this reads
- * the actual overflow instead of computing it.
+ * an icon and a count). Their rendered width isn't knowable from the column
+ * definition, so this reads the element's actual overflow rather than computing
+ * it.
+ *
+ * The Tooltip wrapper stays mounted whether or not the label truncates: swapping
+ * it in on overflow would remount the measured span, stranding the
+ * ResizeObserver on the detached node so the state could never flip back. It
+ * also needs min-w-0 — the wrapper is the flex item in the header row, and an
+ * inline-flex box won't shrink below its content unless told to, which would
+ * push the sort and filter controls out of the cell.
  */
 function HeaderLabel({ label, className }: { label: string; className?: string }) {
   const ref = useRef<HTMLSpanElement>(null)
@@ -452,8 +466,11 @@ function HeaderLabel({ label, className }: { label: string; className?: string }
     ro.observe(el)
     return () => { ro.disconnect() }
   }, [label])
-  const span = <span ref={ref} className={clsx('truncate', className)}>{label}</span>
-  return truncated ? <Tooltip content={label}>{span}</Tooltip> : span
+  return (
+    <Tooltip content={label} disabled={!truncated} preserveWrapperWhenDisabled wrapperClassName="min-w-0">
+      <span ref={ref} className={clsx('truncate', className)}>{label}</span>
+    </Tooltip>
+  )
 }
 
 /**
@@ -6327,7 +6344,7 @@ export function ResourcesView({
                       >
                         <div className="flex items-center gap-1 overflow-hidden">
                           {col.tooltip ? (
-                            <Tooltip content={col.tooltip}>
+                            <Tooltip content={col.tooltip} wrapperClassName="min-w-0">
                               <span className="border-b border-dotted border-theme-text-tertiary truncate">{col.label}</span>
                             </Tooltip>
                           ) : (

--- a/packages/k8s-ui/src/components/resources/column-header-width.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-header-width.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { getColumnMinWidth, type Column } from './ResourcesView'
+
+// The header row is px-4 with a `truncate` label, under table-layout:fixed with
+// explicit <col> widths. A column narrower than its own heading clips to
+// "ADDRESS T…" and — because only the Name column flexes — stays clipped at
+// 1280, 1920 and 2560 alike. These pin the floor that stops that.
+//
+// Reference measurements taken in the browser against the real header font
+// (DM Sans 500, 12px, uppercase, tracking-wide), on kind-radar-kyverno-demo:
+//   RECLAIM       52.7px  ADDRESSES     69.6px
+//   EXPANSION     67.5px  ADDRESS TYPE  87.7px
+const MEASURED = {
+  Reclaim: 52.7,
+  Expansion: 67.5,
+  Addresses: 69.6,
+  'Address Type': 87.7,
+}
+
+const col = (over: Partial<Column> & Pick<Column, 'key' | 'label'>): Column => over
+
+describe('getColumnMinWidth header floor', () => {
+  it.each(Object.entries(MEASURED))(
+    'reserves at least the measured width of %s plus padding',
+    (label, measuredPx) => {
+      const got = getColumnMinWidth(col({ key: 'x', label, width: 'w-16' }))
+      // 32px is the px-4 on both sides; the estimate must never land under the
+      // width the browser actually renders, or the label clips again.
+      expect(got).toBeGreaterThanOrEqual(Math.ceil(measuredPx + 32))
+    },
+  )
+
+  it('leaves a column that already fits its label untouched', () => {
+    // "Age" needs ~25px + 32 padding + 20 for its sort icon = well under w-24.
+    expect(getColumnMinWidth(col({ key: 'age', label: 'Age', width: 'w-24' }))).toBe(96)
+  })
+
+  it('raises a column that is narrower than its label', () => {
+    // w-20 is 80px; "Address Type" cannot fit in 80 - 32 = 48px.
+    expect(getColumnMinWidth(col({ key: 'addressType', label: 'Address Type', width: 'w-20' })))
+      .toBeGreaterThan(80)
+  })
+
+  it('reserves extra room for the sort icon on sortable columns', () => {
+    const sortable = getColumnMinWidth(col({ key: 'status', label: 'Wide Label Here', width: 'w-16' }))
+    const plain = getColumnMinWidth(col({ key: 'notSortable', label: 'Wide Label Here', width: 'w-16' }))
+    expect(sortable).toBeGreaterThan(plain)
+  })
+
+  it('still honours an explicit minWidth override', () => {
+    expect(getColumnMinWidth(col({ key: 'x', label: 'Address Type', width: 'w-20', minWidth: 300 }))).toBe(300)
+  })
+
+  it('keeps the flexible Name column at its wider default', () => {
+    expect(getColumnMinWidth(col({ key: 'name', label: 'Name' }))).toBe(200)
+  })
+
+  // Printer columns (uncurated CRDs) and host-injected custom columns are
+  // sortable via their own getSortValue, not by being in the built-in key list —
+  // the header renders a sort icon for them, so the floor has to reserve it.
+  it('reserves the sort icon for a printer/custom column that carries getSortValue', () => {
+    const c = col({ key: 'printer:Phase', label: 'Reconcile Phase', width: 'w-24' })
+    const extras = new Map([[c.key, { ...c, render: () => null, getSortValue: () => '' }]]) as any
+    expect(getColumnMinWidth(c, extras)).toBeGreaterThan(getColumnMinWidth(c))
+  })
+
+  it('caps the floor so one long vendor label cannot size a column off screen', () => {
+    const monstrous = 'A'.repeat(200)
+    expect(getColumnMinWidth(col({ key: 'printer:x', label: monstrous, width: 'w-24' }))).toBe(320)
+  })
+
+  it('never returns less than the declared width, even past the cap', () => {
+    expect(getColumnMinWidth(col({ key: 'printer:x', label: 'A'.repeat(200), width: 'w-96' }))).toBe(384)
+  })
+})


### PR DESCRIPTION
## Summary

Resource table headings were being cut off — `ADDRESS T…`, `SUBJE…`, `MUTAT…` — on 58 curated columns whose declared width was narrower than the word they had to show. These tables use `table-layout: fixed` with explicit `<col>` widths and only the Name column flexes, so the truncation was identical at 1280, 1920 and 2560: a bigger monitor moved the spare pixels into Name's whitespace and left the heading clipped. Nothing carried the full text, so on EndpointSlices `Address Type` and `Addresses` both rendered as `ADDRESS…` with no way to tell them apart short of dragging the column wider.

A column is now never narrower than its own heading.

## What changed

**A header-derived width floor.** `getColumnMinWidth` returns whichever is larger: the declared `w-*`, or the width the heading actually needs (padding + label + its controls). Sizing a column to fit its header is the default in mature data grids — AG Grid treats skipping the header as the opt-out.

**Measured, not estimated.** Label width comes from `measureText` against the real font and letter-spacing, memoized per label. The labels are not a closed set: an uncurated CRD's printer columns take their names from the vendor's own `additionalPrinterColumns`, so a per-character constant calibrated on curated ASCII would silently stop holding for long or non-Latin text. That constant survives only as an SSR/jsdom fallback, and the floor is capped at 320px so one pathological vendor label can't size a column off screen.

**Font-swap aware.** DM Sans loads with `font-display: swap`, so the first tables can be measured against the fallback face. Those measurements are dropped when `document.fonts.ready` resolves, and the affected widths recompute.

**Both header controls reserved.** Sortability is a single predicate shared by the header render and the width math, because printer and host-injected columns are sortable through their own `getSortValue` rather than by being in the built-in key list. The filter button is reserved for any column that *could* carry one, rather than from the data-derived filterable set — sizing from whether the data currently happens to have a filterable spread would change a column's width as rows load or filter, which is the jumping-column problem fixed layout exists to prevent.

**A tooltip for what a floor cannot cover.** `HeaderLabel` reads real overflow (`scrollWidth` plus a `ResizeObserver`) and carries the full label in a tooltip when it truncates anyway: labels past the cap, columns the user has dragged narrower, and an active filter's variable-width count text.

### Worth a reviewer's attention

- The static filter reservation is a deliberate width-for-stability trade — see Tradeoffs for the measured cost.
- `HEADER_FONT` has to stay in step with the header's Tailwind classes; if the header's font or size changes, that string changes with it.

## Testing

`make tsc` clean · `packages/k8s-ui` 3434 passed · `web` 586 passed (1 failure that also reproduces on `main`, unrelated to this change).

Visually verified against two kind clusters at 880 / 1100 / 1560 / 2200px table widths, with no clipped header on any of: pods, deployments, services, nodes, configmaps, secrets, daemonsets, replicasets, namespaces, endpointslices, storageclasses, rolebindings, clusterroles, networkpolicies, serviceaccounts, kyvernopolicies, jobsets, leaderworkersets, raycronjobs, rayservices and mutatingpolicies. Canvas measurement lands within 0.3px of the width the browser paints.

## Tradeoffs

Reserving both controls costs width. Measured across all 434 curated column sets: eight kinds newly overflow an 880px content area (a 1280px laptop with the sidebar open), none at 1560 or 2200 — against 136 kinds that already overflowed 880. No column is ever squeezed to pay for it; the flexible Name column absorbs the change until the table reaches its minimum and scrolls.

No test simulates the font swap — that invalidation is covered by construction and type-checking only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only table layout and header rendering in k8s-ui; no auth, API, or data-path changes beyond column width and tooltip behavior.
> 
> **Overview**
> Fixes resource table headers clipping (`ADDRESS T…`, etc.) under `table-layout: fixed` by enforcing a **header-derived minimum width** in `getColumnMinWidth`: declared `w-*` vs. padding + measured label text + reserved sort/filter chrome.
> 
> Label width uses canvas `measureText` (with SSR fallback and a **320px cap** for long CRD printer labels), and **`useHeaderFontEpoch`** clears the cache when DM Sans finishes loading so widths don’t stick to fallback metrics. **`isColumnSortable`** is shared between header UI and width math so printer/custom columns with `getSortValue` get sort-icon space. Filter-button space is reserved for any column not in **`SKIP_FILTER_COLUMNS`** (now including Trivy/Kyverno severity/count keys that look filterable but aren’t). **`HeaderLabel`** shows a tooltip when the label still truncates (user resize, cap, active filter).
> 
> Adds **`column-header-width.test.ts`** for the floor behavior; exports **`Column`**, **`getColumnMinWidth`**, **`isColumnSortable`**, and **`useHeaderFontEpoch`** for tests/integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fd98ccacaf9ec8397b846b731f44914d7afc31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->