### PR TITLE
test(k8s): wait for informer status before InitTestResourceCache returns

### DIFF
--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -113,7 +113,40 @@ func InitTestResourceCache(client kubernetes.Interface) error {
 	cacheOnce = new(sync.Once)
 	cacheOnce.Do(func() {})
 
+	waitForInformerStatuses(resourceCache)
+
 	return nil
+}
+
+// waitForInformerStatuses blocks until every informer's InformerSyncStatus
+// reports synced.
+//
+// NewResourceCache returns as soon as the informers themselves report synced,
+// but InformerSyncStatus.Synced is a mirror of that, flipped by a goroutine per
+// informer. Nothing in the product waits on the mirror, so the gap is invisible
+// there — but IsKindReady reads it, and the missing-reference detectors gate on
+// IsKindReady and fail toward silence, so a test that queries on the next line
+// can see a fully-populated cache report nothing at all.
+//
+// The gap is normally sub-millisecond and closes on its own; it only widens
+// when the machine is loaded enough to delay scheduling those goroutines, which
+// is why this reproduced in CI and never locally.
+//
+// Best-effort: on timeout the caller proceeds and its own assertions report the
+// real problem, rather than this returning an error that every call site would
+// have to handle.
+func waitForInformerStatuses(rc *ResourceCache) {
+	if rc == nil {
+		return
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		st := rc.GetSyncStatus()
+		if len(st.PendingCritical) == 0 && len(st.PendingDeferred) == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // InitTestDynamicResourceCache wires the dynamic resource cache and discovery


### PR DESCRIPTION
## Summary

`TestDetectIngressMissingIngressClass` failed in CI. A rerun of the failed job with **no code change went green**, so this looks for the mechanism rather than re-running until it passes.

`NewResourceCache` returns as soon as the informers themselves report synced. `InformerSyncStatus.Synced` is a **mirror** of that, flipped by a goroutine per informer, so the two disagree for a moment after construction.

Nothing in the product waits on the mirror — but `IsKindReady` reads it, and the missing-reference detectors gate on `IsKindReady` and deliberately fail toward silence, because a confident "Missing IngressClass" built on an unobserved kind would fire on every namespace-restricted install. So a test that queries on the very next line can watch a fully-populated cache report nothing:

```
detect_missing_refs_test.go:872: IngressClass problems = [], want only the old authoritative named miss
```

The failing run shows the window directly: **`Critical resource caches synced in 15.86µs`**, against ~100ms on every other line. The sync loop found everything already synced and broke without sleeping once, so the tracking goroutines had not been scheduled yet.

## What changed

One line in `InitTestResourceCache`, plus the helper it calls: wait for `GetSyncStatus()` to report nothing pending before returning. That is the same field `IsKindReady` reads, so the helper's post-condition now matches what its ~150 call sites ask of it on the following line.

`InitLoadTestResourceCache` deliberately does **not** get the barrier — it exists to exercise the real critical/deferred startup phases, and waiting would erase what it measures.

## Evidence, and its limits

**I could not reproduce this locally.** Not at `-count=10`, not as a full package run, and not with the barrier removed under `GOMAXPROCS=1` at `-count=200` (green, 21.8s). The case for the mechanism rests on the CI log and the code path, not on a local repro — reviewers should weigh it on that basis.

There is deliberately **no new test**. A test asserting the helper's post-condition would pass with or without this change on any machine where the gap is sub-millisecond, which is every machine I can run it on. A green test that stays green without the code it purports to protect is not regression coverage, and the barrier's own comment is the durable explanation for why it must not be removed.

## Why the barrier is here and not in `IsKindReady`

The first version of this fix changed `IsKindReady` to answer from the informers directly, keeping the mirror as a fast path. That is arguably the more correct fix, and it was dropped on purpose.

The production window it closes is sub-millisecond, opens only at cache construction (startup and context switch), and self-heals immediately: all three call sites — the dashboard handler, the MCP tool, and the capacity namespace gate — recompute per request and none memoize. Against that, the change added a `HasSynced()` call on a path holding `informerMu.RLock()`, inside a per-resource detector loop, in a package `skyhook-connector` also depends on. That is new logic in cache/sync code — the category where a wrong call is most expensive and least visible — bought for a defect no user can observe.

## Testing

`internal/k8s` passes at `-count=2` in 54.3s, against 59.4s before the change. No measurable cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)