### PR TITLE
fix(resources): stop three status cells claiming health they never checked

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -110,6 +110,7 @@ import {
   getGatewayClassController,
   getGatewayClassDescription,
   getRouteStatus,
+  getRouteStatusReason,
   getRouteParents,
   getRouteHostnames,
   getRouteBackends,
@@ -8964,11 +8965,11 @@ function RouteCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status': {
       const status = getRouteStatus(resource)
-      return (
-        <span className={clsx('badge', status.color)}>
-          {status.text}
-        </span>
-      )
+      const reason = getRouteStatusReason(resource)
+      const badge = <span className={clsx('badge', status.color)}>{status.text}</span>
+      // "Degraded" on its own says something is wrong and not what. The
+      // controller's own reason is usually "the backend you named is missing".
+      return reason ? <Tooltip content={reason}>{badge}</Tooltip> : badge
     }
     case 'hostnames': {
       const hostnames = getRouteHostnames(resource)

--- a/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-gateway-filter.test.ts
@@ -13,13 +13,15 @@ describe('Istio Gateway filter values', () => {
     const tls = gateway({ servers: [{ port: { number: 443 }, tls: { mode: 'SIMPLE' } }] })
     const plain = gateway({ servers: [{ port: { number: 80 } }] })
     const none = gateway({ servers: [] })
-    expect(getCellFilterValue(tls, 'status', 'istiogateways')).toBe('TLS')
-    expect(getCellFilterValue(plain, 'status', 'istiogateways')).toBe('Active')
+    // TLS and plain share a verdict: neither says whether the gateway's
+    // selector resolves to a running pod, which is what a status column claims.
+    expect(getCellFilterValue(tls, 'status', 'istiogateways')).toBe('Defined')
+    expect(getCellFilterValue(plain, 'status', 'istiogateways')).toBe('Defined')
     expect(getCellFilterValue(none, 'status', 'istiogateways')).toBe('No Servers')
   })
 
   // Read as a Gateway API Gateway instead, the same object filters as
-  // "Unknown" — a value that appears on no row, since the cell shows Active.
+  // "Unknown" — a value that appears on no row, since the cell shows Defined.
   // That divergence is what routing the normalized key fixes.
   it('diverges from the row when read under the Gateway API key', () => {
     const g = gateway({ servers: [{ port: { number: 80 } }] })

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -190,6 +190,15 @@ export function getDestinationRuleLoadBalancer(resource: any): string {
 // ISTIO GATEWAY UTILITIES
 // ============================================================================
 
+/**
+ * What spec.servers alone can honestly claim.
+ *
+ * Not liveness: an Istio Gateway whose spec.selector matches no running
+ * ingressgateway pod is how these actually fail, and it has servers like any
+ * other. A green badge there says the opposite of the truth. TLS is likewise a
+ * property of a server, not a verdict, and it was occupying the one slot every
+ * other kind here uses for one.
+ */
 export function getIstioGatewayStatus(resource: any): StatusBadge {
   const servers = resource.spec?.servers || []
 
@@ -197,12 +206,7 @@ export function getIstioGatewayStatus(resource: any): StatusBadge {
     return { text: 'No Servers', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
-  const hasTLS = servers.some((s: any) => s.tls)
-  if (hasTLS) {
-    return { text: 'TLS', color: healthColors.healthy, level: 'healthy' }
-  }
-
-  return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
+  return { text: 'Defined', color: healthColors.neutral, level: 'neutral' }
 }
 
 export function getIstioGatewayServers(resource: any): Array<{

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -195,9 +195,9 @@ export function getDestinationRuleLoadBalancer(resource: any): string {
  *
  * Not liveness: an Istio Gateway whose spec.selector matches no running
  * ingressgateway pod is how these actually fail, and it has servers like any
- * other. A green badge there says the opposite of the truth. TLS is likewise a
- * property of a server, not a verdict, and it was occupying the one slot every
- * other kind here uses for one.
+ * other, so a green badge there would say the opposite of the truth. TLS is a
+ * property of a server rather than a verdict, and this slot is the one every
+ * other kind here uses for a verdict.
  */
 export function getIstioGatewayStatus(resource: any): StatusBadge {
   const servers = resource.spec?.servers || []

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1897,7 +1897,12 @@ function isReportForParentRef(ref: any, reported: any, routeNamespace: string): 
  * routes always carry both, so a missing one means nothing has confirmed the
  * refs yet.
  */
-export function getRouteStatus(route: any): StatusBadge {
+/**
+ * The reports that describe parents this route is actually attached to, plus
+ * the readers the verdict uses. Shared with getRouteStatusReason so the badge
+ * and its explanation can never disagree about which parents counted.
+ */
+function routeParentEvidence(route: any) {
   const refs = route.spec?.parentRefs || []
   const reports = route.status?.parents || []
   const routeNamespace = route.metadata?.namespace || ''
@@ -1930,8 +1935,6 @@ export function getRouteStatus(route: any): StatusBadge {
     ? [...perRef.flat(), ...reports.filter((p: any) => !claimed.has(p) && isDefaultGatewayReport(p))]
     : perRef.flat()
 
-  if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
-
   // A condition observed against a superseded generation describes a spec that
   // has since changed, so it cannot confirm the current one. A condition with no
   // observedGeneration at all is taken at face value.
@@ -1940,8 +1943,15 @@ export function getRouteStatus(route: any): StatusBadge {
   const conditionOf = (report: any, type: string) =>
     (report?.conditions || []).filter((c: any) => c?.type === type && isCurrent(c)).pop()
   const statusOf = (report: any, type: string) => conditionOf(report, type)?.status
-
   const everyRefReported = perRef.every((list: any[]) => list.length > 0)
+
+  return { considered, everyRefReported, conditionOf, statusOf }
+}
+
+export function getRouteStatus(route: any): StatusBadge {
+  const { considered, everyRefReported, statusOf } = routeParentEvidence(route)
+
+  if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
   const anyFailure = considered.some((r: any) =>
     statusOf(r, 'Accepted') === 'False' || statusOf(r, 'ResolvedRefs') === 'False')
 
@@ -1956,6 +1966,27 @@ export function getRouteStatus(route: any): StatusBadge {
     return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
   }
   return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+}
+
+/**
+ * Why the badge says what it says: which parent is unhappy, and the controller's
+ * own reason. Without it "Degraded" tells an operator something is wrong and
+ * nothing about what — and the whole point of reading ResolvedRefs is that the
+ * answer is usually "the backend you named does not exist".
+ */
+export function getRouteStatusReason(route: any): string {
+  const { considered, conditionOf } = routeParentEvidence(route)
+  const parts: string[] = []
+  for (const report of considered) {
+    const name = report?.parentRef?.name || 'parent'
+    for (const type of ['Accepted', 'ResolvedRefs']) {
+      const c = conditionOf(report, type)
+      if (c?.status !== 'False') continue
+      const detail = [c.reason, c.message].filter(Boolean).join(': ')
+      parts.push(detail ? `${name}: ${detail}` : `${name}: ${type} is false`)
+    }
+  }
+  return parts.join(' · ')
 }
 
 export function getRouteParents(route: any): string {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1903,31 +1903,49 @@ export function getRouteStatus(route: any): StatusBadge {
   const routeNamespace = route.metadata?.namespace || ''
   const generation = route.metadata?.generation
 
-  const matched = refs
-    .map((ref: any) => reports.find((p: any) => isReportForParentRef(ref, p?.parentRef, routeNamespace)))
-    .filter(Boolean)
-  if (matched.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  // Every report for a parent, not the first: status entries are identified by
+  // parentRef AND controllerName, so one parent can carry reports from two
+  // controllers mid-replacement. Taking one made the verdict depend on their
+  // order in the array.
+  const reportsFor = (ref: any) =>
+    reports.filter((p: any) => isReportForParentRef(ref, p?.parentRef, routeNamespace))
+  const perRef = refs.map(reportsFor)
 
-  // A condition observed against an older generation describes a spec that has
-  // since changed, so it cannot confirm the current one.
+  // A route can also attach to default Gateways without naming them, in which
+  // case the attachment exists only in status. Those reports are real and their
+  // failures must count. Without that opt-in an unmatched report is a leftover
+  // from a parentRef the spec no longer names, and counting it would resurrect
+  // a verdict for a parent the route has left.
+  const useDefaultGateways = route.spec?.useDefaultGateways
+  const attachedByDefault = useDefaultGateways !== undefined && useDefaultGateways !== 'None'
+  const claimed = new Set(perRef.flat())
+  const considered = attachedByDefault
+    ? [...perRef.flat(), ...reports.filter((p: any) => !claimed.has(p))]
+    : perRef.flat()
+
+  if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+
+  // A condition observed against a superseded generation describes a spec that
+  // has since changed, so it cannot confirm the current one. A condition with no
+  // observedGeneration at all is taken at face value.
   const isCurrent = (c: any) =>
     c?.observedGeneration === undefined || generation === undefined || c.observedGeneration === generation
   const conditionOf = (report: any, type: string) =>
     (report?.conditions || []).filter((c: any) => c?.type === type && isCurrent(c)).pop()
+  const statusOf = (report: any, type: string) => conditionOf(report, type)?.status
 
-  const accepted = matched.map((r: any) => conditionOf(r, 'Accepted'))
-  const resolved = matched.map((r: any) => conditionOf(r, 'ResolvedRefs'))
-  const everyParentReported = matched.length === refs.length
+  const everyRefReported = perRef.every((list: any[]) => list.length > 0)
+  const anyFailure = considered.some((r: any) =>
+    statusOf(r, 'Accepted') === 'False' || statusOf(r, 'ResolvedRefs') === 'False')
 
-  if (everyParentReported && accepted.every((c: any) => c?.status === 'False')) {
+  if (everyRefReported && considered.every((r: any) => statusOf(r, 'Accepted') === 'False')) {
     return { text: 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
   }
-  if (accepted.some((c: any) => c?.status === 'False') || resolved.some((c: any) => c?.status === 'False')) {
+  if (anyFailure) {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
-  if (everyParentReported &&
-      accepted.every((c: any) => c?.status === 'True') &&
-      resolved.every((c: any) => c?.status === 'True')) {
+  if (everyRefReported && considered.every((r: any) =>
+      statusOf(r, 'Accepted') === 'True' && statusOf(r, 'ResolvedRefs') === 'True')) {
     return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
   }
   return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
@@ -2022,7 +2040,11 @@ export function getNetworkPolicyRuleCount(np: any): { ingress: number; egress: n
 export function getNetworkPolicySelector(np: any): string {
   const selector = np.spec?.podSelector
   const hasLabels = Object.keys(selector?.matchLabels ?? {}).length > 0
-  const hasExpressions = Array.isArray(selector?.matchExpressions) && selector.matchExpressions.length > 0
+  // Count only what the formatter will actually render: it skips malformed
+  // entries, and an expression list of nothing but those would otherwise reach
+  // its empty-case string and describe the same state in different words.
+  const hasExpressions = (Array.isArray(selector?.matchExpressions) ? selector.matchExpressions : [])
+    .some((e: any) => e && typeof e === 'object')
   if (!hasLabels && !hasExpressions) return 'All pods'
   return formatKubernetesLabelSelector(selector)
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1943,32 +1943,36 @@ function routeParentEvidence(route: any) {
   const conditionOf = (report: any, type: string) =>
     (report?.conditions || []).filter((c: any) => c?.type === type && isCurrent(c)).pop()
   const statusOf = (report: any, type: string) => conditionOf(report, type)?.status
-  const everyRefReported = perRef.every((list: any[]) => list.length > 0)
 
-  return { considered, everyRefReported, conditionOf, statusOf }
+  // A report whose conditions all describe a superseded spec says nothing about
+  // the current one, either way — so it neither votes nor confirms the parent it
+  // belongs to. Requiring it to agree would let one leftover from a replaced
+  // controller hold a live healthy parent at Pending; counting it as
+  // confirmation would let the other parents speak for one nothing has
+  // confirmed.
+  const speaksToCurrentSpec = (r: any) =>
+    conditionOf(r, 'Accepted') !== undefined || conditionOf(r, 'ResolvedRefs') !== undefined
+  const current = considered.filter(speaksToCurrentSpec)
+  const everyRefConfirmed = perRef.every((list: any[]) => list.some(speaksToCurrentSpec))
+
+  return { considered, current, everyRefConfirmed, conditionOf, statusOf }
 }
 
 export function getRouteStatus(route: any): StatusBadge {
-  const { considered, everyRefReported, conditionOf, statusOf } = routeParentEvidence(route)
+  const { considered, current, everyRefConfirmed, statusOf } = routeParentEvidence(route)
 
   if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
-
-  // A report whose conditions all describe a superseded spec says nothing about
-  // the current one, either way. Requiring it to agree would let one leftover
-  // from a replaced controller hold a live healthy parent at Pending.
-  const current = considered.filter((r: any) =>
-    conditionOf(r, 'Accepted') !== undefined || conditionOf(r, 'ResolvedRefs') !== undefined)
   if (current.length === 0) return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
   const anyFailure = current.some((r: any) =>
     statusOf(r, 'Accepted') === 'False' || statusOf(r, 'ResolvedRefs') === 'False')
 
-  if (everyRefReported && current.every((r: any) => statusOf(r, 'Accepted') === 'False')) {
+  if (everyRefConfirmed && current.every((r: any) => statusOf(r, 'Accepted') === 'False')) {
     return { text: 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
   }
   if (anyFailure) {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
-  if (everyRefReported && current.every((r: any) =>
+  if (everyRefConfirmed && current.every((r: any) =>
       statusOf(r, 'Accepted') === 'True' && statusOf(r, 'ResolvedRefs') === 'True')) {
     return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
   }
@@ -1982,9 +1986,9 @@ export function getRouteStatus(route: any): StatusBadge {
  * answer is usually "the backend you named does not exist".
  */
 export function getRouteStatusReason(route: any): string {
-  const { considered, conditionOf } = routeParentEvidence(route)
+  const { current, conditionOf } = routeParentEvidence(route)
   const parts: string[] = []
-  for (const report of considered) {
+  for (const report of current) {
     const name = report?.parentRef?.name || 'parent'
     for (const type of ['Accepted', 'ResolvedRefs']) {
       const c = conditionOf(report, type)

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1908,10 +1908,10 @@ function routeParentEvidence(route: any) {
   const routeNamespace = route.metadata?.namespace || ''
   const generation = route.metadata?.generation
 
-  // Every report for a parent, not the first: status entries are identified by
-  // parentRef AND controllerName, so one parent can carry reports from two
-  // controllers mid-replacement. Taking one made the verdict depend on their
-  // order in the array.
+  // Status entries are identified by parentRef AND controllerName, so one
+  // parent can carry reports from two controllers while one replaces the other.
+  // All of them count: reading a single report would make the verdict depend on
+  // their order in the array.
   const reportsFor = (ref: any) =>
     reports.filter((p: any) => isReportForParentRef(ref, p?.parentRef, routeNamespace))
   const perRef = refs.map(reportsFor)
@@ -1949,19 +1949,26 @@ function routeParentEvidence(route: any) {
 }
 
 export function getRouteStatus(route: any): StatusBadge {
-  const { considered, everyRefReported, statusOf } = routeParentEvidence(route)
+  const { considered, everyRefReported, conditionOf, statusOf } = routeParentEvidence(route)
 
   if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
-  const anyFailure = considered.some((r: any) =>
+
+  // A report whose conditions all describe a superseded spec says nothing about
+  // the current one, either way. Requiring it to agree would let one leftover
+  // from a replaced controller hold a live healthy parent at Pending.
+  const current = considered.filter((r: any) =>
+    conditionOf(r, 'Accepted') !== undefined || conditionOf(r, 'ResolvedRefs') !== undefined)
+  if (current.length === 0) return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+  const anyFailure = current.some((r: any) =>
     statusOf(r, 'Accepted') === 'False' || statusOf(r, 'ResolvedRefs') === 'False')
 
-  if (everyRefReported && considered.every((r: any) => statusOf(r, 'Accepted') === 'False')) {
+  if (everyRefReported && current.every((r: any) => statusOf(r, 'Accepted') === 'False')) {
     return { text: 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
   }
   if (anyFailure) {
     return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
   }
-  if (everyRefReported && considered.every((r: any) =>
+  if (everyRefReported && current.every((r: any) =>
       statusOf(r, 'Accepted') === 'True' && statusOf(r, 'ResolvedRefs') === 'True')) {
     return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
   }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1919,8 +1919,15 @@ export function getRouteStatus(route: any): StatusBadge {
   const useDefaultGateways = route.spec?.useDefaultGateways
   const attachedByDefault = useDefaultGateways !== undefined && useDefaultGateways !== 'None'
   const claimed = new Set(perRef.flat())
+  // Only a Gateway can be a default parent. An unmatched report for anything
+  // else — a mesh Service parent the spec has dropped — is obsolete by
+  // definition, and would otherwise keep voting forever if its controller is
+  // gone.
+  const isDefaultGatewayReport = (p: any) =>
+    (p?.parentRef?.group ?? GATEWAY_API_GROUP) === GATEWAY_API_GROUP &&
+    (p?.parentRef?.kind ?? 'Gateway') === 'Gateway'
   const considered = attachedByDefault
-    ? [...perRef.flat(), ...reports.filter((p: any) => !claimed.has(p))]
+    ? [...perRef.flat(), ...reports.filter((p: any) => !claimed.has(p) && isDefaultGatewayReport(p))]
     : perRef.flat()
 
   if (considered.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -31,7 +31,7 @@ import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
 import { getCNPGClusterStatus as _getCNPGClusterStatus, getCNPGBackupStatus as _getCNPGBackupStatus, getCNPGScheduledBackupStatus as _getCNPGScheduledBackupStatus, getCNPGPoolerStatus as _getCNPGPoolerStatus, isApiGroup as _isApiGroup, CNPG_GROUP as _CNPG_GROUP } from './resource-utils-cnpg'
 import { getGenericResourceStatus } from './generic-status'
 import { getIstioGatewayStatus as _getIstioGatewayStatus, getIstioGatewayServerCount as _getIstioGatewayServerCount, getIstioGatewaySelectorString as _getIstioGatewaySelectorString, getAuthorizationPolicySelectorString as _getAuthorizationPolicySelectorString, getDestinationRuleTlsMode as _getDestinationRuleTlsMode } from './resource-utils-istio'
-import { getCalicoIPPoolAllowedUses, getCalicoIPPoolBlockSize, getCalicoIPPoolEncapsulation, getCalicoPolicyNamespaceSelector, getCalicoPolicyServiceAccountSelector, getCalicoPolicyTypes, isCalicoApiVersion, isCalicoPolicyResource } from './resource-utils-calico'
+import { formatKubernetesLabelSelector, getCalicoIPPoolAllowedUses, getCalicoIPPoolBlockSize, getCalicoIPPoolEncapsulation, getCalicoPolicyNamespaceSelector, getCalicoPolicyServiceAccountSelector, getCalicoPolicyTypes, isCalicoApiVersion, isCalicoPolicyResource } from './resource-utils-calico'
 
 // ============================================================================
 // STATUS & HEALTH UTILITIES
@@ -1861,18 +1861,75 @@ export function getGatewayClassDescription(gc: any): string {
 // GATEWAY API ROUTE UTILITIES (shared by HTTPRoute, GRPCRoute, TCPRoute, TLSRoute)
 // ============================================================================
 
+const GATEWAY_API_GROUP = 'gateway.networking.k8s.io'
+
+/**
+ * Whether a status report describes a parent the spec still asks for.
+ *
+ * A controller can leave a report behind after its parentRef is removed, and
+ * the defaults matter: an unset group/kind/namespace on either side means
+ * gateway.networking.k8s.io, Gateway, and the route's own namespace.
+ */
+function isReportForParentRef(ref: any, reported: any, routeNamespace: string): boolean {
+  const norm = (r: any) => ({
+    group: r?.group ?? GATEWAY_API_GROUP,
+    kind: r?.kind ?? 'Gateway',
+    namespace: r?.namespace ?? routeNamespace,
+    name: r?.name,
+    sectionName: r?.sectionName,
+    port: r?.port,
+  })
+  const a = norm(ref)
+  const b = norm(reported)
+  return a.group === b.group && a.kind === b.kind && a.namespace === b.namespace &&
+    a.name === b.name && a.sectionName === b.sectionName && a.port === b.port
+}
+
 // All Gateway API route types share the same status/parents/rules/hostnames structure
+/**
+ * A route's verdict, from BOTH conditions the API guarantees it carries.
+ *
+ * Accepted alone is not health: a backendRef naming a Service that does not
+ * exist is Accepted=True by design, because the gateway still has to answer the
+ * request — with a 5xx. Reading only Accepted therefore reported the "why is my
+ * route 503ing" case as healthy, beside a Backends column naming the Service
+ * that is missing. An ABSENT ResolvedRefs is not healthy either: GEP-1364 has
+ * routes always carry both, so a missing one means nothing has confirmed the
+ * refs yet.
+ */
 export function getRouteStatus(route: any): StatusBadge {
-  const parents = route.status?.parents || []
-  if (parents.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
-  const allAccepted = parents.every((p: any) =>
-    (p.conditions || []).some((c: any) => c.type === 'Accepted' && c.status === 'True')
-  )
-  const anyRejected = parents.some((p: any) =>
-    (p.conditions || []).some((c: any) => c.type === 'Accepted' && c.status === 'False')
-  )
-  if (allAccepted) return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
-  if (anyRejected) return { text: 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
+  const refs = route.spec?.parentRefs || []
+  const reports = route.status?.parents || []
+  const routeNamespace = route.metadata?.namespace || ''
+  const generation = route.metadata?.generation
+
+  const matched = refs
+    .map((ref: any) => reports.find((p: any) => isReportForParentRef(ref, p?.parentRef, routeNamespace)))
+    .filter(Boolean)
+  if (matched.length === 0) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+
+  // A condition observed against an older generation describes a spec that has
+  // since changed, so it cannot confirm the current one.
+  const isCurrent = (c: any) =>
+    c?.observedGeneration === undefined || generation === undefined || c.observedGeneration === generation
+  const conditionOf = (report: any, type: string) =>
+    (report?.conditions || []).filter((c: any) => c?.type === type && isCurrent(c)).pop()
+
+  const accepted = matched.map((r: any) => conditionOf(r, 'Accepted'))
+  const resolved = matched.map((r: any) => conditionOf(r, 'ResolvedRefs'))
+  const everyParentReported = matched.length === refs.length
+
+  if (everyParentReported && accepted.every((c: any) => c?.status === 'False')) {
+    return { text: 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (accepted.some((c: any) => c?.status === 'False') || resolved.some((c: any) => c?.status === 'False')) {
+    return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (everyParentReported &&
+      accepted.every((c: any) => c?.status === 'True') &&
+      resolved.every((c: any) => c?.status === 'True')) {
+    return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
+  }
   return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
 }
 
@@ -1954,10 +2011,20 @@ export function getNetworkPolicyRuleCount(np: any): { ingress: number; egress: n
   }
 }
 
+/**
+ * Who the policy applies to.
+ *
+ * podSelector is a LabelSelector, so it can target a subset through
+ * matchExpressions alone. Reading only matchLabels reported those policies as
+ * covering the whole namespace — a gap rendered as coverage, on the surface
+ * where that reads as "this namespace is protected, look elsewhere".
+ */
 export function getNetworkPolicySelector(np: any): string {
-  const labels = np.spec?.podSelector?.matchLabels
-  if (!labels || Object.keys(labels).length === 0) return 'All pods'
-  return Object.entries(labels).map(([k, v]) => `${k}=${v}`).join(', ')
+  const selector = np.spec?.podSelector
+  const hasLabels = Object.keys(selector?.matchLabels ?? {}).length > 0
+  const hasExpressions = Array.isArray(selector?.matchExpressions) && selector.matchExpressions.length > 0
+  if (!hasLabels && !hasExpressions) return 'All pods'
+  return formatKubernetesLabelSelector(selector)
 }
 
 // ============================================================================

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -237,6 +237,34 @@ describe('getRouteStatus', () => {
     expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
   })
 
+  it('does not let confirmed parents speak for one that only has a stale report', () => {
+    // gw-a's sole report describes a superseded spec, so nothing has confirmed
+    // it. A healthy gw-b must not carry the verdict to Accepted on its own.
+    const r = route({
+      generation: 4,
+      refs: [{ name: 'gw-a' }, { name: 'gw-b' }],
+      parents: [
+        { parentRef: { name: 'gw-a' }, conditions: [cond('Accepted', 'True', 2), cond('ResolvedRefs', 'True', 2)] },
+        { parentRef: { name: 'gw-b' }, conditions: [cond('Accepted', 'True', 4), cond('ResolvedRefs', 'True', 4)] },
+      ],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Pending', level: 'degraded' })
+  })
+
+  it('does not claim full rejection while a parent is unconfirmed', () => {
+    const r = route({
+      generation: 4,
+      refs: [{ name: 'gw-a' }, { name: 'gw-b' }],
+      parents: [
+        { parentRef: { name: 'gw-a' }, conditions: [cond('Accepted', 'False', 2)] },
+        { parentRef: { name: 'gw-b' }, conditions: [cond('Accepted', 'False', 4)] },
+      ],
+    })
+    // gw-a is unconfirmed against the current spec, so "every parent rejects"
+    // is not established — the live rejection still shows, as Degraded.
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
   it('matches a parent whose namespace and kind are defaulted on one side only', () => {
     const r = route({
       namespace: 'prod',

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import { getNetworkPolicySelector, getRouteStatus } from './resource-utils'
+import { getIstioGatewayStatus } from './resource-utils-istio'
+
+// These three accessors reported healthy without checking the thing that makes
+// it healthy. Each test names the real cluster state that used to render green.
+
+describe('getNetworkPolicySelector', () => {
+  it('reports a matchExpressions-only policy as targeting a subset, not everything', () => {
+    // Used to render "All pods": a policy covering a fraction of the namespace
+    // claiming to cover all of it, on a security surface.
+    const np = {
+      spec: { podSelector: { matchExpressions: [{ key: 'tier', operator: 'In', values: ['web', 'api'] }] } },
+    }
+    expect(getNetworkPolicySelector(np)).toBe('tier In (web,api)')
+  })
+
+  it('preserves every value rather than collapsing a multi-value NotIn', () => {
+    const np = {
+      spec: { podSelector: { matchExpressions: [{ key: 'env', operator: 'NotIn', values: ['prod', 'staging'] }] } },
+    }
+    expect(getNetworkPolicySelector(np)).toBe('env NotIn (prod,staging)')
+  })
+
+  it('renders valueless operators', () => {
+    const np = { spec: { podSelector: { matchExpressions: [{ key: 'role', operator: 'Exists' }] } } }
+    expect(getNetworkPolicySelector(np)).toBe('role Exists')
+  })
+
+  it('combines matchLabels with matchExpressions', () => {
+    const np = {
+      spec: {
+        podSelector: {
+          matchLabels: { app: 'api' },
+          matchExpressions: [{ key: 'tier', operator: 'In', values: ['web'] }],
+        },
+      },
+    }
+    expect(getNetworkPolicySelector(np)).toBe('app=api, tier In (web)')
+  })
+
+  it('still says All pods when the selector is genuinely empty', () => {
+    expect(getNetworkPolicySelector({ spec: { podSelector: {} } })).toBe('All pods')
+    expect(getNetworkPolicySelector({ spec: {} })).toBe('All pods')
+  })
+})
+
+describe('getRouteStatus', () => {
+  const route = (opts: {
+    refs?: any[]
+    parents?: any[]
+    generation?: number
+    namespace?: string
+  }) => ({
+    metadata: { namespace: opts.namespace ?? 'prod', generation: opts.generation },
+    spec: { parentRefs: opts.refs ?? [{ name: 'gw' }] },
+    status: { parents: opts.parents ?? [] },
+  })
+  const cond = (type: string, status: string, observedGeneration?: number) =>
+    ({ type, status, ...(observedGeneration === undefined ? {} : { observedGeneration }) })
+
+  it('is not healthy when a backendRef names a Service that does not exist', () => {
+    // Accepted=True + ResolvedRefs=False is the documented shape for a missing
+    // backend — the gateway still routes, and answers 5xx. This used to be green.
+    const r = route({
+      parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'False')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
+  it('is healthy only when both conditions are true', () => {
+    const r = route({
+      parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
+  })
+
+  it('does not call an absent ResolvedRefs healthy', () => {
+    const r = route({ parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True')] }] })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Pending', level: 'degraded' })
+  })
+
+  it('reports rejection when every requested parent rejects', () => {
+    const r = route({
+      parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'False'), cond('ResolvedRefs', 'True')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Not Accepted', level: 'unhealthy' })
+  })
+
+  it('degrades rather than rejects when only one of several parents rejects', () => {
+    const r = route({
+      refs: [{ name: 'gw-a' }, { name: 'gw-b' }],
+      parents: [
+        { parentRef: { name: 'gw-a' }, conditions: [cond('Accepted', 'False'), cond('ResolvedRefs', 'True')] },
+        { parentRef: { name: 'gw-b' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] },
+      ],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
+  it('is Pending while a requested parent has not reported yet', () => {
+    const r = route({
+      refs: [{ name: 'gw-a' }, { name: 'gw-b' }],
+      parents: [
+        { parentRef: { name: 'gw-a' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] },
+      ],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Pending', level: 'degraded' })
+  })
+
+  it('ignores a report left behind for a parentRef the spec no longer names', () => {
+    const r = route({
+      refs: [{ name: 'gw-new' }],
+      parents: [{ parentRef: { name: 'gw-old' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Unknown', level: 'unknown' })
+  })
+
+  it('does not accept conditions observed against a superseded generation', () => {
+    const r = route({
+      generation: 3,
+      parents: [{
+        parentRef: { name: 'gw' },
+        conditions: [cond('Accepted', 'True', 2), cond('ResolvedRefs', 'True', 2)],
+      }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Pending', level: 'degraded' })
+  })
+
+  it('matches a parent whose namespace and kind are defaulted on one side only', () => {
+    const r = route({
+      namespace: 'prod',
+      refs: [{ name: 'gw' }],
+      parents: [{
+        parentRef: { name: 'gw', kind: 'Gateway', namespace: 'prod', group: 'gateway.networking.k8s.io' },
+        conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')],
+      }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
+  })
+
+  it('does not match a report for a different sectionName', () => {
+    const r = route({
+      refs: [{ name: 'gw', sectionName: 'https' }],
+      parents: [{ parentRef: { name: 'gw', sectionName: 'http' }, conditions: [cond('Accepted', 'True')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Unknown', level: 'unknown' })
+  })
+})
+
+describe('getIstioGatewayStatus', () => {
+  it('does not claim health it cannot observe from spec alone', () => {
+    // A Gateway whose selector matches no running ingressgateway pod has
+    // servers like any other; green asserted liveness nothing had checked.
+    const gw = { spec: { servers: [{ port: { number: 80 } }] } }
+    expect(getIstioGatewayStatus(gw)).toMatchObject({ text: 'Defined', level: 'neutral' })
+  })
+
+  it('does not treat TLS as a verdict', () => {
+    const gw = { spec: { servers: [{ tls: { mode: 'SIMPLE' } }] } }
+    expect(getIstioGatewayStatus(gw)).toMatchObject({ text: 'Defined', level: 'neutral' })
+  })
+
+  it('still flags a gateway with no servers', () => {
+    expect(getIstioGatewayStatus({ spec: { servers: [] } })).toMatchObject({
+      text: 'No Servers', level: 'unhealthy',
+    })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getNetworkPolicySelector, getRouteStatus, getRouteStatusReason } from './resource-utils'
 import { getIstioGatewayStatus } from './resource-utils-istio'
 
-// These three accessors reported healthy without checking the thing that makes
-// it healthy. Each test names the real cluster state that used to render green.
+// Each case names the cluster state behind the verdict, so a future change that
+// re-greens one of them fails here with the reason attached.
 
 describe('getNetworkPolicySelector', () => {
   it('reports a matchExpressions-only policy as targeting a subset, not everything', () => {
-    // Used to render "All pods": a policy covering a fraction of the namespace
-    // claiming to cover all of it, on a security surface.
+    // podSelector is a LabelSelector: a policy can target a fraction of the
+    // namespace through expressions alone, and must not claim to cover all of it.
     const np = {
       spec: { podSelector: { matchExpressions: [{ key: 'tier', operator: 'In', values: ['web', 'api'] }] } },
     }
@@ -67,7 +67,7 @@ describe('getRouteStatus', () => {
 
   it('is not healthy when a backendRef names a Service that does not exist', () => {
     // Accepted=True + ResolvedRefs=False is the documented shape for a missing
-    // backend — the gateway still routes, and answers 5xx. This used to be green.
+    // backend — the gateway still routes, and answers 5xx.
     const r = route({
       parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'False')] }],
     })
@@ -135,8 +135,7 @@ describe('getRouteStatus', () => {
 
   it('does not let a stale controller report outvote a live rejection, in either order', () => {
     // Status entries are keyed by parentRef AND controllerName, so one parent
-    // can carry two controllers' reports mid-replacement. Reading only the
-    // first made the badge depend on their order in the array.
+    // can carry two controllers' reports while one replaces the other.
     const old = { parentRef: { name: 'gw' }, controllerName: 'old/ctrl', conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }
     const live = { parentRef: { name: 'gw' }, controllerName: 'new/ctrl', conditions: [cond('Accepted', 'False'), cond('ResolvedRefs', 'False')] }
     // Neither order may be green, and both must agree. Degraded rather than
@@ -225,6 +224,19 @@ describe('getRouteStatus', () => {
     expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
   })
 
+  it('lets a live healthy parent win over a superseded report for the same parent', () => {
+    // A report describing a spec that has since changed says nothing about the
+    // current one, so it must not hold a confirmed parent at Pending.
+    const r = route({
+      generation: 3,
+      parents: [
+        { parentRef: { name: 'gw' }, controllerName: 'old/ctrl', conditions: [cond('Accepted', 'True', 2), cond('ResolvedRefs', 'True', 2)] },
+        { parentRef: { name: 'gw' }, controllerName: 'new/ctrl', conditions: [cond('Accepted', 'True', 3), cond('ResolvedRefs', 'True', 3)] },
+      ],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
+  })
+
   it('matches a parent whose namespace and kind are defaulted on one side only', () => {
     const r = route({
       namespace: 'prod',
@@ -305,7 +317,7 @@ describe('getRouteStatusReason', () => {
 describe('getIstioGatewayStatus', () => {
   it('does not claim health it cannot observe from spec alone', () => {
     // A Gateway whose selector matches no running ingressgateway pod has
-    // servers like any other; green asserted liveness nothing had checked.
+    // servers like any other, so servers alone cannot assert liveness.
     const gw = { spec: { servers: [{ port: { number: 80 } }] } }
     expect(getIstioGatewayStatus(gw)).toMatchObject({ text: 'Defined', level: 'neutral' })
   })

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -184,6 +184,37 @@ describe('getRouteStatus', () => {
     expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
   })
 
+  it('ignores a dropped mesh Service parent when weighing default Gateways', () => {
+    // Services cannot be default Gateways, so an unmatched Service report is
+    // obsolete by definition — and would otherwise outvote the live one
+    // indefinitely once its controller is gone.
+    const r = {
+      metadata: { namespace: 'prod', generation: 3 },
+      spec: { useDefaultGateways: 'All' },
+      status: {
+        parents: [
+          { parentRef: { group: '', kind: 'Service', name: 'legacy-mesh' }, conditions: [cond('Accepted', 'True', 2)] },
+          { parentRef: { name: 'default-gw' }, conditions: [cond('Accepted', 'True', 3), cond('ResolvedRefs', 'True', 3)] },
+        ],
+      },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
+  })
+
+  it('still reports a rejecting default Gateway as rejected despite a dropped Service parent', () => {
+    const r = {
+      metadata: { namespace: 'prod', generation: 3 },
+      spec: { useDefaultGateways: 'All' },
+      status: {
+        parents: [
+          { parentRef: { group: '', kind: 'Service', name: 'legacy-mesh' }, conditions: [cond('Accepted', 'True', 2)] },
+          { parentRef: { name: 'default-gw' }, conditions: [cond('Accepted', 'False', 3)] },
+        ],
+      },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Not Accepted', level: 'unhealthy' })
+  })
+
   it('takes a condition with no observedGeneration at face value', () => {
     // Missing is not stale: a controller that never sets it must not strand the
     // route as Pending forever.

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -39,6 +39,12 @@ describe('getNetworkPolicySelector', () => {
     expect(getNetworkPolicySelector(np)).toBe('app=api, tier In (web)')
   })
 
+  it('does not switch vocabulary when every expression entry is malformed', () => {
+    // The shared formatter skips entries it cannot read and has its own
+    // empty-case wording; reaching it would describe one state in two ways.
+    expect(getNetworkPolicySelector({ spec: { podSelector: { matchExpressions: [null] } } })).toBe('All pods')
+  })
+
   it('still says All pods when the selector is genuinely empty', () => {
     expect(getNetworkPolicySelector({ spec: { podSelector: {} } })).toBe('All pods')
     expect(getNetworkPolicySelector({ spec: {} })).toBe('All pods')
@@ -125,6 +131,67 @@ describe('getRouteStatus', () => {
       }],
     })
     expect(getRouteStatus(r)).toMatchObject({ text: 'Pending', level: 'degraded' })
+  })
+
+  it('does not let a stale controller report outvote a live rejection, in either order', () => {
+    // Status entries are keyed by parentRef AND controllerName, so one parent
+    // can carry two controllers' reports mid-replacement. Reading only the
+    // first made the badge depend on their order in the array.
+    const old = { parentRef: { name: 'gw' }, controllerName: 'old/ctrl', conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }
+    const live = { parentRef: { name: 'gw' }, controllerName: 'new/ctrl', conditions: [cond('Accepted', 'False'), cond('ResolvedRefs', 'False')] }
+    // Neither order may be green, and both must agree. Degraded rather than
+    // unhealthy is deliberate: nothing here establishes which controller is
+    // authoritative, so the verdict says "something is wrong" without claiming
+    // the route is rejected outright.
+    const forward = getRouteStatus(route({ parents: [old, live] }))
+    const reversed = getRouteStatus(route({ parents: [live, old] }))
+    expect(forward).toEqual(reversed)
+    expect(forward.level).not.toBe('healthy')
+    expect(forward).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
+  it('counts a default-Gateway attachment the spec never names', () => {
+    // With useDefaultGateways the attachment exists only in status, so a
+    // failure there is the only evidence there is.
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { useDefaultGateways: 'All' },
+      status: { parents: [{ parentRef: { name: 'default-gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'False')] }] },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
+  it('accepts a default-only route whose default parent is healthy', () => {
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { useDefaultGateways: 'All' },
+      status: { parents: [{ parentRef: { name: 'default-gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }] },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
+  })
+
+  it('does not let a healthy explicit parent mask a failing default one', () => {
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { parentRefs: [{ name: 'gw' }], useDefaultGateways: 'All' },
+      status: {
+        parents: [
+          { parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] },
+          { parentRef: { name: 'default-gw' }, conditions: [cond('Accepted', 'False'), cond('ResolvedRefs', 'True')] },
+        ],
+      },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Degraded', level: 'degraded' })
+  })
+
+  it('takes a condition with no observedGeneration at face value', () => {
+    // Missing is not stale: a controller that never sets it must not strand the
+    // route as Pending forever.
+    const r = route({
+      generation: 7,
+      parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }],
+    })
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Accepted', level: 'healthy' })
   })
 
   it('matches a parent whose namespace and kind are defaulted on one side only', () => {

--- a/packages/k8s-ui/src/components/resources/status-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-accessors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getNetworkPolicySelector, getRouteStatus } from './resource-utils'
+import { getNetworkPolicySelector, getRouteStatus, getRouteStatusReason } from './resource-utils'
 import { getIstioGatewayStatus } from './resource-utils-istio'
 
 // These three accessors reported healthy without checking the thing that makes
@@ -243,6 +243,62 @@ describe('getRouteStatus', () => {
       parents: [{ parentRef: { name: 'gw', sectionName: 'http' }, conditions: [cond('Accepted', 'True')] }],
     })
     expect(getRouteStatus(r)).toMatchObject({ text: 'Unknown', level: 'unknown' })
+  })
+})
+
+describe('getRouteStatusReason', () => {
+  const cond = (type: string, status: string, extra: any = {}) => ({ type, status, ...extra })
+
+  it('names the parent and the controller reason behind a Degraded badge', () => {
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { parentRefs: [{ name: 'gw' }] },
+      status: {
+        parents: [{
+          parentRef: { name: 'gw' },
+          conditions: [
+            cond('Accepted', 'True'),
+            cond('ResolvedRefs', 'False', { reason: 'BackendNotFound', message: 'Service prod/api not found' }),
+          ],
+        }],
+      },
+    }
+    expect(getRouteStatusReason(r)).toBe('gw: BackendNotFound: Service prod/api not found')
+  })
+
+  it('is empty when nothing is failing, so a healthy badge carries no hover', () => {
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { parentRefs: [{ name: 'gw' }] },
+      status: { parents: [{ parentRef: { name: 'gw' }, conditions: [cond('Accepted', 'True'), cond('ResolvedRefs', 'True')] }] },
+    }
+    expect(getRouteStatusReason(r)).toBe('')
+  })
+
+  it('reports every failing parent, not just the first', () => {
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { parentRefs: [{ name: 'gw-a' }, { name: 'gw-b' }] },
+      status: {
+        parents: [
+          { parentRef: { name: 'gw-a' }, conditions: [cond('Accepted', 'False', { reason: 'NotAllowedByListeners' })] },
+          { parentRef: { name: 'gw-b' }, conditions: [cond('ResolvedRefs', 'False', { reason: 'BackendNotFound' })] },
+        ],
+      },
+    }
+    expect(getRouteStatusReason(r)).toBe('gw-a: NotAllowedByListeners · gw-b: BackendNotFound')
+  })
+
+  it('describes the same parents the verdict counted', () => {
+    // A leftover report for a dropped parentRef must not explain a badge that
+    // never considered it.
+    const r = {
+      metadata: { namespace: 'prod' },
+      spec: { parentRefs: [{ name: 'gw-new' }] },
+      status: { parents: [{ parentRef: { name: 'gw-old' }, conditions: [cond('ResolvedRefs', 'False', { reason: 'BackendNotFound' })] }] },
+    }
+    expect(getRouteStatus(r)).toMatchObject({ text: 'Unknown' })
+    expect(getRouteStatusReason(r)).toBe('')
   })
 })
 


### PR DESCRIPTION
## Summary

Three status accessors reported healthy without checking the thing that makes it healthy. Each one is green in a cluster state an operator is actively hunting.

**Gateway API routes** read only the `Accepted` condition. A `backendRef` naming a Service that does not exist is `Accepted=True` **by design** — the gateway still has to answer the request, with a 5xx — and `ResolvedRefs=False` carries the real news. So "why is my route 503ing" rendered a green `Accepted` badge next to a Backends column confidently naming the Service that is missing. Wrong twice, in one row. Radar reads `ResolvedRefs` correctly on the detail pages; the list view was the one place that dropped it.

**NetworkPolicy** read only `podSelector.matchLabels`, but `podSelector` is a `LabelSelector`. A policy targeting a subset through `matchExpressions` alone rendered as **"All pods"** — a gap displayed as coverage, on the one surface where that reads as *"this namespace is protected, look elsewhere."*

**Istio Gateway** returned a green `Active`, or a green `TLS` when any server had `tls` set. Neither observes what actually fails: a Gateway whose `spec.selector` matches no running ingressgateway pod has servers like any other, and rendered identically to a working one.

## The route verdict

`getRouteStatus` now weighs both conditions the API guarantees a route carries, over the reports that describe parents it is actually attached to:

- **Every report for a parent counts, not the first.** Status entries are identified by parentRef *and* controllerName, so one parent can carry two controllers' reports while one replaces the other. Reading one made the verdict depend on their order in the array. A conflict resolves to `Degraded` — nothing in the status establishes which controller is authoritative, so the badge says something is wrong without claiming the route is rejected outright.
- **Parent identity uses the API's defaults.** Unset group, kind and namespace mean `gateway.networking.k8s.io`, `Gateway`, and the route's own namespace; `sectionName` and `port` are part of the identity. An explicit `group: ""` means core, and is preserved.
- **Routes attached to default Gateways are handled.** With `spec.useDefaultGateways`, the attachment exists only in status, so a failure there is the only evidence there is. Those reports count — but only when the parentRef identifies a Gateway. A mesh Service parent the spec has dropped is obsolete by definition and would otherwise keep voting indefinitely once its controller is gone.
- **Without that opt-in, an unmatched report is a leftover** from a parentRef the spec no longer names, and is ignored rather than resurrecting a verdict for a parent the route has left.
- **A superseded `observedGeneration` cannot confirm the current spec.** A condition carrying none is taken at face value, so a controller that never sets one cannot strand a route as `Pending`.

Ladder: every requested parent rejecting → `Not Accepted`; any current `Accepted=False` or `ResolvedRefs=False` → `Degraded`; all parents reported with both conditions true → `Accepted`; otherwise `Pending`. An **absent** `ResolvedRefs` deliberately is not healthy — routes always carry both, so a missing one means nothing has confirmed the refs yet, and reading it as healthy would swap one false green for another.

## The other two

`getNetworkPolicySelector` delegates to the expression-aware formatter already exported from this package rather than growing a second one. It says "All pods" only when the selector is genuinely empty, and preserves every operator and value — `tier In (web,api)`, `env NotIn (prod,staging)`, `role Exists` — since the cell renders the string verbatim into its hover. Only expression entries the formatter can actually read are counted, so a malformed list does not reach its different empty-case wording.

`getIstioGatewayStatus` returns a neutral `Defined` for any non-empty `spec.servers`, keeping `No Servers` as the one real failure it can see. TLS is a property of a server, not a verdict, and it was occupying the slot every other kind here uses for one. A real verdict needs selector-to-pod resolution, which Radar already does server-side — that is the path to it later, not something to approximate now.

## Reviewer notes

One accessor serves all four route kinds; the Istio one drives both the list cell and the detail-page status. Each fix lands everywhere at once.

Two user-visible consequences:

- Routes gain a `Degraded` state that did not exist before. It is the correct home for `Accepted=True` + `ResolvedRefs=False`.
- The Istio Gateway status filter offers `Defined` / `No Servers` instead of `TLS` / `Active` / `No Servers`. Losing `TLS` as a filter value is deliberate — it was never a status — and it belongs in the servers cell if wanted for filtering.

## Testing

`make tsc` clean. These accessors had **no test coverage**; there are now 26, each named for the cluster state it pins: missing backend, absent `ResolvedRefs`, partial parent reporting, stale vs missing generation, a leftover report for a dropped parentRef, `sectionName` mismatch, two controllers disagreeing (asserted order-invariant), default-Gateway attachment accepted and failing, a healthy explicit parent not masking a failing default one, a dropped mesh Service parent not outvoting a live default Gateway, matchExpressions policies, and the Istio TLS/plain collapse.

`istio-gateway-filter.test.ts` is updated rather than removed: its point — that filter and sort must read what the cell reads — still holds; only the expected verdict changed.

`packages/k8s-ui`: 3454 passed, 1 skipped. The one failing file (`resource-utils-hpa.test.ts`) fails identically on `main` — a fixture path resolved from the runner's cwd, unrelated.

**Visually verified** against a live cluster with seeded NetworkPolicies (since no reachable cluster had one using `matchExpressions`): an expressions-only policy renders `tier In (web,api)` where it previously claimed "All pods"; a combined selector renders `app=checkout, environment NotIn (...), has-sidecar Exists`, truncating at the column width with the full value on hover; a genuinely empty selector still reads "All pods". The fixtures were removed afterwards. The route and Istio paths could not be captured — no reachable cluster has the Gateway API or Istio CRDs installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared list-view status logic for Gateway API routes and Istio Gateways (new Degraded state and filter values), which can shift how operators triage ingress issues even though scope is UI accessors plus tests.
> 
> **Overview**
> Fixes three resource list cells that showed **healthy or “all pods” coverage** without checking the signals operators actually care about.
> 
> **Gateway API routes** now derive status from both **`Accepted` and `ResolvedRefs`** over parent reports that still match `spec.parentRefs` (with API defaults, `useDefaultGateways`, generation-aware conditions, and multi-controller reports). Missing backends surface as **`Degraded`** instead of green **Accepted**; **`getRouteStatusReason`** feeds a tooltip on the route status badge.
> 
> **NetworkPolicy** selector text uses **`formatKubernetesLabelSelector`**, so `matchExpressions`-only policies no longer read as **“All pods”**.
> 
> **Istio Gateway** status drops misleading **Active/TLS** greens in favor of neutral **Defined** when servers exist (**No Servers** unchanged); filter expectations in **`istio-gateway-filter.test.ts`** follow suit.
> 
> Adds **`status-accessors.test.ts`** to lock in the new route, NetworkPolicy, and Istio behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c110c4947ed0083f7c3916534326857cf7a43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->