### PR TITLE
Allow capable hosted agents to explain saved assessments

### DIFF
--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -13,6 +13,8 @@ export interface AgentInfo {
   profiles?: ExecutionProfile[];
   consentSurfaces?: Partial<Record<ExecutionProfile, string>>;
   hosted?: boolean;
+  /** Hosted backends opt in only when they implement assessment-bound, tool-free explanations. */
+  assessmentExplanations?: boolean;
 }
 
 export interface AgentsResponse {

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -8,7 +8,10 @@ import {
   prefersReducedMotion,
   useDisclosureReveal,
 } from "./useDisclosureReveal";
-import { investigationExplanation } from "./investigationExplanation";
+import {
+  investigationExplanation,
+  supportsAssessmentExplanation,
+} from "./investigationExplanation";
 import {
   initialInvestigationPane,
   investigationEvidenceShouldMarkUnread,
@@ -160,8 +163,17 @@ export function InvestigationView({
   const { kind, namespace, name } = run;
   // Apply is off for hosted agents (read-only server-side). Keyed on the selected
   // agent, which matches run.agent unless a deployment mixes hosted + local agents.
-  const { refreshRuns, openInvestigation, startError, dismissError, hosted } =
-    useDiagnose();
+  const {
+    refreshRuns,
+    openInvestigation,
+    startError,
+    dismissError,
+    hosted,
+    agents,
+  } = useDiagnose();
+  const explanationEnabled = supportsAssessmentExplanation(
+    agents.find((agent) => agent.name === run.agent),
+  );
   // Investigate again means look again, so it asks for a new session explicitly and only
   // carries the issue forward — being handed the previous answer is the one
   // thing someone clicking this doesn't want.
@@ -754,15 +766,14 @@ export function InvestigationView({
     const sequence = assessment.resultSequence;
     if (!sequence || !assessment.diagnosis?.rootCause) return undefined;
     const saved = investigationExplanation(turns, sequence);
-    // This intent is implemented by the local run manager; hosted continuation
-    // alone does not imply support for assessment-bound explanation turns.
-    if ((readOnly || hosted) && saved.status === "idle") return undefined;
+    if ((readOnly || !explanationEnabled) && saved.status === "idle")
+      return undefined;
     const state =
       explanationRequest?.sequence === sequence ? explanationRequest : saved;
     return {
       ...state,
       onGenerate:
-        !hosted && !interactionsBlocked
+        explanationEnabled && !interactionsBlocked
           ? () => askExplanation(sequence)
           : undefined,
       openRequest:

--- a/web/src/components/diagnose/investigationExplanation.test.ts
+++ b/web/src/components/diagnose/investigationExplanation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { investigationExplanation } from "./investigationExplanation";
+import {
+  investigationExplanation,
+  supportsAssessmentExplanation,
+} from "./investigationExplanation";
+import type { AgentInfo } from "../../api/diagnose";
 import type { Turn } from "./parts";
 
 const turn = (overrides: Partial<Turn> = {}): Turn => ({
@@ -10,6 +14,31 @@ const turn = (overrides: Partial<Turn> = {}): Turn => ({
   ...overrides,
 });
 describe("assessment-local explanation", () => {
+  it("requires explicit hosted support without enabling mutations or changing local support", () => {
+    const agent: AgentInfo = {
+      name: "hub",
+      label: "Managed agent",
+      path: "",
+      version: "",
+      supported: true,
+      present: true,
+      hosted: true,
+    };
+    expect(supportsAssessmentExplanation(undefined)).toBe(false);
+    expect(supportsAssessmentExplanation(agent)).toBe(false);
+    expect(
+      supportsAssessmentExplanation({
+        ...agent,
+        assessmentExplanations: false,
+      }),
+    ).toBe(false);
+    expect(
+      supportsAssessmentExplanation({ ...agent, assessmentExplanations: true }),
+    ).toBe(true);
+    expect(supportsAssessmentExplanation({ ...agent, hosted: false })).toBe(
+      true,
+    );
+  });
   it("does not mistake an ordinary answer for an explanation", () => {
     expect(
       investigationExplanation([turn({ question: "Explain simply" })], 2),

--- a/web/src/components/diagnose/investigationExplanation.ts
+++ b/web/src/components/diagnose/investigationExplanation.ts
@@ -1,4 +1,11 @@
 import type { AssessmentExplanation, Turn } from "./parts";
+import type { AgentInfo } from "../../api/diagnose";
+
+export function supportsAssessmentExplanation(
+  agent: AgentInfo | undefined,
+): boolean {
+  return !!agent && (!agent.hosted || agent.assessmentExplanations === true);
+}
 
 export function investigationExplanation(
   turns: readonly Turn[],


### PR DESCRIPTION
## Summary

Allow hosted agents that implement assessment-bound, tool-free explanations to expose the existing **Explain simply** interaction. Hosts opt in with `AgentInfo.assessmentExplanations`; an unsupported hosted agent continues to hide generation.

## What changed

- Add an optional, additive hosted explanation capability.
- Resolve it against the investigation's actual agent rather than the currently selected agent.
- Reuse the existing assessment-local generation, loading, replay and display path. Local-agent behavior and hosted Apply restrictions are unchanged.

This is a frontend capability declaration, not a hosted backend implementation. A host must implement the existing `explainAssessment` request contract before advertising support.

## Testing

- `make build` — typecheck, frontend build and embedded Go binary.
- Frontend suite: 907 tests passed with bounded worker concurrency and a 30s test timeout.
- Capability tests cover missing agent, unsupported hosted agent, explicit false/true and existing local behavior.
- Browser-tested a locally packed artifact in a hosted integration fixture: inline completion, saved explanation replay, source highlighting, narrow/wide and light/dark. Synthetic backend/model; no live hosted model call.

Additive patch-compatible change; no new k8s-ui exports or package publication included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive frontend capability flag and UI gating only; local-agent behavior and apply restrictions are unchanged.
> 
> **Overview**
> **Explain simply** is no longer blocked for every hosted investigation. Hosted backends can advertise support via optional `AgentInfo.assessmentExplanations`; unsupported hosted agents still hide generation when no saved explanation exists.
> 
> The UI resolves capability from the **run’s agent** (`run.agent` in the agents list), not the global `hosted` flag. `supportsAssessmentExplanation` treats local agents as always eligible and hosted agents as eligible only when they opt in. **Explain simply** generation and idle-state hiding now use `explanationEnabled` instead of `!hosted`, while existing replay, loading, and display paths are unchanged. Apply and other hosted read-only rules are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923171325065750d5c4a7a717f3001cdec3ba411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->