### PR TITLE
fix(resources): show newly added columns to users who have saved settings

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3139,12 +3139,26 @@ export function mergeSavedVisibleColumns(
   savedVisible: string[],
   extraKeys: string[],
   printerColumns: ExtraColumn[],
+  effective?: Column[],
+  known?: string[],
 ): Set<string> {
   const merged = new Set(savedVisible)
   for (const k of extraKeys) merged.add(k)
   if (!savedVisible.some(k => k.startsWith(PRINTER_COLUMN_PREFIX))) {
     for (const c of printerColumns) {
       if (c.defaultVisible !== false) merged.add(c.key)
+    }
+  }
+  // Curated columns added since the blob was written. Same principle as the two
+  // above, but it needs a record of what the user was actually offered: the blob
+  // stores only what is visible, so a curated key's absence is ambiguous between
+  // "hidden on purpose" and "did not exist yet". `known` is that record. Blobs
+  // written before it existed have none, and stay on the old behaviour rather
+  // than guessing — the next save adopts the current set as their baseline.
+  if (effective && known) {
+    const seen = new Set(known)
+    for (const c of effective) {
+      if (!seen.has(c.key) && c.defaultVisible !== false) merged.add(c.key)
     }
   }
   return merged
@@ -3202,6 +3216,10 @@ interface ColumnSettings {
   visible: string[]
   widths: Record<string, number>
   custom?: CustomColumnDef[]
+  /** Every column key the user was offered when this was written. Lets a later
+   *  load tell a column they hid from one that did not exist yet. Absent on
+   *  blobs written before this field. */
+  known?: string[]
 }
 
 function loadColumnSettings(kind: string, group?: string): ColumnSettings | null {
@@ -3779,6 +3797,12 @@ export function ResourcesView({
     return [...filteredExtras, ...kindColumns, ...builtCustomColumns]
   }, [selectedKind.name, selectedKind.group, extraLeadingColumns, builtCustomColumns, builtPrinterColumns])
 
+  // The offered key set, and a stable signature for it. allColumns is a new
+  // identity on every printer-column refetch; depending on the array itself
+  // would rewrite the settings blob on each poll.
+  const allColumnKeys = useMemo(() => allColumns.map(c => c.key), [allColumns])
+  const allColumnKeysSig = allColumnKeys.join('\u0000')
+
   // Map of extra column keys for fast O(1) lookup on each render path
   // (cell render, sort, column-filter unique-values).
   // Recompute header-derived widths once the web font swaps in (see watchHeaderFont).
@@ -3847,7 +3871,7 @@ export function ResourcesView({
         setVisibleColumns(getDefaultVisibleColumns(effective))
         setColumnWidths({})
       } else {
-        setVisibleColumns(mergeSavedVisibleColumns(saved.visible, extraKeys, builtPrinterColumns))
+        setVisibleColumns(mergeSavedVisibleColumns(saved.visible, extraKeys, builtPrinterColumns, effective, saved.known))
         setColumnWidths(saved.widths || {})
       }
     } else {
@@ -3871,11 +3895,13 @@ export function ResourcesView({
       visible: Array.from(visibleColumns),
       widths: columnWidths,
       custom: customColumns,
+      known: allColumnKeys,
     })
     // A persisted blob blocks GPU auto-show from here on — same rule in-session
     // as across sessions, so a later data refresh can't override user choices.
     hadSavedColumnSettings.current = true
-  }, [visibleColumns, columnWidths, customColumns, selectedKind.name, selectedKind.group])
+    // allColumnKeysSig, not allColumnKeys: see the memo above.
+  }, [visibleColumns, columnWidths, customColumns, selectedKind.name, selectedKind.group, allColumnKeysSig])
 
   // Close column picker on outside click or Escape
   useEffect(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3831,6 +3831,7 @@ export function ResourcesView({
   // — and a shrunk snapshot would forget that a column absent from `visible`
   // was one the user hid rather than one never shown.
   const knownColumnKeys = useRef<Set<string>>(new Set())
+  const knownColumnKeysKind = useRef('')
   // Whether the user has a persisted column blob for this kind — data-driven
   // column defaults (GPU auto-show) must never override explicit user choices.
   const hadSavedColumnSettings = useRef(false)
@@ -3856,9 +3857,15 @@ export function ResourcesView({
     // (non-array, blank path, bad source) must not crash the later .map or add dead columns.
     const savedCustom = sanitizeCustomColumnDefs(saved?.custom)
     setCustomColumns(savedCustom)
-    // Per kind: keys accumulated for the previous one would suppress seeding
-    // here for any key the two happen to share.
-    knownColumnKeys.current = new Set()
+    // Reset on a kind change only. This effect also re-runs when the printer
+    // columns arrive, and that is the moment the offered set shrinks — clearing
+    // here would drop the evidence for the column they replaced just before the
+    // next save persists the record without it.
+    const knownKeysIdentity = selectedKindIdentityOf(selectedKind)
+    if (knownColumnKeysKind.current !== knownKeysIdentity) {
+      knownColumnKeys.current = new Set()
+      knownColumnKeysKind.current = knownKeysIdentity
+    }
     const kindColumns = columnsForKindWithPrinter(selectedKind.name, selectedKind.group, builtPrinterColumns)
     const builtinKeys = new Set(kindColumns.map(c => c.key))
     const extras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3149,15 +3149,21 @@ export function mergeSavedVisibleColumns(
       if (c.defaultVisible !== false) merged.add(c.key)
     }
   }
-  // Curated columns added since the blob was written. Same principle as the two
-  // above, but it needs a record of what the user was actually offered: the blob
-  // stores only what is visible, so a curated key's absence is ambiguous between
-  // "hidden on purpose" and "did not exist yet". `known` is that record. Blobs
-  // written before it existed have none, and stay on the old behaviour rather
-  // than guessing — the next save adopts the current set as their baseline.
-  if (effective && known) {
+  // Curated columns the blob predates. Same principle as the two above, but it
+  // needs a record of what the user was actually offered: the blob stores only
+  // what is visible, so a curated key's absence is ambiguous between "hidden on
+  // purpose" and "not offered yet". `known` is that record. Without one the two
+  // cases are indistinguishable, so nothing is inferred and visibility is left
+  // to the saved set alone.
+  //
+  // Printer columns are excluded even when `known` lists none of them. They are
+  // fetched, so `known` can be written during the window before the printer
+  // table arrives; treating their absence as "new" would re-show ones the user
+  // hid. Their own rule above already covers them.
+  if (effective && Array.isArray(known)) {
     const seen = new Set(known)
     for (const c of effective) {
+      if (c.key.startsWith(PRINTER_COLUMN_PREFIX)) continue
       if (!seen.has(c.key) && c.defaultVisible !== false) merged.add(c.key)
     }
   }
@@ -3871,7 +3877,12 @@ export function ResourcesView({
         setVisibleColumns(getDefaultVisibleColumns(effective))
         setColumnWidths({})
       } else {
-        setVisibleColumns(mergeSavedVisibleColumns(saved.visible, extraKeys, builtPrinterColumns, effective, saved.known))
+        setVisibleColumns(mergeSavedVisibleColumns(
+          saved.visible, extraKeys, builtPrinterColumns, effective,
+          // Persisted JSON: only an array of keys is usable, anything else is
+          // treated as no record at all.
+          Array.isArray(saved.known) ? saved.known.filter((k): k is string => typeof k === 'string') : undefined,
+        ))
         setColumnWidths(saved.widths || {})
       }
     } else {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3825,6 +3825,12 @@ export function ResourcesView({
   // Guards the save effect from persisting on the initial load of each kind
   // (set false by the load effect, flipped true on its first skipped save).
   const isColumnSettingsLoaded = useRef(false)
+  // Every column key this kind has ever offered, accumulated. A single save
+  // cannot stand in for it: the offered set shrinks as well as grows — an
+  // uncurated kind's generic Status disappears once its printer columns arrive
+  // — and a shrunk snapshot would forget that a column absent from `visible`
+  // was one the user hid rather than one never shown.
+  const knownColumnKeys = useRef<Set<string>>(new Set())
   // Whether the user has a persisted column blob for this kind — data-driven
   // column defaults (GPU auto-show) must never override explicit user choices.
   const hadSavedColumnSettings = useRef(false)
@@ -3850,6 +3856,9 @@ export function ResourcesView({
     // (non-array, blank path, bad source) must not crash the later .map or add dead columns.
     const savedCustom = sanitizeCustomColumnDefs(saved?.custom)
     setCustomColumns(savedCustom)
+    // Per kind: keys accumulated for the previous one would suppress seeding
+    // here for any key the two happen to share.
+    knownColumnKeys.current = new Set()
     const kindColumns = columnsForKindWithPrinter(selectedKind.name, selectedKind.group, builtPrinterColumns)
     const builtinKeys = new Set(kindColumns.map(c => c.key))
     const extras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)
@@ -3866,22 +3875,31 @@ export function ResourcesView({
       // discard the stale save and use the specialized columns instead. User-added
       // custom columns mean the blob isn't a stale pure-defaults save — keep it, or
       // the migration would clear them from storage (and un-hide hidden ones).
+      // Persisted JSON: only an array of keys is usable, anything else reads as
+      // no record at all.
+      const savedKnown = Array.isArray(saved.known)
+        ? saved.known.filter((k): k is string => typeof k === 'string')
+        : undefined
+      for (const k of savedKnown ?? []) knownColumnKeys.current.add(k)
+
       const defaultKeys = DEFAULT_COLUMNS.map(c => c.key)
+      // A blob carrying an offered-key record is not a pre-curation leftover:
+      // its visible set matching the generic defaults means the user hid their
+      // way down to them, and clearing it would undo exactly that.
       const isStaleDefaults = kindColumns !== DEFAULT_COLUMNS &&
+        !savedKnown &&
         !savedCustom.length &&
         saved.visible.length === defaultKeys.length &&
         saved.visible.every(v => defaultKeys.includes(v))
       if (isStaleDefaults) {
         clearColumnSettings(selectedKind.name, selectedKind.group)
+        knownColumnKeys.current = new Set()
         hadSavedColumnSettings.current = false
         setVisibleColumns(getDefaultVisibleColumns(effective))
         setColumnWidths({})
       } else {
         setVisibleColumns(mergeSavedVisibleColumns(
-          saved.visible, extraKeys, builtPrinterColumns, effective,
-          // Persisted JSON: only an array of keys is usable, anything else is
-          // treated as no record at all.
-          Array.isArray(saved.known) ? saved.known.filter((k): k is string => typeof k === 'string') : undefined,
+          saved.visible, extraKeys, builtPrinterColumns, effective, savedKnown,
         ))
         setColumnWidths(saved.widths || {})
       }
@@ -3898,6 +3916,7 @@ export function ResourcesView({
   // Save column settings when they change (skip the initial load of each kind)
   useEffect(() => {
     if (visibleColumns.size === 0) return // not loaded yet
+    for (const k of allColumnKeys) knownColumnKeys.current.add(k)
     if (!isColumnSettingsLoaded.current) {
       isColumnSettingsLoaded.current = true
       return
@@ -3906,7 +3925,7 @@ export function ResourcesView({
       visible: Array.from(visibleColumns),
       widths: columnWidths,
       custom: customColumns,
-      known: allColumnKeys,
+      known: Array.from(knownColumnKeys.current),
     })
     // A persisted blob blocks GPU auto-show from here on — same rule in-session
     // as across sessions, so a later data refresh can't override user choices.
@@ -4015,6 +4034,7 @@ export function ResourcesView({
   // Reset column settings to defaults (also drops user-added custom columns)
   const resetColumnSettings = useCallback(() => {
     clearColumnSettings(selectedKind.name, selectedKind.group)
+    knownColumnKeys.current = new Set()
     setCustomColumns([])
     const customKeys = new Set(builtCustomColumns.map(c => c.key))
     setVisibleColumns(getDefaultVisibleColumns(allColumns.filter(c => !customKeys.has(c.key))))

--- a/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
@@ -82,6 +82,18 @@ describe('mergeSavedVisibleColumns', () => {
     expect(call().has('status')).toBe(false)
   })
 
+  it('keeps a column hidden after the offered set shrinks and grows again', () => {
+    // Uncurated kinds offer a generic Status until their printer columns arrive,
+    // and stop offering it afterwards. If the record were replaced on each save
+    // rather than accumulated, that second save would forget Status was ever
+    // offered — and a later load without printer data would read the user's
+    // hide as "never shown" and undo it.
+    const known = ['name', 'namespace', 'status', 'age', 'printer:Phase']
+    const effective = [col('name'), col('namespace'), col('status'), col('age')]
+    const got = mergeSavedVisibleColumns(['name', 'namespace', 'age'], [], [], effective, known)
+    expect(got.has('status')).toBe(false)
+  })
+
   it('seeds a new curated column alongside printer columns without disturbing them', () => {
     const cols = [printer('printer:Phase')]
     const effective = [col('name'), col('lastSuccess'), printer('printer:Phase')]

--- a/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { mergeSavedVisibleColumns, type Column, type ExtraColumn } from './ResourcesView'
+
+// A saved blob records only what is VISIBLE, so a curated key's absence is
+// ambiguous: the user hid it, or it did not exist when they saved. `known` — the
+// key set they were offered at save time — is what separates the two. Without
+// it, every column added to a curated kind is invisible to anyone who has ever
+// touched that kind's column picker.
+
+const col = (key: string, defaultVisible?: boolean): Column =>
+  defaultVisible === undefined ? { key, label: key } : { key, label: key, defaultVisible }
+
+const printer = (key: string, defaultVisible?: boolean): ExtraColumn =>
+  ({ ...col(key, defaultVisible), render: () => null })
+
+describe('mergeSavedVisibleColumns', () => {
+  it('shows a curated column added since the blob was written', () => {
+    const effective = [col('name'), col('status'), col('lastSuccess')]
+    const got = mergeSavedVisibleColumns(['name', 'status'], [], [], effective, ['name', 'status'])
+    expect(got.has('lastSuccess')).toBe(true)
+  })
+
+  it('keeps a column the user actually hid hidden', () => {
+    // 'status' was offered and is absent from visible — a deliberate hide.
+    const effective = [col('name'), col('status')]
+    const got = mergeSavedVisibleColumns(['name'], [], [], effective, ['name', 'status'])
+    expect(got.has('status')).toBe(false)
+  })
+
+  it('respects defaultVisible:false on a newly added column', () => {
+    const effective = [col('name'), col('podIP', false)]
+    const got = mergeSavedVisibleColumns(['name'], [], [], effective, ['name'])
+    expect(got.has('podIP')).toBe(false)
+  })
+
+  it('leaves blobs written before `known` on the old behaviour', () => {
+    // No record of what was offered, so absence stays ambiguous and we don't
+    // guess — the next save adopts the current set as the baseline.
+    const effective = [col('name'), col('status'), col('lastSuccess')]
+    const got = mergeSavedVisibleColumns(['name', 'status'], [], [], effective, undefined)
+    expect(got.has('lastSuccess')).toBe(false)
+    expect(Array.from(got).sort()).toEqual(['name', 'status'])
+  })
+
+  it('does nothing without the effective column set', () => {
+    const got = mergeSavedVisibleColumns(['name'], [], [], undefined, ['name'])
+    expect(Array.from(got)).toEqual(['name'])
+  })
+
+  it('still seeds host extras unconditionally', () => {
+    const got = mergeSavedVisibleColumns(['name'], ['cluster'], [], [col('name')], ['name'])
+    expect(got.has('cluster')).toBe(true)
+  })
+
+  it('still seeds printer columns only when the blob names none', () => {
+    const cols = [printer('printer:Phase'), printer('printer:Ready')]
+    expect(mergeSavedVisibleColumns(['name'], [], cols).has('printer:Phase')).toBe(true)
+    // Once the blob names one, the user has seen the set — absence is a hide.
+    expect(mergeSavedVisibleColumns(['name', 'printer:Ready'], [], cols).has('printer:Phase')).toBe(false)
+  })
+
+  it('seeds a new curated column alongside printer columns without disturbing them', () => {
+    const cols = [printer('printer:Phase')]
+    const effective = [col('name'), col('lastSuccess'), printer('printer:Phase')]
+    const got = mergeSavedVisibleColumns(['name', 'printer:Phase'], [], cols, effective, ['name', 'printer:Phase'])
+    expect(got.has('lastSuccess')).toBe(true)
+    expect(got.has('printer:Phase')).toBe(true)
+  })
+})

--- a/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-settings-merge.test.ts
@@ -59,6 +59,29 @@ describe('mergeSavedVisibleColumns', () => {
     expect(mergeSavedVisibleColumns(['name', 'printer:Ready'], [], cols).has('printer:Phase')).toBe(false)
   })
 
+  it('does not re-show a hidden printer column when known predates the printer table', () => {
+    // Printer columns are fetched, so `known` can be written during the window
+    // before the table arrives — listing curated keys only. Treating their
+    // absence as "not offered yet" would un-hide one the user had hidden.
+    const cols = [printer('printer:Phase'), printer('printer:Ready')]
+    const effective = [col('name'), ...cols]
+    const got = mergeSavedVisibleColumns(
+      ['name', 'printer:Phase'], [], cols, effective,
+      ['name'], // written before the printer table loaded
+    )
+    expect(got.has('printer:Ready')).toBe(false)
+    expect(got.has('printer:Phase')).toBe(true)
+  })
+
+  it('treats a persisted known that is not an array as no record at all', () => {
+    // The blob is untyped JSON and can be corrupted or hand-edited; a throw
+    // here would abort the load effect and strand the table's column state.
+    const effective = [col('name'), col('status')]
+    const call = () => mergeSavedVisibleColumns(['name'], [], [], effective, {} as unknown as string[])
+    expect(call).not.toThrow()
+    expect(call().has('status')).toBe(false)
+  })
+
   it('seeds a new curated column alongside printer columns without disturbing them', () => {
     const cols = [printer('printer:Phase')]
     const effective = [col('name'), col('lastSuccess'), printer('printer:Phase')]


### PR DESCRIPTION
## Summary

A saved column blob records only which keys are **visible**. That makes a curated key's absence ambiguous — the user hid it, or it did not exist when they saved — and `mergeSavedVisibleColumns` resolved the ambiguity toward "hidden" for every curated column, seeding only host extras and printer columns.

The effect: **anyone who has ever opened a kind's column picker never sees a column added to that kind afterwards.** The blob is per kind, so it is not all-or-nothing across the app — it silently applies to whichever kinds a user has customised.

This matters now because a run of column changes is queued behind it. Without this, each one ships to new users only, and a change that adds one column while hiding another can apply the hide without the add, leaving that table worse than before.

## What changed

`ColumnSettings` gains `known?: string[]` — the keys the user has been offered for this kind. `mergeSavedVisibleColumns` uses it to separate the two cases:

- a key **absent** from `known` was never offered, so it defaults by its own `defaultVisible`;
- a key **present** in `known` but absent from `visible` was offered and dismissed, so it stays hidden.

This is the same principle the helper already applies to host extras and printer columns — *a user cannot have decided to hide something they were never shown* — extended to the one column category that was never covered.

Three properties the record has to hold, each of which took a fix:

**It accumulates, rather than being a snapshot.** The offered set shrinks as well as grows: an uncurated kind offers a generic Status column until its printer columns arrive, and stops offering it after. Writing each save's snapshot as the whole record forgot Status had ever been offered, so a later load without printer data read the user's hide as "never shown" and undid it. The record is now the union across saves, cleared only on an explicit reset or when the migration below discards the blob.

**It is reset on a kind change, and only then.** Keys accumulated for one kind must not suppress seeding for another that shares a key name — but the load effect also re-runs when the printer columns arrive, which is exactly when the offered set shrinks. Resetting there would drop the evidence for the column they replaced, just before the next save persists the record without it.

**Printer columns are excluded from seeding.** They are fetched, so the record can be written during the window before the printer table arrives. Treating their absence as "not offered yet" would re-show ones the user hid; their own rule already governs them.

## Stale-defaults migration

`isStaleDefaults` now additionally requires that the blob carry no record. Hiding a specialized kind's columns down to name/namespace/status/age produced a visible set matching the generic defaults, which the migration read as a pre-curation leftover and cleared — restoring every column the user had just hidden. Its own comment already flagged that risk and guarded only against custom columns. A record is the evidence it was missing, so the heuristic now applies only to blobs that predate one.

## Compatibility

Blobs written before `known` existed carry none. They keep the previous behaviour rather than guessing, and their next save establishes a baseline, so the gap closes per kind with no migration pass and no reset.

## Reviewer notes

The invariant worth checking is that **a column the user hid never comes back**. Three of the four fixes above exist only to hold it, and it is pinned at the helper boundary by the hidden-column, hidden-printer-column, and shrink-then-grow tests.

Known gap, deliberately not closed: there is no component-level test exercising effect ordering across kind switches and refetches. The helper tests pin the merge semantics; testing the accumulation lifecycle would mean rendering a 9k-line component, and the cost did not look worth it. Flagging it rather than implying coverage that isn't there.

## Testing

`make tsc` clean. `column-settings-merge.test.ts` — 11 tests: a new column appears; a hidden column stays hidden; a hidden printer column stays hidden when the record predates the printer table; a column stays hidden after the offered set shrinks and grows again; `defaultVisible: false` respected on a new column; pre-`known` blobs unchanged; malformed `known` neither throws nor infers; host extras still seeded unconditionally; printer columns still seeded only when the blob names none.

`packages/k8s-ui`: 3430 passed, 1 skipped. The one failing file (`resource-utils-hpa.test.ts`) fails identically on `main` — a fixture path resolved from the runner's cwd, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes localStorage column-settings shape and load/save merge heuristics; mistakes could resurrect hidden columns or wipe customised layouts, though behaviour is covered by targeted unit tests.
> 
> **Overview**
> Saved resource table column preferences only stored **visible** keys, so newly added curated columns stayed hidden for anyone who had already customised that kind. This change adds a persisted **`known`** list of every column key the user has been offered and extends **`mergeSavedVisibleColumns`** to auto-show keys that were never in `known` (unless `defaultVisible: false`), while keys in `known` but not in `visible` remain deliberately hidden.
> 
> **`ResourcesView`** accumulates offered keys across saves (not per-save snapshots), resets that accumulator on kind change or column reset, writes `known` with each save, and passes **`effective`** + saved **`known`** into the merge on load. Printer columns are excluded from this curated seeding so a record written before printer data loads cannot resurrect hidden printer columns. The stale-defaults blob migration now skips blobs that already have **`known`**, so users who hid specialised columns down to generic defaults are not cleared back to full visibility.
> 
> New **`column-settings-merge.test.ts`** covers merge behaviour (new vs hidden columns, pre-`known` blobs, malformed `known`, printer edge cases, shrinking offered sets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34966a72777e8bb0ca241c6f59769c36de575e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
