### PR TITLE
Prepare investigation package compatibility and stream reliability

### DIFF
--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -513,6 +513,10 @@ func (s *Server) handleDiagnoseStop(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, map[string]any{"ok": true})
 }
 
+// historyUnavailableRetryMillis is the EventSource reconnect delay sent with a
+// retryable hydration failure.
+const historyUnavailableRetryMillis = 10000
+
 // handleDiagnoseRunStream streams a run's events over SSE: a replay of everything
 // after Last-Event-ID (or ?after=), then the live tail. Disconnecting does NOT
 // stop the run — that's the whole point of server-side jobs.
@@ -561,6 +565,11 @@ func (s *Server) handleDiagnoseRunStream(w http.ResponseWriter, r *http.Request)
 	backlog, ch, alreadyFinalized, cancel, err := run.Subscribe(afterSeq)
 	if err != nil {
 		retryable := !errors.Is(err, ai.ErrHistoryCorrupt)
+		if retryable {
+			// EventSource's default reconnect delay is a few seconds, and every
+			// retry re-reads the transcript; a store outage does not clear that fast.
+			fmt.Fprintf(w, "retry: %d\n", historyUnavailableRetryMillis)
+		}
 		sendSSEEvent(w, flusher, "history_unavailable", map[string]any{
 			"type":      "history_unavailable",
 			"error":     err.Error(),

--- a/internal/server/ai_diagnose_stream_test.go
+++ b/internal/server/ai_diagnose_stream_test.go
@@ -106,6 +106,7 @@ func TestHandleDiagnoseRunStreamReturnsRetryableSSEWhenHydrationFails(t *testing
 	}
 	body := recorder.Body.String()
 	for _, want := range []string{
+		"retry: 10000\n",
 		"event: history_unavailable",
 		`"type":"history_unavailable"`,
 		`"retryable":true`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6607,7 +6607,7 @@
         "vite": "^8.2.2"
       },
       "peerDependencies": {
-        "@skyhook-io/k8s-ui": ">=1.13.4",
+        "@skyhook-io/k8s-ui": ">=1.14.2",
         "@tanstack/react-query": ">=5",
         "@xyflow/react": ">=12.0.0",
         "clsx": ">=2",

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -492,6 +492,44 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 			"match", "other-ns", "other-kind", "other-name", "other-source")
 	})
 
+	// APIGroups narrows on the group parsed from APIVersion before the limit
+	// applies, so same-kind rows from another group cannot crowd out the
+	// requested resource's history. Rows with no recorded APIVersion are
+	// unknown rather than mismatches and stay visible under every group filter.
+	t.Run("api group filter runs before the limit and keeps unknown versions", func(t *testing.T) {
+		store := newStore(t)
+		web := func(id string, offset time.Duration, apiVersion string) timeline.TimelineEvent {
+			e := informer(id, offset)
+			e.Name, e.APIVersion = "web", apiVersion
+			return e
+		}
+		mustAppend(t, store, web("matching", 0, "apps/v1"))
+		mustAppend(t, store, web("unknown", time.Minute, ""))
+		mustAppend(t, store, web("wrong-core", 2*time.Minute, "v1"))
+		for i := 0; i < 5; i++ {
+			mustAppend(t, store, web(fmt.Sprintf("wrong-%d", i), 3*time.Minute+time.Duration(i)*time.Second, "other.example/v1"))
+		}
+
+		query := func(name string, groups []string, limit int) []string {
+			t.Helper()
+			got, err := store.Query(ctx, timeline.QueryOptions{
+				Kinds: []string{"Deployment"}, Names: []string{"web"}, APIGroups: groups,
+				Limit: limit, IncludeManaged: true,
+			})
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			return idsOfEvents(got)
+		}
+
+		if got := query("apps", []string{"apps"}, 2); fmt.Sprint(got) != "[unknown matching]" {
+			t.Errorf("apps group with limit 2: got %v, want [unknown matching]", got)
+		}
+		if got := query("core", []string{""}, 10); fmt.Sprint(got) != "[wrong-core unknown]" {
+			t.Errorf("core group: got %v, want [wrong-core unknown]", got)
+		}
+	})
+
 	// Time-range narrowing is separate from arrival-order narrowing: Since/Until
 	// bound the event's own timestamp, which for a k8s Event is when the cluster
 	// says it happened, not when Radar saw it.

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "peerDependencies": {
-    "@skyhook-io/k8s-ui": ">=1.13.4",
+    "@skyhook-io/k8s-ui": ">=1.14.2",
     "@tanstack/react-query": ">=5",
     "@xyflow/react": ">=12.0.0",
     "clsx": ">=2",

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -8,11 +8,14 @@ import {
   Timeline,
   TurnView,
   appendThinking,
+  upsertTool,
+  type TimelineItem,
   type Turn,
 } from "./parts";
 import type {
   AgentInfo,
   Diagnosis,
+  DiagnoseStep,
   ExecutionProfile,
 } from "../../api/diagnose";
 import { investigationEvidenceSourceId } from "./investigationEvidence";
@@ -190,6 +193,96 @@ describe("appendThinking", () => {
       },
     ]);
   });
+});
+
+describe("upsertTool", () => {
+  const running: DiagnoseStep = {
+    id: "tool-1",
+    tool: "get_resource",
+    status: "running",
+    summary: "kind=deployment namespace=dev name=api",
+  };
+  const completion: DiagnoseStep = {
+    id: running.id,
+    tool: "",
+    status: "done",
+    ms: 83,
+    result: '{"readyReplicas":1}',
+    evidenceRef: "ev-1",
+    radarEvidence: true,
+    isError: false,
+    truncated: false,
+  };
+
+  it("appends a new call with its identity and input without changing earlier entries", () => {
+    const previous: TimelineItem[] = [
+      { kind: "thinking", text: "Checking the workload" },
+    ];
+    const next = upsertTool(previous, running);
+
+    expect(next).toEqual([
+      previous[0],
+      { kind: "tool", ...running, animate: true },
+    ]);
+    expect(next[0]).toBe(previous[0]);
+    expect(previous).toHaveLength(1);
+  });
+
+  it.each([undefined, ""])(
+    "merges completion in place, preserving running input when summary is %s",
+    (summary) => {
+      const previous = upsertTool([], running, false);
+      previous.push({ kind: "tool", ...running, id: "tool-2", animate: false });
+      const next = upsertTool(previous, { ...completion, summary }, false);
+
+      expect(next).toEqual([
+        {
+          kind: "tool",
+          ...completion,
+          tool: running.tool,
+          summary: running.summary,
+          animate: false,
+        },
+        previous[1],
+      ]);
+      expect(next[1]).toBe(previous[1]);
+      expect(previous[0]).toEqual({ kind: "tool", ...running, animate: false });
+      expect(upsertTool(next, completion, false)).toEqual(next);
+    },
+  );
+
+  it("replaces result and provenance metadata, including explicit false values", () => {
+    const previous = upsertTool([], completion, false);
+    const failed: DiagnoseStep = {
+      ...completion,
+      result: "Permission denied",
+      evidenceRef: "ev-2",
+      radarEvidence: false,
+      isError: true,
+      truncated: true,
+    };
+    const next = upsertTool(previous, failed, false);
+
+    expect(next).toEqual([{ kind: "tool", ...failed, animate: false }]);
+    expect(upsertTool(next, completion, false)).toEqual(previous);
+    expect(previous[0]).toMatchObject(completion);
+  });
+
+  it.each([
+    { arrival: false, update: false, expected: false },
+    { arrival: false, update: true, expected: true },
+    { arrival: true, update: false, expected: true },
+    { arrival: true, update: true, expected: true },
+  ])(
+    "keeps animation $expected for arrival=$arrival and update=$update",
+    ({ arrival, update, expected }) => {
+      const previous = upsertTool([], running, arrival);
+      const next = upsertTool(previous, completion, update);
+
+      expect(previous[0]).toMatchObject({ animate: arrival });
+      expect(next[0]).toMatchObject({ animate: expected });
+    },
+  );
 });
 
 describe("Timeline reasoning density", () => {


### PR DESCRIPTION
## Summary
Prepare the investigation UI for the next patch packages and reduce reconnect pressure during transient transcript-storage failures.

## Changes
- Require @skyhook-io/k8s-ui >=1.14.2 in radar-app and its lockfile. Findings uses the defaultConditionTone export, which is absent from published 1.14.1.
- Send a 10-second EventSource retry delay for retryable history hydration failures; preserve terminal corrupt-history behavior.
- Cover tool-step merging, result/provenance metadata, replay/live animation, and API-group filtering before timeline limits in the shared store conformance suite.

## Validation
- make build (includes frontend type-check and embedded Go binary)
- 225 focused frontend tests across four investigation suites
- go test ./internal/server ./internal/timeline
- From pkg: go test ./timeline/...
- git diff --check
- Visual test: skipped (no rendered UI change).
- PostgreSQL-backed integration cases were not exercised without a test DSN.

## Release ordering
Publish k8s-ui 1.14.2 from code containing the export before radar-app 1.13.2. Both are patch releases. This PR does not publish packages or enable hosted Findings; Hub protocol alignment and its required target-group migration remain separate integration work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency alignment, SSE reconnect tuning, and test coverage; no auth or data-mutation logic changes in production UI code beyond the stream retry line.
> 
> **Overview**
> Prepares the investigation stack for **@skyhook-io/k8s-ui >=1.14.2** (lockfile and `web/package.json` peer) so Findings can rely on exports such as `defaultConditionTone` that are missing from 1.14.1.
> 
> For **retryable** AI run transcript hydration failures on the diagnose SSE stream, the server now emits **`retry: 10000`** before the existing `history_unavailable` frame so EventSource backs off instead of hammering the store on a few-second default reconnect. **Corrupt / non-retryable** history still ends with the explicit `closed` frame; only the transient path changes.
> 
> Adds **shared timeline store conformance** coverage that **`APIGroups` is applied before `Limit`** and rows with empty `APIVersion` stay visible under any group filter. Adds **frontend unit tests** for **`upsertTool`** (append, in-place merge preserving running input, provenance fields, animation flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993a48f1769619b93e817968678b65b8008da556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->