### PR TITLE
Read the pod phase where it is honest, not only where it lies

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -245,6 +245,23 @@ interface TopologyGraphProps {
   children?: ReactNode
 }
 
+// A pod group's children normally carry the health the server computed. Without
+// it, the phase is honest for every state except Running: a crash-looping pod
+// sits at Phase=Running with its container restarting, so that one case says
+// unknown rather than repeating the bug this fallback exists behind.
+export function phaseOnlyHealth(phase: string | undefined): HealthStatus {
+  switch (phase) {
+    case 'Failed':
+      return 'unhealthy'
+    case 'Pending':
+      return 'degraded'
+    case 'Succeeded':
+      return 'neutral'
+    default:
+      return 'unknown'
+  }
+}
+
 export function TopologyGraph({
   topology,
   viewMode,
@@ -430,7 +447,7 @@ export function TopologyGraph({
         // the kubelet's Waiting->Running oscillation, which the phase alone
         // hides — a crash-looping pod sits at Phase=Running. Deriving it here
         // again would rebuild that logic in a second place and get it wrong.
-        status: pod.status ?? 'unknown',
+        status: pod.status ?? phaseOnlyHealth(pod.phase),
         data: {
           ...podGroupNode.data,
           namespace: pod.namespace,

--- a/packages/k8s-ui/src/components/topology/pod-phase-fallback.test.ts
+++ b/packages/k8s-ui/src/components/topology/pod-phase-fallback.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { phaseOnlyHealth } from './TopologyGraph'
+
+// Only reached when the server sent no per-pod status — an older Radar behind a
+// newer embedding host. The point of the fallback is that it must not repeat the
+// bug it stands in for.
+describe('phaseOnlyHealth', () => {
+  it('does not call a Running pod healthy', () => {
+    // A crash-looping pod sits at Phase=Running with its container restarting,
+    // so Running is the one phase that hides a fault.
+    expect(phaseOnlyHealth('Running')).toBe('unknown')
+  })
+
+  it('reads the phases that are honest on their own', () => {
+    expect(phaseOnlyHealth('Failed')).toBe('unhealthy')
+    expect(phaseOnlyHealth('Pending')).toBe('degraded')
+    expect(phaseOnlyHealth('Succeeded')).toBe('neutral')
+  })
+
+  it('says nothing for a phase it does not recognise', () => {
+    expect(phaseOnlyHealth(undefined)).toBe('unknown')
+    expect(phaseOnlyHealth('SomeFuturePhase')).toBe('unknown')
+  })
+})


### PR DESCRIPTION
Expanding a pod group falls back to the pod phase when the server sends no per-pod status — which happens when an embedding host such as Radar Hub points at an older Radar. #1669 made that fallback report `unknown` for every pod, to avoid the case it was fixing: a crash-looping pod sits at `Phase=Running` with its container restarting, so reading the phase there paints it green.

That was the right call for `Running` and too blunt for everything else. It greyed out a whole expanded group to avoid one bad case, on exactly the deployments most likely to be running an older server.

`Failed`, `Pending` and `Succeeded` describe themselves accurately, so they are read. `Running` alone stays `unknown`, because it is the only phase that hides a fault.

## Testing

`make tsc` clean; 2960 frontend tests pass. Four cases pinned: Running does not read as healthy, the three self-describing phases map correctly, and an unrecognised or absent phase says unknown rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only health display fallback for missing server fields; no auth or data mutation.
> 
> **Overview**
> When expanding a pod group without per-pod **status** from the API (e.g. newer UI against an older Radar), pod nodes no longer default every phase to **unknown**. A new **`phaseOnlyHealth`** helper maps **Failed**, **Pending**, and **Succeeded** to **unhealthy**, **degraded**, and **neutral**; **Running** and unrecognized phases stay **unknown** so crash-looping pods are not shown as healthy.
> 
> Expanded pod nodes use `pod.status ?? phaseOnlyHealth(pod.phase)` instead of `pod.status ?? 'unknown'`. Vitest cases lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9ee8598ab0a4f6a827143386b88aadcbbf7819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->