### PR TITLE
Add nine columns that answer a question the table could not

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1296,14 +1296,16 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'action', label: 'Action', width: 'w-36', tooltip: 'Enforcement at admission — Enforce blocks, Audit reports; Background only or Inactive when admission is disabled' },
-    { key: 'rules', label: 'Rules', width: 'w-20' },
+    { key: 'ruleTypes', label: 'Types', width: 'w-40', tooltip: 'Rule kinds this policy declares. A policy can carry several, and the mix decides what it can do to a request.' },
+    { key: 'rules', label: 'Rules', width: 'w-20', defaultVisible: false },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   clusterpolicies: [
     { key: 'name', label: 'Name' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'action', label: 'Action', width: 'w-36', tooltip: 'Enforcement at admission — Enforce blocks, Audit reports; Background only or Inactive when admission is disabled' },
-    { key: 'rules', label: 'Rules', width: 'w-20' },
+    { key: 'ruleTypes', label: 'Types', width: 'w-40', tooltip: 'Rule kinds this policy declares. A policy can carry several, and the mix decides what it can do to a request.' },
+    { key: 'rules', label: 'Rules', width: 'w-20', defaultVisible: false },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   // Kyverno modern CEL family (policies.kyverno.io). "Enforcement" is the
@@ -1410,12 +1412,14 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'schedule', label: 'Schedule', width: 'w-32' },
+    { key: 'lastRun', label: 'Last Run', width: 'w-28', tooltip: 'Time since the controller last recorded an execution. A dash means it has not recorded one.' },
     { key: 'appliesTo', label: 'Deletes', width: 'min-w-40' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   clustercleanuppolicies: [
     { key: 'name', label: 'Name' },
     { key: 'schedule', label: 'Schedule', width: 'w-32' },
+    { key: 'lastRun', label: 'Last Run', width: 'w-28', tooltip: 'Time since the controller last recorded an execution. A dash means it has not recorded one.' },
     { key: 'appliesTo', label: 'Deletes', width: 'min-w-40' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
@@ -1797,6 +1801,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   sbomreports: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'image', label: 'Image', width: 'w-48', tooltip: 'Image the SBOM describes. The container name alone does not identify what was scanned.' },
     { key: 'container', label: 'Container', width: 'w-28' },
     { key: 'components', label: 'Components', width: 'w-24', tooltip: 'Packages and libraries found in the image' },
     { key: 'status', label: 'Status', width: 'w-28' },
@@ -1804,6 +1809,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   ],
   clustersbomreports: [
     { key: 'name', label: 'Name' },
+    { key: 'image', label: 'Image', width: 'w-48', tooltip: 'Image the SBOM describes. The container name alone does not identify what was scanned.' },
     { key: 'components', label: 'Components', width: 'w-24' },
     { key: 'status', label: 'Status', width: 'w-28' },
     { key: 'age', label: 'Age', width: 'w-16' },
@@ -1912,6 +1918,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-36' },
     { key: 'repositoryType', label: 'Type', width: 'w-24', tooltip: 'kopia or restic. Restic is deprecated — Velero 1.17 stopped creating restic backups and 1.19 drops restic restore.' },
+    { key: 'volumeNamespace', label: 'Volume NS', width: 'w-36', tooltip: 'Namespace whose volumes this repository stores. Distinct from the namespace the repository object lives in.' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   backupstoragelocations: [
@@ -2269,6 +2276,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'status', label: 'Status', width: 'w-28' },
     { key: 'dnsNames', label: 'DNS Names', width: 'w-56' },
     { key: 'secretName', label: 'Secret', width: 'w-44' },
+    { key: 'expires', label: 'Expires', width: 'w-28', tooltip: 'Expiry of the certificate in the named Secret, as the controller reported it.' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   serverlessservices: [
@@ -2374,6 +2382,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36 shrink-0' },
     { key: 'cluster', label: 'Cluster', width: 'w-32 shrink-0' },
     { key: 'ready', label: 'Ready', width: 'w-20 shrink-0', tooltip: 'Ready replicas / desired' },
+    { key: 'upToDate', label: 'Up-to-date', width: 'w-24', tooltip: 'Machines already running the current spec. Fewer than Ready means a rollout is still in progress.' },
     { key: 'phase', label: 'Phase', width: 'w-28 shrink-0' },
     { key: 'version', label: 'Version', width: 'w-24 shrink-0' },
     { key: 'age', label: 'Age', width: 'w-24 shrink-0' },
@@ -5078,8 +5087,10 @@ export function ResourcesView({
         // DaemonSet: numberAvailable, others: availableReplicas
         return status.numberAvailable ?? status.availableReplicas ?? 0
       case 'upToDate':
-        // DaemonSet: updatedNumberScheduled, others: updatedReplicas
-        return status.updatedNumberScheduled ?? status.updatedReplicas ?? 0
+        // DaemonSet: updatedNumberScheduled; CAPI v1beta2: upToDateReplicas;
+        // others: updatedReplicas. Same precedence the cells display, or a row
+        // sorts as zero while showing a real count.
+        return status.updatedNumberScheduled ?? status.upToDateReplicas ?? status.updatedReplicas ?? 0
       case 'restarts':
         if (kindLower === 'jobsets') return getJobSetRestarts(resource)
         return getPodRestarts(resource)

--- a/packages/k8s-ui/src/components/resources/renderers/capi-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/capi-cells.tsx
@@ -12,6 +12,7 @@ import {
   getClusterClassStatus,
   getMachineHealthCheckStatus, getMachineHealthCheckHealthy, getMachineHealthCheckClusterName,
   getClusterProvider,
+  getMachineDeploymentUpToDate,
 } from '../resource-utils-capi'
 
 function StatusBadge({ resource, getStatus }: { resource: any; getStatus: (r: any) => { text: string; color: string } }) {
@@ -78,6 +79,8 @@ export function CAPIMachineDeploymentCell({ resource, column }: { resource: any;
       return <TextCell value={getMachineClusterName(resource)} />
     case 'ready':
       return <TextCell value={getMachineDeploymentReplicas(resource)} />
+    case 'upToDate':
+      return <TextCell value={getMachineDeploymentUpToDate(resource)} />
     case 'version':
       return <TextCell value={getMachineDeploymentVersion(resource)} />
     default:

--- a/packages/k8s-ui/src/components/resources/renderers/certmanager-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/certmanager-cells.tsx
@@ -48,8 +48,8 @@ export function CertificateCell({ resource, column }: { resource: any; column: s
     case 'expires': {
       const expiry = getCertificateExpiry(resource)
       return (
-        <span className={clsx(
-          'text-sm font-medium',
+        <span title={expiry.text} className={clsx(
+          'text-sm font-medium truncate block',
           expiry.level === 'unhealthy' ? 'text-red-400' :
           expiry.level === 'degraded' ? 'text-yellow-400' :
           expiry.level === 'healthy' ? 'text-green-400' :

--- a/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
@@ -28,6 +28,9 @@ import {
   getDomainMappingUrl,
   getServerlessServiceMode,
 } from '../resource-utils-knative'
+// Knative's Certificate reports status.notAfter like any other TLS certificate,
+// so it shares the expiry formatter rather than re-deriving the thresholds.
+import { getCertificateExpiry, healthColors } from '../resource-utils'
 
 function StatusCell({ resource, getStatus }: { resource: any; getStatus: (r: any) => { text: string; color: string } }) {
   const status = getStatus(resource)
@@ -366,6 +369,16 @@ export function KnativeCertificateCell({ resource, column }: { resource: any; co
     }
     case 'secretName':
       return <TextCell value={resource?.spec?.secretName || '-'} />
+    case 'expires': {
+      const expiry = getCertificateExpiry(resource)
+      // "Expired 365d ago" is far wider than the column; bound it like the
+      // other status badges that carry arbitrary-length text.
+      return (
+        <span className={clsx('badge truncate max-w-full', healthColors[expiry.level])} title={expiry.text}>
+          {expiry.text}
+        </span>
+      )
+    }
     default:
       return <DefaultCell />
   }

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -8,6 +8,7 @@ import {
   getKyvernoPolicyStatus,
   getKyvernoEnforcement,
   getKyvernoPolicyRuleCount,
+  getKyvernoPolicyRuleTypes,
 } from '../resource-utils-kyverno'
 import {
   getKyvernoRequestState,
@@ -91,6 +92,12 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
         )}>
           {label}
         </span>
+      )
+    }
+    case 'ruleTypes': {
+      const types = getKyvernoPolicyRuleTypes(resource)
+      return (
+        <span className="text-sm text-theme-text-secondary truncate block" title={types}>{types}</span>
       )
     }
     case 'rules': {

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-modern-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-modern-cells.tsx
@@ -129,6 +129,12 @@ export function KyvernoCleanupPolicyCell({ resource, column }: { resource: any; 
       const status = getKyvernoCleanupPolicyStatus(resource)
       return <span className={clsx('badge', status.color)}>{status.text}</span>
     }
+    case 'lastRun': {
+      const last = getKyvernoLastExecutionTime(resource)
+      return last
+        ? <span className="text-sm text-theme-text-secondary">{formatAge(last)}</span>
+        : <span className="text-sm text-theme-text-tertiary">-</span>
+    }
     case 'schedule': {
       const schedule = getKyvernoCleanupSchedule(resource)
       return schedule ? (

--- a/packages/k8s-ui/src/components/resources/renderers/trivy-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/trivy-cells.tsx
@@ -6,6 +6,7 @@ import {
   getVulnerabilityReportSummary,
   getVulnerabilityReportContainer,
   getVulnerabilityReportImage,
+  getSbomReportImage,
   getConfigAuditReportSummary,
   getConfigAuditReportStatus,
   getExposedSecretReportSummary,
@@ -133,6 +134,12 @@ export function ClusterComplianceReportCell({ resource, column }: { resource: an
 
 export function SbomReportCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
+    case 'image': {
+      const image = getSbomReportImage(resource)
+      return (
+        <span className="text-sm text-theme-text-secondary truncate block" title={image}>{image}</span>
+      )
+    }
     case 'container':
       return <span className="text-sm text-theme-text-secondary">{getSbomReportContainer(resource)}</span>
     case 'components': {

--- a/packages/k8s-ui/src/components/resources/renderers/velero-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/velero-cells.tsx
@@ -30,6 +30,7 @@ import {
   getVSLConfig,
   getBackupRepositoryStatus,
   getBackupRepositoryType,
+  getBackupRepositoryVolumeNamespace,
 } from '../resource-utils-velero'
 
 // The detail-page Phase value. The badge carries the same label the table
@@ -235,6 +236,8 @@ export function BackupRepositoryCell({ resource, column }: { resource: any; colu
         </span>
       )
     }
+    case 'volumeNamespace':
+      return <span className="text-sm text-theme-text-secondary">{getBackupRepositoryVolumeNamespace(resource)}</span>
     case 'repositoryType': {
       const type = getBackupRepositoryType(resource)
       // restic is on its way out (no new backups since v1.17, restore dropped in

--- a/packages/k8s-ui/src/components/resources/resource-utils-trivy.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-trivy.ts
@@ -102,6 +102,9 @@ export const getExposedSecretReportSummary = getVulnerabilityReportSummary
 export const getExposedSecretReportContainer = getVulnerabilityReportContainer
 export const getExposedSecretReportImage = getVulnerabilityReportImage
 
+// SBOM reports carry the same report.artifact/registry shape as the scan reports.
+export const getSbomReportImage = getVulnerabilityReportImage
+
 export const getExposedSecretReportStatus = getVulnerabilityReportStatus
 
 // ============================================================================

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -11,7 +11,8 @@ import { getNodePoolStatus, getNodeClaimStatus } from './resource-utils-karpente
 import { getScaledObjectStatus, getScaledJobStatus } from './resource-utils-keda'
 import { getGitRepositoryStatus, getOCIRepositoryStatus, getHelmRepositoryStatus, getHelmRepositoryType, getKustomizationStatus, getFluxHelmReleaseStatus, getFluxAlertStatus } from './resource-utils-flux'
 import { getArgoApplicationStatus, getArgoApplicationSetStatus, getArgoApplicationSync, getArgoApplicationHealth, getArgoApplicationProject } from './resource-utils-argo'
-import { getPolicyReportStatus as _getPolicyReportStatus, getKyvernoPolicyStatus as _getKyvernoPolicyStatus } from './resource-utils-kyverno'
+import { getVulnerabilityReportImage as _getVulnerabilityReportImage } from './resource-utils-trivy'
+import { getKyvernoPolicyRuleTypes as _getKyvernoPolicyRuleTypes, getPolicyReportStatus as _getPolicyReportStatus, getKyvernoPolicyStatus as _getKyvernoPolicyStatus } from './resource-utils-kyverno'
 import { getResourceClaimStatus as _getResourceClaimStatus, getResourceClaimDeviceClasses as _getResourceClaimDeviceClasses, getResourceClaimTemplateDeviceClasses as _getResourceClaimTemplateDeviceClasses, getResourceClaimAllocation as _getResourceClaimAllocation, getResourceClaimReservedFor as _getResourceClaimReservedFor } from './resource-utils-dra'
 import { getNvidiaClusterPolicyStatus as _getNvidiaClusterPolicyStatus, getNvidiaClusterPolicyEnabledComponents as _getNvidiaClusterPolicyEnabledComponents, getNvidiaDriverStatus as _getNvidiaDriverStatus } from './resource-utils-nvidia'
 import { getClusterQueueStatus as _getClusterQueueStatus, getLocalQueueStatus as _getLocalQueueStatus, getKueueWorkloadStatus as _getKueueWorkloadStatus, getResourceFlavorStatus as _getResourceFlavorStatus, getAdmissionCheckStatus as _getAdmissionCheckStatus, getProvisioningRequestStatus as _getProvisioningRequestStatus } from './resource-utils-kueue'
@@ -2594,6 +2595,20 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
     case 'mig':
       if (kindLower === 'nvidiaclusterpolicies') return resource.spec?.mig?.strategy || ''
       break
+    // Trivy keeps the scanned image under report.artifact, so the generic
+    // spec/status probe finds nothing and the header would offer a filter
+    // button that never populates.
+    case 'image':
+      if (kindLower === 'vulnerabilityreports' || kindLower === 'sbomreports'
+        || kindLower === 'clustersbomreports' || kindLower === 'exposedsecretreports') {
+        return _getVulnerabilityReportImage(resource)
+      }
+      break
+    case 'ruleTypes':
+      if (kindLower === 'kyvernopolicies' || kindLower === 'clusterpolicies') {
+        return _getKyvernoPolicyRuleTypes(resource)
+      }
+      break
     // The fallback would read spec.timeZone and yield '' for an undeclared
     // zone, so those rows would drop out of a filter the cell shows a value for.
     case 'timeZone':
@@ -2622,6 +2637,7 @@ export {
   getVulnerabilityReportSummary,
   getVulnerabilityReportStatus,
   getVulnerabilityReportImage,
+  getSbomReportImage,
   getVulnerabilityReportContainer,
   getConfigAuditReportSummary,
   getConfigAuditReportStatus,

--- a/packages/k8s-ui/src/components/resources/resources-column-filter.test.ts
+++ b/packages/k8s-ui/src/components/resources/resources-column-filter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { getCellFilterValue } from './resource-utils'
 import { getCellFilterKind, hasCuratedColumns, isColumnFilterableByDistinctCount, normalizeKindToPlural, SKIP_FILTER_COLUMNS } from './ResourcesView'
 
 describe('isColumnFilterableByDistinctCount', () => {
@@ -96,5 +97,24 @@ describe('GPU ecosystem column routing', () => {
     expect(hasCuratedColumns('inferenceobjectives', 'llm-d.ai')).toBe(true)
     expect(hasCuratedColumns('inferenceobjectives', 'inference.networking.x-k8s.io')).toBe(true)
     expect(hasCuratedColumns('inferenceobjectives', 'example.io')).toBe(false)
+  })
+})
+
+describe('filter values for columns whose data sits outside spec/status', () => {
+  // getCellFilterValue's fallback probes status[key]/spec[key]. A column whose
+  // value lives elsewhere needs an explicit case, or the header reserves a
+  // filter button that can never populate.
+  it('reads the scanned image out of the Trivy report', () => {
+    const report = {
+      report: { registry: { server: 'ghcr.io' }, artifact: { repository: 'acme/api', tag: 'v2' } },
+    }
+    for (const kind of ['vulnerabilityreports', 'sbomreports', 'clustersbomreports']) {
+      expect(getCellFilterValue(report, 'image', kind)).toContain('acme/api')
+    }
+  })
+
+  it('reads Kyverno rule types out of the rules array', () => {
+    const policy = { spec: { rules: [{ validate: {} }, { mutate: {} }] } }
+    expect(getCellFilterValue(policy, 'ruleTypes', 'clusterpolicies')).toBe('validate, mutate')
   })
 })


### PR DESCRIPTION
Nine column additions, drawn from the audit's highest-confidence tier and filtered hard. Each one surfaces an accessor the codebase already had, on a table that could not answer its most obvious question without it.

## What was added, and why it earns the space

**Kyverno policy → Types** (`kyvernopolicies`, `clusterpolicies`). The row showed a rule *count*, which says nothing about what the policy does. Types names the rule kinds it declares — validate, mutate, generate, verifyImages — and that is the policy's identity. The count moves behind the column picker rather than being deleted.

**SBOM report → Image** (`sbomreports`, `clustersbomreports`). A report listed a container name, which does not identify the image the SBOM describes. `clustersbomreports` had neither, so its four-column table gave no way to tell what had been scanned.

**Knative Certificate → Expires.** The table listed the Secret but not when the certificate in it expires — the one fact worth scanning a certificate list for. Knative reports it in `status.notAfter`, described upstream as "the expiration time of the TLS certificate stored in the secret named by this resource".

**CAPI MachineDeployment → Up-to-date.** Ready was there; up-to-date was not. The two diverge exactly during the rollout you opened the table to watch.

**Velero BackupRepository → Volume NS.** The table showed the namespace the repository object lives in, not the namespace whose volumes it stores. Those are different, and only the second one tells you what the repository is for.

**Kyverno cleanup policy → Last Run** (`cleanuppolicies`, `clustercleanuppolicies`). A scheduled deletion policy showed its schedule but never whether it had ever fired.

## What was deliberately left out

The audit had 82 column proposals with external evidence. Most need new data plumbing rather than a column definition, and are not here. Of the ten that reuse an existing accessor, two were rejected on the merits:

- **DestinationRule → TLS** duplicates the `tlsMode` column already in that table.
- **VulnerabilityReport → Unknown** adds a fifth severity count beside critical, high, medium and low. Unknown-severity findings are rarely actionable, and a number that does not change a decision is not worth a column.

Several heavier proposals were also skipped rather than half-built: ClusterRole grant categories and ServiceAccount binding counts both need bulk authorized reads to render honestly, and the audit's own note for the latter says a `0` must not be shown before one completes. Those want their own change.

## Implementation

No new logic. Every cell renders an accessor that already existed — `getKyvernoPolicyRuleTypes`, `getMachineDeploymentUpToDate`, `getBackupRepositoryVolumeNamespace`, `getKyvernoLastExecutionTime`, and the shared Trivy artifact reader, aliased as `getSbomReportImage` alongside the existing `getExposedSecretReportImage` alias. Knative's Certificate shares the expiry formatter rather than re-deriving its thresholds in a second place.

## Testing

`make tsc` clean; 2955 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only column definitions, display wiring, and filter/sort helpers with no cluster mutation or auth changes.
> 
> **Overview**
> Adds **nine curated table columns** across several resource kinds so list views answer common questions without opening each row. Kyverno **Policy** and **ClusterPolicy** get a **Types** column (validate/mutate/etc.) and the raw **Rules** count is hidden by default; **CleanupPolicy** / **ClusterCleanupPolicy** get **Last Run**. Trivy **SBOM** reports (namespaced and cluster) get **Image**; Velero **BackupRepository** gets **Volume NS**; CAPI **MachineDeployment** gets **Up-to-date**; Knative **Certificate** gets **Expires** (reusing the shared cert-manager expiry formatter).
> 
> Cell renderers and **`getCellFilterValue`** are extended so **Image** and **ruleTypes** filters work (values live under Trivy `report.artifact` and Kyverno rules, not plain spec/status). Numeric sort for **upToDate** now includes CAPI **`upToDateReplicas`** so sorting matches what the cell shows. Cert-manager **Expires** cells get truncation/title styling; tests cover the new filter paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef624e779d366a9ab4407d21a4d030ec04d3cb68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->