### PR TITLE
Stop status badges reporting health nothing verified

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1239,7 +1239,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   servicemonitors: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'status', label: 'Status', width: 'w-36' },
     { key: 'endpoints', label: 'Endpoints', width: 'w-20', tooltip: 'Number of scrape endpoints' },
     { key: 'jobLabel', label: 'Job Label', width: 'w-32' },
     { key: 'selector', label: 'Selector', width: 'w-48' },
@@ -1248,7 +1248,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   prometheusrules: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'status', label: 'Status', width: 'w-36' },
     { key: 'groups', label: 'Groups', width: 'w-20' },
     { key: 'rules', label: 'Rules', width: 'w-20', tooltip: 'Total alert + recording rules' },
     { key: 'age', label: 'Age', width: 'w-24' },
@@ -1256,7 +1256,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   podmonitors: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'status', label: 'Status', width: 'w-36' },
     { key: 'endpoints', label: 'Endpoints', width: 'w-20', tooltip: 'Number of pod metrics endpoints' },
     { key: 'selector', label: 'Selector', width: 'w-48' },
     { key: 'age', label: 'Age', width: 'w-24' },
@@ -2095,7 +2095,6 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   serviceentries: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'hosts', label: 'Hosts', width: 'w-48' },
     { key: 'location', label: 'Location', width: 'w-28' },
     { key: 'ports', label: 'Ports', width: 'w-32' },
@@ -2104,7 +2103,6 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   peerauthentications: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
-    { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'mode', label: 'mTLS Mode', width: 'w-28' },
     { key: 'selector', label: 'Selector', width: 'w-48' },
     { key: 'age', label: 'Age', width: 'w-24' },

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -16,11 +16,9 @@ import {
   getIstioGatewayStatus,
   getIstioGatewayServerCount,
   getIstioGatewaySelectorString,
-  getServiceEntryStatus,
   getServiceEntryHosts,
   getServiceEntryLocation,
   getServiceEntryPortsString,
-  getPeerAuthenticationStatus,
   getPeerAuthenticationMode,
   getPeerAuthenticationSelectorString,
   getAuthorizationPolicyStatus,
@@ -121,14 +119,6 @@ export function IstioGatewayCell({ resource, column }: { resource: any; column: 
 
 export function ServiceEntryCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
-    case 'status': {
-      const status = getServiceEntryStatus(resource)
-      return (
-        <span className={clsx('badge', status.color)}>
-          {status.text}
-        </span>
-      )
-    }
     case 'hosts': {
       const hosts = getServiceEntryHosts(resource)
       return <span className="text-sm text-theme-text-secondary truncate block">{hosts}</span>
@@ -152,14 +142,6 @@ export function ServiceEntryCell({ resource, column }: { resource: any; column: 
 
 export function PeerAuthenticationCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
-    case 'status': {
-      const status = getPeerAuthenticationStatus(resource)
-      return (
-        <span className={clsx('badge', status.color)}>
-          {status.text}
-        </span>
-      )
-    }
     case 'mode': {
       const mode = getPeerAuthenticationMode(resource)
       return (

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -73,7 +73,7 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
     case 'status': {
       const status = getKyvernoPolicyStatus(resource)
       return (
-        <span className={clsx('badge', status.color)}>
+        <span className={clsx('badge truncate max-w-full', status.color)} title={status.text}>
           {status.text}
         </span>
       )

--- a/packages/k8s-ui/src/components/resources/renderers/prometheus-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/prometheus-cells.tsx
@@ -19,7 +19,7 @@ export function ServiceMonitorCell({ resource, column }: { resource: any; column
     case 'status': {
       const status = getServiceMonitorStatus(resource)
       return (
-        <span className={clsx('badge', status.color)}>
+        <span className={clsx('badge truncate max-w-full', status.color)} title={status.text}>
           {status.text}
         </span>
       )
@@ -40,7 +40,7 @@ export function PrometheusRuleCell({ resource, column }: { resource: any; column
     case 'status': {
       const status = getPrometheusRuleStatus(resource)
       return (
-        <span className={clsx('badge', status.color)}>
+        <span className={clsx('badge truncate max-w-full', status.color)} title={status.text}>
           {status.text}
         </span>
       )
@@ -59,7 +59,7 @@ export function PodMonitorCell({ resource, column }: { resource: any; column: st
     case 'status': {
       const status = getPodMonitorStatus(resource)
       return (
-        <span className={clsx('badge', status.color)}>
+        <span className={clsx('badge truncate max-w-full', status.color)} title={status.text}>
           {status.text}
         </span>
       )

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -646,6 +646,11 @@ export function getCNPGObjectStoreStatus(resource: any): StatusBadge {
   if (windows.some((w) => w.failingSinceLastSuccess)) {
     return { text: 'Backups Failing', color: healthColors.unhealthy, level: 'unhealthy' }
   }
+  // Every timestamp on a recovery window is optional, so a server can be listed
+  // with no recovery point at all. The entry existing is not a backup existing.
+  if (!windows.some((w) => w.firstRecoverabilityPoint || w.lastSuccessfulBackupTime)) {
+    return { text: 'No recovery point', color: healthColors.unknown, level: 'unknown' }
+  }
   return { text: 'Recoverable', color: healthColors.healthy, level: 'healthy' }
 }
 

--- a/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-istio.ts
@@ -28,13 +28,17 @@ export function getVirtualServiceStatus(resource: any): StatusBadge {
   const tlsRoutes = spec.tls || []
   const hosts = spec.hosts || []
 
-  if (hosts.length === 0) {
-    return { text: 'No Hosts', color: healthColors.unhealthy, level: 'unhealthy' }
-  }
-
+  // Routes are what a VirtualService exists to provide, delegate or not.
   const totalRoutes = httpRoutes.length + tcpRoutes.length + tlsRoutes.length
   if (totalRoutes === 0) {
     return { text: 'No Routes', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  // A delegate VirtualService is required to declare no hosts, and this object
+  // cannot tell us whether a parent delegates to it, so an empty list is not
+  // evidence of a fault.
+  if (hosts.length === 0) {
+    return { text: 'No Hosts', color: healthColors.unknown, level: 'unknown' }
   }
 
   // Check for fault injection on any route
@@ -49,7 +53,7 @@ export function getVirtualServiceStatus(resource: any): StatusBadge {
     return { text: 'Mirroring', color: healthColors.degraded, level: 'degraded' }
   }
 
-  return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
+  return { text: 'Defined', color: healthColors.neutral, level: 'neutral' }
 }
 
 export function getVirtualServiceHosts(resource: any): string {
@@ -248,12 +252,14 @@ export function getServiceEntryStatus(resource: any): StatusBadge {
     return { text: 'No Hosts', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
+  // Location is a mesh-membership classification, not reachability: nothing here
+  // establishes the hosts resolve or answer.
   const location = spec.location || 'MESH_EXTERNAL'
   if (location === 'MESH_EXTERNAL') {
-    return { text: 'External', color: healthColors.healthy, level: 'healthy' }
+    return { text: 'External', color: healthColors.neutral, level: 'neutral' }
   }
 
-  return { text: 'Internal', color: healthColors.healthy, level: 'healthy' }
+  return { text: 'Internal', color: healthColors.neutral, level: 'neutral' }
 }
 
 export function getServiceEntryHosts(resource: any): string {

--- a/packages/k8s-ui/src/components/resources/resource-utils-kyverno.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kyverno.ts
@@ -107,12 +107,9 @@ export function getKyvernoPolicyStatus(resource: any): StatusBadge {
     return { text: readyCond.reason || 'Not Ready', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
-  // Fallback: if spec exists, likely active
-  if (resource.spec?.rules?.length > 0) {
-    return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
-  }
-
-  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  // Reached when the controller has not written Ready, or wrote it as Unknown.
+  // Declaring rules is not the controller accepting them.
+  return { text: 'Not assessed', color: healthColors.unknown, level: 'unknown' }
 }
 
 /**

--- a/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
@@ -7,31 +7,59 @@ import { healthColors } from './resource-utils'
 // SHARED HELPERS
 // ============================================================================
 
-function getConditionStatus(resource: any): StatusBadge {
-  const conditions = resource.status?.conditions || []
+// ServiceMonitor, PodMonitor and PrometheusRule are configuration resources.
+// They have no `status.conditions`: the operator reports per selecting workload
+// under `status.bindings[].conditions`, the only condition type is `Accepted`,
+// and it writes any of it only when the StatusForConfigurationResources feature
+// gate is on. Absence is therefore the ordinary case and is not evidence the
+// configuration works — and `Accepted` means the config was accepted, not that
+// any target is being scraped.
+function getConfigResourceStatus(resource: any): StatusBadge {
+  const generation = resource?.metadata?.generation
+  let reporting = 0
+  let accepted = 0
+  let rejected = 0
+  let rejection = ''
 
-  const reconciledCond = conditions.find((c: any) => c.type === 'Reconciled')
-  if (reconciledCond?.status === 'True') {
-    return { text: 'Reconciled', color: healthColors.healthy, level: 'healthy' }
-  }
-  if (reconciledCond?.status === 'False') {
-    return { text: reconciledCond.reason || 'Not Reconciled', color: healthColors.unhealthy, level: 'unhealthy' }
-  }
-
-  const availableCond = conditions.find((c: any) => c.type === 'Available')
-  if (availableCond?.status === 'True') {
-    return { text: 'Available', color: healthColors.healthy, level: 'healthy' }
-  }
-  if (availableCond?.status === 'False') {
-    return { text: availableCond.reason || 'Unavailable', color: healthColors.unhealthy, level: 'unhealthy' }
-  }
-
-  // Fallback: if resource exists but has no conditions, it's likely active
-  if (resource.spec) {
-    return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
+  for (const binding of resource?.status?.bindings || []) {
+    for (const cond of binding?.conditions || []) {
+      if (cond?.type !== 'Accepted') continue
+      // A condition observed against an older spec does not describe the object
+      // as it stands now.
+      if (generation !== undefined && cond.observedGeneration !== undefined
+        && cond.observedGeneration !== generation) continue
+      reporting++
+      if (cond.status === 'True') accepted++
+      else if (cond.status === 'False') {
+        rejected++
+        if (!rejection) rejection = cond.reason || ''
+      }
+    }
   }
 
-  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  if (reporting === 0) {
+    return { text: 'Not assessed', color: healthColors.unknown, level: 'unknown' }
+  }
+  if (rejected === reporting) {
+    return { text: rejection || 'Not Accepted', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (rejected > 0) {
+    return {
+      text: `Accepted by ${accepted}/${reporting}`,
+      color: healthColors.degraded,
+      level: 'degraded',
+    }
+  }
+  // No rejection, but a workload reported Accepted=Unknown: it has not decided,
+  // so the resource is not accepted everywhere that selects it.
+  if (accepted < reporting) {
+    return {
+      text: `Accepted by ${accepted}/${reporting}`,
+      color: healthColors.unknown,
+      level: 'unknown',
+    }
+  }
+  return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
 }
 
 function formatMatchLabels(selector: any): string {
@@ -45,7 +73,7 @@ function formatMatchLabels(selector: any): string {
 // ============================================================================
 
 export function getServiceMonitorStatus(resource: any): StatusBadge {
-  return getConditionStatus(resource)
+  return getConfigResourceStatus(resource)
 }
 
 export function getServiceMonitorEndpointCount(resource: any): number {
@@ -87,7 +115,7 @@ export function getServiceMonitorNamespaceSelector(resource: any): string {
 // ============================================================================
 
 export function getPrometheusRuleStatus(resource: any): StatusBadge {
-  return getConditionStatus(resource)
+  return getConfigResourceStatus(resource)
 }
 
 export function getPrometheusRuleGroupCount(resource: any): number {
@@ -169,7 +197,7 @@ export function getPrometheusRuleGroups(resource: any): PrometheusRuleGroup[] {
 // ============================================================================
 
 export function getPodMonitorStatus(resource: any): StatusBadge {
-  return getConditionStatus(resource)
+  return getConfigResourceStatus(resource)
 }
 
 export function getPodMonitorEndpointCount(resource: any): number {

--- a/packages/k8s-ui/src/components/resources/status-overclaim.test.ts
+++ b/packages/k8s-ui/src/components/resources/status-overclaim.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import { getServiceMonitorStatus, getPrometheusRuleStatus, getPodMonitorStatus } from './resource-utils-prometheus'
+import { getKyvernoPolicyStatus } from './resource-utils-kyverno'
+import { getServiceEntryStatus, getVirtualServiceStatus } from './resource-utils-istio'
+import { getCNPGObjectStoreStatus } from './resource-utils-cnpg'
+
+// A green badge asserts something a controller checked. These pin the line
+// between what an object declares and what something actually confirmed.
+
+describe('Prometheus configuration resources', () => {
+  // Status lives at status.bindings[].conditions, only condition type
+  // "Accepted" exists, and the operator writes it only under the
+  // StatusForConfigurationResources feature gate.
+  const accepted = (status: string, extra: Record<string, unknown> = {}) => ({
+    metadata: { generation: 3 },
+    status: { bindings: [{ conditions: [{ type: 'Accepted', status, observedGeneration: 3, ...extra }] }] },
+  })
+
+  for (const [name, fn] of [
+    ['ServiceMonitor', getServiceMonitorStatus],
+    ['PrometheusRule', getPrometheusRuleStatus],
+    ['PodMonitor', getPodMonitorStatus],
+  ] as const) {
+    it(`${name} does not report health when the gate wrote nothing`, () => {
+      // The overwhelmingly common shape: no status at all.
+      expect(fn({ spec: {} })).toMatchObject({ text: 'Not assessed', level: 'unknown' })
+    })
+
+    it(`${name} ignores a status.conditions that these kinds never have`, () => {
+      // This path is not part of these resources' schema.
+      expect(fn({ spec: {}, status: { conditions: [{ type: 'Reconciled', status: 'True' }] } }))
+        .toMatchObject({ text: 'Not assessed', level: 'unknown' })
+    })
+
+    it(`${name} surfaces an explicit rejection`, () => {
+      expect(fn(accepted('False', { reason: 'InvalidConfig' })))
+        .toMatchObject({ text: 'InvalidConfig', level: 'unhealthy' })
+    })
+
+    it(`${name} reports acceptance when a workload confirmed it`, () => {
+      expect(fn(accepted('True'))).toMatchObject({ text: 'Accepted', level: 'healthy' })
+    })
+  }
+
+  it('does not read a condition observed against an older spec', () => {
+    const stale = {
+      metadata: { generation: 7 },
+      status: { bindings: [{ conditions: [{ type: 'Accepted', status: 'True', observedGeneration: 4 }] }] },
+    }
+    expect(getServiceMonitorStatus(stale)).toMatchObject({ text: 'Not assessed', level: 'unknown' })
+  })
+
+  it('does not read one workload as all of them when another has not decided', () => {
+    const undecided = {
+      metadata: { generation: 1 },
+      status: {
+        bindings: [
+          { name: 'a', conditions: [{ type: 'Accepted', status: 'True', observedGeneration: 1 }] },
+          { name: 'b', conditions: [{ type: 'Accepted', status: 'Unknown', observedGeneration: 1 }] },
+        ],
+      },
+    }
+    expect(getServiceMonitorStatus(undecided)).toMatchObject({ text: 'Accepted by 1/2', level: 'unknown' })
+  })
+
+  it('reports partial acceptance when workloads disagree', () => {
+    // One config resource can be selected by several Prometheus workloads, and
+    // each reports separately.
+    const mixed = {
+      metadata: { generation: 1 },
+      status: {
+        bindings: [
+          { name: 'a', conditions: [{ type: 'Accepted', status: 'True', observedGeneration: 1 }] },
+          { name: 'b', conditions: [{ type: 'Accepted', status: 'False', observedGeneration: 1 }] },
+        ],
+      },
+    }
+    expect(getServiceMonitorStatus(mixed)).toMatchObject({ text: 'Accepted by 1/2', level: 'degraded' })
+  })
+})
+
+describe('getKyvernoPolicyStatus', () => {
+  it('reads the Ready condition the controller writes', () => {
+    expect(getKyvernoPolicyStatus({ status: { conditions: [{ type: 'Ready', status: 'True' }] } }))
+      .toMatchObject({ text: 'Ready', level: 'healthy' })
+    expect(getKyvernoPolicyStatus({ status: { conditions: [{ type: 'Ready', status: 'False', reason: 'Failed' }] } }))
+      .toMatchObject({ text: 'Failed', level: 'unhealthy' })
+  })
+
+  it('does not read declared rules as the controller accepting them', () => {
+    // Fires before the controller reports, and for Ready=Unknown.
+    expect(getKyvernoPolicyStatus({ spec: { rules: [{}, {}] } }))
+      .toMatchObject({ text: 'Not assessed', level: 'unknown' })
+    expect(getKyvernoPolicyStatus({ spec: { rules: [{}] }, status: { conditions: [{ type: 'Ready', status: 'Unknown' }] } }))
+      .toMatchObject({ text: 'Not assessed', level: 'unknown' })
+  })
+})
+
+describe('getServiceEntryStatus', () => {
+  it('treats location as a classification, not reachability', () => {
+    // MESH_EXTERNAL/MESH_INTERNAL say where the host sits relative to the mesh.
+    // Nothing here establishes it resolves or answers.
+    expect(getServiceEntryStatus({ spec: { hosts: ['api.example.com'] } }))
+      .toMatchObject({ text: 'External', level: 'neutral' })
+    expect(getServiceEntryStatus({ spec: { hosts: ['a'], location: 'MESH_INTERNAL' } }))
+      .toMatchObject({ text: 'Internal', level: 'neutral' })
+  })
+
+  it('still flags an entry that selects nothing', () => {
+    expect(getServiceEntryStatus({ spec: {} })).toMatchObject({ text: 'No Hosts', level: 'unhealthy' })
+  })
+})
+
+describe('getVirtualServiceStatus', () => {
+  it('does not call a hostless VirtualService broken', () => {
+    // Istio requires hosts to be empty on a delegate VirtualService, and this
+    // object cannot see whether a parent delegates to it.
+    expect(getVirtualServiceStatus({ spec: { http: [{ route: [{}] }] } }))
+      .toMatchObject({ text: 'No Hosts', level: 'unknown' })
+  })
+
+  it('does not read a declaration as working routing', () => {
+    expect(getVirtualServiceStatus({ spec: { hosts: ['a'], http: [{ route: [{}] }] } }))
+      .toMatchObject({ text: 'Defined', level: 'neutral' })
+  })
+
+  it('still flags hosts with nowhere to send them', () => {
+    expect(getVirtualServiceStatus({ spec: { hosts: ['a'] } }))
+      .toMatchObject({ text: 'No Routes', level: 'unhealthy' })
+  })
+
+  it('flags a routeless object even when it declares no hosts', () => {
+    // A delegate omits hosts, but it exists to supply routes.
+    expect(getVirtualServiceStatus({ spec: {} }))
+      .toMatchObject({ text: 'No Routes', level: 'unhealthy' })
+  })
+})
+
+describe('getCNPGObjectStoreStatus', () => {
+  it('does not call a listed server recoverable with no recovery point', () => {
+    // Every timestamp on a RecoveryWindow is optional, so the server can be
+    // listed while holding nothing restorable.
+    expect(getCNPGObjectStoreStatus({ status: { serverRecoveryWindow: { pg: {} } } }))
+      .toMatchObject({ text: 'No recovery point', level: 'unknown' })
+  })
+
+  it('reports recoverable once a real point exists', () => {
+    expect(getCNPGObjectStoreStatus({
+      status: { serverRecoveryWindow: { pg: { firstRecoverabilityPoint: '2026-01-01T00:00:00Z' } } },
+    })).toMatchObject({ text: 'Recoverable', level: 'healthy' })
+  })
+
+  it('still reports failing backups ahead of everything else', () => {
+    expect(getCNPGObjectStoreStatus({
+      status: { serverRecoveryWindow: { pg: { lastFailedBackupTime: '2026-02-01T00:00:00Z' } } },
+    })).toMatchObject({ text: 'Backups Failing', level: 'unhealthy' })
+  })
+})


### PR DESCRIPTION
Six status cells painted a row green — or red — on evidence the object does not carry. This continues #1645 and #1649; a census of the remaining status accessors found the class had survived in five more places, and one of them was reading a field that does not exist.

## What changed

**Prometheus configuration resources (ServiceMonitor, PodMonitor, PrometheusRule).** These read `status.conditions`, a path their schema does not define. The operator reports acceptance *per selecting workload* under `status.bindings[].conditions`, the only condition type is `Accepted`, and it writes any of it only when the `StatusForConfigurationResources` feature gate is enabled. The read never matched, so every row fell through to a green "Active" — including a configuration a Prometheus had explicitly rejected.

They now read the real path and report what it says. A resource is `Accepted` only when every workload that reported has accepted it: one rejection among several shows partial acceptance, a workload still reporting `Unknown` keeps the badge off green, an outright rejection surfaces its reason, and nothing reported reads `Not assessed`. A condition whose `observedGeneration` predates the object's is skipped rather than read as current.

Worth being precise about the ceiling: `Accepted` means the operator accepted and wrote the configuration. It does not mean a target exists or that scraping succeeds, and this badge does not claim it does.

**Kyverno policies** counted their own declared rules as readiness. Kyverno writes a `Ready` condition; declaring rules is not the controller accepting them. The fallback now reports `Not assessed`, which also covers `Ready=Unknown` and a conditions list with no `Ready` at all.

**Istio ServiceEntry** rendered `spec.location` in green. `MESH_EXTERNAL` / `MESH_INTERNAL` describe where a host sits relative to the mesh, not whether it resolves or answers — the text stays, the tone becomes neutral.

**ServiceEntry and PeerAuthentication lose their Status column entirely**, because in both cases it could only ever restate the column beside it.

`getServiceEntryStatus` and `getServiceEntryLocation` read `spec.location` with the same default and map it to the same two words. Their only divergence is `No Hosts`, and that state cannot exist: Istio's CRD declares `hosts` both `required` and `minItems: 1` in all three served versions, so the API server rejects a ServiceEntry without them. Status was therefore identical to Location on every row.

PeerAuthentication is the same shape with no escape clause at all — both columns read `spec.mtls.mode || 'UNSET'` and encode the same four severities, differing only in wording (`Strict mTLS` beside `STRICT`).

Location and mTLS Mode are the honest primary representations and are kept. Both accessors stay: the `./components/resources/*` export makes them importable, and the detail pages still use them.

**Istio VirtualService** called any object with hosts and routes "Active", and called every hostless one broken. Istio requires a delegate VirtualService to declare no hosts, and nothing on the object says whether a parent delegates to it, so red was a false alarm on a documented pattern. Hostless is now `unknown`; a declaration with routes is `Defined`. A VirtualService with no routes stays a real defect either way — a delegate omits hosts, but it exists to supply routes.

**CNPG ObjectStore** reported "Recoverable" from the presence of a server entry. Every timestamp on a `RecoveryWindow` is optional, so a server can be listed while holding nothing restorable — `{ pg: {} }` was green. It now requires an actual recovery point.

## Reviewer note

Badges take their colour from the returned `color`, not from `level`. Each change moves both; changing `level` alone would have left every row green.

Vocabulary follows the two prior PRs rather than inventing any: `Not assessed` / `unknown` where nothing confirmed anything (`getDestinationRuleStatus`), and `neutral` for a classification that is not a health claim (`getIstioGatewayStatus`'s `Defined`).

## Deliberately not in scope

- `pkg/topology/builder.go` hardcodes `StatusHealthy` for ServiceMonitor and PodMonitor nodes and treats any routed VirtualService as healthy. Same overclaim, different layer and language — it wants its own change.
- Trivy `ConfigAuditReport` treats an absent `summary` as all-zero and reports "Pass". Upstream marks `summary` optional, so this is reachable in principle, but I have not established the standard scanner emits it.
- `getCronJobStatus` returns green "Scheduled" for any unsuspended CronJob, which establishes that scheduling is enabled rather than working.
- The ServiceEntry detail page still shows a status badge above a Location property — the same restatement, but detail pages have the room and a leading status badge is the convention there.

Checked and deliberately left alone: Trivy `VulnerabilityReport` (all five severity counts are read before "Clean"), Knative Revision (its healthy branches all require `Ready=True`, and upstream excludes `Active` from the readiness set), and CAPI's shared phase helper (already falls through to `Unknown`).

## Testing

`make tsc` clean. 1707 tests pass (77 files), 26 of them new — each pinned to the upstream contract rather than to the implementation: the bindings path and its absence, an explicit rejection, disagreeing workloads, a stale `observedGeneration`, Kyverno's three not-ready shapes, the delegate VirtualService, and an empty CNPG recovery window.

Visually verified against a live cluster, with the CRDs and fixtures installed to reach every branch: a ServiceMonitor with no status, one accepted, one rejected, one selected by two workloads that disagree, and one where a second workload is still undecided; both VirtualService shapes, both ServiceEntry locations, and three PeerAuthentication modes.

The render confirmed the point of the change — `sm-no-status` is grey rather than green, `sm-rejected` is red, and the hostless VirtualService is grey rather than red. The two `Accepted by 1/2` rows are visibly different tones (amber for a rejection, grey for an undecided workload) despite identical text.

It also surfaced two things code review did not. A controller `reason` is arbitrary-length and these kinds could previously only ever render `Active`, so a rejection reason overflowed its cell by 28px into the next column; the status badge is now bounded to the cell with the full value on hover, matching the pattern the CAPI and Karpenter cells already use. And the `w-24` Status column could not fit the new vocabulary — `Accepted by 1/2` ellipsised to `Accepted by…`, losing the count — so the three Prometheus kinds move to `w-36`. Kyverno's status cell renders a `reason` the same way and gets the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only status logic in k8s-ui with regression tests; no API or auth changes, though operators may see more unknown/neutral badges instead of false greens.
> 
> **Overview**
> **Status badges no longer infer “healthy” from spec shape or wrong status paths** across Prometheus Operator monitors/rules, Kyverno policies, Istio VirtualService/ServiceEntry, and CNPG ObjectStores.
> 
> Prometheus **ServiceMonitor**, **PodMonitor**, and **PrometheusRule** now derive status from `status.bindings[].conditions` (`Accepted`), respecting `observedGeneration`, partial/multi-workload outcomes, and explicit rejections; missing operator status shows **Not assessed** instead of green **Active**. Kyverno drops the “has rules ⇒ Ready” fallback. Istio **ServiceEntry** location labels are **neutral**; **VirtualService** treats hostless delegates as **unknown**, valid declarations as **Defined**, and still flags missing routes. CNPG ObjectStore requires a real recovery timestamp before **Recoverable**.
> 
> UI tweaks widen Prometheus status columns and **truncate** long badge text with a `title` tooltip. New **`status-overclaim.test.ts`** pins these contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e36aed14e761acb0f97b261c8431e38ae82dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



