### PR TITLE
Restore context-preserving handoff from automatic investigations

### DIFF
--- a/web/src/api/diagnose.test.ts
+++ b/web/src/api/diagnose.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRun } from "./diagnose";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("investigation start requests", () => {
+  const target = {
+    kind: "Deployment",
+    namespace: "prod",
+    name: "payments",
+    issueId: "issue-1",
+  };
+
+  it.each([
+    ["investigate further", target],
+    ["start fresh", { ...target, fresh: true }],
+  ])("preserves the %s intent on the wire", async (_name, request) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "new-run" })));
+    vi.stubGlobal("fetch", fetch);
+    await createRun(request, { agent: "hub" });
+    const init = fetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      ...request,
+      agent: "hub",
+    });
+    expect(JSON.parse(init.body as string).issueId).toBe("issue-1");
+  });
+});

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { canCopyRunLink, canStartNewInvestigation } from "./DiagnoseSurface";
 import {
   canContinueInvestigation,
+  canInvestigateFurther,
   canStopInvestigation,
 } from "./InvestigationView";
 import type { RunSummary } from "../../api/diagnose";
@@ -179,5 +180,45 @@ describe("canCopyRunLink", () => {
 
   it("treats an empty hosted URL as unavailable", () => {
     expect(canCopyRunLink({ ...run("done"), radarUrl: "" })).toBe(false);
+  });
+});
+
+describe("canInvestigateFurther", () => {
+  it("offers a context-preserving next step on a completed automatic investigation", () => {
+    expect(
+      canInvestigateFurther({
+        ...run("done"),
+        trigger: "background",
+        issueId: "issue-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not promise findings for missing, unfinished, stale or human investigations", () => {
+    expect(canInvestigateFurther(run("done"))).toBe(false);
+    expect(
+      canInvestigateFurther({ ...run("done"), trigger: "background" }),
+    ).toBe(false);
+    for (const status of [
+      "running",
+      "stopping",
+      "error",
+      "stopped",
+      "stale",
+    ] as const) {
+      expect(
+        canInvestigateFurther({
+          ...run(status),
+          trigger: "background",
+          issueId: "issue-1",
+        }),
+      ).toBe(false);
+    }
+    expect(
+      canInvestigateFurther(
+        { ...run("done"), trigger: "background", issueId: "issue-1" },
+        true,
+      ),
+    ).toBe(false);
   });
 });

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -527,7 +527,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
           {headerRun &&
             canStartNewInvestigation(d.view, headerRun, d.needsConsent) && (
               <Tooltip
-                content="New investigation on this resource"
+                content="Start fresh — ignore earlier findings"
                 position="bottom"
               >
                 <button
@@ -541,7 +541,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
                     })
                   }
                   className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
-                  aria-label="New investigation on this resource"
+                  aria-label="Start fresh — ignore earlier findings"
                 >
                   <Plus className="h-4 w-4" />
                 </button>

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -73,6 +73,15 @@ export function canContinueInvestigation(
   );
 }
 
+export function canInvestigateFurther(run: RunSummary, gone = false): boolean {
+  return (
+    !gone &&
+    run.trigger === "background" &&
+    run.status === "done" &&
+    !!run.issueId
+  );
+}
+
 export function InvestigationView({
   run,
   agentLabel,
@@ -685,9 +694,39 @@ export function InvestigationView({
           </div>
         ) : !canContinue ? (
           <div className="rounded-lg border border-theme-border bg-theme-base px-3 py-2 text-xs text-theme-text-secondary">
-            {run.trigger === "background"
-              ? "Automatic investigation · read-only. Start a new investigation on this resource to continue digging."
-              : "This investigation is read-only."}
+            {run.trigger === "background" ? (
+              <>
+                <p>Automatic investigation · read-only.</p>
+                {canInvestigateFurther(run, gone) ? (
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <button
+                      className="btn-brand px-3 py-2 text-xs"
+                      onClick={() =>
+                        openInvestigation({
+                          kind,
+                          namespace,
+                          name,
+                          issueId: run.issueId,
+                        })
+                      }
+                    >
+                      Investigate further
+                    </button>
+                    <span>
+                      Re-checks current state, including recent automatic
+                      findings when available.
+                    </span>
+                  </div>
+                ) : (
+                  <p>
+                    Start a new investigation on this resource to continue
+                    digging.
+                  </p>
+                )}
+              </>
+            ) : (
+              "This investigation is read-only."
+            )}
           </div>
         ) : (
           <div className="flex items-end gap-2">


### PR DESCRIPTION
## Summary

Restore the path from retained automatic evidence to a human investigation without
discarding the available findings or turning the original transcript into a mutable chat.

Completed automatic investigations offer **Investigate further**. It opens a new
human conversation with the original resource and issue ID, using Hub's existing
recent-verdict seeding. The header's separate action is explicitly labeled
**Start fresh — ignore earlier findings** and sends `fresh: true`.

The new action requires a completed background run with an issue ID; running,
failed, stopped, stale and unavailable runs do not advertise this handoff. Copy
does not promise findings when no eligible recent verdict exists.

## OSS versus hosted behavior

- **Radar Cloud SaaS and licensed self-hosted Hub:** automatic retained evidence
  supports the new context-preserving handoff. The original transcript stays read-only.
- **Standalone OSS Radar:** no organization sharing or hosted-copy controls are
  introduced. Existing human investigation behavior remains; the fresh-start
  tooltip now states its intent explicitly.

This is verdict seeding, not a full transcript or SDK-session fork, and it does
not change sharing permissions or model-provider consent.

## Verification

| Journey | Proof |
|---|---|
| Completed automatic evidence → Investigate further | Actual local browser click sends resource + issueId without fresh |
| Explicit fresh start | Actual local browser click sends same target + issueId and fresh:true |
| Ineligible state / OSS human run | Eligibility matrix covers absent issueId, human trigger, running/error/stopped/stale/gone states |
| Request serialization | Both start intents tested at API boundary |
| Standalone build | Type-check, 23 targeted tests, full frontend/embed/Go build pass |

Browser verification used real local Hub/Postgres and synthetic retained evidence
on the existing kind cluster. Job POSTs were intentionally intercepted; this is UI
request proof, not a newly executed model investigation. Hub separately tests prompt
seeding and authorization. Screenshots were captured and inspected locally.

## Dependencies

Follows merged [Radar #1640](https://github.com/skyhook-io/radar/pull/1640).
Uses the issueId and prior-evidence authorization from merged [Hub #218](https://github.com/skyhook-dev/radar-hub/pull/218).
The retained-evidence entrypoint is in merged [Web #280](https://github.com/skyhook-dev/radar-hub-web/pull/280).
Published radar-app 1.13.1 does not include this change. After merging, publish a new
Radar package and adopt it in Web to complete the context-preserving handoff.
No package publication or deployment is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only diagnose flow changes with guarded eligibility; no auth or sharing logic modified in this diff.
> 
> **Overview**
> Restores a **context-preserving** path from completed automatic investigations into a new human run, while keeping the original automatic transcript read-only.
> 
> Eligible background runs (`done`, with `issueId`) now show an **Investigate further** action that starts a new investigation with the same resource and issue ID and **without** `fresh: true`, so Hub can seed from recent verdict evidence. The header **+** control is relabeled **Start fresh — ignore earlier findings** and continues to pass `fresh: true` for an explicit clean slate.
> 
> `canInvestigateFurther` centralizes eligibility (no handoff for in-flight, failed, stopped, stale, missing issue, human runs, or when the run is gone). Copy falls back to generic “start a new investigation” when further investigation isn’t offered.
> 
> Adds Vitest coverage for the eligibility matrix and for `createRun` POST bodies for both start intents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0815ae8c01f96c8c2eff492de115a5d4ee85de02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->