### PR TITLE
fix(k8score): unwrap delete tombstone before dynamic-cache callbacks

### DIFF
--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -645,6 +645,10 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 			return
 		}
 	}
+	// Callbacks consume the resource object, not client-go's delivery
+	// wrapper. Keeping the wrapper here silently drops dynamic deletes in
+	// Radar's timeline callback even though identity was resolved above.
+	obj = u
 
 	namespace := u.GetNamespace()
 	name := u.GetName()

--- a/pkg/k8score/dynamic_cache_delete_test.go
+++ b/pkg/k8score/dynamic_cache_delete_test.go
@@ -1,0 +1,42 @@
+package k8score
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestDynamicDeleteTombstonePassesUnwrappedObjectToCallbacks(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group: "example.io", Version: "v1", Resource: "widgets",
+	}
+	deleted := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"namespace": "shop",
+			"name":      "checkout",
+			"uid":       "widget-uid",
+		},
+	}}
+
+	var callbackObject any
+	dynamicCache := &DynamicResourceCache{config: DynamicCacheConfig{
+		OnChange: func(_ ResourceChange, obj, _ any) {
+			callbackObject = obj
+		},
+	}}
+	dynamicCache.enqueueDynamicChange(
+		"Widget",
+		gvr,
+		cache.DeletedFinalStateUnknown{Key: "shop/checkout", Obj: deleted},
+		nil,
+		OpDelete,
+	)
+
+	if callbackObject != deleted {
+		t.Fatalf("OnChange object = %T %p, want unwrapped object %p", callbackObject, callbackObject, deleted)
+	}
+}


### PR DESCRIPTION
## Summary

`DynamicResourceCache.enqueueDynamicChange` resolves a deleted dynamic resource's namespace/name/UID from client-go's `DeletedFinalStateUnknown` tombstone wrapper when the informer's own cache already evicted the object before the delete handler ran. It correctly extracts identity from `tombstone.Obj`, but then passes the *original, still-wrapped* `obj` — not the unwrapped resource — to `OnChange`/`OnDrop` and `ComputeDiff`. Callbacks expect the resource object itself, not client-go's delivery wrapper, so a dynamic resource's delete could be silently dropped from Radar's timeline instead of recorded.

## What changed

- `pkg/k8score/dynamic_cache.go`: once the tombstone is unwrapped to resolve identity, reassign `obj` to the unwrapped object so every downstream callback receives it.

## Testing

- Added `TestDynamicDeleteTombstonePassesUnwrappedObjectToCallbacks`, asserting `OnChange` receives the unwrapped object for a `DeletedFinalStateUnknown` delete.
- `go build ./...`, `go vet ./...`, `go test ./...` — both Go modules (`.` and `pkg/`), full pass
- `gofmt -l` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted event-handling fix with a regression test; aligns dynamic-cache behavior with the existing typed cache tombstone handling.
> 
> **Overview**
> Fixes **dynamic resource deletes** being mishandled when client-go delivers a `DeletedFinalStateUnknown` tombstone (common after the informer store has already evicted the object).
> 
> `enqueueDynamicChange` already unwrapped the tombstone to read namespace/name/UID, but still forwarded the **wrapped** `obj` to `OnChange`, `ComputeDiff`, and related paths. Consumers expect an `*unstructured.Unstructured`, so deletes could be **silently skipped** in Radar’s timeline. The change sets `obj = u` after unwrapping, matching the typed `ResourceCache` delete path.
> 
> Adds `TestDynamicDeleteTombstonePassesUnwrappedObjectToCallbacks` to assert `OnChange` receives the unwrapped object on tombstone deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b966de22e19631a9cf07fceee2fd4ba5271bf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->