### PR TITLE
Make informer seen/recreate-diff tracking API-group aware

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -686,8 +686,15 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 		return
 	}
 
+	obj := newObj
+	if obj == nil {
+		obj = oldObj
+	}
+	apiVersion := timelineAPIVersion(kind, obj)
+	apiGroup := GroupFromAPIVersion(apiVersion)
+
 	if op == "add" {
-		if store.IsResourceSeen(clusterContext, kind, namespace, name) {
+		if store.IsResourceSeen(clusterContext, apiGroup, kind, namespace, name) {
 			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonAlreadySeen, op, clusterContext)
 			if DebugEvents {
 				log.Printf("[DEBUG] Already seen, skipping: %s/%s/%s", kind, namespace, name)
@@ -695,12 +702,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 			return
 		}
 	} else if op == "delete" {
-		store.ClearResourceSeen(clusterContext, kind, namespace, name)
-	}
-
-	obj := newObj
-	if obj == nil {
-		obj = oldObj
+		store.ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 	}
 
 	resourceVersion := ""
@@ -711,7 +713,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	}
 
 	if op == "delete" {
-		stashDeletedForRecreate(kind, namespace, name, uid, obj)
+		stashDeletedForRecreate(apiGroup, kind, namespace, name, uid, obj)
 	}
 
 	// One extraction of owner/labels/createdAt, reused for both the event and
@@ -722,7 +724,6 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	labels := entry.Labels
 	createdAt := entry.CreatedAt
 	healthState := classifyTimelineHealth(kind, obj, time.Now())
-	apiVersion := extractAPIVersion(obj)
 
 	// Feed the tombstone on every add/update/delete. While the object is live
 	// this mirrors its enrichment; once it is gone (delete, or a late K8s event
@@ -792,7 +793,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	recreated := false
 	if op == "add" && newObj != nil && initialSyncComplete {
 		if meta, ok := newObj.(metav1.Object); ok && time.Since(meta.GetCreationTimestamp().Time) <= 30*time.Second {
-			if stashed, ok := takeRecreateMatch(kind, namespace, name, uid); ok {
+			if stashed, ok := takeRecreateMatch(apiGroup, kind, namespace, name, uid); ok {
 				if localDiff := ComputeDiff(kind, stripStatusForRecreateDiff(stashed), stripStatusForRecreateDiff(newObj)); localDiff != nil && len(localDiff.Fields) > 0 {
 					diff = &timeline.DiffInfo{
 						Fields:  make([]timeline.FieldChange, len(localDiff.Fields)),
@@ -866,7 +867,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 					return
 				}
 			}
-			store.MarkResourceSeen(clusterContext, kind, namespace, name)
+			store.MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 			return
 		}
 	}
@@ -883,7 +884,7 @@ func recordToTimelineStore(clusterContext, kind, namespace, name, uid, op string
 	timeline.IncrementRecorded(kind)
 
 	if op == "add" {
-		store.MarkResourceSeen(clusterContext, kind, namespace, name)
+		store.MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name)
 	}
 }
 
@@ -893,15 +894,33 @@ func isUnstructuredUpdate(oldObj, newObj any) bool {
 	return oldOK && newOK
 }
 
-// extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")
-// for unstructured/CRD objects. Typed informer objects strip kind/apiVersion, so they
-// fall through to "" — the navigation layer treats an empty group as "core/typed kind",
-// which is correct since core kinds don't collide.
+// extractAPIVersion returns the resource's apiVersion (e.g.
+// "cluster.x-k8s.io/v1beta1") for unstructured/CRD objects. Typed informer
+// objects strip kind/apiVersion and are completed by timelineAPIVersion.
 func extractAPIVersion(obj any) string {
 	if u, ok := obj.(*unstructured.Unstructured); ok {
 		return u.GetAPIVersion()
 	}
 	return ""
+}
+
+// timelineAPIVersion returns the exact version written into new informer
+// timeline rows. Dynamic objects already carry their discovered apiVersion and
+// must win even when their Kind shadows a built-in. Typed informer objects have
+// empty TypeMeta, so use the same canonical typed GVR table as resource fetches
+// rather than persisting an identity-ambiguous row.
+func timelineAPIVersion(kind string, obj any) string {
+	if apiVersion := extractAPIVersion(obj); apiVersion != "" {
+		return apiVersion
+	}
+	if _, dynamic := obj.(*unstructured.Unstructured); dynamic {
+		return ""
+	}
+	gvr, ok := lookupTypedBuiltinGVR(kind)
+	if !ok {
+		return ""
+	}
+	return gvr.GroupVersion().String()
 }
 
 // extractTimelineHistoricalEvents extracts historical events from resource metadata/status

--- a/internal/k8s/history_group_dispatch_test.go
+++ b/internal/k8s/history_group_dispatch_test.go
@@ -153,6 +153,55 @@ func TestRecordToTimelineStore_CollidingCRDUpdateSurvives(t *testing.T) {
 	}
 }
 
+func TestRecordToTimelineStore_StampsTypedAPIVersionWithoutOverwritingDynamicIdentity(t *testing.T) {
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	t.Cleanup(timeline.ResetStore)
+
+	typedOld := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "typed", Namespace: "gpu-demo", UID: types.UID("typed-job-uid"), ResourceVersion: "1",
+	}, Status: batchv1.JobStatus{Active: 1}}
+	typedNew := typedOld.DeepCopy()
+	typedNew.ResourceVersion = "2"
+	typedNew.Status.Active = 2
+	recordToTimelineStore(
+		ActiveClusterContext(), "Job", "gpu-demo", "typed", "typed-job-uid", "update",
+		typedOld, typedNew, ComputeDiff("Job", typedOld, typedNew), true,
+	)
+
+	dynamicOld := collisionObject("batch.volcano.sh/v1alpha1", "Job", map[string]any{
+		"status": map[string]any{"state": map[string]any{"phase": "Pending"}},
+	})
+	dynamicNew := dynamicOld.DeepCopy()
+	dynamicNew.SetResourceVersion("2")
+	if err := unstructured.SetNestedField(dynamicNew.Object, "Running", "status", "state", "phase"); err != nil {
+		t.Fatalf("set dynamic phase: %v", err)
+	}
+	recordToTimelineStore(
+		ActiveClusterContext(), "Job", "gpu-demo", "collision-demo", "volcano-job-uid", "update",
+		dynamicOld, dynamicNew, ComputeDiff("Job", dynamicOld, dynamicNew), true,
+	)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Job"}, Namespaces: []string{"gpu-demo"},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	versionsByName := map[string]string{}
+	for _, event := range events {
+		versionsByName[event.Name] = event.APIVersion
+	}
+	if got := versionsByName["typed"]; got != "batch/v1" {
+		t.Fatalf("typed Job apiVersion = %q, want batch/v1", got)
+	}
+	if got := versionsByName["collision-demo"]; got != "batch.volcano.sh/v1alpha1" {
+		t.Fatalf("dynamic Job apiVersion = %q, want batch.volcano.sh/v1alpha1", got)
+	}
+}
+
 func collisionObject(apiVersion, kind string, body map[string]any) *unstructured.Unstructured {
 	object := map[string]any{
 		"apiVersion": apiVersion,

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -183,7 +183,7 @@ func TestRecordToTimelineStore_SyncAddMarksResourceSeen(t *testing.T) {
 	if store == nil {
 		t.Fatal("timeline store is nil")
 	}
-	if !store.IsResourceSeen(ActiveClusterContext(), "Pod", "default", "p") {
+	if !store.IsResourceSeen(ActiveClusterContext(), "", "Pod", "default", "p") {
 		t.Fatal("sync add should mark resource seen after historical event recording")
 	}
 }

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -69,13 +69,13 @@ var (
 	recreateStash   = map[string]recreateEntry{}
 )
 
-func recreateKey(kind, namespace, name string) string {
-	return kind + "/" + namespace + "/" + name
+func recreateKey(apiGroup, kind, namespace, name string) string {
+	return apiGroup + "\x00" + kind + "\x00" + namespace + "\x00" + name
 }
 
 // stashDeletedForRecreate records a deleted object for a potential
 // recreate-join. No-op for kinds outside the allowlist.
-func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
+func stashDeletedForRecreate(apiGroup, kind, namespace, name, uid string, obj any) {
 	if obj == nil || !recreateStashKinds[kind] {
 		return
 	}
@@ -84,7 +84,7 @@ func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
 	if len(recreateStash) >= recreateStashCap {
 		evictRecreateStashLocked()
 	}
-	recreateStash[recreateKey(kind, namespace, name)] = recreateEntry{
+	recreateStash[recreateKey(apiGroup, kind, namespace, name)] = recreateEntry{
 		obj:       obj,
 		uid:       uid,
 		deletedAt: time.Now(),
@@ -94,13 +94,13 @@ func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
 // takeRecreateMatch returns the stashed predecessor of kind/ns/name when the
 // new UID differs and the delete is within the join TTL. The entry is
 // consumed (or discarded, if stale or same-UID) either way.
-func takeRecreateMatch(kind, namespace, name, newUID string) (any, bool) {
+func takeRecreateMatch(apiGroup, kind, namespace, name, newUID string) (any, bool) {
 	if !recreateStashKinds[kind] {
 		return nil, false
 	}
 	recreateStashMu.Lock()
 	defer recreateStashMu.Unlock()
-	key := recreateKey(kind, namespace, name)
+	key := recreateKey(apiGroup, kind, namespace, name)
 	entry, ok := recreateStash[key]
 	if !ok {
 		return nil, false

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -132,13 +132,13 @@ func TestTakeRecreateMatch_TTLExpiry(t *testing.T) {
 	defer resetRecreateStash()
 
 	recreateStashMu.Lock()
-	recreateStash[recreateKey("Deployment", "shop", "web")] = recreateEntry{
+	recreateStash[recreateKey("apps", "Deployment", "shop", "web")] = recreateEntry{
 		obj: testDeployment("uid-1", "nginx:1.0", time.Now()), uid: "uid-1",
 		deletedAt: time.Now().Add(-recreateJoinTTL - time.Minute),
 	}
 	recreateStashMu.Unlock()
 
-	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+	if _, ok := takeRecreateMatch("apps", "Deployment", "shop", "web", "uid-2"); ok {
 		t.Fatal("expired stash entry must not join")
 	}
 	recreateStashMu.Lock()
@@ -153,15 +153,30 @@ func TestRecreateStash_KindGateAndReset(t *testing.T) {
 	resetRecreateStash()
 	defer resetRecreateStash()
 
-	stashDeletedForRecreate("Pod", "shop", "p", "uid-1", &corev1.Pod{})
-	if _, ok := takeRecreateMatch("Pod", "shop", "p", "uid-2"); ok {
+	stashDeletedForRecreate("", "Pod", "shop", "p", "uid-1", &corev1.Pod{})
+	if _, ok := takeRecreateMatch("", "Pod", "shop", "p", "uid-2"); ok {
 		t.Fatal("Pod is outside the stash allowlist")
 	}
 
-	stashDeletedForRecreate("Deployment", "shop", "web", "uid-1", testDeployment("uid-1", "nginx:1.0", time.Now()))
+	stashDeletedForRecreate("apps", "Deployment", "shop", "web", "uid-1", testDeployment("uid-1", "nginx:1.0", time.Now()))
 	resetRecreateStash()
-	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+	if _, ok := takeRecreateMatch("apps", "Deployment", "shop", "web", "uid-2"); ok {
 		t.Fatal("reset must clear the stash")
+	}
+}
+
+func TestRecreateStash_APIGroupScoped(t *testing.T) {
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	old := testDeployment("uid-1", "nginx:1.0", time.Now())
+	stashDeletedForRecreate("apps", "Deployment", "shop", "web", "uid-1", old)
+	if _, ok := takeRecreateMatch("example.io", "Deployment", "shop", "web", "uid-2"); ok {
+		t.Fatal("a same-named resource from another API group must not consume the recreate predecessor")
+	}
+	got, ok := takeRecreateMatch("apps", "Deployment", "shop", "web", "uid-2")
+	if !ok || got != old {
+		t.Fatal("the exact API-group identity should still retrieve its predecessor")
 	}
 }
 
@@ -170,7 +185,7 @@ func TestRecreateStash_CapEviction(t *testing.T) {
 	defer resetRecreateStash()
 
 	for i := 0; i < recreateStashCap+100; i++ {
-		stashDeletedForRecreate("ConfigMap", "shop", fmt.Sprintf("cm-%d", i), fmt.Sprintf("uid-%d", i), &corev1.ConfigMap{})
+		stashDeletedForRecreate("", "ConfigMap", "shop", fmt.Sprintf("cm-%d", i), fmt.Sprintf("uid-%d", i), &corev1.ConfigMap{})
 	}
 	recreateStashMu.Lock()
 	size := len(recreateStash)
@@ -180,7 +195,7 @@ func TestRecreateStash_CapEviction(t *testing.T) {
 	}
 	// The newest entries must have survived eviction — recreates that matter
 	// happen seconds after the delete.
-	if _, ok := takeRecreateMatch("ConfigMap", "shop", fmt.Sprintf("cm-%d", recreateStashCap+99), "other-uid"); !ok {
+	if _, ok := takeRecreateMatch("", "ConfigMap", "shop", fmt.Sprintf("cm-%d", recreateStashCap+99), "other-uid"); !ok {
 		t.Fatal("newest entry was evicted; eviction must drop oldest first")
 	}
 }

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -95,8 +95,8 @@ func CompileFilter(preset *FilterPreset) (*CompiledFilter, error) {
 func ResourceKey(kind, namespace, name string) string {
 	return pkgtimeline.ResourceKey(kind, namespace, name)
 }
-func SeenResourceKey(clusterContext, kind, namespace, name string) string {
-	return pkgtimeline.SeenResourceKey(clusterContext, kind, namespace, name)
+func SeenResourceKey(clusterContext, apiGroup, kind, namespace, name string) string {
+	return pkgtimeline.SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)
 }
 
 // Converter functions.

--- a/internal/timeline/postgres_store.go
+++ b/internal/timeline/postgres_store.go
@@ -502,8 +502,8 @@ func (s *PostgresStore) GetChangesForOwner(ctx context.Context, ownerKind, owner
 }
 
 // MarkResourceSeen records that a resource has been seen.
-func (s *PostgresStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *PostgresStore) MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)
 
 	s.seenMu.Lock()
 	s.seenResources[key] = true
@@ -514,15 +514,15 @@ func (s *PostgresStore) MarkResourceSeen(clusterContext, kind, namespace, name s
 
 // IsResourceSeen checks if a resource has been seen before in the given cluster
 // context.
-func (s *PostgresStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+func (s *PostgresStore) IsResourceSeen(clusterContext, apiGroup, kind, namespace, name string) bool {
 	s.seenMu.RLock()
 	defer s.seenMu.RUnlock()
-	return s.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return s.seenResources[SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set.
-func (s *PostgresStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *PostgresStore) ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)
 
 	s.seenMu.Lock()
 	delete(s.seenResources, key)

--- a/internal/timeline/postgres_store_test.go
+++ b/internal/timeline/postgres_store_test.go
@@ -226,7 +226,7 @@ func TestNewPostgresStoreHydratesNULSeenResourceKey(t *testing.T) {
 		t.Fatalf("first NewPostgresStore: %v", err)
 	}
 
-	key := SeenResourceKey("cluster-a", "Deployment", "default", "api")
+	key := SeenResourceKey("cluster-a", "", "Deployment", "default", "api")
 	if !strings.ContainsRune(key, '\x00') {
 		t.Fatalf("SeenResourceKey %q does not contain NUL", key)
 	}
@@ -915,7 +915,7 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first NewPostgresStore: %v", err)
 	}
-	store1.MarkResourceSeen("ctx1", "Deployment", "default", "web")
+	store1.MarkResourceSeen("ctx1", "", "Deployment", "default", "web")
 	if err := store1.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
@@ -926,12 +926,12 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 	}
 	defer store2.Close()
 
-	if !store2.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	if !store2.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("seen resource was not persisted")
 	}
 
-	store2.ClearResourceSeen("ctx1", "Deployment", "default", "web")
-	if store2.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	store2.ClearResourceSeen("ctx1", "", "Deployment", "default", "web")
+	if store2.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("seen resource was not cleared")
 	}
 
@@ -940,7 +940,7 @@ func TestPostgresStore_SeenResourcesPersist(t *testing.T) {
 		t.Fatalf("third NewPostgresStore: %v", err)
 	}
 	defer store3.Close()
-	if store3.IsResourceSeen("ctx1", "Deployment", "default", "web") {
+	if store3.IsResourceSeen("ctx1", "", "Deployment", "default", "web") {
 		t.Fatal("cleared seen resource reappeared after restart")
 	}
 }
@@ -1205,11 +1205,11 @@ func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 
 	const n = 1200 // more than one batch
 	for i := 0; i < n; i++ {
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i))
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("app-%d", i))
 	}
 	// A mark immediately followed by a clear must not resurrect the row.
-	store.MarkResourceSeen("cluster-a", "Deployment", "default", "transient")
-	store.ClearResourceSeen("cluster-a", "Deployment", "default", "transient")
+	store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "transient")
+	store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "transient")
 
 	// Close drains the queue; nothing here should depend on the flush interval.
 	if err := store.Close(); err != nil {
@@ -1227,14 +1227,14 @@ func TestPostgresStore_SeenWritesPersistAsynchronously(t *testing.T) {
 	})
 
 	for _, i := range []int{0, n / 2, n - 1} {
-		if !reopened.IsResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("app-%d", i)) {
+		if !reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("app-%d", i)) {
 			t.Errorf("app-%d not persisted across restart", i)
 		}
 	}
-	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "transient") {
+	if reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", "transient") {
 		t.Error("cleared resource came back after restart: the clear was applied before its mark")
 	}
-	if reopened.IsResourceSeen("cluster-b", "Deployment", "default", "app-0") {
+	if reopened.IsResourceSeen("cluster-b", "", "Deployment", "default", "app-0") {
 		t.Error("seen state leaked across cluster contexts")
 	}
 }
@@ -1255,12 +1255,12 @@ func TestPostgresStore_ClearSurvivesQueuePressure(t *testing.T) {
 	// Saturate the queue well past its depth, with the key under test marked
 	// part-way through so a queued mark for it is in flight behind the clear.
 	for i := 0; i < seenWriteQueueDepth*3; i++ {
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", fmt.Sprintf("noise-%d", i))
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", fmt.Sprintf("noise-%d", i))
 		if i == seenWriteQueueDepth {
-			store.MarkResourceSeen("cluster-a", "Deployment", "default", "recreated")
+			store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "recreated")
 		}
 	}
-	store.ClearResourceSeen("cluster-a", "Deployment", "default", "recreated")
+	store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "recreated")
 
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -1275,7 +1275,7 @@ func TestPostgresStore_ClearSurvivesQueuePressure(t *testing.T) {
 			t.Errorf("Close reopened: %v", err)
 		}
 	})
-	if reopened.IsResourceSeen("cluster-a", "Deployment", "default", "recreated") {
+	if reopened.IsResourceSeen("cluster-a", "", "Deployment", "default", "recreated") {
 		t.Fatal("clear was lost under queue pressure: the resource is still marked seen after restart")
 	}
 }

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -753,8 +753,8 @@ func (s *SQLiteStore) GetChangesForOwner(ctx context.Context, ownerKind, ownerNa
 // cluster-qualified: this store outlives kubeconfig context switches, so a bare
 // kind/namespace/name would let a same-named resource in another cluster read
 // as already-seen and drop its add.
-func (s *SQLiteStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *SQLiteStore) MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)
 
 	s.seenMu.Lock()
 	s.seenResources[key] = true
@@ -766,15 +766,15 @@ func (s *SQLiteStore) MarkResourceSeen(clusterContext, kind, namespace, name str
 
 // IsResourceSeen checks if a resource has been seen before in the given cluster
 // context.
-func (s *SQLiteStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+func (s *SQLiteStore) IsResourceSeen(clusterContext, apiGroup, kind, namespace, name string) bool {
 	s.seenMu.RLock()
 	defer s.seenMu.RUnlock()
-	return s.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return s.seenResources[SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set
-func (s *SQLiteStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
-	key := SeenResourceKey(clusterContext, kind, namespace, name)
+func (s *SQLiteStore) ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
+	key := SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)
 
 	s.seenMu.Lock()
 	delete(s.seenResources, key)

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -463,23 +463,23 @@ func TestSQLiteStore_ResourceSeen(t *testing.T) {
 	defer cleanup()
 
 	// Initially not seen
-	if store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen initially")
 	}
 
 	// Mark as seen
-	store.MarkResourceSeen("ctx", "Pod", "default", "test-pod")
+	store.MarkResourceSeen("ctx", "", "Pod", "default", "test-pod")
 
 	// Now should be seen
-	if !store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if !store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should be seen after marking")
 	}
 
 	// Clear seen
-	store.ClearResourceSeen("ctx", "Pod", "default", "test-pod")
+	store.ClearResourceSeen("ctx", "", "Pod", "default", "test-pod")
 
 	// Should not be seen again
-	if store.IsResourceSeen("ctx", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("ctx", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen after clearing")
 	}
 }
@@ -675,8 +675,8 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore: %v", err)
 	}
-	store1.MarkResourceSeen("ctx", "Pod", "default", "p1")
-	store1.MarkResourceSeen("ctx", "Deployment", "kube-system", "d1")
+	store1.MarkResourceSeen("ctx", "", "Pod", "default", "p1")
+	store1.MarkResourceSeen("ctx", "apps", "Deployment", "kube-system", "d1")
 	store1.Close()
 
 	store2, err := NewSQLiteStore(dbPath)
@@ -685,13 +685,13 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	}
 	defer store2.Close()
 
-	if !store2.IsResourceSeen("ctx", "Pod", "default", "p1") {
+	if !store2.IsResourceSeen("ctx", "", "Pod", "default", "p1") {
 		t.Error("expected Pod default/p1 to be seen after restart")
 	}
-	if !store2.IsResourceSeen("ctx", "Deployment", "kube-system", "d1") {
+	if !store2.IsResourceSeen("ctx", "apps", "Deployment", "kube-system", "d1") {
 		t.Error("expected Deployment kube-system/d1 to be seen after restart")
 	}
-	if store2.IsResourceSeen("ctx", "Pod", "default", "never-marked") {
+	if store2.IsResourceSeen("ctx", "", "Pod", "default", "never-marked") {
 		t.Error("did not expect unmarked resource to be seen")
 	}
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -641,6 +641,10 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 			if !ok {
 				return
 			}
+			// Callbacks consume the resource object, not client-go's delivery
+			// wrapper. Keeping the wrapper here silently drops dynamic deletes in
+			// Radar's timeline callback even though identity was resolved above.
+			obj = u
 		} else {
 			return
 		}

--- a/pkg/k8score/dynamic_cache_delete_test.go
+++ b/pkg/k8score/dynamic_cache_delete_test.go
@@ -1,0 +1,42 @@
+package k8score
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestDynamicDeleteTombstonePassesUnwrappedObjectToCallbacks(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group: "example.io", Version: "v1", Resource: "widgets",
+	}
+	deleted := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"namespace": "shop",
+			"name":      "checkout",
+			"uid":       "widget-uid",
+		},
+	}}
+
+	var callbackObject any
+	dynamicCache := &DynamicResourceCache{config: DynamicCacheConfig{
+		OnChange: func(_ ResourceChange, obj, _ any) {
+			callbackObject = obj
+		},
+	}}
+	dynamicCache.enqueueDynamicChange(
+		"Widget",
+		gvr,
+		cache.DeletedFinalStateUnknown{Key: "shop/checkout", Obj: deleted},
+		nil,
+		OpDelete,
+	)
+
+	if callbackObject != deleted {
+		t.Fatalf("OnChange object = %T %p, want unwrapped object %p", callbackObject, callbackObject, deleted)
+	}
+}

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -311,24 +311,24 @@ func (m *MemoryStore) GetChangesForOwner(ctx context.Context, ownerKind, ownerNa
 }
 
 // MarkResourceSeen records that a resource has been seen
-func (m *MemoryStore) MarkResourceSeen(clusterContext, kind, namespace, name string) {
+func (m *MemoryStore) MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
 	m.seenMu.Lock()
 	defer m.seenMu.Unlock()
-	m.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)] = true
+	m.seenResources[SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)] = true
 }
 
 // IsResourceSeen checks if a resource has been seen before
-func (m *MemoryStore) IsResourceSeen(clusterContext, kind, namespace, name string) bool {
+func (m *MemoryStore) IsResourceSeen(clusterContext, apiGroup, kind, namespace, name string) bool {
 	m.seenMu.RLock()
 	defer m.seenMu.RUnlock()
-	return m.seenResources[SeenResourceKey(clusterContext, kind, namespace, name)]
+	return m.seenResources[SeenResourceKey(clusterContext, apiGroup, kind, namespace, name)]
 }
 
 // ClearResourceSeen removes a resource from the seen set
-func (m *MemoryStore) ClearResourceSeen(clusterContext, kind, namespace, name string) {
+func (m *MemoryStore) ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name string) {
 	m.seenMu.Lock()
 	defer m.seenMu.Unlock()
-	delete(m.seenResources, SeenResourceKey(clusterContext, kind, namespace, name))
+	delete(m.seenResources, SeenResourceKey(clusterContext, apiGroup, kind, namespace, name))
 }
 
 // Stats returns storage statistics

--- a/pkg/timeline/memory_store_test.go
+++ b/pkg/timeline/memory_store_test.go
@@ -267,23 +267,23 @@ func TestMemoryStore_ResourceSeen(t *testing.T) {
 	store := NewMemoryStore(100)
 
 	// Initially not seen
-	if store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen initially")
 	}
 
 	// Mark as seen
-	store.MarkResourceSeen("cluster-a", "Pod", "default", "test-pod")
+	store.MarkResourceSeen("cluster-a", "", "Pod", "default", "test-pod")
 
 	// Now should be seen
-	if !store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if !store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should be seen after marking")
 	}
 
 	// Clear seen
-	store.ClearResourceSeen("cluster-a", "Pod", "default", "test-pod")
+	store.ClearResourceSeen("cluster-a", "", "Pod", "default", "test-pod")
 
 	// Should not be seen again
-	if store.IsResourceSeen("cluster-a", "Pod", "default", "test-pod") {
+	if store.IsResourceSeen("cluster-a", "", "Pod", "default", "test-pod") {
 		t.Error("Resource should not be seen after clearing")
 	}
 }
@@ -294,13 +294,30 @@ func TestMemoryStore_ResourceSeen(t *testing.T) {
 func TestMemoryStore_ResourceSeen_ClusterScoped(t *testing.T) {
 	store := NewMemoryStore(100)
 
-	store.MarkResourceSeen("cluster-a", "Deployment", "team-a", "web")
+	store.MarkResourceSeen("cluster-a", "apps", "Deployment", "team-a", "web")
 
-	if !store.IsResourceSeen("cluster-a", "Deployment", "team-a", "web") {
+	if !store.IsResourceSeen("cluster-a", "apps", "Deployment", "team-a", "web") {
 		t.Error("cluster-a/web should be seen after marking")
 	}
-	if store.IsResourceSeen("cluster-b", "Deployment", "team-a", "web") {
+	if store.IsResourceSeen("cluster-b", "apps", "Deployment", "team-a", "web") {
 		t.Error("cluster-b/web must NOT be suppressed by cluster-a's seen entry")
+	}
+}
+
+// API group is part of Kubernetes resource identity. A CRD can legitimately
+// reuse a built-in kind/name, and its add/delete lifecycle must not suppress or
+// clear the built-in resource's seen marker.
+func TestMemoryStore_ResourceSeen_APIGroupScoped(t *testing.T) {
+	store := NewMemoryStore(100)
+
+	store.MarkResourceSeen("cluster-a", "", "Service", "shop", "api")
+	if store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("Knative Service must not inherit the core Service seen marker")
+	}
+	store.MarkResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api")
+	store.ClearResourceSeen("cluster-a", "", "Service", "shop", "api")
+	if !store.IsResourceSeen("cluster-a", "serving.knative.dev", "Service", "shop", "api") {
+		t.Fatal("clearing the core Service must not clear the Knative Service marker")
 	}
 }
 

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -37,18 +37,18 @@ type EventStore interface {
 	// store, so current-cluster callers must pass it.
 	GetChangesForOwner(ctx context.Context, ownerKind, ownerNamespace, ownerName, clusterContext string, since time.Time, limit int) ([]TimelineEvent, error)
 
-	// MarkResourceSeen records that a resource has been seen (for dedup on
-	// restart). clusterContext scopes the key — the store outlives kubeconfig
-	// context switches, so a same-named resource in another cluster must not
-	// read as already-seen.
-	MarkResourceSeen(clusterContext, kind, namespace, name string)
+	// MarkResourceSeen records that an exact resource identity has been seen (for
+	// dedup on restart). clusterContext and apiGroup are both part of the key: the
+	// store outlives kubeconfig context switches, and Kubernetes kinds may collide
+	// across API groups.
+	MarkResourceSeen(clusterContext, apiGroup, kind, namespace, name string)
 
 	// IsResourceSeen checks if a resource has been seen before in the given
 	// cluster context.
-	IsResourceSeen(clusterContext, kind, namespace, name string) bool
+	IsResourceSeen(clusterContext, apiGroup, kind, namespace, name string) bool
 
 	// ClearResourceSeen removes a resource from the seen set (on delete)
-	ClearResourceSeen(clusterContext, kind, namespace, name string)
+	ClearResourceSeen(clusterContext, apiGroup, kind, namespace, name string)
 
 	// Stats returns storage statistics
 	Stats() StoreStats
@@ -259,12 +259,11 @@ func ResourceKey(kind, namespace, name string) string {
 	return kind + "/" + namespace + "/" + name
 }
 
-// SeenResourceKey qualifies the seen-tracking key with the cluster context.
-// The NUL separator can't appear in a kubeconfig context name, so it can't
-// collide with the resource portion. Rows written before this qualification
-// (bare kind/namespace/name) simply never match, which is correct: their
-// cluster is unknowable, so the resource is re-extracted once per cluster
-// after upgrade rather than being wrongly suppressed.
-func SeenResourceKey(clusterContext, kind, namespace, name string) string {
-	return clusterContext + "\x00" + ResourceKey(kind, namespace, name)
+// SeenResourceKey qualifies the seen-tracking key with cluster context and API
+// group. NUL cannot appear in either Kubernetes API groups or kubeconfig context
+// names, so the fields cannot collide. Older keys lack one or both qualifiers
+// and deliberately never match: their exact identity is unknowable, so the
+// resource is re-extracted once after upgrade rather than wrongly suppressed.
+func SeenResourceKey(clusterContext, apiGroup, kind, namespace, name string) string {
+	return clusterContext + "\x00" + apiGroup + "\x00" + ResourceKey(kind, namespace, name)
 }

--- a/pkg/timeline/storetest/conformance.go
+++ b/pkg/timeline/storetest/conformance.go
@@ -678,18 +678,18 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) timeline.EventStor
 	// two clusters is two distinct sightings.
 	t.Run("seen resources are tracked per cluster and can be cleared", func(t *testing.T) {
 		store := newStore(t)
-		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		if store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource reported seen before it was marked")
 		}
-		store.MarkResourceSeen("cluster-a", "Deployment", "default", "api")
-		if !store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		store.MarkResourceSeen("cluster-a", "", "Deployment", "default", "api")
+		if !store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource not reported seen after MarkResourceSeen")
 		}
-		if store.IsResourceSeen("cluster-b", "Deployment", "default", "api") {
+		if store.IsResourceSeen("cluster-b", "", "Deployment", "default", "api") {
 			t.Fatal("seen state leaked across cluster contexts")
 		}
-		store.ClearResourceSeen("cluster-a", "Deployment", "default", "api")
-		if store.IsResourceSeen("cluster-a", "Deployment", "default", "api") {
+		store.ClearResourceSeen("cluster-a", "", "Deployment", "default", "api")
+		if store.IsResourceSeen("cluster-a", "", "Deployment", "default", "api") {
 			t.Fatal("resource still reported seen after ClearResourceSeen")
 		}
 	})


### PR DESCRIPTION
## Summary

Radar's shared informer cache tracks "have I already recorded this resource" and matches delete→recreate pairs (for a clean recreate diff) using a key of just `(cluster, kind, namespace, name)` — no API group. A CRD that shares a Kind name with a built-in or another CRD (e.g. a Volcano/Kueue-style `Job` outside the core `batch` group) can therefore have its seen-state or recreate-diff confused with an unrelated resource of the same name. Separately, a dynamic resource's delete event could reach Radar's timeline callback still wrapped in client-go's `DeletedFinalStateUnknown` tombstone instead of the actual object, silently dropping that delete from the timeline.

## What changed

- **Group-aware seen/recreate tracking.** The resource's API group is now part of the seen-tracking key. `EventStore.MarkResourceSeen` / `IsResourceSeen` / `ClearResourceSeen` (and the underlying `SeenResourceKey`) gain an `apiGroup` parameter, implemented consistently across all three store backends (in-memory, SQLite, Postgres). `internal/k8s/cache.go` resolves the exact `apiVersion` for both dynamic (unstructured) and typed informer objects — via a new `timelineAPIVersion` helper — before recording, so the group is always known at the point of use.
- **Fixed a dynamic-delete tombstone bug.** `pkg/k8score/dynamic_cache.go`'s `enqueueDynamicChange` was passing client-go's `DeletedFinalStateUnknown` wrapper straight to `OnChange` callbacks instead of unwrapping it, even though it had already resolved the real object's identity. Callbacks (including the timeline recorder) expect the resource object itself.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — both Go modules (`.` and `pkg/`), full pass
- `gofmt -l` on all changed files — clean