### PR TITLE
fix(helm): persist and recover chart sources

### DIFF
--- a/internal/helm/artifacthub_recovery.go
+++ b/internal/helm/artifacthub_recovery.go
@@ -1,0 +1,395 @@
+package helm
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	artifactHubRecoveryPageSize   = 50
+	artifactHubRecoveryMaxResults = 250
+	artifactHubRecoveryTimeout    = 20 * time.Second
+)
+
+type artifactHubRecoverySearch func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error)
+type artifactHubRecoveryVerifier func(context.Context, *action.Configuration, *release.Release, ChartSourceCandidate) (ChartSourceCandidate, error)
+
+type artifactHubVerificationError struct {
+	kind string
+	err  error
+}
+
+func (e *artifactHubVerificationError) Error() string { return e.err.Error() }
+func (e *artifactHubVerificationError) Unwrap() error { return e.err }
+
+// DiscoverArtifactHubSources performs the optional, user-triggered final source
+// discovery step. ArtifactHub only supplies possible locations; every returned
+// candidate has independently yielded the exact complete installed chart.
+func (c *Client) DiscoverArtifactHubSources(ctx context.Context, namespace, name string) ([]ChartSourceCandidate, error) {
+	cfg, err := c.getActionConfig(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return c.discoverArtifactHubSourcesWith(ctx, cfg, name, SearchArtifactHubContext, c.verifyArtifactHubSource)
+}
+
+func (c *Client) DiscoverArtifactHubSourcesAsUser(ctx context.Context, namespace, name, username string, groups []string) ([]ChartSourceCandidate, error) {
+	cfg, err := c.getActionConfigForUser(namespace, username, groups)
+	if err != nil {
+		return nil, err
+	}
+	return c.discoverArtifactHubSourcesWith(ctx, cfg, name, SearchArtifactHubContext, c.verifyArtifactHubSource)
+}
+
+func (c *Client) discoverArtifactHubSourcesWith(ctx context.Context, cfg *action.Configuration, releaseName string, search artifactHubRecoverySearch, verify artifactHubRecoveryVerifier) ([]ChartSourceCandidate, error) {
+	ctx, cancel := context.WithTimeout(ctx, artifactHubRecoveryTimeout)
+	defer cancel()
+
+	rel, err := action.NewGet(cfg).Run(releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("get release for source discovery: %w", err)
+	}
+	if rel.Chart == nil || rel.Chart.Metadata == nil || rel.Chart.Metadata.Name == "" || rel.Chart.Metadata.Version == "" {
+		return nil, fmt.Errorf("release has no usable chart name and version")
+	}
+
+	// Recorded provenance remains authoritative while it is usable. If it has
+	// become unavailable, an explicit ArtifactHub request may suggest a
+	// replacement, but discovery never persists that replacement itself.
+	var unavailableRecorded *ChartSourceCandidate
+	if recorded, ok := chartSourceFromRelease(rel); ok && (recorded.Type == "oci" || recorded.URL != "") {
+		if _, verifyErr := verify(ctx, cfg, rel, *recorded); verifyErr == nil {
+			return nil, fmt.Errorf("release already has exact recorded chart-source provenance")
+		}
+		unavailableRecorded = recorded
+	}
+	configured, err := c.configuredChartSourceCandidates(rel.Chart.Metadata.Name, rel.Chart.Metadata.Version, nil)
+	if err != nil {
+		return nil, fmt.Errorf("check configured chart sources before ArtifactHub: %w", err)
+	}
+	if unavailableRecorded != nil {
+		configured = slices.DeleteFunc(configured, func(candidate ChartSourceCandidate) bool {
+			return chartSourceCandidatesEquivalent(candidate, *unavailableRecorded)
+		})
+	}
+	if len(configured) != 0 {
+		return nil, fmt.Errorf("an exact configured chart source is already available")
+	}
+
+	// The search receives only the chart name. Namespace, release name, cluster
+	// identity, credentials, and kubeconfig data never leave Radar.
+	hits := make([]ArtifactHubChart, 0, artifactHubRecoveryPageSize)
+	for offset := 0; offset < artifactHubRecoveryMaxResults; offset += artifactHubRecoveryPageSize {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("ArtifactHub discovery stopped: %w", err)
+		}
+		result, searchErr := search(ctx, rel.Chart.Metadata.Name, offset, artifactHubRecoveryPageSize, false, false, "relevance")
+		if searchErr != nil {
+			return nil, fmt.Errorf("ArtifactHub discovery failed: %w", searchErr)
+		}
+		if result == nil {
+			return nil, fmt.Errorf("ArtifactHub discovery returned an empty response")
+		}
+		remaining := artifactHubRecoveryMaxResults - len(hits)
+		page := result.Charts
+		if len(page) > remaining {
+			page = page[:remaining]
+		}
+		hits = append(hits, page...)
+		if len(result.Charts) < artifactHubRecoveryPageSize || len(hits) >= artifactHubRecoveryMaxResults {
+			break
+		}
+	}
+	verified := make([]ChartSourceCandidate, 0)
+	seen := make(map[string]struct{})
+	var authFailure, infrastructureFailure error
+	for _, hit := range hits {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("ArtifactHub verification stopped: %w", err)
+		}
+		if hit.Name != rel.Chart.Metadata.Name {
+			continue
+		}
+		candidate, ok := artifactHubRecoveryCandidate(hit, rel.Chart.Metadata.Name)
+		if !ok {
+			continue
+		}
+		key := chartSourceCandidateIdentity(candidate)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		verifiedCandidate, verifyErr := verify(ctx, cfg, rel, candidate)
+		if verifyErr != nil {
+			var classified *artifactHubVerificationError
+			if errors.As(verifyErr, &classified) {
+				switch classified.kind {
+				case "authentication":
+					authFailure = verifyErr
+				case "infrastructure":
+					infrastructureFailure = verifyErr
+				}
+			}
+			continue
+		}
+		verifiedKey := chartSourceCandidateIdentity(verifiedCandidate)
+		if slices.ContainsFunc(verified, func(existing ChartSourceCandidate) bool {
+			return chartSourceCandidateIdentity(existing) == verifiedKey
+		}) {
+			continue
+		}
+		verified = append(verified, verifiedCandidate)
+	}
+	if len(verified) == 0 {
+		if authFailure != nil {
+			return nil, fmt.Errorf("source found but verification requires authentication using existing Helm credentials: %w", authFailure)
+		}
+		if infrastructureFailure != nil {
+			return nil, fmt.Errorf("source found but verification failed due to a network or service error: %w", infrastructureFailure)
+		}
+	}
+	slices.SortFunc(verified, func(a, b ChartSourceCandidate) int {
+		return strings.Compare(a.Type+"\x00"+a.Reference+"\x00"+a.URL, b.Type+"\x00"+b.Reference+"\x00"+b.URL)
+	})
+	return verified, nil
+}
+
+func chartSourceCandidateIdentity(candidate ChartSourceCandidate) string {
+	if candidate.Type == "repository" {
+		return candidate.Type + "\x00" + candidate.URL
+	}
+	return candidate.Type + "\x00" + candidate.Reference
+}
+
+func chartSourceCandidatesEquivalent(a, b ChartSourceCandidate) bool {
+	return a.Type == b.Type && chartSourceCandidateIdentity(a) == chartSourceCandidateIdentity(b)
+}
+
+func artifactHubRecoveryCandidate(hit ArtifactHubChart, chartName string) (ChartSourceCandidate, bool) {
+	raw := strings.TrimSpace(hit.Repository.URL)
+	if strings.HasPrefix(raw, "oci://") {
+		ref, err := normalizeOCIPrefix(raw)
+		if err != nil || !strings.HasSuffix(ref, "/"+chartName) {
+			return ChartSourceCandidate{}, false
+		}
+		candidate := ChartSourceCandidate{Type: "oci", Reference: ref}
+		return candidate, validateChartSourceCandidate(&candidate) == nil
+	}
+	repositoryURL, err := canonicalClassicRepositoryURL(raw)
+	if err != nil {
+		return ChartSourceCandidate{}, false
+	}
+	name := normalizedRepositoryName(hit.Repository.Name)
+	if name == "" {
+		name = stableRepositoryName(hit.Repository.Name, repositoryURL)
+	}
+	candidate := ChartSourceCandidate{Type: "repository", Reference: name, URL: repositoryURL}
+	return candidate, validateChartSourceCandidate(&candidate) == nil
+}
+
+func (c *Client) verifyArtifactHubSource(ctx context.Context, cfg *action.Configuration, rel *release.Release, candidate ChartSourceCandidate) (ChartSourceCandidate, error) {
+	if err := ctx.Err(); err != nil {
+		return ChartSourceCandidate{}, classifyArtifactHubVerificationError(err)
+	}
+	var loaded *chart.Chart
+	var err error
+	switch candidate.Type {
+	case "repository":
+		var canonicalURL string
+		loaded, canonicalURL, err = c.loadExactHTTPChart(ctx, candidate.URL, rel.Chart.Metadata.Name, rel.Chart.Metadata.Version)
+		if err == nil {
+			candidate.URL = canonicalURL
+		}
+	case "oci":
+		copy := *rel
+		copy.Labels = mergeChartSourceLabels(rel.Labels, &candidate)
+		loaded, err = c.loadTargetChart(cfg, &copy, rel.Chart.Metadata.Version, "", func(string, string, string) {})
+	default:
+		err = fmt.Errorf("unsupported chart source type %q", candidate.Type)
+	}
+	if err != nil {
+		return ChartSourceCandidate{}, classifyArtifactHubVerificationError(err)
+	}
+	if loaded.Metadata == nil || loaded.Metadata.Name != rel.Chart.Metadata.Name || loaded.Metadata.Version != rel.Chart.Metadata.Version {
+		return ChartSourceCandidate{}, fmt.Errorf("source returned a different chart identity or version")
+	}
+	if err := validateChartDependencyBodies(loaded); err != nil {
+		return ChartSourceCandidate{}, err
+	}
+	return candidate, nil
+}
+
+func (c *Client) loadExactHTTPChart(ctx context.Context, repositoryURL, chartName, version string) (*chart.Chart, string, error) {
+	repositoryURL, err := canonicalClassicRepositoryURL(repositoryURL)
+	if err != nil {
+		return nil, "", err
+	}
+	credentials := c.configuredRepositoryByURL(repositoryURL)
+	indexBody, finalIndexURL, err := fetchArtifactHubVerificationBytes(ctx, repositoryURL+"/index.yaml", maxPreparedIndexBytes, "repository index", credentials)
+	if err != nil {
+		return nil, "", err
+	}
+	index := &repo.IndexFile{}
+	if err := yaml.Unmarshal(indexBody, index); err != nil {
+		return nil, "", fmt.Errorf("parse repository index: %w", err)
+	}
+	index.SortEntries()
+	baseURL := *finalIndexURL
+	baseURL.RawQuery, baseURL.Fragment = "", ""
+	baseURL.Path = strings.TrimSuffix(baseURL.Path, "index.yaml")
+	canonicalURL, err := canonicalClassicRepositoryURL(baseURL.String())
+	if err != nil {
+		return nil, "", fmt.Errorf("canonicalize redirected repository URL: %w", err)
+	}
+	var selectedURL, digest string
+	for _, candidate := range index.Entries[chartName] {
+		if candidate != nil && candidate.Metadata != nil && !candidate.Removed && candidate.Version == version && len(candidate.URLs) > 0 {
+			selectedURL, digest = candidate.URLs[0], strings.TrimSpace(strings.ToLower(candidate.Digest))
+			break
+		}
+	}
+	if selectedURL == "" {
+		return nil, "", fmt.Errorf("chart %s version %s is absent from repository", chartName, version)
+	}
+	want, err := hex.DecodeString(strings.TrimPrefix(digest, "sha256:"))
+	if err != nil || len(want) != sha256.Size {
+		return nil, "", fmt.Errorf("chart %s version %s has no valid SHA-256 digest", chartName, version)
+	}
+	chartURL, err := resolveChartURL(canonicalURL+"/", selectedURL)
+	if err != nil {
+		return nil, "", err
+	}
+	body, _, err := fetchArtifactHubVerificationBytes(ctx, chartURL, maxPreparedChartBytes, "chart", credentials)
+	if err != nil {
+		return nil, "", err
+	}
+	actual := sha256.Sum256(body)
+	if !bytes.Equal(actual[:], want) {
+		return nil, "", fmt.Errorf("chart %s version %s digest does not match repository index", chartName, version)
+	}
+	loaded, err := loader.LoadArchive(bytes.NewReader(body))
+	if err != nil {
+		return nil, "", fmt.Errorf("load chart %s version %s: %w", chartName, version, err)
+	}
+	return loaded, canonicalURL, nil
+}
+
+func (c *Client) configuredRepositoryByURL(repositoryURL string) *repo.Entry {
+	if c.settings == nil {
+		return nil
+	}
+	f, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil {
+		return nil
+	}
+	for _, configured := range f.Repositories {
+		configuredURL, err := canonicalClassicRepositoryURL(configured.URL)
+		if err == nil && configuredURL == repositoryURL {
+			return configured
+		}
+	}
+	return nil
+}
+
+func fetchArtifactHubVerificationBytes(ctx context.Context, target string, maxBytes int64, kind string, credentials *repo.Entry) ([]byte, *url.URL, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch %s: %w", kind, err)
+	}
+	if credentials != nil && (credentials.Username != "" || credentials.Password != "") {
+		request.SetBasicAuth(credentials.Username, credentials.Password)
+	}
+	client := *httpClient
+	client.CheckRedirect = func(next *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		previous := via[len(via)-1].URL
+		if next.URL.Scheme != "http" && next.URL.Scheme != "https" {
+			return fmt.Errorf("repository redirect uses unsupported scheme %q", next.URL.Scheme)
+		}
+		if previous.Scheme == "https" && next.URL.Scheme != "https" {
+			return fmt.Errorf("repository redirect would downgrade HTTPS")
+		}
+		if next.URL.User != nil {
+			return fmt.Errorf("repository redirect contains credentials")
+		}
+		if credentials != nil && (credentials.Username != "" || credentials.Password != "") &&
+			(credentials.PassCredentialsAll || strings.EqualFold(previous.Hostname(), next.URL.Hostname())) {
+			next.SetBasicAuth(credentials.Username, credentials.Password)
+		}
+		return nil
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch %s: %w", kind, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, response.Request.URL, &artifactHubHTTPStatusError{kind: kind, statusCode: response.StatusCode, status: response.Status}
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxBytes+1))
+	if err != nil {
+		return nil, response.Request.URL, fmt.Errorf("read %s: %w", kind, err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, response.Request.URL, fmt.Errorf("read %s: response exceeds %d bytes", kind, maxBytes)
+	}
+	return body, response.Request.URL, nil
+}
+
+type artifactHubHTTPStatusError struct {
+	kind       string
+	statusCode int
+	status     string
+}
+
+func (e *artifactHubHTTPStatusError) Error() string {
+	return fmt.Sprintf("fetch %s: server returned %s", e.kind, e.status)
+}
+
+func classifyArtifactHubVerificationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var statusErr *artifactHubHTTPStatusError
+	if errors.As(err, &statusErr) {
+		if statusErr.statusCode == http.StatusUnauthorized || statusErr.statusCode == http.StatusForbidden {
+			return &artifactHubVerificationError{kind: "authentication", err: err}
+		}
+		if statusErr.statusCode == http.StatusTooManyRequests || statusErr.statusCode >= 500 {
+			return &artifactHubVerificationError{kind: "infrastructure", err: err}
+		}
+		return err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &artifactHubVerificationError{kind: "infrastructure", err: err}
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) {
+		return &artifactHubVerificationError{kind: "infrastructure", err: err}
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "unauthorized") || strings.Contains(lower, "authentication required") || strings.Contains(lower, "denied") || strings.Contains(lower, "401") || strings.Contains(lower, "403") {
+		return &artifactHubVerificationError{kind: "authentication", err: err}
+	}
+	return err
+}

--- a/internal/helm/artifacthub_recovery_test.go
+++ b/internal/helm/artifacthub_recovery_test.go
@@ -1,0 +1,692 @@
+package helm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+func artifactHubRecoveryRelease(t *testing.T, chartName, version string) (*action.Configuration, *release.Release) {
+	t.Helper()
+	cfg := memoryActionConfig(t)
+	rel := &release.Release{
+		Name: "installed", Namespace: "default", Version: 1,
+		Info:  &release.Info{Status: release.StatusDeployed},
+		Chart: &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: chartName, Version: version}},
+	}
+	if err := cfg.Releases.Create(rel); err != nil {
+		t.Fatal(err)
+	}
+	return cfg, rel
+}
+
+func artifactHubTestRepository(t *testing.T, ch *chart.Chart, indexVersion string) string {
+	t.Helper()
+	archive := artifactHubChartArchive(t, ch)
+	digest := sha256.Sum256(archive)
+	index := fmt.Sprintf("apiVersion: v1\nentries:\n  %s:\n  - apiVersion: v2\n    name: %s\n    version: %s\n    urls: [%s-%s.tgz]\n    digest: %s\n",
+		ch.Metadata.Name, ch.Metadata.Name, indexVersion, ch.Metadata.Name, indexVersion, hex.EncodeToString(digest[:]))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.yaml":
+			_, _ = w.Write([]byte(index))
+		case "/" + ch.Metadata.Name + "-" + indexVersion + ".tgz":
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func artifactHubChartArchive(t *testing.T, ch *chart.Chart) []byte {
+	t.Helper()
+	archivePath, err := chartutil.Save(ch, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return archive
+}
+
+func artifactHubSearchResult(chartName, version, repositoryName, repositoryURL string) *ArtifactHubSearchResult {
+	return &ArtifactHubSearchResult{Charts: []ArtifactHubChart{{
+		Name: chartName, Version: version,
+		Repository: ArtifactHubRepository{Name: repositoryName, URL: repositoryURL},
+	}}}
+}
+
+func TestArtifactHubRecoveryUniqueHTTPVerifiesAndAssociates(t *testing.T) {
+	withOCISources(t, nil)
+	const chartName, version = "example-chart", "1.2.3"
+	repositoryURL := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: chartName, Version: version}}, version)
+	cfg, rel := artifactHubRecoveryRelease(t, chartName, version)
+	dir := t.TempDir()
+	c := &Client{settings: testEnvSettings(filepath.Join(dir, "repositories.yaml"), dir)}
+	var searchQuery string
+	search := func(_ context.Context, query string, offset, limit int, official, verified bool, sort string) (*ArtifactHubSearchResult, error) {
+		searchQuery = query
+		if offset != 0 || limit != artifactHubRecoveryPageSize || official || verified || sort != "relevance" {
+			t.Fatalf("unexpected search controls: %d %d %v %v %q", offset, limit, official, verified, sort)
+		}
+		return artifactHubSearchResult(chartName, version, "example-repo", repositoryURL), nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ChartSourceCandidate{{Type: "repository", Reference: "example-repo", URL: repositoryURL}}
+	if searchQuery != chartName || !slices.Equal(found, want) {
+		t.Fatalf("query/candidates = %q / %+v, want chart name only / %+v", searchQuery, found, want)
+	}
+	beforeConfirmation, err := cfg.Releases.Get(rel.Name, rel.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, associated := chartSourceFromRelease(beforeConfirmation); associated {
+		t.Fatal("ArtifactHub discovery persisted an unconfirmed source")
+	}
+	if name, err := c.ensureClassicRepository(found[0].URL, found[0].Reference); err != nil || name != "example-repo" {
+		t.Fatalf("add verified repository = %q, %v", name, err)
+	}
+	if err := c.setSourceWith(cfg, rel.Name, found[0]); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := cfg.Releases.Get(rel.Name, rel.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source, ok := chartSourceFromRelease(stored); !ok || *source != found[0] {
+		t.Fatalf("associated source = %+v, %v", source, ok)
+	}
+	history, err := cfg.Releases.History(rel.Name)
+	if err != nil || len(history) != 1 || history[0].Version != 1 {
+		t.Fatalf("source association changed Helm revision history: %+v, %v", history, err)
+	}
+}
+
+func TestArtifactHubRecoveryUniqueOCIRequiresIndependentVerification(t *testing.T) {
+	withOCISources(t, nil)
+	cfg, rel := artifactHubRecoveryRelease(t, "external-dns", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	want := ChartSourceCandidate{Type: "oci", Reference: "oci://ghcr.io/example/charts/external-dns"}
+	verified := 0
+	verify := func(_ context.Context, _ *action.Configuration, got *release.Release, candidate ChartSourceCandidate) (ChartSourceCandidate, error) {
+		verified++
+		if got.Name != rel.Name || candidate != want {
+			t.Fatalf("verifier input = %s / %+v", got.Name, candidate)
+		}
+		return candidate, nil
+	}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return artifactHubSearchResult("external-dns", "1.2.3", "external-dns", want.Reference), nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, verify)
+	if err != nil || verified != 1 || !slices.Equal(found, []ChartSourceCandidate{want}) {
+		t.Fatalf("OCI discovery = %+v, verification calls %d, error %v", found, verified, err)
+	}
+}
+
+func TestArtifactHubRecoveryMultipleCandidatesNeverSelects(t *testing.T) {
+	withOCISources(t, nil)
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return &ArtifactHubSearchResult{Charts: []ArtifactHubChart{
+			{Name: "app", Repository: ArtifactHubRepository{Name: "one", URL: "https://one.example.test"}},
+			{Name: "app", Repository: ArtifactHubRepository{Name: "two", URL: "https://two.example.test"}},
+		}}, nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, func(_ context.Context, _ *action.Configuration, _ *release.Release, candidate ChartSourceCandidate) (ChartSourceCandidate, error) {
+		return candidate, nil
+	})
+	if err != nil || len(found) != 2 {
+		t.Fatalf("multiple candidates = %+v, %v", found, err)
+	}
+}
+
+func TestArtifactHubRecoveryRejectsAbsentVersionAndIncompleteUmbrella(t *testing.T) {
+	withOCISources(t, nil)
+	for _, tc := range []struct {
+		name         string
+		chart        *chart.Chart
+		indexVersion string
+	}{
+		{name: "exact version absent", chart: &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "9.9.9"}}, indexVersion: "9.9.9"},
+		{name: "dependency body absent", chart: &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3", Dependencies: []*chart.Dependency{{Name: "child", Version: "1.0.0"}}}}, indexVersion: "1.2.3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repositoryURL := artifactHubTestRepository(t, tc.chart, tc.indexVersion)
+			cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+			c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+			search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+				return artifactHubSearchResult("app", "1.2.3", "example", repositoryURL), nil
+			}
+			found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+			if err != nil || len(found) != 0 {
+				t.Fatalf("unverified source was offered: %+v, %v", found, err)
+			}
+		})
+	}
+}
+
+func TestArtifactHubRecoveryNoResultAndExactProvenancePriority(t *testing.T) {
+	withOCISources(t, nil)
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	dir := t.TempDir()
+	c := &Client{settings: testEnvSettings(filepath.Join(dir, "repositories.yaml"), dir)}
+	searches := 0
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		searches++
+		return &ArtifactHubSearchResult{}, nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil || found == nil || len(found) != 0 || searches != 1 {
+		t.Fatalf("empty discovery = %+v, searches %d, %v", found, searches, err)
+	}
+	repositoryURL := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}}, "1.2.3")
+	rel.Labels = mergeChartSourceLabels(rel.Labels, &ChartSourceCandidate{Type: "repository", Reference: "recorded", URL: repositoryURL})
+	if err := cfg.Releases.Update(rel); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource); err == nil || searches != 1 {
+		t.Fatalf("ArtifactHub queried despite exact provenance: searches=%d err=%v", searches, err)
+	}
+}
+
+func TestArtifactHubRecoveryConfiguredSourcePriority(t *testing.T) {
+	withOCISources(t, nil)
+	cfg, rel := artifactHubRecoveryRelease(t, "argo-cd", "1.2.3")
+	c := testHelmClientWithRepoVersions(t, map[string][]string{"bitnami": {"1.2.3"}})
+	searches := 0
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		searches++
+		return &ArtifactHubSearchResult{}, nil
+	}
+	if _, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource); err == nil || searches != 0 {
+		t.Fatalf("ArtifactHub queried despite configured exact source: searches=%d err=%v", searches, err)
+	}
+}
+
+func TestArtifactHubRecoveryPaginationBoundsAndCancellation(t *testing.T) {
+	withOCISources(t, nil)
+	t.Run("valid package on later page", func(t *testing.T) {
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+		offsets := []int{}
+		search := func(ctx context.Context, _ string, offset, limit int, _ bool, _ bool, _ string) (*ArtifactHubSearchResult, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			offsets = append(offsets, offset)
+			if limit != artifactHubRecoveryPageSize {
+				t.Fatalf("limit = %d", limit)
+			}
+			if offset == 0 {
+				page := make([]ArtifactHubChart, artifactHubRecoveryPageSize)
+				for i := range page {
+					page[i] = ArtifactHubChart{Name: fmt.Sprintf("unrelated-%d", i)}
+				}
+				return &ArtifactHubSearchResult{Charts: page}, nil
+			}
+			return artifactHubSearchResult("app", "1.2.3", "later", "https://later.example.test"), nil
+		}
+		verify := func(_ context.Context, _ *action.Configuration, _ *release.Release, candidate ChartSourceCandidate) (ChartSourceCandidate, error) {
+			return candidate, nil
+		}
+		found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, verify)
+		if err != nil || !slices.Equal(offsets, []int{0, artifactHubRecoveryPageSize}) || len(found) != 1 || found[0].Reference != "later" {
+			t.Fatalf("later-page discovery = %+v offsets=%v err=%v", found, offsets, err)
+		}
+	})
+
+	t.Run("search is bounded", func(t *testing.T) {
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+		calls := 0
+		search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+			calls++
+			page := make([]ArtifactHubChart, artifactHubRecoveryPageSize)
+			for i := range page {
+				page[i] = ArtifactHubChart{Name: "unrelated"}
+			}
+			return &ArtifactHubSearchResult{Charts: page}, nil
+		}
+		found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+		if err != nil || len(found) != 0 || calls != artifactHubRecoveryMaxResults/artifactHubRecoveryPageSize {
+			t.Fatalf("bounded discovery = %+v calls=%d err=%v", found, calls, err)
+		}
+	})
+
+	t.Run("request cancellation stops paging", func(t *testing.T) {
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		search := func(ctx context.Context, _ string, _ int, _ int, _ bool, _ bool, _ string) (*ArtifactHubSearchResult, error) {
+			calls++
+			return nil, ctx.Err()
+		}
+		if _, err := c.discoverArtifactHubSourcesWith(ctx, cfg, rel.Name, search, c.verifyArtifactHubSource); err == nil || !strings.Contains(err.Error(), "canceled") || calls != 0 {
+			t.Fatalf("canceled discovery calls=%d err=%v", calls, err)
+		}
+	})
+}
+
+func TestArtifactHubRecoveryExactSemVerAndIdentity(t *testing.T) {
+	withOCISources(t, nil)
+	for _, version := range []string{"1.2.3", "1.2.3-beta.1", "1.2.3+build.7", "v1.2.3"} {
+		t.Run(version, func(t *testing.T) {
+			repositoryURL := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: version}}, version)
+			cfg, rel := artifactHubRecoveryRelease(t, "app", version)
+			c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+			search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+				return artifactHubSearchResult("app", version, "semver", repositoryURL), nil
+			}
+			found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+			if err != nil || len(found) != 1 {
+				t.Fatalf("exact version %q = %+v, %v", version, found, err)
+			}
+		})
+	}
+
+	t.Run("semantic neighbor is never substituted", func(t *testing.T) {
+		repositoryURL := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.4"}}, "1.2.4")
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+		search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+			return artifactHubSearchResult("app", "1.2.4", "newer", repositoryURL), nil
+		}
+		found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+		if err != nil || len(found) != 0 {
+			t.Fatalf("semantic neighbor was accepted: %+v, %v", found, err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name           string
+		archiveName    string
+		archiveVersion string
+	}{
+		{name: "chart name mismatch", archiveName: "different", archiveVersion: "1.2.3"},
+		{name: "chart version mismatch", archiveName: "app", archiveVersion: "1.2.4"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			archive := artifactHubChartArchive(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: tc.archiveName, Version: tc.archiveVersion}})
+			digest := sha256.Sum256(archive)
+			index := fmt.Sprintf("apiVersion: v1\nentries:\n  app:\n  - apiVersion: v2\n    name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n    digest: %s\n", hex.EncodeToString(digest[:]))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/index.yaml" {
+					_, _ = w.Write([]byte(index))
+					return
+				}
+				_, _ = w.Write(archive)
+			}))
+			defer server.Close()
+			cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+			c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+			search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+				return artifactHubSearchResult("app", "1.2.3", "mismatch", server.URL), nil
+			}
+			found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+			if err != nil || len(found) != 0 {
+				t.Fatalf("mismatched package was accepted: %+v, %v", found, err)
+			}
+		})
+	}
+}
+
+func TestArtifactHubRecoveryRejectsBrokenRepositoryPackages(t *testing.T) {
+	withOCISources(t, nil)
+	validArchive := artifactHubChartArchive(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}})
+	validDigest := sha256.Sum256(validArchive)
+	for _, tc := range []struct {
+		name          string
+		archiveStatus int
+		archive       []byte
+		digest        string
+	}{
+		{name: "archive missing", archiveStatus: http.StatusNotFound, digest: hex.EncodeToString(validDigest[:])},
+		{name: "archive corrupt", archiveStatus: http.StatusOK, archive: []byte("not a chart"), digest: hex.EncodeToString(sha256.New().Sum(nil))},
+		{name: "digest mismatch", archiveStatus: http.StatusOK, archive: validArchive, digest: strings.Repeat("0", sha256.Size*2)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			digest := tc.digest
+			if tc.name == "archive corrupt" {
+				sum := sha256.Sum256(tc.archive)
+				digest = hex.EncodeToString(sum[:])
+			}
+			index := fmt.Sprintf("apiVersion: v1\nentries:\n  app:\n  - apiVersion: v2\n    name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n    digest: %s\n", digest)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/index.yaml" {
+					_, _ = w.Write([]byte(index))
+					return
+				}
+				w.WriteHeader(tc.archiveStatus)
+				if tc.archiveStatus == http.StatusOK {
+					_, _ = w.Write(tc.archive)
+				}
+			}))
+			defer server.Close()
+			cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+			c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+			search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+				return artifactHubSearchResult("app", "1.2.3", "broken", server.URL), nil
+			}
+			found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+			if err != nil || len(found) != 0 {
+				t.Fatalf("broken package was accepted: %+v, %v", found, err)
+			}
+		})
+	}
+}
+
+func TestArtifactHubRecoveryVerificationInfrastructureErrorIsNotNoResult(t *testing.T) {
+	withOCISources(t, nil)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return artifactHubSearchResult("app", "1.2.3", "unavailable", server.URL), nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err == nil || !strings.Contains(err.Error(), "network or service error") || found != nil {
+		t.Fatalf("infrastructure failure became no-result: %+v, %v", found, err)
+	}
+}
+
+func TestArtifactHubRecoveryRepositoryAuthentication(t *testing.T) {
+	withOCISources(t, nil)
+	const username, password = "existing-user", "existing-password"
+	archive := artifactHubChartArchive(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}})
+	digest := sha256.Sum256(archive)
+	index := fmt.Sprintf("apiVersion: v1\nentries:\n  app:\n  - apiVersion: v2\n    name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n    digest: %s\n", hex.EncodeToString(digest[:]))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPassword, ok := r.BasicAuth()
+		if !ok || gotUser != username || gotPassword != password {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/index.yaml" {
+			_, _ = w.Write([]byte(index))
+			return
+		}
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return artifactHubSearchResult("app", "1.2.3", "private", server.URL), nil
+	}
+
+	t.Run("missing credentials is explicit", func(t *testing.T) {
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+		if found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource); err == nil || !strings.Contains(err.Error(), "verification requires authentication") || found != nil {
+			t.Fatalf("missing auth = %+v, %v", found, err)
+		}
+	})
+
+	t.Run("existing Helm credentials are reused", func(t *testing.T) {
+		dir := t.TempDir()
+		settings := testEnvSettings(filepath.Join(dir, "repositories.yaml"), dir)
+		file := repo.NewFile()
+		file.Update(&repo.Entry{Name: "private", URL: server.URL, Username: username, Password: password})
+		if err := file.WriteFile(settings.RepositoryConfig, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+		c := &Client{settings: settings}
+		found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+		if err != nil || len(found) != 1 || strings.Contains(found[0].URL, username) || strings.Contains(found[0].URL, password) {
+			t.Fatalf("credential reuse = %+v, %v", found, err)
+		}
+	})
+}
+
+func TestArtifactHubRecoveryFollowsSafeHTTPSRedirectAndDeduplicates(t *testing.T) {
+	withOCISources(t, nil)
+	archive := artifactHubChartArchive(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}})
+	digest := sha256.Sum256(archive)
+	index := fmt.Sprintf("apiVersion: v1\nentries:\n  app:\n  - apiVersion: v2\n    name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n    digest: %s\n", hex.EncodeToString(digest[:]))
+	tlsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/index.yaml" {
+			_, _ = w.Write([]byte(index))
+			return
+		}
+		if r.URL.Path == "/app-1.2.3.tgz" {
+			_, _ = w.Write(archive)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer tlsServer.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tlsServer.URL+r.URL.Path, http.StatusMovedPermanently)
+	}))
+	defer redirect.Close()
+	oldClient := httpClient
+	httpClient = tlsServer.Client()
+	defer func() { httpClient = oldClient }()
+
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return &ArtifactHubSearchResult{Charts: []ArtifactHubChart{
+			{Name: "app", Repository: ArtifactHubRepository{Name: "redirected", URL: redirect.URL + "/"}},
+			{Name: "app", Repository: ArtifactHubRepository{Name: "canonical", URL: tlsServer.URL}},
+		}}, nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil || len(found) != 1 || found[0].URL != tlsServer.URL {
+		t.Fatalf("redirected/deduplicated source = %+v, %v", found, err)
+	}
+}
+
+func TestArtifactHubRecoveryMovedProvenanceRequiresConfirmation(t *testing.T) {
+	withOCISources(t, nil)
+	newURL := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}}, "1.2.3")
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	oldSource := ChartSourceCandidate{Type: "repository", Reference: "old", URL: "http://127.0.0.1:1/unavailable"}
+	rel.Labels = mergeChartSourceLabels(rel.Labels, &oldSource)
+	if err := cfg.Releases.Update(rel); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	c := &Client{settings: testEnvSettings(filepath.Join(dir, "repositories.yaml"), dir)}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return artifactHubSearchResult("app", "1.2.3", "moved", newURL), nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil || len(found) != 1 {
+		t.Fatalf("moved source discovery = %+v, %v", found, err)
+	}
+	stored, _ := cfg.Releases.Get(rel.Name, rel.Version)
+	if source, ok := chartSourceFromRelease(stored); !ok || *source != oldSource {
+		t.Fatalf("discovery silently replaced provenance: %+v", source)
+	}
+	if _, err := c.ensureClassicRepository(found[0].URL, found[0].Reference); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.setSourceWith(cfg, rel.Name, found[0]); err != nil {
+		t.Fatal(err)
+	}
+	stored, _ = cfg.Releases.Get(rel.Name, rel.Version)
+	if source, ok := chartSourceFromRelease(stored); !ok || *source != found[0] {
+		t.Fatalf("confirmed replacement not persisted: %+v", source)
+	}
+}
+
+func TestArtifactHubRecoveryMultipleVerifiedPublishersRemainAmbiguous(t *testing.T) {
+	withOCISources(t, nil)
+	one := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}}, "1.2.3")
+	two := artifactHubTestRepository(t, &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3"}}, "1.2.3")
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return &ArtifactHubSearchResult{Charts: []ArtifactHubChart{
+			{Name: "app", Repository: ArtifactHubRepository{Name: "publisher-one", URL: one}},
+			{Name: "app", Repository: ArtifactHubRepository{Name: "publisher-two", URL: two}},
+		}}, nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil || len(found) != 2 {
+		t.Fatalf("verified alternatives = %+v, %v", found, err)
+	}
+	if _, associated := chartSourceFromRelease(rel); associated {
+		t.Fatal("ambiguous alternatives were automatically associated")
+	}
+}
+
+func TestArtifactHubRecoveryRecursiveDependencyRemainsFailClosed(t *testing.T) {
+	withOCISources(t, nil)
+	child := &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "child", Version: "1.0.0", Dependencies: []*chart.Dependency{{Name: "grandchild", Version: "1.0.0"}}}}
+	parent := &chart.Chart{Metadata: &chart.Metadata{APIVersion: "v2", Name: "app", Version: "1.2.3", Dependencies: []*chart.Dependency{{Name: "child", Version: "1.0.0"}}}}
+	parent.AddDependency(child)
+	repositoryURL := artifactHubTestRepository(t, parent, "1.2.3")
+	cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+	c := &Client{settings: testEnvSettings(filepath.Join(t.TempDir(), "repositories.yaml"), t.TempDir())}
+	search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+		return artifactHubSearchResult("app", "1.2.3", "incomplete", repositoryURL), nil
+	}
+	found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, c.verifyArtifactHubSource)
+	if err != nil || len(found) != 0 {
+		t.Fatalf("recursive dependency gap was accepted: %+v, %v", found, err)
+	}
+}
+
+func TestArtifactHubRecoveryOCIAuthenticationOutcomes(t *testing.T) {
+	withOCISources(t, nil)
+	for _, tc := range []struct {
+		name                string
+		existingCredentials bool
+		verifyErr           error
+		wantError           string
+	}{
+		{name: "public OCI"},
+		{name: "private OCI with existing Helm registry credentials", existingCredentials: true},
+		{name: "private OCI without credentials", verifyErr: errors.New("unauthorized: authentication required"), wantError: "verification requires authentication"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, rel := artifactHubRecoveryRelease(t, "app", "1.2.3")
+			dir := t.TempDir()
+			settings := testEnvSettings(filepath.Join(dir, "repositories.yaml"), dir)
+			if tc.existingCredentials {
+				settings.RegistryConfig = filepath.Join(dir, "registry.json")
+				if err := os.WriteFile(settings.RegistryConfig, []byte(`{"auths":{"registry.example.test":{"auth":"dGVzdDp0ZXN0"}}}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			c := &Client{settings: settings}
+			search := func(context.Context, string, int, int, bool, bool, string) (*ArtifactHubSearchResult, error) {
+				return artifactHubSearchResult("app", "1.2.3", "oci", "oci://registry.example.test/charts/app"), nil
+			}
+			verify := func(_ context.Context, _ *action.Configuration, _ *release.Release, candidate ChartSourceCandidate) (ChartSourceCandidate, error) {
+				if tc.existingCredentials {
+					if _, err := c.newRegistryClientConcrete(); err != nil {
+						return ChartSourceCandidate{}, err
+					}
+				}
+				if tc.verifyErr != nil {
+					return ChartSourceCandidate{}, classifyArtifactHubVerificationError(tc.verifyErr)
+				}
+				return candidate, nil
+			}
+			found, err := c.discoverArtifactHubSourcesWith(context.Background(), cfg, rel.Name, search, verify)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) || found != nil {
+					t.Fatalf("OCI auth failure = %+v, %v", found, err)
+				}
+				return
+			}
+			if err != nil || len(found) != 1 {
+				t.Fatalf("OCI auth success = %+v, %v", found, err)
+			}
+		})
+	}
+}
+
+func TestArtifactHubSearchNetworkFailuresRemainDistinct(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(status) }))
+			defer server.Close()
+			_, err := searchArtifactHubAt(context.Background(), server.URL, "app", 0, 1, false, false, "relevance")
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("HTTP %d", status)) {
+				t.Fatalf("status %d error = %v", status, err)
+			}
+		})
+	}
+
+	oldClient := httpClient
+	defer func() { httpClient = oldClient }()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "DNS", err: &url.Error{Op: "Get", URL: "https://artifacthub.invalid", Err: &net.DNSError{Err: "no such host", Name: "artifacthub.invalid"}}, want: "DNS lookup failed"},
+		{name: "TLS", err: errors.New("x509: certificate signed by unknown authority"), want: "TLS validation failed"},
+		{name: "timeout", err: &timeoutNetworkError{}, want: "timed out"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, tc.err })}
+			_, err := searchArtifactHubAt(context.Background(), "https://artifacthub.example.test", "app", 0, 1, false, false, "relevance")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("%s error = %v", tc.name, err)
+			}
+		})
+	}
+
+	t.Run("canceled", func(t *testing.T) {
+		httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		})}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := searchArtifactHubAt(ctx, "https://artifacthub.example.test", "app", 0, 1, false, false, "relevance")
+		if err == nil || !strings.Contains(err.Error(), "canceled") {
+			t.Fatalf("cancel error = %v", err)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+type timeoutNetworkError struct{}
+
+func (*timeoutNetworkError) Error() string   { return "network timeout" }
+func (*timeoutNetworkError) Timeout() bool   { return true }
+func (*timeoutNetworkError) Temporary() bool { return true }
+
+func testEnvSettings(repositoryConfig, repositoryCache string) *cli.EnvSettings {
+	return &cli.EnvSettings{RepositoryConfig: repositoryConfig, RepositoryCache: repositoryCache}
+}

--- a/internal/helm/chart_sources.go
+++ b/internal/helm/chart_sources.go
@@ -1,0 +1,582 @@
+package helm
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+const (
+	chartSourceTypeLabel = "radar.skyhook.io/chart-source-type"
+	chartSourceRefLabel  = "radar.skyhook.io/chart-source-ref-"
+	chartSourceURLLabel  = "radar.skyhook.io/chart-source-url-"
+	chartSourceChunkSize = 63
+	chartSourceMaxChunks = 16
+)
+
+var repositoryNamePartRE = regexp.MustCompile(`[^a-z0-9._-]+`)
+
+// chartSourceLabels encodes the credential-free source reference into Helm
+// release labels. Helm persists these labels with the release Secret and merges
+// them forward on upgrades, so provenance is cluster-scoped and survives Radar
+// restarts without introducing a second database.
+func addChartSourceLabelChunks(labels map[string]string, prefix, value string) bool {
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(value))
+	if encoded == "" || len(encoded) > chartSourceChunkSize*chartSourceMaxChunks {
+		return false
+	}
+	for i := 0; len(encoded) > 0; i++ {
+		n := min(chartSourceChunkSize, len(encoded))
+		labels[fmt.Sprintf("%s%d", prefix, i)] = encoded[:n]
+		encoded = encoded[n:]
+	}
+	return true
+}
+
+func decodeChartSourceLabelChunks(labels map[string]string, prefix string) (string, bool) {
+	var encoded strings.Builder
+	for i := 0; i < chartSourceMaxChunks; i++ {
+		chunk, ok := labels[fmt.Sprintf("%s%d", prefix, i)]
+		if !ok {
+			break
+		}
+		encoded.WriteString(chunk)
+	}
+	if encoded.Len() == 0 {
+		return "", false
+	}
+	decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(encoded.String())
+	if err != nil || len(decoded) == 0 {
+		return "", false
+	}
+	return string(decoded), true
+}
+
+func chartSourceLabels(source *ChartSourceCandidate) map[string]string {
+	if source == nil || (source.Type != "repository" && source.Type != "oci") || source.Reference == "" {
+		return nil
+	}
+	var repositoryURL string
+	if source.Type == "repository" {
+		var err error
+		repositoryURL, err = canonicalClassicRepositoryURL(source.URL)
+		if err != nil {
+			return nil
+		}
+	} else if source.URL != "" {
+		return nil
+	}
+	labels := map[string]string{chartSourceTypeLabel: source.Type}
+	if !addChartSourceLabelChunks(labels, chartSourceRefLabel, source.Reference) {
+		return nil
+	}
+	if repositoryURL != "" && !addChartSourceLabelChunks(labels, chartSourceURLLabel, repositoryURL) {
+		return nil
+	}
+	return labels
+}
+
+func validateChartSourceCandidate(source *ChartSourceCandidate) error {
+	if len(chartSourceLabels(source)) == 0 {
+		return fmt.Errorf("chart source is invalid or too long to persist safely")
+	}
+	return nil
+}
+
+func chartSourceFromRelease(rel *release.Release) (*ChartSourceCandidate, bool) {
+	if rel == nil || rel.Labels == nil {
+		return nil, false
+	}
+	typ := rel.Labels[chartSourceTypeLabel]
+	if typ != "repository" && typ != "oci" {
+		return nil, false
+	}
+	reference, ok := decodeChartSourceLabelChunks(rel.Labels, chartSourceRefLabel)
+	if !ok {
+		return nil, false
+	}
+	source := &ChartSourceCandidate{Type: typ, Reference: reference}
+	if rawURL, hasURL := decodeChartSourceLabelChunks(rel.Labels, chartSourceURLLabel); hasURL {
+		if typ != "repository" {
+			return nil, false
+		}
+		canonicalURL, err := canonicalClassicRepositoryURL(rawURL)
+		if err != nil {
+			return nil, false
+		}
+		source.URL = canonicalURL
+	}
+	return source, true
+}
+
+func mergeChartSourceLabels(current map[string]string, source *ChartSourceCandidate) map[string]string {
+	labels := make(map[string]string, len(current)+chartSourceMaxChunks+1)
+	for k, v := range current {
+		if k != chartSourceTypeLabel && !strings.HasPrefix(k, chartSourceRefLabel) && !strings.HasPrefix(k, chartSourceURLLabel) {
+			labels[k] = v
+		}
+	}
+	for k, v := range chartSourceLabels(source) {
+		labels[k] = v
+	}
+	return labels
+}
+
+func normalizedRepositoryName(preferred string) string {
+	base := strings.ToLower(strings.TrimSpace(preferred))
+	base = repositoryNamePartRE.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-._")
+	if len(base) > 40 {
+		base = strings.TrimRight(base[:40], "-._")
+	}
+	return base
+}
+
+func stableRepositoryName(preferred, rawURL string) string {
+	base := normalizedRepositoryName(preferred)
+	if base == "" {
+		if parsed, err := url.Parse(rawURL); err == nil {
+			base = normalizedRepositoryName(parsed.Hostname())
+		}
+	}
+	if base == "" {
+		base = "source"
+	}
+	sum := sha256.Sum256([]byte(rawURL))
+	return fmt.Sprintf("radar-%s-%x", base, sum[:4])
+}
+
+func resolveOCIInstallSource(raw, chartName string) (chartURL, prefix string, err error) {
+	ref := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if !strings.HasPrefix(ref, "oci://") || chartName == "" {
+		return "", "", fmt.Errorf("invalid OCI chart source")
+	}
+	if strings.HasSuffix(ref, "/"+chartName) {
+		chartURL = ref
+		prefix = strings.TrimSuffix(ref, "/"+chartName)
+	} else {
+		prefix = ref
+		chartURL = ref + "/" + chartName
+	}
+	if _, err := normalizeOCIPrefix(prefix); err != nil {
+		return "", "", err
+	}
+	return chartURL, prefix, nil
+}
+
+// ensureClassicRepository reuses repositories.yaml as the durable registry for
+// a resolved HTTP source (notably ArtifactHub discovery). Credentials embedded
+// in repository URLs are rejected; authenticated repos continue to use Helm's
+// own repository configuration mechanisms.
+func canonicalClassicRepositoryURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(rawURL), "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid Helm repository URL")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", fmt.Errorf("invalid Helm repository URL")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("repository URL must not contain credentials")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("repository URL must not contain query credentials or fragments")
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "http" && port == "80") || (parsed.Scheme == "https" && port == "443") {
+		port = ""
+	}
+	parsed.Host = hostname
+	if port != "" {
+		parsed.Host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		parsed.Host = "[" + hostname + "]"
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = strings.TrimRight(parsed.RawPath, "/")
+	return parsed.String(), nil
+}
+
+func (c *Client) ensureClassicRepository(rawURL, preferredName string) (string, error) {
+	repoURL, err := canonicalClassicRepositoryURL(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	f, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("failed to load repo file: %w", err)
+		}
+		f = repo.NewFile()
+	}
+	for _, existing := range f.Repositories {
+		existingURL, canonicalErr := canonicalClassicRepositoryURL(existing.URL)
+		if canonicalErr == nil && existingURL == repoURL {
+			chartRepo, err := repo.NewChartRepository(existing, getter.All(c.settings))
+			if err != nil {
+				return "", fmt.Errorf("failed to create chart repository: %w", err)
+			}
+			chartRepo.CachePath = c.settings.RepositoryCache
+			if _, err := chartRepo.DownloadIndexFile(); err != nil {
+				return "", fmt.Errorf("failed to refresh repository index: %w", err)
+			}
+			return existing.Name, nil
+		}
+	}
+
+	name := normalizedRepositoryName(preferredName)
+	if name == "" {
+		name = stableRepositoryName("", repoURL)
+	}
+	if existing := f.Get(name); existing != nil {
+		existingURL, canonicalErr := canonicalClassicRepositoryURL(existing.URL)
+		if canonicalErr != nil || existingURL != repoURL {
+			return "", fmt.Errorf("repository name %q is already configured with a different URL", name)
+		}
+	}
+	entry := &repo.Entry{Name: name, URL: repoURL}
+	chartRepo, err := repo.NewChartRepository(entry, getter.All(c.settings))
+	if err != nil {
+		return "", fmt.Errorf("failed to create chart repository: %w", err)
+	}
+	chartRepo.CachePath = c.settings.RepositoryCache
+	if _, err := chartRepo.DownloadIndexFile(); err != nil {
+		return "", fmt.Errorf("failed to download repository index: %w", err)
+	}
+	f.Update(entry)
+	if err := f.WriteFile(c.settings.RepositoryConfig, 0o600); err != nil {
+		return "", fmt.Errorf("failed to persist Helm repository: %w", err)
+	}
+	return name, nil
+}
+
+func (c *Client) configuredChartSourceCandidates(chartName, version string, lister ociTagLister) ([]ChartSourceCandidate, error) {
+	candidates := make([]ChartSourceCandidate, 0)
+	f, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("[helm] source recovery could not read classic repository config: %v", err)
+	}
+	if err == nil {
+		for _, configured := range f.Repositories {
+			repositoryURL, urlErr := canonicalClassicRepositoryURL(configured.URL)
+			if urlErr != nil {
+				continue
+			}
+			idx, loadErr := repo.LoadIndexFile(c.settings.RepositoryCache + string(os.PathSeparator) + configured.Name + "-index.yaml")
+			if loadErr != nil {
+				continue
+			}
+			for _, entry := range idx.Entries[chartName] {
+				if entry.Version == version {
+					candidates = append(candidates, ChartSourceCandidate{Type: "repository", Reference: configured.Name, URL: repositoryURL})
+					break
+				}
+			}
+		}
+	}
+	if len(ListOCISources()) > 0 {
+		if lister == nil {
+			lister = c.newRegistryClient()
+		}
+		if lister != nil {
+			for _, prefix := range ListOCISources() {
+				tags, tagErr := lister.Tags(ociRef(prefix, chartName))
+				if tagErr == nil && slices.Contains(tags, version) {
+					candidates = append(candidates, ChartSourceCandidate{Type: "oci", Reference: ociChartURL(prefix, chartName)})
+				}
+			}
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Type != candidates[j].Type {
+			return candidates[i].Type < candidates[j].Type
+		}
+		return candidates[i].Reference < candidates[j].Reference
+	})
+	return candidates, nil
+}
+
+// configuredRepositoryForSource resolves durable classic provenance on the
+// current machine. Legacy metadata resolves by local alias only. New metadata
+// requires the recorded alias to have the same URL, but can reuse an identical
+// URL registered under another local alias.
+func (c *Client) configuredRepositoryForSource(source ChartSourceCandidate) *repo.Entry {
+	if source.Type != "repository" || source.Reference == "" {
+		return nil
+	}
+	f, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil {
+		return nil
+	}
+	byName := f.Get(source.Reference)
+	if source.URL == "" {
+		return byName
+	}
+	recordedURL, err := canonicalClassicRepositoryURL(source.URL)
+	if err != nil {
+		return nil
+	}
+	if byName != nil {
+		configuredURL, err := canonicalClassicRepositoryURL(byName.URL)
+		if err != nil || configuredURL != recordedURL {
+			return nil
+		}
+		return byName
+	}
+	for _, configured := range f.Repositories {
+		configuredURL, err := canonicalClassicRepositoryURL(configured.URL)
+		if err == nil && configuredURL == recordedURL {
+			return configured
+		}
+	}
+	return nil
+}
+
+func (c *Client) applyCandidateUpgrade(info *UpgradeInfo, candidate ChartSourceCandidate, chartName, currentVersion string, lister ociTagLister) bool {
+	switch candidate.Type {
+	case "repository":
+		configured := c.configuredRepositoryForSource(candidate)
+		if configured == nil {
+			return false
+		}
+		idx, err := repo.LoadIndexFile(c.settings.RepositoryCache + string(os.PathSeparator) + configured.Name + "-index.yaml")
+		if err != nil {
+			return false
+		}
+		var latest string
+		for _, entry := range idx.Entries[chartName] {
+			if latest == "" || compareVersions(entry.Version, latest) > 0 {
+				latest = entry.Version
+			}
+		}
+		if latest == "" {
+			return false
+		}
+		info.LatestVersion = latest
+		info.RepositoryName = configured.Name
+		info.SourceType = "repository"
+		info.UpdateAvailable = compareVersions(latest, currentVersion) > 0
+		return true
+	case "oci":
+		if lister == nil {
+			lister = c.newRegistryClient()
+		}
+		if lister == nil {
+			return false
+		}
+		tags, err := lister.Tags(strings.TrimPrefix(candidate.Reference, "oci://"))
+		if err != nil || !slices.Contains(tags, currentVersion) || len(tags) == 0 {
+			return false
+		}
+		info.LatestVersion = tags[0]
+		info.ChartRef = candidate.Reference
+		info.SourceType = "oci"
+		info.UpdateAvailable = compareVersions(tags[0], currentVersion) > 0
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Client) candidateVersions(candidate ChartSourceCandidate, chartName string, lister ociTagLister) []string {
+	switch candidate.Type {
+	case "repository":
+		configured := c.configuredRepositoryForSource(candidate)
+		if configured == nil {
+			return nil
+		}
+		idx, err := repo.LoadIndexFile(c.settings.RepositoryCache + string(os.PathSeparator) + configured.Name + "-index.yaml")
+		if err != nil {
+			return nil
+		}
+		versions := make([]string, 0, len(idx.Entries[chartName]))
+		for _, entry := range idx.Entries[chartName] {
+			versions = append(versions, entry.Version)
+		}
+		return sortVersionsDesc(versions)
+	case "oci":
+		if lister == nil {
+			lister = c.newRegistryClient()
+		}
+		if lister == nil {
+			return nil
+		}
+		tags, err := lister.Tags(strings.TrimPrefix(candidate.Reference, "oci://"))
+		if err != nil {
+			return nil
+		}
+		return tags
+	default:
+		return nil
+	}
+}
+
+func (c *Client) sourceCandidatesWith(actionConfig *action.Configuration, name string) ([]ChartSourceCandidate, error) {
+	rel, err := action.NewGet(actionConfig).Run(name)
+	if err != nil {
+		return nil, err
+	}
+	if rel.Chart == nil || rel.Chart.Metadata == nil {
+		return nil, fmt.Errorf("release has no usable chart metadata")
+	}
+	// New-format classic provenance is sufficient to bootstrap a machine that
+	// does not yet have the repository in repositories.yaml. Return it directly;
+	// SetSource still verifies the exact chart/version after the repository is
+	// added and its index is refreshed.
+	if recorded, ok := chartSourceFromRelease(rel); ok && recorded.Type == "repository" && recorded.URL != "" {
+		return []ChartSourceCandidate{*recorded}, nil
+	}
+	return c.configuredChartSourceCandidates(rel.Chart.Metadata.Name, rel.Chart.Metadata.Version, nil)
+}
+
+func (c *Client) SourceCandidates(namespace, name string) ([]ChartSourceCandidate, error) {
+	cfg, err := c.getActionConfig(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return c.sourceCandidatesWith(cfg, name)
+}
+
+func (c *Client) SourceCandidatesAsUser(namespace, name, username string, groups []string) ([]ChartSourceCandidate, error) {
+	cfg, err := c.getActionConfigForUser(namespace, username, groups)
+	if err != nil {
+		return nil, err
+	}
+	return c.sourceCandidatesWith(cfg, name)
+}
+
+// recoverLegacyClassicSource upgrades old name-only provenance when the local
+// alias still publishes the exact installed chart/version, or when that alias
+// is absent and exactly one configured classic repository does. Ambiguous,
+// absent, version-mismatched, and OCI-only matches remain fail-closed.
+func (c *Client) recoverLegacyClassicSource(actionConfig *action.Configuration, rel *release.Release, legacy ChartSourceCandidate, lister ociTagLister) (*ChartSourceCandidate, error) {
+	if legacy.Type != "repository" || legacy.URL != "" {
+		return nil, nil
+	}
+	if rel == nil || rel.Chart == nil || rel.Chart.Metadata == nil {
+		return nil, fmt.Errorf("release has no usable chart metadata")
+	}
+	candidates, err := c.configuredChartSourceCandidates(rel.Chart.Metadata.Name, rel.Chart.Metadata.Version, lister)
+	if err != nil {
+		return nil, err
+	}
+	var recovered *ChartSourceCandidate
+	if configured := c.configuredRepositoryForSource(legacy); configured != nil {
+		for i := range candidates {
+			if candidates[i].Type == "repository" && candidates[i].Reference == configured.Name {
+				recovered = &candidates[i]
+				break
+			}
+		}
+	} else if len(candidates) == 1 && candidates[0].Type == "repository" {
+		recovered = &candidates[0]
+	}
+	if recovered == nil {
+		return nil, nil
+	}
+	if err := validateChartSourceCandidate(recovered); err != nil {
+		return nil, err
+	}
+	rel.Labels = mergeChartSourceLabels(rel.Labels, recovered)
+	if err := actionConfig.Releases.Update(rel); err != nil {
+		return nil, fmt.Errorf("persist recovered chart source: %w", err)
+	}
+	return recovered, nil
+}
+
+func (c *Client) setSourceWith(actionConfig *action.Configuration, name string, selected ChartSourceCandidate) error {
+	if selected.Reference == "" || (selected.Type != "repository" && selected.Type != "oci") {
+		return fmt.Errorf("chart source is invalid")
+	}
+	selectedURL := ""
+	if selected.Type == "repository" && selected.URL != "" {
+		var err error
+		selectedURL, err = canonicalClassicRepositoryURL(selected.URL)
+		if err != nil {
+			return err
+		}
+	} else if selected.Type == "oci" {
+		if err := validateChartSourceCandidate(&selected); err != nil {
+			return err
+		}
+	}
+	rel, err := action.NewGet(actionConfig).Run(name)
+	if err != nil {
+		return err
+	}
+	if rel.Chart == nil || rel.Chart.Metadata == nil {
+		return fmt.Errorf("release has no usable chart metadata")
+	}
+	candidates, err := c.configuredChartSourceCandidates(rel.Chart.Metadata.Name, rel.Chart.Metadata.Version, nil)
+	if err != nil {
+		return err
+	}
+	var persisted *ChartSourceCandidate
+	for i := range candidates {
+		candidate := &candidates[i]
+		switch selected.Type {
+		case "repository":
+			if candidate.Type != "repository" {
+				continue
+			}
+			if selectedURL != "" {
+				if candidate.URL != selectedURL {
+					continue
+				}
+			} else if candidate.Reference != selected.Reference {
+				continue
+			}
+			persisted = candidate
+		case "oci":
+			if *candidate == selected {
+				persisted = candidate
+			}
+		}
+		if persisted != nil {
+			break
+		}
+	}
+	if persisted == nil {
+		return fmt.Errorf("selected source does not publish %s version %s", rel.Chart.Metadata.Name, rel.Chart.Metadata.Version)
+	}
+	if err := validateChartSourceCandidate(persisted); err != nil {
+		return err
+	}
+	rel.Labels = mergeChartSourceLabels(rel.Labels, persisted)
+	return actionConfig.Releases.Update(rel)
+}
+
+func (c *Client) SetSource(namespace, name string, selected ChartSourceCandidate) error {
+	cfg, err := c.getActionConfig(namespace)
+	if err != nil {
+		return err
+	}
+	return c.setSourceWith(cfg, name, selected)
+}
+
+func (c *Client) SetSourceAsUser(namespace, name string, selected ChartSourceCandidate, username string, groups []string) error {
+	cfg, err := c.getActionConfigForUser(namespace, username, groups)
+	if err != nil {
+		return err
+	}
+	return c.setSourceWith(cfg, name, selected)
+}

--- a/internal/helm/chart_sources_test.go
+++ b/internal/helm/chart_sources_test.go
@@ -1,0 +1,378 @@
+package helm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/repo"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestChartSourceLabelsRoundTripSurvivesReleaseReload(t *testing.T) {
+	sources := []ChartSourceCandidate{
+		{Type: "repository", Reference: "radar-example-12345678", URL: "https://charts.example.test"},
+		{Type: "oci", Reference: "oci://ghcr.io/example/charts/example-chart"},
+	}
+	for _, source := range sources {
+		labels := chartSourceLabels(&source)
+		for key, value := range labels {
+			if errors := validation.IsValidLabelValue(value); len(errors) > 0 {
+				t.Fatalf("label %s value %q is invalid: %v", key, value, errors)
+			}
+		}
+		rel := &release.Release{Labels: labels}
+		got, ok := chartSourceFromRelease(rel)
+		if !ok || *got != source {
+			t.Fatalf("round trip = %+v, %v; want %+v", got, ok, source)
+		}
+	}
+}
+
+func TestEnsureClassicRepositoryPersistsResolvedArtifactHubSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/index.yaml" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("apiVersion: v1\nentries:\n  app:\n  - name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n"))
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	c := &Client{settings: &cli.EnvSettings{RepositoryConfig: filepath.Join(dir, "repositories.yaml"), RepositoryCache: dir}}
+
+	name, err := c.ensureClassicRepository(server.URL, "Artifact Hub Example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "artifact-hub-example" {
+		t.Fatalf("repository name = %q, want requested normalized name", name)
+	}
+	if repeated, err := c.ensureClassicRepository(server.URL+"/", name); err != nil || repeated != name {
+		t.Fatalf("identical repository must succeed idempotently: %q, %v", repeated, err)
+	}
+	if _, err := c.ensureClassicRepository(server.URL+"/different", name); err == nil {
+		t.Fatal("same name with different URL must report a conflict")
+	}
+	reloaded, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Get(name) == nil || reloaded.Get(name).URL != server.URL {
+		t.Fatalf("persisted repository = %+v, want %s", reloaded.Repositories, server.URL)
+	}
+	if len(reloaded.Repositories) != 1 {
+		t.Fatalf("idempotent add duplicated repository: %d entries", len(reloaded.Repositories))
+	}
+	if _, err := os.Stat(filepath.Join(dir, name+"-index.yaml")); err != nil {
+		t.Fatalf("persisted index: %v", err)
+	}
+	candidates, err := c.configuredChartSourceCandidates("app", "1.2.3", &fakeTagLister{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(candidates, []ChartSourceCandidate{{Type: "repository", Reference: name, URL: server.URL}}) {
+		t.Fatalf("recovery candidates = %+v, want newly added repository", candidates)
+	}
+}
+
+func TestCanonicalClassicRepositoryURLNormalizesEquivalentURLs(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{input: "https://CHARTS.Example.Test:443/path///", want: "https://charts.example.test/path"},
+		{input: "http://CHARTS.Example.Test:80/", want: "http://charts.example.test"},
+		{input: "https://charts.example.test/path", want: "https://charts.example.test/path"},
+	} {
+		got, err := canonicalClassicRepositoryURL(tc.input)
+		if err != nil || got != tc.want {
+			t.Fatalf("canonicalClassicRepositoryURL(%q) = %q, %v; want %q", tc.input, got, err, tc.want)
+		}
+	}
+}
+
+func TestExistingReleaseRecoversAndPersistsUniqueClassicSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/index.yaml" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("apiVersion: v1\nentries:\n  example-chart:\n  - name: example-chart\n    version: 1.2.3\n    urls: [example-chart-1.2.3.tgz]\n"))
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	c := &Client{settings: &cli.EnvSettings{RepositoryConfig: filepath.Join(dir, "repositories.yaml"), RepositoryCache: dir}}
+	if name, err := c.ensureClassicRepository(server.URL, "example-repo"); err != nil || name != "example-repo" {
+		t.Fatalf("add repository = %q, %v", name, err)
+	}
+
+	memory := driver.NewMemory()
+	memory.SetNamespace("example-namespace")
+	releases := storage.Init(memory)
+	rel := &release.Release{
+		Name:      "example-release",
+		Namespace: "example-namespace",
+		Version:   1,
+		Info:      &release.Info{Status: release.StatusDeployed},
+		Chart:     &chart.Chart{Metadata: &chart.Metadata{Name: "example-chart", Version: "1.2.3"}},
+	}
+	if err := releases.Create(rel); err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := c.configuredChartSourceCandidates(rel.Chart.Metadata.Name, rel.Chart.Metadata.Version, &fakeTagLister{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(candidates, []ChartSourceCandidate{{Type: "repository", Reference: "example-repo", URL: server.URL}}) {
+		t.Fatalf("candidates = %+v", candidates)
+	}
+	rel.Labels = mergeChartSourceLabels(rel.Labels, &candidates[0])
+	if err := releases.Update(rel); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := releases.Get(rel.Name, rel.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, ok := chartSourceFromRelease(stored)
+	if !ok || source.Type != "repository" || source.Reference != "example-repo" || source.URL != server.URL {
+		t.Fatalf("stored source = %+v, %v", source, ok)
+	}
+}
+
+func TestClassicRepositoryProvenanceRecoversAcrossMachines(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/index.yaml" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("apiVersion: v1\nentries:\n  app:\n  - name: app\n    version: 1.2.3\n    urls: [app-1.2.3.tgz]\n"))
+	}))
+	defer server.Close()
+	withOCISources(t, nil)
+
+	newMachine := func() *Client {
+		dir := t.TempDir()
+		return &Client{settings: &cli.EnvSettings{RepositoryConfig: filepath.Join(dir, "repositories.yaml"), RepositoryCache: dir}}
+	}
+	machineA := newMachine()
+	if name, err := machineA.ensureClassicRepository(server.URL, "example-repo"); err != nil || name != "example-repo" {
+		t.Fatalf("machine A repository = %q, %v", name, err)
+	}
+
+	memory := driver.NewMemory()
+	memory.SetNamespace("example")
+	releases := storage.Init(memory)
+	rel := &release.Release{
+		Name:      "app",
+		Namespace: "example",
+		Version:   1,
+		Info:      &release.Info{Status: release.StatusDeployed},
+		Chart:     &chart.Chart{Metadata: &chart.Metadata{Name: "app", Version: "1.2.3"}},
+	}
+	if err := releases.Create(rel); err != nil {
+		t.Fatal(err)
+	}
+	actionConfig := &action.Configuration{
+		Releases:   releases,
+		KubeClient: &fake.PrintingKubeClient{},
+		Log:        func(string, ...interface{}) {},
+	}
+	candidates, err := machineA.configuredChartSourceCandidates("app", "1.2.3", &fakeTagLister{})
+	if err != nil || len(candidates) != 1 {
+		t.Fatalf("machine A candidates = %+v, %v", candidates, err)
+	}
+	if err := machineA.setSourceWith(actionConfig, rel.Name, candidates[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	machineB := newMachine()
+	if _, err := os.Stat(machineB.settings.RepositoryConfig); !os.IsNotExist(err) {
+		t.Fatalf("machine B unexpectedly has repositories.yaml: %v", err)
+	}
+	recorded, err := machineB.sourceCandidatesWith(actionConfig, rel.Name)
+	if err != nil || !slices.Equal(recorded, []ChartSourceCandidate{{Type: "repository", Reference: "example-repo", URL: server.URL}}) {
+		t.Fatalf("machine B recorded source = %+v, %v", recorded, err)
+	}
+	if name, err := machineB.ensureClassicRepository(recorded[0].URL, recorded[0].Reference); err != nil || name != "example-repo" {
+		t.Fatalf("machine B add repository = %q, %v", name, err)
+	}
+	if err := machineB.setSourceWith(actionConfig, rel.Name, recorded[0]); err != nil {
+		t.Fatal(err)
+	}
+	info := &UpgradeInfo{CurrentVersion: "1.2.3"}
+	if !machineB.applyCandidateUpgrade(info, recorded[0], "app", "1.2.3", &fakeTagLister{}) {
+		t.Fatal("machine B could not reconstruct the exact recorded chart/version")
+	}
+}
+
+func TestLegacyNameOnlyClassicProvenanceCompatibility(t *testing.T) {
+	c := testHelmClientWithRepoVersions(t, map[string][]string{"bitnami": {"1.2.3"}})
+	legacyLabels := map[string]string{chartSourceTypeLabel: "repository"}
+	if !addChartSourceLabelChunks(legacyLabels, chartSourceRefLabel, "missing-on-machine-b") {
+		t.Fatal("encode legacy source")
+	}
+	rel := &release.Release{
+		Name: "argo", Namespace: "default", Version: 1, Labels: legacyLabels,
+		Info:  &release.Info{Status: release.StatusDeployed},
+		Chart: &chart.Chart{Metadata: &chart.Metadata{Name: "argo-cd", Version: "1.2.3"}},
+	}
+	memory := driver.NewMemory()
+	memory.SetNamespace("default")
+	releases := storage.Init(memory)
+	if err := releases.Create(rel); err != nil {
+		t.Fatal(err)
+	}
+	legacy, ok := chartSourceFromRelease(rel)
+	if !ok || legacy.Reference != "missing-on-machine-b" || legacy.URL != "" {
+		t.Fatalf("legacy source = %+v, %v", legacy, ok)
+	}
+	recovered, err := c.recoverLegacyClassicSource(&action.Configuration{Releases: releases}, rel, *legacy, &fakeTagLister{})
+	if err != nil || recovered == nil || recovered.Reference != "bitnami" || recovered.URL != "https://charts.bitnami.com/bitnami" {
+		t.Fatalf("recovered source = %+v, %v", recovered, err)
+	}
+	stored, err := releases.Get(rel.Name, rel.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upgraded, ok := chartSourceFromRelease(stored)
+	if !ok || *upgraded != *recovered {
+		t.Fatalf("upgraded provenance = %+v, %v; want %+v", upgraded, ok, recovered)
+	}
+
+	localLabels := map[string]string{chartSourceTypeLabel: "repository"}
+	if !addChartSourceLabelChunks(localLabels, chartSourceRefLabel, "bitnami") {
+		t.Fatal("encode local legacy source")
+	}
+	localRel := &release.Release{
+		Name: "argo-local", Namespace: "default", Version: 1, Labels: localLabels,
+		Info:  &release.Info{Status: release.StatusDeployed},
+		Chart: rel.Chart,
+	}
+	if err := releases.Create(localRel); err != nil {
+		t.Fatal(err)
+	}
+	localLegacy := ChartSourceCandidate{Type: "repository", Reference: "bitnami"}
+	localRecovered, err := c.recoverLegacyClassicSource(&action.Configuration{Releases: releases}, localRel, localLegacy, &fakeTagLister{})
+	if err != nil || localRecovered == nil || localRecovered.Reference != "bitnami" || localRecovered.URL != "https://charts.bitnami.com/bitnami" {
+		t.Fatalf("local alias migration = %+v, %v", localRecovered, err)
+	}
+	info := &UpgradeInfo{CurrentVersion: "1.2.3"}
+	if !c.applyCandidateUpgrade(info, *localRecovered, "argo-cd", "1.2.3", &fakeTagLister{}) {
+		t.Fatal("legacy name-only provenance with a local alias no longer resolves")
+	}
+
+	emptyDir := t.TempDir()
+	emptyClient := &Client{settings: &cli.EnvSettings{
+		RepositoryConfig: filepath.Join(emptyDir, "repositories.yaml"),
+		RepositoryCache:  emptyDir,
+	}}
+	missing, err := emptyClient.recoverLegacyClassicSource(
+		&action.Configuration{Releases: releases},
+		&release.Release{Chart: rel.Chart},
+		ChartSourceCandidate{Type: "repository", Reference: "unknown"},
+		&fakeTagLister{},
+	)
+	if err != nil || missing != nil {
+		t.Fatalf("legacy source without an exact configured candidate must fail closed: %+v, %v", missing, err)
+	}
+}
+
+func TestConfiguredChartSourceCandidatesExactRecovery(t *testing.T) {
+	c := testHelmClientWithRepoVersions(t, map[string][]string{
+		"bitnami": {"1.2.3"},
+		"argo":    {"1.2.2"},
+	})
+	withOCISources(t, []string{"oci://reg/charts"})
+	lister := &fakeTagLister{tags: map[string][]string{"reg/charts/argo-cd": {"1.2.2"}}}
+
+	got, err := c.configuredChartSourceCandidates("argo-cd", "1.2.3", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ChartSourceCandidate{{Type: "repository", Reference: "bitnami", URL: "https://charts.bitnami.com/bitnami"}}
+	if !slices.Equal(got, want) {
+		t.Fatalf("candidates = %+v, want %+v", got, want)
+	}
+}
+
+func TestConfiguredChartSourceCandidatesAmbiguousAcrossClassicAndOCI(t *testing.T) {
+	c := testHelmClientWithRepoVersions(t, map[string][]string{
+		"bitnami": {"1.2.3"},
+		"argo":    {"1.2.3"},
+	})
+	withOCISources(t, []string{"oci://reg/charts"})
+	lister := &fakeTagLister{tags: map[string][]string{"reg/charts/argo-cd": {"1.2.3"}}}
+
+	got, err := c.configuredChartSourceCandidates("argo-cd", "1.2.3", lister)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("candidates = %+v, want two classic and one OCI match", got)
+	}
+}
+
+func TestConfiguredChartSourceCandidatesNoMatchFailsClosed(t *testing.T) {
+	c := testHelmClientWithRepoVersions(t, map[string][]string{"bitnami": {"1.2.2"}, "argo": {"1.2.2"}})
+	withOCISources(t, []string{"oci://reg/charts"})
+	got, err := c.configuredChartSourceCandidates("argo-cd", "1.2.3", &fakeTagLister{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("candidates = %+v, want none", got)
+	}
+}
+
+func TestResolveOCIUpgradeURLMultipleExactMatchesNeverGuesses(t *testing.T) {
+	withOCISources(t, []string{"oci://reg1/charts", "oci://reg2/charts"})
+	lister := &fakeTagLister{tags: map[string][]string{
+		"reg1/charts/app": {"1.2.3"},
+		"reg2/charts/app": {"1.2.3"},
+	}}
+	c := &Client{}
+	if got, ok := c.resolveOCIUpgradeURLWithLister("app", "1.2.3", lister); ok || got != "" {
+		t.Fatalf("ambiguous OCI resolution = %q, %v; want fail closed", got, ok)
+	}
+	if got := c.resolveOCIUpgradeURLsWithLister("app", "1.2.3", lister); len(got) != 2 {
+		t.Fatalf("candidate URLs = %v, want both sources", got)
+	}
+}
+
+func TestResolveOCIInstallSourceAcceptsPrefixAndFullReference(t *testing.T) {
+	for _, input := range []string{"oci://ghcr.io/acme/charts", "oci://ghcr.io/acme/charts/app"} {
+		chartURL, prefix, err := resolveOCIInstallSource(input, "app")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if chartURL != "oci://ghcr.io/acme/charts/app" || prefix != "oci://ghcr.io/acme/charts" {
+			t.Fatalf("input %q => %q, %q", input, chartURL, prefix)
+		}
+	}
+}
+
+func TestChartSourcesNeverPersistCredentialsOrTruncateReferences(t *testing.T) {
+	if _, err := normalizeOCIPrefix("oci://user:password@ghcr.io/acme"); err == nil {
+		t.Fatal("expected credential-bearing OCI source to be rejected")
+	}
+	tooLong := &ChartSourceCandidate{Type: "oci", Reference: "oci://registry.example/" + string(make([]byte, chartSourceChunkSize*chartSourceMaxChunks))}
+	if err := validateChartSourceCandidate(tooLong); err == nil {
+		t.Fatal("expected an unpersistable source reference to fail closed")
+	}
+	credentialURL := &ChartSourceCandidate{Type: "repository", Reference: "private", URL: "https://user:password@charts.example.test"}
+	if err := validateChartSourceCandidate(credentialURL); err == nil {
+		t.Fatal("expected credential-bearing classic repository URL to be rejected")
+	}
+}

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2561,10 +2561,96 @@ func (c *Client) upgradeWithValues(actionConfig *action.Configuration, name, tar
 }
 
 func (c *Client) chartForUpgradeTarget(actionConfig *action.Configuration, rel *release.Release, targetVersion, repositoryName string, sendProgress func(phase, message, detail string)) (*chart.Chart, error) {
-	if targetVersion == "" || targetVersion == rel.Chart.Metadata.Version {
-		return rel.Chart, nil
+	return c.chartForUpgradeTargetWithLoader(actionConfig, rel, targetVersion, repositoryName, sendProgress, c.loadTargetChart)
+}
+
+type targetChartLoader func(*action.Configuration, *release.Release, string, string, func(string, string, string)) (*chart.Chart, error)
+
+// chartForUpgradeTargetWithLoader returns a chart that is safe to render. Helm's
+// stored release representation does not serialize Chart.dependencies, so an
+// umbrella release can retain dependency declarations in Chart.yaml while all
+// child chart bodies are absent. Reusing that object for a same-version values
+// operation renders only the parent and makes the resulting upgrade destructive.
+//
+// A complete in-memory release chart remains reusable. An incomplete one is
+// reconstructed through the same configured-source resolver used by upgrades,
+// pinned to the installed chart version. The loaded chart is checked again so a
+// source package that merely declares (but does not vendor) dependencies fails
+// closed.
+func (c *Client) chartForUpgradeTargetWithLoader(actionConfig *action.Configuration, rel *release.Release, targetVersion, repositoryName string, sendProgress func(phase, message, detail string), load targetChartLoader) (*chart.Chart, error) {
+	if rel == nil || rel.Chart == nil || rel.Chart.Metadata == nil {
+		return nil, fmt.Errorf("release has no usable chart metadata")
 	}
-	return c.loadTargetChart(actionConfig, rel, targetVersion, repositoryName, sendProgress)
+
+	currentVersion := rel.Chart.Metadata.Version
+	if targetVersion == "" {
+		targetVersion = currentVersion
+	}
+
+	reconstructingStoredChart := false
+	if targetVersion == currentVersion {
+		if err := validateChartDependencyBodies(rel.Chart); err == nil {
+			return rel.Chart, nil
+		}
+		reconstructingStoredChart = true
+	}
+
+	loaded, err := load(actionConfig, rel, targetVersion, repositoryName, sendProgress)
+	if err != nil {
+		if reconstructingStoredChart {
+			return nil, fmt.Errorf("could not reconstruct complete chart %s version %s for values operation: %w", rel.Chart.Metadata.Name, targetVersion, err)
+		}
+		return nil, err
+	}
+	if err := validateChartDependencyBodies(loaded); err != nil {
+		return nil, fmt.Errorf("refusing to render incomplete chart %s version %s: %w", rel.Chart.Metadata.Name, targetVersion, err)
+	}
+	return loaded, nil
+}
+
+// validateChartDependencyBodies verifies that every dependency declared by each
+// chart in the tree has a corresponding loaded chart body. Alias names are
+// accepted because Helm rewrites an aliased child name while processing values.
+func validateChartDependencyBodies(ch *chart.Chart) error {
+	if ch == nil || ch.Metadata == nil {
+		return fmt.Errorf("chart metadata is missing")
+	}
+
+	children := ch.Dependencies()
+	matchedChildren := make([]bool, len(children))
+	for _, declared := range ch.Metadata.Dependencies {
+		if declared == nil {
+			continue
+		}
+		found := false
+		for i, child := range children {
+			if matchedChildren[i] {
+				continue
+			}
+			if child == nil || child.Metadata == nil {
+				continue
+			}
+			if child.Metadata.Name == declared.Name || (declared.Alias != "" && child.Metadata.Name == declared.Alias) {
+				matchedChildren[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			name := declared.Name
+			if declared.Alias != "" {
+				name += " (alias " + declared.Alias + ")"
+			}
+			return fmt.Errorf("dependency body %q declared by chart %q is missing", name, ch.Metadata.Name)
+		}
+	}
+
+	for _, child := range children {
+		if err := validateChartDependencyBodies(child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // loadTargetChart resolves, downloads and loads the chart for a target upgrade
@@ -2994,11 +3080,17 @@ func (c *Client) ApplyValuesAsUser(namespace, name string, newValues map[string]
 }
 
 func (c *Client) applyValuesWith(actionConfig *action.Configuration, name string, newValues map[string]any) error {
-	// Get the current release to reuse its chart
+	// Get the current release and reconstruct its exact installed chart when
+	// Helm storage omitted vendored dependency bodies.
 	getAction := action.NewGet(actionConfig)
 	rel, err := getAction.Run(name)
 	if err != nil {
 		return fmt.Errorf("failed to get current release: %w", err)
+	}
+	noop := func(phase, message, detail string) {}
+	applyChart, err := c.chartForUpgradeTarget(actionConfig, rel, rel.Chart.Metadata.Version, "", noop)
+	if err != nil {
+		return err
 	}
 
 	// Create upgrade action — no Wait, Radar shows resource status in real-time
@@ -3007,8 +3099,8 @@ func (c *Client) applyValuesWith(actionConfig *action.Configuration, name string
 	upgradeAction.Timeout = 120 * time.Second
 	upgradeAction.ResetValues = true // Use only the provided values, don't merge
 
-	// Run the upgrade with the existing chart and new values
-	_, err = upgradeAction.Run(name, rel.Chart, newValues)
+	// Run the upgrade with the complete installed-version chart and new values.
+	_, err = upgradeAction.Run(name, applyChart, newValues)
 	if err != nil {
 		return fmt.Errorf("failed to apply values: %w", err)
 	}

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1918,6 +1919,38 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	info := &UpgradeInfo{
 		CurrentVersion: currentVersion,
 	}
+	if associated, ok := chartSourceFromRelease(rel); ok {
+		var recoverErr error
+		if associated.Type == "repository" && associated.URL == "" {
+			if recovered, err := c.recoverLegacyClassicSource(actionConfig, rel, *associated, nil); err != nil {
+				recoverErr = err
+			} else if recovered != nil {
+				associated = recovered
+			}
+		}
+		if c.applyCandidateUpgrade(info, *associated, chartName, currentVersion, nil) {
+			return info, nil
+		}
+		if recoverErr != nil {
+			markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, recoverErr.Error())
+			return info, nil
+		}
+		if associated.Type == "repository" && associated.URL != "" {
+			info.SourceCandidates = []ChartSourceCandidate{*associated}
+		}
+		markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, "the release's recorded chart source is no longer configured or does not publish the installed version")
+		return info, nil
+	}
+	exactCandidates, candidateErr := c.configuredChartSourceCandidates(chartName, currentVersion, nil)
+	if candidateErr == nil && len(exactCandidates) == 1 {
+		c.applyCandidateUpgrade(info, exactCandidates[0], chartName, currentVersion, nil)
+		return info, nil
+	}
+	if candidateErr == nil && len(exactCandidates) > 1 {
+		info.SourceCandidates = exactCandidates
+		markUpgradeSourceIssue(info, UpgradeSourceIssueAmbiguousSource, "multiple configured chart sources publish the installed chart and version; select the original source")
+		return info, nil
+	}
 
 	// Load repository file. A missing/empty/unreadable repo config is not fatal —
 	// the user may rely solely on registered OCI sources, so we fall through to the
@@ -2061,6 +2094,18 @@ func (c *Client) availableVersions(namespace, name, username string, groups []st
 		return nil, fmt.Errorf("failed to get release: %w", err)
 	}
 	chartName := rel.Chart.Metadata.Name
+	if associated, ok := chartSourceFromRelease(rel); ok {
+		return capVersions(c.candidateVersions(*associated, chartName, nil)), nil
+	}
+	exactCandidates, err := c.configuredChartSourceCandidates(chartName, rel.Chart.Metadata.Version, nil)
+	if err == nil {
+		if len(exactCandidates) == 1 {
+			return capVersions(c.candidateVersions(exactCandidates[0], chartName, nil)), nil
+		}
+		if len(exactCandidates) > 1 {
+			return nil, nil
+		}
+	}
 
 	// Resolve the classic repo the same way the upgrade check does, then return
 	// that repo's full version list — never a union across repos, which could mix
@@ -2661,9 +2706,27 @@ func (c *Client) loadTargetChart(actionConfig *action.Configuration, rel *releas
 	chartName := rel.Chart.Metadata.Name
 	sendProgress("resolving", fmt.Sprintf("Finding %s version %s in repositories...", chartName, targetVersion), "")
 
-	chartPath, resolvedRepo, err := c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources))
+	var chartPath, resolvedRepo string
+	var err error
+	if source, ok := chartSourceFromRelease(rel); ok {
+		switch source.Type {
+		case "repository":
+			repositoryName := source.Reference
+			if configured := c.configuredRepositoryForSource(*source); configured != nil {
+				repositoryName = configured.Name
+			}
+			chartPath, resolvedRepo, err = c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, nil)
+		case "oci":
+			chartPath, resolvedRepo = source.Reference, "oci"
+		}
+	} else {
+		chartPath, resolvedRepo, err = c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources))
+	}
 	if err != nil {
 		return nil, err
+	}
+	if chartPath == "" {
+		return nil, fmt.Errorf("stored chart source for %s is invalid", chartName)
 	}
 
 	sendProgress("downloading", fmt.Sprintf("Downloading %s-%s from %s...", chartName, targetVersion, resolvedRepo), chartPath)
@@ -2714,7 +2777,7 @@ func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryNam
 	return c.resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion, repositoryName, sourceHosts, c.resolveOCIUpgradeURL)
 }
 
-func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion, repositoryName string, sourceHosts []string, resolveOCIUpgradeURL func(string, string) (string, bool)) (chartPath, resolvedRepo string, err error) {
+func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion, repositoryName string, sourceHosts []string, resolveOCIUpgradeURL func(string, string) (string, bool, bool)) (chartPath, resolvedRepo string, err error) {
 	// A missing/unreadable repo config is not fatal: a pure-OCI user has no
 	// repositories.yaml, and discovery may have advertised an OCI upgrade. Proceed
 	// with an empty classic set so the OCI fallback below can still resolve.
@@ -2783,7 +2846,9 @@ func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion
 	// unrelated index failures; the server re-derives the oci:// ref from a
 	// configured prefix (never a client-supplied ref), keeping the upgrade path
 	// configured-only.
-	if url, ok := resolveOCIUpgradeURL(chartName, targetVersion); ok {
+	if url, ok, ambiguous := resolveOCIUpgradeURL(chartName, targetVersion); ambiguous {
+		return "", "", fmt.Errorf("multiple registered OCI sources publish %s version %s; select the correct source", chartName, targetVersion)
+	} else if ok {
 		return url, "oci", nil
 	}
 
@@ -2966,6 +3031,42 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		currentVersion := rel.Chart.Metadata.Version
 		chartName := rel.Chart.Metadata.Name
 		info := &UpgradeInfo{CurrentVersion: currentVersion}
+		if associated, ok := chartSourceFromRelease(rel); ok {
+			var recoverErr error
+			if associated.Type == "repository" && associated.URL == "" {
+				if recovered, err := c.recoverLegacyClassicSource(actionConfig, rel, *associated, ociLister); err != nil {
+					recoverErr = err
+				} else if recovered != nil {
+					associated = recovered
+				}
+			}
+			if c.applyCandidateUpgrade(info, *associated, chartName, currentVersion, ociLister) {
+				result.Releases[key] = info
+				continue
+			}
+			if associated.Type == "repository" && associated.URL != "" {
+				info.SourceCandidates = []ChartSourceCandidate{*associated}
+			}
+			if recoverErr != nil {
+				markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, recoverErr.Error())
+			} else {
+				markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, "the release's recorded chart source is no longer configured or does not publish the installed version")
+			}
+			result.Releases[key] = info
+			continue
+		}
+		exactCandidates, candidateErr := c.configuredChartSourceCandidates(chartName, currentVersion, ociLister)
+		if candidateErr == nil && len(exactCandidates) == 1 {
+			c.applyCandidateUpgrade(info, exactCandidates[0], chartName, currentVersion, ociLister)
+			result.Releases[key] = info
+			continue
+		}
+		if candidateErr == nil && len(exactCandidates) > 1 {
+			info.SourceCandidates = exactCandidates
+			markUpgradeSourceIssue(info, UpgradeSourceIssueAmbiguousSource, "multiple configured chart sources publish the installed chart and version; select the original source")
+			result.Releases[key] = info
+			continue
+		}
 
 		baseCandidates, ok := chartRepoVersions[chartName]
 		if !ok {
@@ -3308,7 +3409,7 @@ func (c *Client) GetChartDetail(repoName, chartName, version string) (*ChartDeta
 
 	// Download and load the chart to get README and values
 	chartURL := chartVersion.URLs[0]
-	if !strings.HasPrefix(chartURL, "http://") && !strings.HasPrefix(chartURL, "https://") {
+	if !isAbsoluteChartURL(chartURL) {
 		chartURL = strings.TrimSuffix(repoEntry.URL, "/") + "/" + chartURL
 	}
 
@@ -3320,6 +3421,13 @@ func (c *Client) GetChartDetail(repoName, chartName, version string) (*ChartDeta
 
 	client := action.NewInstall(actionConfig)
 	client.Version = chartVersion.Version
+	if registry.IsOCI(chartURL) {
+		rc, err := c.newRegistryClientConcrete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build OCI registry client: %w", err)
+		}
+		client.SetRegistryClient(rc)
+	}
 
 	cp, err := client.ChartPathOptions.LocateChart(chartURL, c.settings)
 	if err != nil {
@@ -3399,11 +3507,24 @@ func (c *Client) InstallAsUser(req *InstallRequest, username string, groups []st
 func (c *Client) installWith(actionConfig *action.Configuration, req *InstallRequest) (*HelmRelease, error) {
 
 	var chartURL string
+	var source ChartSourceCandidate
 
 	// Check if the repository is a URL (for ArtifactHub installs) or a local repo name
 	isRepoURL := strings.HasPrefix(req.Repository, "http://") || strings.HasPrefix(req.Repository, "https://")
+	isOCI := registry.IsOCI(req.Repository)
 
-	if isRepoURL {
+	if isOCI {
+		var prefix string
+		var err error
+		chartURL, prefix, err = resolveOCIInstallSource(req.Repository, req.ChartName)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := AddOCISource(prefix); err != nil {
+			return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+		}
+		source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+	} else if isRepoURL {
 		// Direct URL - fetch the repository index to find the chart
 		repoURL := strings.TrimSuffix(req.Repository, "/")
 
@@ -3463,8 +3584,28 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 
 		// Build chart URL
 		chartURL = chartVersion.URLs[0]
-		if !strings.HasPrefix(chartURL, "http://") && !strings.HasPrefix(chartURL, "https://") {
+		if !isAbsoluteChartURL(chartURL) {
 			chartURL = repoURL + "/" + chartURL
+		}
+		if registry.IsOCI(chartURL) {
+			_, prefix, err := resolveOCIInstallSource(chartURL, req.ChartName)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := AddOCISource(prefix); err != nil {
+				return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+			}
+			source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+		} else {
+			repoName, err := c.ensureClassicRepository(repoURL, req.RepositoryName)
+			if err != nil {
+				return nil, err
+			}
+			repositoryURL, err := canonicalClassicRepositoryURL(repoURL)
+			if err != nil {
+				return nil, err
+			}
+			source = ChartSourceCandidate{Type: "repository", Reference: repoName, URL: repositoryURL}
 		}
 	} else {
 		// Local repository name - use existing logic
@@ -3518,11 +3659,30 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 
 		// Build chart URL
 		chartURL = chartVersion.URLs[0]
-		if !strings.HasPrefix(chartURL, "http://") && !strings.HasPrefix(chartURL, "https://") {
+		if !isAbsoluteChartURL(chartURL) {
 			chartURL = strings.TrimSuffix(repoEntry.URL, "/") + "/" + chartURL
+		}
+		if registry.IsOCI(chartURL) {
+			_, prefix, err := resolveOCIInstallSource(chartURL, req.ChartName)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := AddOCISource(prefix); err != nil {
+				return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+			}
+			source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+		} else {
+			repositoryURL, err := canonicalClassicRepositoryURL(repoEntry.URL)
+			if err != nil {
+				return nil, err
+			}
+			source = ChartSourceCandidate{Type: "repository", Reference: req.Repository, URL: repositoryURL}
 		}
 	}
 
+	if err := validateChartSourceCandidate(&source); err != nil {
+		return nil, err
+	}
 	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
 	if err != nil {
 		return nil, err
@@ -3531,6 +3691,13 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 	// action.Install carries ChartPathOptions; instantiated here as a locator only.
 	locator := action.NewInstall(actionConfig)
 	locator.Version = req.Version
+	if registry.IsOCI(chartURL) {
+		rc, err := c.newRegistryClientConcrete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build OCI registry client: %w", err)
+		}
+		locator.SetRegistryClient(rc)
+	}
 	cp, err := locator.ChartPathOptions.LocateChart(chartURL, c.settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate chart: %w", err)
@@ -3543,6 +3710,7 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 	if mode != installFresh {
 		log.Printf("[helm] install %q/%q: prior release record exists, recovering via %s", req.Namespace, req.ReleaseName, recoveryMode(mode))
 	}
+	req.resolvedSource = &source
 	rel, err := runInstallOrUpgrade(actionConfig, req, chart, mode)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
@@ -3579,11 +3747,25 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 	}
 
 	var chartURL string
+	var source ChartSourceCandidate
 
 	// Check if the repository is a URL (for ArtifactHub installs) or a local repo name
 	isRepoURL := strings.HasPrefix(req.Repository, "http://") || strings.HasPrefix(req.Repository, "https://")
+	isOCI := registry.IsOCI(req.Repository)
 
-	if isRepoURL {
+	if isOCI {
+		var prefix string
+		var err error
+		chartURL, prefix, err = resolveOCIInstallSource(req.Repository, req.ChartName)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := AddOCISource(prefix); err != nil {
+			return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+		}
+		source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+		sendProgress("resolving", "Resolving chart from registered OCI source...", chartURL)
+	} else if isRepoURL {
 		sendProgress("fetching", "Fetching repository index...", req.Repository)
 
 		repoURL := strings.TrimSuffix(req.Repository, "/")
@@ -3641,8 +3823,28 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		}
 
 		chartURL = chartVersion.URLs[0]
-		if !strings.HasPrefix(chartURL, "http://") && !strings.HasPrefix(chartURL, "https://") {
+		if !isAbsoluteChartURL(chartURL) {
 			chartURL = repoURL + "/" + chartURL
+		}
+		if registry.IsOCI(chartURL) {
+			_, prefix, err := resolveOCIInstallSource(chartURL, req.ChartName)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := AddOCISource(prefix); err != nil {
+				return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+			}
+			source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+		} else {
+			repoName, err := c.ensureClassicRepository(repoURL, req.RepositoryName)
+			if err != nil {
+				return nil, err
+			}
+			repositoryURL, err := canonicalClassicRepositoryURL(repoURL)
+			if err != nil {
+				return nil, err
+			}
+			source = ChartSourceCandidate{Type: "repository", Reference: repoName, URL: repositoryURL}
 		}
 	} else {
 		sendProgress("resolving", "Resolving chart from local repository...", req.Repository)
@@ -3694,14 +3896,33 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		}
 
 		chartURL = chartVersion.URLs[0]
-		if !strings.HasPrefix(chartURL, "http://") && !strings.HasPrefix(chartURL, "https://") {
+		if !isAbsoluteChartURL(chartURL) {
 			chartURL = strings.TrimSuffix(repoEntry.URL, "/") + "/" + chartURL
+		}
+		if registry.IsOCI(chartURL) {
+			_, prefix, err := resolveOCIInstallSource(chartURL, req.ChartName)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := AddOCISource(prefix); err != nil {
+				return nil, fmt.Errorf("failed to register OCI chart source: %w", err)
+			}
+			source = ChartSourceCandidate{Type: "oci", Reference: chartURL}
+		} else {
+			repositoryURL, err := canonicalClassicRepositoryURL(repoEntry.URL)
+			if err != nil {
+				return nil, err
+			}
+			source = ChartSourceCandidate{Type: "repository", Reference: req.Repository, URL: repositoryURL}
 		}
 	}
 
 	// Pre-flight before downloading: a deployed/pending release is knowable
 	// from local Helm storage and we shouldn't waste bandwidth + show
 	// "Downloading..." progress to a user who'll get a 409 anyway.
+	if err := validateChartSourceCandidate(&source); err != nil {
+		return nil, err
+	}
 	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
 	if err != nil {
 		return nil, err
@@ -3709,37 +3930,56 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 
 	sendProgress("downloading", fmt.Sprintf("Downloading chart %s-%s...", req.ChartName, req.Version), chartURL)
 
-	// Download the chart archive directly via HTTP, bypassing the Helm SDK's
-	// ChartPathOptions.LocateChart / ChartDownloader machinery. That code loads
-	// every locally-registered repo's cached index file and fails with "no cached
-	// repo found" if any index file is stale or missing (e.g. a bitnami repo
-	// entry exists in repositories.yaml but the index cache was deleted).
-	chartResp, err := httpClient.Get(chartURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download chart: %w", err)
-	}
-	defer chartResp.Body.Close()
-	if chartResp.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to download chart: server returned %d", chartResp.StatusCode)
-	}
+	var loadedChart *chart.Chart
+	if registry.IsOCI(chartURL) {
+		locator := action.NewInstall(actionConfig)
+		locator.Version = req.Version
+		rc, err := c.newRegistryClientConcrete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build OCI registry client: %w", err)
+		}
+		locator.SetRegistryClient(rc)
+		cp, err := locator.ChartPathOptions.LocateChart(chartURL, c.settings)
+		if err != nil {
+			return nil, fmt.Errorf("failed to locate chart: %w", err)
+		}
+		loadedChart, err = loader.Load(cp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load chart: %w", err)
+		}
+	} else {
+		// Download the chart archive directly via HTTP, bypassing the Helm SDK's
+		// ChartPathOptions.LocateChart / ChartDownloader machinery. That code loads
+		// every locally-registered repo's cached index file and fails with "no cached
+		// repo found" if any index file is stale or missing (e.g. a bitnami repo
+		// entry exists in repositories.yaml but the index cache was deleted).
+		chartResp, err := httpClient.Get(chartURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download chart: %w", err)
+		}
+		defer chartResp.Body.Close()
+		if chartResp.StatusCode != 200 {
+			return nil, fmt.Errorf("failed to download chart: server returned %d", chartResp.StatusCode)
+		}
 
-	tmpChart, err := os.CreateTemp("", "helm-chart-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file for chart: %w", err)
-	}
-	defer os.Remove(tmpChart.Name())
-	defer tmpChart.Close()
+		tmpChart, err := os.CreateTemp("", "helm-chart-*.tgz")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp file for chart: %w", err)
+		}
+		defer os.Remove(tmpChart.Name())
+		defer tmpChart.Close()
 
-	if _, err := tmpChart.ReadFrom(chartResp.Body); err != nil {
-		return nil, fmt.Errorf("failed to write chart to temp file: %w", err)
-	}
-	tmpChart.Close()
+		if _, err := tmpChart.ReadFrom(chartResp.Body); err != nil {
+			return nil, fmt.Errorf("failed to write chart to temp file: %w", err)
+		}
+		tmpChart.Close()
 
-	sendProgress("loading", "Loading chart...", tmpChart.Name())
+		sendProgress("loading", "Loading chart...", tmpChart.Name())
 
-	chart, err := loader.Load(tmpChart.Name())
-	if err != nil {
-		return nil, fmt.Errorf("failed to load chart: %w", err)
+		loadedChart, err = loader.Load(tmpChart.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load chart: %w", err)
+		}
 	}
 
 	switch mode {
@@ -3754,7 +3994,8 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		sendProgress("installing", fmt.Sprintf("Recovering prior failed release %s in %s...", req.ReleaseName, req.Namespace), "")
 	}
 
-	rel, err := runInstallOrUpgrade(actionConfig, req, chart, mode)
+	req.resolvedSource = &source
+	rel, err := runInstallOrUpgrade(actionConfig, req, loadedChart, mode)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
 	}
@@ -3796,12 +4037,23 @@ func chartVersionToInfo(v *repo.ChartVersion, repoName string) ChartInfo {
 
 const artifactHubBaseURL = "https://artifacthub.io/api/v1"
 
+const maxArtifactHubSearchResponseBytes = 4 << 20
+
 // SearchArtifactHub searches for charts on ArtifactHub
 // sort can be: "relevance" (default), "stars", or "last_updated"
 func SearchArtifactHub(query string, offset, limit int, official, verified bool, sort string) (*ArtifactHubSearchResult, error) {
+	return SearchArtifactHubContext(context.Background(), query, offset, limit, official, verified, sort)
+}
+
+// SearchArtifactHubContext is the cancellable form used by release recovery.
+func SearchArtifactHubContext(ctx context.Context, query string, offset, limit int, official, verified bool, sort string) (*ArtifactHubSearchResult, error) {
+	return searchArtifactHubAt(ctx, artifactHubBaseURL, query, offset, limit, official, verified, sort)
+}
+
+func searchArtifactHubAt(ctx context.Context, baseURL, query string, offset, limit int, official, verified bool, sort string) (*ArtifactHubSearchResult, error) {
 	// Build query URL (escape user input to prevent query string injection)
 	searchURL := fmt.Sprintf("%s/packages/search?kind=0&ts_query_web=%s&offset=%d&limit=%d",
-		artifactHubBaseURL, url.QueryEscape(query), offset, limit)
+		strings.TrimRight(baseURL, "/"), url.QueryEscape(query), offset, limit)
 
 	// Add sort parameter (ArtifactHub uses "sort" query param)
 	if sort != "" && sort != "relevance" {
@@ -3816,20 +4068,32 @@ func SearchArtifactHub(query string, offset, limit int, official, verified bool,
 		searchURL += "&verified_publisher=true"
 	}
 
-	// Make HTTP request
-	resp, err := httpClient.Get(searchURL)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to search ArtifactHub: %w", err)
+		return nil, fmt.Errorf("failed to create ArtifactHub search request: %w", err)
+	}
+	resp, err := httpClient.Do(request)
+	if err != nil {
+		return nil, classifyArtifactHubSearchError(err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("ArtifactHub returned status %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("ArtifactHub rate limited the search (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return nil, fmt.Errorf("ArtifactHub rejected the search (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("ArtifactHub service failed the search (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ArtifactHub returned unexpected status %d", resp.StatusCode)
 	}
 
 	// Parse response
 	var apiResp artifactHubSearchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxArtifactHubSearchResponseBytes)).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("failed to parse ArtifactHub response: %w", err)
 	}
 
@@ -3845,6 +4109,28 @@ func SearchArtifactHub(query string, offset, limit int, official, verified bool,
 	}
 
 	return result, nil
+}
+
+func classifyArtifactHubSearchError(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("ArtifactHub search canceled: %w", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("ArtifactHub search timed out: %w", err)
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return fmt.Errorf("ArtifactHub DNS lookup failed: %w", err)
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) && networkErr.Timeout() {
+		return fmt.Errorf("ArtifactHub search timed out: %w", err)
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "tls") || strings.Contains(lower, "x509") || strings.Contains(lower, "certificate") {
+		return fmt.Errorf("ArtifactHub TLS validation failed: %w", err)
+	}
+	return fmt.Errorf("ArtifactHub network request failed: %w", err)
 }
 
 // GetArtifactHubChart gets detailed chart info from ArtifactHub

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,9 @@ import (
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/engine"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	helmstorage "helm.sh/helm/v3/pkg/storage"
@@ -652,6 +655,161 @@ func TestChartForUpgradeTargetReusesReleaseChartForSameVersion(t *testing.T) {
 	if got != rel.Chart {
 		t.Fatal("chartForUpgradeTarget returned a different chart, want current release chart")
 	}
+}
+
+// Regression for Values Preview/Apply on umbrella releases. Helm storage keeps
+// Chart.yaml's dependency declarations but JSON serialization drops the chart
+// dependency bodies. Both values paths select their chart through
+// chartForUpgradeTarget, so same-version selection must reconstruct the exact
+// installed version before rendering or applying.
+func TestValuesPreviewApplyReconstructSameVersionUmbrella(t *testing.T) {
+	complete := valuesIsolationUmbrellaChart()
+	stored := roundTripStoredChart(t, complete)
+	if len(stored.Metadata.Dependencies) != 1 || len(stored.Dependencies()) != 0 {
+		t.Fatalf("test precondition failed: stored chart declarations=%d bodies=%d, want 1 and 0", len(stored.Metadata.Dependencies), len(stored.Dependencies()))
+	}
+
+	rel := helmTestRelease("umbrella", "demo", 1, release.StatusDeployed, "deployed")
+	rel.Chart = stored
+	client := &Client{}
+	loadCalls := 0
+	selected, err := client.chartForUpgradeTargetWithLoader(nil, rel, "", "", func(string, string, string) {}, func(_ *action.Configuration, gotRel *release.Release, version, repository string, _ func(string, string, string)) (*chart.Chart, error) {
+		loadCalls++
+		if gotRel != rel || version != "1.0.4" || repository != "" {
+			t.Fatalf("loader got release=%p version=%q repository=%q", gotRel, version, repository)
+		}
+		return complete, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadCalls != 1 || selected != complete {
+		t.Fatalf("loader calls=%d selected=%p, want one call and complete chart %p", loadCalls, selected, complete)
+	}
+
+	before := renderValuesIsolationChart(t, selected, map[string]any{"parentTag": "1.0.0", "child": map[string]any{"imageTag": "2.0.0"}})
+	after := renderValuesIsolationChart(t, selected, map[string]any{"parentTag": "1.0.1", "child": map[string]any{"imageTag": "2.0.0"}})
+	if len(before) != 2 || len(after) != 2 {
+		t.Fatalf("rendered inventory before=%v after=%v, want parent and child", mapKeys(before), mapKeys(after))
+	}
+	for name, body := range before {
+		afterBody, ok := after[name]
+		if !ok {
+			t.Fatalf("object inventory changed: %q missing after values edit", name)
+		}
+		if strings.Contains(name, "/charts/child/") {
+			if afterBody != body {
+				t.Fatalf("child workload changed for parent-only values override\nbefore:\n%s\nafter:\n%s", body, afterBody)
+			}
+		} else if afterBody == body || !strings.Contains(afterBody, "parent:1.0.1") {
+			t.Fatalf("parent workload did not receive intended image override\nbefore:\n%s\nafter:\n%s", body, afterBody)
+		}
+	}
+}
+
+func TestValuesPreviewApplyFailsClosedWhenDependencyBodiesUnavailable(t *testing.T) {
+	stored := roundTripStoredChart(t, valuesIsolationUmbrellaChart())
+	rel := helmTestRelease("umbrella", "demo", 1, release.StatusDeployed, "deployed")
+	rel.Chart = stored
+
+	t.Run("source cannot resolve exact installed version", func(t *testing.T) {
+		_, err := (&Client{}).chartForUpgradeTargetWithLoader(nil, rel, "1.0.4", "", func(string, string, string) {}, func(*action.Configuration, *release.Release, string, string, func(string, string, string)) (*chart.Chart, error) {
+			return nil, errors.New("chart not found in configured sources")
+		})
+		if err == nil || !strings.Contains(err.Error(), "could not reconstruct complete chart umbrella version 1.0.4") {
+			t.Fatalf("error = %v, want fail-closed reconstruction error", err)
+		}
+	})
+
+	t.Run("resolved package also lacks dependency body", func(t *testing.T) {
+		_, err := (&Client{}).chartForUpgradeTargetWithLoader(nil, rel, "1.0.4", "", func(string, string, string) {}, func(*action.Configuration, *release.Release, string, string, func(string, string, string)) (*chart.Chart, error) {
+			return stored, nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "refusing to render incomplete chart") || !strings.Contains(err.Error(), "dependency body \"child\"") {
+			t.Fatalf("error = %v, want explicit missing-dependency refusal", err)
+		}
+	})
+}
+
+func valuesIsolationUmbrellaChart() *chart.Chart {
+	child := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "child", Version: "2.0.0", Type: "application"},
+		Values:   map[string]any{"imageTag": "2.0.0"},
+		Templates: []*chart.File{{Name: "templates/deployment.yaml", Data: []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: child
+spec:
+  selector:
+    matchLabels: {app: child}
+  template:
+    metadata:
+      labels: {app: child}
+    spec:
+      containers:
+      - name: child
+        image: child:{{ .Values.imageTag }}
+`)}},
+	}
+	parent := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name: "umbrella", Version: "1.0.4", Type: "application",
+			Dependencies: []*chart.Dependency{{Name: "child", Version: "2.0.0"}},
+		},
+		Values: map[string]any{"parentTag": "1.0.0", "child": map[string]any{"imageTag": "2.0.0"}},
+		Templates: []*chart.File{{Name: "templates/deployment.yaml", Data: []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: parent
+spec:
+  selector:
+    matchLabels: {app: parent}
+  template:
+    metadata:
+      labels: {app: parent}
+    spec:
+      containers:
+      - name: parent
+        image: parent:{{ .Values.parentTag }}
+`)}},
+	}
+	parent.SetDependencies(child)
+	return parent
+}
+
+func roundTripStoredChart(t *testing.T, ch *chart.Chart) *chart.Chart {
+	t.Helper()
+	b, err := json.Marshal(ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored chart.Chart
+	if err := json.Unmarshal(b, &stored); err != nil {
+		t.Fatal(err)
+	}
+	return &stored
+}
+
+func renderValuesIsolationChart(t *testing.T, ch *chart.Chart, values map[string]any) map[string]string {
+	t.Helper()
+	renderValues, err := chartutil.ToRenderValues(ch, values, chartutil.ReleaseOptions{Name: "umbrella", Namespace: "demo", IsUpgrade: true}, chartutil.DefaultCapabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := engine.Render(ch, renderValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rendered
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func TestDiffResourceRefs(t *testing.T) {

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1721,11 +1721,11 @@ func TestResolveUpgradeChartPath_UsesOCIBeforeUnrelatedIndexError(t *testing.T) 
 		"0.19.6",
 		"",
 		nil,
-		func(chartName, targetVersion string) (string, bool) {
+		func(chartName, targetVersion string) (string, bool, bool) {
 			if chartName != "postgres" || targetVersion != "0.19.6" {
-				return "", false
+				return "", false, false
 			}
-			return "oci://registry-1.docker.io/cloudpirates/postgres", true
+			return "oci://registry-1.docker.io/cloudpirates/postgres", true, false
 		},
 	)
 	if err != nil {

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -91,6 +91,7 @@ func (h *Handlers) RegisterRoutes(r chi.Router) {
 		r.Get("/releases/{namespace}/{name}/resources/diff", h.handleGetResourceDiff)
 		r.Get("/releases/{namespace}/{name}/upgrade-info", h.handleCheckUpgrade)
 		r.Get("/releases/{namespace}/{name}/versions", h.handleAvailableVersions)
+		r.Get("/releases/{namespace}/{name}/source-candidates", h.handleSourceCandidates)
 		r.Get("/upgrade-check", h.handleBatchUpgradeCheck)
 		// Actions (write operations)
 		r.Post("/releases/{namespace}/{name}/rollback", h.handleRollback)
@@ -99,10 +100,13 @@ func (h *Handlers) RegisterRoutes(r chi.Router) {
 		r.Post("/releases/{namespace}/{name}/upgrade-stream", h.handleUpgradeStream)
 		r.Post("/releases/{namespace}/{name}/values/preview", h.handlePreviewValues)
 		r.Put("/releases/{namespace}/{name}/values", h.handleApplyValues)
+		r.Put("/releases/{namespace}/{name}/source", h.handleSetSource)
+		r.Post("/releases/{namespace}/{name}/source-discovery/artifacthub", h.handleArtifactHubSourceDiscovery)
 		r.Delete("/releases/{namespace}/{name}", h.handleUninstall)
 
 		// Chart browser (local repositories)
 		r.Get("/repositories", h.handleListRepositories)
+		r.Post("/repositories", h.handleAddRepository)
 		r.Post("/repositories/{name}/update", h.handleUpdateRepository)
 
 		// Registered OCI chart sources (the OCI analog of `helm repo add`) — let
@@ -896,6 +900,83 @@ func (h *Handlers) handleApplyValues(w http.ResponseWriter, r *http.Request) {
 // Chart Browser Handlers
 // ============================================================================
 
+func (h *Handlers) handleSourceCandidates(w http.ResponseWriter, r *http.Request) {
+	client := GetClient()
+	if client == nil {
+		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
+		return
+	}
+	namespace, name := chi.URLParam(r, "namespace"), chi.URLParam(r, "name")
+	var candidates []ChartSourceCandidate
+	var err error
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		candidates, err = client.SourceCandidatesAsUser(namespace, name, user.Username, user.Groups)
+	} else {
+		candidates, err = client.SourceCandidates(namespace, name)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, candidates)
+}
+
+func (h *Handlers) handleSetSource(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "select a Helm chart source") || !requireHelmWrite(w, r) {
+		return
+	}
+	var req SetChartSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	selected := ChartSourceCandidate{Type: req.Type, Reference: req.Reference, URL: req.URL}
+	client := GetClient()
+	if client == nil {
+		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
+		return
+	}
+	namespace, name := chi.URLParam(r, "namespace"), chi.URLParam(r, "name")
+	var err error
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		err = client.SetSourceAsUser(namespace, name, selected, user.Username, user.Groups)
+	} else {
+		err = client.SetSource(namespace, name, selected)
+	}
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, map[string]string{"status": "success"})
+}
+
+func (h *Handlers) handleArtifactHubSourceDiscovery(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "discover a Helm chart source") || !requireHelmWrite(w, r) {
+		return
+	}
+	client := GetClient()
+	if client == nil {
+		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
+		return
+	}
+	namespace, name := chi.URLParam(r, "namespace"), chi.URLParam(r, "name")
+	var candidates []ChartSourceCandidate
+	var err error
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		candidates, err = client.DiscoverArtifactHubSourcesAsUser(r.Context(), namespace, name, user.Username, user.Groups)
+	} else {
+		candidates, err = client.DiscoverArtifactHubSources(r.Context(), namespace, name)
+	}
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if candidates == nil {
+		candidates = []ChartSourceCandidate{}
+	}
+	writeJSON(w, candidates)
+}
+
 // handleListRepositories returns all configured Helm repositories
 func (h *Handlers) handleListRepositories(w http.ResponseWriter, r *http.Request) {
 	client := GetClient()
@@ -911,6 +992,54 @@ func (h *Handlers) handleListRepositories(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, repos)
+}
+
+func (h *Handlers) handleAddRepository(w http.ResponseWriter, r *http.Request) {
+	if !requireHelmWrite(w, r) {
+		return
+	}
+	var req AddRepositoryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	client := GetClient()
+	if client == nil {
+		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
+		return
+	}
+	name, err := client.ensureClassicRepository(req.URL, req.Name)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	response := map[string]any{"name": name, "associated": false}
+	if req.Namespace != "" && req.ReleaseName != "" {
+		var candidates []ChartSourceCandidate
+		if user := auth.UserFromContext(r.Context()); user != nil {
+			candidates, err = client.SourceCandidatesAsUser(req.Namespace, req.ReleaseName, user.Username, user.Groups)
+		} else {
+			candidates, err = client.SourceCandidates(req.Namespace, req.ReleaseName)
+		}
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "repository added, but source recovery failed: "+err.Error())
+			return
+		}
+		response["candidates"] = candidates
+		if len(candidates) == 1 {
+			if user := auth.UserFromContext(r.Context()); user != nil {
+				err = client.SetSourceAsUser(req.Namespace, req.ReleaseName, candidates[0], user.Username, user.Groups)
+			} else {
+				err = client.SetSource(req.Namespace, req.ReleaseName, candidates[0])
+			}
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "repository added, but source association failed: "+err.Error())
+				return
+			}
+			response["associated"] = true
+		}
+	}
+	writeJSON(w, response)
 }
 
 // handleUpdateRepository updates the index for a specific repository.

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -10,8 +10,39 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/skyhook-io/radar/internal/auth"
 )
+
+func TestSourceRecoveryRouteIsRegistered(t *testing.T) {
+	old := globalClient
+	globalClient = nil
+	defer func() { globalClient = old }()
+
+	router := chi.NewRouter()
+	NewHandlers(nil).RegisterRoutes(router)
+	req := httptest.NewRequest(http.MethodGet, "/helm/releases/default/example/source-candidates", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d (registered route with uninitialized client)", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestArtifactHubRecoveryRouteIsRegisteredAndExplicit(t *testing.T) {
+	old := globalClient
+	globalClient = nil
+	defer func() { globalClient = old }()
+
+	router := chi.NewRouter()
+	NewHandlers(nil).RegisterRoutes(router)
+	req := httptest.NewRequest(http.MethodPost, "/helm/releases/default/example/source-discovery/artifacthub", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (explicit discovery route must be Helm-write gated)", rec.Code, http.StatusForbidden)
+	}
+}
 
 // TestRequireCloudRole exercises the role gate without standing up a
 // Helm client — the gate runs first, so we never hit the client. This

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -198,6 +198,7 @@ func freshInstallCheck(actionConfig *action.Configuration, name, namespace strin
 func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest, ch *chart.Chart, mode installMode) (*release.Release, error) {
 	if mode == installUpgrade {
 		upgrade := action.NewUpgrade(actionConfig)
+		upgrade.Labels = chartSourceLabels(req.resolvedSource)
 		upgrade.Install = true
 		upgrade.Namespace = req.Namespace
 		upgrade.Timeout = 120 * time.Second
@@ -209,6 +210,7 @@ func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest
 		return upgrade.Run(req.ReleaseName, ch, req.Values)
 	}
 	install := action.NewInstall(actionConfig)
+	install.Labels = chartSourceLabels(req.resolvedSource)
 	install.ReleaseName = req.ReleaseName
 	install.Namespace = req.Namespace
 	install.CreateNamespace = req.CreateNamespace

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -47,6 +48,16 @@ func normalizeOCIPrefix(raw string) (string, error) {
 	}
 	if !strings.HasPrefix(p, "oci://") {
 		return "", fmt.Errorf("source must be an oci:// reference, got %q", raw)
+	}
+	parsed, err := url.Parse(p)
+	if err != nil || parsed.Host == "" {
+		return "", fmt.Errorf("source must include a registry host")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("OCI source must not contain credentials; use Helm's registry credential store")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("OCI source must not contain query credentials or fragments")
 	}
 	// Strip the scheme before trimming slashes — trimming "oci://" directly would
 	// eat the "//" and yield "oci:".
@@ -261,24 +272,45 @@ func (c *Client) discoverOCIVersions(chartName string) []string {
 // resolved from the SAME prefix discovery/the version picker used (selectBestOCIPrefix),
 // so the upgrade pulls from the registry the user's version list came from. The server
 // only ever pulls from a registered (configured) source — never a client-supplied ref.
-func (c *Client) resolveOCIUpgradeURL(chartName, targetVersion string) (string, bool) {
+func (c *Client) resolveOCIUpgradeURL(chartName, targetVersion string) (string, bool, bool) {
 	if len(ListOCISources()) == 0 {
-		return "", false
+		return "", false, false
 	}
 	lister := c.newRegistryClient()
 	if lister == nil {
-		return "", false
+		return "", false, false
 	}
-	return c.resolveOCIUpgradeURLWithLister(chartName, targetVersion, lister)
+	matches := c.resolveOCIUpgradeURLsWithLister(chartName, targetVersion, lister)
+	if len(matches) > 1 {
+		return "", false, true
+	}
+	if len(matches) == 1 {
+		return matches[0], true, false
+	}
+	return "", false, false
 }
 
 func (c *Client) resolveOCIUpgradeURLWithLister(chartName, targetVersion string, lister ociTagLister) (string, bool) {
-	if lister == nil || len(ListOCISources()) == 0 {
+	matches := c.resolveOCIUpgradeURLsWithLister(chartName, targetVersion, lister)
+	if len(matches) != 1 {
 		return "", false
 	}
-	prefix, tags := c.selectBestOCIPrefix(chartName, lister, nil)
-	if prefix != "" && slices.Contains(tags, targetVersion) {
-		return ociChartURL(prefix, chartName), true
+	return matches[0], true
+}
+
+// resolveOCIUpgradeURLsWithLister returns every registered OCI source that
+// publishes the exact chart version. Callers must never guess when more than one
+// source matches; an explicit per-release association is required instead.
+func (c *Client) resolveOCIUpgradeURLsWithLister(chartName, targetVersion string, lister ociTagLister) []string {
+	if lister == nil || len(ListOCISources()) == 0 {
+		return nil
 	}
-	return "", false
+	var matches []string
+	for _, prefix := range ListOCISources() {
+		tags, err := lister.Tags(ociRef(prefix, chartName))
+		if err == nil && slices.Contains(tags, targetVersion) {
+			matches = append(matches, ociChartURL(prefix, chartName))
+		}
+	}
+	return matches
 }

--- a/internal/helm/prepared_install.go
+++ b/internal/helm/prepared_install.go
@@ -119,6 +119,18 @@ func (c *Client) PrepareFreshInstall(ctx context.Context, req *InstallRequest, m
 	if err != nil {
 		return nil, err
 	}
+	repoName, err := c.ensureClassicRepository(request.Repository, request.RepositoryName)
+	if err != nil {
+		return nil, fmt.Errorf("persist prepared chart source: %w", err)
+	}
+	repositoryURL, err := canonicalClassicRepositoryURL(request.Repository)
+	if err != nil {
+		return nil, fmt.Errorf("persist prepared chart source: %w", err)
+	}
+	request.resolvedSource = &ChartSourceCandidate{Type: "repository", Reference: repoName, URL: repositoryURL}
+	if err := validateChartSourceCandidate(request.resolvedSource); err != nil {
+		return nil, err
+	}
 	request.Version = exactVersion
 	dryRun, err := runServerDryRun(ctx, actionConfig, &request, loaded)
 	if err != nil {
@@ -188,6 +200,7 @@ func (p *PreparedInstall) Install(ctx context.Context, values map[string]any) (*
 	request := p.request
 	request.Values = cloneInstallValues(values)
 	install := action.NewInstall(actionConfig)
+	install.Labels = chartSourceLabels(request.resolvedSource)
 	install.ReleaseName = request.ReleaseName
 	install.Namespace = request.Namespace
 	install.CreateNamespace = request.CreateNamespace

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -279,7 +279,19 @@ const (
 	UpgradeSourceIssueUntracked           UpgradeSourceIssue = "untracked"
 	UpgradeSourceIssueRepoIndexError      UpgradeSourceIssue = "repo_index_error"
 	UpgradeSourceIssueAmbiguousRepository UpgradeSourceIssue = "ambiguous_repository"
+	UpgradeSourceIssueAmbiguousSource     UpgradeSourceIssue = "ambiguous_source"
 )
+
+// ChartSourceCandidate is an exact source that publishes the installed chart
+// name and version. Reference is a Helm repository name for classic
+// repositories and a full oci:// chart reference for OCI. URL is the canonical,
+// credential-free classic repository URL; it is empty for OCI and for legacy
+// name-only release metadata.
+type ChartSourceCandidate struct {
+	Type      string `json:"type"`
+	Reference string `json:"reference"`
+	URL       string `json:"url,omitempty"`
+}
 
 // UpgradeInfo contains information about available upgrades
 type UpgradeInfo struct {
@@ -296,6 +308,9 @@ type UpgradeInfo struct {
 	ChartRef    string             `json:"chartRef,omitempty"`
 	Error       string             `json:"error,omitempty"`
 	SourceIssue UpgradeSourceIssue `json:"sourceIssue,omitempty"`
+	// SourceCandidates are safe, credential-free configured sources that match
+	// the exact installed chart/version. More than one requires explicit choice.
+	SourceCandidates []ChartSourceCandidate `json:"sourceCandidates,omitempty"`
 	// Untracked marks the specific error state where Radar genuinely can't tell
 	// where the chart comes from — i.e. registering a chart source could fix it.
 	// Kept for compatibility; SourceIssue is the richer reason code.
@@ -364,13 +379,35 @@ type Maintainer struct {
 
 // InstallRequest is the request body for installing a new chart
 type InstallRequest struct {
-	ReleaseName     string         `json:"releaseName"`
-	Namespace       string         `json:"namespace"`
-	ChartName       string         `json:"chartName"`
-	Version         string         `json:"version"`
-	Repository      string         `json:"repository"`
+	ReleaseName string `json:"releaseName"`
+	Namespace   string `json:"namespace"`
+	ChartName   string `json:"chartName"`
+	Version     string `json:"version"`
+	Repository  string `json:"repository"`
+	// RepositoryName is the discovery repository's stable name. ArtifactHub
+	// installs send this alongside Repository (the resolved HTTP/OCI URL) so
+	// Radar can durably register the real source rather than ArtifactHub itself.
+	RepositoryName  string         `json:"repositoryName,omitempty"`
 	Values          map[string]any `json:"values,omitempty"`
 	CreateNamespace bool           `json:"createNamespace,omitempty"`
+	resolvedSource  *ChartSourceCandidate
+}
+
+// SetChartSourceRequest explicitly associates an existing release with one of
+// the exact configured candidates returned by the source-candidates endpoint.
+type SetChartSourceRequest struct {
+	Type      string `json:"type"`
+	Reference string `json:"reference"`
+	URL       string `json:"url,omitempty"`
+}
+
+// AddRepositoryRequest adds a classic HTTP Helm repository without storing
+// credentials. Helm's repositories.yaml remains the durable source registry.
+type AddRepositoryRequest struct {
+	Name        string `json:"name"`
+	URL         string `json:"url"`
+	Namespace   string `json:"namespace,omitempty"`
+	ReleaseName string `json:"releaseName,omitempty"`
 }
 
 // ChartSearchResult contains search results for charts

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -1021,10 +1021,19 @@ export interface UpgradeInfo {
   error?: string
   // Machine-readable source-resolution failure, used to make the Helm drawer
   // explain whether tracking an OCI source can help.
-  sourceIssue?: 'untracked' | 'repo_index_error' | 'ambiguous_repository'
+  sourceIssue?: 'untracked' | 'repo_index_error' | 'ambiguous_repository' | 'ambiguous_source'
+  sourceCandidates?: ChartSourceCandidate[]
   // True only when the error is a genuinely untracked source (registering a
   // chart source could fix it). Kept for compatibility; prefer sourceIssue.
   untracked?: boolean
+}
+
+export interface ChartSourceCandidate {
+  type: 'repository' | 'oci'
+  reference: string
+  // Canonical classic repository URL. Absent for OCI and legacy name-only
+  // provenance written by older Radar versions.
+  url?: string
 }
 
 // Batch upgrade info keyed by "storageNamespace/name".
@@ -1099,6 +1108,7 @@ export interface InstallChartRequest {
   chartName: string
   version: string
   repository: string
+  repositoryName?: string
   values?: Record<string, unknown>
   createNamespace?: boolean
 }

--- a/web/scripts/test-helm-repository-click.mjs
+++ b/web/scripts/test-helm-repository-click.mjs
@@ -1,0 +1,164 @@
+import { createServer } from 'vite'
+import { chromium } from 'playwright'
+import assert from 'node:assert/strict'
+
+// Render the real dialog and real React Query mutations against HTTP fixtures.
+// No Kubernetes requests or release writes are made by this test.
+const server = await createServer({ optimizeDeps: { include: ['react', 'react-dom/client', '@tanstack/react-query'] }, server: { host: '127.0.0.1', port: 0 }, plugins: [{
+  name: 'repository-click-fixture',
+  configureServer(server) {
+    server.middlewares.use('/__repository-click', async (req, res, next) => {
+      if (req.url.includes('?')) return next()
+      res.setHeader('Content-Type', 'text/html')
+      res.end(await server.transformIndexHtml('/__repository-click', `<div id="root"></div><script type="module">
+        import React from 'react';
+        import ReactDOMClient from 'react-dom/client';
+        import {QueryClient,QueryClientProvider} from '@tanstack/react-query';
+        import {TrackChartSourceDialog} from '/src/components/helm/TrackChartSourceDialog.tsx';
+        const client = new QueryClient({defaultOptions:{queries:{retry:false}}});
+        client.getQueryCache().subscribe(event => {
+          if(event.action?.type==='invalidate') (window.invalidated ||= []).push(event.query.queryKey[0]);
+        });
+        client.setQueryData(['helm-upgrade-info'], {});
+        client.setQueryData(['helm-batch-upgrade-info'], {});
+        function Fixture() {
+          const [open,setOpen]=React.useState(true);
+          return React.createElement(TrackChartSourceDialog,{open,namespace:'example-namespace',releaseName:'example-release',
+            chartName:'example-chart',sourceIssue:'untracked',onClose:()=>{window.closedDialog=true;setOpen(false)}});
+        }
+        ReactDOMClient.createRoot(document.getElementById('root')).render(React.createElement(QueryClientProvider,{client},React.createElement(Fixture)));
+      </script>`))
+    })
+  },
+}] })
+await server.listen()
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  page.on('pageerror', error => console.error(error.message))
+  page.on('console', message => { if(message.type() === 'error') console.error(message.text()) })
+  page.on('requestfailed', request => console.error(request.url(), request.failure()?.errorText))
+  page.on('response', response => { if(response.status() >= 400) console.error(response.status(), response.url()) })
+  const requests = []
+  let reject = true
+  await page.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) return route.continue()
+    if (route.request().method() === 'POST' && path.endsWith('/repositories')) {
+      requests.push(route.request().postDataJSON())
+      await new Promise(resolve => setTimeout(resolve, 300))
+      return route.fulfill({ status: reject ? 400 : 200, json: reject
+        ? {error:'repository name conflicts with a different URL'} : {name:'recorded-repo',associated:true} })
+    }
+    return route.fulfill({json: path.endsWith('/repositories')
+      ? [{name:'recorded-repo',url:'https://recorded.example.test/charts/'}]
+      : path.endsWith('/source-candidates') ? [{type:'repository',reference:'recorded-repo'}]
+      : path.endsWith('/cluster-info') ? {} : []})
+  })
+  await page.goto(`http://127.0.0.1:${server.httpServer.address().port}/__repository-click`)
+  const form = page.getByTestId('helm-repository-form')
+  await form.waitFor({timeout: 120000})
+  await page.waitForFunction(() => document.querySelector('[data-testid="helm-repository-form"] input')?.value === 'recorded-repo')
+  assert.equal(await form.getByLabel('Repository URL').inputValue(), 'https://recorded.example.test/charts/')
+  await page.getByLabel('Prefix', {exact:true}).fill('https://invalid-in-oci.example')
+  await form.getByRole('button', {name:'Add repository',exact:true}).click()
+  assert.equal(await form.getByRole('button',{name:'Adding repository…'}).isDisabled(),true)
+  await form.getByRole('alert').waitFor()
+  assert.match(await form.getByRole('alert').innerText(),/conflicts with a different URL/)
+  assert.deepEqual(requests,[{name:'recorded-repo',url:'https://recorded.example.test/charts/',namespace:'example-namespace',releaseName:'example-release'}])
+  await form.getByLabel('Name',{exact:true}).fill('edited')
+  await form.getByLabel('Repository URL').fill('https://manual.example/charts/')
+  reject=false
+  await form.getByRole('button',{name:'Add repository',exact:true}).click()
+  await page.waitForFunction(()=>window.closedDialog)
+  assert.equal(requests.length,2)
+  assert.equal(requests[1].name,'edited')
+  assert.equal(requests[1].url,'https://manual.example/charts/')
+  const invalidated=await page.evaluate(()=>window.invalidated)
+  for(const key of ['helm-repositories','helm-source-candidates','helm-upgrade-info','helm-batch-upgrade-info']) assert.ok(invalidated.includes(key),key)
+
+  // Prove the prefill is driven by arbitrary API data, not the recorded-source
+  // regression fixture above.
+  const genericPage = await browser.newPage()
+  await genericPage.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) return route.continue()
+    if (route.request().method() !== 'GET') {
+      return route.fulfill({status: 500, json: {error: 'unexpected mutation'}})
+    }
+    return route.fulfill({json: path.endsWith('/repositories')
+      ? []
+      : path.endsWith('/source-candidates') ? [{type:'repository',reference:'example-repo',url:'https://charts.example.test'}]
+      : path.endsWith('/cluster-info') ? {} : []})
+  })
+  await genericPage.goto(`http://127.0.0.1:${server.httpServer.address().port}/__repository-click`)
+  const genericForm = genericPage.getByTestId('helm-repository-form')
+  await genericForm.waitFor({timeout: 120000})
+  await genericPage.waitForFunction(() => document.querySelector('[data-testid="helm-repository-form"] input')?.value === 'example-repo')
+  assert.equal(await genericForm.getByLabel('Name',{exact:true}).inputValue(), 'example-repo')
+  assert.equal(await genericForm.getByLabel('Repository URL').inputValue(), 'https://charts.example.test')
+  assert.equal(await genericForm.getByRole('button',{name:'Add repository',exact:true}).isEnabled(), true)
+  await genericPage.close()
+
+  // ArtifactHub is opt-in: opening the dialog performs no external discovery.
+  // Once clicked, a uniquely verified candidate fills the actual controlled
+  // form state while manual recovery remains present.
+  const discoveryPage = await browser.newPage()
+  let discoveryRequests = 0
+  await discoveryPage.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) return route.continue()
+    if (path.endsWith('/source-discovery/artifacthub')) {
+      discoveryRequests++
+      assert.equal(route.request().method(), 'POST')
+      assert.equal(route.request().postData(), null)
+      return route.fulfill({json:[{type:'repository',reference:'fixture-repo',url:'https://verified.example.test/charts'}]})
+    }
+    return route.fulfill({json: path.endsWith('/source-candidates') || path.endsWith('/repositories') ? [] : {}})
+  })
+  await discoveryPage.goto(`http://127.0.0.1:${server.httpServer.address().port}/__repository-click`)
+  const discovery = discoveryPage.getByTestId('artifacthub-recovery')
+  await discovery.waitFor({timeout: 120000})
+  assert.equal(discoveryRequests, 0)
+  await discovery.getByRole('button',{name:'Search ArtifactHub for possible source',exact:true}).click()
+  await discovery.getByText('Possible source found via ArtifactHub',{exact:true}).waitFor()
+  const discoveryForm = discoveryPage.getByTestId('helm-repository-form')
+  assert.equal(await discoveryForm.getByLabel('Name',{exact:true}).inputValue(), 'fixture-repo')
+  assert.equal(await discoveryForm.getByLabel('Repository URL').inputValue(), 'https://verified.example.test/charts')
+  assert.equal(await discoveryForm.getByRole('button',{name:'Add and use repository',exact:true}).isEnabled(), true)
+  assert.equal(discoveryRequests, 1)
+  await discoveryPage.close()
+
+  // Closing the dialog aborts an in-flight external discovery request instead
+  // of leaving a background search or pagination loop running.
+  const cancellationPage = await browser.newPage()
+  let cancellationStarted = false
+  let cancellationObserved = false
+  cancellationPage.on('requestfailed', request => {
+    if (request.url().includes('/source-discovery/artifacthub')) cancellationObserved = true
+  })
+  await cancellationPage.route('**/api/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (!path.startsWith('/api/')) return route.continue()
+    if (path.endsWith('/source-discovery/artifacthub')) {
+      cancellationStarted = true
+      await new Promise(resolve => setTimeout(resolve, 1500))
+      return route.fulfill({json: []}).catch(() => {})
+    }
+    return route.fulfill({json: path.endsWith('/source-candidates') || path.endsWith('/repositories') ? [] : {}})
+  })
+  await cancellationPage.goto(`http://127.0.0.1:${server.httpServer.address().port}/__repository-click`)
+  await cancellationPage.getByTestId('artifacthub-recovery').getByRole('button',{name:'Search ArtifactHub for possible source',exact:true}).click()
+  await cancellationPage.waitForFunction(() => true, undefined, {timeout: 100})
+  assert.equal(cancellationStarted, true)
+  await cancellationPage.getByRole('button',{name:'Close',exact:true}).click()
+  await cancellationPage.waitForFunction(() => !document.querySelector('[data-testid="artifacthub-recovery"]'))
+  await new Promise(resolve => setTimeout(resolve, 100))
+  assert.equal(cancellationObserved, true)
+  await cancellationPage.close()
+
+  console.log('PASS: generic dynamic prefill, explicit ArtifactHub opt-in, verified candidate state, cancellation, input UX, one POST per click, loading/error, manual edits, independent OCI state')
+} finally {
+  await browser.close()
+  await server.close()
+}

--- a/web/src/api/client.helmSource.test.ts
+++ b/web/src/api/client.helmSource.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { HELM_REPOSITORY_ADD_INVALIDATION_KEYS } from './client'
+
+describe('Helm repository source recovery invalidation', () => {
+  it('refreshes repositories, exact candidates, and upgrade state after add', () => {
+    expect(HELM_REPOSITORY_ADD_INVALIDATION_KEYS).toEqual([
+      ['helm-repositories'],
+      ['helm-source-candidates'],
+      ['helm-upgrade-info'],
+      ['helm-batch-upgrade-info'],
+    ])
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -44,6 +44,7 @@ import type {
   ChartSearchResult,
   ChartDetail,
   InstallChartRequest,
+  ChartSourceCandidate,
   ArtifactHubSearchResult,
   ArtifactHubChartDetail,
   GitOpsResourceTree,
@@ -5489,6 +5490,75 @@ export function useHelmRepositories() {
   return useQuery<HelmRepository[]>({
     queryKey: ["helm-repositories"],
     queryFn: () => fetchJSON("/helm/repositories"),
+  });
+}
+
+export const HELM_REPOSITORY_ADD_INVALIDATION_KEYS = [
+  ["helm-repositories"],
+  ["helm-source-candidates"],
+  ["helm-upgrade-info"],
+  ["helm-batch-upgrade-info"],
+] as const;
+
+export function useAddHelmRepository() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ name, url, namespace, releaseName }: { name: string; url: string; namespace?: string; releaseName?: string }) => {
+      const response = await apiFetch(`${getApiBase()}/helm/repositories`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, url, namespace, releaseName }),
+      });
+      if (!response.ok) throw new Error((await response.json().catch(() => ({}))).error || `HTTP ${response.status}`);
+      return response.json() as Promise<{ name: string; associated: boolean; candidates?: ChartSourceCandidate[] }>;
+    },
+    onSuccess: async () => {
+      await Promise.all(HELM_REPOSITORY_ADD_INVALIDATION_KEYS.map((queryKey) => queryClient.invalidateQueries({ queryKey })));
+    },
+  });
+}
+
+export function useHelmSourceCandidates(namespace: string, name: string, enabled = true) {
+  return useQuery<ChartSourceCandidate[]>({
+    queryKey: ["helm-source-candidates", namespace, name],
+    queryFn: () => fetchJSON(`/helm/releases/${namespace}/${name}/source-candidates`),
+    enabled: enabled && Boolean(namespace && name),
+  });
+}
+
+// ArtifactHub recovery is deliberately a mutation: it is an explicit user
+// action that performs an external lookup and source verification, never a
+// background query caused by opening the dialog.
+export function useDiscoverArtifactHubSources(namespace: string, name: string) {
+  return useMutation({
+    mutationFn: async (signal?: AbortSignal) => {
+      const response = await apiFetch(`${getApiBase()}/helm/releases/${namespace}/${name}/source-discovery/artifacthub`, {
+        method: "POST",
+        signal,
+      });
+      if (!response.ok) throw new Error((await response.json().catch(() => ({}))).error || `HTTP ${response.status}`);
+      return response.json() as Promise<ChartSourceCandidate[]>;
+    },
+  });
+}
+
+export function useSetHelmSource(namespace: string, name: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (source: ChartSourceCandidate) => {
+      const response = await apiFetch(`${getApiBase()}/helm/releases/${namespace}/${name}/source`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(source),
+      });
+      if (!response.ok) throw new Error((await response.json().catch(() => ({}))).error || `HTTP ${response.status}`);
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["helm-source-candidates", namespace, name] });
+      queryClient.invalidateQueries({ queryKey: ["helm-upgrade-info", namespace, name] });
+      queryClient.invalidateQueries({ queryKey: ["helm-batch-upgrade-info"] });
+    },
   });
 }
 

--- a/web/src/components/helm/HelmReleaseDrawer.test.ts
+++ b/web/src/components/helm/HelmReleaseDrawer.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { isUpgradeSourceIssueActionable } from './HelmReleaseDrawer'
 
 describe('isUpgradeSourceIssueActionable', () => {
-  it('keeps classic repository ambiguity informational', () => {
-    expect(isUpgradeSourceIssueActionable('ambiguous_repository')).toBe(false)
+  it('allows explicit recovery from classic or cross-source ambiguity', () => {
+    expect(isUpgradeSourceIssueActionable('ambiguous_repository')).toBe(true)
+    expect(isUpgradeSourceIssueActionable('ambiguous_source')).toBe(true)
   })
 
   it('lets OCI registration help untracked and repo-index states', () => {

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -50,7 +50,7 @@ interface ParsedUpgradeValues {
 }
 
 type UpgradeSourceIssue = NonNullable<UpgradeInfo['sourceIssue']>
-type ActionableUpgradeSourceIssue = Exclude<UpgradeSourceIssue, 'ambiguous_repository'>
+type ActionableUpgradeSourceIssue = UpgradeSourceIssue
 
 function getUpgradeSourceIssue(upgradeInfo: UpgradeInfo): UpgradeSourceIssue | undefined {
   return upgradeInfo.sourceIssue
@@ -75,9 +75,11 @@ function getUpgradeSourceIssueTooltip(issue: UpgradeSourceIssue, error: string |
     case 'repo_index_error':
       return 'A configured Helm repo index failed. Fix or refresh that repo, or register an OCI prefix if this chart came from OCI.'
     case 'ambiguous_repository':
-      return 'Multiple configured Helm repos match this chart. Fix the repo list or source metadata so Radar can identify one source.'
+      return 'Multiple configured Helm repos match this chart. Select the exact source.'
+    case 'ambiguous_source':
+      return 'Multiple configured sources match this chart and version. Select the exact source.'
     case 'untracked':
-      return "Radar can't tell where this chart was installed from. Register an OCI chart source to track upgrades."
+      return "Radar can't tell where this chart was installed from. Add or select its Helm repository or OCI source."
   }
 }
 
@@ -95,7 +97,7 @@ function parseUpgradeValuesYaml(raw: string): ParsedUpgradeValues {
 }
 
 export function isUpgradeSourceIssueActionable(issue: UpgradeInfo['sourceIssue']): issue is ActionableUpgradeSourceIssue {
-  return Boolean(issue && issue !== 'ambiguous_repository')
+	return Boolean(issue)
 }
 
 const MIN_WIDTH = 500
@@ -1011,6 +1013,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         open={showTrackSource}
         onClose={() => setShowTrackSource(false)}
         chartName={releaseDetail?.chart}
+        namespace={release.storageNamespace || release.namespace}
+        releaseName={release.name}
         sourceIssue={upgradeSourceIssue}
         sourceError={upgradeInfo?.error}
       />

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -151,6 +151,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
           chartName,
           version,
           repository,
+          repositoryName: isLocal ? repo : artifactHubDetail?.repository.name,
           values,
           createNamespace,
         },

--- a/web/src/components/helm/TrackChartSourceDialog.test.ts
+++ b/web/src/components/helm/TrackChartSourceDialog.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canAddHelmRepository,
+  getSourceIssueCopy,
+  HELM_REPOSITORY_FORM_GRID_CLASS,
+  isValidHelmRepositoryURL,
+  isValidOCIPrefix,
+  ociPrefixForCandidate,
+  SOURCE_INPUT_BASE_CLASS,
+  uniqueSourceCandidate,
+} from './TrackChartSourceDialog'
+
+describe('chart source forms', () => {
+  it('keeps the classic row inside a responsive, shrinkable grid', () => {
+    expect(HELM_REPOSITORY_FORM_GRID_CLASS).toContain('grid-cols-1')
+    expect(HELM_REPOSITORY_FORM_GRID_CLASS).toContain('md:grid-cols-')
+    expect(HELM_REPOSITORY_FORM_GRID_CLASS).toContain('minmax(0,')
+  })
+
+  it('makes every source input visually unmistakable and accessible', () => {
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('border')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('bg-theme-elevated')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('placeholder:text-theme-text-disabled')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('focus:ring-2')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('focus:border-accent')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('disabled:opacity-50')
+    expect(SOURCE_INPUT_BASE_CLASS).toContain('disabled:cursor-not-allowed')
+  })
+
+  it('accepts HTTP only in the classic form and OCI only in the OCI form', () => {
+    expect(isValidHelmRepositoryURL('https://charts.example.test/')).toBe(true)
+    expect(isValidHelmRepositoryURL('oci://ghcr.io/example')).toBe(false)
+    expect(isValidOCIPrefix('https://charts.example.test/')).toBe(false)
+    expect(isValidOCIPrefix('oci://ghcr.io/example')).toBe(true)
+  })
+
+  it('validates classic and OCI actions independently', () => {
+    expect(canAddHelmRepository('example-repo', 'https://charts.example.test/')).toBe(true)
+    expect(isValidOCIPrefix('https://wrong-field.example')).toBe(false)
+
+    expect(canAddHelmRepository('', 'not-a-url')).toBe(false)
+    expect(isValidOCIPrefix('oci://ghcr.io/example')).toBe(true)
+  })
+
+  it('automatically selects only an unambiguous recovered source', () => {
+    const classic = { type: 'repository' as const, reference: 'example-repo' }
+    expect(uniqueSourceCandidate([classic])).toEqual(classic)
+    expect(uniqueSourceCandidate([classic, { type: 'oci', reference: 'oci://ghcr.io/example/chart' }])).toBeUndefined()
+  })
+
+  it('derives a registrable OCI prefix from a verified full chart reference', () => {
+    expect(ociPrefixForCandidate('oci://ghcr.io/example/charts/app', 'app')).toBe('oci://ghcr.io/example/charts')
+    expect(ociPrefixForCandidate('oci://ghcr.io/example/charts', 'app')).toBe('oci://ghcr.io/example/charts')
+  })
+})
+
+describe('getSourceIssueCopy', () => {
+  it('offers both classic repository and OCI recovery for untracked charts', () => {
+    const copy = getSourceIssueCopy('untracked')
+    expect(copy?.body).toContain('classic repository')
+    expect(copy?.body).toContain('OCI source')
+  })
+
+  it('requires explicit selection for ambiguous classic and cross-source matches', () => {
+    expect(getSourceIssueCopy('ambiguous_repository')?.body).toContain('Select')
+    expect(getSourceIssueCopy('ambiguous_source')?.body).toContain('Select')
+  })
+})

--- a/web/src/components/helm/TrackChartSourceDialog.tsx
+++ b/web/src/components/helm/TrackChartSourceDialog.tsx
@@ -1,21 +1,53 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
-import { X, Plus, Trash2, Link2, AlertTriangle } from 'lucide-react'
+import { X, Plus, Trash2, Link2, AlertTriangle, Search } from 'lucide-react'
 import { clsx } from 'clsx'
-import { useHelmOCISources, useAddOCISource, useRemoveOCISource, useClusterInfo } from '../../api/client'
+import { useHelmRepositories, useHelmOCISources, useAddOCISource, useRemoveOCISource, useClusterInfo, useHelmSourceCandidates, useSetHelmSource, useAddHelmRepository, useDiscoverArtifactHubSources } from '../../api/client'
 import { Input } from '@skyhook-io/k8s-ui'
-import type { UpgradeInfo } from '../../types'
+import type { ChartSourceCandidate, UpgradeInfo } from '../../types'
 
 interface TrackChartSourceDialogProps {
   open: boolean
   onClose: () => void
   /** Chart name of the release this was opened from, for the example prompt. */
   chartName?: string
+  namespace: string
+  releaseName: string
   sourceIssue?: UpgradeInfo['sourceIssue']
   sourceError?: string
 }
 
-function getSourceIssueCopy(sourceIssue: UpgradeInfo['sourceIssue'], sourceError?: string) {
+export const HELM_REPOSITORY_FORM_GRID_CLASS = 'grid grid-cols-1 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1.8fr)_auto] gap-2 items-end'
+export const SOURCE_INPUT_BASE_CLASS = 'w-full min-w-0 px-3 py-2 rounded-lg border bg-theme-elevated text-sm text-theme-text-primary placeholder:text-theme-text-disabled shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-theme-surface'
+
+export function isValidHelmRepositoryURL(value: string) {
+  try {
+    const parsed = new URL(value.trim())
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function isValidOCIPrefix(value: string) {
+  return value.trim().startsWith('oci://')
+}
+
+export function canAddHelmRepository(name: string, repositoryURL: string) {
+  return name.trim() !== '' && isValidHelmRepositoryURL(repositoryURL)
+}
+
+export function uniqueSourceCandidate(candidates: ChartSourceCandidate[] | undefined) {
+  return candidates?.length === 1 ? candidates[0] : undefined
+}
+
+export function ociPrefixForCandidate(reference: string, chartName?: string) {
+  const normalized = reference.trim().replace(/\/+$/, '')
+  const suffix = chartName?.trim() ? `/${chartName.trim()}` : ''
+  return suffix && normalized.endsWith(suffix) ? normalized.slice(0, -suffix.length) : normalized
+}
+
+export function getSourceIssueCopy(sourceIssue: UpgradeInfo['sourceIssue'], sourceError?: string) {
   switch (sourceIssue) {
     case 'repo_index_error':
       return {
@@ -25,12 +57,17 @@ function getSourceIssueCopy(sourceIssue: UpgradeInfo['sourceIssue'], sourceError
     case 'ambiguous_repository':
       return {
         title: 'Multiple Helm repos match',
-        body: 'Radar will not guess between classic repos. Adding an OCI prefix will not enable direct upgrades while those repos remain ambiguous.',
+        body: 'Radar will not guess. Select the repository that originally supplied this release.',
+      }
+    case 'ambiguous_source':
+      return {
+        title: 'Multiple chart sources match',
+        body: 'Select the exact classic repository or OCI source that originally supplied this release.',
       }
     case 'untracked':
       return {
         title: 'Source not tracked',
-        body: 'Helm does not record the install source. Add the OCI prefix that contains this chart.',
+        body: 'Helm does not record the install source. Add or select the classic repository or OCI source that contains this chart.',
       }
     default:
       return sourceError
@@ -44,33 +81,178 @@ function getSourceIssueCopy(sourceIssue: UpgradeInfo['sourceIssue'], sourceError
 // installed from, so for charts published to an OCI registry (and not managed by
 // GitOps) Radar can only track upgrades once the user declares where they live.
 // Registering a registry/org prefix lets Radar probe "<prefix>/<chartName>".
-export function TrackChartSourceDialog({ open, onClose, chartName, sourceIssue, sourceError }: TrackChartSourceDialogProps) {
-  const [value, setValue] = useState('')
+export function TrackChartSourceDialog({ open, onClose, chartName, namespace, releaseName, sourceIssue, sourceError }: TrackChartSourceDialogProps) {
+  const [ociPrefix, setOCIPrefix] = useState('')
+  const [repositoryName, setRepositoryName] = useState('')
+  const [repositoryURL, setRepositoryURL] = useState('')
+  const [repositoryError, setRepositoryError] = useState<string | null>(null)
+  const [repositoryMessage, setRepositoryMessage] = useState<string | null>(null)
+  const [repositorySubmitting, setRepositorySubmitting] = useState(false)
+  const [ociError, setOCIError] = useState<string | null>(null)
+  const [artifactHubCandidates, setArtifactHubCandidates] = useState<ChartSourceCandidate[] | null>(null)
+  const [artifactHubError, setArtifactHubError] = useState<string | null>(null)
+  const [selectedArtifactHubCandidate, setSelectedArtifactHubCandidate] = useState<ChartSourceCandidate | null>(null)
+  const repositoryEdited = useRef(false)
+  const repositoryInFlight = useRef(false)
+  const artifactHubAbort = useRef<AbortController | null>(null)
+  const { data: repositories } = useHelmRepositories()
   const { data: sources } = useHelmOCISources()
   const { data: clusterInfo } = useClusterInfo()
   const addSource = useAddOCISource()
   const removeSource = useRemoveOCISource()
+  const addRepository = useAddHelmRepository()
+  const discoverArtifactHub = useDiscoverArtifactHubSources(namespace, releaseName)
+  const { data: candidates, refetch: refetchCandidates } = useHelmSourceCandidates(namespace, releaseName, open)
+  const setSource = useSetHelmSource(namespace, releaseName)
+
+  useEffect(() => {
+    artifactHubAbort.current?.abort()
+    artifactHubAbort.current = null
+    repositoryEdited.current = false
+    setRepositoryName('')
+    setRepositoryURL('')
+    setRepositoryError(null)
+    setRepositoryMessage(null)
+    setOCIError(null)
+    setArtifactHubCandidates(null)
+    setArtifactHubError(null)
+    setSelectedArtifactHubCandidate(null)
+  }, [namespace, releaseName])
+
+  useEffect(() => {
+    if (!open) {
+      artifactHubAbort.current?.abort()
+      artifactHubAbort.current = null
+    }
+    return () => artifactHubAbort.current?.abort()
+  }, [open])
+
+  useEffect(() => {
+    if (!open || repositoryEdited.current) return
+    const candidate = uniqueSourceCandidate(candidates)
+    if (candidate?.type !== 'repository') return
+    const repository = repositories?.find(repo => repo.name === candidate.reference)
+    const repositoryURL = candidate.url ?? repository?.url
+    if (repositoryURL) {
+      setRepositoryName(candidate.reference)
+      setRepositoryURL(repositoryURL)
+    }
+  }, [open, candidates, repositories, namespace, releaseName])
 
   // In-cluster Radar has no `helm registry login` store (the pod's HELM_CONFIG_HOME
   // points at an empty /tmp), so private registries can't authenticate — only
   // public charts can be tracked. Be honest about it rather than silently failing.
   const inCluster = clusterInfo?.inCluster ?? false
 
-  const trimmed = value.trim()
-  const invalid = trimmed !== '' && !trimmed.startsWith('oci://')
-  const normalizedInput = trimmed.replace(/\/+$/, '')
+  const trimmedOCIPrefix = ociPrefix.trim()
+  const invalidOCI = trimmedOCIPrefix !== '' && !isValidOCIPrefix(trimmedOCIPrefix)
+  const trimmedRepositoryName = repositoryName.trim()
+  const trimmedRepositoryURL = repositoryURL.trim()
+  const invalidRepositoryURL = trimmedRepositoryURL !== '' && !isValidHelmRepositoryURL(trimmedRepositoryURL)
+  const canAddRepository = canAddHelmRepository(trimmedRepositoryName, trimmedRepositoryURL)
+  const normalizedInput = trimmedOCIPrefix.replace(/\/+$/, '')
   const normalizedChartName = chartName?.trim().replace(/^\/+|\/+$/g, '') ?? ''
   const probedRef = normalizedInput && normalizedChartName ? `${normalizedInput}/${normalizedChartName}` : ''
   const looksLikeFullChartRef = Boolean(normalizedInput && normalizedChartName && normalizedInput.endsWith(`/${normalizedChartName}`))
   const sourceIssueCopy = getSourceIssueCopy(sourceIssue, sourceError)
 
-  const handleAdd = () => {
-    if (!trimmed || invalid) return
-    addSource.mutate(trimmed, { onSuccess: () => setValue('') })
+  const handleAddOCI = (event?: FormEvent) => {
+    event?.preventDefault()
+    if (!trimmedOCIPrefix || invalidOCI) return
+    void (async () => {
+      setOCIError(null)
+      try {
+        await addSource.mutateAsync(trimmedOCIPrefix)
+        if (selectedArtifactHubCandidate?.type === 'oci') {
+          await setSource.mutateAsync(selectedArtifactHubCandidate)
+          onClose()
+        } else {
+          setOCIPrefix('')
+        }
+      } catch (error) {
+        setOCIError(error instanceof Error ? error.message : String(error))
+      }
+    })()
+  }
+
+  const selectArtifactHubCandidate = (candidate: ChartSourceCandidate) => {
+    setSelectedArtifactHubCandidate(candidate)
+    if (candidate.type === 'repository' && candidate.url) {
+      repositoryEdited.current = false
+      setRepositoryName(candidate.reference)
+      setRepositoryURL(candidate.url)
+    } else if (candidate.type === 'oci') {
+      setOCIPrefix(ociPrefixForCandidate(candidate.reference, chartName))
+    }
+  }
+
+  const handleArtifactHubDiscovery = async () => {
+	artifactHubAbort.current?.abort()
+	const controller = new AbortController()
+	artifactHubAbort.current = controller
+    setArtifactHubError(null)
+    setArtifactHubCandidates(null)
+    setSelectedArtifactHubCandidate(null)
+    try {
+	  const found = await discoverArtifactHub.mutateAsync(controller.signal)
+	  if (controller.signal.aborted) return
+      setArtifactHubCandidates(found)
+      const unique = uniqueSourceCandidate(found)
+      if (unique) selectArtifactHubCandidate(unique)
+    } catch (error) {
+	  if (controller.signal.aborted) return
+      setArtifactHubError(error instanceof Error ? error.message : String(error))
+	} finally {
+	  if (artifactHubAbort.current === controller) artifactHubAbort.current = null
+    }
+  }
+
+  const handleClose = () => {
+	artifactHubAbort.current?.abort()
+	artifactHubAbort.current = null
+	onClose()
+	}
+
+  const handleAddRepository = async (event?: FormEvent) => {
+    event?.preventDefault()
+    if (repositoryInFlight.current) return
+    if (!canAddRepository) {
+      setRepositoryError('Enter a repository name and a valid HTTP/HTTPS URL.')
+      return
+    }
+    repositoryInFlight.current = true
+    setRepositorySubmitting(true)
+    setRepositoryError(null)
+    setRepositoryMessage(null)
+    try {
+      const result = await addRepository.mutateAsync({
+        name: trimmedRepositoryName,
+        url: trimmedRepositoryURL,
+        namespace,
+        releaseName,
+      })
+      if (result.associated) {
+        onClose()
+        return
+      }
+      await refetchCandidates()
+      setRepositoryMessage(result.candidates?.length
+        ? 'Repository added. Select the original chart source above to finish recovery.'
+        : 'Repository added, but no exact chart/version match was found. Check the repository or refresh its index.')
+    } catch (error) {
+      setRepositoryError(error instanceof Error ? error.message : String(error))
+    } finally {
+      repositoryInFlight.current = false
+      setRepositorySubmitting(false)
+    }
+  }
+
+  const handleSelect = (candidate: NonNullable<typeof candidates>[number]) => {
+    setSource.mutate(candidate, { onSuccess: onClose })
   }
 
   return (
-    <DialogPortal open={open} onClose={onClose} className="max-w-lg w-full">
+    <DialogPortal open={open} onClose={handleClose} className="max-w-2xl w-full overflow-x-hidden">
       <div className="flex items-start gap-3 p-4 border-b border-theme-border">
         <div className="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-theme-hover">
           <Link2 className="w-5 h-5 text-theme-text-secondary" />
@@ -78,12 +260,12 @@ export function TrackChartSourceDialog({ open, onClose, chartName, sourceIssue, 
         <div className="flex-1 min-w-0">
           <h3 className="text-lg font-semibold text-theme-text-primary">Track chart source</h3>
           <p className="text-sm text-theme-text-secondary mt-1">
-            Helm doesn&apos;t record where a chart was installed from. Register your OCI
-            registry prefix and Radar will check it for newer versions of your charts.
+            Associate this release with the exact Helm repository or OCI chart source.
           </p>
         </div>
         <button
-          onClick={onClose}
+          onClick={handleClose}
+          aria-label="Close"
           className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           <X className="w-5 h-5" />
@@ -101,41 +283,110 @@ export function TrackChartSourceDialog({ open, onClose, chartName, sourceIssue, 
           </div>
         )}
 
-        <div>
-          <label className="block text-sm font-medium text-theme-text-secondary mb-2">
-            OCI registry prefix
-          </label>
-          <div className="flex gap-2">
+        {candidates && candidates.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-theme-text-tertiary uppercase tracking-wide mb-2">Matching exact sources</p>
+            <ul className="space-y-1">
+              {candidates.map((candidate) => (
+                <li key={`${candidate.type}:${candidate.reference}`} className="flex items-center justify-between gap-2 px-3 py-2 bg-theme-elevated rounded-lg">
+                  <span className="text-sm text-theme-text-primary font-mono truncate">{candidate.type === 'repository' ? `Helm repository: ${candidate.reference}` : candidate.reference}</span>
+                  <button onClick={() => handleSelect(candidate)} disabled={setSource.isPending} className="btn-brand px-2 py-1 text-xs disabled:opacity-50">Select</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {sourceIssue === 'untracked' && candidates?.length === 0 && (
+          <div className="rounded-lg border border-theme-border bg-theme-surface/40 p-3 space-y-2" data-testid="artifacthub-recovery">
+            <div>
+              <h4 className="text-sm font-semibold text-theme-text-primary">Optional ArtifactHub discovery</h4>
+              <p className="text-xs text-theme-text-tertiary">Search using only the installed chart name. Radar independently verifies the exact installed version and complete chart package before showing a result.</p>
+            </div>
+            <button type="button" onClick={handleArtifactHubDiscovery} disabled={discoverArtifactHub.isPending} className="inline-flex items-center gap-1.5 rounded-lg border border-theme-border-light bg-theme-elevated px-3 py-2 text-sm text-theme-text-primary hover:bg-theme-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50">
+              <Search className="w-4 h-4" />
+              {discoverArtifactHub.isPending ? 'Searching and verifying…' : 'Search ArtifactHub for possible source'}
+            </button>
+            {artifactHubError && <p role="alert" className="text-xs text-red-500 break-words">{artifactHubError}</p>}
+            {artifactHubCandidates && artifactHubCandidates.length === 0 && <p role="status" className="text-xs text-theme-text-secondary">No verified source found</p>}
+            {artifactHubCandidates && artifactHubCandidates.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-theme-text-secondary">{artifactHubCandidates.length === 1 ? 'Possible source found via ArtifactHub' : 'Possible sources found via ArtifactHub — choose one'}</p>
+                <ul className="space-y-1">
+                  {artifactHubCandidates.map(candidate => (
+                    <li key={`artifacthub:${candidate.type}:${candidate.reference}:${candidate.url ?? ''}`} className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-theme-border bg-theme-elevated px-3 py-2">
+                      <span className="min-w-0 break-all font-mono text-xs text-theme-text-primary">{candidate.type === 'repository' ? `Helm repository: ${candidate.reference} — ${candidate.url}` : `OCI: ${candidate.reference}`}</span>
+                      {artifactHubCandidates.length > 1 && <button type="button" onClick={() => selectArtifactHubCandidate(candidate)} className="btn-brand shrink-0 px-2 py-1 text-xs">Use this source</button>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        <form onSubmit={handleAddRepository} className="rounded-lg border border-theme-border p-3 space-y-3" data-testid="helm-repository-form">
+          <div>
+            <h4 className="text-sm font-semibold text-theme-text-primary">Helm repository</h4>
+            <p className="text-xs text-theme-text-tertiary">Add an HTTP/HTTPS chart repository.</p>
+          </div>
+          <div className={HELM_REPOSITORY_FORM_GRID_CLASS}>
+            <label className="block min-w-0">
+              <span className="block text-xs font-medium text-theme-text-secondary mb-1">Name</span>
+              <Input className={clsx(SOURCE_INPUT_BASE_CLASS, 'border-theme-border-light')} disabled={repositorySubmitting} value={repositoryName} onChange={(e) => { repositoryEdited.current = true; setSelectedArtifactHubCandidate(null); setRepositoryName(e.target.value) }} placeholder="Repository name" />
+            </label>
+            <label className="block min-w-0">
+              <span className="block text-xs font-medium text-theme-text-secondary mb-1">Repository URL</span>
+              <Input className={clsx(SOURCE_INPUT_BASE_CLASS, invalidRepositoryURL ? 'border-red-500/60 focus:ring-red-500 focus:border-red-500' : 'border-theme-border-light')} disabled={repositorySubmitting} value={repositoryURL} onChange={(e) => { repositoryEdited.current = true; setSelectedArtifactHubCandidate(null); setRepositoryURL(e.target.value) }} placeholder="https://charts.example.org/" aria-invalid={invalidRepositoryURL ? true : undefined} aria-describedby={invalidRepositoryURL ? 'repository-url-error' : undefined} />
+              {invalidRepositoryURL && <span id="repository-url-error" className="mt-1 block text-xs text-red-500">Must be an http:// or https:// Helm repository URL.</span>}
+            </label>
+            <button type="submit" disabled={!canAddRepository || repositorySubmitting || addRepository.isPending || setSource.isPending} className="btn-brand w-full md:w-auto px-3 py-2 text-sm whitespace-nowrap disabled:opacity-50 disabled:pointer-events-none">{repositorySubmitting ? 'Adding repository…' : selectedArtifactHubCandidate?.type === 'repository' ? 'Add and use repository' : 'Add repository'}</button>
+          </div>
+          {repositoryError && <p role="alert" className="text-xs text-red-500 break-words">{repositoryError}</p>}
+          {repositoryMessage && <p role="status" className="text-xs text-theme-text-secondary">{repositoryMessage}</p>}
+          <p className="mt-1 text-xs text-theme-text-tertiary">Credentials remain in Helm&apos;s repository configuration; Radar stores no repository credentials.</p>
+        </form>
+
+        <form onSubmit={handleAddOCI} className="rounded-lg border border-theme-border p-3 space-y-3" data-testid="oci-source-form">
+          <div>
+            <h4 className="text-sm font-semibold text-theme-text-primary">OCI registry</h4>
+            <p className="text-xs text-theme-text-tertiary">Register an OCI prefix. HTTP Helm repository URLs belong in the form above.</p>
+          </div>
+          <label htmlFor="oci-source-prefix" className="block text-xs font-medium text-theme-text-secondary">Prefix</label>
+          <div className="flex flex-col sm:flex-row gap-2 min-w-0">
             <Input
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
-              placeholder="oci://ghcr.io/myorg/charts"
-              aria-invalid={invalid ? true : undefined}
+              id="oci-source-prefix"
+              value={ociPrefix}
+              onChange={(e) => { setSelectedArtifactHubCandidate(null); setOCIPrefix(e.target.value) }}
+              disabled={addSource.isPending || setSource.isPending}
+              placeholder="oci://ghcr.io/example"
+              aria-invalid={invalidOCI ? true : undefined}
+              aria-describedby={invalidOCI ? 'oci-prefix-error' : undefined}
               className={clsx(
-                'flex-1 px-3 py-2 bg-theme-elevated border rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2',
-                invalid ? 'border-red-500/60 focus:ring-red-500' : 'border-theme-border-light focus:ring-accent',
+                SOURCE_INPUT_BASE_CLASS,
+                'flex-1',
+                invalidOCI ? 'border-red-500/60 focus:ring-red-500 focus:border-red-500' : 'border-theme-border-light',
               )}
             />
             <button
-              onClick={handleAdd}
-              disabled={!trimmed || invalid || addSource.isPending}
-              className="btn-brand px-3 py-2 text-sm inline-flex items-center gap-1 disabled:opacity-50 disabled:pointer-events-none"
+              type="submit"
+              disabled={!trimmedOCIPrefix || invalidOCI || addSource.isPending}
+              className="btn-brand w-full sm:w-auto px-3 py-2 text-sm inline-flex justify-center items-center gap-1 whitespace-nowrap disabled:opacity-50 disabled:pointer-events-none"
             >
               <Plus className="w-4 h-4" />
-              Add
+              {selectedArtifactHubCandidate?.type === 'oci' ? 'Add and use OCI source' : 'Add OCI source'}
             </button>
           </div>
+          {invalidOCI && <p id="oci-prefix-error" className="text-xs text-red-500">Must be an oci:// reference.</p>}
+          {ociError && <p role="alert" className="text-xs text-red-500 break-words">{ociError}</p>}
           <p className="mt-1 text-xs text-theme-text-tertiary">
-            {invalid
-              ? 'Must be an oci:// reference.'
-              : looksLikeFullChartRef
+            {looksLikeFullChartRef
                 ? `This looks like a full chart ref. Radar would probe "${probedRef}"; remove the final "/${normalizedChartName}" if "${normalizedChartName}" is the chart name.`
               : chartName
                 ? `Radar will probe "${probedRef || `<prefix>/${normalizedChartName}`}".`
                 : 'Radar probes <prefix>/<chartName> for each untracked release.'}
           </p>
-        </div>
+        </form>
 
         {sources && sources.length > 0 && (
           <div>


### PR DESCRIPTION
### Problem

Helm release storage retains chart metadata but not reliable original chart-source provenance. After restart, moving Radar between machines, or for older releases, Radar can therefore lose the repository/OCI source required to reconstruct the exact installed chart.

This is especially important for safe Values Preview/Apply because complete chart reconstruction must not depend on machine-local repository aliases.

### Fix

- Persist per-release chart-source provenance.
- For classic Helm repositories, retain both repository name and canonical URL.
- For OCI, retain the exact chart source without storing credentials.
- Recover existing releases from configured sources when unambiguous.
- Never guess between multiple matching sources.
- Support cross-machine recovery.
- Keep manual Helm repository and OCI recovery available.
- Add explicit opt-in ArtifactHub-assisted discovery for legacy unresolved releases.
- Treat ArtifactHub only as discovery metadata; independently verify the exact chart name/version/package/source before association.
- Improve Track Chart Source form clarity and recovery UX.
- Preserve fail-closed complete-chart reconstruction.

### Safety

- No credentials are persisted in release provenance.
- ArtifactHub lookup is explicit/opt-in and sends only the chart name.
- Ambiguous or unverifiable sources remain unresolved.
- Exact installed versions are required.
- Incomplete dependency trees remain fail-closed.

### Tests

- `go test ./internal/helm -count=1`
- Classic repository and OCI provenance/recovery, including cross-machine recovery and ambiguity handling.
- ArtifactHub HTTP/OCI discovery, privacy, independent exact-version verification, and dependency validation.
- Focused frontend source-recovery tests and frontend typecheck.
- Real existing-release Preview/recovery validation without unintended Helm revision changes.

### Dependency

Depends on #1631, which provides the fail-closed complete-chart reconstruction used by this recovery path.
