### PR TITLE
Offer the browser path when the Cloud dialog has no connected cluster

### DIFF
--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -294,7 +294,12 @@ export function CloudFunnelButton() {
         ) : (
           <>
             <div className="min-h-0 overflow-y-auto">
-              <PitchBody lane={lane} freeTier={connectInfo.data?.freeTier} />
+              {/* With no cluster to install into, the pitch must not promise
+                  that setup runs here: describe the Cloud-side path instead. */}
+              <PitchBody
+                lane={lane === 'driver' && driverConnectUnavailableNote(connectionState) ? 'wizard' : lane}
+                freeTier={connectInfo.data?.freeTier}
+              />
             </div>
             <ModalFooter
               lane={lane}

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -160,7 +160,7 @@ export function CloudFunnelButton() {
       if (err instanceof ApiError && err.status === 503) {
         setServerReportedNoCluster(true)
         exitFlow(false)
-        showApiError("Radar isn't connected to a cluster yet", 'Connect a cluster first, or set up Radar Cloud in the browser.')
+        showApiError("Radar isn't connected to a cluster yet", 'Connect a cluster first, or continue in Radar Cloud.')
         return
       }
       // Anything else failed before a flow existed. Return to the pitch rather
@@ -449,7 +449,7 @@ function ModalFooter({
               rel="noopener noreferrer"
               className={PRIMARY_ACTION_CLASS}
             >
-              Set up in the browser
+              Continue in Radar Cloud
             </a>
           </Tooltip>
         ) : lane === 'driver' ? (
@@ -471,7 +471,7 @@ function ModalFooter({
               rel="noopener noreferrer"
               className="whitespace-nowrap text-[12.5px] text-theme-text-secondary hover:text-theme-text-primary hover:underline underline-offset-2 transition-colors"
             >
-              or set up in the browser
+              or set up in Radar Cloud
             </a>
           </>
         ) : cliOnly ? null : (

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -371,8 +371,8 @@ function ModalFooter({
   driverEscapeUrl: string
   prepareFailed: boolean
   // Non-null while Radar has no connected cluster: the in-app connect has
-  // nothing to inspect, so the browser path takes its place and this line
-  // explains why.
+  // nothing to inspect, so the browser path takes its place and this text
+  // explains why on hover.
   connectUnavailableNote: string | null
   // Live copy from the Hub; undefined until (or unless) it arrives.
   assurances?: string[]
@@ -437,23 +437,21 @@ function ModalFooter({
       {notice && (
         <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">{notice}</div>
       )}
-      {lane === 'driver' && connectUnavailableNote && (
-        <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">
-          {connectUnavailableNote}
-        </div>
-      )}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
         {lane === 'driver' && connectUnavailableNote ? (
           // No cluster to inspect, so the browser wizard is the only path and
-          // takes the primary slot; the note above says why.
-          <a
-            href={driverEscapeUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={PRIMARY_ACTION_CLASS}
-          >
-            Set up in the browser
-          </a>
+          // takes the primary slot. The reason lives in a tooltip: a visible
+          // note here competed with the pitch above it for attention.
+          <Tooltip content={connectUnavailableNote} delay={100} position="top">
+            <a
+              href={driverEscapeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={PRIMARY_ACTION_CLASS}
+            >
+              Set up in the browser
+            </a>
+          </Tooltip>
         ) : lane === 'driver' ? (
           <>
             <button

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -5,7 +5,9 @@ import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Coll
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
 import { CloudConnectFlow } from './CloudConnectFlow'
+import { driverConnectUnavailableNote, driverEscapeContent } from './cloudFunnelState'
 import { showApiError } from './ui/Toast'
+import { useConnection } from '../context/ConnectionContext'
 import {
   ApiError,
   cloudInstallActive,
@@ -88,6 +90,10 @@ export function CloudFunnelButton() {
 
   const capabilities = useCapabilities()
   const lane = capabilities.data?.cloudConnect?.lane ?? 'wizard'
+  // The driver lane inspects the live cluster, so it has nothing to offer
+  // until Radar is connected to one. The header shows this button from the
+  // first paint, before that connection exists.
+  const connectionState = useConnection().connection.state
   const appUrl = capabilities.data?.cloudConnect?.appUrl || FALLBACK_APP_URL
   // utm_content distinguishes the lane that opened the Hub — measured Hub-side
   // only when the user actually navigates there; Radar transmits nothing.
@@ -130,6 +136,14 @@ export function CloudFunnelButton() {
       const live = err instanceof ApiError && err.status === 409 ? (err.data as CloudInstallStatus | undefined) : undefined
       if (live?.state) {
         applyStatus(live)
+        return
+      }
+      // A 503 means there was no cluster to inspect (the connection dropped
+      // between render and click). Nothing about the install path broke, so
+      // the pitch must not come back reading "Try again".
+      if (err instanceof ApiError && err.status === 503) {
+        exitFlow(false)
+        showApiError("Radar isn't connected to a cluster yet", 'Connect a cluster first, or set up Radar Cloud in the browser.')
         return
       }
       // Anything else failed before a flow existed. Return to the pitch rather
@@ -261,10 +275,9 @@ export function CloudFunnelButton() {
             <ModalFooter
               lane={lane}
               signupUrl={signupUrl}
-              // driver-escape after a failed attempt, driver-alt before one, so
-              // the Hub can tell "prefers the browser" from "app path broke".
-              driverEscapeUrl={signupUrlFor(prepareFailed ? 'driver-escape' : 'driver-alt')}
+              driverEscapeUrl={signupUrlFor(driverEscapeContent(connectionState, prepareFailed))}
               prepareFailed={prepareFailed}
+              connectUnavailableNote={driverConnectUnavailableNote(connectionState)}
               assurances={connectInfo.data?.assurances}
               notice={connectInfo.data?.notice}
               self={inCluster ? self.data : undefined}
@@ -318,6 +331,7 @@ function ModalFooter({
   signupUrl,
   driverEscapeUrl,
   prepareFailed,
+  connectUnavailableNote,
   assurances,
   notice,
   self,
@@ -328,9 +342,14 @@ function ModalFooter({
   lane: 'driver' | 'wizard'
   signupUrl: string
   // Same destination as signupUrl, distinct utm_content: the caller encodes
-  // whether this render follows a failed in-app attempt.
+  // whether this render follows a failed in-app attempt or has no connected
+  // cluster to attempt against.
   driverEscapeUrl: string
   prepareFailed: boolean
+  // Non-null while Radar has no connected cluster: the in-app connect has
+  // nothing to inspect, so the browser path takes its place and this line
+  // explains why.
+  connectUnavailableNote: string | null
   // Live copy from the Hub; undefined until (or unless) it arrives.
   assurances?: string[]
   notice?: string
@@ -394,8 +413,24 @@ function ModalFooter({
       {notice && (
         <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">{notice}</div>
       )}
+      {lane === 'driver' && connectUnavailableNote && (
+        <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">
+          {connectUnavailableNote}
+        </div>
+      )}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
-        {lane === 'driver' ? (
+        {lane === 'driver' && connectUnavailableNote ? (
+          // No cluster to inspect, so the browser wizard is the only path and
+          // takes the primary slot; the note above says why.
+          <a
+            href={driverEscapeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+          >
+            Set up in the browser
+          </a>
+        ) : lane === 'driver' ? (
           <>
             <button
               onClick={onConnect}
@@ -435,7 +470,7 @@ function ModalFooter({
       </div>
       {/* Mechanics, not marketing: a falsifiable claim the plan card then
           fulfills. Sits next to the button whose click it de-risks. */}
-      {lane === 'driver' && (
+      {lane === 'driver' && !connectUnavailableNote && (
         <p className="mt-2.5 text-[11px] leading-relaxed text-theme-text-tertiary">
           Nothing installs on click. Radar inspects the cluster and shows you a plan; you approve it in
           the browser before anything changes.

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -5,7 +5,7 @@ import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Coll
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
 import { CloudConnectFlow } from './CloudConnectFlow'
-import { driverConnectUnavailableNote, driverEscapeContent } from './cloudFunnelState'
+import { driverConnectUnavailableNote, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
 import { showApiError } from './ui/Toast'
 import { useConnection } from '../context/ConnectionContext'
 import {
@@ -50,6 +50,12 @@ const DEFAULT_ASSURANCES = [
   '3 clusters free, no card required',
 ]
 const SIGNUP_QUERY = '?utm_source=radar-oss&utm_medium=app&utm_campaign=cloud-modal'
+
+// The footer's primary action, whichever element fills that slot. Emerald is
+// this dialog's Cloud accent (eyebrow, sweep, check marks), not a generic
+// surface, so it stays literal here rather than a theme token.
+const PRIMARY_ACTION_CLASS =
+  'whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all'
 const ABOUT_URL = 'https://radarhq.io/about'
 const PRICING_URL = 'https://radarhq.io/pricing'
 const SELF_HOSTED_DOCS_URL = 'https://radarhq.io/docs/cloud/self-hosted/'
@@ -93,7 +99,14 @@ export function CloudFunnelButton() {
   // The driver lane inspects the live cluster, so it has nothing to offer
   // until Radar is connected to one. The header shows this button from the
   // first paint, before that connection exists.
-  const connectionState = useConnection().connection.state
+  const liveConnectionState = useConnection().connection.state
+  // Set when prepare answered 503: the server has no cluster even if the
+  // connection feed still says otherwise. Cleared once that feed moves.
+  const [serverReportedNoCluster, setServerReportedNoCluster] = useState(false)
+  useEffect(() => {
+    setServerReportedNoCluster(false)
+  }, [liveConnectionState])
+  const connectionState = effectiveConnectionState(liveConnectionState, serverReportedNoCluster)
   const appUrl = capabilities.data?.cloudConnect?.appUrl || FALLBACK_APP_URL
   // utm_content distinguishes the lane that opened the Hub — measured Hub-side
   // only when the user actually navigates there; Radar transmits nothing.
@@ -142,6 +155,7 @@ export function CloudFunnelButton() {
       // between render and click). Nothing about the install path broke, so
       // the pitch must not come back reading "Try again".
       if (err instanceof ApiError && err.status === 503) {
+        setServerReportedNoCluster(true)
         exitFlow(false)
         showApiError("Radar isn't connected to a cluster yet", 'Connect a cluster first, or set up Radar Cloud in the browser.')
         return
@@ -194,6 +208,7 @@ export function CloudFunnelButton() {
   const contextName = useClusterInfo().data?.context
   useEffect(() => {
     setPrepareFailed(false)
+    setServerReportedNoCluster(false)
   }, [contextName])
 
   // The server owns the "nothing to pitch" decision: an already-tunneled
@@ -426,7 +441,7 @@ function ModalFooter({
             href={driverEscapeUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+            className={PRIMARY_ACTION_CLASS}
           >
             Set up in the browser
           </a>
@@ -434,7 +449,7 @@ function ModalFooter({
           <>
             <button
               onClick={onConnect}
-              className="whitespace-nowrap px-6 py-2.5 rounded-[10px] bg-emerald-500 hover:bg-emerald-400 text-emerald-950 text-[14px] font-bold shadow-[0_0_22px_rgba(16,185,129,0.35)] hover:shadow-[0_0_30px_rgba(16,185,129,0.5)] hover:-translate-y-px transition-all"
+              className={PRIMARY_ACTION_CLASS}
             >
               {/* Trailing ellipsis: further input follows the click — the
                   inspect step and a plan the user approves in the browser. */}

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -101,7 +101,10 @@ export function CloudFunnelButton() {
   // first paint, before that connection exists.
   const liveConnectionState = useConnection().connection.state
   // Set when prepare answered 503: the server has no cluster even if the
-  // connection feed still says otherwise. Cleared once that feed moves.
+  // connection feed still says otherwise. Cleared once that feed moves and
+  // whenever the dialog opens or closes, so a blip the feed never surfaced
+  // (it holds 'connected' across short reconnects) cannot hide the in-app
+  // connect for good.
   const [serverReportedNoCluster, setServerReportedNoCluster] = useState(false)
   useEffect(() => {
     setServerReportedNoCluster(false)
@@ -171,9 +174,15 @@ export function CloudFunnelButton() {
     // a running install. Toast explicitly on the paths that are failures.
   })
 
+  const closeModal = () => {
+    setOpen(false)
+    setServerReportedNoCluster(false)
+  }
+
   const openModal = () => {
     setOpen(true)
     setSeen(true)
+    setServerReportedNoCluster(false)
     markSeen()
     // Re-open lands on a live flow if one is running.
     if (lane === 'driver' && flowLive) setInFlowView(true)
@@ -255,11 +264,11 @@ export function CloudFunnelButton() {
 
       <DialogPortal
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={closeModal}
         className="w-[580px] max-w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col"
       >
         <button
-          onClick={() => setOpen(false)}
+          onClick={closeModal}
           aria-label="Close"
           className="absolute top-3.5 right-3.5 z-10 p-1.5 rounded-md text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover transition-colors"
         >
@@ -301,7 +310,7 @@ export function CloudFunnelButton() {
               // in-cluster, so the CTA would escape before classification.
               selfLoading={inCluster && self.isPending}
               onConnect={startConnect}
-              onLater={() => setOpen(false)}
+              onLater={closeModal}
             />
           </>
         )}

--- a/web/src/components/CloudFunnelButton.tsx
+++ b/web/src/components/CloudFunnelButton.tsx
@@ -5,7 +5,7 @@ import { Collapse, CollapseChevron } from '@skyhook-io/k8s-ui/components/ui/Coll
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { Tooltip } from './ui/Tooltip'
 import { CloudConnectFlow } from './CloudConnectFlow'
-import { driverConnectUnavailableNote, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
+import { driverConnectAvailable, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
 import { showApiError } from './ui/Toast'
 import { useConnection } from '../context/ConnectionContext'
 import {
@@ -297,7 +297,7 @@ export function CloudFunnelButton() {
               {/* With no cluster to install into, the pitch must not promise
                   that setup runs here: describe the Cloud-side path instead. */}
               <PitchBody
-                lane={lane === 'driver' && driverConnectUnavailableNote(connectionState) ? 'wizard' : lane}
+                lane={lane === 'driver' && !driverConnectAvailable(connectionState) ? 'wizard' : lane}
                 freeTier={connectInfo.data?.freeTier}
               />
             </div>
@@ -306,7 +306,7 @@ export function CloudFunnelButton() {
               signupUrl={signupUrl}
               driverEscapeUrl={signupUrlFor(driverEscapeContent(connectionState, prepareFailed))}
               prepareFailed={prepareFailed}
-              connectUnavailableNote={driverConnectUnavailableNote(connectionState)}
+              connectAvailable={driverConnectAvailable(connectionState)}
               assurances={connectInfo.data?.assurances}
               notice={connectInfo.data?.notice}
               self={inCluster ? self.data : undefined}
@@ -360,7 +360,7 @@ function ModalFooter({
   signupUrl,
   driverEscapeUrl,
   prepareFailed,
-  connectUnavailableNote,
+  connectAvailable,
   assurances,
   notice,
   self,
@@ -375,10 +375,9 @@ function ModalFooter({
   // cluster to attempt against.
   driverEscapeUrl: string
   prepareFailed: boolean
-  // Non-null while Radar has no connected cluster: the in-app connect has
-  // nothing to inspect, so the browser path takes its place and this text
-  // explains why on hover.
-  connectUnavailableNote: string | null
+  // False while Radar has no connected cluster: the in-app connect has
+  // nothing to inspect, so the Cloud path takes its place.
+  connectAvailable: boolean
   // Live copy from the Hub; undefined until (or unless) it arrives.
   assurances?: string[]
   notice?: string
@@ -443,20 +442,18 @@ function ModalFooter({
         <div className="mb-3.5 card-inner p-3 text-[12px] leading-relaxed text-theme-text-secondary">{notice}</div>
       )}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5">
-        {lane === 'driver' && connectUnavailableNote ? (
-          // No cluster to inspect, so the browser wizard is the only path and
-          // takes the primary slot. The reason lives in a tooltip: a visible
-          // note here competed with the pitch above it for attention.
-          <Tooltip content={connectUnavailableNote} delay={100} position="top">
-            <a
-              href={driverEscapeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={PRIMARY_ACTION_CLASS}
-            >
-              Continue in Radar Cloud
-            </a>
-          </Tooltip>
+        {lane === 'driver' && !connectAvailable ? (
+          // No cluster to inspect, so the Cloud wizard is the only path and
+          // takes the primary slot. No explanation: someone with no cluster
+          // connected is not expecting Radar to install into one.
+          <a
+            href={driverEscapeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={PRIMARY_ACTION_CLASS}
+          >
+            Continue in Radar Cloud
+          </a>
         ) : lane === 'driver' ? (
           <>
             <button
@@ -497,7 +494,7 @@ function ModalFooter({
       </div>
       {/* Mechanics, not marketing: a falsifiable claim the plan card then
           fulfills. Sits next to the button whose click it de-risks. */}
-      {lane === 'driver' && !connectUnavailableNote && (
+      {lane === 'driver' && connectAvailable && (
         <p className="mt-2.5 text-[11px] leading-relaxed text-theme-text-tertiary">
           Nothing installs on click. Radar inspects the cluster and shows you a plan; you approve it in
           the browser before anything changes.

--- a/web/src/components/cloudFunnelState.test.ts
+++ b/web/src/components/cloudFunnelState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { driverConnectUnavailableNote, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
+import { driverConnectAvailable, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
 
 describe('effectiveConnectionState', () => {
   it('trusts the render-time state when the server has not contradicted it', () => {
@@ -10,7 +10,7 @@ describe('effectiveConnectionState', () => {
   it('lets a prepare 503 override a stale connected state', () => {
     expect(effectiveConnectionState('connected', true)).toBe('disconnected')
     expect(driverEscapeContent(effectiveConnectionState('connected', true), false)).toBe('driver-unconnected')
-    expect(driverConnectUnavailableNote(effectiveConnectionState('connected', true))).not.toBeNull()
+    expect(driverConnectAvailable(effectiveConnectionState('connected', true))).toBe(false)
   })
 })
 
@@ -34,16 +34,10 @@ describe('driverEscapeContent', () => {
   })
 })
 
-describe('driverConnectUnavailableNote', () => {
-  it('offers the in-app connect once connected', () => {
-    expect(driverConnectUnavailableNote('connected')).toBeNull()
-  })
-
-  it('explains the wait while connecting', () => {
-    expect(driverConnectUnavailableNote('connecting')).toMatch(/Still connecting/)
-  })
-
-  it('explains the missing cluster when disconnected', () => {
-    expect(driverConnectUnavailableNote('disconnected')).toMatch(/No cluster is connected/)
+describe('driverConnectAvailable', () => {
+  it('offers the in-app connect only once connected', () => {
+    expect(driverConnectAvailable('connected')).toBe(true)
+    expect(driverConnectAvailable('connecting')).toBe(false)
+    expect(driverConnectAvailable('disconnected')).toBe(false)
   })
 })

--- a/web/src/components/cloudFunnelState.test.ts
+++ b/web/src/components/cloudFunnelState.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { driverConnectUnavailableNote, driverEscapeContent } from './cloudFunnelState'
+import { driverConnectUnavailableNote, driverEscapeContent, effectiveConnectionState } from './cloudFunnelState'
+
+describe('effectiveConnectionState', () => {
+  it('trusts the render-time state when the server has not contradicted it', () => {
+    expect(effectiveConnectionState('connected', false)).toBe('connected')
+    expect(effectiveConnectionState('connecting', false)).toBe('connecting')
+  })
+
+  it('lets a prepare 503 override a stale connected state', () => {
+    expect(effectiveConnectionState('connected', true)).toBe('disconnected')
+    expect(driverEscapeContent(effectiveConnectionState('connected', true), false)).toBe('driver-unconnected')
+    expect(driverConnectUnavailableNote(effectiveConnectionState('connected', true))).not.toBeNull()
+  })
+})
 
 describe('driverEscapeContent', () => {
   it('reads as a preference when the cluster is connected and nothing failed', () => {

--- a/web/src/components/cloudFunnelState.test.ts
+++ b/web/src/components/cloudFunnelState.test.ts
@@ -40,10 +40,10 @@ describe('driverConnectUnavailableNote', () => {
   })
 
   it('explains the wait while connecting', () => {
-    expect(driverConnectUnavailableNote('connecting')).toMatch(/still connecting/)
+    expect(driverConnectUnavailableNote('connecting')).toMatch(/Still connecting/)
   })
 
   it('explains the missing cluster when disconnected', () => {
-    expect(driverConnectUnavailableNote('disconnected')).toMatch(/isn't connected to a cluster/)
+    expect(driverConnectUnavailableNote('disconnected')).toMatch(/No cluster is connected/)
   })
 })

--- a/web/src/components/cloudFunnelState.test.ts
+++ b/web/src/components/cloudFunnelState.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { driverConnectUnavailableNote, driverEscapeContent } from './cloudFunnelState'
+
+describe('driverEscapeContent', () => {
+  it('reads as a preference when the cluster is connected and nothing failed', () => {
+    expect(driverEscapeContent('connected', false)).toBe('driver-alt')
+  })
+
+  it('reads as a broken in-app path only after a failed attempt on a connected cluster', () => {
+    expect(driverEscapeContent('connected', true)).toBe('driver-escape')
+  })
+
+  it('names the missing cluster while connecting, regardless of any earlier failure', () => {
+    expect(driverEscapeContent('connecting', false)).toBe('driver-unconnected')
+    expect(driverEscapeContent('connecting', true)).toBe('driver-unconnected')
+  })
+
+  it('names the missing cluster when disconnected, regardless of any earlier failure', () => {
+    expect(driverEscapeContent('disconnected', false)).toBe('driver-unconnected')
+    expect(driverEscapeContent('disconnected', true)).toBe('driver-unconnected')
+  })
+})
+
+describe('driverConnectUnavailableNote', () => {
+  it('offers the in-app connect once connected', () => {
+    expect(driverConnectUnavailableNote('connected')).toBeNull()
+  })
+
+  it('explains the wait while connecting', () => {
+    expect(driverConnectUnavailableNote('connecting')).toMatch(/still connecting/)
+  })
+
+  it('explains the missing cluster when disconnected', () => {
+    expect(driverConnectUnavailableNote('disconnected')).toMatch(/isn't connected to a cluster/)
+  })
+})

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -32,8 +32,8 @@ export function driverConnectUnavailableNote(connectionState: ConnectionStateTyp
     case 'connected':
       return null
     case 'connecting':
-      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready.'
+      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready, or continue in Radar Cloud now.'
     case 'disconnected':
-      return "Radar isn't connected to a cluster, so it can't install the connection for you. Connect a cluster first, or set up in the browser."
+      return "Radar isn't connected to a cluster, so it can't install the connection for you. Connect a cluster first, or continue in Radar Cloud."
   }
 }

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -32,8 +32,8 @@ export function driverConnectUnavailableNote(connectionState: ConnectionStateTyp
     case 'connected':
       return null
     case 'connecting':
-      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready, or continue in Radar Cloud now.'
+      return 'Still connecting to this cluster. Once it is ready, you can connect it from here.'
     case 'disconnected':
-      return "Radar isn't connected to a cluster, so it can't install the connection for you. Connect a cluster first, or continue in Radar Cloud."
+      return 'No cluster is connected. Radar Cloud walks you through connecting one.'
   }
 }

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -24,16 +24,8 @@ export function driverEscapeContent(connectionState: ConnectionStateType, prepar
 }
 
 // The in-app connect inspects the live cluster, so it has nothing to do until
-// Radar is connected to one. Until then the browser path is the only way
-// forward, and this text (shown on hover) says why instead of offering a
-// button that would only produce an error.
-export function driverConnectUnavailableNote(connectionState: ConnectionStateType): string | null {
-  switch (connectionState) {
-    case 'connected':
-      return null
-    case 'connecting':
-      return 'Still connecting to this cluster. Once it is ready, you can connect it from here.'
-    case 'disconnected':
-      return 'No cluster is connected. Radar Cloud walks you through connecting one.'
-  }
+// Radar is connected to one. Until then the Cloud wizard is the only way
+// forward, offered in place of a button that would only produce an error.
+export function driverConnectAvailable(connectionState: ConnectionStateType): boolean {
+  return connectionState === 'connected'
 }

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -1,0 +1,27 @@
+import type { ConnectionStateType } from '../context/ConnectionContext'
+
+// utm_content values the Hub reads to tell the driver lane's exits apart.
+// Each one names a different situation, so the funnel report can separate
+// "prefers the browser" from "the in-app path broke" from "there was no
+// cluster to connect yet".
+export type DriverEscapeContent = 'driver-alt' | 'driver-escape' | 'driver-unconnected'
+
+export function driverEscapeContent(connectionState: ConnectionStateType, prepareFailed: boolean): DriverEscapeContent {
+  if (connectionState !== 'connected') return 'driver-unconnected'
+  return prepareFailed ? 'driver-escape' : 'driver-alt'
+}
+
+// The in-app connect inspects the live cluster, so it has nothing to do until
+// Radar is connected to one. Until then the browser path is the only way
+// forward, and the footer says why instead of offering a button that would
+// only produce an error.
+export function driverConnectUnavailableNote(connectionState: ConnectionStateType): string | null {
+  switch (connectionState) {
+    case 'connected':
+      return null
+    case 'connecting':
+      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready, or you can set up in the browser now.'
+    case 'disconnected':
+      return "Radar isn't connected to a cluster, so it can't install the connection for you. Set up in the browser, or connect a cluster first."
+  }
+}

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -25,15 +25,15 @@ export function driverEscapeContent(connectionState: ConnectionStateType, prepar
 
 // The in-app connect inspects the live cluster, so it has nothing to do until
 // Radar is connected to one. Until then the browser path is the only way
-// forward, and the footer says why instead of offering a button that would
-// only produce an error.
+// forward, and this text (shown on hover) says why instead of offering a
+// button that would only produce an error.
 export function driverConnectUnavailableNote(connectionState: ConnectionStateType): string | null {
   switch (connectionState) {
     case 'connected':
       return null
     case 'connecting':
-      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready, or you can set up in the browser now.'
+      return 'Radar is still connecting to this cluster. The in-app connect appears once it is ready.'
     case 'disconnected':
-      return "Radar isn't connected to a cluster, so it can't install the connection for you. Set up in the browser, or connect a cluster first."
+      return "Radar isn't connected to a cluster, so it can't install the connection for you. Connect a cluster first, or set up in the browser."
   }
 }

--- a/web/src/components/cloudFunnelState.ts
+++ b/web/src/components/cloudFunnelState.ts
@@ -6,6 +6,18 @@ import type { ConnectionStateType } from '../context/ConnectionContext'
 // cluster to connect yet".
 export type DriverEscapeContent = 'driver-alt' | 'driver-escape' | 'driver-unconnected'
 
+// A prepare 503 is the server saying it has no cluster right now, which can
+// arrive before the connection feed has noticed the drop. Until that feed
+// changes (or the context does), the server's word wins over the stale
+// render-time state, so the footer does not re-offer an attempt that would
+// only fail again.
+export function effectiveConnectionState(
+  connectionState: ConnectionStateType,
+  serverReportedNoCluster: boolean,
+): ConnectionStateType {
+  return serverReportedNoCluster ? 'disconnected' : connectionState
+}
+
 export function driverEscapeContent(connectionState: ConnectionStateType, prepareFailed: boolean): DriverEscapeContent {
   if (connectionState !== 'connected') return 'driver-unconnected'
   return prepareFailed ? 'driver-escape' : 'driver-alt'


### PR DESCRIPTION
## Why

The Cloud dialog's driver lane ("Connect this cluster…") inspects the live cluster, but the header renders the Cloud button from first paint, before Radar has connected to anything. A first-run user who clicks it immediately hits the prepare endpoint's 503, sees "Could not inspect this cluster for Cloud connect", and the escape link flips to `utm_content=driver-escape`. The daily funnel report then reads "no cluster yet" as "the in-app install path broke".

This is exactly what happened with the first funnel-attributed org creation this week: six seconds between the dialog opening on a fresh desktop install and the Hub signup landing via `driver-escape`, with no connect request ever reaching the Hub.

## What changes

- While the cluster is `connecting` or `disconnected`, the driver-lane footer replaces the in-app Connect button with "Set up in the browser" as the primary action. No explanation is attached: someone with no cluster connected is not expecting Radar to install into one. The footer keeps the same quiet layout as the wizard lane, and "How it works" describes the Cloud-side path in that state.
- That link carries a new `utm_content=driver-unconnected`, so the Hub can tell "prefers the browser" (`driver-alt`), "in-app path broke" (`driver-escape`) and "no cluster to connect" apart. The existing two values keep their meaning.
- A 503 from prepare (connection dropped between render and click) no longer marks the attempt as failed: specific toast, back to the pitch, no "Try again". The server's answer overrides a stale `connected` feed until the feed moves, the context changes, or the dialog is reopened.
- The decisions live in pure helpers in `cloudFunnelState.ts` with unit tests.

No Go changes. The embedded Hub build hides this button entirely, so library consumers are unaffected.

## Follow-up outside this repo

Wherever the daily radar-stats report interprets `utm_content` values, add `driver-unconnected` so it is not reported as unknown.

## Verified

- `tsc` clean, `vitest run src` 914/914.
- Dev-mode Radar against an unreachable kubeconfig: the modal shows the promoted button, and the link resolves to `…&utm_content=driver-unconnected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Cloud funnel and analytics tagging; no auth, API, or data-path changes beyond clearer prepare error handling.
> 
> **Overview**
> Fixes the driver-lane Cloud modal so users without a live cluster are not pushed into **Connect this cluster…** only to hit prepare **503** and mis-tagged `driver-escape` analytics.
> 
> **Connection-aware footer:** While Radar is `connecting` or `disconnected`, the primary CTA becomes **Continue in Radar Cloud**; in-app connect returns once connected. Pitch copy temporarily follows the wizard lane when connect is unavailable so it does not promise an on-cluster install.
> 
> **503 handling:** Prepare **503** sets `serverReportedNoCluster`, shows a connect-first toast, exits the flow without **Try again**, and treats the cluster as disconnected until the connection feed, kube context, or modal lifecycle clears the flag.
> 
> **Analytics:** Hub signup links use a new `utm_content=driver-unconnected` via `cloudFunnelState` helpers (`effectiveConnectionState`, `driverEscapeContent`, `driverConnectUnavailableNote`), with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9153e35b80ece75e98addd198e838a150124516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
