### PR TITLE
fix(istio): stop policy rows asserting a security posture no single object establishes

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2090,10 +2090,11 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   destinationrules: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
-    { key: 'host', label: 'Host', width: 'w-48' },
-    { key: 'subsets', label: 'Subsets', width: 'w-20' },
-    { key: 'loadBalancer', label: 'LB Policy', width: 'w-28' },
+    { key: 'status', label: 'Status', width: 'w-24', defaultVisible: false },
+    { key: 'host', label: 'Host', width: 'w-48', tooltip: "The service this rule's traffic policy applies to" },
+    { key: 'subsets', label: 'Subsets', width: 'w-20', tooltip: 'Named backend groups that routes can select, often for canary releases. Defining subsets does not send traffic to them.' },
+    { key: 'tls', label: 'Client TLS', width: 'w-28', tooltip: 'Declared client-side TLS mode for this host at the rule level. Subset and port policies can override it; this does not establish the effective mTLS posture.' },
+    { key: 'loadBalancer', label: 'LB Policy', width: 'w-28', tooltip: "No algorithm set on this rule — Istio applies its mesh default (LEAST_REQUEST since Istio 1.14, overridable per mesh). Subset and port policies can differ." },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   serviceentries: [
@@ -2116,10 +2117,10 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   authorizationpolicies: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
-    { key: 'action', label: 'Action', width: 'w-24' },
-    { key: 'rules', label: 'Rules', width: 'w-20' },
-    { key: 'selector', label: 'Selector', width: 'w-48' },
+    { key: 'status', label: 'Status', width: 'w-24', defaultVisible: false },
+    { key: 'action', label: 'Action', width: 'w-24', tooltip: 'ALLOW contributes permitted matches; DENY blocks matches; AUDIT marks matches for a configured audit plugin; CUSTOM adds an external check. Other policies also affect the decision.' },
+    { key: 'rules', label: 'Rules', width: 'w-20', tooltip: 'Rules are alternatives — zero rules match nothing, an empty rule matches everything. An ALLOW policy with zero rules permits nothing on its own.' },
+    { key: 'selector', label: 'Applies to', width: 'w-48', tooltip: 'Declared workload labels or resource attachments. With neither, scope is inherited — the namespace, or the whole mesh when the policy sits in the mesh root namespace.' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   // Knative Serving

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2093,8 +2093,8 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'status', label: 'Status', width: 'w-24', defaultVisible: false },
     { key: 'host', label: 'Host', width: 'w-48', tooltip: "The service this rule's traffic policy applies to" },
     { key: 'subsets', label: 'Subsets', width: 'w-20', tooltip: 'Named backend groups that routes can select, often for canary releases. Defining subsets does not send traffic to them.' },
-    { key: 'tls', label: 'Client TLS', width: 'w-28', tooltip: 'Declared client-side TLS mode for this host at the rule level. Subset and port policies can override it; this does not establish the effective mTLS posture.' },
-    { key: 'loadBalancer', label: 'LB Policy', width: 'w-28', tooltip: "No algorithm set on this rule — Istio applies its mesh default (LEAST_REQUEST since Istio 1.14, overridable per mesh). Subset and port policies can differ." },
+    { key: 'tlsMode', label: 'Client TLS', width: 'w-28', tooltip: 'Declared client-side TLS mode for this host at the rule level. Subset and port policies can override it; this does not establish the effective mTLS posture.' },
+    { key: 'loadBalancer', label: 'LB Policy', width: 'w-28', tooltip: "Load balancing algorithm declared by this rule. '-' means none is set, so Istio applies its mesh default (LEAST_REQUEST since 1.14, overridable per mesh). Subset and port policies can differ." },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   serviceentries: [

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -61,7 +61,9 @@ describe('getAuthorizationPolicySelectorString', () => {
     expect(getAuthorizationPolicySelectorString(p)).toBe('Gateway/waypoint')
   })
 
-  it('qualifies a target in another namespace', () => {
+  it('qualifies a target naming another namespace', () => {
+    // Rendering only — supported attachments are same-namespace, so this
+    // records what the cell shows, not that the attachment would be enforced.
     const p = {
       metadata: { namespace: 'prod' },
       spec: { targetRef: { kind: 'Gateway', name: 'shared', namespace: 'infra' } },

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -4,6 +4,7 @@ import {
   getAuthorizationPolicySelectorString,
   getAuthorizationPolicyStatus,
   getDestinationRuleStatus,
+  getAuthorizationPolicyRuleNotice,
   getDestinationRuleTlsMode,
 } from './resource-utils-istio'
 
@@ -136,5 +137,42 @@ describe('AuthorizationPolicy action badge', () => {
     expect(tones).toEqual(new Set(['neutral']))
     expect(Object.keys(AUTHORIZATION_POLICY_ACTION_SEVERITY).sort())
       .toEqual(['ALLOW', 'AUDIT', 'CUSTOM', 'DENY'])
+  })
+})
+
+describe('getAuthorizationPolicyRuleNotice', () => {
+  it('does not claim an empty DENY blocks anything', () => {
+    // "If not set, the match will never occur" — a DENY with no rules matches
+    // nothing and denies nothing. Calling it Deny All is the dangerous
+    // direction: it tells an operator an ineffective policy protects them.
+    for (const spec of [{ action: 'DENY' }, { action: 'DENY', rules: [] }]) {
+      const notice = getAuthorizationPolicyRuleNotice({ spec })
+      expect(notice).toMatchObject({ level: 'info', title: 'No deny rules' })
+      expect(notice!.message).not.toMatch(/denies all/i)
+    }
+  })
+
+  it('says nothing about a DENY that does match', () => {
+    // rules: [{}] is an unconditional match — a real deny-all, and not this
+    // helper's business to editorialise about.
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'DENY', rules: [{}] } })).toBeNull()
+  })
+
+  it('warns on a rule-less ALLOW without asserting an outage', () => {
+    for (const spec of [{}, { action: 'ALLOW', rules: [] }]) {
+      const notice = getAuthorizationPolicyRuleNotice({ spec })
+      expect(notice).toMatchObject({ level: 'warning', title: 'No allow rules' })
+      expect(notice!.message).toMatch(/may still permit/i)
+      expect(notice!.message).not.toMatch(/no traffic is allowed/i)
+    }
+  })
+
+  it('stays quiet when the policy has rules', () => {
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'ALLOW', rules: [{}] } })).toBeNull()
+  })
+
+  it('does not editorialise about AUDIT or CUSTOM', () => {
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'AUDIT' } })).toBeNull()
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'CUSTOM' } })).toBeNull()
   })
 })

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -111,7 +111,9 @@ describe('getDestinationRuleStatus', () => {
 })
 
 describe('getDestinationRuleTlsMode', () => {
-  it('surfaces the mode that can defeat a STRICT PeerAuthentication', () => {
+  it('surfaces a declared DISABLE, whose outcome depends on the server policy', () => {
+    // Against a PERMISSIVE PeerAuthentication this sends unencrypted traffic;
+    // against a STRICT one the requests fail. The row shows neither.
     expect(getDestinationRuleTlsMode({ spec: { host: 'api', trafficPolicy: { tls: { mode: 'DISABLE' } } } }))
       .toBe('DISABLE')
   })

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -152,10 +152,22 @@ describe('getAuthorizationPolicyRuleNotice', () => {
     }
   })
 
-  it('says nothing about a DENY that does match', () => {
-    // rules: [{}] is an unconditional match — a real deny-all, and not this
-    // helper's business to editorialise about.
-    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'DENY', rules: [{}] } })).toBeNull()
+  it('explains an unconditional DENY, which no ALLOW can carve an exception from', () => {
+    // rules: [{}] matches every request. DENY is evaluated before ALLOW, so
+    // this is not a baseline with exceptions — it blocks everything it selects.
+    const notice = getAuthorizationPolicyRuleNotice({ spec: { action: 'DENY', rules: [{}] } })
+    expect(notice).toMatchObject({ level: 'info', title: 'Matches all requests' })
+  })
+
+  it('stays quiet on a DENY whose rules have conditions', () => {
+    expect(getAuthorizationPolicyRuleNotice({
+      spec: { action: 'DENY', rules: [{ from: [{ source: { namespaces: ['dev'] } }] }] },
+    })).toBeNull()
+  })
+
+  it('does not flag an unconditional ALLOW the same way', () => {
+    // An ALLOW matching everything is permissive, not a blanket block.
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'ALLOW', rules: [{}] } })).toBeNull()
   })
 
   it('warns on a rule-less ALLOW without asserting an outage', () => {

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { AUTHORIZATION_POLICY_ACTION_SEVERITY } from './renderers/istio-cells'
+import {
+  getAuthorizationPolicySelectorString,
+  getAuthorizationPolicyStatus,
+  getDestinationRuleStatus,
+  getDestinationRuleTlsMode,
+} from './resource-utils-istio'
+
+// A request decision is made across every policy selecting a workload, so no
+// single object can establish it. These pin the line between what one policy
+// declares and what the mesh actually does.
+
+describe('getAuthorizationPolicyStatus', () => {
+  it('marks the deny-all idiom rather than presenting it as permitted', () => {
+    // `spec: {}` is Istio's documented deny-all: action defaults to ALLOW, and
+    // rules are alternatives, so zero of them match nothing.
+    expect(getAuthorizationPolicyStatus({ spec: {} })).toMatchObject({
+      text: 'No allow rules', level: 'degraded',
+    })
+  })
+
+  it('treats an explicit rule-less ALLOW the same as the defaulted one', () => {
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'ALLOW', rules: [] } })).toMatchObject({
+      text: 'No allow rules', level: 'degraded',
+    })
+  })
+
+  it('does not call a DENY doing its job unhealthy', () => {
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'DENY', rules: [{}] } })).toMatchObject({
+      text: 'Deny (1 rule)', level: 'neutral',
+    })
+  })
+
+  it('does not present an ALLOW with rules as proof anything is permitted', () => {
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'ALLOW', rules: [{}, {}] } })).toMatchObject({
+      text: 'Allow (2 rules)', level: 'neutral',
+    })
+  })
+
+  it('keeps AUDIT and CUSTOM neutral — neither blocks nor permits on its own', () => {
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'AUDIT', rules: [{}] } }).level).toBe('neutral')
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'CUSTOM', rules: [{}] } }).level).toBe('neutral')
+  })
+
+  it('does not claim to recognise an unknown action', () => {
+    expect(getAuthorizationPolicyStatus({ spec: { action: 'FUTURE' } })).toMatchObject({
+      text: 'FUTURE', level: 'unknown',
+    })
+  })
+})
+
+describe('getAuthorizationPolicySelectorString', () => {
+  it('reports a targetRef attachment instead of claiming namespace scope', () => {
+    // Waypoint and Gateway attachment in ambient mode uses targetRefs, not
+    // labels; reading only the selector called these namespace-wide.
+    const p = {
+      metadata: { namespace: 'prod' },
+      spec: { targetRefs: [{ kind: 'Gateway', name: 'waypoint' }] },
+    }
+    expect(getAuthorizationPolicySelectorString(p)).toBe('Gateway/waypoint')
+  })
+
+  it('qualifies a target in another namespace', () => {
+    const p = {
+      metadata: { namespace: 'prod' },
+      spec: { targetRef: { kind: 'Gateway', name: 'shared', namespace: 'infra' } },
+    }
+    expect(getAuthorizationPolicySelectorString(p)).toBe('infra/Gateway/shared')
+  })
+
+  it('lists every target', () => {
+    const p = {
+      metadata: { namespace: 'prod' },
+      spec: { targetRefs: [{ kind: 'Gateway', name: 'a' }, { kind: 'Service', name: 'b' }] },
+    }
+    expect(getAuthorizationPolicySelectorString(p)).toBe('Gateway/a, Service/b')
+  })
+
+  it('falls back to selector labels', () => {
+    const p = { metadata: { namespace: 'prod' }, spec: { selector: { matchLabels: { app: 'api' } } } }
+    expect(getAuthorizationPolicySelectorString(p)).toBe('app=api')
+  })
+
+  it('names both possible scopes when neither is declared', () => {
+    // Which one applies depends on MeshConfig.rootNamespace, which this object
+    // cannot see — and the root namespace is configurable, so the conventional
+    // name is not evidence.
+    expect(getAuthorizationPolicySelectorString({ metadata: { namespace: 'istio-system' }, spec: {} }))
+      .toBe('Namespace / mesh scope')
+  })
+})
+
+describe('getDestinationRuleStatus', () => {
+  it('flags a rule that applies to nothing', () => {
+    expect(getDestinationRuleStatus({ spec: {} })).toMatchObject({ text: 'No Host', level: 'unhealthy' })
+  })
+
+  it('does not restate the subset count as a health verdict', () => {
+    expect(getDestinationRuleStatus({ spec: { host: 'api', subsets: [{ name: 'v1' }, { name: 'v2' }] } }))
+      .toMatchObject({ text: 'Not assessed', level: 'unknown' })
+  })
+
+  it('does not read a declared traffic policy as working', () => {
+    expect(getDestinationRuleStatus({ spec: { host: 'api', trafficPolicy: { tls: { mode: 'ISTIO_MUTUAL' } } } }))
+      .toMatchObject({ text: 'Not assessed', level: 'unknown' })
+  })
+})
+
+describe('getDestinationRuleTlsMode', () => {
+  it('surfaces the mode that can defeat a STRICT PeerAuthentication', () => {
+    expect(getDestinationRuleTlsMode({ spec: { host: 'api', trafficPolicy: { tls: { mode: 'DISABLE' } } } }))
+      .toBe('DISABLE')
+  })
+
+  it('shows the declared mode when one is set', () => {
+    expect(getDestinationRuleTlsMode({ spec: { trafficPolicy: { tls: { mode: 'ISTIO_MUTUAL' } } } }))
+      .toBe('ISTIO_MUTUAL')
+  })
+
+  it('reports nothing declared rather than inventing a default', () => {
+    expect(getDestinationRuleTlsMode({ spec: { host: 'api' } })).toBe('-')
+    expect(getDestinationRuleTlsMode({ spec: { host: 'api', trafficPolicy: {} } })).toBe('-')
+  })
+})
+
+describe('AuthorizationPolicy action badge', () => {
+  it('gives every action the same tone', () => {
+    // The action is a declaration, not a verdict. Colouring ALLOW green made a
+    // deny-all policy the greenest row on the page; colouring DENY red made a
+    // control doing its job look like a failure. This is also the badge that
+    // stays visible when the Status column is off by default.
+    const tones = new Set(Object.values(AUTHORIZATION_POLICY_ACTION_SEVERITY))
+    expect(tones).toEqual(new Set(['neutral']))
+    expect(Object.keys(AUTHORIZATION_POLICY_ACTION_SEVERITY).sort())
+      .toEqual(['ALLOW', 'AUDIT', 'CUSTOM', 'DENY'])
+  })
+})

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -161,6 +161,21 @@ describe('getAuthorizationPolicyRuleNotice', () => {
     expect(notice).toMatchObject({ level: 'info', title: 'Matches all requests' })
   })
 
+  it('recognises a blanket DENY written with empty condition lists', () => {
+    // from: [] / to: [] / when: [] serialize as present but impose nothing, so
+    // the rule still matches every request the policy selects.
+    for (const rule of [{ from: [] }, { to: [] }, { when: [] }, { from: [], to: [], when: [] }]) {
+      expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'DENY', rules: [rule] } }))
+        .toMatchObject({ title: 'Matches all requests' })
+    }
+  })
+
+  it('does not read an unrecognised rule field as unconditional', () => {
+    // A future condition type must not be mistaken for the absence of one.
+    expect(getAuthorizationPolicyRuleNotice({ spec: { action: 'DENY', rules: [{ someFutureMatcher: [{}] }] } }))
+      .toBeNull()
+  })
+
   it('stays quiet on a DENY whose rules have conditions', () => {
     expect(getAuthorizationPolicyRuleNotice({
       spec: { action: 'DENY', rules: [{ from: [{ source: { namespaces: ['dev'] } }] }] },

--- a/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
+++ b/packages/k8s-ui/src/components/resources/istio-policy-accessors.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import { AUTHORIZATION_POLICY_ACTION_SEVERITY } from './renderers/istio-cells'
 import {
   getAuthorizationPolicySelectorString,
   getAuthorizationPolicyStatus,
@@ -126,19 +125,6 @@ describe('getDestinationRuleTlsMode', () => {
   it('reports nothing declared rather than inventing a default', () => {
     expect(getDestinationRuleTlsMode({ spec: { host: 'api' } })).toBe('-')
     expect(getDestinationRuleTlsMode({ spec: { host: 'api', trafficPolicy: {} } })).toBe('-')
-  })
-})
-
-describe('AuthorizationPolicy action badge', () => {
-  it('gives every action the same tone', () => {
-    // The action is a declaration, not a verdict. Colouring ALLOW green made a
-    // deny-all policy the greenest row on the page; colouring DENY red made a
-    // control doing its job look like a failure. This is also the badge that
-    // stays visible when the Status column is off by default.
-    const tones = new Set(Object.values(AUTHORIZATION_POLICY_ACTION_SEVERITY))
-    expect(tones).toEqual(new Set(['neutral']))
-    expect(Object.keys(AUTHORIZATION_POLICY_ACTION_SEVERITY).sort())
-      .toEqual(['ALLOW', 'AUDIT', 'CUSTOM', 'DENY'])
   })
 })
 

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -9,9 +9,9 @@ import {
 } from '../resource-utils-istio'
 
 const actionSeverity: Record<string, BadgeSeverity> = {
-  // Deliberately uniform: an action is a declaration, not a verdict. Colouring
-  // ALLOW green and DENY red made a deny-all policy the greenest row on the
-  // page, and a DENY doing its job look like a failure.
+  // Deliberately uniform: an action is a declaration, not a verdict. A green
+  // ALLOW would make a deny-all policy the healthiest row on the page, and a
+  // red DENY would make a control doing its job look like a failure.
   ALLOW: 'neutral',
   DENY: 'neutral',
   CUSTOM: 'neutral',

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -44,8 +44,8 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
       {isAllowNothing && (
         <AlertBanner
           variant="warning"
-          title="Allow Nothing"
-          message="This policy has ALLOW action but no rules, which means no traffic is allowed."
+          title="No allow rules"
+          message="Rules are alternatives, so an ALLOW policy with none of them matches nothing and contributes no permitted traffic. Other ALLOW policies selecting the same workload may still permit requests — a default-deny-plus-exceptions setup looks exactly like this."
         />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -1,22 +1,12 @@
 import { Shield } from 'lucide-react'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList } from '../../ui/drawer-components'
-import { Badge, type BadgeSeverity } from '../../ui/Badge'
+import { Badge } from '../../ui/Badge'
 import {
   getAuthorizationPolicyAction,
   getAuthorizationPolicyRules,
   getAuthorizationPolicyRuleNotice,
   getAuthorizationPolicySelector,
 } from '../resource-utils-istio'
-
-const actionSeverity: Record<string, BadgeSeverity> = {
-  // Deliberately uniform: an action is a declaration, not a verdict. A green
-  // ALLOW would make a deny-all policy the healthiest row on the page, and a
-  // red DENY would make a control doing its job look like a failure.
-  ALLOW: 'neutral',
-  DENY: 'neutral',
-  CUSTOM: 'neutral',
-  AUDIT: 'neutral',
-}
 
 interface IstioAuthorizationPolicyRendererProps {
   data: any
@@ -29,6 +19,9 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
   const hasSelector = Object.keys(selector).length > 0
 
   const ruleNotice = getAuthorizationPolicyRuleNotice(data)
+  // The action badge is uniformly neutral: an action is a declaration, not a
+  // verdict. A green ALLOW would make a deny-all policy look healthiest, and a
+  // red DENY would make a control doing its job look failed.
 
   return (
     <>
@@ -44,7 +37,7 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
       <Section title="Authorization Policy" icon={Shield} defaultExpanded>
         <PropertyList>
           <Property label="Action" value={
-            <Badge severity={actionSeverity[action] ?? 'neutral'}>
+            <Badge severity="neutral">
               {action}
             </Badge>
           } />

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -8,10 +8,13 @@ import {
 } from '../resource-utils-istio'
 
 const actionSeverity: Record<string, BadgeSeverity> = {
-  ALLOW: 'success',
-  DENY: 'error',
-  CUSTOM: 'info',
-  AUDIT: 'warning',
+  // Deliberately uniform: an action is a declaration, not a verdict. Colouring
+  // ALLOW green and DENY red made a deny-all policy the greenest row on the
+  // page, and a DENY doing its job look like a failure.
+  ALLOW: 'neutral',
+  DENY: 'neutral',
+  CUSTOM: 'neutral',
+  AUDIT: 'neutral',
 }
 
 interface IstioAuthorizationPolicyRendererProps {
@@ -27,7 +30,7 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
   // Special case: DENY with no rules = deny all
   const isDenyAll = action === 'DENY' && rules.length === 0
   // Special case: ALLOW with no rules = allow nothing (deny all)
-  const isAllowNothing = action === 'ALLOW' && rules.length === 0 && !data.spec?.rules
+  const isAllowNothing = action === 'ALLOW' && rules.length === 0
 
   return (
     <>

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -4,6 +4,7 @@ import { Badge, type BadgeSeverity } from '../../ui/Badge'
 import {
   getAuthorizationPolicyAction,
   getAuthorizationPolicyRules,
+  getAuthorizationPolicyRuleNotice,
   getAuthorizationPolicySelector,
 } from '../resource-utils-istio'
 
@@ -27,25 +28,15 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
   const selector = getAuthorizationPolicySelector(data)
   const hasSelector = Object.keys(selector).length > 0
 
-  // Special case: DENY with no rules = deny all
-  const isDenyAll = action === 'DENY' && rules.length === 0
-  // Special case: ALLOW with no rules = allow nothing (deny all)
-  const isAllowNothing = action === 'ALLOW' && rules.length === 0
+  const ruleNotice = getAuthorizationPolicyRuleNotice(data)
 
   return (
     <>
-      {isDenyAll && (
+      {ruleNotice && (
         <AlertBanner
-          variant="error"
-          title="Deny All"
-          message="This policy denies all traffic to the target workload (DENY action with no rules)."
-        />
-      )}
-      {isAllowNothing && (
-        <AlertBanner
-          variant="warning"
-          title="No allow rules"
-          message="Rules are alternatives, so an ALLOW policy with none of them matches nothing and contributes no permitted traffic. Other ALLOW policies selecting the same workload may still permit requests — a default-deny-plus-exceptions setup looks exactly like this."
+          variant={ruleNotice.level}
+          title={ruleNotice.title}
+          message={ruleNotice.message}
         />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -96,7 +96,8 @@ export function DestinationRuleCell({ resource, column }: { resource: any; colum
     }
     case 'tls': {
       // Every mode reads neutral: this is the rule's declaration, not the
-      // posture in force, which subset and port policies can still change.
+      // posture in force. What a DISABLE produces depends on the server's
+      // PeerAuthentication — unencrypted traffic, or failed requests.
       const mode = getDestinationRuleTlsMode(resource)
       return <span className="text-sm text-theme-text-secondary">{mode}</span>
     }

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -36,9 +36,9 @@ const modeSeverity: Record<string, BadgeSeverity> = {
 }
 
 export const AUTHORIZATION_POLICY_ACTION_SEVERITY: Record<string, BadgeSeverity> = {
-  // Deliberately uniform: an action is a declaration, not a verdict. Colouring
-  // ALLOW green and DENY red made a deny-all policy the greenest row on the
-  // page, and a DENY doing its job look like a failure.
+  // Deliberately uniform: an action is a declaration, not a verdict. A green
+  // ALLOW would make a deny-all policy the healthiest row on the page, and a
+  // red DENY would make a control doing its job look like a failure.
   ALLOW: 'neutral',
   DENY: 'neutral',
   CUSTOM: 'neutral',
@@ -94,7 +94,7 @@ export function DestinationRuleCell({ resource, column }: { resource: any; colum
       const lb = getDestinationRuleLoadBalancer(resource)
       return <span className="text-sm text-theme-text-secondary">{lb}</span>
     }
-    case 'tls': {
+    case 'tlsMode': {
       // Every mode reads neutral: this is the rule's declaration, not the
       // posture in force. What a DISABLE produces depends on the server's
       // PeerAuthentication — unencrypted traffic, or failed requests.

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -210,9 +210,16 @@ export function AuthorizationPolicyCell({ resource, column }: { resource: any; c
       // Istio's deny-all idiom. This is the default-visible cell that carries
       // the warning; the Status column is off by default.
       const allowsNothing = count === 0 && (resource.spec?.action || 'ALLOW') === 'ALLOW'
-      // Amber on the count itself: it fits the column, reads at a glance against
-      // grey neighbours, and the column tooltip carries the explanation.
-      if (allowsNothing) return <Badge severity="warning">0</Badge>
+      // Amber on the count itself: it fits the column and reads at a glance
+      // against grey neighbours. The explanation rides on the badge so it does
+      // not depend on finding the column header's tooltip.
+      if (allowsNothing) {
+        return (
+          <Tooltip content="Rules are alternatives, so this ALLOW policy matches nothing and permits no traffic on its own. Other ALLOW policies selecting the same workload may still permit requests.">
+            <Badge severity="warning">0</Badge>
+          </Tooltip>
+        )
+      }
       return <span className="text-sm text-theme-text-secondary">{count}</span>
     }
     case 'selector': {

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -35,16 +35,6 @@ const modeSeverity: Record<string, BadgeSeverity> = {
   DISABLE: 'error',
 }
 
-export const AUTHORIZATION_POLICY_ACTION_SEVERITY: Record<string, BadgeSeverity> = {
-  // Deliberately uniform: an action is a declaration, not a verdict. A green
-  // ALLOW would make a deny-all policy the healthiest row on the page, and a
-  // red DENY would make a control doing its job look like a failure.
-  ALLOW: 'neutral',
-  DENY: 'neutral',
-  CUSTOM: 'neutral',
-  AUDIT: 'neutral',
-}
-
 export function VirtualServiceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status': {
@@ -199,8 +189,11 @@ export function AuthorizationPolicyCell({ resource, column }: { resource: any; c
     }
     case 'action': {
       const action = getAuthorizationPolicyAction(resource)
+      // Uniformly neutral: an action is a declaration, not a verdict. A green
+      // ALLOW would make a deny-all policy look healthiest, and a red DENY
+      // would make a control doing its job look failed.
       return (
-        <Badge severity={AUTHORIZATION_POLICY_ACTION_SEVERITY[action] ?? 'neutral'}>
+        <Badge severity="neutral">
           {action}
         </Badge>
       )

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx'
 import { Badge, type BadgeSeverity } from '../../ui/Badge'
+import { Tooltip } from '../../ui/Tooltip'
 import {
   getVirtualServiceStatus,
   getVirtualServiceHosts,
@@ -11,6 +12,7 @@ import {
   getDestinationRuleHost,
   getDestinationRuleSubsetCount,
   getDestinationRuleLoadBalancer,
+  getDestinationRuleTlsMode,
   getIstioGatewayStatus,
   getIstioGatewayServerCount,
   getIstioGatewaySelectorString,
@@ -24,6 +26,7 @@ import {
   getAuthorizationPolicyStatus,
   getAuthorizationPolicyAction,
   getAuthorizationPolicyRuleCount,
+  getAuthorizationPolicySelectorString,
 } from '../resource-utils-istio'
 
 const modeSeverity: Record<string, BadgeSeverity> = {
@@ -32,11 +35,14 @@ const modeSeverity: Record<string, BadgeSeverity> = {
   DISABLE: 'error',
 }
 
-const actionSeverity: Record<string, BadgeSeverity> = {
-  ALLOW: 'success',
-  DENY: 'error',
-  CUSTOM: 'info',
-  AUDIT: 'warning',
+export const AUTHORIZATION_POLICY_ACTION_SEVERITY: Record<string, BadgeSeverity> = {
+  // Deliberately uniform: an action is a declaration, not a verdict. Colouring
+  // ALLOW green and DENY red made a deny-all policy the greenest row on the
+  // page, and a DENY doing its job look like a failure.
+  ALLOW: 'neutral',
+  DENY: 'neutral',
+  CUSTOM: 'neutral',
+  AUDIT: 'neutral',
 }
 
 export function VirtualServiceCell({ resource, column }: { resource: any; column: string }) {
@@ -87,6 +93,12 @@ export function DestinationRuleCell({ resource, column }: { resource: any; colum
     case 'loadBalancer': {
       const lb = getDestinationRuleLoadBalancer(resource)
       return <span className="text-sm text-theme-text-secondary">{lb}</span>
+    }
+    case 'tls': {
+      // Every mode reads neutral: this is the rule's declaration, not the
+      // posture in force, which subset and port policies can still change.
+      const mode = getDestinationRuleTlsMode(resource)
+      return <span className="text-sm text-theme-text-secondary">{mode}</span>
     }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>
@@ -187,14 +199,29 @@ export function AuthorizationPolicyCell({ resource, column }: { resource: any; c
     case 'action': {
       const action = getAuthorizationPolicyAction(resource)
       return (
-        <Badge severity={actionSeverity[action] ?? 'neutral'}>
+        <Badge severity={AUTHORIZATION_POLICY_ACTION_SEVERITY[action] ?? 'neutral'}>
           {action}
         </Badge>
       )
     }
     case 'rules': {
       const count = getAuthorizationPolicyRuleCount(resource)
+      // Rules are alternatives, so an ALLOW with none of them matches nothing —
+      // Istio's deny-all idiom. This is the default-visible cell that carries
+      // the warning; the Status column is off by default.
+      const allowsNothing = count === 0 && (resource.spec?.action || 'ALLOW') === 'ALLOW'
+      // Amber on the count itself: it fits the column, reads at a glance against
+      // grey neighbours, and the column tooltip carries the explanation.
+      if (allowsNothing) return <Badge severity="warning">0</Badge>
       return <span className="text-sm text-theme-text-secondary">{count}</span>
+    }
+    case 'selector': {
+      const scope = getAuthorizationPolicySelectorString(resource)
+      return (
+        <Tooltip content={scope}>
+          <span className="text-sm text-theme-text-secondary truncate block">{scope}</span>
+        </Tooltip>
+      )
     }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -123,26 +123,19 @@ export function getVirtualServiceDestinations(resource: any): Array<{ host: stri
 // DESTINATIONRULE UTILITIES
 // ============================================================================
 
+/**
+ * The only failure this object can show on its own.
+ *
+ * A rule without a host applies to nothing. Everything else it declares —
+ * subsets, a traffic policy — describes configuration, and restating the count
+ * of subsets already shown two columns over said nothing about whether the
+ * host is reachable or the policy is in effect.
+ */
 export function getDestinationRuleStatus(resource: any): StatusBadge {
-  const spec = resource.spec || {}
-  const host = spec.host
-
-  if (!host) {
+  if (!resource.spec?.host) {
     return { text: 'No Host', color: healthColors.unhealthy, level: 'unhealthy' }
   }
-
-  const subsets = spec.subsets || []
-  const trafficPolicy = spec.trafficPolicy
-
-  if (subsets.length > 0) {
-    return { text: pluralize(subsets.length, 'Subset'), color: healthColors.healthy, level: 'healthy' }
-  }
-
-  if (trafficPolicy) {
-    return { text: 'Configured', color: healthColors.healthy, level: 'healthy' }
-  }
-
-  return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
+  return { text: 'Not assessed', color: healthColors.unknown, level: 'unknown' }
 }
 
 export function getDestinationRuleHost(resource: any): string {
@@ -159,6 +152,18 @@ export function getDestinationRuleSubsets(resource: any): Array<{ name: string; 
     labels: s.labels || {},
     trafficPolicy: s.trafficPolicy,
   }))
+}
+
+/**
+ * The client-side TLS mode this rule declares for its host.
+ *
+ * DISABLE here turns off client mTLS for the host even where a PeerAuthentication
+ * requires it on the server side, and both rows read as configured while it
+ * happens. This reports only what the rule declares at the top level: subset and
+ * port policies can override it, so it does not establish the effective posture.
+ */
+export function getDestinationRuleTlsMode(resource: any): string {
+  return getDestinationRuleTrafficPolicy(resource)?.tls?.mode || '-'
 }
 
 export function getDestinationRuleTrafficPolicy(resource: any): {
@@ -327,21 +332,33 @@ export function getPeerAuthenticationPortLevelMtls(resource: any): Record<string
 // AUTHORIZATIONPOLICY UTILITIES
 // ============================================================================
 
+/**
+ * What one AuthorizationPolicy declares — never a health verdict.
+ *
+ * An action is not a state of wellness: a DENY doing its job is not unhealthy,
+ * and an ALLOW is not proof anything is permitted. The request decision is made
+ * across every policy selecting the workload, so no single object can establish
+ * it, and toning one green or red asserts an answer it does not have.
+ *
+ * The one shape worth marking is an ALLOW — the default action — carrying no
+ * rules. Rules are alternatives, so zero of them match nothing, and Istio
+ * documents `spec: {}` as the deny-all idiom. Amber says look closer; it stops
+ * short of claiming the outage, because other policies may permit the traffic.
+ */
 export function getAuthorizationPolicyStatus(resource: any): StatusBadge {
   const action = resource.spec?.action || 'ALLOW'
   const rules = resource.spec?.rules || []
 
-  switch (action) {
-    case 'ALLOW':
-      return { text: `Allow (${pluralize(rules.length, 'rule')})`, color: healthColors.healthy, level: 'healthy' }
-    case 'DENY':
-      return { text: `Deny (${pluralize(rules.length, 'rule')})`, color: healthColors.unhealthy, level: 'unhealthy' }
-    case 'CUSTOM':
-      return { text: 'Custom', color: healthColors.degraded, level: 'degraded' }
-    case 'AUDIT':
-      return { text: 'Audit', color: healthColors.degraded, level: 'degraded' }
-    default:
-      return { text: action, color: healthColors.unknown, level: 'unknown' }
+  if (action === 'ALLOW' && rules.length === 0) {
+    return { text: 'No allow rules', color: healthColors.degraded, level: 'degraded' }
+  }
+  const known: Record<string, string> = { ALLOW: 'Allow', DENY: 'Deny', CUSTOM: 'Custom', AUDIT: 'Audit' }
+  const label = known[action]
+  if (!label) return { text: action, color: healthColors.unknown, level: 'unknown' }
+  return {
+    text: `${label} (${pluralize(rules.length, 'rule')})`,
+    color: healthColors.neutral,
+    level: 'neutral',
   }
 }
 
@@ -365,9 +382,34 @@ export function getAuthorizationPolicySelector(resource: any): Record<string, st
   return resource.spec?.selector?.matchLabels || {}
 }
 
+/**
+ * What the policy declares it applies to.
+ *
+ * A policy can attach by targetRef instead of by labels — waypoints and
+ * Gateways in ambient mode do — and reading only the selector reported those as
+ * scoped to the namespace, which is a different and much wider claim. With
+ * neither, scope is inherited: the namespace, or the whole mesh when the policy
+ * sits in the mesh root namespace. Which of those applies depends on
+ * MeshConfig.rootNamespace, which is not readable from this object, so the cell
+ * names both rather than guessing from the conventional namespace name.
+ */
 export function getAuthorizationPolicySelectorString(resource: any): string {
-  const labels = resource.spec?.selector?.matchLabels || {}
-  const entries = Object.entries(labels)
-  if (entries.length === 0) return 'Namespace-wide'
+  const spec = resource.spec || {}
+  const targets = [
+    ...(Array.isArray(spec.targetRefs) ? spec.targetRefs : []),
+    ...(spec.targetRef ? [spec.targetRef] : []),
+  ].filter(Boolean)
+  if (targets.length > 0) {
+    return targets
+      .map((t: any) => {
+        const name = [t?.kind, t?.name].filter(Boolean).join('/') || 'target'
+        return t?.namespace && t.namespace !== resource.metadata?.namespace
+          ? `${t.namespace}/${name}`
+          : name
+      })
+      .join(', ')
+  }
+  const entries = Object.entries(spec.selector?.matchLabels || {})
+  if (entries.length === 0) return 'Namespace / mesh scope'
   return entries.map(([k, v]) => `${k}=${v}`).join(', ')
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -429,7 +429,22 @@ export function getAuthorizationPolicyRuleNotice(
 ): { level: 'warning' | 'info'; title: string; message: string } | null {
   const action = resource?.spec?.action || 'ALLOW'
   const rules = resource?.spec?.rules
-  if (Array.isArray(rules) && rules.length > 0) return null
+  if (Array.isArray(rules) && rules.length > 0) {
+    // A rule with no conditions matches every request. On a DENY that is not a
+    // baseline other policies carve exceptions out of: DENY is evaluated first,
+    // so no ALLOW can re-permit what it matches.
+    const matchesEverything = rules.some(
+      (r: any) => r && typeof r === 'object' && Object.keys(r).length === 0,
+    )
+    if (action === 'DENY' && matchesEverything) {
+      return {
+        level: 'info',
+        title: 'Matches all requests',
+        message: 'A rule with no conditions matches every request, so this policy denies all traffic to the workloads it selects. DENY is evaluated before ALLOW, so no ALLOW policy can permit an exception.',
+      }
+    }
+    return null
+  }
   if (action === 'ALLOW') {
     return {
       level: 'warning',

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -413,3 +413,36 @@ export function getAuthorizationPolicySelectorString(resource: any): string {
   if (entries.length === 0) return 'Namespace / mesh scope'
   return entries.map(([k, v]) => `${k}=${v}`).join(', ')
 }
+
+/**
+ * What an AuthorizationPolicy's rule list means for the traffic it governs.
+ *
+ * Rules are alternatives and an unset list never matches, so BOTH actions with
+ * no rules are inert in the same way — a DENY with none denies nothing, an
+ * ALLOW with none permits nothing. Only the ALLOW case has a consequence worth
+ * raising, because a workload with any ALLOW policy admits only what one of
+ * them matches. Neither can be stated as an outcome for the workload: every
+ * policy selecting it takes part in the decision.
+ */
+export function getAuthorizationPolicyRuleNotice(
+  resource: any,
+): { level: 'warning' | 'info'; title: string; message: string } | null {
+  const action = resource?.spec?.action || 'ALLOW'
+  const rules = resource?.spec?.rules
+  if (Array.isArray(rules) && rules.length > 0) return null
+  if (action === 'ALLOW') {
+    return {
+      level: 'warning',
+      title: 'No allow rules',
+      message: 'Rules are alternatives, so an ALLOW policy with none of them matches nothing and contributes no permitted traffic. Other ALLOW policies selecting the same workload may still permit requests — a default-deny-plus-exceptions setup looks exactly like this.',
+    }
+  }
+  if (action === 'DENY') {
+    return {
+      level: 'info',
+      title: 'No deny rules',
+      message: 'This DENY policy has no rules, so it matches no requests and denies no traffic. Other policies may still deny requests.',
+    }
+  }
+  return null
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -127,9 +127,8 @@ export function getVirtualServiceDestinations(resource: any): Array<{ host: stri
  * The only failure this object can show on its own.
  *
  * A rule without a host applies to nothing. Everything else it declares —
- * subsets, a traffic policy — describes configuration, and restating the count
- * of subsets already shown two columns over said nothing about whether the
- * host is reachable or the policy is in effect.
+ * subsets, a traffic policy — is configuration, and says nothing about whether
+ * the host is reachable or the policy is in effect.
  */
 export function getDestinationRuleStatus(resource: any): StatusBadge {
   if (!resource.spec?.host) {
@@ -340,7 +339,7 @@ export function getPeerAuthenticationPortLevelMtls(resource: any): Record<string
  * An action is not a state of wellness: a DENY doing its job is not unhealthy,
  * and an ALLOW is not proof anything is permitted. The request decision is made
  * across every policy selecting the workload, so no single object can establish
- * it, and toning one green or red asserts an answer it does not have.
+ * it, and a green or red tone would assert an answer this object does not have.
  *
  * The one shape worth marking is an ALLOW — the default action — carrying no
  * rules. Rules are alternatives, so zero of them match nothing, and Istio
@@ -388,9 +387,8 @@ export function getAuthorizationPolicySelector(resource: any): Record<string, st
  * What the policy declares it applies to.
  *
  * A policy can attach by targetRef instead of by labels — waypoints and
- * Gateways in ambient mode do — and reading only the selector reported those as
- * scoped to the namespace, which is a different and much wider claim. With
- * neither, scope is inherited: the namespace, or the whole mesh when the policy
+ * Gateways in ambient mode do — so the selector alone does not describe scope.
+ * With neither, scope is inherited: the namespace, or the whole mesh when the policy
  * sits in the mesh root namespace. Which of those applies depends on
  * MeshConfig.rootNamespace, which is not readable from this object, so the cell
  * names both rather than guessing from the conventional namespace name.
@@ -432,12 +430,18 @@ export function getAuthorizationPolicyRuleNotice(
   const action = resource?.spec?.action || 'ALLOW'
   const rules = resource?.spec?.rules
   if (Array.isArray(rules) && rules.length > 0) {
-    // A rule with no conditions matches every request. On a DENY that is not a
-    // baseline other policies carve exceptions out of: DENY is evaluated first,
-    // so no ALLOW can re-permit what it matches.
-    const matchesEverything = rules.some(
-      (r: any) => r && typeof r === 'object' && Object.keys(r).length === 0,
-    )
+    // A rule matches every request when it carries no conditions — which
+    // includes serialized empty lists, not just an empty object. On a DENY that
+    // is not a baseline other policies carve exceptions out of: DENY is
+    // evaluated first, so no ALLOW can re-permit what it matches. Unknown keys
+    // are treated as conditions, so a future field cannot be read as blanket.
+    const CONDITION_KEYS = ['from', 'to', 'when']
+    const matchesEverything = rules.some((r: any) => {
+      if (!r || typeof r !== 'object') return false
+      const keys = Object.keys(r)
+      if (keys.some(k => !CONDITION_KEYS.includes(k))) return false
+      return CONDITION_KEYS.every(k => !Array.isArray(r[k]) || r[k].length === 0)
+    })
     if (action === 'DENY' && matchesEverything) {
       return {
         level: 'info',

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -157,10 +157,12 @@ export function getDestinationRuleSubsets(resource: any): Array<{ name: string; 
 /**
  * The client-side TLS mode this rule declares for its host.
  *
- * DISABLE here turns off client mTLS for the host even where a PeerAuthentication
- * requires it on the server side, and both rows read as configured while it
- * happens. This reports only what the rule declares at the top level: subset and
- * port policies can override it, so it does not establish the effective posture.
+ * What it means depends on a different object. A DISABLE here sends plaintext:
+ * against a PERMISSIVE PeerAuthentication that succeeds and the traffic is
+ * simply unencrypted; against a STRICT one the server rejects it and the
+ * requests fail. Neither outcome is visible from this row, and subset and port
+ * policies can override the mode besides — so this reports the declaration and
+ * not the effective posture.
  */
 export function getDestinationRuleTlsMode(resource: any): string {
   return getDestinationRuleTrafficPolicy(resource)?.tls?.mode || '-'

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -156,12 +156,14 @@ export function getDestinationRuleSubsets(resource: any): Array<{ name: string; 
 /**
  * The client-side TLS mode this rule declares for its host.
  *
- * What it means depends on a different object. A DISABLE here sends plaintext:
- * against a PERMISSIVE PeerAuthentication that succeeds and the traffic is
- * simply unencrypted; against a STRICT one the server rejects it and the
- * requests fail. Neither outcome is visible from this row, and subset and port
- * policies can override the mode besides — so this reports the declaration and
- * not the effective posture.
+ * What it means depends on a different object. DISABLE is defined as "do not
+ * setup a TLS connection to the upstream endpoint", so the client sends
+ * plaintext; a PeerAuthentication STRICT is "an mTLS tunnel (TLS with client
+ * cert must be presented)" and PERMISSIVE is "either plaintext or mTLS tunnel".
+ * The pairing therefore lands as unencrypted traffic or as rejected requests —
+ * deduced from those two definitions, since neither API documents the mismatch
+ * directly. Nothing in this row shows which, and subset and port policies can
+ * override the mode besides, so it reports the declaration and not the posture.
  */
 export function getDestinationRuleTlsMode(resource: any): string {
   return getDestinationRuleTrafficPolicy(resource)?.tls?.mode || '-'

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -30,7 +30,7 @@ import { getExternalSecretStatus as _getExternalSecretStatus, getClusterExternal
 import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
 import { getCNPGClusterStatus as _getCNPGClusterStatus, getCNPGBackupStatus as _getCNPGBackupStatus, getCNPGScheduledBackupStatus as _getCNPGScheduledBackupStatus, getCNPGPoolerStatus as _getCNPGPoolerStatus, isApiGroup as _isApiGroup, CNPG_GROUP as _CNPG_GROUP } from './resource-utils-cnpg'
 import { getGenericResourceStatus } from './generic-status'
-import { getIstioGatewayStatus as _getIstioGatewayStatus, getIstioGatewayServerCount as _getIstioGatewayServerCount, getIstioGatewaySelectorString as _getIstioGatewaySelectorString } from './resource-utils-istio'
+import { getIstioGatewayStatus as _getIstioGatewayStatus, getIstioGatewayServerCount as _getIstioGatewayServerCount, getIstioGatewaySelectorString as _getIstioGatewaySelectorString, getAuthorizationPolicySelectorString as _getAuthorizationPolicySelectorString, getDestinationRuleTlsMode as _getDestinationRuleTlsMode } from './resource-utils-istio'
 import { getCalicoIPPoolAllowedUses, getCalicoIPPoolBlockSize, getCalicoIPPoolEncapsulation, getCalicoPolicyNamespaceSelector, getCalicoPolicyServiceAccountSelector, getCalicoPolicyTypes, isCalicoApiVersion, isCalicoPolicyResource } from './resource-utils-calico'
 
 // ============================================================================
@@ -2320,6 +2320,13 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       return ''
     case 'selector':
       if (kindLower === 'istiogateways') return _getIstioGatewaySelectorString(resource)
+      if (kindLower === 'authorizationpolicies') return _getAuthorizationPolicySelectorString(resource)
+      return ''
+    case 'tlsMode':
+      // Distinct from Traefik's boolean 'tls' key, which SKIP_FILTER_COLUMNS
+      // excludes — sharing it would have made this reader unreachable. The
+      // generic fallback cannot reach spec.trafficPolicy.tls.mode.
+      if (kindLower === 'destinationrules') return _getDestinationRuleTlsMode(resource)
       return ''
     case 'state':
       if (kindLower === 'orders') return getOrderState(resource).text


### PR DESCRIPTION
## Summary

An Istio AuthorizationPolicy's action is a declaration, not a verdict. The request decision is made across **every** policy selecting a workload — Istio evaluates `CUSTOM`, then `DENY`, then `ALLOW` — so no single object can establish the outcome. Radar's rows did anyway, and got it backwards in the cases that matter most.

`spec: {}` is Istio's documented deny-all: the action defaults to `ALLOW`, rules are alternatives, and *"if not set, the match will never occur… equivalent to setting a default of deny."* Radar rendered it **green**. Meanwhile a `DENY` policy doing its job rendered **red**, and a `DENY` with no rules — which matches nothing and therefore denies nothing — carried a red **"Deny All"** banner telling an operator that an inert policy was protecting them.

Two neighbouring rows lied in the same way: the Applies-to column was blank for every policy in every cluster, and DestinationRule restated the subset count beside it as a green badge.

## AuthorizationPolicy

**Actions read neutral everywhere** — table, detail page, status accessor. An action is what the policy declares; a tone would assert a decision this object does not make.

**The one shape worth marking is an `ALLOW` with no rules**, since a workload with any `ALLOW` policy admits only what one of them matches. It carries an amber count in the default-visible Rules cell, with the explanation on the badge itself rather than behind the column header. The Status column defaults to hidden, so this is what an operator sees without opting in.

**Applies-to now renders.** `AuthorizationPolicyCell` had no `selector` case, so the column showed `-` for every policy. Its accessor also read only `spec.selector.matchLabels`, which is wrong twice: a policy attached through `targetRef`/`targetRefs` — as waypoints and ambient Gateways are — has no selector at all, and an empty selector in the mesh root namespace applies **mesh-wide**, not namespace-wide. Attachments render as `kind/name`; with nothing declared the cell names both possible scopes, because the root namespace is configurable and Radar cannot read `MeshConfig.rootNamespace` from this object.

**The drawer's rule banners describe what the policy contributes**, not an outcome for the workload:

- `DENY` with no rules → informational: it matches no requests and denies no traffic; other policies may still deny.
- `ALLOW` with no rules → warning: it permits nothing on its own; other `ALLOW` policies may still permit. A default-deny-plus-exceptions setup looks exactly like this.
- `DENY` whose rule carries no conditions → informational: it matches everything it selects, and since `DENY` is evaluated before `ALLOW`, nothing can carve an exception from it.

A rule counts as unconditional when `from`, `to` and `when` are all absent or empty — serialized empty lists impose nothing. An unrecognised field is treated as a condition, so a future matcher is never misread as the absence of one.

## DestinationRule

Status keeps the one failure the object can show — a rule with no host applies to nothing — and reports everything else as not assessed, rather than restating the subset count or calling a declared traffic policy `Configured`. It also defaults to hidden.

A **Client TLS** column shows the declared mode, because what it produces depends on an object this row cannot see. `DISABLE` is *"do not setup a TLS connection to the upstream endpoint"*; against a `PERMISSIVE` PeerAuthentication (*"either plaintext or mTLS tunnel"*) the traffic simply goes unencrypted, against a `STRICT` one (*"an mTLS tunnel… must be presented"*) the requests fail. All values are neutral, and subset and port policies can override the mode besides.

## Reviewer notes

The column key is `tlsMode`, not `tls`: Traefik's IngressRoute already owns `tls`, and that key sits in `SKIP_FILTER_COLUMNS`, which would have left this column's filter permanently empty.

Both the new and the repaired columns have `getCellFilterValue` branches — the generic fallback cannot reach `spec.trafficPolicy.tls.mode`, and the existing selector branch served only Istio Gateways — so the filter dropdown offers the values the table is showing.

## Scope

**PeerAuthentication is deliberately untouched.** Its findings need a *verified* `MeshConfig.rootNamespace` to distinguish a namespace default from a mesh default, and to tell whether a selector renders a root-namespace policy inert. That is data the frontend does not have, and inferring it from the conventional namespace name is the guess this PR removes elsewhere.

## Testing

`make tsc` clean. `packages/k8s-ui`: 3456 passed, 1 skipped — the one failing file (`resource-utils-hpa.test.ts`) fails identically on `main`, a fixture path resolved from the runner's cwd.

26 tests where these accessors had none: the deny-all idiom and its explicit-empty-array twin, `DENY` and `ALLOW` inertness, blanket `DENY` written as `{}` or as empty condition lists, an unrecognised rule field, `AUDIT`/`CUSTOM`, unknown actions, `targetRef` and `targetRefs` attachment, the both-scopes literal, subset-count and traffic-policy restatement, and every `tls.mode` case.

**Visually verified** at 1920 against a cluster with the Istio CRDs installed and fixtures covering each path — Radar renders from the API objects, so no control plane is needed.

*AuthorizationPolicy:* a `spec: {}` policy shows a neutral `ALLOW` beside an amber `0`, and a `DENY` with real rules shows a neutral `DENY`. The Applies-to column renders `Gateway/waypoint` for a `targetRefs` attachment and `Namespace / mesh scope` where nothing is declared, on a column that previously rendered `-` for every policy. The amber badge fits the `w-20` column without overflow and carries dark-mode variants.

*DestinationRule:* Client TLS renders `ISTIO_MUTUAL`, `DISABLE` and `-`; a rule with two subsets shows the count without a green badge restating it. Table minimum width is 969px, so the added column introduces no horizontal scroll at 1280.

Long values in Applies-to truncate at `w-48` and are recoverable on hover, consistent with the other text columns.

Semantics are quoted from the Istio authorization-policy reference, the security-concepts page, and the `destination_rule` / `peer_authentication` protos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how operators interpret Istio security policy tables and detail banners; semantics are safer but could surprise users accustomed to the old green/red cues.
> 
> **Overview**
> **AuthorizationPolicy** rows and detail views no longer use green/red action badges or status text that implied a workload was permitted or blocked. Actions render **neutral**; only **ALLOW with zero rules** (Istio’s deny-all idiom) gets a **degraded** status and an amber **0** rules badge with tooltip. The **Applies to** column actually renders scope via `getAuthorizationPolicySelectorString` (`targetRef`/`targetRefs`, labels, or “Namespace / mesh scope”), and drawer banners come from **`getAuthorizationPolicyRuleNotice`**—fixing the old **“Deny All”** on empty **DENY** and overstated **“Allow Nothing”** messaging.
> 
> **DestinationRule** status no longer treats subset count or traffic policy as healthy; only **missing host** is unhealthy, otherwise **Not assessed**. A new **Client TLS** column shows declared `trafficPolicy.tls.mode` neutrally, with column tooltips and **Status** hidden by default on both resource types.
> 
> Filter dropdowns now match table cells for auth policy **selector** and destination rule **`tlsMode`**. **`istio-policy-accessors.test.ts`** locks the new accessor semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a184b2431eb4f1092c2c2dddb0c89258b6a91e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
