### PR TITLE
Move 116 hand-rolled badge colours onto the theme classes

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/AWSManagedControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSManagedControlPlaneRenderer.tsx
@@ -145,9 +145,9 @@ export function AWSManagedControlPlaneRenderer({ data }: Props) {
                   <td className="py-1 text-theme-text-secondary font-mono text-[10px]">{a.statusVersion !== '-' ? a.statusVersion : a.specVersion}</td>
                   <td className="py-1">
                     <span className={`badge badge-sm ${a.status === 'ACTIVE'
-                      ? 'status-healthy'
+                      ? 'status-green'
                       : a.status === 'DEGRADED'
-                      ? 'status-unhealthy'
+                      ? 'status-red'
                       : 'status-neutral'
                     }`}>{a.status}</span>
                   </td>

--- a/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
@@ -92,9 +92,9 @@ export function AlertRenderer({ data }: AlertRendererProps) {
             value={
               <span className={clsx(
                 'badge',
-                eventSeverity === 'error' ? 'bg-red-500/20 text-red-400' :
-                eventSeverity === 'warning' ? 'bg-yellow-500/20 text-yellow-400' :
-                'bg-blue-500/20 text-blue-400'
+                eventSeverity === 'error' ? 'status-unhealthy' :
+                eventSeverity === 'warning' ? 'status-degraded' :
+                'status-blue'
               )}>
                 {eventSeverity}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AlertRenderer.tsx
@@ -92,8 +92,8 @@ export function AlertRenderer({ data }: AlertRendererProps) {
             value={
               <span className={clsx(
                 'badge',
-                eventSeverity === 'error' ? 'status-unhealthy' :
-                eventSeverity === 'warning' ? 'status-degraded' :
+                eventSeverity === 'error' ? 'status-red' :
+                eventSeverity === 'warning' ? 'status-amber' :
                 'status-blue'
               )}>
                 {eventSeverity}

--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -178,7 +178,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <button
                 onClick={() => onTerminate({ namespace, name })}
                 disabled={isTerminating}
-                className="flex items-center gap-1.5 px-2 py-1 rounded text-xs bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors disabled:opacity-50"
+                className="flex items-center gap-1.5 px-2 py-1 rounded text-xs status-unhealthy hover:opacity-80 transition-colors disabled:opacity-50"
                 title="Terminate sync"
               >
                 <XCircle className="w-3.5 h-3.5" />
@@ -237,7 +237,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <span
                 className={clsx(
                   'badge',
-                  syncPolicy.automated ? 'bg-green-500/20 text-green-400' : BADGE_INACTIVE
+                  syncPolicy.automated ? 'status-healthy' : BADGE_INACTIVE
                 )}
               >
                 {syncPolicy.automated ? 'Enabled' : 'Disabled'}
@@ -281,11 +281,11 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
                   className={clsx(
                     'badge',
                     operationState.phase === 'Succeeded'
-                      ? 'bg-green-500/20 text-green-400'
+                      ? 'status-healthy'
                       : operationState.phase === 'Running'
-                      ? 'bg-blue-500/20 text-blue-400'
+                      ? 'status-blue'
                       : operationState.phase === 'Failed' || operationState.phase === 'Error'
-                      ? 'bg-red-500/20 text-red-400'
+                      ? 'status-unhealthy'
                       : BADGE_INACTIVE
                   )}
                 >

--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -178,7 +178,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <button
                 onClick={() => onTerminate({ namespace, name })}
                 disabled={isTerminating}
-                className="flex items-center gap-1.5 px-2 py-1 rounded text-xs status-unhealthy hover:opacity-80 transition-colors disabled:opacity-50"
+                className="flex items-center gap-1.5 px-2 py-1 rounded text-xs status-red hover:opacity-80 transition-colors disabled:opacity-50"
                 title="Terminate sync"
               >
                 <XCircle className="w-3.5 h-3.5" />
@@ -237,7 +237,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <span
                 className={clsx(
                   'badge',
-                  syncPolicy.automated ? 'status-healthy' : BADGE_INACTIVE
+                  syncPolicy.automated ? 'status-green' : BADGE_INACTIVE
                 )}
               >
                 {syncPolicy.automated ? 'Enabled' : 'Disabled'}
@@ -281,11 +281,11 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
                   className={clsx(
                     'badge',
                     operationState.phase === 'Succeeded'
-                      ? 'status-healthy'
+                      ? 'status-green'
                       : operationState.phase === 'Running'
                       ? 'status-blue'
                       : operationState.phase === 'Failed' || operationState.phase === 'Error'
-                      ? 'status-unhealthy'
+                      ? 'status-red'
                       : BADGE_INACTIVE
                   )}
                 >

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -287,7 +287,7 @@ export function CNPGClusterRenderer({ data, onNavigate, declared}: CNPGClusterRe
           )}
           {data.spec?.enableSuperuserAccess !== undefined && (
             <Property label="Superuser Access" value={
-              <span className={`badge-sm ${data.spec.enableSuperuserAccess ? 'bg-green-500/20 text-green-400' : 'bg-theme-hover text-theme-text-secondary'}`}>
+              <span className={`badge-sm ${data.spec.enableSuperuserAccess ? 'status-healthy' : 'bg-theme-hover text-theme-text-secondary'}`}>
                 {data.spec.enableSuperuserAccess ? 'Enabled' : 'Disabled'}
               </span>
             } />

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -287,7 +287,7 @@ export function CNPGClusterRenderer({ data, onNavigate, declared}: CNPGClusterRe
           )}
           {data.spec?.enableSuperuserAccess !== undefined && (
             <Property label="Superuser Access" value={
-              <span className={`badge-sm ${data.spec.enableSuperuserAccess ? 'status-healthy' : 'bg-theme-hover text-theme-text-secondary'}`}>
+              <span className={`badge-sm ${data.spec.enableSuperuserAccess ? 'status-green' : 'bg-theme-hover text-theme-text-secondary'}`}>
                 {data.spec.enableSuperuserAccess ? 'Enabled' : 'Disabled'}
               </span>
             } />

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
@@ -120,8 +120,8 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
                 <span className={clsx(
                   'badge',
                   isReady
-                    ? 'status-healthy'
-                    : 'status-unhealthy'
+                    ? 'status-green'
+                    : 'status-red'
                 )}>
                   {isReady ? 'Ready' : 'Not Ready'}
                 </span>

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
@@ -120,13 +120,13 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
                 <span className={clsx(
                   'badge',
                   isReady
-                    ? 'bg-green-500/20 text-green-400'
-                    : 'bg-red-500/20 text-red-400'
+                    ? 'status-healthy'
+                    : 'status-unhealthy'
                 )}>
                   {isReady ? 'Ready' : 'Not Ready'}
                 </span>
                 {spec.isCA && (
-                  <span className="badge bg-purple-500/20 text-purple-400">
+                  <span className="badge status-purple">
                     CA Certificate
                   </span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
@@ -54,8 +54,8 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
               <span className={clsx(
                 'badge',
                 isReady
-                  ? 'status-healthy'
-                  : 'status-unhealthy'
+                  ? 'status-green'
+                  : 'status-red'
               )}>
                 {isReady ? 'Ready' : 'Not Ready'}
               </span>
@@ -67,10 +67,10 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
               <span className={clsx(
                 'badge',
                 isApproved
-                  ? 'status-healthy'
+                  ? 'status-green'
                   : isDenied
-                    ? 'status-unhealthy'
-                    : 'status-degraded'
+                    ? 'status-red'
+                    : 'status-amber'
               )}>
                 {isApproved ? 'Yes' : isDenied ? 'No' : 'Pending'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRequestRenderer.tsx
@@ -54,8 +54,8 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
               <span className={clsx(
                 'badge',
                 isReady
-                  ? 'bg-green-500/20 text-green-400'
-                  : 'bg-red-500/20 text-red-400'
+                  ? 'status-healthy'
+                  : 'status-unhealthy'
               )}>
                 {isReady ? 'Ready' : 'Not Ready'}
               </span>
@@ -67,10 +67,10 @@ export function CertificateRequestRenderer({ data }: CertificateRequestRendererP
               <span className={clsx(
                 'badge',
                 isApproved
-                  ? 'bg-green-500/20 text-green-400'
+                  ? 'status-healthy'
                   : isDenied
-                    ? 'bg-red-500/20 text-red-400'
-                    : 'bg-yellow-500/20 text-yellow-400'
+                    ? 'status-unhealthy'
+                    : 'status-degraded'
               )}>
                 {isApproved ? 'Yes' : isDenied ? 'No' : 'Pending'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -7,19 +7,19 @@ import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 function getChallengeStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
     case 'valid':
-      return { text: 'Valid', color: 'status-healthy' }
+      return { text: 'Valid', color: 'status-green' }
     case 'ready':
       return { text: 'Ready', color: 'status-blue' }
     case 'pending':
-      return { text: 'Pending', color: 'status-degraded' }
+      return { text: 'Pending', color: 'status-amber' }
     case 'processing':
-      return { text: 'Processing', color: 'status-degraded' }
+      return { text: 'Processing', color: 'status-amber' }
     case 'invalid':
-      return { text: 'Invalid', color: 'status-unhealthy' }
+      return { text: 'Invalid', color: 'status-red' }
     case 'expired':
-      return { text: 'Expired', color: 'status-unhealthy' }
+      return { text: 'Expired', color: 'status-red' }
     case 'errored':
-      return { text: 'Errored', color: 'status-unhealthy' }
+      return { text: 'Errored', color: 'status-red' }
     default:
       return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -7,19 +7,19 @@ import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 function getChallengeStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
     case 'valid':
-      return { text: 'Valid', color: 'bg-green-500/20 text-green-400' }
+      return { text: 'Valid', color: 'status-healthy' }
     case 'ready':
-      return { text: 'Ready', color: 'bg-blue-500/20 text-blue-400' }
+      return { text: 'Ready', color: 'status-blue' }
     case 'pending':
-      return { text: 'Pending', color: 'bg-yellow-500/20 text-yellow-400' }
+      return { text: 'Pending', color: 'status-degraded' }
     case 'processing':
-      return { text: 'Processing', color: 'bg-yellow-500/20 text-yellow-400' }
+      return { text: 'Processing', color: 'status-degraded' }
     case 'invalid':
-      return { text: 'Invalid', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Invalid', color: 'status-unhealthy' }
     case 'expired':
-      return { text: 'Expired', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Expired', color: 'status-unhealthy' }
     case 'errored':
-      return { text: 'Errored', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Errored', color: 'status-unhealthy' }
     default:
       return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }
@@ -78,7 +78,7 @@ export function ChallengeRenderer({ data }: { data: any }) {
                   {challengeType}
                 </span>
                 {spec.wildcard && (
-                  <span className="badge bg-purple-500/20 text-purple-400">
+                  <span className="badge status-purple">
                     Wildcard
                   </span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
@@ -144,7 +144,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">From Entities</div>
           <div className="flex flex-wrap gap-1">
             {fromEntities.map((e, j) => (
-              <span key={j} className="badge bg-purple-500/20 text-purple-400 border-purple-500/30">{e}</span>
+              <span key={j} className="badge status-purple">{e}</span>
             ))}
           </div>
         </div>
@@ -215,7 +215,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">To Entities</div>
           <div className="flex flex-wrap gap-1">
             {toEntities.map((e, j) => (
-              <span key={j} className="badge bg-purple-500/20 text-purple-400 border-purple-500/30">{e}</span>
+              <span key={j} className="badge status-purple">{e}</span>
             ))}
           </div>
         </div>
@@ -365,7 +365,7 @@ function L7Rules({ rules, ports }: { rules: any; ports?: any[] }) {
             {httpRules.map((r: any, i: number) => (
               <div key={i} className="flex flex-wrap items-center gap-1">
                 {r.method && (
-                  <span className="badge badge-sm bg-blue-500/20 text-blue-400 border-blue-500/30">
+                  <span className="badge badge-sm status-blue">
                     {r.method}
                   </span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
@@ -81,8 +81,8 @@ function IssuerRendererBase({ data, kind }: { data: any; kind: string }) {
               <span className={clsx(
                 'badge',
                 isReady
-                  ? 'bg-green-500/20 text-green-400'
-                  : 'bg-red-500/20 text-red-400'
+                  ? 'status-healthy'
+                  : 'status-unhealthy'
               )}>
                 {isReady ? 'Ready' : 'Not Ready'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
@@ -81,8 +81,8 @@ function IssuerRendererBase({ data, kind }: { data: any; kind: string }) {
               <span className={clsx(
                 'badge',
                 isReady
-                  ? 'status-healthy'
-                  : 'status-unhealthy'
+                  ? 'status-green'
+                  : 'status-red'
               )}>
                 {isReady ? 'Ready' : 'Not Ready'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
@@ -76,10 +76,10 @@ function AdminRuleCard({ rule, direction }: { rule: any; direction: 'from' | 'to
   const ports: any[] = rule.ports || []
 
   const actionColor = action === 'Deny'
-    ? 'status-unhealthy'
+    ? 'status-red'
     : action === 'Pass'
-      ? 'status-degraded'
-      : 'status-healthy'
+      ? 'status-amber'
+      : 'status-green'
 
   return (
     <div className="card-inner-lg">

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
@@ -76,10 +76,10 @@ function AdminRuleCard({ rule, direction }: { rule: any; direction: 'from' | 'to
   const ports: any[] = rule.ports || []
 
   const actionColor = action === 'Deny'
-    ? 'bg-red-500/20 text-red-400 border-red-500/30'
+    ? 'status-unhealthy'
     : action === 'Pass'
-      ? 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
-      : 'bg-green-500/20 text-green-400 border-green-500/30'
+      ? 'status-degraded'
+      : 'status-healthy'
 
   return (
     <div className="card-inner-lg">

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
@@ -131,9 +131,9 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                       <span className={clsx(
                         'w-4 h-4 rounded-full flex items-center justify-center text-xs shrink-0',
                         isListenerAccepted
-                          ? 'bg-green-500/20 text-green-400'
+                          ? 'status-healthy'
                           : isListenerNotAccepted
-                            ? 'bg-red-500/20 text-red-400'
+                            ? 'status-unhealthy'
                             : BADGE_INACTIVE
                       )}>
                         {isListenerAccepted ? '\u2713' : isListenerNotAccepted ? '\u2717' : '?'}

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
@@ -131,9 +131,9 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                       <span className={clsx(
                         'w-4 h-4 rounded-full flex items-center justify-center text-xs shrink-0',
                         isListenerAccepted
-                          ? 'status-healthy'
+                          ? 'status-green'
                           : isListenerNotAccepted
-                            ? 'status-unhealthy'
+                            ? 'status-red'
                             : BADGE_INACTIVE
                       )}>
                         {isListenerAccepted ? '\u2713' : isListenerNotAccepted ? '\u2717' : '?'}

--- a/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
@@ -364,7 +364,7 @@ function GenericConditionsSection({ conditions }: { conditions: any[] }) {
                   <span className="text-theme-text-primary font-medium">{cond.type}</span>
                   <span className={clsx(
                     'badge-sm',
-                    isTrue ? 'bg-theme-elevated text-theme-text-secondary' : 'status-unhealthy'
+                    isTrue ? 'bg-theme-elevated text-theme-text-secondary' : 'status-red'
                   )}>
                     {cond.status}
                   </span>

--- a/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
@@ -364,7 +364,7 @@ function GenericConditionsSection({ conditions }: { conditions: any[] }) {
                   <span className="text-theme-text-primary font-medium">{cond.type}</span>
                   <span className={clsx(
                     'badge-sm',
-                    isTrue ? 'bg-theme-elevated text-theme-text-secondary' : 'bg-red-500/20 text-red-400'
+                    isTrue ? 'bg-theme-elevated text-theme-text-secondary' : 'status-unhealthy'
                   )}>
                     {cond.status}
                   </span>

--- a/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
@@ -24,7 +24,7 @@ export function IngressClassRenderer({ data }: IngressClassRendererProps) {
               <span className={clsx(
                 'badge',
                 isDefault
-                  ? 'status-healthy'
+                  ? 'status-green'
                   : BADGE_INACTIVE
               )}>
                 {isDefault ? 'Yes' : 'No'}

--- a/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
@@ -24,7 +24,7 @@ export function IngressClassRenderer({ data }: IngressClassRendererProps) {
               <span className={clsx(
                 'badge',
                 isDefault
-                  ? 'bg-green-500/20 text-green-400'
+                  ? 'status-healthy'
                   : BADGE_INACTIVE
               )}>
                 {isDefault ? 'Yes' : 'No'}

--- a/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
@@ -9,9 +9,9 @@ import {
 import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const modeColors: Record<string, string> = {
-  STRICT: 'bg-green-500/20 text-green-400',
-  PERMISSIVE: 'bg-yellow-500/20 text-yellow-400',
-  DISABLE: 'bg-red-500/20 text-red-400',
+  STRICT: 'status-healthy',
+  PERMISSIVE: 'status-degraded',
+  DISABLE: 'status-unhealthy',
   UNSET: BADGE_INACTIVE,
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
@@ -9,9 +9,9 @@ import {
 import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const modeColors: Record<string, string> = {
-  STRICT: 'status-healthy',
-  PERMISSIVE: 'status-degraded',
-  DISABLE: 'status-unhealthy',
+  STRICT: 'status-green',
+  PERMISSIVE: 'status-amber',
+  DISABLE: 'status-red',
   UNSET: BADGE_INACTIVE,
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/IstioServiceEntryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioServiceEntryRenderer.tsx
@@ -47,8 +47,8 @@ export function IstioServiceEntryRenderer({ data }: IstioServiceEntryRendererPro
             <span className={clsx(
               'badge',
               location === 'MESH_EXTERNAL'
-                ? 'bg-orange-500/20 text-orange-400'
-                : 'bg-blue-500/20 text-blue-400'
+                ? 'status-orange'
+                : 'status-blue'
             )}>
               {location}
             </span>

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -186,9 +186,9 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
                 <span
                   className={clsx(
                     'w-5 h-5 rounded-full flex items-center justify-center text-xs shrink-0',
-                    isComplete && 'status-healthy',
+                    isComplete && 'status-green',
                     isCurrent && 'status-blue',
-                    isFailed && 'status-unhealthy',
+                    isFailed && 'status-red',
                     isPending && !isCurrent && BADGE_INACTIVE
                   )}
                 >

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -186,9 +186,9 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
                 <span
                   className={clsx(
                     'w-5 h-5 rounded-full flex items-center justify-center text-xs shrink-0',
-                    isComplete && 'bg-green-500/20 text-green-400',
-                    isCurrent && 'bg-blue-500/20 text-blue-400',
-                    isFailed && 'bg-red-500/20 text-red-400',
+                    isComplete && 'status-healthy',
+                    isCurrent && 'status-blue',
+                    isFailed && 'status-unhealthy',
                     isPending && !isCurrent && BADGE_INACTIVE
                   )}
                 >

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeEventingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeEventingRenderer.tsx
@@ -193,10 +193,10 @@ export function ChannelRenderer({ data }: RendererProps) {
               <div key={i} className="text-sm text-theme-text-secondary">
                 {sub.subscriberURI || sub.replyURI || `Subscriber ${i + 1}`}
                 {sub.ready === 'True' && (
-                  <span className="ml-2 px-1.5 py-0.5 bg-green-500/20 text-green-400 rounded text-[10px]">ready</span>
+                  <span className="ml-2 px-1.5 py-0.5 status-healthy rounded text-[10px]">ready</span>
                 )}
                 {sub.ready === 'False' && (
-                  <span className="ml-2 px-1.5 py-0.5 bg-red-500/20 text-red-400 rounded text-[10px]">not ready</span>
+                  <span className="ml-2 px-1.5 py-0.5 status-unhealthy rounded text-[10px]">not ready</span>
                 )}
               </div>
             ))}

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeEventingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeEventingRenderer.tsx
@@ -193,10 +193,10 @@ export function ChannelRenderer({ data }: RendererProps) {
               <div key={i} className="text-sm text-theme-text-secondary">
                 {sub.subscriberURI || sub.replyURI || `Subscriber ${i + 1}`}
                 {sub.ready === 'True' && (
-                  <span className="ml-2 px-1.5 py-0.5 status-healthy rounded text-[10px]">ready</span>
+                  <span className="ml-2 px-1.5 py-0.5 status-green rounded text-[10px]">ready</span>
                 )}
                 {sub.ready === 'False' && (
-                  <span className="ml-2 px-1.5 py-0.5 status-unhealthy rounded text-[10px]">not ready</span>
+                  <span className="ml-2 px-1.5 py-0.5 status-red rounded text-[10px]">not ready</span>
                 )}
               </div>
             ))}

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
@@ -44,7 +44,7 @@ export function KnativeRevisionRenderer({ data }: KnativeRevisionRendererProps) 
           {routingState && <Property label="Routing" value={
             <span className={clsx(
               'badge',
-              routingState === 'active' ? 'bg-green-500/20 text-green-400' : 'bg-theme-hover text-theme-text-secondary'
+              routingState === 'active' ? 'status-healthy' : 'bg-theme-hover text-theme-text-secondary'
             )}>
               {routingState}
             </span>

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
@@ -44,7 +44,7 @@ export function KnativeRevisionRenderer({ data }: KnativeRevisionRendererProps) 
           {routingState && <Property label="Routing" value={
             <span className={clsx(
               'badge',
-              routingState === 'active' ? 'status-healthy' : 'bg-theme-hover text-theme-text-secondary'
+              routingState === 'active' ? 'status-green' : 'bg-theme-hover text-theme-text-secondary'
             )}>
               {routingState}
             </span>

--- a/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
@@ -27,18 +27,18 @@ interface PolicyReportRendererProps {
 }
 
 const resultColorMap: Record<string, string> = {
-  pass: 'bg-green-500/20 text-green-400',
-  fail: 'bg-red-500/20 text-red-400',
-  warn: 'bg-yellow-500/20 text-yellow-400',
-  error: 'bg-red-500/20 text-red-400',
-  skip: 'bg-blue-500/20 text-blue-400',
+  pass: 'status-healthy',
+  fail: 'status-unhealthy',
+  warn: 'status-degraded',
+  error: 'status-unhealthy',
+  skip: 'status-blue',
 }
 
 const severityColorMap: Record<string, string> = {
-  critical: 'bg-red-500/20 text-red-400',
-  high: 'bg-orange-500/20 text-orange-400',
-  medium: 'bg-yellow-500/20 text-yellow-400',
-  low: 'bg-blue-500/20 text-blue-400',
+  critical: 'status-unhealthy',
+  high: 'status-orange',
+  medium: 'status-degraded',
+  low: 'status-blue',
   info: 'bg-theme-hover text-theme-text-tertiary',
 }
 
@@ -237,10 +237,10 @@ interface KyvernoPolicyRendererProps {
 }
 
 const ruleTypeColorMap: Record<string, string> = {
-  validate: 'bg-blue-500/20 text-blue-400',
-  mutate: 'bg-purple-500/20 text-purple-400',
-  generate: 'bg-green-500/20 text-green-400',
-  verifyImages: 'bg-orange-500/20 text-orange-400',
+  validate: 'status-blue',
+  mutate: 'status-purple',
+  generate: 'status-healthy',
+  verifyImages: 'status-orange',
 }
 
 export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyRendererProps) {
@@ -273,10 +273,10 @@ export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyR
             <span className={clsx(
               'badge',
               enforcement.blocks
-                ? 'bg-red-500/20 text-red-400'
+                ? 'status-unhealthy'
                 : enforcement.discrepancy
-                  ? 'bg-orange-500/20 text-orange-400'
-                  : 'bg-yellow-500/20 text-yellow-400',
+                  ? 'status-orange'
+                  : 'status-degraded',
             )}>
               {enforcement.label}
             </span>
@@ -298,22 +298,22 @@ export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyR
         {/* Rule count summary */}
         <div className="mt-3 flex flex-wrap gap-2">
           {ruleCountByType.validate > 0 && (
-            <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400">
+            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-blue">
               {ruleCountByType.validate} validate
             </span>
           )}
           {ruleCountByType.mutate > 0 && (
-            <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-purple-500/20 text-purple-400">
+            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-purple">
               {ruleCountByType.mutate} mutate
             </span>
           )}
           {ruleCountByType.generate > 0 && (
-            <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-green-500/20 text-green-400">
+            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-healthy">
               {ruleCountByType.generate} generate
             </span>
           )}
           {ruleCountByType.verifyImages > 0 && (
-            <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-orange-500/20 text-orange-400">
+            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-orange">
               {ruleCountByType.verifyImages} verifyImages
             </span>
           )}

--- a/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
@@ -34,10 +34,13 @@ const resultColorMap: Record<string, string> = {
   skip: 'status-blue',
 }
 
+// A severity gradient, not a set of categories: critical/high/medium are the
+// three tiers the theme defines for exactly this (see the alert tier in
+// DESIGN.md). low and info sit below the gradient and take a plain accent.
 const severityColorMap: Record<string, string> = {
-  critical: 'status-red',
-  high: 'status-orange',
-  medium: 'status-amber',
+  critical: 'status-unhealthy',
+  high: 'status-alert',
+  medium: 'status-degraded',
   low: 'status-blue',
   info: 'bg-theme-hover text-theme-text-tertiary',
 }

--- a/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
@@ -27,17 +27,17 @@ interface PolicyReportRendererProps {
 }
 
 const resultColorMap: Record<string, string> = {
-  pass: 'status-healthy',
-  fail: 'status-unhealthy',
-  warn: 'status-degraded',
-  error: 'status-unhealthy',
+  pass: 'status-green',
+  fail: 'status-red',
+  warn: 'status-amber',
+  error: 'status-red',
   skip: 'status-blue',
 }
 
 const severityColorMap: Record<string, string> = {
-  critical: 'status-unhealthy',
+  critical: 'status-red',
   high: 'status-orange',
-  medium: 'status-degraded',
+  medium: 'status-amber',
   low: 'status-blue',
   info: 'bg-theme-hover text-theme-text-tertiary',
 }
@@ -239,7 +239,7 @@ interface KyvernoPolicyRendererProps {
 const ruleTypeColorMap: Record<string, string> = {
   validate: 'status-blue',
   mutate: 'status-purple',
-  generate: 'status-healthy',
+  generate: 'status-green',
   verifyImages: 'status-orange',
 }
 
@@ -273,10 +273,10 @@ export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyR
             <span className={clsx(
               'badge',
               enforcement.blocks
-                ? 'status-unhealthy'
+                ? 'status-red'
                 : enforcement.discrepancy
                   ? 'status-orange'
-                  : 'status-degraded',
+                  : 'status-amber',
             )}>
               {enforcement.label}
             </span>
@@ -308,7 +308,7 @@ export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyR
             </span>
           )}
           {ruleCountByType.generate > 0 && (
-            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-healthy">
+            <span className="px-2 py-0.5 rounded text-[10px] font-medium status-green">
               {ruleCountByType.generate} generate
             </span>
           )}

--- a/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KyvernoPolicyReportRenderer.tsx
@@ -278,7 +278,7 @@ export function KyvernoPolicyRenderer({ data, coverage, queued }: KyvernoPolicyR
               enforcement.blocks
                 ? 'status-red'
                 : enforcement.discrepancy
-                  ? 'status-orange'
+                  ? 'status-alert'
                   : 'status-amber',
             )}>
               {enforcement.label}

--- a/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyRenderer.tsx
@@ -43,8 +43,8 @@ export function NetworkPolicyRenderer({ data, staged = false }: NetworkPolicyRen
                   className={clsx(
                     'badge',
                     type === 'Ingress'
-                      ? 'bg-blue-500/20 text-blue-400 border-blue-500/30'
-                      : 'bg-purple-500/20 text-purple-400 border-purple-500/30'
+                      ? 'status-blue'
+                      : 'status-purple'
                   )}
                 >
                   {type}

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -301,9 +301,9 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
               <div key={`${taint.key}-${taint.effect}-${i}`} className="text-sm">
                 <span className={clsx(
                   'badge',
-                  taint.effect === 'NoSchedule' ? 'bg-yellow-500/20 text-yellow-400' :
-                  taint.effect === 'NoExecute' ? 'bg-red-500/20 text-red-400' :
-                  'bg-blue-500/20 text-blue-400'
+                  taint.effect === 'NoSchedule' ? 'status-degraded' :
+                  taint.effect === 'NoExecute' ? 'status-unhealthy' :
+                  'status-blue'
                 )}>
                   {taint.key}{taint.value ? `=${taint.value}` : ''}:{taint.effect}
                 </span>

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -301,8 +301,8 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
               <div key={`${taint.key}-${taint.effect}-${i}`} className="text-sm">
                 <span className={clsx(
                   'badge',
-                  taint.effect === 'NoSchedule' ? 'status-degraded' :
-                  taint.effect === 'NoExecute' ? 'status-unhealthy' :
+                  taint.effect === 'NoSchedule' ? 'status-amber' :
+                  taint.effect === 'NoExecute' ? 'status-red' :
                   'status-blue'
                 )}>
                   {taint.key}{taint.value ? `=${taint.value}` : ''}:{taint.effect}

--- a/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
@@ -6,17 +6,17 @@ import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 function getOrderStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
     case 'valid':
-      return { text: 'Valid', color: 'status-healthy' }
+      return { text: 'Valid', color: 'status-green' }
     case 'ready':
       return { text: 'Ready', color: 'status-blue' }
     case 'pending':
-      return { text: 'Pending', color: 'status-degraded' }
+      return { text: 'Pending', color: 'status-amber' }
     case 'invalid':
-      return { text: 'Invalid', color: 'status-unhealthy' }
+      return { text: 'Invalid', color: 'status-red' }
     case 'expired':
-      return { text: 'Expired', color: 'status-unhealthy' }
+      return { text: 'Expired', color: 'status-red' }
     case 'errored':
-      return { text: 'Errored', color: 'status-unhealthy' }
+      return { text: 'Errored', color: 'status-red' }
     default:
       return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }

--- a/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
@@ -6,17 +6,17 @@ import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 function getOrderStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
     case 'valid':
-      return { text: 'Valid', color: 'bg-green-500/20 text-green-400' }
+      return { text: 'Valid', color: 'status-healthy' }
     case 'ready':
-      return { text: 'Ready', color: 'bg-blue-500/20 text-blue-400' }
+      return { text: 'Ready', color: 'status-blue' }
     case 'pending':
-      return { text: 'Pending', color: 'bg-yellow-500/20 text-yellow-400' }
+      return { text: 'Pending', color: 'status-degraded' }
     case 'invalid':
-      return { text: 'Invalid', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Invalid', color: 'status-unhealthy' }
     case 'expired':
-      return { text: 'Expired', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Expired', color: 'status-unhealthy' }
     case 'errored':
-      return { text: 'Errored', color: 'bg-red-500/20 text-red-400' }
+      return { text: 'Errored', color: 'status-unhealthy' }
     default:
       return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }

--- a/packages/k8s-ui/src/components/resources/renderers/RoleRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleRenderer.tsx
@@ -99,7 +99,7 @@ export function RoleRenderer({ data, rbacRoleData, rbacRoleLoading, rbacRoleErro
                     {rule.resources.map((resource: string) => (
                       <span
                         key={resource}
-                        className="badge bg-purple-500/20 text-purple-400"
+                        className="badge status-purple"
                       >
                         {resource}
                       </span>
@@ -133,7 +133,7 @@ export function RoleRenderer({ data, rbacRoleData, rbacRoleLoading, rbacRoleErro
                     {rule.resourceNames.map((name: string) => (
                       <span
                         key={name}
-                        className="badge bg-cyan-500/20 text-cyan-400"
+                        className="badge status-cyan"
                       >
                         {name}
                       </span>
@@ -150,7 +150,7 @@ export function RoleRenderer({ data, rbacRoleData, rbacRoleLoading, rbacRoleErro
                     {rule.nonResourceURLs.map((url: string) => (
                       <span
                         key={url}
-                        className="badge bg-orange-500/20 text-orange-400"
+                        className="badge status-orange"
                       >
                         {url}
                       </span>

--- a/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
@@ -609,8 +609,8 @@ export function RolloutRenderer({ data, onNavigate, capabilities, onAction, pend
                   <span
                     className={clsx(
                       'w-5 h-5 rounded-full flex items-center justify-center text-xs shrink-0',
-                      isCompleted && 'bg-green-500/20 text-green-400',
-                      isCurrent && 'bg-blue-500/20 text-blue-400',
+                      isCompleted && 'status-healthy',
+                      isCurrent && 'status-blue',
                       isPending && BADGE_INACTIVE
                     )}
                   >

--- a/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
@@ -609,7 +609,7 @@ export function RolloutRenderer({ data, onNavigate, capabilities, onAction, pend
                   <span
                     className={clsx(
                       'w-5 h-5 rounded-full flex items-center justify-center text-xs shrink-0',
-                      isCompleted && 'status-healthy',
+                      isCompleted && 'status-green',
                       isCurrent && 'status-blue',
                       isPending && BADGE_INACTIVE
                     )}

--- a/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
@@ -58,10 +58,10 @@ export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererP
               <span className={clsx(
                 'badge',
                 isSynced
-                  ? 'bg-green-500/20 text-green-400'
+                  ? 'status-healthy'
                   : isNotSynced
-                    ? 'bg-red-500/20 text-red-400'
-                    : 'bg-yellow-500/20 text-yellow-400'
+                    ? 'status-unhealthy'
+                    : 'status-degraded'
               )}>
                 {isSynced ? 'Synced' : isNotSynced ? 'Not Synced' : 'Unknown'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
@@ -58,10 +58,10 @@ export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererP
               <span className={clsx(
                 'badge',
                 isSynced
-                  ? 'status-healthy'
+                  ? 'status-green'
                   : isNotSynced
-                    ? 'status-unhealthy'
-                    : 'status-degraded'
+                    ? 'status-red'
+                    : 'status-amber'
               )}>
                 {isSynced ? 'Synced' : isNotSynced ? 'Not Synced' : 'Unknown'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/SecretStoreRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SecretStoreRenderer.tsx
@@ -12,14 +12,14 @@ import {
 // Provider-specific color for visual distinction
 function getProviderColor(providerKey: string): string {
   switch (providerKey) {
-    case 'aws': return 'bg-orange-500/15 text-orange-400 border-orange-500/30'
-    case 'azurekv': return 'bg-blue-500/15 text-blue-400 border-blue-500/30'
-    case 'gcpsm': return 'bg-blue-500/15 text-blue-400 border-blue-500/30'
-    case 'vault': return 'bg-purple-500/15 text-purple-400 border-purple-500/30'
-    case 'kubernetes': return 'bg-cyan-500/15 text-cyan-400 border-cyan-500/30'
-    case 'doppler': return 'bg-green-500/15 text-green-400 border-green-500/30'
-    case 'onepassword': return 'bg-blue-500/15 text-blue-400 border-blue-500/30'
-    case 'akeyless': return 'bg-indigo-500/15 text-indigo-400 border-indigo-500/30'
+    case 'aws': return 'status-orange'
+    case 'azurekv': return 'status-blue'
+    case 'gcpsm': return 'status-blue'
+    case 'vault': return 'status-purple'
+    case 'kubernetes': return 'status-cyan'
+    case 'doppler': return 'status-green'
+    case 'onepassword': return 'status-blue'
+    case 'akeyless': return 'status-purple'
     default: return 'bg-theme-elevated text-theme-text-secondary border-theme-border'
   }
 }

--- a/packages/k8s-ui/src/components/resources/renderers/VPARenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VPARenderer.tsx
@@ -150,7 +150,7 @@ export function VPARenderer({ data, onNavigate }: VPARendererProps) {
                   {policy.mode && (
                     <span className={clsx(
                       'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                      policy.mode === 'Off' ? 'bg-theme-hover text-theme-text-tertiary' : 'bg-blue-500/20 text-blue-400'
+                      policy.mode === 'Off' ? 'bg-theme-hover text-theme-text-tertiary' : 'status-blue'
                     )}>
                       {policy.mode}
                     </span>

--- a/packages/k8s-ui/src/components/resources/renderers/VulnerabilityReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VulnerabilityReportRenderer.tsx
@@ -151,7 +151,7 @@ export function VulnerabilityReportRenderer({ data }: VulnerabilityReportRendere
               <span className="flex items-center gap-1.5">
                 {osDisplay}
                 {os.eosl && (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium status-degraded">
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium status-amber">
                     End of Service Life
                   </span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/VulnerabilityReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VulnerabilityReportRenderer.tsx
@@ -151,7 +151,7 @@ export function VulnerabilityReportRenderer({ data }: VulnerabilityReportRendere
               <span className="flex items-center gap-1.5">
                 {osDisplay}
                 {os.eosl && (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-400">
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium status-degraded">
                     End of Service Life
                   </span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
@@ -8,17 +8,17 @@ interface WebhookConfigRendererProps {
 }
 
 function getOperationColor(op: string): string {
-  if (op === 'CREATE') return 'bg-green-500/20 text-green-400'
-  if (op === 'UPDATE') return 'bg-yellow-500/20 text-yellow-400'
-  if (op === 'DELETE') return 'bg-red-500/20 text-red-400'
-  if (op === '*') return 'bg-red-500/20 text-red-400'
-  if (op === 'CONNECT') return 'bg-blue-500/20 text-blue-400'
+  if (op === 'CREATE') return 'status-healthy'
+  if (op === 'UPDATE') return 'status-degraded'
+  if (op === 'DELETE') return 'status-unhealthy'
+  if (op === '*') return 'status-unhealthy'
+  if (op === 'CONNECT') return 'status-blue'
   return 'bg-theme-elevated text-theme-text-secondary'
 }
 
 function getSideEffectsColor(se: string): string {
-  if (se === 'None' || se === 'NoneOnDryRun') return 'bg-green-500/20 text-green-400'
-  return 'bg-amber-500/20 text-amber-400'
+  if (se === 'None' || se === 'NoneOnDryRun') return 'status-healthy'
+  return 'status-degraded'
 }
 
 export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendererProps) {
@@ -75,7 +75,7 @@ export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendere
 
                 {/* Policy badges */}
                 <div className="flex flex-wrap gap-1.5 mt-2">
-                  <span className={clsx('badge-sm', wh.failurePolicy === 'Fail' ? 'bg-red-500/20 text-red-400' : 'bg-theme-elevated text-theme-text-secondary')}>
+                  <span className={clsx('badge-sm', wh.failurePolicy === 'Fail' ? 'status-unhealthy' : 'bg-theme-elevated text-theme-text-secondary')}>
                     {wh.failurePolicy || 'Fail'}
                   </span>
                   {wh.sideEffects && (
@@ -108,7 +108,7 @@ export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendere
                         ))}
                         <span className="text-theme-text-tertiary">on</span>
                         {(rule.resources || []).map((r: string) => (
-                          <span key={r} className="px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">{r}</span>
+                          <span key={r} className="px-1.5 py-0.5 rounded status-purple">{r}</span>
                         ))}
                         {(rule.apiGroups || []).map((g: string) => (
                           <span key={g} className="px-1.5 py-0.5 rounded bg-theme-elevated text-theme-text-secondary">{g === '' ? 'core' : g}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
@@ -8,17 +8,17 @@ interface WebhookConfigRendererProps {
 }
 
 function getOperationColor(op: string): string {
-  if (op === 'CREATE') return 'status-healthy'
-  if (op === 'UPDATE') return 'status-degraded'
-  if (op === 'DELETE') return 'status-unhealthy'
-  if (op === '*') return 'status-unhealthy'
+  if (op === 'CREATE') return 'status-green'
+  if (op === 'UPDATE') return 'status-amber'
+  if (op === 'DELETE') return 'status-red'
+  if (op === '*') return 'status-red'
   if (op === 'CONNECT') return 'status-blue'
   return 'bg-theme-elevated text-theme-text-secondary'
 }
 
 function getSideEffectsColor(se: string): string {
-  if (se === 'None' || se === 'NoneOnDryRun') return 'status-healthy'
-  return 'status-degraded'
+  if (se === 'None' || se === 'NoneOnDryRun') return 'status-green'
+  return 'status-amber'
 }
 
 export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendererProps) {
@@ -75,7 +75,7 @@ export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendere
 
                 {/* Policy badges */}
                 <div className="flex flex-wrap gap-1.5 mt-2">
-                  <span className={clsx('badge-sm', wh.failurePolicy === 'Fail' ? 'status-unhealthy' : 'bg-theme-elevated text-theme-text-secondary')}>
+                  <span className={clsx('badge-sm', wh.failurePolicy === 'Fail' ? 'status-red' : 'bg-theme-elevated text-theme-text-secondary')}>
                     {wh.failurePolicy || 'Fail'}
                   </span>
                   {wh.sideEffects && (

--- a/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
@@ -20,18 +20,12 @@ const CHIP_RE =
 // Renderer files that still contain hand-rolled chips, pending migration.
 // Ratchet: this list only shrinks. Do not add to it.
 const BASELINE = new Set<string>([
-  'AlertRenderer.tsx', 'ArgoApplicationRenderer.tsx', 'CertificateRenderer.tsx',
-  'CertificateRequestRenderer.tsx', 'ChallengeRenderer.tsx', 'CiliumNetworkPolicyRenderer.tsx',
-  'ClusterExternalSecretRenderer.tsx', 'ClusterIssuerRenderer.tsx', 'ClusterNetworkPolicyRenderer.tsx',
-  'cnpg-cells.tsx', 'CNPGClusterRenderer.tsx', 'GatewayRenderer.tsx',
-  'GenericRenderer.tsx', 'IngressClassRenderer.tsx', 'IstioPeerAuthenticationRenderer.tsx',
-  'IstioServiceEntryRenderer.tsx', 'KarpenterNodeClaimRenderer.tsx', 'knative-cells.tsx',
-  'KnativeEventingRenderer.tsx', 'KnativeRevisionRenderer.tsx', 'kyverno-cells.tsx',
-  'KyvernoPolicyReportRenderer.tsx', 'NetworkPolicyRenderer.tsx', 'NodeRenderer.tsx',
-  'OrderRenderer.tsx', 'PodRenderer.tsx', 'RoleRenderer.tsx', 'RolloutRenderer.tsx',
-  'SealedSecretRenderer.tsx', 'SecretRenderer.tsx', 'SecretStoreRenderer.tsx',
-  'VeleroBackupRenderer.tsx', 'VeleroRestoreRenderer.tsx', 'VeleroScheduleRenderer.tsx',
-  'VPARenderer.tsx', 'VulnerabilityReportRenderer.tsx', 'WebhookConfigRenderer.tsx',
+  'ClusterExternalSecretRenderer.tsx',
+  'PodRenderer.tsx',
+  'SecretRenderer.tsx',
+  'VeleroBackupRenderer.tsx',
+  'VeleroRestoreRenderer.tsx',
+  'VeleroScheduleRenderer.tsx',
 ])
 
 const dir = fileURLToPath(new URL('.', import.meta.url))

--- a/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/cnpg-cells.tsx
@@ -287,7 +287,7 @@ export function CNPGPoolerCell({ resource, column }: { resource: any; column: st
       return (
         <span className={clsx(
           'badge-sm',
-          type === 'rw' ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400'
+          type === 'rw' ? 'status-blue' : 'status-purple'
         )}>
           {type}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
@@ -384,7 +384,7 @@ export function ServerlessServiceCell({ resource, column }: { resource: any; col
       return (
         <span className={clsx(
           'badge',
-          mode === 'Proxy' ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
+          mode === 'Proxy' ? 'status-degraded' : 'status-healthy'
         )}>
           {mode}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/knative-cells.tsx
@@ -384,7 +384,7 @@ export function ServerlessServiceCell({ resource, column }: { resource: any; col
       return (
         <span className={clsx(
           'badge',
-          mode === 'Proxy' ? 'status-degraded' : 'status-healthy'
+          mode === 'Proxy' ? 'status-amber' : 'status-green'
         )}>
           {mode}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -1,7 +1,6 @@
 // Kyverno / Policy Report cell components for ResourcesView table
 
 import { clsx } from 'clsx'
-import { healthColors } from '../resource-utils'
 import {
   getPolicyReportScope,
   getPolicyReportStatus,
@@ -84,11 +83,13 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
       return (
         <span className={clsx(
           'badge',
+          // Enforce/Audit is a configured posture, not evidence of a fault, so
+          // it takes colour-named accents rather than the health palette.
           blocks
-            ? healthColors.unhealthy
+            ? 'status-red'
             : discrepancy
-              ? healthColors.alert
-              : healthColors.degraded,
+              ? 'status-orange'
+              : 'status-amber',
         )}>
           {label}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -88,7 +88,7 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
           blocks
             ? 'status-red'
             : discrepancy
-              ? 'status-orange'
+              ? 'status-alert'
               : 'status-amber',
         )}>
           {label}

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -1,6 +1,7 @@
 // Kyverno / Policy Report cell components for ResourcesView table
 
 import { clsx } from 'clsx'
+import { healthColors } from '../resource-utils'
 import {
   getPolicyReportScope,
   getPolicyReportStatus,
@@ -84,10 +85,10 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
         <span className={clsx(
           'badge',
           blocks
-            ? 'bg-red-500/20 text-red-400'
+            ? healthColors.unhealthy
             : discrepancy
-              ? 'bg-orange-500/20 text-orange-400'
-              : 'bg-yellow-500/20 text-yellow-400',
+              ? healthColors.alert
+              : healthColors.degraded,
         )}>
           {label}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kyverno-cells.tsx
@@ -83,8 +83,10 @@ export function KyvernoPolicyCell({ resource, column }: { resource: any; column:
       return (
         <span className={clsx(
           'badge',
-          // Enforce/Audit is a configured posture, not evidence of a fault, so
-          // it takes colour-named accents rather than the health palette.
+          // Enforce and Audit are configured postures, so they take colour-named
+          // accents. A discrepancy is not a posture — the policy declares Enforce
+          // while admission evaluation is off, so it blocks nothing it claims to
+          // — and that is a fault, which is what the alert tier is for.
           blocks
             ? 'status-red'
             : discrepancy

--- a/packages/k8s-ui/src/components/resources/resource-utils-certmanager.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-certmanager.ts
@@ -126,7 +126,7 @@ export function getOrderState(order: any): StatusBadge {
     case 'valid':
       return { text: 'Valid', color: healthColors.healthy, level: 'healthy' }
     case 'ready':
-      return { text: 'Ready', color: 'bg-blue-500/20 text-blue-400', level: 'healthy' }
+      return { text: 'Ready', color: 'status-blue', level: 'healthy' }
     case 'pending':
       return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
     case 'invalid':
@@ -162,7 +162,7 @@ export function getChallengeState(challenge: any): StatusBadge {
     case 'valid':
       return { text: 'Valid', color: healthColors.healthy, level: 'healthy' }
     case 'ready':
-      return { text: 'Ready', color: 'bg-blue-500/20 text-blue-400', level: 'healthy' }
+      return { text: 'Ready', color: 'status-blue', level: 'healthy' }
     case 'pending':
       return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
     case 'processing':

--- a/packages/k8s-ui/src/components/resources/resource-utils-knative.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-knative.ts
@@ -62,14 +62,14 @@ export function getRevisionStatus(resource: any): StatusBadge {
   if (ready?.status === 'True' && active?.status === 'False') {
     const reason = active.reason || ''
     if (reason === 'NoTraffic') {
-      return { text: 'Scaled to Zero', color: 'bg-blue-500/20 text-blue-400', level: 'healthy' }
+      return { text: 'Scaled to Zero', color: 'status-blue', level: 'healthy' }
     }
-    return { text: reason || 'Inactive', color: 'bg-yellow-500/20 text-yellow-400', level: 'degraded' }
+    return { text: reason || 'Inactive', color: 'status-amber', level: 'degraded' }
   }
 
   // Check for activating: Active condition is Unknown (scaling up)
   if (ready?.status === 'True' && active?.status === 'Unknown') {
-    return { text: 'Activating', color: 'bg-blue-500/20 text-blue-400', level: 'healthy' }
+    return { text: 'Activating', color: 'status-blue', level: 'healthy' }
   }
 
   return getKnativeConditionStatus(resource)

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -229,7 +229,28 @@
   }
 
   /* Colour-named accents carry no health meaning — they exist so an
-     informational badge can pick a hue without borrowing a status semantic. */
+     informational badge can pick a hue without borrowing a status semantic.
+     A categorical badge (an admission verb, a policy action, a configured
+     mode) belongs here; only evidence about a resource's condition belongs on
+     .status-healthy / -degraded / -unhealthy. */
+  .status-green {
+    background-color: light-dark(rgba(34, 197, 94, 0.15), rgba(34, 197, 94, 0.2));
+    color: light-dark(#15803d, #4ade80);
+    border-color: transparent;
+  }
+
+  .status-red {
+    background-color: light-dark(rgba(239, 68, 68, 0.15), rgba(239, 68, 68, 0.2));
+    color: light-dark(#b91c1c, #f87171);
+    border-color: transparent;
+  }
+
+  .status-amber {
+    background-color: light-dark(rgba(234, 179, 8, 0.15), rgba(234, 179, 8, 0.2));
+    color: light-dark(#a16207, #facc15);
+    border-color: transparent;
+  }
+
   .status-blue {
     background-color: light-dark(rgba(59, 130, 246, 0.15), rgba(59, 130, 246, 0.2));
     color: light-dark(#2563eb, #60a5fa);

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -228,6 +228,14 @@
     border-color: transparent;
   }
 
+  /* Colour-named accents carry no health meaning — they exist so an
+     informational badge can pick a hue without borrowing a status semantic. */
+  .status-blue {
+    background-color: light-dark(rgba(59, 130, 246, 0.15), rgba(59, 130, 246, 0.2));
+    color: light-dark(#2563eb, #60a5fa);
+    border-color: transparent;
+  }
+
   .status-cyan {
     background-color: light-dark(rgba(6, 182, 212, 0.15), rgba(6, 182, 212, 0.2));
     color: light-dark(#0891b2, #22d3ee);

--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -74,7 +74,7 @@ export const NODEPOOL_MODE_BADGE: Record<string, string> = {
 
 // Translucent gray badge for "inactive / unknown / pending / unset / disabled" states.
 // The de-facto fallback in renderers when no severity or category applies.
-export const BADGE_INACTIVE = 'bg-gray-500/20 text-gray-400'
+export const BADGE_INACTIVE = 'status-unknown'
 
 // Best practices category colors
 export const BP_CATEGORY_BADGE: Record<string, string> = {


### PR DESCRIPTION
Badges across the resource renderers spelled their colours inline as `bg-<hue>-500/20 text-<hue>-400`. Measured in the pre-sweep build, those resolve to **byte-identical values in light and dark** — a `-400` text weight chosen against a dark surface, painted unchanged onto a light one. That is the wash-out: the reported case was an `Audit` badge at roughly **1.2:1**, where WCAG AA asks for 4.5.

116 sites across 32 files now use the `.status-*` classes, which resolve through `light-dark()`.

## Colour is preserved; meaning is not invented

Two separate questions, and the second one drove most of the work.

**Does it still look the same?** Measured across a theme toggle, the colour-named accents are byte-identical in dark to the strings they replaced — orange `#fb923c`, blue `#60a5fa`, purple `#c084fc`, cyan `#22d3ee`. The health tones lighten by one step (`#4ade80`→`#6ee7b7`), which is the health palette's existing choice rather than anything introduced here.

**Does it mean the same?** Mapping by hue alone would have bound a lot of badges to semantics they never had. An admission verb, a policy action, a secret-store provider, an mTLS mode, a taint effect — these were red or green for emphasis, never as evidence about a resource's condition. Putting them on `.status-unhealthy` would mean a future change to what "unhealthy" looks like silently drags them along.

So the colour-named accent family is completed with `green`, `red` and `amber` alongside the existing `orange`, `purple`, `cyan`, `violet`, and a new `blue`. Categorical badges live there; only badges already reading a `HealthLevel` keep the health classes. The blue case is the clearest: `.status-neutral` is reserved for *intentionally idle* things — a suspended or scaled-to-zero workload — and an ACME Order that is `Ready`, or the "current revision" highlight, is not idle.

## Verification

Contrast measured in the browser across both themes, compositing the page background under each badge's alpha:

| | light | dark |
|---|---|---|
| Ready | 9.52 | 4.84 |
| Audit | 9.91 | 6.37 |
| Enforce | 7.98 | 5.30 |

All above the 4.5 AA threshold in both themes, against roughly 1.2 in light before.

`make tsc` clean; 2955 frontend tests pass. Also sweeps what the `/20` pattern missed: the knative and cert-manager status helpers, and the eight SecretStore provider palettes at `/15`.

The two `bg-skyhook-500/20` occurrences are the brand accent rather than a status colour and are deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/theming-only changes across badges with no auth, data, or API behavior; main risk is inconsistent badge meaning if a class was mapped wrong.
> 
> **Overview**
> Replaces **116** inline `bg-<hue>-500/20 text-<hue>-400` badge styles across resource renderers, table cells, and cert-manager/Knative helpers with shared **`.status-*`** theme classes so light and dark mode use **`light-dark()`** and contrast stays WCAG-friendly.
> 
> Adds **colour-named accents** (`status-green`, `status-red`, `status-amber`, `status-blue`) for categorical chips (verbs, providers, taint effects, rule types) while keeping **health/alert semantics** (`status-healthy`, `status-unhealthy`, `status-alert`, etc.) for real condition evidence. Kyverno enforcement/discrepancy and policy-report severity maps follow that split; **`BADGE_INACTIVE`** becomes **`status-unknown`**.
> 
> Shrinks the **`badge-no-handrolled`** test baseline to the few renderer files still on hand-rolled chips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634d7463ce7f7d011c7ec06cae324b1c7a3194e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->