### PR TITLE
fix(topology): scope sidebar counts to namespaces

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -66,7 +66,7 @@ import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNam
 import { SettingsDialog, type SettingsSectionId } from './components/settings/SettingsDialog'
 import type { APIResource, TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPluralWithGroup, pluralToKind, openExternal, apiVersionToGroup, relatedResourcePath, searchHitToSelectedResource } from './utils/navigation'
-import { findSelectedTopologyNode } from './utils/topology-selection'
+import { findSelectedTopologyNode, scopeTopologyNodesToNamespaces } from './utils/topology-selection'
 import { type OmnibarHandle } from './components/ui/Omnibar'
 import { RadarOmnibar } from './components/ui/RadarOmnibar'
 import type { ContextSwitcherHandle } from './components/ContextSwitcher'
@@ -1575,6 +1575,11 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     if (!params.has('release')) setSelectedHelmRelease(null)
   }, [namespacesKey])
 
+  const namespaceScopedTopologyNodes = useMemo(
+    () => scopeTopologyNodesToNamespaces(displayedTopology?.nodes ?? [], namespaces),
+    [displayedTopology, namespaces],
+  )
+
   // Filter topology based on visible kinds (uses displayedTopology which respects pause)
   const filteredTopology = useMemo((): Topology | null => {
     if (!displayedTopology) return null
@@ -1582,12 +1587,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     // Fleet mode overrides visible kinds to show only CAPI resources + Node
     const effectiveKinds = topologyMode === 'fleet' ? FLEET_MODE_KINDS : visibleKinds
 
-    // Filter by namespace (client-side) and by visible kinds
-    const nsSet = namespaces.length > 0 ? new Set(namespaces) : null
-    const filteredNodes = displayedTopology.nodes.filter(node =>
-      effectiveKinds.has(node.kind) &&
-      (!nsSet || nsSet.has(node.data.namespace as string) || !(node.data.namespace as string))
-    )
+    // Filter by visible kinds after namespace scoping so the sidebar can use the
+    // same complete scoped node set without inheriting kind visibility.
+    const filteredNodes = namespaceScopedTopologyNodes.filter(node => effectiveKinds.has(node.kind))
     const filteredNodeIds = new Set(filteredNodes.map(n => n.id))
 
     // Keep edges where both source and target are visible
@@ -1609,7 +1611,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       nodes: filteredNodes,
       edges: filteredEdges,
     }
-  }, [displayedTopology, visibleKinds, namespaces, topologyMode])
+  }, [displayedTopology, namespaceScopedTopologyNodes, visibleKinds, topologyMode])
 
   // Cluster Audit findings, joined onto topology nodes by the audit key the
   // backend stamps on each node (data.auditKey). Only badge-worthy findings
@@ -2163,7 +2165,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
               <>
                 {/* Filter sidebar */}
                 <TopologyFilterSidebar
-                  nodes={topology?.nodes || []}
+                  nodes={namespaceScopedTopologyNodes}
                   visibleKinds={visibleKinds}
                   onToggleKind={handleToggleKind}
                   onShowAll={handleShowAllKinds}

--- a/web/src/utils/topology-selection.test.ts
+++ b/web/src/utils/topology-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { SelectedResource, Topology, TopologyNode } from '@skyhook-io/k8s-ui/types/core'
-import { findSelectedTopologyNode } from './topology-selection'
+import { findSelectedTopologyNode, scopeTopologyNodesToNamespaces } from './topology-selection'
 
 function node(id: string, kind: string, name: string, apiVersion?: string): TopologyNode {
   return {
@@ -36,5 +36,27 @@ describe('findSelectedTopologyNode', () => {
     const topology: Topology = { nodes: [first, second], edges: [] }
 
     expect(findSelectedTopologyNode(topology, selected('two.example', 'widgets'))?.id).toBe('second')
+  })
+})
+
+describe('scopeTopologyNodesToNamespaces', () => {
+  it('keeps selected namespaces and cluster-scoped nodes', () => {
+    const selected = node('selected', 'Pod', 'selected')
+    const other = { ...node('other', 'Pod', 'other'), data: { namespace: 'other' } }
+    const clusterScoped = { ...node('cluster', 'Node', 'cluster'), data: {} }
+    const emptyNamespace = { ...node('empty', 'Namespace', 'default'), data: { namespace: '' } }
+
+    const scoped = scopeTopologyNodesToNamespaces(
+      [selected, other, clusterScoped, emptyNamespace],
+      ['default'],
+    )
+
+    expect(scoped.map(item => item.id)).toEqual(['selected', 'cluster', 'empty'])
+  })
+
+  it('keeps the full node set when no namespace is selected', () => {
+    const nodes = [node('default', 'Pod', 'default')]
+
+    expect(scopeTopologyNodesToNamespaces(nodes, [])).toBe(nodes)
   })
 })

--- a/web/src/utils/topology-selection.ts
+++ b/web/src/utils/topology-selection.ts
@@ -38,3 +38,16 @@ export function findSelectedTopologyNode(
   // highlighting a resource from another API group.
   return candidates.some(node => topologyNodeGroup(node) !== undefined) ? undefined : candidates[0]
 }
+
+export function scopeTopologyNodesToNamespaces(
+  nodes: TopologyNode[],
+  namespaces: string[],
+): TopologyNode[] {
+  if (namespaces.length === 0) return nodes
+
+  const selectedNamespaces = new Set(namespaces)
+  return nodes.filter(node => {
+    const namespace = node.data.namespace
+    return typeof namespace !== 'string' || namespace === '' || selectedNamespaces.has(namespace)
+  })
+}


### PR DESCRIPTION
## Description

Scope the topology filter sidebar to the same pause-buffered namespace node set as the graph, while retaining cluster-scoped nodes. Kind visibility remains a later graph-only filter.

## Type of change

- [x] Bug fix

## How has this been tested?

- [x] Added/updated unit tests
- `npm test --workspace=web` (607 passed)
- `npm run build --workspace=web`
- `npm run lint --workspace=web` (0 errors; existing warnings only)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related issues

Fixes #1647

Developed with AI assistance; I reviewed and validated the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side topology filtering and sidebar display only; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes topology filter sidebar kind counts reflecting resources outside the active namespace scope (#1647).
> 
> **Namespace scoping is split from kind visibility.** A new `scopeTopologyNodesToNamespaces` helper filters nodes to the selected namespaces while still including cluster-scoped nodes (missing, empty, or non-string `data.namespace`). With no namespaces selected it returns the original array unchanged.
> 
> **`App.tsx` wires the same scoped set to the sidebar and graph.** `namespaceScopedTopologyNodes` is derived from pause-buffered `displayedTopology` and the namespace pick; `TopologyFilterSidebar` now receives that list instead of the full SSE topology. The graph still applies kind/fleet visibility on top of that scoped set, so sidebar totals match the namespace-filtered graph without hiding kinds from the sidebar counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8beb28f99ac75dbbd0f5b703b8fbbf3b507acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->