### PR TITLE
Render cited Prometheus range queries as chart cards with change markers

### DIFF
--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -115,14 +115,24 @@ func metricsNudge(m MetricsAvailability) string {
 	return fmt.Sprintf("Prometheus is connected at %s; for resource, restart, throttling or latency questions run one `query_prometheus` range query over the failure window and cite it.", promptSafeAddress(m.Address))
 }
 
-// promptSafeAddress drops any credentials embedded in a configured URL: the
-// prompt is model-visible and the agent only needs to know where the backend is.
+// promptSafeAddress reduces a configured URL to where the backend is: scheme,
+// host and path. The prompt is model-visible and leaves the machine, and a
+// Prometheus behind an auth proxy is commonly configured with the credential
+// in the query string (`?token=…`) rather than in userinfo, so stripping
+// userinfo alone still discloses it. The fragment goes for the same reason.
 func promptSafeAddress(address string) string {
 	u, err := url.Parse(address)
-	if err != nil || u.User == nil {
+	if err != nil {
+		return address
+	}
+	if u.User == nil && u.RawQuery == "" && u.Fragment == "" {
 		return address
 	}
 	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	u.RawFragment = ""
 	return u.String()
 }
 

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -91,6 +91,50 @@ type Request struct {
 	// across the run's turns). Backends that need filesystem-scoped session state
 	// use it (Cursor's --resume is workspace-scoped); others ignore it.
 	WorkDir string
+	// Metrics is the RunManager's probe of the metrics backend for this turn.
+	// Only a confirmed connection reaches the prompt; the zero value says nothing.
+	Metrics MetricsAvailability
+}
+
+// MetricsAvailability is what the investigation prompt needs to know about
+// Prometheus: whether a probe just succeeded and, if so, where. It carries no
+// failure detail because the agent is never told about an unreachable backend.
+type MetricsAvailability struct {
+	Connected bool
+	Address   string
+}
+
+// metricsNudge tells the agent Prometheus is reachable so it queries instead
+// of guessing. The sentence names one bounded query shape and asks for a
+// citation so the result lands in Findings as evidence.
+func metricsNudge(m MetricsAvailability) string {
+	if !m.Connected {
+		return ""
+	}
+	return fmt.Sprintf("Prometheus is connected at %s; for resource, restart, throttling or latency questions run one `query_prometheus` range query over the failure window and cite it.", m.Address)
+}
+
+// turnPrompt selects the prompt for a turn. Apply and explanation turns are
+// exact scripts; read-only investigation turns (initial and follow-up) may
+// additionally learn that metrics are available.
+func turnPrompt(req Request) string {
+	if req.Apply {
+		return applyPrompt(req) // explicit, user-confirmed remediation turn
+	}
+	if req.Explanation != nil {
+		return explanationPrompt(*req.Explanation)
+	}
+	prompt := taskPrompt(req)
+	if strings.TrimSpace(req.Question) != "" {
+		// Restate the structured/citation contract on every read-only turn. Some
+		// agent hosts compress resumed context, and verification must never silently
+		// lose the exact evidence links established on the opening turn.
+		prompt = req.Question + "\n\n" + diagnosisJSONInstruction
+	}
+	if nudge := metricsNudge(req.Metrics); nudge != "" {
+		prompt += "\n\n" + nudge
+	}
+	return prompt
 }
 
 // ResourceHealthSignal is the compact server-side health frame captured when a
@@ -511,17 +555,7 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 		sessionID = ""
 	}
 
-	prompt := taskPrompt(req)
-	if req.Apply {
-		prompt = applyPrompt(req) // explicit, user-confirmed remediation turn
-	} else if req.Explanation != nil {
-		prompt = explanationPrompt(*req.Explanation)
-	} else if strings.TrimSpace(req.Question) != "" {
-		// Restate the structured/citation contract on every read-only turn. Some
-		// agent hosts compress resumed context, and verification must never silently
-		// lose the exact evidence links established on the opening turn.
-		prompt = req.Question + "\n\n" + diagnosisJSONInstruction
-	}
+	prompt := turnPrompt(req)
 	sys := ""
 	if sessionID == "" {
 		sys = systemPrompt // a fresh session establishes the SRE + security framing

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,7 +112,18 @@ func metricsNudge(m MetricsAvailability) string {
 	if !m.Connected {
 		return ""
 	}
-	return fmt.Sprintf("Prometheus is connected at %s; for resource, restart, throttling or latency questions run one `query_prometheus` range query over the failure window and cite it.", m.Address)
+	return fmt.Sprintf("Prometheus is connected at %s; for resource, restart, throttling or latency questions run one `query_prometheus` range query over the failure window and cite it.", promptSafeAddress(m.Address))
+}
+
+// promptSafeAddress drops any credentials embedded in a configured URL: the
+// prompt is model-visible and the agent only needs to know where the backend is.
+func promptSafeAddress(address string) string {
+	u, err := url.Parse(address)
+	if err != nil || u.User == nil {
+		return address
+	}
+	u.User = nil
+	return u.String()
 }
 
 // turnPrompt selects the prompt for a turn. Apply and explanation turns are

--- a/internal/ai/metrics_nudge_test.go
+++ b/internal/ai/metrics_nudge_test.go
@@ -54,11 +54,31 @@ func TestTurnPrompt_MetricsNudgeOnlyOnReadOnlyTurnsWhenConnected(t *testing.T) {
 		t.Fatalf("an apply turn must not be sent to gather metrics:\n%s", p)
 	}
 
-	withCredentials := base
-	withCredentials.Metrics = MetricsAvailability{Connected: true, Address: "https://admin:s3cret@prom.example.com:9090"}
-	if p := turnPrompt(withCredentials); strings.Contains(p, "s3cret") || strings.Contains(p, "admin") ||
-		!strings.Contains(p, "https://prom.example.com:9090") {
-		t.Fatalf("credentials in a configured URL reached the prompt:\n%s", p)
+	// The prompt is model-visible and leaves the machine, so every place a
+	// configured URL can carry a credential has to be gone: userinfo, the
+	// query string an auth proxy commonly uses, and the fragment.
+	for _, tc := range []struct {
+		name, address, secret, want string
+	}{
+		{"userinfo", "https://admin:s3cret@prom.example.com:9090", "s3cret", "https://prom.example.com:9090"},
+		{"query", "https://prom.example.com/api?token=s3cret", "s3cret", "https://prom.example.com/api"},
+		{"fragment", "https://prom.example.com/api#s3cret", "s3cret", "https://prom.example.com/api"},
+		{"all three", "https://admin:p@prom.example.com/api?token=s3cret#f", "s3cret", "https://prom.example.com/api"},
+	} {
+		withCredentials := base
+		withCredentials.Metrics = MetricsAvailability{Connected: true, Address: tc.address}
+		p := turnPrompt(withCredentials)
+		if strings.Contains(p, tc.secret) {
+			t.Fatalf("%s: the secret reached the prompt:\n%s", tc.name, p)
+		}
+		if !strings.Contains(p, tc.want) {
+			t.Fatalf("%s: prompt lost the address %q:\n%s", tc.name, tc.want, p)
+		}
+	}
+	withUser := base
+	withUser.Metrics = MetricsAvailability{Connected: true, Address: "https://admin:s3cret@prom.example.com:9090"}
+	if p := turnPrompt(withUser); strings.Contains(p, "admin") {
+		t.Fatalf("the username reached the prompt:\n%s", p)
 	}
 }
 

--- a/internal/ai/metrics_nudge_test.go
+++ b/internal/ai/metrics_nudge_test.go
@@ -53,6 +53,13 @@ func TestTurnPrompt_MetricsNudgeOnlyOnReadOnlyTurnsWhenConnected(t *testing.T) {
 	if p := turnPrompt(apply); strings.Contains(p, "Prometheus") {
 		t.Fatalf("an apply turn must not be sent to gather metrics:\n%s", p)
 	}
+
+	withCredentials := base
+	withCredentials.Metrics = MetricsAvailability{Connected: true, Address: "https://admin:s3cret@prom.example.com:9090"}
+	if p := turnPrompt(withCredentials); strings.Contains(p, "s3cret") || strings.Contains(p, "admin") ||
+		!strings.Contains(p, "https://prom.example.com:9090") {
+		t.Fatalf("credentials in a configured URL reached the prompt:\n%s", p)
+	}
 }
 
 // TestRunManagerProbesMetricsOnlyForReadOnlyTurns pins that the RunManager
@@ -128,6 +135,17 @@ func TestRunManagerProbesMetricsOnlyForReadOnlyTurns(t *testing.T) {
 	waitDone(t)
 	if got := probes.Load(); got != 1 {
 		t.Fatalf("apply turn ran the probe (probes = %d)", got)
+	}
+
+	if err := m.AddTurn(r.ID, "Verify the fix", false, "", true); err != nil {
+		t.Fatalf("AddTurn(verify): %v", err)
+	}
+	if call := next(t); !call.request.Verify || call.request.Metrics.Connected {
+		t.Fatalf("verification request must not carry a probe result: %+v", call.request.Metrics)
+	}
+	waitDone(t)
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("verification turn ran the probe (probes = %d)", got)
 	}
 }
 

--- a/internal/ai/metrics_nudge_test.go
+++ b/internal/ai/metrics_nudge_test.go
@@ -1,0 +1,149 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestTurnPrompt_MetricsNudgeOnlyOnReadOnlyTurnsWhenConnected(t *testing.T) {
+	connected := MetricsAvailability{Connected: true, Address: "http://prometheus.monitoring:9090"}
+	base := Request{Kind: "Deployment", Namespace: "prod", Name: "api"}
+
+	initial := base
+	initial.Metrics = connected
+	if p := turnPrompt(initial); !strings.Contains(p, "Prometheus is connected at http://prometheus.monitoring:9090") ||
+		!strings.Contains(p, "`query_prometheus` range query") || !strings.HasSuffix(strings.TrimSpace(p), "cite it.") {
+		t.Fatalf("initial turn lacks the metrics nudge after the task prompt:\n%s", p)
+	}
+	if p := turnPrompt(initial); strings.Index(p, diagnosisJSONInstruction) > strings.Index(p, "Prometheus is connected") {
+		t.Fatalf("nudge must follow prompt selection, not precede the JSON contract:\n%s", p)
+	}
+
+	followUp := base
+	followUp.Metrics = connected
+	followUp.Question = "Why is it restarting?"
+	followUp.SessionID = "session"
+	if p := turnPrompt(followUp); !strings.HasPrefix(p, "Why is it restarting?") || !strings.Contains(p, "Prometheus is connected at") {
+		t.Fatalf("follow-up lost the question or the nudge:\n%s", p)
+	}
+
+	notConnected := base
+	notConnected.Metrics = MetricsAvailability{Connected: false, Address: "http://prometheus.monitoring:9090"}
+	if p := turnPrompt(notConnected); strings.Contains(p, "Prometheus") {
+		t.Fatalf("a failed probe must say nothing to the agent:\n%s", p)
+	}
+	if p := turnPrompt(base); strings.Contains(p, "Prometheus") {
+		t.Fatalf("an unprobed turn must say nothing to the agent:\n%s", p)
+	}
+
+	explanation := base
+	explanation.Metrics = connected
+	explanation.Explanation = &Diagnosis{RootCause: "Missing Secret", Report: "The saved analysis."}
+	if p := turnPrompt(explanation); strings.Contains(p, "Prometheus") {
+		t.Fatalf("an explanation turn must not be sent to gather metrics:\n%s", p)
+	}
+
+	apply := base
+	apply.Metrics = connected
+	apply.Apply = true
+	apply.Fix = "set replicas to 2"
+	if p := turnPrompt(apply); strings.Contains(p, "Prometheus") {
+		t.Fatalf("an apply turn must not be sent to gather metrics:\n%s", p)
+	}
+}
+
+// TestRunManagerProbesMetricsOnlyForReadOnlyTurns pins that the RunManager
+// asks the probe before investigation turns (initial and follow-up), skips it
+// for explanation and apply turns, and bounds it with a deadline.
+func TestRunManagerProbesMetricsOnlyForReadOnlyTurns(t *testing.T) {
+	m, r, calls := controlledRunManager(t, nil)
+	var probes atomic.Int32
+	m.MetricsAvailability = func(ctx context.Context) MetricsAvailability {
+		probes.Add(1)
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("metrics probe ran without a deadline")
+		}
+		return MetricsAvailability{Connected: true, Address: "http://prom:9090"}
+	}
+	r.append(StreamEvent{Type: "turn"})
+	r.append(StreamEvent{Type: "done", Diag: &Diagnosis{RootCause: "Missing Secret", Report: "The saved analysis."}})
+
+	next := func(t *testing.T) controlledDiagnoseCall {
+		t.Helper()
+		select {
+		case call := <-calls:
+			call.respond <- controlledDiagnoseResponse{diag: Diagnosis{Report: "ok", SessionID: "read-session"}}
+			<-call.returned
+			return call
+		case <-time.After(2 * time.Second):
+			t.Fatal("agent not invoked")
+			return controlledDiagnoseCall{}
+		}
+	}
+	waitDone := func(t *testing.T) {
+		t.Helper()
+		for i := 0; i < 200; i++ {
+			r.mu.Lock()
+			inFlight := r.inFlight
+			r.mu.Unlock()
+			if !inFlight {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatal("turn did not finish")
+	}
+
+	if err := m.AddTurn(r.ID, "Why is it restarting?", false, "", false); err != nil {
+		t.Fatalf("AddTurn(follow-up): %v", err)
+	}
+	if call := next(t); !call.request.Metrics.Connected || call.request.Metrics.Address != "http://prom:9090" {
+		t.Fatalf("follow-up request did not carry the probe result: %+v", call.request.Metrics)
+	}
+	waitDone(t)
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("follow-up probes = %d, want 1", got)
+	}
+
+	if err := m.AddExplanation(r.ID, 2); err != nil {
+		t.Fatalf("AddExplanation: %v", err)
+	}
+	if call := next(t); call.request.Explanation == nil || call.request.Metrics.Connected {
+		t.Fatalf("explanation request must not carry a probe result: %+v", call.request.Metrics)
+	}
+	waitDone(t)
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("explanation turn ran the probe (probes = %d)", got)
+	}
+
+	if err := m.AddTurn(r.ID, "", true, "set replicas to 2", false); err != nil {
+		t.Fatalf("AddTurn(apply): %v", err)
+	}
+	if call := next(t); !call.request.Apply || call.request.Metrics.Connected {
+		t.Fatalf("apply request must not carry a probe result: %+v", call.request.Metrics)
+	}
+	waitDone(t)
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("apply turn ran the probe (probes = %d)", got)
+	}
+}
+
+func TestRunManagerWithoutMetricsProbeSaysNothing(t *testing.T) {
+	m, r, calls := controlledRunManager(t, nil)
+	if err := m.AddTurn(r.ID, "Why?", false, "", false); err != nil {
+		t.Fatalf("AddTurn: %v", err)
+	}
+	select {
+	case call := <-calls:
+		if call.request.Metrics != (MetricsAvailability{}) {
+			t.Fatalf("request carried metrics without a probe: %+v", call.request.Metrics)
+		}
+		call.respond <- controlledDiagnoseResponse{diag: Diagnosis{Report: "ok", SessionID: "read-session"}}
+		<-call.returned
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent not invoked")
+	}
+}

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -35,6 +35,12 @@ type RunManager struct {
 	mcpBasePath string        // --base-path prefix the MCP mounts sit under ("" at the root)
 	ctxLabel    func() string // current kube-context label, for the run's baseline
 
+	// MetricsAvailability probes the metrics backend before a read-only
+	// investigation turn so the prompt can say Prometheus is reachable. nil
+	// means never mention metrics. The probe runs under metricsProbeTimeout so
+	// a slow discovery cannot hold a turn back.
+	MetricsAvailability func(context.Context) MetricsAvailability
+
 	baseCtx    context.Context // parent of every run ctx; cancelled on Shutdown
 	baseCancel context.CancelFunc
 
@@ -654,6 +660,20 @@ func (m *RunManager) launchTurn(r *Run, turn runTurn) {
 	go m.executeTurns(r, turn)
 }
 
+const metricsProbeTimeout = 2 * time.Second
+
+// metricsForTurn probes the metrics backend for a read-only investigation
+// turn. Apply turns act on a confirmed fix and explanation turns restate a
+// saved assessment; neither should be sent looking for new evidence.
+func (m *RunManager) metricsForTurn(turn runTurn) MetricsAvailability {
+	if m.MetricsAvailability == nil || turn.apply || turn.explanation != nil {
+		return MetricsAvailability{}
+	}
+	ctx, cancel := context.WithTimeout(turn.ctx, metricsProbeTimeout)
+	defer cancel()
+	return m.MetricsAvailability(ctx)
+}
+
 // executeTurns runs one ordinary turn, or the two-step apply→verify compound
 // job. The continuation stays inside this goroutine and never re-enters public
 // AddTurn, so it neither releases nor re-reserves the concurrency slot.
@@ -685,6 +705,7 @@ func (m *RunManager) executeTurns(r *Run, turn runTurn) {
 			Explanation: turn.explanation,
 			Agent:       r.Agent, Profile: r.Profile, Model: r.Model, Effort: r.Effort,
 			Health: r.Health, WorkDir: r.WorkDir,
+			Metrics: m.metricsForTurn(turn),
 		}, func(ev StreamEvent) {
 			if turn.apply {
 				mutation.observe(ev)

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -663,10 +663,11 @@ func (m *RunManager) launchTurn(r *Run, turn runTurn) {
 const metricsProbeTimeout = 2 * time.Second
 
 // metricsForTurn probes the metrics backend for a read-only investigation
-// turn. Apply turns act on a confirmed fix and explanation turns restate a
-// saved assessment; neither should be sent looking for new evidence.
+// turn. Apply turns act on a confirmed fix, explanation turns restate a saved
+// assessment, and verification turns check that fix against current state;
+// none of them should be sent looking for new evidence.
 func (m *RunManager) metricsForTurn(turn runTurn) MetricsAvailability {
-	if m.MetricsAvailability == nil || turn.apply || turn.explanation != nil {
+	if m.MetricsAvailability == nil || turn.apply || turn.verify || turn.explanation != nil {
 		return MetricsAvailability{}
 	}
 	ctx, cancel := context.WithTimeout(turn.ctx, metricsProbeTimeout)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -259,6 +259,13 @@ func New(cfg Config) *Server {
 				}
 			}
 			s.aiRuns = ai.NewRunManager(d, s.ActualPort, s.basePath, k8s.GetContextName, store)
+			s.aiRuns.MetricsAvailability = func(ctx context.Context) ai.MetricsAvailability {
+				state := prometheuspkg.Availability(ctx)
+				return ai.MetricsAvailability{
+					Connected: state.State == prometheuspkg.AvailabilityConnected,
+					Address:   state.Address,
+				}
+			}
 			if historyBroken {
 				// Persistence was requested but isn't working — the UI must say
 				// history won't survive a restart, not just a log line.

--- a/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { AreaChart } from './AreaChart'
+import { layoutAnnotations, ANNOTATION_LABEL_ROWS } from './annotations'
+import { formatTimestamp } from './format'
+import type { ChartAnnotation, TimeSeries } from './types'
+
+const t0 = 1_788_679_000
+
+function series(points: Array<[number, number | null]>, labels: Record<string, string> = {}): TimeSeries {
+  return { labels, dataPoints: points.map(([offset, value]) => ({ timestamp: t0 + offset, value })) }
+}
+
+function render(props: Partial<Parameters<typeof AreaChart>[0]> & { series: TimeSeries[] }) {
+  return renderToStaticMarkup(
+    <AreaChart color="#3b82f6" fillColor="#3b82f622" unit="" {...props} />,
+  )
+}
+
+function attrs(html: string, tag: string, attr: string): string[] {
+  const out: string[] = []
+  const re = new RegExp(`<${tag}\\b[^>]*\\s${attr}="([^"]*)"`, 'g')
+  for (const match of html.matchAll(re)) out.push(match[1])
+  return out
+}
+
+describe('AreaChart annotations', () => {
+  const base = [series([[0, 1], [600, 2], [1200, 3], [1800, 2]])]
+
+  it('renders a marker and label per annotation inside the domain and none outside', () => {
+    const annotations: ChartAnnotation[] = [
+      { timestamp: t0 + 600, label: 'ConfigMap api-config', kind: 'change' },
+      { timestamp: t0 + 9_000, label: 'outside', kind: 'change' },
+    ]
+    const html = render({ series: base, annotations })
+    expect(html.match(/data-chart-annotation="change"/g)).toHaveLength(1)
+    expect(html).toContain('data-chart-annotation-label="visible"')
+    expect(html).toContain('ConfigMap api-config')
+    expect(html).not.toContain('outside')
+  })
+
+  it('stacks overlapping labels into rows and hides labels past the row limit', () => {
+    const toX = (ts: number) => 84 + ((ts - t0) / 1800) * 876
+    const crowded: ChartAnnotation[] = Array.from({ length: ANNOTATION_LABEL_ROWS + 1 }, (_, i) => ({
+      timestamp: t0 + i * 5,
+      label: `Change ${i}`,
+      kind: 'change',
+    }))
+    const placed = layoutAnnotations(crowded, toX, { minTs: t0, maxTs: t0 + 1800 }, { left: 84, right: 960 })
+    expect(placed.map(p => p.row)).toEqual([0, 1, 2, -1])
+    expect(placed.at(-1)?.labelHidden).toBe(true)
+    const far: ChartAnnotation[] = [
+      { timestamp: t0, label: 'first', kind: 'change' },
+      { timestamp: t0 + 1200, label: 'second', kind: 'change' },
+    ]
+    expect(layoutAnnotations(far, toX, { minTs: t0, maxTs: t0 + 1800 }, { left: 84, right: 960 }).map(p => p.row)).toEqual([0, 0])
+    const html = render({ series: base, annotations: crowded })
+    expect(html.match(/data-chart-annotation-label="visible"/g)).toHaveLength(ANNOTATION_LABEL_ROWS)
+    expect(html.match(/data-chart-annotation-label="hidden"/g)).toHaveLength(1)
+  })
+
+  it('keeps a long label readable by truncating it', () => {
+    const html = render({
+      series: base,
+      annotations: [{ timestamp: t0 + 600, label: 'ConfigMap a-very-long-configmap-name-that-goes-on', kind: 'change' }],
+    })
+    expect(html).toContain('ConfigMap a-very-long-confi…')
+  })
+})
+
+describe('AreaChart domain and axes', () => {
+  it('uses an explicit domain wider than the samples for the X axis', () => {
+    const html = render({
+      series: [series([[600, 1], [1200, 2]])],
+      domain: { start: t0, end: t0 + 3600 },
+    })
+    const labels = attrs(html, 'text', 'text-anchor')
+    expect(labels.length).toBeGreaterThan(0)
+    expect(html).toContain(`>${formatTimestamp(t0)}<`)
+    expect(html).toContain(`>${formatTimestamp(t0 + 3600)}<`)
+    const xs = attrs(html, 'text', 'x').map(Number).filter(x => x >= 84)
+    expect(Math.max(...xs)).toBeCloseTo(960, 0)
+  })
+
+  it('extends the Y axis below zero and draws a zero line for negative values', () => {
+    const html = render({ series: [series([[0, -4], [600, 2], [1200, -1]])] })
+    expect(html).toContain('data-chart-zero-line')
+    expect(html).toContain('>-4.40<')
+    const positive = render({ series: [series([[0, 1], [600, 2]])] })
+    expect(positive).not.toContain('data-chart-zero-line')
+    expect(positive).toContain('>0<')
+  })
+
+  it('breaks the line across null gaps instead of bridging them', () => {
+    const html = render({ series: [series([[0, 1], [300, 2], [600, null], [900, 3], [1200, 4]])] })
+    const lines = attrs(html, 'path', 'fill').filter(fill => fill === 'none')
+    expect(lines).toHaveLength(2)
+  })
+
+  it('renders sparse samples without a path until two finite points exist', () => {
+    expect(attrs(render({ series: [series([[0, 1]])] }), 'path', 'fill')).toHaveLength(0)
+    expect(attrs(render({ series: [series([[0, 1], [3600, 5]])] }), 'path', 'fill').filter(fill => fill === 'none')).toHaveLength(1)
+  })
+
+  it('renders nothing for an empty series list', () => {
+    expect(render({ series: [] })).toBe('')
+  })
+})

--- a/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
@@ -135,6 +135,15 @@ describe('AreaChart compact layout and count axes', () => {
     expect(html).toContain(`>${formatTimestamp(t0 + 1800)}<`)
   })
 
+  it('widens the compact left margin so a long Y label is not clipped', () => {
+    const html = render({ series: [series([[0, 100 * 1024 * 1024], [600, 161.5 * 1024 * 1024]])], unit: 'bytes', layout: 'compact' })
+    expect(html).toContain('177.7 MiB')
+    const yLabelX = Math.min(...attrs(html, 'text', 'x').map(Number).filter(x => x > 0))
+    expect(yLabelX).toBeGreaterThan(70)
+    const compactSmall = render({ series: [series([[0, 1], [600, 2]])], layout: 'compact' })
+    expect(Math.min(...attrs(compactSmall, 'text', 'x').map(Number).filter(x => x > 0))).toBe(52)
+  })
+
   it('uses integer ticks with a nice step for count series', () => {
     const zero = render({ series: [series([[0, 0], [600, 0], [1200, 0]])], unit: 'count' })
     expect(zero).toContain('>0<')

--- a/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.test.tsx
@@ -106,3 +106,46 @@ describe('AreaChart domain and axes', () => {
     expect(render({ series: [] })).toBe('')
   })
 })
+
+describe('AreaChart compact layout and count axes', () => {
+  const base = [series([[0, 1], [600, 2], [1200, 3], [1800, 2]])]
+
+  it('keeps the full layout for existing callers', () => {
+    const html = render({ series: base })
+    expect(html).toContain('viewBox="0 0 1000 300"')
+    expect(html).toContain('data-chart-layout="full"')
+    expect(attrs(html, 'text', 'text-anchor').filter(a => a === 'end')).toHaveLength(5)
+  })
+
+  it('draws two ticks per axis, larger text and a taller plot when compact', () => {
+    const html = render({
+      series: base,
+      layout: 'compact',
+      annotations: [{ timestamp: t0 + 600, label: 'ConfigMap api-config', kind: 'change' }],
+    })
+    expect(html).toContain('viewBox="0 0 400 260"')
+    expect(html).toContain('data-chart-layout="compact"')
+    // Two Y labels plus the right-aligned last X label.
+    expect(attrs(html, 'text', 'text-anchor').filter(a => a === 'end')).toHaveLength(3)
+    expect(attrs(html, 'text', 'text-anchor').filter(a => a === 'start')).toHaveLength(1)
+    expect(attrs(html, 'text', 'text-anchor').filter(a => a === 'middle')).toHaveLength(0)
+    expect(html).toContain('font-size="14"')
+    expect(html).toContain('data-chart-annotation-label="hidden"')
+    expect(html).toContain(`>${formatTimestamp(t0)}<`)
+    expect(html).toContain(`>${formatTimestamp(t0 + 1800)}<`)
+  })
+
+  it('uses integer ticks with a nice step for count series', () => {
+    const zero = render({ series: [series([[0, 0], [600, 0], [1200, 0]])], unit: 'count' })
+    expect(zero).toContain('>0<')
+    expect(zero).toContain('>1<')
+    expect(zero).not.toContain('1.10')
+    const restarts = render({ series: [series([[0, 6], [600, 12], [1200, 18]])], unit: 'count' })
+    for (const tick of ['0', '5', '10', '15', '20']) expect(restarts).toContain(`>${tick}<`)
+    expect(restarts).not.toContain('6.05')
+    const compactCount = render({ series: [series([[0, 6], [600, 18]])], unit: 'count', layout: 'compact' })
+    expect(attrs(compactCount, 'text', 'text-anchor').filter(a => a === 'end')).toHaveLength(3)
+    expect(compactCount).toContain('>20<')
+    expect(compactCount).not.toContain('>10<')
+  })
+})

--- a/packages/k8s-ui/src/components/charts/AreaChart.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.tsx
@@ -3,6 +3,7 @@ import type * as React from 'react'
 import { seriesColor, seriesFill, computeShortLabels, seriesDisplayLabels } from './colors'
 import { formatMetricValue, formatTimestamp } from './format'
 import { layoutAnnotations } from './annotations'
+import { chartLayout, integerAxisTop, isCountUnit, yAxisValues } from './axis'
 import type { TimeSeries, ReferenceLine, ChartAnnotation } from './types'
 
 // Below this rendered width the annotation label pills would cover most of the
@@ -11,7 +12,7 @@ import type { TimeSeries, ReferenceLine, ChartAnnotation } from './types'
 export const ANNOTATION_LABEL_MIN_WIDTH_PX = 420
 const ANNOTATION_HOVER_TOLERANCE = 8
 
-export function AreaChart({ series, color, fillColor, unit, referenceLines, annotations, domain, seriesLabels }: {
+export function AreaChart({ series, color, fillColor, unit, referenceLines, annotations, domain, seriesLabels, layout = 'full' }: {
   series: TimeSeries[]
   color: string
   fillColor: string
@@ -27,12 +28,21 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
    * the whole result; defaults to names derived from the labels given.
    */
   seriesLabels?: string[]
+  /**
+   * 'full' is the fixed wide layout every existing caller gets. 'auto' switches
+   * to the compact layout (two ticks per axis, larger text, taller plot) when
+   * the rendered chart is narrower than ANNOTATION_LABEL_MIN_WIDTH_PX;
+   * 'compact' forces it.
+   */
+  layout?: 'full' | 'auto' | 'compact'
 }) {
   const svgRef = useRef<SVGSVGElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [hoverX, setHoverX] = useState<number | null>(null)
   const [labelsFit, setLabelsFit] = useState(true)
   const multiSeries = series.length > 1
+  const compact = layout === 'compact' || (layout === 'auto' && !labelsFit)
+  const countAxis = isCountUnit(unit)
 
   const chartData = useMemo(() => {
     if (!series.length) return null
@@ -70,21 +80,18 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
     }
 
     const padding = Math.max(maxVal, -minVal) * 0.1
-    const yMax = maxVal + padding
+    // A count axis ends on a whole step so its ticks are integers; other
+    // units keep headroom above the maximum.
+    const yMax = countAxis && minVal >= 0 ? integerAxisTop(maxVal, compact ? 1 : 4) : maxVal + padding
     const yMin = minVal < 0 ? minVal - padding : 0
 
     return { minTs, maxTs, yMax, yMin, series }
-  }, [series, unit, referenceLines, domain])
+  }, [series, unit, referenceLines, domain, countAxis, compact])
 
   // Layout constants. marginLeft sized for the widest expected Y-tick label
   // ("422.4 MiB" etc.) — narrow grid panels squeeze the X axis so labels
   // need extra viewBox-space to survive the down-scale.
-  const width = 1000
-  const height = 300
-  const marginLeft = 84
-  const marginRight = 40
-  const marginTop = 10
-  const marginBottom = 30
+  const { width, height, marginLeft, marginRight, marginTop, marginBottom, fontSize, yIntervals, xIntervals } = chartLayout(compact)
   const plotWidth = width - marginLeft - marginRight
   const plotHeight = height - marginTop - marginBottom
 
@@ -103,22 +110,22 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
   const yTicks = useMemo(() => {
     if (!chartData) return []
     const { yMax, yMin } = chartData
-    const count = 4
-    return Array.from({ length: count + 1 }, (_, i) => {
-      const val = yMin + ((yMax - yMin) / count) * i
-      return { val, y: toY(val), label: formatMetricValue(val, unit) }
-    })
-  }, [chartData, unit])
+    return yAxisValues(yMin, yMax, yIntervals, countAxis).map(val => ({
+      val, y: toY(val), label: formatMetricValue(val, unit),
+    }))
+  }, [chartData, unit, yIntervals, countAxis])
 
   const xTicks = useMemo(() => {
     if (!chartData) return []
     const { minTs, maxTs } = chartData
-    const count = 6
-    return Array.from({ length: count + 1 }, (_, i) => {
-      const ts = minTs + ((maxTs - minTs) / count) * i
-      return { ts, x: toX(ts), label: formatTimestamp(ts) }
+    return Array.from({ length: xIntervals + 1 }, (_, i) => {
+      const ts = minTs + ((maxTs - minTs) / xIntervals) * i
+      // In the compact layout the two labels sit at the plot edges and would
+      // otherwise spill past the viewBox.
+      const anchor: 'start' | 'middle' | 'end' = !compact ? 'middle' : i === 0 ? 'start' : 'end'
+      return { ts, x: toX(ts), label: formatTimestamp(ts), anchor }
     })
-  }, [chartData])
+  }, [chartData, xIntervals, compact])
 
   const paths = useMemo(() => {
     if (!chartData) return []
@@ -186,13 +193,13 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
 
   useEffect(() => {
     const el = wrapperRef.current
-    if (!el || placedAnnotations.length === 0 || typeof ResizeObserver === 'undefined') return
+    if (!el || (placedAnnotations.length === 0 && layout !== 'auto') || typeof ResizeObserver === 'undefined') return
     const update = () => setLabelsFit(el.getBoundingClientRect().width >= ANNOTATION_LABEL_MIN_WIDTH_PX)
     update()
     const observer = new ResizeObserver(update)
     observer.observe(el)
     return () => observer.disconnect()
-  }, [placedAnnotations.length])
+  }, [placedAnnotations.length, layout])
 
   // Hover: only emit a tooltip row when the hovered timestamp lies within
   // the series' actual sample range (with 2× median-step tolerance). Without
@@ -274,6 +281,7 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
         viewBox={`0 0 ${width} ${height}`}
         className="w-full h-full"
         preserveAspectRatio="xMidYMid meet"
+        data-chart-layout={compact ? 'compact' : 'full'}
       >
         {/* Grid lines */}
         {yTicks.map((tick, i) => (
@@ -311,7 +319,7 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
             y={tick.y + 4}
             textAnchor="end"
             className="fill-theme-text-secondary"
-            fontSize="11"
+            fontSize={fontSize}
             fontFamily="ui-monospace, monospace"
           >
             {tick.label}
@@ -324,9 +332,9 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
             key={`xlabel-${i}`}
             x={tick.x}
             y={height - 4}
-            textAnchor="middle"
+            textAnchor={tick.anchor}
             className="fill-theme-text-secondary"
-            fontSize="11"
+            fontSize={fontSize}
             fontFamily="ui-monospace, monospace"
           >
             {tick.label}
@@ -407,7 +415,7 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
             in stacked rows at the top of the plot. */}
         {placedAnnotations.map((placed, i) => {
           const labelY = marginTop + placed.row * (annotationLabelHeight + 2)
-          const showLabel = labelsFit && !placed.labelHidden
+          const showLabel = labelsFit && !compact && !placed.labelHidden
           return (
             <g
               key={`annotation-${i}`}

--- a/packages/k8s-ui/src/components/charts/AreaChart.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.tsx
@@ -91,7 +91,16 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
   // Layout constants. marginLeft sized for the widest expected Y-tick label
   // ("422.4 MiB" etc.) — narrow grid panels squeeze the X axis so labels
   // need extra viewBox-space to survive the down-scale.
-  const { width, height, marginLeft, marginRight, marginTop, marginBottom, fontSize, yIntervals, xIntervals } = chartLayout(compact)
+  const base = chartLayout(compact)
+  const { width, height, marginRight, marginTop, marginBottom, fontSize, yIntervals, xIntervals } = base
+  const yValues = chartData ? yAxisValues(chartData.yMin, chartData.yMax, yIntervals, countAxis) : []
+  const yLabels = yValues.map(val => formatMetricValue(val, unit))
+  // The compact layout's larger text makes a label like "161.5 MiB" wider
+  // than the fixed margin, and SVG clips it; grow the margin to the widest
+  // label there. The full layout keeps its fixed margin for existing callers.
+  const marginLeft = compact
+    ? Math.max(base.marginLeft, Math.ceil(Math.max(0, ...yLabels.map(label => label.length)) * fontSize * 0.62 + 12))
+    : base.marginLeft
   const plotWidth = width - marginLeft - marginRight
   const plotHeight = height - marginTop - marginBottom
 
@@ -109,11 +118,8 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
 
   const yTicks = useMemo(() => {
     if (!chartData) return []
-    const { yMax, yMin } = chartData
-    return yAxisValues(yMin, yMax, yIntervals, countAxis).map(val => ({
-      val, y: toY(val), label: formatMetricValue(val, unit),
-    }))
-  }, [chartData, unit, yIntervals, countAxis])
+    return yValues.map((val, i) => ({ val, y: toY(val), label: yLabels[i] }))
+  }, [chartData, yValues, yLabels])
 
   const xTicks = useMemo(() => {
     if (!chartData) return []

--- a/packages/k8s-ui/src/components/charts/AreaChart.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.tsx
@@ -11,7 +11,7 @@ import type { TimeSeries, ReferenceLine, ChartAnnotation } from './types'
 export const ANNOTATION_LABEL_MIN_WIDTH_PX = 420
 const ANNOTATION_HOVER_TOLERANCE = 8
 
-export function AreaChart({ series, color, fillColor, unit, referenceLines, annotations, domain }: {
+export function AreaChart({ series, color, fillColor, unit, referenceLines, annotations, domain, seriesLabels }: {
   series: TimeSeries[]
   color: string
   fillColor: string
@@ -21,6 +21,12 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
   annotations?: ChartAnnotation[]
   /** X axis window in unix seconds. Defaults to the sample extent. */
   domain?: { start: number; end: number }
+  /**
+   * Display name per series, parallel to `series`. Pass it when the chart
+   * shows a subset of a larger result so names stay distinguishable across
+   * the whole result; defaults to names derived from the labels given.
+   */
+  seriesLabels?: string[]
 }) {
   const svgRef = useRef<SVGSVGElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -202,8 +208,8 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
       .map((s, i) => ({ s, i }))
       .filter(({ s }) => s.dataPoints.filter(dp => dp.value != null).length >= 2)
 
-    const allLabels = seriesDisplayLabels(chartData.series)
-    const fullLabels = validSeries.map(({ i }) => allLabels[i])
+    const allLabels = seriesLabels ?? seriesDisplayLabels(chartData.series)
+    const fullLabels = validSeries.map(({ i }) => allLabels[i] ?? `series-${i}`)
     const shortLabels = computeShortLabels(fullLabels)
 
     const points = validSeries.map(({ s, i }, vi) => {
@@ -244,7 +250,7 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
     )
 
     return { ts, x: clampedX, points, nearbyAnnotations }
-  }, [hoverX, chartData, placedAnnotations])
+  }, [hoverX, chartData, placedAnnotations, seriesLabels])
 
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGRectElement>) => {
     const svg = svgRef.current
@@ -284,7 +290,6 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines, anno
           />
         ))}
 
-        {/* Zero line when the axis extends below zero */}
         {zeroLineY !== null && (
           <line
             data-chart-zero-line

--- a/packages/k8s-ui/src/components/charts/AreaChart.tsx
+++ b/packages/k8s-ui/src/components/charts/AreaChart.tsx
@@ -1,18 +1,31 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type * as React from 'react'
-import { seriesColor, seriesFill, computeShortLabels } from './colors'
+import { seriesColor, seriesFill, computeShortLabels, seriesDisplayLabels } from './colors'
 import { formatMetricValue, formatTimestamp } from './format'
-import type { TimeSeries, ReferenceLine } from './types'
+import { layoutAnnotations } from './annotations'
+import type { TimeSeries, ReferenceLine, ChartAnnotation } from './types'
 
-export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
+// Below this rendered width the annotation label pills would cover most of the
+// plot once the 1000-unit viewBox is scaled down; the lines stay and the label
+// text moves into the hover tooltip.
+export const ANNOTATION_LABEL_MIN_WIDTH_PX = 420
+const ANNOTATION_HOVER_TOLERANCE = 8
+
+export function AreaChart({ series, color, fillColor, unit, referenceLines, annotations, domain }: {
   series: TimeSeries[]
   color: string
   fillColor: string
   unit: string
   referenceLines?: ReferenceLine[]
+  /** Vertical markers; only those inside the X domain render. */
+  annotations?: ChartAnnotation[]
+  /** X axis window in unix seconds. Defaults to the sample extent. */
+  domain?: { start: number; end: number }
 }) {
   const svgRef = useRef<SVGSVGElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const [hoverX, setHoverX] = useState<number | null>(null)
+  const [labelsFit, setLabelsFit] = useState(true)
   const multiSeries = series.length > 1
 
   const chartData = useMemo(() => {
@@ -21,17 +34,23 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
     let minTs = Infinity
     let maxTs = -Infinity
     let maxVal = 0
+    let minVal = 0
 
     for (const s of series) {
       for (const dp of s.dataPoints) {
         if (dp.timestamp < minTs) minTs = dp.timestamp
         if (dp.timestamp > maxTs) maxTs = dp.timestamp
         if (dp.value != null && dp.value > maxVal) maxVal = dp.value
+        if (dp.value != null && dp.value < minVal) minVal = dp.value
       }
     }
 
+    if (domain && Number.isFinite(domain.start) && Number.isFinite(domain.end) && domain.end > domain.start) {
+      minTs = domain.start
+      maxTs = domain.end
+    }
     if (minTs === maxTs) maxTs = minTs + 60
-    if (maxVal === 0) {
+    if (maxVal === 0 && minVal === 0) {
       // Unit-appropriate floor so the Y-axis isn't misleadingly large.
       maxVal = unit === 'cores' ? 0.01 : unit === 'bytes' ? 1024 * 1024 : unit === 'bytes/s' ? 1024 : 1
     }
@@ -44,11 +63,12 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
       }
     }
 
-    const padding = maxVal * 0.1
+    const padding = Math.max(maxVal, -minVal) * 0.1
     const yMax = maxVal + padding
+    const yMin = minVal < 0 ? minVal - padding : 0
 
-    return { minTs, maxTs, yMax, series }
-  }, [series, unit, referenceLines])
+    return { minTs, maxTs, yMax, yMin, series }
+  }, [series, unit, referenceLines, domain])
 
   // Layout constants. marginLeft sized for the widest expected Y-tick label
   // ("422.4 MiB" etc.) — narrow grid panels squeeze the X axis so labels
@@ -71,15 +91,15 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
   }
   const toY = (val: number) => {
     if (!chartData) return marginTop + plotHeight
-    return marginTop + plotHeight - (val / chartData.yMax) * plotHeight
+    return marginTop + plotHeight - ((val - chartData.yMin) / (chartData.yMax - chartData.yMin)) * plotHeight
   }
 
   const yTicks = useMemo(() => {
     if (!chartData) return []
-    const { yMax } = chartData
+    const { yMax, yMin } = chartData
     const count = 4
     return Array.from({ length: count + 1 }, (_, i) => {
-      const val = (yMax / count) * i
+      const val = yMin + ((yMax - yMin) / count) * i
       return { val, y: toY(val), label: formatMetricValue(val, unit) }
     })
   }, [chartData, unit])
@@ -96,6 +116,9 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
 
   const paths = useMemo(() => {
     if (!chartData) return []
+    // The area fills toward zero, not the plot floor, so a series that dips
+    // below zero is shaded on the correct side of the axis.
+    const baseline = toY(0)
     const segments: {
       linePath: string
       areaPath: string
@@ -118,8 +141,8 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
         if (run.length >= 2) {
           const linePath = run.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ')
           const areaPath = linePath +
-            ` L${run[run.length - 1].x},${marginTop + plotHeight}` +
-            ` L${run[0].x},${marginTop + plotHeight} Z`
+            ` L${run[run.length - 1].x},${baseline}` +
+            ` L${run[0].x},${baseline} Z`
           segments.push({
             linePath,
             areaPath,
@@ -145,6 +168,26 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
     return segments
   }, [chartData])
 
+  const placedAnnotations = useMemo(() => {
+    if (!chartData || !annotations?.length) return []
+    return layoutAnnotations(
+      annotations,
+      toX,
+      { minTs: chartData.minTs, maxTs: chartData.maxTs },
+      { left: marginLeft, right: width - marginRight },
+    )
+  }, [chartData, annotations])
+
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el || placedAnnotations.length === 0 || typeof ResizeObserver === 'undefined') return
+    const update = () => setLabelsFit(el.getBoundingClientRect().width >= ANNOTATION_LABEL_MIN_WIDTH_PX)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [placedAnnotations.length])
+
   // Hover: only emit a tooltip row when the hovered timestamp lies within
   // the series' actual sample range (with 2× median-step tolerance). Without
   // this filter a series that ended mid-window leaves stale ghost entries.
@@ -159,9 +202,8 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
       .map((s, i) => ({ s, i }))
       .filter(({ s }) => s.dataPoints.filter(dp => dp.value != null).length >= 2)
 
-    const fullLabels = validSeries.map(({ s, i }) =>
-      s.labels.pod || s.labels.instance || s.labels.node || `series-${i}`
-    )
+    const allLabels = seriesDisplayLabels(chartData.series)
+    const fullLabels = validSeries.map(({ i }) => allLabels[i])
     const shortLabels = computeShortLabels(fullLabels)
 
     const points = validSeries.map(({ s, i }, vi) => {
@@ -197,8 +239,12 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
       }
     }).filter((p): p is NonNullable<typeof p> => p !== null)
 
-    return { ts, x: clampedX, points }
-  }, [hoverX, chartData])
+    const nearbyAnnotations = placedAnnotations.filter(
+      p => Math.abs(p.x - clampedX) <= ANNOTATION_HOVER_TOLERANCE,
+    )
+
+    return { ts, x: clampedX, points, nearbyAnnotations }
+  }, [hoverX, chartData, placedAnnotations])
 
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGRectElement>) => {
     const svg = svgRef.current
@@ -212,8 +258,11 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
   // every hook has been invoked (Rules of Hooks).
   if (!chartData) return null
 
+  const annotationLabelHeight = 14
+  const zeroLineY = chartData.yMin < 0 ? toY(0) : null
+
   return (
-    <div className="relative">
+    <div className="relative" ref={wrapperRef}>
       <svg
         ref={svgRef}
         viewBox={`0 0 ${width} ${height}`}
@@ -234,6 +283,20 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
             strokeDasharray={i === 0 ? undefined : '4 4'}
           />
         ))}
+
+        {/* Zero line when the axis extends below zero */}
+        {zeroLineY !== null && (
+          <line
+            data-chart-zero-line
+            x1={marginLeft}
+            y1={zeroLineY}
+            x2={width - marginRight}
+            y2={zeroLineY}
+            stroke="currentColor"
+            className="text-theme-border/60"
+            strokeWidth="1"
+          />
+        )}
 
         {/* Y axis labels */}
         {yTicks.map((tick, i) => (
@@ -335,6 +398,67 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
           )
         })}
 
+        {/* Annotation markers: a vertical line per recorded instant, labelled
+            in stacked rows at the top of the plot. */}
+        {placedAnnotations.map((placed, i) => {
+          const labelY = marginTop + placed.row * (annotationLabelHeight + 2)
+          const showLabel = labelsFit && !placed.labelHidden
+          return (
+            <g
+              key={`annotation-${i}`}
+              data-chart-annotation={placed.annotation.kind}
+              data-chart-annotation-label={showLabel ? 'visible' : 'hidden'}
+            >
+              <line
+                x1={placed.x}
+                y1={marginTop}
+                x2={placed.x}
+                y2={marginTop + plotHeight}
+                stroke="currentColor"
+                className="text-accent"
+                strokeWidth="1.5"
+                strokeDasharray="3 3"
+                opacity="0.9"
+              />
+              {showLabel && (
+                <>
+                  <rect
+                    x={placed.labelX}
+                    y={labelY}
+                    width={placed.labelWidth}
+                    height={annotationLabelHeight}
+                    rx="3"
+                    fill="currentColor"
+                    className="text-theme-surface"
+                    opacity="0.9"
+                  />
+                  <rect
+                    x={placed.labelX}
+                    y={labelY}
+                    width={placed.labelWidth}
+                    height={annotationLabelHeight}
+                    rx="3"
+                    fill="none"
+                    stroke="currentColor"
+                    className="text-accent/50"
+                    strokeWidth="1"
+                  />
+                  <text
+                    x={placed.labelX + 5}
+                    y={labelY + annotationLabelHeight - 3.5}
+                    fontSize="11"
+                    fontFamily="ui-monospace, monospace"
+                    fontWeight="500"
+                    className="fill-accent-text"
+                  >
+                    {placed.labelText}
+                  </text>
+                </>
+              )}
+            </g>
+          )
+        })}
+
         {/* Hover crosshair + dots */}
         {hoverData && (
           <>
@@ -383,6 +507,15 @@ export function AreaChart({ series, color, fillColor, unit, referenceLines }: {
             <div className="text-theme-text-tertiary mb-1.5 font-mono">
               {new Date(hoverData.ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
             </div>
+            {hoverData.nearbyAnnotations.map((placed, i) => (
+              <div key={`annotation-${i}`} className="flex items-center gap-2 py-0.5">
+                <span className="w-2 h-2 rounded-full shrink-0 bg-accent" />
+                <span className="text-accent-text">Change recorded</span>
+                <span className="text-theme-text-primary font-mono ml-auto pl-3">
+                  {placed.annotation.label}
+                </span>
+              </div>
+            ))}
             {hoverData.points.map((p, i) => (
               <div key={i} className="flex items-center gap-2 py-0.5">
                 <div

--- a/packages/k8s-ui/src/components/charts/SeriesLegend.tsx
+++ b/packages/k8s-ui/src/components/charts/SeriesLegend.tsx
@@ -1,10 +1,10 @@
-import { seriesColor } from './colors'
+import { seriesColor, seriesDisplayLabels } from './colors'
 import type { TimeSeries } from './types'
 
 // Caps visible entries to match AreaChart's SERIES_COLORS length; extras
 // collapse to "+N more".
 export function SeriesLegend({ series, color }: { series: TimeSeries[]; color: string }) {
-  const labels = series.map((s, i) => s.labels.pod || s.labels.instance || `series-${i}`)
+  const labels = seriesDisplayLabels(series)
   return (
     <div className="flex flex-wrap gap-x-4 gap-y-1 px-1">
       {series.slice(0, 10).map((_, i) => {

--- a/packages/k8s-ui/src/components/charts/SeriesLegend.tsx
+++ b/packages/k8s-ui/src/components/charts/SeriesLegend.tsx
@@ -3,8 +3,13 @@ import type { TimeSeries } from './types'
 
 // Caps visible entries to match AreaChart's SERIES_COLORS length; extras
 // collapse to "+N more".
-export function SeriesLegend({ series, color }: { series: TimeSeries[]; color: string }) {
-  const labels = seriesDisplayLabels(series)
+export function SeriesLegend({ series, color, seriesLabels }: {
+  series: TimeSeries[]
+  color: string
+  /** Display name per series, parallel to `series`; defaults to label-derived names. */
+  seriesLabels?: string[]
+}) {
+  const labels = seriesLabels ?? seriesDisplayLabels(series)
   return (
     <div className="flex flex-wrap gap-x-4 gap-y-1 px-1">
       {series.slice(0, 10).map((_, i) => {

--- a/packages/k8s-ui/src/components/charts/annotations.ts
+++ b/packages/k8s-ui/src/components/charts/annotations.ts
@@ -1,0 +1,59 @@
+import type { ChartAnnotation } from './types'
+
+export interface PlacedAnnotation {
+  annotation: ChartAnnotation
+  x: number
+  /** Left edge of the label pill, kept inside the plot. */
+  labelX: number
+  /** Stacking row for the label pill; 0 is the top row. */
+  row: number
+  labelText: string
+  labelWidth: number
+  /** True when the label could not find a free row and only the line renders. */
+  labelHidden: boolean
+}
+
+export const ANNOTATION_LABEL_MAX_CHARS = 28
+export const ANNOTATION_LABEL_ROWS = 3
+const LABEL_GAP = 6
+
+export function truncateAnnotationLabel(label: string): string {
+  return label.length > ANNOTATION_LABEL_MAX_CHARS
+    ? `${label.slice(0, ANNOTATION_LABEL_MAX_CHARS - 1)}…`
+    : label
+}
+
+/**
+ * Positions annotation labels so none overlap: markers are sorted by time and
+ * each label takes the first row whose previous label ends before it starts,
+ * shifting left only as far as the plot edge allows. A label that fits no row
+ * is hidden; its line still renders and its text remains in the hover tooltip.
+ */
+export function layoutAnnotations(
+  annotations: readonly ChartAnnotation[],
+  toX: (timestamp: number) => number,
+  domain: { minTs: number; maxTs: number },
+  plot: { left: number; right: number },
+): PlacedAnnotation[] {
+  const inWindow = annotations
+    .filter(a => Number.isFinite(a.timestamp) && a.timestamp >= domain.minTs && a.timestamp <= domain.maxTs)
+    .map(a => ({ annotation: a, x: toX(a.timestamp) }))
+    .sort((a, b) => a.x - b.x)
+  const rowEnds: number[] = []
+  return inWindow.map(({ annotation, x }) => {
+    const labelText = truncateAnnotationLabel(annotation.label)
+    const labelWidth = labelText.length * 6.5 + 10
+    const start = Math.max(plot.left, Math.min(plot.right - labelWidth, x + 4))
+    let row = rowEnds.findIndex(end => end + LABEL_GAP <= start)
+    if (row === -1) {
+      if (rowEnds.length >= ANNOTATION_LABEL_ROWS) {
+        return { annotation, x, labelX: start, row: -1, labelText, labelWidth, labelHidden: true }
+      }
+      row = rowEnds.length
+      rowEnds.push(start + labelWidth)
+    } else {
+      rowEnds[row] = start + labelWidth
+    }
+    return { annotation, x, labelX: start, row, labelText, labelWidth, labelHidden: false }
+  })
+}

--- a/packages/k8s-ui/src/components/charts/axis.test.ts
+++ b/packages/k8s-ui/src/components/charts/axis.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { chartLayout, integerAxisTop, yAxisValues } from './axis'
+
+describe('integer axes', () => {
+  it('ends a count axis on a whole step that reaches the maximum', () => {
+    expect(integerAxisTop(0, 4)).toBe(1)
+    expect(integerAxisTop(1, 4)).toBe(1)
+    expect(integerAxisTop(3, 4)).toBe(3)
+    expect(integerAxisTop(18, 4)).toBe(20)
+    expect(integerAxisTop(250, 4)).toBe(300)
+    expect(integerAxisTop(1.1, 4)).toBe(2)
+    expect(integerAxisTop(18, 1)).toBe(20)
+    expect(integerAxisTop(7, 1)).toBe(10)
+  })
+
+  it('never yields fractional ticks on an integer axis', () => {
+    expect(yAxisValues(0, 1, 4, true)).toEqual([0, 1])
+    expect(yAxisValues(0, 3, 4, true)).toEqual([0, 1, 2, 3])
+    expect(yAxisValues(0, 20, 4, true)).toEqual([0, 5, 10, 15, 20])
+    expect(yAxisValues(0, 20, 1, true)).toEqual([0, 20])
+    expect(yAxisValues(0, 1.1, 4, false)).toEqual([0, 0.275, 0.55, 0.8250000000000001, 1.1])
+  })
+
+  it('has a compact layout with two ticks per axis and larger text', () => {
+    const full = chartLayout(false)
+    const compact = chartLayout(true)
+    expect([full.yIntervals, full.xIntervals, full.fontSize]).toEqual([4, 6, 11])
+    expect([compact.yIntervals, compact.xIntervals]).toEqual([1, 1])
+    expect(compact.fontSize).toBeGreaterThan(full.fontSize)
+    expect(compact.height / compact.width).toBeGreaterThan(full.height / full.width)
+  })
+})

--- a/packages/k8s-ui/src/components/charts/axis.ts
+++ b/packages/k8s-ui/src/components/charts/axis.ts
@@ -1,0 +1,60 @@
+// Axis helpers shared by the chart's full and compact layouts. Pure so the
+// tick choices can be tested without rendering.
+
+export interface ChartLayout {
+  width: number
+  height: number
+  marginLeft: number
+  marginRight: number
+  marginTop: number
+  marginBottom: number
+  fontSize: number
+  /** Number of Y intervals between the lowest and highest tick. */
+  yIntervals: number
+  /** Number of X intervals between the first and last tick. */
+  xIntervals: number
+}
+
+// The compact layout trades tick density for legible text: a 400-unit
+// viewBox scaled into a ~280px pane keeps 14-unit text near 10px, where the
+// full layout's 11-unit text in a 1000-unit viewBox would be 3px.
+export function chartLayout(compact: boolean): ChartLayout {
+  return compact
+    ? { width: 400, height: 260, marginLeft: 60, marginRight: 14, marginTop: 12, marginBottom: 28, fontSize: 14, yIntervals: 1, xIntervals: 1 }
+    : { width: 1000, height: 300, marginLeft: 84, marginRight: 40, marginTop: 10, marginBottom: 30, fontSize: 11, yIntervals: 4, xIntervals: 6 }
+}
+
+export function isCountUnit(unit: string): boolean {
+  return unit === 'count' || unit === 'restarts'
+}
+
+/**
+ * Top of an integer axis: the smallest 1/2/5×10ⁿ step that reaches `max`
+ * within `intervals` ticks, rounded up to a whole step. `max` 0 or 1 gives 1,
+ * 18 gives 20 (step 5), 3 gives 3 (step 1).
+ */
+export function integerAxisTop(max: number, intervals: number): number {
+  const target = Math.max(1, Math.ceil(max))
+  const steps = Math.max(1, intervals)
+  let magnitude = 1
+  for (;;) {
+    for (const base of [1, 2, 5]) {
+      const step = base * magnitude
+      if (step * steps >= target) return step * Math.ceil(target / step)
+    }
+    magnitude *= 10
+  }
+}
+
+/** Tick values from yMin to yMax; integer axes never produce fractional ticks. */
+export function yAxisValues(yMin: number, yMax: number, intervals: number, integer: boolean): number[] {
+  if (integer && yMin === 0) {
+    const step = yMax / intervals
+    const wholeStep = Number.isInteger(step) ? step : Math.max(1, Math.ceil(step))
+    const values: number[] = []
+    for (let value = 0; value <= yMax; value += wholeStep) values.push(value)
+    if (values[values.length - 1] !== yMax) values.push(yMax)
+    return values
+  }
+  return Array.from({ length: intervals + 1 }, (_, i) => yMin + ((yMax - yMin) / intervals) * i)
+}

--- a/packages/k8s-ui/src/components/charts/colors.test.ts
+++ b/packages/k8s-ui/src/components/charts/colors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { seriesDisplayLabels } from './colors'
+
+describe('seriesDisplayLabels', () => {
+  it('prefers pod, instance or node labels when they are distinct', () => {
+    expect(seriesDisplayLabels([
+      { labels: { pod: 'api-a', container: 'api' } },
+      { labels: { instance: '10.0.0.2:9100' } },
+      { labels: { node: 'n1' } },
+    ])).toEqual(['api-a', '10.0.0.2:9100', 'n1'])
+  })
+
+  it('shows every label when the preferred label is missing or shared', () => {
+    expect(seriesDisplayLabels([
+      { labels: { container: 'api' } },
+      { labels: { container: 'envoy' } },
+    ])).toEqual(['container=api', 'container=envoy'])
+    expect(seriesDisplayLabels([
+      { labels: { pod: 'api-a', container: 'api' } },
+      { labels: { pod: 'api-a', container: 'envoy' } },
+    ])).toEqual(['pod=api-a, container=api', 'pod=api-a, container=envoy'])
+  })
+
+  it('falls back to a positional name for an unlabelled series', () => {
+    expect(seriesDisplayLabels([{ labels: {} }, { labels: { pod: 'a' } }])).toEqual(['series-0', 'a'])
+  })
+})

--- a/packages/k8s-ui/src/components/charts/colors.ts
+++ b/packages/k8s-ui/src/components/charts/colors.ts
@@ -22,6 +22,29 @@ export function seriesFill(index: number, fallback: string): string {
   return (SERIES_COLORS[index % SERIES_COLORS.length] ?? fallback) + '22'
 }
 
+const PREFERRED_SERIES_LABELS = ['pod', 'instance', 'node'] as const
+
+function allLabels(labels: Record<string, string>): string {
+  return Object.entries(labels).map(([key, value]) => `${key}=${value}`).join(', ')
+}
+
+/**
+ * One display name per series. A pod, instance or node label is the name
+ * operators recognise, but an aggregation may drop it or two series may
+ * share it (one per container); then every label is shown so no two series
+ * become indistinguishable.
+ */
+export function seriesDisplayLabels(series: readonly { labels: Record<string, string> }[]): string[] {
+  const preferred = series.map((s, i) => {
+    for (const key of PREFERRED_SERIES_LABELS) {
+      if (s.labels[key]) return s.labels[key]
+    }
+    return Object.keys(s.labels).length > 0 ? allLabels(s.labels) : `series-${i}`
+  })
+  if (new Set(preferred).size === preferred.length) return preferred
+  return series.map((s, i) => (Object.keys(s.labels).length > 0 ? allLabels(s.labels) : `series-${i}`))
+}
+
 /**
  * Strip the shared prefix from a set of labels so the differentiating suffix
  * is what's shown. Example:

--- a/packages/k8s-ui/src/components/charts/format.test.ts
+++ b/packages/k8s-ui/src/components/charts/format.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { formatMetricValue } from './format'
+
+describe('formatMetricValue', () => {
+  it('scales unitless values with SI prefixes instead of a runaway k', () => {
+    expect(formatMetricValue(19_027_100, '')).toBe('19.0M')
+    expect(formatMetricValue(38_054_300, '')).toBe('38.1M')
+    expect(formatMetricValue(57_081, '')).toBe('57.1k')
+    expect(formatMetricValue(4_200_000_000, '')).toBe('4.20G')
+    expect(formatMetricValue(812, '')).toBe('812')
+  })
+
+  it('formats seconds and negative values', () => {
+    expect(formatMetricValue(0.25, 'seconds')).toBe('250ms')
+    expect(formatMetricValue(90, 'seconds')).toBe('1.5m')
+    expect(formatMetricValue(-3.5, '')).toBe('-3.50')
+    expect(formatMetricValue(-2048, 'bytes')).toBe('-2.0 KiB')
+  })
+})

--- a/packages/k8s-ui/src/components/charts/format.ts
+++ b/packages/k8s-ui/src/components/charts/format.ts
@@ -39,7 +39,9 @@ export function formatMetricValue(value: number, unit: string): string {
       if (value < 1) return value.toFixed(3)
       if (value < 100) return value.toFixed(2)
       if (value < 10000) return value.toFixed(0)
-      return `${(value / 1000).toFixed(1)}k`
+      if (value < 1e6) return `${(value / 1e3).toFixed(1)}k`
+      if (value < 1e9) return `${(value / 1e6).toFixed(1)}M`
+      return `${(value / 1e9).toFixed(2)}G`
   }
 }
 

--- a/packages/k8s-ui/src/components/charts/format.ts
+++ b/packages/k8s-ui/src/components/charts/format.ts
@@ -4,6 +4,7 @@
 
 export function formatMetricValue(value: number, unit: string): string {
   if (value === 0) return '0'
+  if (value < 0) return `-${formatMetricValue(-value, unit)}`
 
   switch (unit) {
     case 'cores': {
@@ -25,6 +26,13 @@ export function formatMetricValue(value: number, unit: string): string {
       if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB/s`
       if (value < 1024 * 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MiB/s`
       return `${(value / (1024 * 1024 * 1024)).toFixed(2)} GiB/s`
+    }
+    case 'seconds': {
+      if (value < 0.001) return `${(value * 1_000_000).toFixed(0)}µs`
+      if (value < 1) return `${(value * 1000).toFixed(value < 0.01 ? 2 : 0)}ms`
+      if (value < 60) return `${value.toFixed(value < 10 ? 2 : 1)}s`
+      if (value < 3600) return `${(value / 60).toFixed(1)}m`
+      return `${(value / 3600).toFixed(1)}h`
     }
     default:
       if (value < 0.01) return value.toExponential(1)

--- a/packages/k8s-ui/src/components/charts/format.ts
+++ b/packages/k8s-ui/src/components/charts/format.ts
@@ -27,6 +27,12 @@ export function formatMetricValue(value: number, unit: string): string {
       if (value < 1024 * 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MiB/s`
       return `${(value / (1024 * 1024 * 1024)).toFixed(2)} GiB/s`
     }
+    case 'count':
+    case 'restarts': {
+      if (value < 10000) return value.toFixed(0)
+      if (value < 1e6) return `${(value / 1e3).toFixed(1)}k`
+      return `${(value / 1e6).toFixed(1)}M`
+    }
     case 'seconds': {
       if (value < 0.001) return `${(value * 1_000_000).toFixed(0)}µs`
       if (value < 1) return `${(value * 1000).toFixed(value < 0.01 ? 2 : 0)}ms`

--- a/packages/k8s-ui/src/components/charts/index.ts
+++ b/packages/k8s-ui/src/components/charts/index.ts
@@ -14,13 +14,14 @@ export type {
   MetricCategoryDef,
   PrometheusResourceMetricsResult,
 } from './PrometheusChartsView'
-export { SERIES_COLORS, seriesColor, seriesFill, computeShortLabels } from './colors'
+export { SERIES_COLORS, seriesColor, seriesFill, computeShortLabels, seriesDisplayLabels } from './colors'
 export { formatMetricValue, formatTimestamp } from './format'
 export { computeSaturation } from './saturation'
 export type {
   TimeSeriesPoint,
   TimeSeries,
   ReferenceLine,
+  ChartAnnotation,
   // Deprecated Prom-prefixed aliases — see types.ts.
   PrometheusDataPoint,
   PrometheusSeries,

--- a/packages/k8s-ui/src/components/charts/types.ts
+++ b/packages/k8s-ui/src/components/charts/types.ts
@@ -35,3 +35,15 @@ export interface ReferenceLine {
   label: string
   kind: 'request' | 'limit'
 }
+
+/**
+ * Vertical marker on a chart at one instant. `kind` names what Radar recorded
+ * there; the chart draws the marker and its label and never implies that the
+ * marked instant explains the series around it.
+ */
+export interface ChartAnnotation {
+  /** Unix seconds, the same clock as {@link TimeSeriesPoint.timestamp}. */
+  timestamp: number
+  label: string
+  kind: 'change'
+}

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -2881,6 +2881,18 @@ describe("InvestigationEvidencePane metrics cards", () => {
     expect(html).not.toContain("metric result");
   });
 
+  it("counts a withheld chart once, not in both lines", () => {
+    // The pane heads two separate lines with these counts — "results about
+    // other resources" and "broader metric results" — so a chart counted in
+    // both announces one withheld result as two, and the numbers stop summing.
+    const projection = project(
+      tool("prom", "query_prometheus", rangeResult([])),
+    );
+    const partition = partitionInvestigationEvidence(projection.groups);
+    expect(partition.hiddenMetrics).toBe(1);
+    expect(partition.hiddenBroader).toBe(0);
+  });
+
   it("withholds an uncited broader chart and says so", () => {
     const projection = project(
       tool("prom", "query_prometheus", rangeResult([])),

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -2900,7 +2900,8 @@ describe("InvestigationEvidencePane metrics cards", () => {
 
   it("promotes a cited broader chart into main with its expression as the axis label", () => {
     const ref = evidenceRef("a", "b");
-    const query = "sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace)";
+    const query =
+      "sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace)";
     const projection = project(
       tool("prom", "query_prometheus", rangeResult([], query), {
         evidenceRef: ref,
@@ -2971,7 +2972,9 @@ describe("InvestigationEvidencePane metrics cards", () => {
       "1 series has a single sample in this window, listed with its time:",
     );
     expect(html).toContain("container=init");
-    expect(html.match(/data-testid="investigation-metrics-sparse-series"/g)).toHaveLength(2);
+    expect(
+      html.match(/data-testid="investigation-metrics-sparse-series"/g),
+    ).toHaveLength(2);
     expect(html).toContain("api-7f6-abc");
   });
 
@@ -3056,7 +3059,13 @@ describe("InvestigationEvidencePane metrics cards", () => {
       tool("prom", "query_prometheus", rangeResult(targetSelectors)),
     );
     const onOpenResource = vi.fn();
-    const html = render(projection, false, undefined, undefined, onOpenResource);
+    const html = render(
+      projection,
+      false,
+      undefined,
+      undefined,
+      onOpenResource,
+    );
     expect(html).toContain('data-chart-annotation="change"');
     expect(html.match(/data-chart-annotation="change"/g)).toHaveLength(1);
     expect(html).toContain("ConfigMap api-config");

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -764,7 +764,7 @@ describe("InvestigationEvidencePane hierarchy and provenance", () => {
     const projection = project(
       tool(
         "metrics-cited",
-        "query_prometheus",
+        "discover_metrics",
         { result: [1] },
         { evidenceRef: ref },
       ),
@@ -779,7 +779,7 @@ describe("InvestigationEvidencePane hierarchy and provenance", () => {
     const sources = renderToStaticMarkup(
       <AssessmentSources resolution={resolution} onViewSource={onViewSource} />,
     );
-    expect(sources).toContain("Query Prometheus");
+    expect(sources).toContain("Discover Metrics");
     expect(sources).toContain("Sources used for this assessment");
     expect(html).not.toContain("Cited sources in Activity");
     expect(html).not.toContain("Agent-selected check");
@@ -2831,5 +2831,197 @@ describe("grouped startup cards", () => {
     expect(html).toContain(">api-abc<");
     expect(html).toContain(">api-def<");
     expect(html).toContain('aria-expanded="false"');
+  });
+});
+
+describe("InvestigationEvidencePane metrics cards", () => {
+  const window = { start: "2026-09-06T07:00:00Z", end: "2026-09-06T09:00:00Z" };
+  const targetSelectors = [
+    {
+      metric: "container_memory_working_set_bytes",
+      matchers: [
+        { label: "namespace", op: "=", value: "shop" },
+        { label: "pod", op: "=~", value: "api-.*" },
+      ],
+    },
+  ];
+  function rangeResult(selectors: unknown[], query?: string) {
+    return {
+      query:
+        query ??
+        'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"})',
+      type: "range",
+      ...window,
+      step: "60s",
+      series: [
+        {
+          labels: {},
+          dataPoints: [
+            { timestamp: Date.parse(window.start) / 1000, value: 1 },
+            { timestamp: Date.parse(window.end) / 1000, value: 2 },
+          ],
+        },
+      ],
+      selectors,
+    };
+  }
+
+  it("keeps an uncited target-scoped chart in the workload collection", () => {
+    const projection = project(
+      tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+    );
+    const partition = partitionInvestigationEvidence(projection.groups);
+    expect(partition.main).toHaveLength(0);
+    expect(partition.workload.map((group) => group.kind)).toEqual(["metrics"]);
+    expect(partition.hiddenMetrics).toBe(0);
+    const html = render(projection);
+    expect(html).toContain("Prometheus metrics");
+    expect(html).not.toContain("metric result");
+  });
+
+  it("withholds an uncited broader chart and says so", () => {
+    const projection = project(
+      tool("prom", "query_prometheus", rangeResult([])),
+      tool(
+        "prom-2",
+        "query_prometheus",
+        rangeResult([], "sum(machine_memory_bytes)"),
+      ),
+    );
+    const partition = partitionInvestigationEvidence(projection.groups);
+    expect(partition.collectionByGroup.size).toBe(0);
+    expect(partition.hiddenMetrics).toBe(2);
+    const html = render(projection);
+    expect(html).toContain(
+      "2 broader metric results are not shown; they appear here when the assessment cites them.",
+    );
+    expect(html).not.toContain("Prometheus metrics");
+  });
+
+  it("promotes a cited broader chart into main with its expression as the axis label", () => {
+    const ref = evidenceRef("a", "b");
+    const query = "sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace)";
+    const projection = project(
+      tool("prom", "query_prometheus", rangeResult([], query), {
+        evidenceRef: ref,
+      }),
+    );
+    const resolution = resolveInvestigationRootCauseEvidence(
+      projection,
+      { status: "linked", refs: [ref] },
+      0,
+    );
+    expect(resolution.status).toBe("linked");
+    const partition = partitionInvestigationEvidence(
+      projection.groups,
+      resolution,
+    );
+    expect(partition.main.map((group) => group.kind)).toEqual(["metrics"]);
+    expect(partition.hiddenMetrics).toBe(0);
+    const html = render(projection, false, undefined, resolution);
+    expect(html).toContain("Prometheus metrics");
+    expect(html).toContain("1 series · 2h window · 60s step");
+    expect(html).not.toContain("metric result");
+  });
+
+  it("lists single-sample series with their time instead of an empty chart, and names aggregated series", () => {
+    const start = Date.parse(window.start) / 1000;
+    const projection = project(
+      tool("prom", "query_prometheus", {
+        ...rangeResult(
+          targetSelectors,
+          "sum by (container) (rate(container_cpu_usage_seconds_total[5m]))",
+        ),
+        series: [
+          {
+            labels: { container: "api" },
+            dataPoints: [
+              { timestamp: start, value: 0.2 },
+              { timestamp: start + 60, value: 0.4 },
+            ],
+          },
+          {
+            labels: { container: "envoy" },
+            dataPoints: [
+              { timestamp: start, value: 0.1 },
+              { timestamp: start + 60, value: 0.1 },
+            ],
+          },
+          {
+            labels: { container: "init" },
+            dataPoints: [{ timestamp: start + 120, value: 0.05 }],
+          },
+        ],
+      }),
+      tool("sparse", "query_prometheus", {
+        ...rangeResult(targetSelectors, "up"),
+        series: [
+          {
+            labels: { pod: "api-7f6-abc" },
+            dataPoints: [{ timestamp: start + 30, value: 1 }],
+          },
+        ],
+      }),
+    );
+    const html = render(projection);
+    expect(html).toContain("container=api");
+    expect(html).toContain("container=envoy");
+    expect(html).not.toContain("series-0");
+    expect(html).toContain(
+      "1 series has a single sample in this window, listed with its time:",
+    );
+    expect(html).toContain("container=init");
+    expect(html.match(/data-testid="investigation-metrics-sparse-series"/g)).toHaveLength(2);
+    expect(html).toContain("api-7f6-abc");
+  });
+
+  it("draws same-turn changes to the subject on the chart and links the subject", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        resourceContext: {
+          tier: "diagnostic",
+          uses: {
+            configMaps: [
+              { kind: "ConfigMap", namespace: "shop", name: "api-config" },
+            ],
+          },
+        },
+        recentChanges: [
+          {
+            kind: "ConfigMap",
+            apiVersion: "v1",
+            namespace: "shop",
+            name: "api-config",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "worker",
+            changeType: "update",
+            timestamp: "2026-09-06T08:00:00Z",
+          },
+        ],
+        pods: 1,
+      }),
+      tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+    );
+    const onOpenResource = vi.fn();
+    const html = render(projection, false, undefined, undefined, onOpenResource);
+    expect(html).toContain('data-chart-annotation="change"');
+    expect(html.match(/data-chart-annotation="change"/g)).toHaveLength(1);
+    expect(html).toContain("ConfigMap api-config");
+    expect(html).not.toContain("Deployment worker");
+    expect(html).toContain(
+      "1 change recorded in this window is marked on the chart.",
+    );
+    expect(html).toContain("Open current Deployment shop/api in Radar");
   });
 });

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -2875,7 +2875,9 @@ describe("InvestigationEvidencePane metrics cards", () => {
     expect(partition.workload.map((group) => group.kind)).toEqual(["metrics"]);
     expect(partition.hiddenMetrics).toBe(0);
     const html = render(projection);
-    expect(html).toContain("Prometheus metrics");
+    expect(html).toContain("container_memory_working_set_bytes");
+    expect(html).toContain("Prometheus · 1 series");
+    expect(html).not.toContain("Prometheus metrics");
     expect(html).not.toContain("metric result");
   });
 
@@ -2896,6 +2898,7 @@ describe("InvestigationEvidencePane metrics cards", () => {
       "2 broader metric results are not shown; they appear here when the assessment cites them.",
     );
     expect(html).not.toContain("Prometheus metrics");
+    expect(html).not.toContain("container_memory_working_set_bytes");
   });
 
   it("promotes a cited broader chart into main with its expression as the axis label", () => {

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -2975,6 +2975,48 @@ describe("InvestigationEvidencePane metrics cards", () => {
     expect(html).toContain("api-7f6-abc");
   });
 
+  it("keeps series that differ only by a hidden label distinguishable across chart and table, and names null-only series honestly", () => {
+    const start = Date.parse(window.start) / 1000;
+    const projection = project(
+      tool("prom", "query_prometheus", {
+        ...rangeResult(
+          targetSelectors,
+          'rate(container_cpu_usage_seconds_total{namespace="shop",pod=~"api-.*"}[5m])',
+        ),
+        series: [
+          {
+            labels: { pod: "api-7f6-abc", container: "api" },
+            dataPoints: [
+              { timestamp: start, value: 0.2 },
+              { timestamp: start + 60, value: 0.4 },
+            ],
+          },
+          {
+            labels: { pod: "api-7f6-abc", container: "envoy" },
+            dataPoints: [{ timestamp: start + 120, value: 0.05 }],
+          },
+          {
+            labels: { pod: "api-7f6-abc", container: "init" },
+            dataPoints: [
+              { timestamp: start, value: null },
+              { timestamp: start + 60, value: null },
+            ],
+          },
+        ],
+      }),
+    );
+    const html = render(projection);
+    expect(html).toContain("pod=api-7f6-abc, container=envoy");
+    expect(html).toContain(
+      "1 series has a single sample in this window, listed with its time:",
+    );
+    expect(html).toContain(
+      "1 series returned no finite values in this window: ",
+    );
+    expect(html).toContain("pod=api-7f6-abc, container=init");
+    expect(html).not.toContain("2 series have a single sample");
+  });
+
   it("draws same-turn changes to the subject on the chart and links the subject", () => {
     const projection = project(
       tool("diag", "diagnose", {

--- a/web/src/components/diagnose/InvestigationEvidencePane.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.tsx
@@ -2182,14 +2182,16 @@ function finiteSamples(series: TimeSeries): TimeSeries["dataPoints"] {
 
 function MetricsValueTable({
   series,
+  labels,
   unit,
   withTime,
 }: {
   series: TimeSeries[];
+  /** Display name per series, derived from the complete result. */
+  labels: string[];
   unit: string;
   withTime: boolean;
 }) {
-  const labels = seriesDisplayLabels(series);
   return (
     <table className="w-full text-xs">
       <tbody>
@@ -2259,7 +2261,12 @@ function MetricsBody({
   if (data.mode === "instant") {
     return (
       <div className="space-y-2">
-        <MetricsValueTable series={data.series} unit={unit} withTime={false} />
+        <MetricsValueTable
+          series={data.series}
+          labels={seriesDisplayLabels(data.series)}
+          unit={unit}
+          withTime={false}
+        />
         <pre className="whitespace-pre-wrap break-all rounded-md border border-theme-border/70 bg-theme-base/30 p-2 font-mono text-xs text-theme-text-secondary">
           {data.query}
         </pre>
@@ -2269,10 +2276,20 @@ function MetricsBody({
       </div>
     );
   }
-  // A series with one finite sample has no line to draw. Listing it keeps the
-  // captured measurement readable instead of leaving an axis with nothing on it.
-  const charted = data.series.filter((item) => finiteSamples(item).length >= 2);
-  const sparse = data.series.filter((item) => finiteSamples(item).length < 2);
+  // Names come from the whole result so two series that differ only by a
+  // label the chart would hide stay distinguishable wherever they are listed.
+  const labels = seriesDisplayLabels(data.series);
+  const indexed = data.series.map((item, index) => ({
+    item,
+    label: labels[index],
+    finite: finiteSamples(item).length,
+  }));
+  // A series with one finite sample has no line to draw, and one with none
+  // (Prometheus serializes NaN and infinities as gaps) has nothing to show.
+  // Listing both keeps what was captured readable and states what was not.
+  const charted = indexed.filter((entry) => entry.finite >= 2);
+  const single = indexed.filter((entry) => entry.finite === 1);
+  const empty = indexed.filter((entry) => entry.finite === 0);
   return (
     <div className="space-y-2">
       <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xs">
@@ -2299,7 +2316,8 @@ function MetricsBody({
       {charted.length > 0 ? (
         <div className="space-y-1.5 rounded-md border border-theme-border/70 bg-theme-base/30 p-2">
           <AreaChart
-            series={charted}
+            series={charted.map((entry) => entry.item)}
+            seriesLabels={charted.map((entry) => entry.label)}
             color={SERIES_COLORS[0]}
             fillColor={seriesFill(0, SERIES_COLORS[0])}
             unit={unit}
@@ -2307,22 +2325,44 @@ function MetricsBody({
             domain={domain}
           />
           {charted.length > 1 ? (
-            <SeriesLegend series={charted} color={SERIES_COLORS[0]} />
+            <SeriesLegend
+              series={charted.map((entry) => entry.item)}
+              seriesLabels={charted.map((entry) => entry.label)}
+              color={SERIES_COLORS[0]}
+            />
           ) : null}
         </div>
       ) : null}
-      {sparse.length > 0 ? (
+      {single.length > 0 ? (
         <div
           className="space-y-1"
           data-testid="investigation-metrics-sparse-series"
         >
           <p className="text-xs text-theme-text-tertiary">
-            {sparse.length === 1
+            {single.length === 1
               ? "1 series has a single sample in this window, listed with its time:"
-              : `${sparse.length} series have a single sample in this window, listed with their times:`}
+              : `${single.length} series have a single sample in this window, listed with their times:`}
           </p>
-          <MetricsValueTable series={sparse} unit={unit} withTime />
+          <MetricsValueTable
+            series={single.map((entry) => entry.item)}
+            labels={single.map((entry) => entry.label)}
+            unit={unit}
+            withTime
+          />
         </div>
+      ) : null}
+      {empty.length > 0 ? (
+        <p
+          className="text-xs text-theme-text-tertiary [overflow-wrap:anywhere]"
+          data-testid="investigation-metrics-empty-series"
+        >
+          {empty.length === 1
+            ? "1 series returned no finite values in this window: "
+            : `${empty.length} series returned no finite values in this window: `}
+          <span className="font-mono">
+            {empty.map((entry) => entry.label).join("; ")}
+          </span>
+        </p>
       ) : null}
       {annotations?.length && charted.length > 0 ? (
         <p className="text-xs text-theme-text-tertiary">

--- a/web/src/components/diagnose/InvestigationEvidencePane.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.tsx
@@ -2323,6 +2323,7 @@ function MetricsBody({
             unit={unit}
             annotations={annotations}
             domain={domain}
+            layout="auto"
           />
           {charted.length > 1 ? (
             <SeriesLegend

--- a/web/src/components/diagnose/InvestigationEvidencePane.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.tsx
@@ -190,9 +190,13 @@ export function partitionInvestigationEvidence(
           )
         : [];
       if (!selected.has(group.id) || !focused || sourceGroups.length !== 1) {
-        if (!group.historical) hiddenBroader += 1;
-        if (group.latest.data.type === "metrics" && !group.historical)
-          hiddenMetrics += 1;
+        // The two counts head separate lines in the pane, so they have to be
+        // disjoint: a withheld chart announced by both would read as two
+        // withheld results.
+        if (!group.historical) {
+          if (group.latest.data.type === "metrics") hiddenMetrics += 1;
+          else hiddenBroader += 1;
+        }
         continue;
       }
     }

--- a/web/src/components/diagnose/InvestigationEvidencePane.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.tsx
@@ -15,6 +15,7 @@ import {
   BellRing,
   Boxes,
   Bug,
+  ChartLine,
   CheckCircle2,
   CircleAlert,
   Clock3,
@@ -44,8 +45,19 @@ import {
   ResourceLink,
   stripAnsi,
 } from "@skyhook-io/k8s-ui";
+import {
+  AreaChart,
+  SERIES_COLORS,
+  SeriesLegend,
+  formatMetricValue,
+  seriesDisplayLabels,
+  seriesFill,
+  type ChartAnnotation,
+  type TimeSeries,
+} from "@skyhook-io/k8s-ui/components/charts";
 import { apiVersionToGroup } from "../../utils/navigation";
 import { parseLogLine } from "../../utils/log-format";
+import { metricsChangeMarkers, metricsDomain } from "./investigationMetrics";
 import {
   evidenceDisplaySnapshot,
   groupEvidenceCoverage,
@@ -96,12 +108,19 @@ const EvidenceNavigationContext = createContext<{
   expandedGroupIds?: ReadonlySet<string>;
   onGroupOpenChange?: (id: string, open: boolean) => void;
   citedOrderByGroup?: ReadonlyMap<string, number>;
+  /** Change markers for each metrics observation, keyed by its source id. */
+  metricsMarkersBySource?: ReadonlyMap<string, ChartAnnotation[]>;
 }>({});
 
 function evidenceTypePrefersFullRow(
   type: InvestigationEvidenceData["type"],
 ): boolean {
-  return type === "logs" || type === "events" || type === "alerts";
+  return (
+    type === "logs" ||
+    type === "events" ||
+    type === "alerts" ||
+    type === "metrics"
+  );
 }
 
 // Supporting evidence becomes a two-column grid when the pane is wide enough.
@@ -148,6 +167,10 @@ export function partitionInvestigationEvidence(
   // withheld unless cited, and the pane says how many were withheld so a
   // reader knows the agent looked at things it did not build its case on.
   let hiddenBroader = 0;
+  // Broader metrics are facts about something other than the target. They are
+  // withheld unless cited, and the pane says how many were withheld so a
+  // reader knows the agent ran queries it did not build its case on.
+  let hiddenMetrics = 0;
   for (const group of groups) {
     const broader = group.latest.relevance === "broader";
     // Citations select tool results, not individual rows in a broad search.
@@ -168,6 +191,8 @@ export function partitionInvestigationEvidence(
         : [];
       if (!selected.has(group.id) || !focused || sourceGroups.length !== 1) {
         if (!group.historical) hiddenBroader += 1;
+        if (group.latest.data.type === "metrics" && !group.historical)
+          hiddenMetrics += 1;
         continue;
       }
     }
@@ -192,7 +217,7 @@ export function partitionInvestigationEvidence(
       Number(adverse(right)) - Number(adverse(left)) ||
       left.firstOrder - right.firstOrder,
   );
-  return { ...collections, collectionByGroup, hiddenBroader };
+  return { ...collections, collectionByGroup, hiddenBroader, hiddenMetrics };
 }
 
 // Kinds whose card is one unambiguous subject, so a citation of their source
@@ -205,6 +230,7 @@ const FOCUSED_EVIDENCE_TYPES: readonly InvestigationEvidenceData["type"][] = [
   "helm",
   "alerts",
   "permissions",
+  "metrics",
 ];
 
 export function investigationEvidenceRevealCollection(
@@ -426,6 +452,17 @@ export function InvestigationEvidencePane({
           </p>
         ) : null}
 
+        {partition.hiddenMetrics > 0 ? (
+          <p
+            className="text-xs text-theme-text-tertiary"
+            data-testid="investigation-hidden-metrics"
+          >
+            {partition.hiddenMetrics === 1
+              ? "1 broader metric result is not shown; it appears here when the assessment cites it."
+              : `${partition.hiddenMetrics} broader metric results are not shown; they appear here when the assessment cites them.`}
+          </p>
+        ) : null}
+
         {!hasCurrentEvidence ? (
           <EmptyCollection
             collecting={collecting}
@@ -469,6 +506,20 @@ export function InvestigationEvidencePane({
         onGroupOpenChange,
         revealSourceId: revealRequest?.sourceId,
         revealRequestId: revealRequest?.requestId,
+        metricsMarkersBySource: new Map(
+          projection.groups.flatMap((group) =>
+            group.observations.flatMap((observation) =>
+              observation.data.type === "metrics"
+                ? [
+                    [
+                      observation.source.id,
+                      metricsChangeMarkers(projection.groups, observation),
+                    ] as const,
+                  ]
+                : [],
+            ),
+          ),
+        ),
         citedOrderByGroup: new Map(
           rootCauseEvidence?.links.flatMap((link) =>
             link.originalGroupId
@@ -989,6 +1040,7 @@ function EvidenceCard({
     citedOrderByGroup,
     expandedGroupIds,
     onGroupOpenChange,
+    metricsMarkersBySource,
   } = useContext(EvidenceNavigationContext);
   const open = expandedGroupIds?.has(group.id) ?? false;
   const setOpen = useCallback(
@@ -1186,6 +1238,9 @@ function EvidenceCard({
                 <EvidenceBody
                   data={observation.data}
                   cardSummary={observation.summary}
+                  annotations={metricsMarkersBySource?.get(
+                    observation.source.id,
+                  )}
                 />
               ) : null}
               {meaningfulHistory ? (
@@ -1293,9 +1348,12 @@ function uniquePrimarySources(
 function EvidenceBody({
   data,
   cardSummary,
+  annotations,
 }: {
   data: InvestigationEvidenceData;
   cardSummary?: string;
+  /** Change markers for a metrics chart; derived by the pane, never by data. */
+  annotations?: ChartAnnotation[];
 }) {
   switch (data.type) {
     case "issue":
@@ -1332,6 +1390,8 @@ function EvidenceBody({
       return <HelmBody data={data} />;
     case "permissions":
       return <PermissionsBody data={data} />;
+    case "metrics":
+      return <MetricsBody data={data} annotations={annotations} />;
   }
 }
 
@@ -2114,6 +2174,175 @@ function TopologyStat({ label, value }: { label: string; value: number }) {
   );
 }
 
+const METRICS_AXIS_LABEL_MAX_CHARS = 72;
+
+function finiteSamples(series: TimeSeries): TimeSeries["dataPoints"] {
+  return series.dataPoints.filter((point) => typeof point.value === "number");
+}
+
+function MetricsValueTable({
+  series,
+  unit,
+  withTime,
+}: {
+  series: TimeSeries[];
+  unit: string;
+  withTime: boolean;
+}) {
+  const labels = seriesDisplayLabels(series);
+  return (
+    <table className="w-full text-xs">
+      <tbody>
+        {series.map((item, index) => {
+          const sample = finiteSamples(item).at(-1);
+          return (
+            <tr
+              key={`${labels[index]}-${index}`}
+              className="border-b border-theme-border/60 last:border-b-0"
+            >
+              <td className="py-1 pr-3 font-mono text-theme-text-secondary [overflow-wrap:anywhere]">
+                {labels[index]}
+              </td>
+              {withTime ? (
+                <td className="py-1 pr-3 text-right text-theme-text-tertiary tabular-nums">
+                  {sample
+                    ? new Date(sample.timestamp * 1000).toLocaleTimeString()
+                    : ""}
+                </td>
+              ) : null}
+              <td className="py-1 text-right font-mono tabular-nums text-theme-text-primary">
+                {sample && typeof sample.value === "number"
+                  ? formatMetricValue(sample.value, unit)
+                  : "no value"}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function MetricsBody({
+  data,
+  annotations,
+}: {
+  data: EvidenceDataOf<"metrics">;
+  annotations?: ChartAnnotation[];
+}) {
+  const unit = data.unit ?? "";
+  const axisLabel = data.label ?? data.query;
+  const axisTruncated = axisLabel.length > METRICS_AXIS_LABEL_MAX_CHARS;
+  const axisText = axisTruncated
+    ? `${axisLabel.slice(0, METRICS_AXIS_LABEL_MAX_CHARS - 1)}…`
+    : axisLabel;
+  const domain = metricsDomain(data);
+  const windowText = domain
+    ? `${new Date(domain.start * 1000).toLocaleString()} to ${new Date(domain.end * 1000).toLocaleString()}`
+    : undefined;
+  if (data.series.length === 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-theme-text-secondary">
+          No series matched this query
+          {data.mode === "range" ? " in the window" : ""}.
+        </p>
+        <pre className="whitespace-pre-wrap break-all rounded-md border border-theme-border/70 bg-theme-base/30 p-2 font-mono text-xs text-theme-text-secondary">
+          {data.query}
+        </pre>
+        {data.note ? (
+          <p className="text-xs text-theme-text-tertiary">{data.note}</p>
+        ) : null}
+      </div>
+    );
+  }
+  if (data.mode === "instant") {
+    return (
+      <div className="space-y-2">
+        <MetricsValueTable series={data.series} unit={unit} withTime={false} />
+        <pre className="whitespace-pre-wrap break-all rounded-md border border-theme-border/70 bg-theme-base/30 p-2 font-mono text-xs text-theme-text-secondary">
+          {data.query}
+        </pre>
+        {data.note ? (
+          <p className="text-xs text-theme-text-tertiary">{data.note}</p>
+        ) : null}
+      </div>
+    );
+  }
+  // A series with one finite sample has no line to draw. Listing it keeps the
+  // captured measurement readable instead of leaving an axis with nothing on it.
+  const charted = data.series.filter((item) => finiteSamples(item).length >= 2);
+  const sparse = data.series.filter((item) => finiteSamples(item).length < 2);
+  return (
+    <div className="space-y-2">
+      <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xs">
+        <Tooltip
+          content={axisLabel}
+          delay={200}
+          position="top"
+          disabled={!axisTruncated}
+        >
+          <span
+            className="min-w-0 truncate font-mono text-theme-text-secondary"
+            data-testid="investigation-metrics-axis-label"
+          >
+            {axisText}
+          </span>
+        </Tooltip>
+        {unit ? (
+          <span className="text-theme-text-tertiary">({unit})</span>
+        ) : null}
+        {windowText ? (
+          <span className="ml-auto text-theme-text-tertiary">{windowText}</span>
+        ) : null}
+      </div>
+      {charted.length > 0 ? (
+        <div className="space-y-1.5 rounded-md border border-theme-border/70 bg-theme-base/30 p-2">
+          <AreaChart
+            series={charted}
+            color={SERIES_COLORS[0]}
+            fillColor={seriesFill(0, SERIES_COLORS[0])}
+            unit={unit}
+            annotations={annotations}
+            domain={domain}
+          />
+          {charted.length > 1 ? (
+            <SeriesLegend series={charted} color={SERIES_COLORS[0]} />
+          ) : null}
+        </div>
+      ) : null}
+      {sparse.length > 0 ? (
+        <div
+          className="space-y-1"
+          data-testid="investigation-metrics-sparse-series"
+        >
+          <p className="text-xs text-theme-text-tertiary">
+            {sparse.length === 1
+              ? "1 series has a single sample in this window, listed with its time:"
+              : `${sparse.length} series have a single sample in this window, listed with their times:`}
+          </p>
+          <MetricsValueTable series={sparse} unit={unit} withTime />
+        </div>
+      ) : null}
+      {annotations?.length && charted.length > 0 ? (
+        <p className="text-xs text-theme-text-tertiary">
+          {annotations.length === 1
+            ? "1 change recorded in this window is marked on the chart."
+            : `${annotations.length} changes recorded in this window are marked on the chart.`}
+        </p>
+      ) : null}
+      {axisTruncated ? (
+        <pre className="whitespace-pre-wrap break-all rounded-md border border-theme-border/70 bg-theme-base/30 p-2 font-mono text-xs text-theme-text-secondary">
+          {data.query}
+        </pre>
+      ) : null}
+      {data.note ? (
+        <p className="text-xs text-theme-text-tertiary">{data.note}</p>
+      ) : null}
+    </div>
+  );
+}
+
 function InventoryBody({ data }: { data: EvidenceDataOf<"inventory"> }) {
   return (
     <div className="max-h-72 overflow-y-auto rounded-md border border-theme-border">
@@ -2615,6 +2844,7 @@ function RevisionHistory({
 }) {
   const [open, setOpen] = useState(false);
   const regionId = useId();
+  const { metricsMarkersBySource } = useContext(EvidenceNavigationContext);
   const { elementRef, revealAfterToggle } =
     useDisclosureReveal<HTMLDivElement>();
   useLayoutEffect(() => {
@@ -2659,6 +2889,9 @@ function RevisionHistory({
                     <EvidenceBody
                       data={observation.data}
                       cardSummary={observation.summary}
+                      annotations={metricsMarkersBySource?.get(
+                        observation.source.id,
+                      )}
                     />
                   )}
                 </div>
@@ -2816,6 +3049,8 @@ function evidenceIcon(type: InvestigationEvidenceData["type"]) {
       return Package;
     case "permissions":
       return KeyRound;
+    case "metrics":
+      return ChartLine;
   }
 }
 

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5248,8 +5248,10 @@ describe("query_prometheus evidence", () => {
     expect(group.latest.relevance).toBe("target");
     expect(group.latest.tier).toBe("supporting");
     expect(group.latest.tone).toBe("neutral");
-    expect(group.latest.title).toBe("Prometheus metrics");
-    expect(group.latest.summary).toBe("1 series · 2h window · 25s step");
+    expect(group.latest.title).toBe("container_memory_working_set_bytes");
+    expect(group.latest.summary).toBe(
+      "Prometheus · 1 series · 2h window · 25s step",
+    );
     const data = group.latest.data;
     if (data.type !== "metrics") throw new Error("expected metrics");
     expect(data.mode).toBe("range");
@@ -5318,8 +5320,8 @@ describe("query_prometheus evidence", () => {
       ),
     ]);
     const [group] = groupsOf(projection.groups, "metrics");
-    expect(group.latest.title).toBe("Prometheus values");
-    expect(group.latest.summary).toBe("1 series");
+    expect(group.latest.title).toBe("container_memory_working_set_bytes");
+    expect(group.latest.summary).toBe("Prometheus · 1 series");
     expect(group.latest.data.type === "metrics" && group.latest.data.mode).toBe(
       "instant",
     );
@@ -5360,7 +5362,7 @@ describe("query_prometheus evidence", () => {
     ]);
     const [group] = groupsOf(projection.groups, "metrics");
     expect(group.latest.summary).toBe(
-      "No series matched · 2h window · 25s step",
+      "Prometheus · No series matched · 2h window · 25s step",
     );
   });
 

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5237,6 +5237,27 @@ describe("query_prometheus evidence", () => {
     };
   }
 
+  it("keeps the generic title when the selectors name no metric", () => {
+    const projection = project([
+      tool(
+        "prom",
+        "query_prometheus",
+        promResult({
+          query: 'sum({namespace="shop"})',
+          selectors: [
+            {
+              metric: "",
+              matchers: [{ label: "namespace", op: "=", value: "shop" }],
+            },
+          ],
+        }),
+      ),
+    ]);
+    const [group] = groupsOf(projection.groups, "metrics");
+    expect(group.latest.title).toBe("Prometheus metrics");
+    expect(group.latest.summary).toBe("1 series · 2h window · 25s step");
+  });
+
   it("charts a range query scoped to the target as target evidence", () => {
     const projection = project([
       tool("prom", "query_prometheus", promResult(), {

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5260,7 +5260,7 @@ describe("query_prometheus evidence", () => {
       namespace: "shop",
       name: "api",
     });
-    expect(data.unit).toBe("");
+    expect(data.unit).toBe("bytes");
     expect(data.series).toEqual(rangeSeries);
     expect(investigationEvidenceSubjectRef(data)).toEqual(data.subject);
     expect(projection.coverage.projected).toBe(1);
@@ -5478,17 +5478,21 @@ describe("query_prometheus evidence", () => {
         },
         "broader",
       ],
-      ["other namespace", {
-        selectors: [
-          {
-            metric: "up",
-            matchers: [
-              { label: "namespace", op: "=", value: "other" },
-              { label: "pod", op: "=~", value: "api-.*" },
-            ],
-          },
-        ],
-      }, "broader"],
+      [
+        "other namespace",
+        {
+          selectors: [
+            {
+              metric: "up",
+              matchers: [
+                { label: "namespace", op: "=", value: "other" },
+                { label: "pod", op: "=~", value: "api-.*" },
+              ],
+            },
+          ],
+        },
+        "broader",
+      ],
       ["empty selectors", { selectors: [] }, "broader"],
       [
         "unknown selectors",
@@ -5507,12 +5511,16 @@ describe("query_prometheus evidence", () => {
           ? group.latest.data.subject
           : "missing",
         name,
-      ).toEqual(expected === "target" ? {
-        kind: "Deployment",
-        group: "apps",
-        namespace: "shop",
-        name: "api",
-      } : undefined);
+      ).toEqual(
+        expected === "target"
+          ? {
+              kind: "Deployment",
+              group: "apps",
+              namespace: "shop",
+              name: "api",
+            }
+          : undefined,
+      );
       expect(group?.latest.tier, name).toBe(
         expected === "broader" ? "context" : "supporting",
       );
@@ -5582,16 +5590,32 @@ describe("query_prometheus evidence", () => {
     ];
     const exactNs = { op: "=", value: "shop" };
     expect(
-      metricsScope(pod, selector(exactNs, { op: "=~", value: "api-7f6-abc-.*" }), false),
+      metricsScope(
+        pod,
+        selector(exactNs, { op: "=~", value: "api-7f6-abc-.*" }),
+        false,
+      ),
     ).toBe("producer-related");
     expect(
-      metricsScope(pod, selector(exactNs, { op: "=", value: "api-7f6-abc" }), false),
+      metricsScope(
+        pod,
+        selector(exactNs, { op: "=", value: "api-7f6-abc" }),
+        false,
+      ),
     ).toBe("target");
     expect(
-      metricsScope(pod, selector(exactNs, { op: "=~", value: "api-7f6-abc" }), false),
+      metricsScope(
+        pod,
+        selector(exactNs, { op: "=~", value: "api-7f6-abc" }),
+        false,
+      ),
     ).toBe("target");
     expect(
-      metricsScope(pod, selector(exactNs, { op: "=", value: "api-7f6-abc-extra" }), false),
+      metricsScope(
+        pod,
+        selector(exactNs, { op: "=", value: "api-7f6-abc-extra" }),
+        false,
+      ),
     ).toBe("producer-related");
     expect(
       metricsScope(
@@ -5603,14 +5627,20 @@ describe("query_prometheus evidence", () => {
     expect(
       metricsScope(
         target,
-        selector({ op: "=~", value: "shop|other" }, { op: "=~", value: "api-.*" }),
+        selector(
+          { op: "=~", value: "shop|other" },
+          { op: "=~", value: "api-.*" },
+        ),
         false,
       ),
     ).toBe("broader");
     expect(
       metricsScope(
         target,
-        selector({ op: "!=", value: "kube-system" }, { op: "=~", value: "api-.*" }),
+        selector(
+          { op: "!=", value: "kube-system" },
+          { op: "=~", value: "api-.*" },
+        ),
         false,
       ),
     ).toBe("broader");

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5566,6 +5566,56 @@ describe("query_prometheus evidence", () => {
     ).toBe("producer-related");
   });
 
+  it("names a Pod target only by its exact name and accepts an anchored namespace regex", () => {
+    const pod = { ...target, kind: "Pod", group: "", name: "api-7f6-abc" };
+    const selector = (
+      namespace: { op: string; value: string },
+      podMatcher: { op: string; value: string },
+    ) => [
+      {
+        metric: "container_memory_working_set_bytes",
+        matchers: [
+          { label: "namespace", ...namespace },
+          { label: "pod", ...podMatcher },
+        ],
+      },
+    ];
+    const exactNs = { op: "=", value: "shop" };
+    expect(
+      metricsScope(pod, selector(exactNs, { op: "=~", value: "api-7f6-abc-.*" }), false),
+    ).toBe("producer-related");
+    expect(
+      metricsScope(pod, selector(exactNs, { op: "=", value: "api-7f6-abc" }), false),
+    ).toBe("target");
+    expect(
+      metricsScope(pod, selector(exactNs, { op: "=~", value: "api-7f6-abc" }), false),
+    ).toBe("target");
+    expect(
+      metricsScope(pod, selector(exactNs, { op: "=", value: "api-7f6-abc-extra" }), false),
+    ).toBe("producer-related");
+    expect(
+      metricsScope(
+        target,
+        selector({ op: "=~", value: "shop" }, { op: "=~", value: "api-.*" }),
+        false,
+      ),
+    ).toBe("target");
+    expect(
+      metricsScope(
+        target,
+        selector({ op: "=~", value: "shop|other" }, { op: "=~", value: "api-.*" }),
+        false,
+      ),
+    ).toBe("broader");
+    expect(
+      metricsScope(
+        target,
+        selector({ op: "!=", value: "kube-system" }, { op: "=~", value: "api-.*" }),
+        false,
+      ),
+    ).toBe("broader");
+  });
+
   it("rejects a result without the producer's selector inventory", () => {
     const projection = project([
       tool("old", "query_prometheus", promResult({ selectors: undefined })),

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -6,6 +6,7 @@ import {
   investigationEvidenceSourceDomId,
   investigationEvidenceSourceId,
   investigationEvidenceSubjectRef,
+  metricsScope,
   projectInvestigationEvidence,
   resolveInvestigationRootCauseEvidence,
   type InvestigationEvidenceGroup,
@@ -560,7 +561,7 @@ describe("root-cause evidence resolution", () => {
     const projection = project([
       tool(
         "metrics-1",
-        "query_prometheus",
+        "discover_metrics",
         { result: [1] },
         { evidenceRef: ref },
       ),
@@ -2595,7 +2596,7 @@ describe("strict evidence adapters", () => {
 
   it("keeps unknown tools in Activity and limits invalid known contracts", () => {
     const result = project([
-      tool("other", "query_prometheus", { data: "ignored" }),
+      tool("other", "discover_metrics", { data: "ignored" }),
       tool("bad-events", "get_events", { events: [{ nope: true }] }),
     ]);
     expect(result.sources.map((source) => source.stepId)).toEqual([
@@ -5198,5 +5199,413 @@ describe("live-run follow-ups", () => {
     expect(changes[0].latest.title).toBe("Recent changes · last 48h");
     expect(changes[0].latest.summary).toBe("2 changes · Deployment shop/api");
     expect(changes[1].latest.title).toBe("Recent changes · last 24h");
+  });
+});
+
+describe("query_prometheus evidence", () => {
+  const rangeSeries = [
+    {
+      labels: { pod: "api-7f6-abc" },
+      dataPoints: [
+        { timestamp: 1_788_679_043, value: 169_377_792 },
+        { timestamp: 1_788_679_068, value: 171_401_216 },
+      ],
+    },
+  ];
+  const targetSelectors = [
+    {
+      metric: "container_memory_working_set_bytes",
+      matchers: [
+        { label: "namespace", op: "=", value: "shop" },
+        { label: "pod", op: "=~", value: "api-.*" },
+      ],
+    },
+  ];
+  function promResult(patch: Record<string, unknown> = {}) {
+    return {
+      query:
+        'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"})',
+      type: "range",
+      start: "2026-09-06T07:17:23Z",
+      end: "2026-09-06T09:17:23Z",
+      step: "25s",
+      resultType: "matrix",
+      seriesCount: 1,
+      series: rangeSeries,
+      selectors: targetSelectors,
+      ...patch,
+    };
+  }
+
+  it("charts a range query scoped to the target as target evidence", () => {
+    const projection = project([
+      tool("prom", "query_prometheus", promResult(), {
+        summary: JSON.stringify({ query: "sum(...)", type: "range" }),
+      }),
+    ]);
+    const [group] = groupsOf(projection.groups, "metrics");
+    expect(group).toBeDefined();
+    expect(group.latest.relevance).toBe("target");
+    expect(group.latest.tier).toBe("supporting");
+    expect(group.latest.tone).toBe("neutral");
+    expect(group.latest.title).toBe("Prometheus metrics");
+    expect(group.latest.summary).toBe("1 series · 2h window · 25s step");
+    const data = group.latest.data;
+    if (data.type !== "metrics") throw new Error("expected metrics");
+    expect(data.mode).toBe("range");
+    expect(data.origin).toBe("query");
+    expect(data.subject).toEqual({
+      kind: "Deployment",
+      group: "apps",
+      namespace: "shop",
+      name: "api",
+    });
+    expect(data.unit).toBe("");
+    expect(data.series).toEqual(rangeSeries);
+    expect(investigationEvidenceSubjectRef(data)).toEqual(data.subject);
+    expect(projection.coverage.projected).toBe(1);
+  });
+
+  it("claims a unit only for a single bare metric that states one", () => {
+    const projection = project([
+      tool(
+        "bare",
+        "query_prometheus",
+        promResult({
+          query:
+            'container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"}',
+        }),
+      ),
+      tool(
+        "rate",
+        "query_prometheus",
+        promResult({
+          query:
+            'rate(container_cpu_usage_seconds_total{namespace="shop",pod=~"api-.*"}[5m])',
+          selectors: [
+            {
+              metric: "container_cpu_usage_seconds_total",
+              matchers: targetSelectors[0].matchers,
+            },
+          ],
+        }),
+      ),
+    ]);
+    const units = groupsOf(projection.groups, "metrics").map((group) =>
+      group.latest.data.type === "metrics" ? group.latest.data.unit : "?",
+    );
+    expect(units).toEqual(["bytes", ""]);
+  });
+
+  it("renders an instant query as values, not a chart", () => {
+    const projection = project([
+      tool(
+        "instant",
+        "query_prometheus",
+        promResult({
+          type: "instant",
+          start: undefined,
+          end: undefined,
+          step: undefined,
+          resultType: "vector",
+          series: [
+            {
+              labels: { pod: "api-7f6-abc" },
+              dataPoints: [{ timestamp: 1_788_679_068, value: 3 }],
+            },
+          ],
+        }),
+      ),
+    ]);
+    const [group] = groupsOf(projection.groups, "metrics");
+    expect(group.latest.title).toBe("Prometheus values");
+    expect(group.latest.summary).toBe("1 series");
+    expect(group.latest.data.type === "metrics" && group.latest.data.mode).toBe(
+      "instant",
+    );
+  });
+
+  it("reports a truncated result as a limitation with its cardinality, never as a chart", () => {
+    const projection = project([
+      tool(
+        "big",
+        "query_prometheus",
+        promResult({
+          series: [],
+          truncated: true,
+          summary: {
+            seriesCount: 812,
+            totalDataPoints: 194_880,
+            labelCardinality: { pod: 812, container: 3 },
+            suggestion: "topk(5, ...)",
+          },
+          note: "Result exceeded the 96 KiB cap.",
+        }),
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    expect(projection.limitations).toHaveLength(1);
+    expect(projection.limitations[0].kind).toBe("truncated");
+    expect(projection.limitations[0].message).toContain("812 series");
+    expect(projection.limitations[0].message).toContain(
+      "812 distinct pod values",
+    );
+    expect(projection.limitations[0].message).toContain("Result exceeded");
+    expect(projection.coverage.limited).toBe(1);
+  });
+
+  it("keeps a query that matched nothing as a fact about the window", () => {
+    const projection = project([
+      tool("none", "query_prometheus", promResult({ series: [] })),
+    ]);
+    const [group] = groupsOf(projection.groups, "metrics");
+    expect(group.latest.summary).toBe(
+      "No series matched · 2h window · 25s step",
+    );
+  });
+
+  it("classifies scope from the producer's selectors, never from the expression text", () => {
+    const withNamespace = (
+      metric: string,
+      extra: Array<{ label: string; op: string; value: string }> = [],
+    ) => ({
+      metric,
+      matchers: [{ label: "namespace", op: "=", value: "shop" }, ...extra],
+    });
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      [
+        "namespace only",
+        { selectors: [withNamespace("up")] },
+        "producer-related",
+      ],
+      [
+        "workload label",
+        {
+          selectors: [
+            withNamespace("kube_deployment_status_replicas_available", [
+              { label: "deployment", op: "=", value: "api" },
+            ]),
+          ],
+        },
+        "target",
+      ],
+      [
+        "exact pod name prefix",
+        {
+          selectors: [
+            withNamespace("kube_pod_container_status_restarts_total", [
+              { label: "pod", op: "=", value: "api-7f6-abc" },
+            ]),
+          ],
+        },
+        "target",
+      ],
+      [
+        "container alone",
+        {
+          selectors: [
+            withNamespace("container_memory_working_set_bytes", [
+              { label: "container", op: "=", value: "api" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "sibling workload",
+        {
+          selectors: [
+            withNamespace("kube_deployment_status_replicas_available", [
+              { label: "deployment", op: "=", value: "worker" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "pod regex with an optional dash",
+        {
+          selectors: [
+            withNamespace("kube_pod_container_status_restarts_total", [
+              { label: "pod", op: "=~", value: "api-?.*" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "pod regex alternation behind the target prefix",
+        {
+          selectors: [
+            withNamespace("kube_pod_container_status_restarts_total", [
+              { label: "pod", op: "=~", value: "api-.*|worker-.*" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "workload alternation",
+        {
+          selectors: [
+            withNamespace("kube_deployment_status_replicas_available", [
+              { label: "deployment", op: "=~", value: "api|worker" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "statefulset label on a deployment target",
+        {
+          selectors: [
+            withNamespace("kube_statefulset_status_replicas_ready", [
+              { label: "statefulset", op: "=", value: "api" },
+            ]),
+          ],
+        },
+        "producer-related",
+      ],
+      [
+        "braced target numerator over a bare cluster denominator",
+        {
+          query:
+            'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"}) / scalar(sum(machine_memory_bytes))',
+          selectors: [
+            ...targetSelectors,
+            { metric: "machine_memory_bytes", matchers: [] },
+          ],
+        },
+        "broader",
+      ],
+      ["other namespace", {
+        selectors: [
+          {
+            metric: "up",
+            matchers: [
+              { label: "namespace", op: "=", value: "other" },
+              { label: "pod", op: "=~", value: "api-.*" },
+            ],
+          },
+        ],
+      }, "broader"],
+      ["empty selectors", { selectors: [] }, "broader"],
+      [
+        "unknown selectors",
+        { selectors: targetSelectors, selectorsUnknown: true },
+        "broader",
+      ],
+    ];
+    for (const [name, patch, expected] of cases) {
+      const projection = project([
+        tool(`case-${name}`, "query_prometheus", promResult(patch)),
+      ]);
+      const [group] = groupsOf(projection.groups, "metrics");
+      expect(group?.latest.relevance, name).toBe(expected);
+      expect(
+        group?.latest.data.type === "metrics"
+          ? group.latest.data.subject
+          : "missing",
+        name,
+      ).toEqual(expected === "target" ? {
+        kind: "Deployment",
+        group: "apps",
+        namespace: "shop",
+        name: "api",
+      } : undefined);
+      expect(group?.latest.tier, name).toBe(
+        expected === "broader" ? "context" : "supporting",
+      );
+    }
+  });
+
+  it("treats an unescaped dot in a workload regex as naming more than the target", () => {
+    const dotted = { ...target, name: "api.v2" };
+    const selector = (value: string) => [
+      {
+        metric: "kube_deployment_status_replicas_available",
+        matchers: [
+          { label: "namespace", op: "=", value: "shop" },
+          { label: "deployment", op: "=~", value },
+        ],
+      },
+    ];
+    expect(metricsScope(dotted, selector("api.v2"), false)).toBe(
+      "producer-related",
+    );
+    expect(metricsScope(dotted, selector("api\\.v2"), false)).toBe("target");
+    expect(
+      metricsScope(
+        dotted,
+        [
+          {
+            metric: "up",
+            matchers: [
+              { label: "namespace", op: "=", value: "shop" },
+              { label: "pod", op: "=~", value: "api\\.v2-.*" },
+            ],
+          },
+        ],
+        false,
+      ),
+    ).toBe("target");
+    expect(
+      metricsScope(
+        dotted,
+        [
+          {
+            metric: "up",
+            matchers: [
+              { label: "namespace", op: "=", value: "shop" },
+              { label: "pod", op: "=~", value: "api.v2-.*" },
+            ],
+          },
+        ],
+        false,
+      ),
+    ).toBe("producer-related");
+  });
+
+  it("rejects a result without the producer's selector inventory", () => {
+    const projection = project([
+      tool("old", "query_prometheus", promResult({ selectors: undefined })),
+      tool(
+        "bad-series",
+        "query_prometheus",
+        promResult({
+          series: [{ labels: {}, dataPoints: [{ timestamp: "x", value: 1 }] }],
+        }),
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    expect(projection.limitations.map((item) => item.kind)).toEqual([
+      "unknown",
+    ]);
+    expect(projection.limitations[0].source).toBe("Prometheus query");
+    expect(projection.limitations[0].sources).toHaveLength(2);
+  });
+
+  it("merges the same query into one card with revisions", () => {
+    const projection = project(
+      [tool("first", "query_prometheus", promResult())],
+      [
+        tool(
+          "second",
+          "query_prometheus",
+          promResult({
+            series: [
+              {
+                labels: { pod: "api-7f6-abc" },
+                dataPoints: [{ timestamp: 1_788_679_043, value: 1 }],
+              },
+            ],
+          }),
+        ),
+      ],
+    );
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].observations).toHaveLength(2);
+    expect(groups[0].observations[1].changedFromPrevious).toBe(true);
   });
 });

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -4747,8 +4747,13 @@ function adaptQueryPrometheus(
   const windowLabel = metricsWindowLabel({ mode, start, end, step });
   // One metric names the card; the title is Radar's reading of the query,
   // never the agent's, so a wrong claim cannot become the card's identity.
+  // A bare matcher block such as `{namespace="shop"}` names no metric.
   const metricNames = [
-    ...new Set(selectors.map((selector) => selector.metric)),
+    ...new Set(
+      selectors.flatMap((selector) =>
+        selector.metric.trim() ? [selector.metric.trim()] : [],
+      ),
+    ),
   ];
   const title =
     metricNames.length === 1

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -4606,12 +4606,15 @@ function selectorNamesTarget(
 ): boolean {
   const { label, op, value } = matcher;
   if (label === "pod") {
-    if (op === "=~") return regexNamesExactly(value, target.name, "-.*");
-    if (op === "=") {
-      return target.kind.toLowerCase() === "pod"
-        ? value === target.name
-        : value.startsWith(`${target.name}-`);
+    // A Pod target is named only by its own exact name: its "<name>-" prefix
+    // selects other pods, never itself.
+    if (target.kind.toLowerCase() === "pod") {
+      if (op === "=") return value === target.name;
+      if (op === "=~") return regexNamesExactly(value, target.name, "");
+      return false;
     }
+    if (op === "=~") return regexNamesExactly(value, target.name, "-.*");
+    if (op === "=") return value.startsWith(`${target.name}-`);
     return false;
   }
   if (!(label in WORKLOAD_SELECTOR_LABELS)) return false;
@@ -4638,11 +4641,13 @@ export function metricsScope(
   }
   let allNameTarget = true;
   for (const selector of selectors) {
+    // Prometheus anchors regex matchers, so namespace=~"shop" is exact too.
     const inNamespace = selector.matchers.some(
       (matcher) =>
         matcher.label === "namespace" &&
-        matcher.op === "=" &&
-        matcher.value === target.namespace,
+        ((matcher.op === "=" && matcher.value === target.namespace) ||
+          (matcher.op === "=~" &&
+            regexNamesExactly(matcher.value, target.namespace ?? "", ""))),
     );
     if (!inNamespace) return "broader";
     if (!selector.matchers.some((matcher) => selectorNamesTarget(target, matcher)))

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -4745,6 +4745,17 @@ function adaptQueryPrometheus(
     return;
   }
   const windowLabel = metricsWindowLabel({ mode, start, end, step });
+  // One metric names the card; the title is Radar's reading of the query,
+  // never the agent's, so a wrong claim cannot become the card's identity.
+  const metricNames = [
+    ...new Set(selectors.map((selector) => selector.metric)),
+  ];
+  const title =
+    metricNames.length === 1
+      ? metricNames[0]
+      : mode === "range"
+        ? "Prometheus metrics"
+        : "Prometheus values";
   const data: InvestigationMetricsEvidence = {
     type: "metrics",
     origin: "query",
@@ -4777,8 +4788,9 @@ function adaptQueryPrometheus(
       tier: evidenceTierForRelevance("supporting", relevance),
       relevance,
       tone: "neutral",
-      title: mode === "range" ? "Prometheus metrics" : "Prometheus values",
+      title,
       summary: [
+        metricNames.length === 1 ? "Prometheus" : undefined,
         series.length === 0 ? "No series matched" : `${series.length} series`,
         windowLabel,
       ]

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -10,6 +10,7 @@ import {
   type Topology,
 } from "@skyhook-io/k8s-ui";
 import { fnv1a32 } from "@skyhook-io/k8s-ui/utils/structure-hash";
+import type { TimeSeries } from "@skyhook-io/k8s-ui/components/charts";
 import { apiVersionToGroup } from "../../utils/navigation";
 
 import {
@@ -28,6 +29,7 @@ import {
 } from "./diagnoseEvidenceTypes";
 import type { RootCauseEvidence } from "../../api/diagnose";
 import { investigationResourceEvidenceSummary } from "./investigationResourceEvidenceModel";
+import { metricsUnitForExpression } from "./investigationMetrics";
 
 /**
  * The projection deliberately consumes only the small, structural portion of
@@ -92,7 +94,8 @@ export type InvestigationEvidenceKind =
   | "receipt"
   | "alerts"
   | "helm"
-  | "permissions";
+  | "permissions"
+  | "metrics";
 
 type InvestigationSemanticDomain = "issue" | "startup" | "crash" | "dns";
 
@@ -445,7 +448,40 @@ export type InvestigationEvidenceData =
       truncated?: boolean;
       usedByPods?: string[];
       podsTotal?: number;
-    };
+    }
+  | InvestigationMetricsEvidence;
+/** One PromQL vector selector as the producer tokenized it. */
+export interface InvestigationMetricsSelector {
+  metric: string;
+  matchers: Array<{ label: string; op: string; value: string }>;
+}
+
+/**
+ * A Prometheus result captured during the investigation. `origin` says which
+ * producer ran the query; the shape is shared so every metrics card renders
+ * the same way. `subject` is set only when the query's selectors are all
+ * scoped to the investigation target.
+ */
+export interface InvestigationMetricsEvidence {
+  type: "metrics";
+  origin: "query" | "diagnose";
+  query: string;
+  mode: "range" | "instant";
+  start?: string;
+  end?: string;
+  step?: string;
+  unit?: string;
+  label?: string;
+  series: TimeSeries[];
+  truncated: boolean;
+  summary?: unknown;
+  note?: string;
+  selectors?: InvestigationMetricsSelector[];
+  selectorsUnknown?: boolean;
+  subject?: DiagnosisResourceRef;
+  pods?: number;
+  partial?: boolean;
+}
 
 export interface InvestigationEvidenceObservation {
   source: InvestigationEvidenceSource;
@@ -635,6 +671,8 @@ export function investigationEvidenceSubjectRef(
           namespace: data.subject.namespace,
           name: data.subject.name,
         };
+      case "metrics":
+        return data.subject;
       default:
         return undefined;
     }
@@ -1270,6 +1308,7 @@ const INVESTIGATION_RESULT_LABELS: Readonly<Record<string, string>> = {
   get_prometheus_rules: "Alert rules",
   get_helm_release: "Helm release",
   get_subject_permissions: "Permissions",
+  query_prometheus: "Prometheus query",
 };
 
 function investigationResultLabel(source: InvestigationEvidenceSource): string {
@@ -4486,6 +4525,264 @@ function adaptSubjectPermissions(
   }
 }
 
+function timeSeries(value: unknown): TimeSeries | undefined {
+  const item = record(value);
+  if (!item || !Array.isArray(item.dataPoints)) return undefined;
+  const labels = record(item.labels) ?? {};
+  if (Object.values(labels).some((label) => typeof label !== "string")) {
+    return undefined;
+  }
+  const dataPoints: TimeSeries["dataPoints"] = [];
+  for (const raw of item.dataPoints) {
+    const point = record(raw);
+    if (!point || typeof point.timestamp !== "number") return undefined;
+    if (
+      point.value !== undefined &&
+      point.value !== null &&
+      typeof point.value !== "number"
+    ) {
+      return undefined;
+    }
+    dataPoints.push({
+      timestamp: point.timestamp,
+      value: typeof point.value === "number" ? point.value : null,
+    });
+  }
+  return { labels: labels as Record<string, string>, dataPoints };
+}
+
+function metricsSelector(
+  value: unknown,
+): InvestigationMetricsSelector | undefined {
+  const item = record(value);
+  if (!item || typeof item.metric !== "string" || !Array.isArray(item.matchers))
+    return undefined;
+  const matchers: InvestigationMetricsSelector["matchers"] = [];
+  for (const raw of item.matchers) {
+    const matcher = record(raw);
+    if (
+      !matcher ||
+      typeof matcher.label !== "string" ||
+      typeof matcher.op !== "string" ||
+      typeof matcher.value !== "string"
+    ) {
+      return undefined;
+    }
+    matchers.push({
+      label: matcher.label,
+      op: matcher.op,
+      value: matcher.value,
+    });
+  }
+  return { metric: item.metric, matchers };
+}
+
+const WORKLOAD_SELECTOR_LABELS: Readonly<Record<string, string | undefined>> =
+  {
+    deployment: "deployment",
+    statefulset: "statefulset",
+    daemonset: "daemonset",
+    workload: undefined,
+  };
+
+/**
+ * A regex matcher names the target only in the exact forms the plan admits,
+ * with the name's regex metacharacters (a dot in a Kubernetes name) escaped
+ * or absent. "api-?.*" also selects "apiworker-…" and an unescaped "api.v2"
+ * also selects "api-v2", so neither may claim the target.
+ */
+function regexNamesExactly(
+  value: string,
+  name: string,
+  suffix: string,
+): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return value === `${escaped}${suffix}`;
+}
+
+function selectorNamesTarget(
+  target: InvestigationEvidenceTarget,
+  matcher: InvestigationMetricsSelector["matchers"][number],
+): boolean {
+  const { label, op, value } = matcher;
+  if (label === "pod") {
+    if (op === "=~") return regexNamesExactly(value, target.name, "-.*");
+    if (op === "=") {
+      return target.kind.toLowerCase() === "pod"
+        ? value === target.name
+        : value.startsWith(`${target.name}-`);
+    }
+    return false;
+  }
+  if (!(label in WORKLOAD_SELECTOR_LABELS)) return false;
+  const requiredKind = WORKLOAD_SELECTOR_LABELS[label];
+  if (requiredKind && target.kind.toLowerCase() !== requiredKind) return false;
+  if (op === "=") return value === target.name;
+  if (op === "=~") return regexNamesExactly(value, target.name, "");
+  return false;
+}
+
+/**
+ * A metrics result is about the target only when every selector says so:
+ * the target namespace plus a pod or workload matcher naming it. A query with
+ * any bare or foreign selector (a cluster denominator, a sibling workload, an
+ * alternation) could be about anything, so it stays broader.
+ */
+export function metricsScope(
+  target: InvestigationEvidenceTarget,
+  selectors: readonly InvestigationMetricsSelector[],
+  selectorsUnknown: boolean,
+): InvestigationEvidenceRelevance {
+  if (selectorsUnknown || selectors.length === 0 || !target.namespace) {
+    return "broader";
+  }
+  let allNameTarget = true;
+  for (const selector of selectors) {
+    const inNamespace = selector.matchers.some(
+      (matcher) =>
+        matcher.label === "namespace" &&
+        matcher.op === "=" &&
+        matcher.value === target.namespace,
+    );
+    if (!inNamespace) return "broader";
+    if (!selector.matchers.some((matcher) => selectorNamesTarget(target, matcher)))
+      allNameTarget = false;
+  }
+  return allNameTarget ? "target" : "producer-related";
+}
+
+function metricsWindowLabel(data: {
+  mode: "range" | "instant";
+  start?: string;
+  end?: string;
+  step?: string;
+}): string | undefined {
+  if (data.mode !== "range" || !data.start || !data.end) return undefined;
+  const startMs = Date.parse(data.start);
+  const endMs = Date.parse(data.end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs)
+    return undefined;
+  const minutes = Math.round((endMs - startMs) / 60_000);
+  const window =
+    minutes >= 60 * 24 * 2
+      ? `${Math.round(minutes / (60 * 24))}d`
+      : minutes >= 120
+        ? `${Math.round(minutes / 60)}h`
+        : `${minutes}m`;
+  return data.step ? `${window} window · ${data.step} step` : `${window} window`;
+}
+
+function adaptQueryPrometheus(
+  builder: ProjectionBuilder,
+  source: InvestigationEvidenceSource,
+  payload: unknown,
+): void {
+  const value = record(payload);
+  const mode = value?.type;
+  if (
+    !value ||
+    !nonEmptyString(value.query) ||
+    (mode !== "range" && mode !== "instant") ||
+    !Array.isArray(value.series) ||
+    !Array.isArray(value.selectors) ||
+    (value.selectorsUnknown !== undefined &&
+      typeof value.selectorsUnknown !== "boolean") ||
+    (value.truncated !== undefined && typeof value.truncated !== "boolean")
+  ) {
+    invalidPayload(builder, source, "Prometheus query");
+    return;
+  }
+  const series = value.series
+    .map(timeSeries)
+    .filter((item): item is TimeSeries => Boolean(item));
+  const selectors = value.selectors
+    .map(metricsSelector)
+    .filter((item): item is InvestigationMetricsSelector => Boolean(item));
+  if (
+    series.length !== value.series.length ||
+    selectors.length !== value.selectors.length
+  ) {
+    invalidPayload(builder, source, "Prometheus query");
+    return;
+  }
+  const selectorsUnknown = value.selectorsUnknown === true;
+  const relevance = metricsScope(builder.target, selectors, selectorsUnknown);
+  const start = nonEmptyString(value.start) ? value.start : undefined;
+  const end = nonEmptyString(value.end) ? value.end : undefined;
+  const step = nonEmptyString(value.step) ? value.step : undefined;
+  const note = nonEmptyString(value.note) ? value.note : undefined;
+  if (value.truncated === true) {
+    const summary = record(value.summary);
+    const cardinality = record(summary?.labelCardinality);
+    const widest = cardinality
+      ? Object.entries(cardinality).find(
+          ([, count]) => typeof count === "number",
+        )
+      : undefined;
+    const parts = [
+      typeof summary?.seriesCount === "number"
+        ? `${summary.seriesCount} series`
+        : undefined,
+      typeof summary?.totalDataPoints === "number"
+        ? `${summary.totalDataPoints} samples`
+        : undefined,
+      widest ? `${widest[1]} distinct ${widest[0]} values` : undefined,
+    ].filter((part): part is string => Boolean(part));
+    builder.limit(
+      source,
+      "Prometheus query",
+      `The result of \`${value.query}\` was too large to keep${parts.length ? ` (${parts.join(", ")})` : ""}, so Radar cannot chart it.${note ? ` ${note}` : ""}`,
+      "truncated",
+    );
+    return;
+  }
+  const windowLabel = metricsWindowLabel({ mode, start, end, step });
+  const data: InvestigationMetricsEvidence = {
+    type: "metrics",
+    origin: "query",
+    query: value.query,
+    mode,
+    start,
+    end,
+    step,
+    unit: metricsUnitForExpression(value.query, selectors),
+    series,
+    truncated: false,
+    note,
+    selectors,
+    selectorsUnknown,
+    subject:
+      relevance === "target"
+        ? {
+            kind: builder.target.kind,
+            ...(builder.target.group ? { group: builder.target.group } : {}),
+            namespace: builder.target.namespace,
+            name: builder.target.name,
+          }
+        : undefined,
+  };
+  builder.observe(
+    `metrics:${mode}:${value.query}:${start ?? ""}:${end ?? ""}:${step ?? ""}`,
+    "metrics",
+    source,
+    {
+      tier: evidenceTierForRelevance("supporting", relevance),
+      relevance,
+      tone: "neutral",
+      title: mode === "range" ? "Prometheus metrics" : "Prometheus values",
+      summary: [
+        series.length === 0
+          ? "No series matched"
+          : `${series.length} series`,
+        windowLabel,
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(" · "),
+      data,
+    },
+  );
+}
+
 const ADAPTERS: Record<
   string,
   (
@@ -4507,6 +4804,7 @@ const ADAPTERS: Record<
   get_prometheus_rules: adaptPrometheusRules,
   get_helm_release: adaptHelmRelease,
   get_subject_permissions: adaptSubjectPermissions,
+  query_prometheus: adaptQueryPrometheus,
 };
 
 export function projectInvestigationEvidence(

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -4577,13 +4577,12 @@ function metricsSelector(
   return { metric: item.metric, matchers };
 }
 
-const WORKLOAD_SELECTOR_LABELS: Readonly<Record<string, string | undefined>> =
-  {
-    deployment: "deployment",
-    statefulset: "statefulset",
-    daemonset: "daemonset",
-    workload: undefined,
-  };
+const WORKLOAD_SELECTOR_LABELS: Readonly<Record<string, string | undefined>> = {
+  deployment: "deployment",
+  statefulset: "statefulset",
+  daemonset: "daemonset",
+  workload: undefined,
+};
 
 /**
  * A regex matcher names the target only in the exact forms the plan admits,
@@ -4650,7 +4649,9 @@ export function metricsScope(
             regexNamesExactly(matcher.value, target.namespace ?? "", ""))),
     );
     if (!inNamespace) return "broader";
-    if (!selector.matchers.some((matcher) => selectorNamesTarget(target, matcher)))
+    if (
+      !selector.matchers.some((matcher) => selectorNamesTarget(target, matcher))
+    )
       allNameTarget = false;
   }
   return allNameTarget ? "target" : "producer-related";
@@ -4674,7 +4675,9 @@ function metricsWindowLabel(data: {
       : minutes >= 120
         ? `${Math.round(minutes / 60)}h`
         : `${minutes}m`;
-  return data.step ? `${window} window · ${data.step} step` : `${window} window`;
+  return data.step
+    ? `${window} window · ${data.step} step`
+    : `${window} window`;
 }
 
 function adaptQueryPrometheus(
@@ -4776,9 +4779,7 @@ function adaptQueryPrometheus(
       tone: "neutral",
       title: mode === "range" ? "Prometheus metrics" : "Prometheus values",
       summary: [
-        series.length === 0
-          ? "No series matched"
-          : `${series.length} series`,
+        series.length === 0 ? "No series matched" : `${series.length} series`,
         windowLabel,
       ]
         .filter((part): part is string => Boolean(part))

--- a/web/src/components/diagnose/investigationMetrics.test.ts
+++ b/web/src/components/diagnose/investigationMetrics.test.ts
@@ -365,6 +365,64 @@ describe("metricsChangeMarkers", () => {
     expect(markers).toEqual([]);
   });
 
+  it("marks a Helm change without an apiVersion on the subject's own kind, never on an unrelated kind", () => {
+    const helmChange = {
+      source: "helm",
+      kind: "Deployment",
+      namespace: "shop",
+      name: "api",
+      changeType: "upgrade",
+      summary: "Helm release api upgraded to 2.4.1",
+      timestamp: "2026-09-06T08:00:00Z",
+    };
+    const markers = markersFor(
+      [
+        [
+          tool("diag", "diagnose", {
+            ...diagnoseBundle,
+            recentChanges: [
+              helmChange,
+              { ...helmChange, kind: "Service", changeType: "update" },
+              { ...helmChange, name: "worker" },
+            ],
+          }),
+          tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers).toEqual([
+      {
+        timestamp: Date.parse("2026-09-06T08:00:00Z") / 1000,
+        label: "Deployment api",
+        kind: "change",
+      },
+    ]);
+  });
+
+  it("keeps the strict identity when a change carries an apiVersion", () => {
+    const markers = markersFor(
+      [
+        [
+          tool("diag", "diagnose", {
+            ...diagnoseBundle,
+            recentChanges: [
+              change(
+                "Deployment",
+                "api",
+                "2026-09-06T08:00:00Z",
+                "example.io/v1",
+              ),
+            ],
+          }),
+          tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers).toEqual([]);
+  });
+
   it("never marks a chart that is not about the target", () => {
     const markers = markersFor(
       [

--- a/web/src/components/diagnose/investigationMetrics.test.ts
+++ b/web/src/components/diagnose/investigationMetrics.test.ts
@@ -42,7 +42,8 @@ const window = { start: "2026-09-06T07:00:00Z", end: "2026-09-06T09:00:00Z" };
 
 function rangeResult(selectors: unknown[]) {
   return {
-    query: 'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"})',
+    query:
+      'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"})',
     type: "range",
     ...window,
     step: "60s",
@@ -95,7 +96,9 @@ const diagnoseBundle = {
   resourceContext: {
     tier: "diagnostic",
     uses: {
-      configMaps: [{ kind: "ConfigMap", namespace: "shop", name: "api-config" }],
+      configMaps: [
+        { kind: "ConfigMap", namespace: "shop", name: "api-config" },
+      ],
       secrets: [{ kind: "Secret", namespace: "shop", name: "api-secret" }],
     },
   },
@@ -118,8 +121,71 @@ const diagnoseBundle = {
 };
 
 describe("metricsUnitForExpression", () => {
-  it("names a unit only for a single bare metric with a unit suffix", () => {
-    const selector = (metric: string) => [{ metric, matchers: [] }];
+  const selector = (metric: string) => [{ metric, matchers: [] }];
+
+  it("keeps the unit every metric states through aggregations and wrappers", () => {
+    expect(
+      metricsUnitForExpression(
+        'sum(max by (pod,namespace,container) (container_memory_working_set_bytes{namespace="shop", pod=~"api-.*"}))',
+        selector("container_memory_working_set_bytes"),
+      ),
+    ).toBe("bytes");
+    expect(
+      metricsUnitForExpression(
+        'sum(rate(container_network_receive_bytes_total{namespace="shop"}[5m])) by (pod)',
+        selector("container_network_receive_bytes_total"),
+      ),
+    ).toBe("bytes/s");
+    expect(
+      metricsUnitForExpression(
+        "increase(container_network_receive_bytes_total[1h])",
+        selector("container_network_receive_bytes_total"),
+      ),
+    ).toBe("bytes");
+    expect(
+      metricsUnitForExpression(
+        "max_over_time(http_request_duration_seconds[10m])",
+        selector("http_request_duration_seconds"),
+      ),
+    ).toBe("seconds");
+  });
+
+  it("stays unitless for ratios, mixed metrics and bare numbers", () => {
+    expect(
+      metricsUnitForExpression('a_bytes / b_bytes{path="/api/v1"}', [
+        ...selector("a_bytes"),
+        ...selector("b_bytes"),
+      ]),
+    ).toBe("");
+    expect(
+      metricsUnitForExpression("a_bytes + b_seconds", [
+        ...selector("a_bytes"),
+        ...selector("b_seconds"),
+      ]),
+    ).toBe("");
+    expect(
+      metricsUnitForExpression(
+        "container_memory_working_set_bytes + kube_pod_info",
+        [
+          ...selector("container_memory_working_set_bytes"),
+          ...selector("kube_pod_info"),
+        ],
+      ),
+    ).toBe("");
+    expect(metricsUnitForExpression("42", [])).toBe("");
+    expect(metricsUnitForExpression("1 / 2", [])).toBe("");
+  });
+
+  it("does not turn a matcher value containing a slash into a ratio", () => {
+    expect(
+      metricsUnitForExpression(
+        'container_memory_working_set_bytes{image="ghcr.io/example/api"}',
+        selector("container_memory_working_set_bytes"),
+      ),
+    ).toBe("bytes");
+  });
+
+  it("names a unit for a bare metric with a unit suffix", () => {
     expect(
       metricsUnitForExpression(
         'container_memory_working_set_bytes{namespace="shop"}',
@@ -139,13 +205,16 @@ describe("metricsUnitForExpression", () => {
       ),
     ).toBe("");
     expect(
-      metricsUnitForExpression(
-        "a_bytes / b_bytes",
-        [...selector("a_bytes"), ...selector("b_bytes")],
-      ),
+      metricsUnitForExpression("a_bytes / b_bytes", [
+        ...selector("a_bytes"),
+        ...selector("b_bytes"),
+      ]),
     ).toBe("");
     expect(
-      metricsUnitForExpression("kube_pod_container_status_restarts_total", selector("kube_pod_container_status_restarts_total")),
+      metricsUnitForExpression(
+        "kube_pod_container_status_restarts_total",
+        selector("kube_pod_container_status_restarts_total"),
+      ),
     ).toBe("");
   });
 });
@@ -221,7 +290,12 @@ describe("metricsChangeMarkers", () => {
             "get_changes",
             {
               changes: [
-                change("Deployment", "worker", "2026-09-06T08:20:00Z", "apps/v1"),
+                change(
+                  "Deployment",
+                  "worker",
+                  "2026-09-06T08:20:00Z",
+                  "apps/v1",
+                ),
                 change("Deployment", "api", "2026-09-06T08:10:00Z", "apps/v1"),
               ],
             },

--- a/web/src/components/diagnose/investigationMetrics.test.ts
+++ b/web/src/components/diagnose/investigationMetrics.test.ts
@@ -179,6 +179,8 @@ describe("metricsUnitForExpression", () => {
   it("drops the unit when a function counts or flags instead of measuring", () => {
     for (const query of [
       'count(container_memory_working_set_bytes{namespace="shop"})',
+      'count by (pod) (container_memory_working_set_bytes{namespace="shop"})',
+      "count without (container) (container_memory_working_set_bytes)",
       "count_over_time(container_memory_working_set_bytes[1h])",
       "absent(container_memory_working_set_bytes)",
       "changes(http_request_duration_seconds[10m])",

--- a/web/src/components/diagnose/investigationMetrics.test.ts
+++ b/web/src/components/diagnose/investigationMetrics.test.ts
@@ -176,6 +176,31 @@ describe("metricsUnitForExpression", () => {
     expect(metricsUnitForExpression("1 / 2", [])).toBe("");
   });
 
+  it("drops the unit when a function counts or flags instead of measuring", () => {
+    for (const query of [
+      'count(container_memory_working_set_bytes{namespace="shop"})',
+      "count_over_time(container_memory_working_set_bytes[1h])",
+      "absent(container_memory_working_set_bytes)",
+      "changes(http_request_duration_seconds[10m])",
+      "resets(container_network_receive_bytes_total[1h])",
+      "timestamp(container_memory_working_set_bytes)",
+    ]) {
+      expect(
+        metricsUnitForExpression(
+          query,
+          selector(query.match(/[a-z_]+_(?:bytes|seconds)(?:_total)?/)![0]),
+        ),
+        query,
+      ).toBe("");
+    }
+    expect(
+      metricsUnitForExpression(
+        "topk(3, container_memory_working_set_bytes)",
+        selector("container_memory_working_set_bytes"),
+      ),
+    ).toBe("bytes");
+  });
+
   it("does not turn a matcher value containing a slash into a ratio", () => {
     expect(
       metricsUnitForExpression(

--- a/web/src/components/diagnose/investigationMetrics.test.ts
+++ b/web/src/components/diagnose/investigationMetrics.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  projectInvestigationEvidence,
+  type InvestigationEvidenceTimelineItem,
+} from "./investigationEvidence";
+import {
+  metricsChangeMarkers,
+  metricsDomain,
+  metricsUnitForExpression,
+} from "./investigationMetrics";
+
+const target = {
+  kind: "Deployment",
+  group: "apps",
+  namespace: "shop",
+  name: "api",
+};
+
+function tool(
+  id: string,
+  name: string,
+  result: unknown,
+  patch: Partial<
+    Extract<InvestigationEvidenceTimelineItem, { kind: "tool" }>
+  > = {},
+): Extract<InvestigationEvidenceTimelineItem, { kind: "tool" }> {
+  return {
+    kind: "tool",
+    id,
+    tool: name,
+    status: "done",
+    summary: JSON.stringify({ namespace: "shop", name: "api" }),
+    result: JSON.stringify(result),
+    isError: false,
+    radarEvidence: true,
+    ...patch,
+  };
+}
+
+const window = { start: "2026-09-06T07:00:00Z", end: "2026-09-06T09:00:00Z" };
+
+function rangeResult(selectors: unknown[]) {
+  return {
+    query: 'sum(container_memory_working_set_bytes{namespace="shop",pod=~"api-.*"})',
+    type: "range",
+    ...window,
+    step: "60s",
+    series: [
+      {
+        labels: {},
+        dataPoints: [
+          { timestamp: Date.parse(window.start) / 1000, value: 1 },
+          { timestamp: Date.parse(window.end) / 1000, value: 2 },
+        ],
+      },
+    ],
+    selectors,
+  };
+}
+
+const targetSelectors = [
+  {
+    metric: "container_memory_working_set_bytes",
+    matchers: [
+      { label: "namespace", op: "=", value: "shop" },
+      { label: "pod", op: "=~", value: "api-.*" },
+    ],
+  },
+];
+
+function change(
+  kind: string,
+  name: string,
+  timestamp: string,
+  apiVersion = "v1",
+) {
+  return {
+    kind,
+    apiVersion,
+    namespace: "shop",
+    name,
+    changeType: "update",
+    summary: `${kind} ${name} changed`,
+    timestamp,
+  };
+}
+
+const diagnoseBundle = {
+  resource: {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: { namespace: "shop", name: "api" },
+  },
+  resourceContext: {
+    tier: "diagnostic",
+    uses: {
+      configMaps: [{ kind: "ConfigMap", namespace: "shop", name: "api-config" }],
+      secrets: [{ kind: "Secret", namespace: "shop", name: "api-secret" }],
+    },
+  },
+  logsCurrent: [
+    {
+      pod: "api-7f6-abc",
+      container: "api",
+      logs: { lines: ["boot"], totalLines: 1, matchedLines: 0, fallback: true },
+    },
+  ],
+  recentChanges: [
+    change("ConfigMap", "api-config", "2026-09-06T07:30:00Z"),
+    change("Deployment", "api", "2026-09-06T08:10:00Z", "apps/v1"),
+    change("Pod", "api-7f6-abc", "2026-09-06T08:11:00Z"),
+    change("Deployment", "worker", "2026-09-06T08:20:00Z", "apps/v1"),
+    change("ConfigMap", "api-config", "2026-09-06T06:30:00Z"),
+    change("ConfigMap", "api-config", "2026-09-06T07:30:00Z"),
+  ],
+  pods: 1,
+};
+
+describe("metricsUnitForExpression", () => {
+  it("names a unit only for a single bare metric with a unit suffix", () => {
+    const selector = (metric: string) => [{ metric, matchers: [] }];
+    expect(
+      metricsUnitForExpression(
+        'container_memory_working_set_bytes{namespace="shop"}',
+        selector("container_memory_working_set_bytes"),
+      ),
+    ).toBe("bytes");
+    expect(
+      metricsUnitForExpression(
+        "http_request_duration_seconds",
+        selector("http_request_duration_seconds"),
+      ),
+    ).toBe("seconds");
+    expect(
+      metricsUnitForExpression(
+        "rate(container_cpu_usage_seconds_total[5m])",
+        selector("container_cpu_usage_seconds_total"),
+      ),
+    ).toBe("");
+    expect(
+      metricsUnitForExpression(
+        "a_bytes / b_bytes",
+        [...selector("a_bytes"), ...selector("b_bytes")],
+      ),
+    ).toBe("");
+    expect(
+      metricsUnitForExpression("kube_pod_container_status_restarts_total", selector("kube_pod_container_status_restarts_total")),
+    ).toBe("");
+  });
+});
+
+describe("metricsDomain", () => {
+  it("returns the range window in unix seconds and nothing for instant results", () => {
+    expect(metricsDomain({ mode: "range", ...window })).toEqual({
+      start: Date.parse(window.start) / 1000,
+      end: Date.parse(window.end) / 1000,
+    });
+    expect(metricsDomain({ mode: "instant" })).toBeUndefined();
+    expect(
+      metricsDomain({ mode: "range", start: window.end, end: window.start }),
+    ).toBeUndefined();
+  });
+});
+
+describe("metricsChangeMarkers", () => {
+  function markersFor(
+    timelines: InvestigationEvidenceTimelineItem[][],
+    sourceId: string,
+  ) {
+    const projection = projectInvestigationEvidence(
+      timelines.map((timeline) => ({ timeline })),
+      target,
+    );
+    const observation = projection.groups
+      .flatMap((group) => group.observations)
+      .find(
+        (item) =>
+          item.data.type === "metrics" && item.source.stepId === sourceId,
+      );
+    if (!observation) throw new Error("metrics observation missing");
+    return metricsChangeMarkers(projection.groups, observation);
+  }
+
+  it("marks same-turn changes to the subject and its producer-established relatives, once each, inside the window", () => {
+    const markers = markersFor(
+      [
+        [
+          tool("diag", "diagnose", diagnoseBundle),
+          tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers).toEqual([
+      {
+        timestamp: Date.parse("2026-09-06T07:30:00Z") / 1000,
+        label: "ConfigMap api-config",
+        kind: "change",
+      },
+      {
+        timestamp: Date.parse("2026-09-06T08:10:00Z") / 1000,
+        label: "Deployment api",
+        kind: "change",
+      },
+      {
+        timestamp: Date.parse("2026-09-06T08:11:00Z") / 1000,
+        label: "Pod api-7f6-abc",
+        kind: "change",
+      },
+    ]);
+  });
+
+  it("excludes a sibling workload's change even from a target-scoped change query", () => {
+    const markers = markersFor(
+      [
+        [
+          tool("diag", "diagnose", { ...diagnoseBundle, recentChanges: [] }),
+          tool(
+            "changes",
+            "get_changes",
+            {
+              changes: [
+                change("Deployment", "worker", "2026-09-06T08:20:00Z", "apps/v1"),
+                change("Deployment", "api", "2026-09-06T08:10:00Z", "apps/v1"),
+              ],
+            },
+            {
+              summary: JSON.stringify({
+                kind: "Deployment",
+                namespace: "shop",
+                name: "api",
+              }),
+            },
+          ),
+          tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers.map((marker) => marker.label)).toEqual(["Deployment api"]);
+  });
+
+  it("ignores broader change results and other turns", () => {
+    const markers = markersFor(
+      [
+        [tool("diag", "diagnose", diagnoseBundle)],
+        [
+          tool(
+            "broad",
+            "get_changes",
+            {
+              changes: [
+                change("Deployment", "api", "2026-09-06T08:10:00Z", "apps/v1"),
+              ],
+            },
+            { summary: JSON.stringify({ namespace: "shop" }) },
+          ),
+          tool("prom", "query_prometheus", rangeResult(targetSelectors)),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers).toEqual([]);
+  });
+
+  it("never marks a chart that is not about the target", () => {
+    const markers = markersFor(
+      [
+        [
+          tool("diag", "diagnose", diagnoseBundle),
+          tool("prom", "query_prometheus", rangeResult([])),
+        ],
+      ],
+      "prom",
+    );
+    expect(markers).toEqual([]);
+  });
+});

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -19,9 +19,10 @@ function metricUnitSuffix(metric: string): "bytes" | "seconds" | undefined {
 }
 
 // Functions whose result is a count, a flag or a time, whatever the input
-// metric measured.
+// metric measured. Aggregations may put their grouping clause before the
+// parenthesis: `count by (pod) (...)`.
 const QUANTITY_DISCARDING_FUNCTIONS =
-  /\b(?:count|count_values|count_over_time|absent|absent_over_time|present_over_time|changes|resets|timestamp)\s*\(/;
+  /\b(?:count|count_values|count_over_time|absent|absent_over_time|present_over_time|changes|resets|timestamp)\s*(?:\(|by\b|without\b)/;
 
 /**
  * The unit is what every metric in the expression states through its name,

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -18,13 +18,19 @@ function metricUnitSuffix(metric: string): "bytes" | "seconds" | undefined {
   return undefined;
 }
 
+// Functions whose result is a count, a flag or a time, whatever the input
+// metric measured.
+const QUANTITY_DISCARDING_FUNCTIONS =
+  /\b(?:count|count_values|count_over_time|absent|absent_over_time|present_over_time|changes|resets|timestamp)\s*\(/;
+
 /**
  * The unit is what every metric in the expression states through its name,
  * as the producer's selector inventory lists them. Aggregations keep a unit;
  * a rate turns bytes into bytes per second and seconds into a ratio; a
- * division is a ratio; metrics that disagree, or say nothing, leave the axis
- * unitless. Matcher values and string literals are ignored when looking for
- * operators, so a label value containing "/" cannot demote the unit.
+ * division, or a function that counts or flags rather than measures, is
+ * unitless; metrics that disagree, or say nothing, leave the axis unitless.
+ * Matcher values and string literals are ignored when looking for operators,
+ * so a label value containing "/" cannot demote the unit.
  */
 export function metricsUnitForExpression(
   query: string,
@@ -41,7 +47,8 @@ export function metricsUnitForExpression(
     .replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, '""')
     .replace(/\{[^{}]*\}/g, "")
     .replace(/\[[^\]]*\]/g, "");
-  if (operators.includes("/")) return "";
+  if (operators.includes("/") || QUANTITY_DISCARDING_FUNCTIONS.test(operators))
+    return "";
   if (/\b(?:rate|irate|deriv)\s*\(/.test(operators)) {
     return unit === "bytes" ? "bytes/s" : "";
   }

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -9,24 +9,43 @@ import type {
   InvestigationMetricsSelector,
 } from "./investigationEvidence";
 
-const BARE_METRIC_EXPRESSION = /^([a-zA-Z_:][a-zA-Z0-9_:]*)\s*(\{[^{}]*\})?$/;
+function metricUnitSuffix(metric: string): "bytes" | "seconds" | undefined {
+  const base = metric.endsWith("_total")
+    ? metric.slice(0, -"_total".length)
+    : metric;
+  if (base.endsWith("_bytes")) return "bytes";
+  if (base.endsWith("_seconds")) return "seconds";
+  return undefined;
+}
 
 /**
- * A unit is only claimed for a single bare metric whose name states it. Any
- * function, arithmetic or aggregation changes what the value means (a rate of
- * bytes is bytes per second; a ratio is unitless), so the axis stays unitless.
+ * The unit is what every metric in the expression states through its name,
+ * as the producer's selector inventory lists them. Aggregations keep a unit;
+ * a rate turns bytes into bytes per second and seconds into a ratio; a
+ * division is a ratio; metrics that disagree, or say nothing, leave the axis
+ * unitless. Matcher values and string literals are ignored when looking for
+ * operators, so a label value containing "/" cannot demote the unit.
  */
 export function metricsUnitForExpression(
   query: string,
   selectors: readonly InvestigationMetricsSelector[],
 ): string {
-  const match = BARE_METRIC_EXPRESSION.exec(query.trim());
-  if (!match || selectors.length !== 1 || selectors[0].metric !== match[1]) {
-    return "";
+  if (selectors.length === 0) return "";
+  const units = new Set(
+    selectors.map((selector) => metricUnitSuffix(selector.metric)),
+  );
+  if (units.size !== 1) return "";
+  const [unit] = units;
+  if (!unit) return "";
+  const operators = query
+    .replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, '""')
+    .replace(/\{[^{}]*\}/g, "")
+    .replace(/\[[^\]]*\]/g, "");
+  if (operators.includes("/")) return "";
+  if (/\b(?:rate|irate|deriv)\s*\(/.test(operators)) {
+    return unit === "bytes" ? "bytes/s" : "";
   }
-  if (match[1].endsWith("_bytes")) return "bytes";
-  if (match[1].endsWith("_seconds")) return "seconds";
-  return "";
+  return unit;
 }
 
 export function metricsDomain(
@@ -122,7 +141,11 @@ function producerRelatives(
         case "crash":
           if (data.namespace) {
             for (const pod of data.crash.pods) {
-              relatives.push({ kind: "Pod", namespace: data.namespace, name: pod });
+              relatives.push({
+                kind: "Pod",
+                namespace: data.namespace,
+                name: pod,
+              });
             }
           }
           break;

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -1,0 +1,188 @@
+import { displayKind, type IssueRecentChange } from "@skyhook-io/k8s-ui";
+import type { ChartAnnotation } from "@skyhook-io/k8s-ui/components/charts";
+import { apiVersionToGroup } from "../../utils/navigation";
+import type { DiagnosisResourceRef } from "./diagnoseEvidenceTypes";
+import type {
+  InvestigationEvidenceGroup,
+  InvestigationEvidenceObservation,
+  InvestigationMetricsEvidence,
+  InvestigationMetricsSelector,
+} from "./investigationEvidence";
+
+const BARE_METRIC_EXPRESSION = /^([a-zA-Z_:][a-zA-Z0-9_:]*)\s*(\{[^{}]*\})?$/;
+
+/**
+ * A unit is only claimed for a single bare metric whose name states it. Any
+ * function, arithmetic or aggregation changes what the value means (a rate of
+ * bytes is bytes per second; a ratio is unitless), so the axis stays unitless.
+ */
+export function metricsUnitForExpression(
+  query: string,
+  selectors: readonly InvestigationMetricsSelector[],
+): string {
+  const match = BARE_METRIC_EXPRESSION.exec(query.trim());
+  if (!match || selectors.length !== 1 || selectors[0].metric !== match[1]) {
+    return "";
+  }
+  if (match[1].endsWith("_bytes")) return "bytes";
+  if (match[1].endsWith("_seconds")) return "seconds";
+  return "";
+}
+
+export function metricsDomain(
+  data: Pick<InvestigationMetricsEvidence, "mode" | "start" | "end">,
+): { start: number; end: number } | undefined {
+  if (data.mode !== "range" || !data.start || !data.end) return undefined;
+  const start = Date.parse(data.start) / 1000;
+  const end = Date.parse(data.end) / 1000;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start)
+    return undefined;
+  return { start, end };
+}
+
+function refKey(ref: {
+  kind: string;
+  group?: string;
+  namespace?: string;
+  name: string;
+}): string {
+  return [
+    ref.kind.toLowerCase(),
+    (ref.group ?? "").toLowerCase(),
+    ref.namespace ?? "",
+    ref.name,
+  ].join("/");
+}
+
+function changeKey(change: IssueRecentChange): string {
+  return refKey({
+    kind: change.kind,
+    group: change.apiVersion ? apiVersionToGroup(change.apiVersion) : "",
+    namespace: change.namespace,
+    name: change.name,
+  });
+}
+
+function sameResource(
+  left: DiagnosisResourceRef,
+  right: DiagnosisResourceRef,
+): boolean {
+  return refKey(left) === refKey(right);
+}
+
+/**
+ * The resources a change may be recorded against and still count as a change
+ * to the chart's subject: the subject itself and the relatives producers named
+ * in the same turn (the configuration it consumes, and the pods and ReplicaSets
+ * diagnosis rows identified). Name prefixes never qualify.
+ */
+function producerRelatives(
+  groups: readonly InvestigationEvidenceGroup[],
+  subject: DiagnosisResourceRef,
+  turnIndex: number,
+): DiagnosisResourceRef[] {
+  const relatives: DiagnosisResourceRef[] = [subject];
+  for (const group of groups) {
+    for (const observation of group.observations) {
+      if (
+        observation.source.turnIndex !== turnIndex ||
+        observation.relevance === "broader"
+      ) {
+        continue;
+      }
+      const { data } = observation;
+      switch (data.type) {
+        case "resource": {
+          const ref: DiagnosisResourceRef = {
+            kind: data.resource.kind,
+            group: apiVersionToGroup(data.resource.apiVersion) || undefined,
+            namespace: data.resource.metadata.namespace,
+            name: data.resource.metadata.name,
+          };
+          if (!sameResource(ref, subject)) break;
+          const uses = data.resourceContext?.uses;
+          relatives.push(...(uses?.configMaps ?? []), ...(uses?.secrets ?? []));
+          if (data.resourceContext?.owner) {
+            relatives.push(data.resourceContext.owner);
+          }
+          break;
+        }
+        case "startup":
+          if (data.subject) relatives.push(data.subject);
+          break;
+        case "logs":
+          if (data.namespace) {
+            relatives.push({
+              kind: "Pod",
+              namespace: data.namespace,
+              name: data.pod,
+            });
+          }
+          break;
+        case "crash":
+          if (data.namespace) {
+            for (const pod of data.crash.pods) {
+              relatives.push({ kind: "Pod", namespace: data.namespace, name: pod });
+            }
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  return relatives;
+}
+
+/**
+ * Changes Radar recorded for the chart's subject inside the chart window,
+ * taken only from the same turn's change observations that producers related
+ * to the target. Each marker says a change was recorded at that instant and
+ * nothing more.
+ */
+export function metricsChangeMarkers(
+  groups: readonly InvestigationEvidenceGroup[],
+  observation: InvestigationEvidenceObservation,
+): ChartAnnotation[] {
+  const { data } = observation;
+  if (data.type !== "metrics" || !data.subject) return [];
+  const domain = metricsDomain(data);
+  if (!domain) return [];
+  const turnIndex = observation.source.turnIndex;
+  const relativeKeys = new Set(
+    producerRelatives(groups, data.subject, turnIndex).map(refKey),
+  );
+  const seen = new Set<string>();
+  const markers: ChartAnnotation[] = [];
+  for (const group of groups) {
+    for (const candidate of group.observations) {
+      if (
+        candidate.data.type !== "changes" ||
+        candidate.source.turnIndex !== turnIndex ||
+        candidate.relevance === "broader"
+      ) {
+        continue;
+      }
+      for (const change of candidate.data.changes) {
+        const timestamp = Date.parse(change.timestamp) / 1000;
+        if (
+          !Number.isFinite(timestamp) ||
+          timestamp < domain.start ||
+          timestamp > domain.end ||
+          !relativeKeys.has(changeKey(change))
+        ) {
+          continue;
+        }
+        const identity = `${change.apiVersion ?? ""}|${change.kind}|${change.namespace ?? ""}|${change.name}|${change.timestamp}`;
+        if (seen.has(identity)) continue;
+        seen.add(identity);
+        markers.push({
+          timestamp,
+          label: `${displayKind(change.kind)} ${change.name}`,
+          kind: "change",
+        });
+      }
+    }
+  }
+  return markers.sort((left, right) => left.timestamp - right.timestamp);
+}

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -81,13 +81,36 @@ function refKey(ref: {
   ].join("/");
 }
 
-function changeKey(change: IssueRecentChange): string {
-  return refKey({
-    kind: change.kind,
-    group: change.apiVersion ? apiVersionToGroup(change.apiVersion) : "",
-    namespace: change.namespace,
-    name: change.name,
-  });
+function looseKey(ref: {
+  kind: string;
+  namespace?: string;
+  name: string;
+}): string {
+  return [ref.kind.toLowerCase(), ref.namespace ?? "", ref.name].join("/");
+}
+
+/**
+ * A change names its resource exactly when it carries an apiVersion. Helm
+ * history rows and older stores omit it, so those match on kind, namespace
+ * and name alone, which is unambiguous only against the subject and its
+ * producer-established relatives.
+ */
+function changeMatchesRelative(
+  change: IssueRecentChange,
+  strictKeys: ReadonlySet<string>,
+  looseKeys: ReadonlySet<string>,
+): boolean {
+  if (change.apiVersion) {
+    return strictKeys.has(
+      refKey({
+        kind: change.kind,
+        group: apiVersionToGroup(change.apiVersion),
+        namespace: change.namespace,
+        name: change.name,
+      }),
+    );
+  }
+  return looseKeys.has(looseKey(change));
 }
 
 function sameResource(
@@ -180,9 +203,9 @@ export function metricsChangeMarkers(
   const domain = metricsDomain(data);
   if (!domain) return [];
   const turnIndex = observation.source.turnIndex;
-  const relativeKeys = new Set(
-    producerRelatives(groups, data.subject, turnIndex).map(refKey),
-  );
+  const relatives = producerRelatives(groups, data.subject, turnIndex);
+  const strictKeys = new Set(relatives.map(refKey));
+  const looseKeys = new Set(relatives.map(looseKey));
   const seen = new Set<string>();
   const markers: ChartAnnotation[] = [];
   for (const group of groups) {
@@ -200,7 +223,7 @@ export function metricsChangeMarkers(
           !Number.isFinite(timestamp) ||
           timestamp < domain.start ||
           timestamp > domain.end ||
-          !relativeKeys.has(changeKey(change))
+          !changeMatchesRelative(change, strictKeys, looseKeys)
         ) {
           continue;
         }

--- a/web/src/components/diagnose/investigationSourceFocus.ts
+++ b/web/src/components/diagnose/investigationSourceFocus.ts
@@ -33,6 +33,8 @@ export function evidenceSourceExcerpt(
       return data.release.healthIssue;
     case "permissions":
       return data.accessCheck?.reason;
+    case "metrics":
+      return data.query;
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

When the investigating agent runs a Prometheus range query, Findings now renders it as a chart card with the query underneath, and draws the changes Radar recorded for that workload in the same window as vertical markers on the chart. The prompt tells the agent when Prometheus is actually connected, so it queries instead of guessing. Track B of the Findings next layer, stacked on #1678 (Track 0), which provides `internal/prometheus.Availability` and the `selectors` inventory on `query_prometheus` results.

A chart only claims to be about the investigation target when every selector in the query is scoped to it; anything broader shows only when the assessment cites it. Markers say "a change was recorded here", never "this caused that".

## What changed

**Findings (`web/`)**
- New `metrics` evidence kind and a `query_prometheus` adapter. Range results become a chart, instant results a compact value table, producer-truncated results a coverage limitation carrying the cardinality summary (no chart).
- Scope comes from the producer's `selectors` inventory, never from the expression text. `target` only when every selector carries the target namespace (`namespace="shop"` or the anchored `namespace=~"shop"`) and a pod or workload matcher naming the target: `pod="<name>-…"`, `deployment|statefulset|daemonset|workload="<name>"` matching the target kind, or the exact regex forms `pod=~"<name>-.*"` / `<label>=~"<name>"` with the name's dot escaped (an unescaped `api.v2` or an `api-?.*` also selects other workloads, so those stay unclaimed). A Pod target is named only by its own exact name, since its `<name>-` prefix selects other pods. Namespace-only selectors are `producer-related`; a bare selector, a sibling workload, an alternation, empty selectors or `selectorsUnknown` are `broader`.
- `metrics` joins the focused kinds in `partitionInvestigationEvidence`, so a cited broader chart enters the main list (one observation per `query_prometheus` result, so today's legacy citation selects it). Uncited target-scoped charts sit in "More evidence about this workload"; uncited broader charts are withheld and counted: "N broader metric results are not shown; they appear here when the assessment cites them."
- Change markers (`investigationMetrics.ts`): only same-turn `changes` observations with relevance target or producer-related, only changes whose resource is the chart's subject or one of the relatives producers named in that turn (consumed ConfigMaps/Secrets, the owner, and the pods/ReplicaSets the diagnosis rows identified). Absolute `IssueRecentChange.timestamp` only, inside the chart window, deduplicated on apiVersion+kind+namespace+name+timestamp. A change without an apiVersion (Helm history rows, older stores) matches on kind, namespace and name against the subject and its relatives; one with an apiVersion must match the group exactly. Label names the changed resource; hover tooltip says "Change recorded". No crash markers, no relative `changeContext.when`.
- Axis label is the raw expression, truncated with the full text in a tooltip and repeated in full under the chart when truncated. The unit is what every metric in the query states through its name (from the selector inventory): `_bytes` stays bytes through aggregations, a `rate()` of bytes is bytes/s, `_seconds` stays seconds; a division, disagreeing metrics or a bare number leave the axis unitless, and unitless axes scale with k/M/G.
- Series are named by every label when the pod/instance/node label is missing or shared (an aggregation `by (container)` reads `container=api`, not `series-0`), derived once from the whole result so names stay distinct across chart and table, with a legend under multi-series charts. A series with a single finite sample cannot draw a line, so it is listed with its time and value under the chart; a series whose samples are all gaps (Prometheus serializes NaN and infinities as null) is named as returning no finite values.
- Card actions are the existing View source and the existing open-resource button (subject = target when scope is target).

**`@skyhook-io/k8s-ui` `AreaChart` (additive)**
- `annotations?: ChartAnnotation[]` and `domain?: {start, end}`. Vertical dashed line plus a label pill per annotation; labels stack into rows to avoid collisions, are hidden past three rows or when the rendered chart is narrower than 420px, and the text moves into the hover tooltip in both cases.
- Y axis handles negative minima (zero line drawn, area fills toward zero). A `count` unit gets an integer axis on a 1/2/5 step (0 and 1 for an all-zero series, 0/5/10/15/20 for a maximum of 18). Existing callers are unchanged: with no annotations, no domain and non-negative data the geometry is identical.
- `layout="auto"` (opt-in; Findings uses it) switches to a compact layout below the 420px label-hiding width: two Y ticks, first and last X ticks, larger text and a taller plot, so a narrow pane shows a readable chart instead of a strip. `layout="compact"` forces it for tests.
- `ChartAnnotation` exported from `charts/types.ts` and the charts index; `formatMetricValue` gains a `seconds` unit and a sign for negative values; `seriesDisplayLabels` is the one place the chart tooltip and `SeriesLegend` derive series names from, and both accept an optional `seriesLabels` override for callers that chart a subset of a result.

**Prompt nudge (Go)**
- `RunManager.MetricsAvailability` hook, wired in `internal/server` to `prometheus.Availability`. Probed under a 2 s timeout only for investigation turns (initial and follow-up); explanation, apply and the scripted post-apply verification turn never probe, so verification stays on checking the confirmed fix.
- `Request.Metrics` carries the result; prompt selection moved into `turnPrompt`, which appends the sentence after selection so follow-ups get it too. Only `connected` produces text: "Prometheus is connected at <address>; for resource, restart, throttling or latency questions run one `query_prometheus` range query over the failure window and cite it." Other states say nothing. Credentials embedded in a configured URL are stripped before the address reaches the model-visible prompt.

## Testing

- `make tsc`: pass
- `cd web && npm test`: 927 passed, 2 failed in `src/api/client.authRedirect.test.ts` (5 s timeouts). The same file fails the same way on `main` at b54b3117 in a clean checkout; unrelated to this diff.
- `cd packages/k8s-ui && npm test`: pass (3560 tests, 1 skipped)
- `go test ./...`: pass
- `make build`: pass
- `git diff --check`: clean
- New tests: adapter (range, instant, truncated, empty result, revision merge, 13 scope cases including a braced target numerator over a bare cluster denominator, empty selectors, unknown selectors, pod regex alternation, optional-dash regex, dotted names escaped and unescaped, Pod targets, anchored and alternated namespace regexes), series display labels, sparse and null-only series listing, legend, unit inference (aggregations, rate and increase wrappers, mixed metrics, ratios, bare numbers, slashes inside matcher values), unitless value formatting, marker derivation (relatives, sibling exclusion, other-turn and broader exclusion, non-target chart), pane placement (uncited target → workload, uncited broader → withheld with note, cited broader → main, markers rendered and subject linked), `AreaChart.test.tsx` (annotations in/out of domain, row stacking and hidden labels, truncation, explicit domain wider than samples, negative values and zero line, null gaps, sparse samples, empty, compact layout, count axes) and `axis.test.ts`, Go (nudge text per turn kind and connection state, credential stripping; RunManager probes only investigation turns with a deadline, not explanation, apply or verification).
- Visual test on a fixture run (a cited target-scoped range query, an uncited cluster-wide query, and two in-window changes, against `kind-radar-kyverno-demo`): verified the chart card in the main list with both markers labelled, the hover tooltip reading "Change recorded · ConfigMap demo-api-config" next to the sample value, the withheld-metrics note, light and dark themes, a 720px viewport, a forced 380px-wide card showing marker lines without labels, and a forced 390px card in the docked pane rendering the compact layout (two Y ticks, edge X ticks, 225px-tall plot). No console errors.

## Scope and tradeoffs

- Uncited broader charts are deliberately withheld; the note tells the reader they exist and how they get shown.
- A `pod=~"<name>-.*"` prefix is accepted as naming a workload target per the plan; a sibling whose name starts with the same prefix would match that regex in Prometheus too, so this mirrors what the query actually selects.
- Relatives for markers come only from producer rows in the same turn; a ReplicaSet or Pod that no producer named in that turn does not qualify, even if its name starts with the workload's.
- No "same range" link: the resource charts are relative-time and curated, so a saved window cannot be reopened there.
- Diagnose-origin metrics (Track D1) use the same payload and renderer; their placement into main waits for Track C per D-5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches investigation evidence partitioning, model-visible prompts, and new chart rendering paths; scope rules and credential stripping reduce mis-attribution and secret leakage risk.
> 
> **Overview**
> Investigation **Findings** now surfaces **`query_prometheus`** results as first-class **metrics** evidence: range queries render as **chart cards** (with instant queries as value tables and oversized results as limitations), scoped using the producer **`selectors`** inventory so only fully target-scoped charts show uncited; broader queries stay hidden until cited, with a separate withheld-metrics count.
> 
> Charts can show **same-turn change markers** (subject and producer-named relatives inside the query window) via extended **`AreaChart`** support (`annotations`, `domain`, compact **`layout="auto"`**, count axes, negative values). The Go **RunManager** probes Prometheus on read-only investigation turns only and appends a **prompt nudge** when connected, with **URL credential stripping** before text reaches the model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54842baf4384597dff03fdb849ba9a89414feb71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->