### PR TITLE
Clarify private investigation links and unavailable access

### DIFF
--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -161,7 +161,10 @@ export function canCopyRunLink(
   return typeof run?.radarUrl === "string" && run.radarUrl.length > 0;
 }
 
-function CopyRunLink({ radarUrl }: { radarUrl: string }) {
+function CopyRunLink({ radarUrl, visibility }: { radarUrl: string; visibility: RunSummary["visibility"] }) {
+  const label = visibility === "private"
+    ? "Copy private link (only you can open it)"
+    : "Copy investigation link";
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
     "idle",
   );
@@ -184,14 +187,14 @@ function CopyRunLink({ radarUrl }: { radarUrl: string }) {
           ? "Link copied"
           : copyState === "error"
             ? "Couldn’t copy link"
-            : "Copy investigation link"
+            : label
       }
       position="bottom"
     >
       <button
         onClick={copy}
         className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
-        aria-label="Copy investigation link"
+        aria-label={label}
       >
         {copyState === "copied" ? (
           <Check className="h-4 w-4 text-emerald-500" />
@@ -425,12 +428,13 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
     </div>
   ) : d.activeRunId && d.runsLoaded ? (
     // A focused id that isn't in the loaded list — a deep link (?ai-run=…) to a
-    // cleared/evicted/unknown run. Say so; the generic "select an
+    // private/revoked/cleared/unknown run. The generic "select an
     // investigation" placeholder would read as a broken link.
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
       <p className="text-sm text-theme-text-secondary">
-        This investigation is no longer available — history keeps the most
-        recent investigations, and this one has been cleared.
+        This investigation is unavailable. It may be private, your access may
+        have changed, or its history may have been cleared. Check your account
+        and organization, or ask the creator for access.
       </p>
       <button
         onClick={d.goHome}
@@ -547,7 +551,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
             <VisibilityControl run={headerRun} onChanged={d.updateRunSummary} />
           )}
           {canCopyRunLink(headerRun) && (
-            <CopyRunLink radarUrl={headerRun.radarUrl} />
+            <CopyRunLink radarUrl={headerRun.radarUrl} visibility={headerRun.visibility} />
           )}
           {headerRun && <InvestigationMenu run={headerRun} />}
           <Tooltip content={maximized ? "Restore" : "Expand"} position="bottom">

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -545,9 +545,10 @@ export function InvestigationView({
                   <div className="flex items-start gap-2">
                     <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
                     <span>
-                      This investigation is no longer available — history keeps
-                      the most recent investigations, and this one has been
-                      cleared. Re-run Diagnose to analyze the current cluster.
+                      This investigation is unavailable. It may be private, your
+                      access may have changed, or its history may have been
+                      cleared. Check your account and organization, or ask the
+                      creator for access.
                     </span>
                   </div>
                   <button


### PR DESCRIPTION
## Summary

Keep investigation links useful without implying that private bookmarks grant access or that every unavailable transcript was deleted.

- Private hosted links say “Copy private link (only you can open it)”. Organization-shared links retain the existing label.
- Both unavailable-investigation surfaces explain possible privacy, changed access or cleared history, with account/org and creator guidance.
- No permission changes. Standalone OSS still has no hosted copy/share controls; those require Hub capabilities.

## Testing

- Radar `make tsc`, `make build`, and 19 targeted DiagnoseSurface tests.
- Hub Web consumer production build with this locally packed Radar source.
- Live browser checks: private-link tooltip and member opening a revoked share. Screenshots captured locally.

Follow-up to merged [#1585](https://github.com/skyhook-io/radar/pull/1585); used with [Hub #218](https://github.com/skyhook-dev/radar-hub/pull/218) and [Web #280](https://github.com/skyhook-dev/radar-hub-web/pull/280). Release/package adoption remains a separate ordered step; no publishing is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and accessibility text only; no API, permissions, or link behavior changes.
> 
> **Overview**
> Updates Diagnose UI copy so users aren’t misled about who can open shared links or why an investigation can’t be loaded.
> 
> **Copy link control** now takes run `visibility`. Private runs use tooltip and `aria-label` **“Copy private link (only you can open it)”**; organization-shared runs keep **“Copy investigation link.”**
> 
> **Unavailable investigation** empty states (deep-linked run missing from the list in `DiagnoseSurface`, and stream-gone with no transcript in `InvestigationView`) replace the old “cleared from history” wording with broader guidance: private run, revoked/changed access, or cleared history, plus account/org checks or asking the creator. Inline comments are aligned with that framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e720aebe23723f258f95f6aff8c8a370e5b90d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->