### PR TITLE
Scope the topology filter sidebar to the selected namespaces

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1611,19 +1611,11 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     }
   }, [displayedTopology, visibleKinds, namespaces, topologyMode])
 
-  // Nodes for the filter sidebar: namespace-scoped, but NOT kind-filtered.
-  //
-  // The sidebar derives both its kind list and its visible/hidden footer counts
-  // from this prop, so it needs the full scoped set: handing it
-  // filteredTopology.nodes would drop every hidden kind out of the list instead
-  // of showing it with a count, and "hidden" would always read zero. It was
-  // previously given the raw topology.nodes, so the counts described the whole
-  // cluster rather than the namespaces on the canvas.
-  //
-  // Reads displayedTopology, not topology, so the counts freeze with the graph
-  // while paused. Nodes with no namespace are cluster-scoped (Node,
-  // PersistentVolume, Namespace, ...) and stay visible in every scope, matching
-  // the carve-out in filteredTopology above.
+  // Namespace-scoped but NOT kind-filtered: the sidebar derives its kind list
+  // and visible/hidden footer counts from this prop, so handing it the
+  // kind-filtered graph nodes would drop every hidden kind from the list and
+  // "hidden" would always read zero. Reads displayedTopology so the counts
+  // freeze with the graph while paused.
   const filterSidebarNodes = useMemo(() => {
     if (!displayedTopology) return []
     return scopeNodesToNamespaces(displayedTopology.nodes, namespaces)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,7 @@ import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
 import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
+import { isInNamespaceScope, scopeNodesToNamespaces } from './utils/topology-namespace'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode, stripBasename } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
@@ -1585,8 +1586,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     // Filter by namespace (client-side) and by visible kinds
     const nsSet = namespaces.length > 0 ? new Set(namespaces) : null
     const filteredNodes = displayedTopology.nodes.filter(node =>
-      effectiveKinds.has(node.kind) &&
-      (!nsSet || nsSet.has(node.data.namespace as string) || !(node.data.namespace as string))
+      effectiveKinds.has(node.kind) && isInNamespaceScope(node, nsSet)
     )
     const filteredNodeIds = new Set(filteredNodes.map(n => n.id))
 
@@ -1610,6 +1610,24 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       edges: filteredEdges,
     }
   }, [displayedTopology, visibleKinds, namespaces, topologyMode])
+
+  // Nodes for the filter sidebar: namespace-scoped, but NOT kind-filtered.
+  //
+  // The sidebar derives both its kind list and its visible/hidden footer counts
+  // from this prop, so it needs the full scoped set: handing it
+  // filteredTopology.nodes would drop every hidden kind out of the list instead
+  // of showing it with a count, and "hidden" would always read zero. It was
+  // previously given the raw topology.nodes, so the counts described the whole
+  // cluster rather than the namespaces on the canvas.
+  //
+  // Reads displayedTopology, not topology, so the counts freeze with the graph
+  // while paused. Nodes with no namespace are cluster-scoped (Node,
+  // PersistentVolume, Namespace, ...) and stay visible in every scope, matching
+  // the carve-out in filteredTopology above.
+  const filterSidebarNodes = useMemo(() => {
+    if (!displayedTopology) return []
+    return scopeNodesToNamespaces(displayedTopology.nodes, namespaces)
+  }, [displayedTopology, namespaces])
 
   // Cluster Audit findings, joined onto topology nodes by the audit key the
   // backend stamps on each node (data.auditKey). Only badge-worthy findings
@@ -2163,14 +2181,14 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
               <>
                 {/* Filter sidebar */}
                 <TopologyFilterSidebar
-                  nodes={topology?.nodes || []}
+                  nodes={filterSidebarNodes}
                   visibleKinds={visibleKinds}
                   onToggleKind={handleToggleKind}
                   onShowAll={handleShowAllKinds}
                   onHideAll={handleHideAllKinds}
                   collapsed={filterSidebarCollapsed}
                   onToggleCollapse={() => setFilterSidebarCollapsed(prev => !prev)}
-                  hiddenKinds={topology?.hiddenKinds}
+                  hiddenKinds={displayedTopology?.hiddenKinds}
                   onEnableHiddenKind={(kind) => {
                     setVisibleKinds(prev => new Set(prev).add(kind as NodeKind))
                     console.log(`[topology] User requested to show hidden kind: ${kind}`)

--- a/web/src/utils/topology-namespace.test.ts
+++ b/web/src/utils/topology-namespace.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { TopologyNode } from '@skyhook-io/k8s-ui/types/core'
+import { isInNamespaceScope, scopeNodesToNamespaces } from './topology-namespace'
+
+function node(id: string, kind: string, namespace?: string): TopologyNode {
+  return {
+    id,
+    kind,
+    name: id,
+    status: 'healthy',
+    data: namespace === undefined ? {} : { namespace },
+  } as TopologyNode
+}
+
+const nodes = [
+  node('web', 'Deployment', 'prod'),
+  node('ing', 'Ingress', 'staging'),
+  node('db', 'StatefulSet', 'prod'),
+  node('node-1', 'Node'),          // cluster-scoped
+  node('pv-1', 'PersistentVolume'), // cluster-scoped
+]
+
+describe('scopeNodesToNamespaces', () => {
+  it('returns every node when no namespace is selected', () => {
+    expect(scopeNodesToNamespaces(nodes, [])).toHaveLength(5)
+  })
+
+  it('keeps only the selected namespace, plus cluster-scoped nodes', () => {
+    const scoped = scopeNodesToNamespaces(nodes, ['prod'])
+    expect(scoped.map(n => n.id)).toEqual(['web', 'db', 'node-1', 'pv-1'])
+  })
+
+  it('drops a kind that exists only outside the scope', () => {
+    // The regression this guards: the sidebar used to receive the raw
+    // cluster-wide nodes, so it advertised Ingress with a count even when the
+    // selected namespace had none on the canvas.
+    const scoped = scopeNodesToNamespaces(nodes, ['prod'])
+    expect(scoped.some(n => n.kind === 'Ingress')).toBe(false)
+  })
+
+  it('accepts several namespaces at once', () => {
+    const scoped = scopeNodesToNamespaces(nodes, ['prod', 'staging'])
+    expect(scoped).toHaveLength(5)
+  })
+
+  it('returns the same array identity when the scope is empty', () => {
+    expect(scopeNodesToNamespaces(nodes, [])).toBe(nodes)
+  })
+})
+
+describe('isInNamespaceScope', () => {
+  it('passes everything for a null scope', () => {
+    expect(isInNamespaceScope(node('x', 'Pod', 'any'), null)).toBe(true)
+  })
+
+  it('always passes a node with no namespace', () => {
+    expect(isInNamespaceScope(node('node-1', 'Node'), new Set(['prod']))).toBe(true)
+  })
+
+  it('treats an empty-string namespace as cluster-scoped', () => {
+    expect(isInNamespaceScope(node('n', 'Node', ''), new Set(['prod']))).toBe(true)
+  })
+
+  it('rejects a namespaced node outside the scope', () => {
+    expect(isInNamespaceScope(node('ing', 'Ingress', 'staging'), new Set(['prod']))).toBe(false)
+  })
+})

--- a/web/src/utils/topology-namespace.test.ts
+++ b/web/src/utils/topology-namespace.test.ts
@@ -31,9 +31,6 @@ describe('scopeNodesToNamespaces', () => {
   })
 
   it('drops a kind that exists only outside the scope', () => {
-    // The regression this guards: the sidebar used to receive the raw
-    // cluster-wide nodes, so it advertised Ingress with a count even when the
-    // selected namespace had none on the canvas.
     const scoped = scopeNodesToNamespaces(nodes, ['prod'])
     expect(scoped.some(n => n.kind === 'Ingress')).toBe(false)
   })

--- a/web/src/utils/topology-namespace.ts
+++ b/web/src/utils/topology-namespace.ts
@@ -1,26 +1,16 @@
 import type { TopologyNode } from '@skyhook-io/k8s-ui/types/core'
 
-/**
- * Whether a topology node belongs to the given namespace scope.
- *
- * A node with no namespace is cluster-scoped (Node, PersistentVolume,
- * Namespace, ...) and stays visible in every scope, so it always passes.
- * An empty scope means "all namespaces".
- */
+// A node with no namespace is cluster-scoped (Node, PersistentVolume,
+// Namespace, ...) and stays visible in every scope.
 export function isInNamespaceScope(node: TopologyNode, nsSet: Set<string> | null): boolean {
   if (!nsSet) return true
   const ns = node.data?.namespace as string | undefined
   return !ns || nsSet.has(ns)
 }
 
-/**
- * Narrow a node list to the selected namespaces.
- *
- * Shared by the topology graph and the filter sidebar so the two cannot
- * disagree about which nodes are in scope. Note this applies the namespace
- * carve-out only: the sidebar needs the full scoped set to compute its
- * visible/hidden counts, so kind filtering is applied separately by the graph.
- */
+// Shared by the topology graph and the filter sidebar so the two cannot
+// disagree about which nodes are in scope. Namespace carve-out only — kind
+// filtering stays on the graph.
 export function scopeNodesToNamespaces(nodes: TopologyNode[], namespaces: string[]): TopologyNode[] {
   if (namespaces.length === 0) return nodes
   const nsSet = new Set(namespaces)

--- a/web/src/utils/topology-namespace.ts
+++ b/web/src/utils/topology-namespace.ts
@@ -1,0 +1,28 @@
+import type { TopologyNode } from '@skyhook-io/k8s-ui/types/core'
+
+/**
+ * Whether a topology node belongs to the given namespace scope.
+ *
+ * A node with no namespace is cluster-scoped (Node, PersistentVolume,
+ * Namespace, ...) and stays visible in every scope, so it always passes.
+ * An empty scope means "all namespaces".
+ */
+export function isInNamespaceScope(node: TopologyNode, nsSet: Set<string> | null): boolean {
+  if (!nsSet) return true
+  const ns = node.data?.namespace as string | undefined
+  return !ns || nsSet.has(ns)
+}
+
+/**
+ * Narrow a node list to the selected namespaces.
+ *
+ * Shared by the topology graph and the filter sidebar so the two cannot
+ * disagree about which nodes are in scope. Note this applies the namespace
+ * carve-out only: the sidebar needs the full scoped set to compute its
+ * visible/hidden counts, so kind filtering is applied separately by the graph.
+ */
+export function scopeNodesToNamespaces(nodes: TopologyNode[], namespaces: string[]): TopologyNode[] {
+  if (namespaces.length === 0) return nodes
+  const nsSet = new Set(namespaces)
+  return nodes.filter(node => isInNamespaceScope(node, nsSet))
+}


### PR DESCRIPTION
Closes #1647.

`TopologyFilterSidebar` was passed `topology?.nodes` — the raw, cluster-wide, unbuffered node list — while the graph rendered `filteredTopology`. With a namespace selected, the sidebar's kind rows and counts therefore described the whole cluster rather than the canvas (the `Ingress (12)` case in the issue), and because it read `topology` rather than `displayedTopology`, its counts kept moving while the graph was paused.

## Change

The sidebar now receives a **namespace-scoped** set derived from `displayedTopology`.

Scoping is namespace-only, deliberately. `TopologyFilterSidebar` builds `availableKinds` from `kindCounts` over its `nodes` prop and computes the footer's visible/hidden totals by intersecting that with `visibleKinds` (`TopologyFilterSidebar.tsx:150-170`, `:400-415`). Handing it the already kind-filtered graph nodes would drop every hidden kind out of the list instead of showing it with a count, and `hidden` would always read zero — which is what the issue warns about.

The namespace carve-out is now a single shared helper (`web/src/utils/topology-namespace.ts`) used by **both** the graph's `filteredTopology` and the sidebar, so the two cannot drift apart again — that is the acceptance criterion stated as code rather than as a convention. Nodes with no namespace are cluster-scoped (`Node`, `PersistentVolume`, `Namespace`) and stay visible in every scope, matching the existing behaviour.

`hiddenKinds` is read from `displayedTopology` for the same pause semantics.

## Acceptance criteria

| criterion | how it is met |
| --- | --- |
| Count and list kinds from the namespace-filtered node set | `filterSidebarNodes` = `scopeNodesToNamespaces(displayedTopology.nodes, namespaces)` |
| Retain cluster-scoped nodes with no namespace | `isInNamespaceScope` returns `true` when `data.namespace` is absent or empty |
| Use the pause-buffered `displayedTopology` | the memo reads `displayedTopology`, not `topology` |
| Do **not** pass the kind-filtered graph nodes | the helper applies the namespace carve-out only; kind filtering stays in `filteredTopology` |

## Verification

- `npm run tsc` (typescript-7, `--noEmit`) — clean
- `npm run lint` — **0 errors** (351 pre-existing warnings, unchanged)
- `npx vitest run src` — **914 passed**, including 9 new tests in `web/src/utils/topology-namespace.test.ts`

Two tests in `src/api/client.authRedirect.test.ts` fail, but they are **pre-existing and flaky**, unrelated to this change: on a clean stash of this branch that file alone still reports `1 failed | 5 passed`, and across runs it reports 1 or 2 failures on the same untouched code.

I could not exercise this against a live cluster, so the namespace behaviour is covered by unit tests on the extracted helper rather than end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only topology filtering refactor with extracted helpers and tests; no auth, API, or data-path changes.
> 
> **Overview**
> **Aligns the topology filter sidebar with the namespace-scoped graph** so kind rows and counts match what you see on the canvas when namespaces are selected, instead of reflecting the full cluster.
> 
> Adds shared helpers in `topology-namespace.ts` (`isInNamespaceScope`, `scopeNodesToNamespaces`) used by both the graph’s `filteredTopology` and a new `filterSidebarNodes` memo. Sidebar nodes are **namespace-scoped only** (from pause-buffered `displayedTopology`), not kind-filtered, so hidden kinds still appear in the list with correct visible/hidden footer counts. `hiddenKinds` now comes from `displayedTopology` so it stays stable while the graph is paused.
> 
> Unit tests cover namespace scoping and cluster-scoped nodes (no/empty namespace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4915b7295312d23c30d439c0e796916375168eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->