### PR TITLE
Clarify private investigations and simplify sharing confirmation

### DIFF
--- a/packages/k8s-ui/src/components/ui/ConfirmDialog.test.tsx
+++ b/packages/k8s-ui/src/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { ConfirmDialog } from './ConfirmDialog'
+
+vi.mock('./DialogPortal', () => ({
+  DialogPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+const props = {
+  open: true,
+  onClose: () => {},
+  onConfirm: () => {},
+  title: 'Share this investigation?',
+  message: 'Organization members can read and continue this investigation.',
+  confirmLabel: 'Share with organization',
+}
+
+describe('ConfirmDialog warning disclosure', () => {
+  it('can omit redundant boilerplate without removing the actual disclosure or actions', () => {
+    const html = renderToStaticMarkup(<ConfirmDialog {...props} variant="warning" showWarning={false} />)
+    expect(html).toContain(props.message)
+    expect(html).toContain(props.confirmLabel)
+    expect(html).toContain('Cancel')
+    expect(html).not.toContain('Please confirm you want to proceed')
+  })
+
+  it('preserves warning boilerplate by default for existing callers', () => {
+    expect(renderToStaticMarkup(<ConfirmDialog {...props} variant="warning" />))
+      .toContain('Please confirm you want to proceed with this action.')
+  })
+
+  it('preserves the irreversible-action warning for destructive callers', () => {
+    expect(renderToStaticMarkup(<ConfirmDialog {...props} />))
+      .toContain('This action cannot be undone.')
+  })
+})

--- a/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
@@ -18,6 +18,7 @@ interface ConfirmDialogProps {
   isLoading?: boolean
   isClosable?: boolean // Allow closing even when isLoading (e.g., for long-running ops the user can dismiss)
   confirmDisabled?: boolean // Block the confirm action while custom content is invalid (e.g., bad YAML)
+  showWarning?: boolean
   className?: string
   children?: ReactNode // Optional custom content (e.g., checkboxes)
 }
@@ -35,6 +36,7 @@ export function ConfirmDialog({
   isLoading = false,
   isClosable = false,
   confirmDisabled = false,
+  showWarning = true,
   className,
   children,
 }: ConfirmDialogProps) {
@@ -84,7 +86,7 @@ export function ConfirmDialog({
       )}
 
       {/* Warning message — hidden once the action is in progress */}
-      {!isLoading && !children && (
+      {showWarning && !isLoading && !children && (
         <div className="p-4">
           <div
             className={clsx(

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -224,6 +224,13 @@ function VisibilityControl({
           Organization
         </Badge>
       </Tooltip>
+    ) : run.visibility === "private" ? (
+      <Tooltip content="Only you can view this investigation. Other organization members don’t have access." position="bottom">
+        <Badge severity="neutral" size="sm" className="shrink-0">
+          <Lock className="h-3 w-3" />
+          Private
+        </Badge>
+      </Tooltip>
     ) : null;
   }
   const shared = run.visibility === "organization";
@@ -277,6 +284,7 @@ function VisibilityControl({
         title="Share this investigation?"
         message="Everyone in your organization can read this entire investigation—including your questions and the logs and manifests Radar read—and can continue or stop it."
         confirmLabel="Share with organization"
+        showWarning={false}
         variant="warning"
         isLoading={busy}
       />


### PR DESCRIPTION
## Summary

Make investigation privacy visible even when sharing controls are unavailable, and keep the sharing confirmation focused on its actual audience and capabilities rather than a redundant generic warning.

## Changes

- Private hosted investigations without sharing controls retain a Private badge. Its tooltip says: “Only you can view this investigation. Other organization members don’t have access.” It does not guess why sharing is unavailable.
- The sharing confirmation retains the disclosure that organization members can read the entire investigation and continue or stop it, along with its confirm/cancel actions.
- Add an optional `showWarning` prop to the shared ConfirmDialog, defaulting to true. Only the investigation-sharing dialog opts out; existing warning and destructive-dialog defaults remain unchanged.

## OSS vs hosted

These investigation affordances apply to hosted runs with visibility metadata, including SaaS and self-hosted Hub. Standalone OSS gains no sharing controls or permissions. Existing callers of the shared dialog retain their current behavior.

## Testing

- Frontend typecheck and full `make build` (frontend, embed, Go binary).
- 24 targeted tests: DiagnoseSurface plus three dialog-rendering tests covering disclosure/action preservation, opt-out, and unchanged warning/destructive defaults.
- Visual-test: skipped for this small copy/affordance change; no new screenshots or live E2E claims.

## Release notes

Companion settings-copy PR: https://github.com/skyhook-dev/radar-hub-web/pull/283 (independent; no runtime dependency).

Before publishing `radar-app`, publish the `k8s-ui` version containing `showWarning`, then raise radar-app's `@skyhook-io/k8s-ui` peer minimum (and matching lock metadata) to that actual release. Merely updating Cloud's installed package is not sufficient: the package contract must exclude incompatible older peers. Adopt the matching packages in Cloud. The version is intentionally not guessed before the release is selected.

No backend API, authorization, retention, or investigation-execution changes. Package publication and deployment are not part of this PR.
