### PR TITLE
Expanding a pod group hid crash-looping pods

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -34,7 +34,7 @@ import { GroupNode } from './GroupNode'
 import { NEUTRAL_OWNER, type WorkloadFocus } from '../../utils/workload-colors'
 import { ownershipOf } from '../../utils/topology-neighborhood'
 import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey, isGroupEffectivelyCollapsed, type GroupDisplayLevel } from './layout'
-import type { Topology, TopologyNode, TopologyEdge, ViewMode, GroupingMode } from '../../types'
+import type { Topology, TopologyNode, TopologyEdge, ViewMode, GroupingMode, HealthStatus } from '../../types'
 import { pluralize } from '../../utils/pluralize'
 import { foldHash } from '../../utils/structure-hash'
 import { recordLayoutDuration, recordLayoutSkipped, recordStructureKeyDuration } from '../../perf'
@@ -408,6 +408,7 @@ export function TopologyGraph({
       phase: string
       restarts: number
       containers: number
+      status?: HealthStatus
     }>
 
     // Find edges pointing to this pod group
@@ -425,7 +426,11 @@ export function TopologyGraph({
         id: podId,
         kind: 'Pod',
         name: pod.name,
-        status: pod.phase === 'Running' ? 'healthy' : pod.phase === 'Pending' ? 'degraded' : 'unhealthy',
+        // The server computes pod health; pkg/health tracks a crash loop across
+        // the kubelet's Waiting->Running oscillation, which the phase alone
+        // hides — a crash-looping pod sits at Phase=Running. Deriving it here
+        // again would rebuild that logic in a second place and get it wrong.
+        status: pod.status ?? 'unknown',
         data: {
           ...podGroupNode.data,
           namespace: pod.namespace,

--- a/pkg/topology/node_health_test.go
+++ b/pkg/topology/node_health_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -208,4 +209,41 @@ func TestHPANodeHealth(t *testing.T) {
 			t.Errorf("hpaNodeHealth(nil) = %q, want %q", got, StatusUnknown)
 		}
 	})
+}
+
+// Expanding a pod group must not re-derive health from the phase: a
+// crash-looping pod sits at Phase=Running, so the group has to carry the
+// verdict pkg/health already computed.
+func TestPodGroupCarriesComputedPodStatus(t *testing.T) {
+	crashing := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-1", Namespace: "prod"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "app",
+				RestartCount: 9,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "CrashLoopBackOff",
+				}},
+			}},
+		},
+	}
+	group := &PodGroup{Key: "prod/Deployment/api", GroupName: "api", Pods: []*corev1.Pod{crashing}}
+	node := CreatePodGroupNode(group, nil)
+
+	details, ok := node.Data["pods"].([]map[string]any)
+	if !ok || len(details) != 1 {
+		t.Fatalf("expected one pod detail, got %#v", node.Data["pods"])
+	}
+	status, _ := details[0]["status"].(string)
+	if status == "" {
+		t.Fatal("pod detail carries no status; the frontend would fall back to the phase")
+	}
+	if status == string(StatusHealthy) {
+		t.Errorf("crash-looping pod reported %q — Phase is Running, which is exactly what hides it", status)
+	}
+	if phase, _ := details[0]["phase"].(string); phase != string(corev1.PodRunning) {
+		t.Fatalf("fixture no longer reproduces the trap: phase = %q", phase)
+	}
 }

--- a/pkg/topology/pod_grouping.go
+++ b/pkg/topology/pod_grouping.go
@@ -199,6 +199,7 @@ type PodDetail struct {
 	Restarts    int32  `json:"restarts"`
 	Containers  int    `json:"containers"`
 	StatusIssue string `json:"statusIssue"`
+	Status      string `json:"status"`
 }
 
 // CreatePodGroupNode creates a Node for a group of pods
@@ -239,6 +240,10 @@ func CreatePodGroupNode(group *PodGroup, provider ResourceProvider) Node {
 			"restarts":    restarts,
 			"containers":  len(pod.Spec.Containers),
 			"statusIssue": podIssue,
+			// Expanding a group must not re-derive health from the phase: a
+			// crash-looping pod stays Phase=Running, and pkg/health already
+			// tracks that across the kubelet's Waiting->Running oscillation.
+			"status": string(getPodStatus(pod)),
 		})
 	}
 


### PR DESCRIPTION
Expanding a pod group in the topology graph painted CrashLoopBackOff pods green.

The expanded children took their status from the pod phase — and a crash-looping pod sits at `Phase=Running`. The pod is running; the *container* is restarting. So the one screen an operator opens to find a broken pod showed it as healthy, and the restart count was sitting unused in the same object two lines below.

## Why the frontend was guessing

The server already knows the answer. `pkg/health` handles the case properly, including the part that makes a naive check unreliable: a crash-looping container oscillates Waiting→Running, so reading the current container state flickers. `podStableCrashLoopLevel` uses crash *history* so the verdict holds steady, and it separates a crash-looping container that is still serving (degraded) from one that is down (unhealthy).

Standalone pod nodes have always used it, via `CreatePodNode` → `getPodStatus` → `health.PodDisplayLevel`. The group's per-pod payload just never carried the result: `PodDetail` shipped name, namespace, phase, restarts, containers and statusIssue, but no status. With only the phase to work from, the frontend derived one.

## What changed

`PodDetail` now carries the computed status, and the graph renders it.

Deriving it in the frontend instead — reading restarts and container states there — would have rebuilt `podStableCrashLoopLevel` in TypeScript, which is precisely how the two sides drifted apart in the first place. A payload arriving without a status reads `unknown` rather than falling back to the phase, so an older server produces a node that admits it does not know instead of one that repeats the bug.

## Testing

`go build` and `go test ./...` clean in both modules; `make tsc` clean; 2953 frontend tests pass.

A regression test builds a pod with `Phase=Running` and a container in CrashLoopBackOff, then asserts the group's payload does not report it healthy. It also asserts the fixture still has `Phase=Running`, so the test fails loudly if it ever stops reproducing the trap rather than passing for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized topology health display fix with backward-compatible unknown fallback; no auth or data-path changes.
> 
> **Overview**
> Fixes **crash-looping pods showing as healthy** when a pod group is expanded in the topology graph. Expanded pod nodes previously inferred health from **pod phase** (`Running` → green), which misses **CrashLoopBackOff** while phase stays `Running`.
> 
> The backend now includes a computed **`status`** on each entry in the pod group’s `pods` payload (`getPodStatus` / `pkg/health`, same path as standalone pod nodes). **`TopologyGraph`** uses `pod.status` when materializing expanded pod nodes and falls back to **`unknown`** if the field is missing (no silent phase-based guess).
> 
> Adds **`TestPodGroupCarriesComputedPodStatus`** to assert a Running-phase, crash-looping pod is not reported healthy in group expansion data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee348893c1e538565426c49d6e1c0f0c6c0ff3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->