### PR TITLE
Stop three topology nodes reporting health nothing checked

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/pkg/health"
+	"github.com/skyhook-io/radar/pkg/hpadiag"
 	"github.com/skyhook-io/radar/pkg/karpenter"
 	"github.com/skyhook-io/radar/pkg/perfstats"
 )
@@ -3635,7 +3637,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			ID:     hpaID,
 			Kind:   KindHPA,
 			Name:   hpa.Name,
-			Status: StatusHealthy,
+			Status: hpaNodeHealth(hpa),
 			Data: map[string]any{
 				"namespace":   hpa.Namespace,
 				"minReplicas": hpa.Spec.MinReplicas,
@@ -5300,7 +5302,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					ID:     secretNodeID,
 					Kind:   KindSecret,
 					Name:   secretName,
-					Status: StatusHealthy,
+					Status: StatusUnknown,
 					Data: map[string]any{
 						"namespace": stNs,
 						"labels":    map[string]string{},
@@ -5338,7 +5340,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					ID:     secretNodeID,
 					Kind:   KindSecret,
 					Name:   secretName,
-					Status: StatusHealthy,
+					Status: StatusUnknown,
 					Data: map[string]any{
 						"namespace": ns,
 						"labels":    map[string]string{},
@@ -5377,7 +5379,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				ID:     secretNodeID,
 				Kind:   KindSecret,
 				Name:   secretName,
-				Status: StatusHealthy,
+				Status: StatusUnknown,
 				Data: map[string]any{
 					"namespace": ns,
 					"labels":    map[string]string{},
@@ -5489,7 +5491,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					ID:     secretNodeID,
 					Kind:   KindSecret,
 					Name:   tlsSecretName,
-					Status: StatusHealthy,
+					Status: StatusUnknown,
 					Data: map[string]any{
 						"namespace": resNs,
 						"labels":    map[string]string{},
@@ -7882,36 +7884,113 @@ func getGatewayHealth(gw *unstructured.Unstructured) HealthStatus {
 
 // getRouteHealth derives route health from status.parents[].conditions
 // All parents Accepted → healthy, some → degraded, none → unhealthy
+// An HPA that cannot scale is one of the most common real failures in a cluster,
+// and pkg/hpadiag already diagnoses it for the drawer. The graph only ever
+// downgrades on negative evidence: routine scaling is not a problem, and MCP
+// turns degraded nodes into reported problems (internal/mcp/tools.go), so
+// promoting normal autoscaling to amber would manufacture false ones.
+func hpaNodeHealth(hpa *autoscalingv2.HorizontalPodAutoscaler) HealthStatus {
+	// Analyze reports "ok" for an autoscaler the controller has never written a
+	// condition for, so without this an unreconciled HPA would read as healthy.
+	if hpa == nil || len(hpa.Status.Conditions) == 0 {
+		return StatusUnknown
+	}
+	diagnosis := hpadiag.Analyze(hpa)
+	if diagnosis == nil {
+		return StatusUnknown
+	}
+	switch diagnosis.State {
+	case hpadiag.StateUnableToScale, hpadiag.StateMetricsUnavailable:
+		return StatusUnhealthy
+	case hpadiag.StateLimitedMax, hpadiag.StateMetricsIncomplete:
+		return StatusDegraded
+	case hpadiag.StateLimitedMin, hpadiag.StateScaledToZero, hpadiag.StateDisabled,
+		hpadiag.StatePinned, hpadiag.StateStabilized:
+		// neutral is this vocabulary's "intentional/idle" (types.go), and the
+		// shipped TS mapping puts exactly these states there.
+		return StatusNeutral
+	case hpadiag.StateStale, hpadiag.StateUnknown:
+		return StatusUnknown
+	default:
+		return StatusHealthy
+	}
+}
+
 func getRouteHealth(route *unstructured.Unstructured) HealthStatus {
 	parents, _, _ := unstructured.NestedSlice(route.Object, "status", "parents")
 	if len(parents) == 0 {
 		return StatusUnknown
 	}
-	accepted := 0
+	generation, _, _ := unstructured.NestedInt64(route.Object, "metadata", "generation")
+
+	reporting, accepted, notAccepted, resolved, unresolved, unassessed := 0, 0, 0, 0, 0, 0
 	for _, p := range parents {
 		pMap, ok := p.(map[string]any)
 		if !ok {
 			continue
 		}
+		var acceptedStatus, resolvedStatus string
 		conditions, _, _ := unstructured.NestedSlice(pMap, "conditions")
 		for _, c := range conditions {
 			cMap, ok := c.(map[string]any)
 			if !ok {
 				continue
 			}
-			if cMap["type"] == "Accepted" && cMap["status"] == "True" {
-				accepted++
-				break
+			// A condition observed against an older spec does not describe the
+			// route as it stands now. The TS accessor does not check this; it is
+			// added here deliberately, not mirrored.
+			if og, found, err := unstructured.NestedInt64(cMap, "observedGeneration"); found && err == nil && generation != 0 && og != generation {
+				continue
+			}
+			switch cMap["type"] {
+			case "Accepted":
+				acceptedStatus, _ = cMap["status"].(string)
+			case "ResolvedRefs":
+				resolvedStatus, _ = cMap["status"].(string)
 			}
 		}
+		if acceptedStatus == "" && resolvedStatus == "" {
+			// A parent whose conditions are absent or all stale has not been
+			// assessed. Dropping it would let the parents that did report speak
+			// for one nothing has confirmed.
+			unassessed++
+			continue
+		}
+		reporting++
+		switch acceptedStatus {
+		case "True":
+			accepted++
+		case "False":
+			notAccepted++
+		}
+		// The gateway accepting the route says nothing about whether the
+		// backends it forwards to exist; an unresolved backendRef is the
+		// failure an operator actually opens the graph to find.
+		switch resolvedStatus {
+		case "True":
+			resolved++
+		case "False":
+			unresolved++
+		}
 	}
-	if accepted == len(parents) {
-		return StatusHealthy
+
+	if reporting == 0 {
+		return StatusUnknown
 	}
-	if accepted > 0 {
+	// A total failure is only established once every parent has spoken.
+	if notAccepted == reporting && unassessed == 0 {
+		return StatusUnhealthy
+	}
+	if notAccepted > 0 || unresolved > 0 {
 		return StatusDegraded
 	}
-	return StatusUnhealthy
+	// Accepted alone does not confirm the backends resolve. A parent that has
+	// not published ResolvedRefs has not resolved them yet, which is the whole
+	// reason this function reads the condition.
+	if accepted == reporting && resolved == reporting && unassessed == 0 {
+		return StatusHealthy
+	}
+	return StatusDegraded
 }
 
 func sealedSecretHealth(resource *unstructured.Unstructured) HealthStatus {

--- a/pkg/topology/node_health_test.go
+++ b/pkg/topology/node_health_test.go
@@ -1,0 +1,211 @@
+package topology
+
+import (
+	"testing"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// A green node in the graph is also a "no problems" answer from MCP
+// (internal/mcp/tools.go builds its problem list from degraded/unhealthy nodes),
+// so these pin the line between declared and confirmed.
+
+func routeWithParents(generation int64, parents ...map[string]any) *unstructured.Unstructured {
+	list := make([]any, 0, len(parents))
+	for _, p := range parents {
+		list = append(list, p)
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"generation": generation},
+		"status":   map[string]any{"parents": list},
+	}}
+}
+
+func parent(conds ...map[string]any) map[string]any {
+	list := make([]any, 0, len(conds))
+	for _, c := range conds {
+		list = append(list, c)
+	}
+	return map[string]any{"conditions": list}
+}
+
+func cond(condType, status string, generation int64) map[string]any {
+	return map[string]any{"type": condType, "status": status, "observedGeneration": generation}
+}
+
+func TestGetRouteHealth(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *unstructured.Unstructured
+		want  HealthStatus
+	}{
+		{
+			// The bug: a gateway accepting the route says nothing about whether
+			// the backends it forwards to exist.
+			name:  "accepted but backend refs unresolved",
+			route: routeWithParents(1, parent(cond("Accepted", "True", 1), cond("ResolvedRefs", "False", 1))),
+			want:  StatusDegraded,
+		},
+		{
+			name:  "accepted and refs resolved",
+			route: routeWithParents(1, parent(cond("Accepted", "True", 1), cond("ResolvedRefs", "True", 1))),
+			want:  StatusHealthy,
+		},
+		{
+			name:  "every parent rejected",
+			route: routeWithParents(1, parent(cond("Accepted", "False", 1))),
+			want:  StatusUnhealthy,
+		},
+		{
+			name: "one parent rejected among several",
+			route: routeWithParents(1,
+				parent(cond("Accepted", "True", 1), cond("ResolvedRefs", "True", 1)),
+				parent(cond("Accepted", "False", 1))),
+			want: StatusDegraded,
+		},
+		{
+			// One parent healthy and one unassessed is not a healthy route: the
+			// parent that reported must not speak for the one that did not.
+			name: "one parent current and healthy, another stale",
+			route: routeWithParents(7,
+				parent(cond("Accepted", "True", 7), cond("ResolvedRefs", "True", 7)),
+				parent(cond("Accepted", "False", 3))),
+			want: StatusDegraded,
+		},
+		{
+			name: "one parent current and healthy, another reporting nothing",
+			route: routeWithParents(1,
+				parent(cond("Accepted", "True", 1), cond("ResolvedRefs", "True", 1)),
+				parent()),
+			want: StatusDegraded,
+		},
+		{
+			name:  "no parent reports at all",
+			route: routeWithParents(1),
+			want:  StatusUnknown,
+		},
+		{
+			// Conditions describing an older spec are not evidence about this one.
+			name:  "conditions observed against an older generation",
+			route: routeWithParents(7, parent(cond("Accepted", "True", 3), cond("ResolvedRefs", "True", 3))),
+			want:  StatusUnknown,
+		},
+		{
+			// Accepted alone is not confirmation the backends resolve.
+			name:  "accepted with no ResolvedRefs reported yet",
+			route: routeWithParents(1, parent(cond("Accepted", "True", 1))),
+			want:  StatusDegraded,
+		},
+		{
+			// A rejection plus a silent parent is not an established total failure.
+			name: "one parent rejected, another unassessed",
+			route: routeWithParents(1,
+				parent(cond("Accepted", "False", 1)),
+				parent()),
+			want: StatusDegraded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRouteHealth(tt.route); got != tt.want {
+				t.Errorf("getRouteHealth() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func hpaWith(conds ...autoscalingv2.HorizontalPodAutoscalerCondition) *autoscalingv2.HorizontalPodAutoscaler {
+	min := int32(1)
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &min,
+			MaxReplicas: 10,
+		},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			CurrentReplicas: 2,
+			DesiredReplicas: 2,
+			Conditions:      conds,
+		},
+	}
+}
+
+func TestHPANodeHealth(t *testing.T) {
+	t.Run("reports an HPA that cannot fetch metrics", func(t *testing.T) {
+		hpa := hpaWith(
+			autoscalingv2.HorizontalPodAutoscalerCondition{
+				Type: "AbleToScale", Status: "True",
+			},
+			autoscalingv2.HorizontalPodAutoscalerCondition{
+				Type: "ScalingActive", Status: "False", Reason: "FailedGetResourceMetric",
+			},
+		)
+		if got := hpaNodeHealth(hpa); got == StatusHealthy {
+			t.Errorf("hpaNodeHealth() = %q, want a non-healthy status for unavailable metrics", got)
+		}
+	})
+
+	t.Run("reports an HPA that cannot scale", func(t *testing.T) {
+		hpa := hpaWith(autoscalingv2.HorizontalPodAutoscalerCondition{
+			Type: "AbleToScale", Status: "False", Reason: "FailedGetScale",
+		})
+		if got := hpaNodeHealth(hpa); got != StatusUnhealthy {
+			t.Errorf("hpaNodeHealth() = %q, want %q", got, StatusUnhealthy)
+		}
+	})
+
+	t.Run("does not manufacture a problem out of a healthy HPA", func(t *testing.T) {
+		hpa := hpaWith(
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "AbleToScale", Status: "True"},
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "ScalingActive", Status: "True"},
+		)
+		if got := hpaNodeHealth(hpa); got != StatusHealthy {
+			t.Errorf("hpaNodeHealth() = %q, want %q", got, StatusHealthy)
+		}
+	})
+
+	t.Run("does not report routine scaling as a problem", func(t *testing.T) {
+		// MCP turns degraded nodes into reported problems, so an HPA doing
+		// exactly its job must not become one.
+		hpa := hpaWith(
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "AbleToScale", Status: "True"},
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "ScalingActive", Status: "True"},
+		)
+		hpa.Status.CurrentReplicas = 2
+		hpa.Status.DesiredReplicas = 5
+		if got := hpaNodeHealth(hpa); got == StatusUnhealthy || got == StatusDegraded {
+			t.Errorf("hpaNodeHealth() = %q, want scaling not to be reported as a problem", got)
+		}
+	})
+
+	t.Run("says nothing about an autoscaler the controller has not reported on", func(t *testing.T) {
+		// hpadiag.Analyze returns "ok" for a conditionless HPA, so absence of
+		// evidence must not reach the graph as health.
+		hpa := hpaWith()
+		if got := hpaNodeHealth(hpa); got != StatusUnknown {
+			t.Errorf("hpaNodeHealth() = %q, want %q for an unreconciled HPA", got, StatusUnknown)
+		}
+	})
+
+	t.Run("treats a deliberately idle autoscaler as idle, not healthy", func(t *testing.T) {
+		zero := int32(0)
+		hpa := hpaWith(
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "AbleToScale", Status: "True"},
+			autoscalingv2.HorizontalPodAutoscalerCondition{Type: "ScalingActive", Status: "False", Reason: "ScalingDisabled"},
+		)
+		hpa.Spec.MinReplicas = &zero
+		hpa.Status.CurrentReplicas = 0
+		hpa.Status.DesiredReplicas = 0
+		if got := hpaNodeHealth(hpa); got != StatusNeutral {
+			t.Errorf("hpaNodeHealth() = %q, want %q", got, StatusNeutral)
+		}
+	})
+
+	t.Run("says nothing when there is no HPA", func(t *testing.T) {
+		if got := hpaNodeHealth(nil); got != StatusUnknown {
+			t.Errorf("hpaNodeHealth(nil) = %q, want %q", got, StatusUnknown)
+		}
+	})
+}


### PR DESCRIPTION
A topology node's status is not just a dot in the graph. MCP builds its `get_topology` problem list from degraded and unhealthy nodes (`internal/mcp/tools.go:1645`), and GitOps derives managed-resource health from it (`pkg/gitops/tree/graph.go:21`). A green node is Radar answering *"nothing is wrong"* — to an operator scanning the graph, and to an AI asked whether the cluster is healthy.

Three places were answering that without checking. This continues #1645/#1649/#1659, which fixed the TypeScript accessors; `pkg/topology` computes health independently in Go and had drifted from them.

## What changed

**Gateway API routes were judged on `Accepted` alone.** A gateway accepting a route says nothing about whether the backends it forwards to exist — so an HTTPRoute whose `backendRef` named a deleted Service reported healthy. That is precisely the failure an operator opens the graph to find, and it is the same defect #1645 fixed on the TS side. `getRouteHealth` now reads `ResolvedRefs` alongside `Accepted`.

A route reads healthy only when every parent reports both `Accepted=True` and `ResolvedRefs=True`. A parent that reports nothing — no conditions, or only ones observed against an earlier `generation` — is counted as unassessed and blocks both the healthy and the unhealthy verdict, so neither a green node nor a total failure is claimed while a gateway is still silent.

Two deliberate differences from the TS accessor, since this is otherwise meant to match it: the `observedGeneration` staleness check is an addition (`speaksToCurrentSpec` in `resource-utils.ts:1953` only tests whether the relevant conditions exist), and a route whose parents all report nothing reads `unknown` here where TS reads `Pending`/degraded — claiming a fault we have not established seemed the wrong direction for this change. Both are candidates for reconciling in TS rather than divergences to keep.

**HorizontalPodAutoscalers were hardcoded healthy** while the builder read `hpa.Status.CurrentReplicas` three lines below. `pkg/hpadiag` already diagnoses HPAs for the detail drawer, so the node now uses it and the graph stops disagreeing with the drawer.

An autoscaler the controller has not written a condition for reads unknown rather than healthy: `hpadiag.Analyze` reports `ok` for a conditionless HPA, so absence of evidence would otherwise arrive as health. States the vocabulary calls intentionally idle — scaled to zero, disabled, pinned, stabilised, at minimum — map to neutral, matching the shipped TS mapping.

Otherwise the mapping only ever *downgrades* on negative evidence — unreachable metrics and inability to scale become unhealthy, capped/incomplete metrics degraded, everything else stays healthy. Notably `scaling_up`/`scaling_down` remain healthy: an HPA doing its job is not a problem, and since degraded nodes become MCP-reported problems, promoting routine autoscaling would manufacture false ones. This differs from `hpaStateLevel` in `resource-utils-hpa.ts:68`, which calls both scaling directions degraded — worth reconciling, but in both places deliberately rather than by divergence here.

**Four Secret nodes are stubs synthesised from a reference** — a TLS or CA secret named by a Traefik or HTTPProxy resource that the Secret listing never produced, either because it does not exist or because it was not listable. They were built green, so a misspelled `certificateRef` rendered as a healthy Secret. They now report unknown.

## Verification

The HPA fix is verified end to end against a real controller failure rather than a hand-written fixture: a `kind` cluster has no metrics-server, so an HPA there genuinely gets `ScalingActive=False / FailedGetResourceMetric` from the HPA controller. With that in the cluster, the topology API returns `status: "unhealthy"` for the node, and `get_topology` over MCP returns the same — where both previously said healthy.

Route health is pinned by table-driven tests covering unresolved backendRefs, full acceptance, partial and total rejection, absent reports, a stale `observedGeneration`, and the mixed cases where one parent is current and healthy while another is stale or silent. I confirmed these actually fail against the previous algorithm rather than passing either way: for a route with `Accepted=True, ResolvedRefs=False` the old code returns `healthy` and the new code returns `degraded`.

`go build` and `go test ./...` clean in both the root and `pkg` modules.

## Scope

Deliberately narrow. A survey found 22 hardcoded `Status: StatusHealthy` node constructions, but most are not defects worth changing:

- **Recolouring config objects** (ConfigMap, listed Secrets, ServiceAccount, the synthetic Internet node) is not done. `StatusNeutral` means *intentionally idle* and paints a sky-blue outline (`K8sResourceNode.tsx:275`), so it would add emphasis to the least interesting nodes rather than remove a claim. That needs a deliberate "health not applicable" presentation instead.
- **NetworkPolicy and the spec-presence-implies-healthy sites** (VirtualService, Istio Gateway, Traefik routes) are consistency gaps, not defects anyone is misled by.
- **Ingress `loadBalancer` and Service endpoints** would be *new* health signals rather than removing a false one. Given that a wrong status propagates into MCP problems and GitOps degraded counts, a false alarm costs more than a missing one here, and Service semantics already live in `internal/k8s/detect.go:1151`.

Known and not addressed: `TraefikService` is marked unhealthy on zero backends in the resources view (`builder.go:2274`) but always healthy in the traffic view (`:6472`); Cilium and ClusterNetworkPolicy expose conditions the builder ignores; VPA conditions are readable and `ConfigUnsupported` currently renders green; and the generic condition helper (`builder.go:7951`) returns on the first Ready/Available/Succeeded it sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how topology health is computed for routes, HPAs, and secrets, which can alter MCP-reported problems and GitOps degraded counts; logic is conservative but user-visible status may shift.
> 
> **Overview**
> Topology nodes were marking **healthy** without checking real status, which flows into MCP problem lists and GitOps health. This PR tightens three cases in `pkg/topology/builder.go`.
> 
> **Gateway API routes** — `getRouteHealth` no longer treats `Accepted=True` as fully healthy. It also requires current `ResolvedRefs` (and ignores conditions on stale `observedGeneration`), counts silent parents as unassessed, and only returns healthy when every reporting parent accepts and resolves refs.
> 
> **HPAs** — HPA graph nodes call new `hpaNodeHealth`, which maps `hpadiag.Analyze` results into graph status (unhealthy/degraded for scale/metrics failures, neutral for intentional idle states, unknown when unreconciled). Routine scaling stays non-problematic so MCP does not get false alarms.
> 
> **Referenced Secret stubs** (Traefik/Contour TLS/CA refs not in the Secret list) switch from **healthy** to **unknown** so missing secrets are not shown as OK.
> 
> Adds `node_health_test.go` table tests for route and HPA health behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf6a40f88289c0491ac9ae11c017483d2b92cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


