### PR TITLE
Name the backend an ExternalSecret actually reads from

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1839,6 +1839,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'store', label: 'Store', width: 'w-36' },
+    { key: 'provider', label: 'Provider', width: 'w-40', tooltip: 'Backend the referenced store reads from. A dash means the store could not be read — it may not exist, or may be outside your access.' },
     { key: 'refreshInterval', label: 'Refresh', width: 'w-24', tooltip: 'How often the value is re-pulled from the provider. A zero interval means it is fetched once and not updated afterward.' },
     { key: 'lastSync', label: 'Last Sync', width: 'w-28' },
     { key: 'age', label: 'Age', width: 'w-24' },
@@ -3270,6 +3271,10 @@ interface ResourcesViewData {
   onNavigate?: (path: string, options?: { replace?: boolean }) => void
   certExpiry?: Record<string, { expired?: boolean; daysLeft: number }>
   certExpiryError?: boolean
+  // Provider type per SecretStore, keyed 'ns/name' and 'name' for the
+  // cluster-scoped kind. An ExternalSecret names a store; only the store
+  // knows which backend it reads from.
+  storeProviders?: Record<string, string>
   /** Cluster Audit findings keyed by "namespace/name". Raw compatibility
    *  counts render danger as High and warning as Medium. */
   auditBadges?: Record<string, { danger: number; warning: number; messages?: AuditBadgeMessage[] }>
@@ -3330,6 +3335,10 @@ interface ResourcesViewProps {
   topNodeMetrics?: TopNodeMetrics[]
   certExpiry?: Record<string, { expired?: boolean; daysLeft: number }>
   certExpiryError?: boolean
+  // Provider type per SecretStore, keyed 'ns/name' and 'name' for the
+  // cluster-scoped kind. An ExternalSecret names a store; only the store
+  // knows which backend it reads from.
+  storeProviders?: Record<string, string>
   /** Cluster Audit findings keyed by "namespace/name". Raw compatibility
    *  counts render danger as High and warning as Medium. */
   auditBadges?: Record<string, { danger: number; warning: number; messages?: AuditBadgeMessage[] }>
@@ -3579,6 +3588,7 @@ export function ResourcesView({
   topNodeMetrics,
   certExpiry,
   certExpiryError,
+  storeProviders,
   auditBadges,
   pinned = [],
   togglePin = () => {},
@@ -6621,6 +6631,7 @@ export function ResourcesView({
                     isChecked={checkedResources.has(resourceKey)}
                     showCheckbox={isCheckboxMode}
                     majorityNodeMinorVersion={majorityNodeMinorVersion}
+                    storeProviders={storeProviders}
                     onRowClick={handleRowClick}
                     onRowMouseEnter={handleRowMouseEnter}
                     compareMode={compareMode}
@@ -6776,6 +6787,7 @@ interface ResourceRowCellsProps {
   isChecked?: boolean
   showCheckbox?: boolean
   majorityNodeMinorVersion?: string
+  storeProviders?: Record<string, string>
   // Row callbacks receive the resource so the parent can pass referentially
   // stable handlers — per-row closures would defeat React.memo and re-render
   // every visible row on each SSE-driven refetch.
@@ -6810,7 +6822,7 @@ function rowHighlightClass(
   return 'group-hover/row:bg-theme-surface/50'
 }
 
-const ResourceRowCells = React.memo(function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, hasSpacerColumn, isSelected, isHighlighted, isChecked, showCheckbox, majorityNodeMinorVersion, onRowClick, onRowMouseEnter, compareMode, comparePickIndex = -1, rowHref, onRowCheckToggle }: ResourceRowCellsProps) {
+const ResourceRowCells = React.memo(function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, hasSpacerColumn, isSelected, isHighlighted, isChecked, showCheckbox, majorityNodeMinorVersion, storeProviders, onRowClick, onRowMouseEnter, compareMode, comparePickIndex = -1, rowHref, onRowCheckToggle }: ResourceRowCellsProps) {
   const rowHighlight = rowHighlightClass(compareMode, comparePickIndex, isSelected, isHighlighted, isChecked)
   const pickedSide = comparePickIndex === 0 ? 'a' : comparePickIndex === 1 ? 'b' : null
   const onClick = onRowClick ? () => onRowClick(resource, !!isSelected) : undefined
@@ -6877,6 +6889,7 @@ const ResourceRowCells = React.memo(function ResourceRowCells({ resource, kind, 
             group={group}
             column={col.key}
             majorityNodeMinorVersion={majorityNodeMinorVersion}
+            storeProviders={storeProviders}
             extraColumn={extraColumnsByKey?.get(col.key)}
             nameHref={col.key === 'name' ? rowHref : undefined}
           />
@@ -6920,6 +6933,7 @@ interface CellContentProps {
   column: string
   group?: string
   majorityNodeMinorVersion?: string
+  storeProviders?: Record<string, string>
   /** When provided, the parent has injected an ExtraColumn for this
    *  column key. Render via the extra's render() and short-circuit
    *  the built-in cell logic. */
@@ -6929,7 +6943,7 @@ interface CellContentProps {
   nameHref?: string
 }
 
-function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, extraColumn, nameHref }: CellContentProps) {
+function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, storeProviders, extraColumn, nameHref }: CellContentProps) {
   const { auditBadges } = useContext(ResourcesViewDataContext)
   // Parent-injected extra columns short-circuit the built-in switch.
   // Used by hosts that inject leading columns (e.g. a multi-cluster Cluster column).
@@ -7317,7 +7331,7 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       return <SbomReportCell resource={resource} column={column} />
     // External Secrets Operator
     case 'externalsecrets':
-      return <ExternalSecretCell resource={resource} column={column} />
+      return <ExternalSecretCell resource={resource} column={column} storeProviders={storeProviders} />
     case 'clusterexternalsecrets':
       return <ClusterExternalSecretCell resource={resource} column={column} />
     case 'secretstores':

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1839,7 +1839,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'store', label: 'Store', width: 'w-36' },
-    { key: 'provider', label: 'Provider', width: 'w-40', tooltip: 'Backend the referenced store reads from. A dash means the store could not be read — it may not exist, or may be outside your access; an ellipsis means the stores are still loading.' },
+    { key: 'provider', label: 'Provider', width: 'w-48', tooltip: 'Backend the referenced store reads from. A dash means the store could not be read — it may not exist, or may be outside your access; an ellipsis means the stores are still loading.' },
     { key: 'refreshInterval', label: 'Refresh', width: 'w-24', tooltip: 'How often the value is re-pulled from the provider. A zero interval means it is fetched once and not updated afterward.' },
     { key: 'lastSync', label: 'Last Sync', width: 'w-28' },
     { key: 'age', label: 'Age', width: 'w-24' },

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1839,7 +1839,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'store', label: 'Store', width: 'w-36' },
-    { key: 'provider', label: 'Provider', width: 'w-40', tooltip: 'Backend the referenced store reads from. A dash means the store could not be read — it may not exist, or may be outside your access.' },
+    { key: 'provider', label: 'Provider', width: 'w-40', tooltip: 'Backend the referenced store reads from. A dash means the store could not be read — it may not exist, or may be outside your access; an ellipsis means the stores are still loading.' },
     { key: 'refreshInterval', label: 'Refresh', width: 'w-24', tooltip: 'How often the value is re-pulled from the provider. A zero interval means it is fetched once and not updated afterward.' },
     { key: 'lastSync', label: 'Last Sync', width: 'w-28' },
     { key: 'age', label: 'Age', width: 'w-24' },

--- a/packages/k8s-ui/src/components/resources/renderers/eso-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/eso-cells.tsx
@@ -38,12 +38,15 @@ export function ExternalSecretCell({ resource, column, storeProviders }: {
       )
     }
     case 'provider': {
-      // The provider lives on the referenced store, not on this object. Without
-      // the store resolved, say nothing rather than repeating the store name.
-      const provider = storeProviders?.[getExternalSecretStoreKey(resource)]
+      // The provider lives on the referenced store, not on this object. Three
+      // states, and the middle one matters: no map yet means the stores are
+      // still loading, which is not the same as a store we looked for and could
+      // not read.
+      if (!storeProviders) return <span className="text-sm text-theme-text-tertiary">…</span>
+      const provider = storeProviders[getExternalSecretStoreKey(resource)]
       return provider
         ? <span className="text-sm text-theme-text-secondary truncate block" title={provider}>{provider}</span>
-        : <span className="text-sm text-theme-text-tertiary">-</span>
+        : <span className="text-sm text-theme-text-tertiary" title="The referenced store could not be read">-</span>
     }
     case 'refreshInterval': {
       const interval = getExternalSecretRefreshInterval(resource)

--- a/packages/k8s-ui/src/components/resources/renderers/eso-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/eso-cells.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import {
   getExternalSecretStatus,
   getExternalSecretStore,
+  getExternalSecretStoreKey,
   getExternalSecretRefreshInterval,
   getExternalSecretLastSync,
   getClusterExternalSecretStatus,
@@ -14,7 +15,11 @@ import {
   getClusterSecretStoreStatus,
 } from '../resource-utils-eso'
 
-export function ExternalSecretCell({ resource, column }: { resource: any; column: string }) {
+export function ExternalSecretCell({ resource, column, storeProviders }: {
+  resource: any
+  column: string
+  storeProviders?: Record<string, string>
+}) {
   switch (column) {
     case 'status': {
       const status = getExternalSecretStatus(resource)
@@ -31,6 +36,14 @@ export function ExternalSecretCell({ resource, column }: { resource: any; column
           {store.name}
         </span>
       )
+    }
+    case 'provider': {
+      // The provider lives on the referenced store, not on this object. Without
+      // the store resolved, say nothing rather than repeating the store name.
+      const provider = storeProviders?.[getExternalSecretStoreKey(resource)]
+      return provider
+        ? <span className="text-sm text-theme-text-secondary truncate block" title={provider}>{provider}</span>
+        : <span className="text-sm text-theme-text-tertiary">-</span>
     }
     case 'refreshInterval': {
       const interval = getExternalSecretRefreshInterval(resource)

--- a/packages/k8s-ui/src/components/resources/resource-utils-eso.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-eso.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getSecretStoreProviderType, getSecretStoreProviderKey } from './resource-utils-eso'
+import { getSecretStoreProviderType, getSecretStoreProviderKey, getExternalSecretStoreKey } from './resource-utils-eso'
 
 // The provider label answers "which backend holds these secrets?", so it has to
 // track the upstream `spec.provider` field names rather than plausible ones.
@@ -52,5 +52,30 @@ describe('getSecretStoreProviderKey', () => {
       getSecretStoreProviderKey({ spec: { provider: { aws: { service } } } })
     expect(key('SecretsManager')).toBe('aws')
     expect(key('ParameterStore')).toBe('aws')
+  })
+})
+
+describe('getExternalSecretStoreKey', () => {
+  // A ClusterSecretStore is referenceable from any namespace, so keying it by
+  // namespace would miss every ExternalSecret outside the store's own.
+  it('keys a ClusterSecretStore by name alone', () => {
+    expect(getExternalSecretStoreKey({
+      metadata: { namespace: 'prod' },
+      spec: { secretStoreRef: { name: 'vault-global', kind: 'ClusterSecretStore' } },
+    })).toBe('vault-global')
+  })
+
+  it('scopes a SecretStore to the ExternalSecret namespace', () => {
+    expect(getExternalSecretStoreKey({
+      metadata: { namespace: 'prod' },
+      spec: { secretStoreRef: { name: 'aws', kind: 'SecretStore' } },
+    })).toBe('prod/aws')
+  })
+
+  it('treats an omitted kind as a SecretStore, as the CRD defaults it', () => {
+    expect(getExternalSecretStoreKey({
+      metadata: { namespace: 'prod' },
+      spec: { secretStoreRef: { name: 'aws' } },
+    })).toBe('prod/aws')
   })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils-eso.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-eso.ts
@@ -235,6 +235,19 @@ export function getExternalSecretStore(resource: any): { name: string; kind: str
   }
 }
 
+/**
+ * Key for looking this ExternalSecret's store up in a provider map.
+ *
+ * A ClusterSecretStore is cluster-scoped and referenceable from any namespace,
+ * so it keys by name alone; a SecretStore only resolves within the
+ * ExternalSecret's own namespace.
+ */
+export function getExternalSecretStoreKey(resource: any): string {
+  const store = getExternalSecretStore(resource)
+  if (store.kind === 'ClusterSecretStore') return store.name
+  return `${resource?.metadata?.namespace ?? ''}/${store.name}`
+}
+
 export function getExternalSecretRefreshInterval(resource: any): string {
   return resource.spec?.refreshInterval || '-'
 }

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -315,10 +315,13 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // from. Two list calls per page beat one lookup per row, and the column shows
   // nothing rather than guessing when a store is unreadable or absent.
   const viewingExternalSecrets = selectedKind?.name === 'externalsecrets'
-  const { data: secretStores } = useResources<any>('secretstores', undefined, undefined, { enabled: viewingExternalSecrets })
-  const { data: clusterSecretStores } = useResources<any>('clustersecretstores', undefined, undefined, { enabled: viewingExternalSecrets })
+  const { data: secretStores, isPending: secretStoresPending } = useResources<any>('secretstores', undefined, undefined, { enabled: viewingExternalSecrets })
+  const { data: clusterSecretStores, isPending: clusterSecretStoresPending } = useResources<any>('clustersecretstores', undefined, undefined, { enabled: viewingExternalSecrets })
   const storeProviders = useMemo(() => {
-    if (!viewingExternalSecrets) return undefined
+    // Undefined until both lists have settled. An empty map would be
+    // indistinguishable from "every store is unreadable", and the column says
+    // that out loud.
+    if (!viewingExternalSecrets || secretStoresPending || clusterSecretStoresPending) return undefined
     const map: Record<string, string> = {}
     for (const store of secretStores ?? []) {
       const ns = store?.metadata?.namespace
@@ -330,7 +333,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       if (name) map[name] = getSecretStoreProviderType(store)
     }
     return map
-  }, [viewingExternalSecrets, secretStores, clusterSecretStores])
+  }, [viewingExternalSecrets, secretStoresPending, clusterSecretStoresPending, secretStores, clusterSecretStores])
 
   // Pinned kinds
   const { pinned, togglePin, isPinned } = usePinnedKinds()

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
+import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useResources, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
 import { isBadgeWorthy } from '../../utils/auditBadges'
 import type { AuditBadgeMessage } from '@skyhook-io/k8s-ui'
 import { apiUrl, getAuthHeaders, getCredentialsMode, stripBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { useConnection } from '../../context/ConnectionContext'
-import { initNavigationMap } from '@skyhook-io/k8s-ui'
+import { initNavigationMap, getSecretStoreProviderType } from '@skyhook-io/k8s-ui'
 import { usePinnedKinds } from '../../hooks/useFavorites'
 import { useOpenLogs, useOpenWorkloadLogs } from '../dock'
 import {
@@ -311,6 +311,27 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // Certificate expiry
   const { data: certExpiry, isError: certExpiryError } = useSecretCertExpiry()
 
+  // An ExternalSecret names a store; only the store says which backend it reads
+  // from. Two list calls per page beat one lookup per row, and the column shows
+  // nothing rather than guessing when a store is unreadable or absent.
+  const viewingExternalSecrets = selectedKind?.name === 'externalsecrets'
+  const { data: secretStores } = useResources<any>('secretstores', undefined, undefined, { enabled: viewingExternalSecrets })
+  const { data: clusterSecretStores } = useResources<any>('clustersecretstores', undefined, undefined, { enabled: viewingExternalSecrets })
+  const storeProviders = useMemo(() => {
+    if (!viewingExternalSecrets) return undefined
+    const map: Record<string, string> = {}
+    for (const store of secretStores ?? []) {
+      const ns = store?.metadata?.namespace
+      const name = store?.metadata?.name
+      if (ns && name) map[`${ns}/${name}`] = getSecretStoreProviderType(store)
+    }
+    for (const store of clusterSecretStores ?? []) {
+      const name = store?.metadata?.name
+      if (name) map[name] = getSecretStoreProviderType(store)
+    }
+    return map
+  }, [viewingExternalSecrets, secretStores, clusterSecretStores])
+
   // Pinned kinds
   const { pinned, togglePin, isPinned } = usePinnedKinds()
 
@@ -380,6 +401,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       topPodMetrics={topPodMetrics}
       topNodeMetrics={topNodeMetrics}
       certExpiry={certExpiry}
+      storeProviders={storeProviders}
       certExpiryError={certExpiryError}
       auditBadges={auditBadges}
       // Pinned kinds


### PR DESCRIPTION
The ExternalSecret **Provider** column was removed in #1658 because it rendered the store's *name*, which the Store column beside it already showed. The name was never the question. An operator scanning a list of ExternalSecrets wants to know whether these values come from AWS Secrets Manager, Vault, or GCP Secret Manager — and a store called `platform-store` does not say.

The provider lives on the referenced SecretStore, not on the ExternalSecret, which is why the original column could not answer it. This resolves the reference.

## How

The host lists SecretStores and ClusterSecretStores once per page — two calls, not one per row — and passes a provider map down through the same channel `certExpiry` and `majorityNodeMinorVersion` already use. `getSecretStoreProviderType` turns each store into its backend name.

Keying is the part worth reading twice: a ClusterSecretStore is cluster-scoped and referenceable from any namespace, so it keys by name alone, while a SecretStore only resolves inside the ExternalSecret's own namespace. `getExternalSecretStoreKey` owns that, including the CRD's default of `SecretStore` when `secretStoreRef.kind` is omitted.

A store that cannot be read — absent, or outside the user's RBAC — renders a dash. Falling back to the store name there is precisely what made the old column worth deleting.

## Depends on #1658

Before that PR, `PROVIDER_MAP` labelled every AWS store "AWS Secrets Manager" with no Parameter Store or Certificate Manager branch, and keyed Bitwarden on a field name that exists in neither API version. Resolving the provider on top of that would have confidently named the wrong product — worse than the duplicate this replaces.

## Testing

`make tsc` clean; 2960 frontend tests pass. Three cases pin the keying: a ClusterSecretStore reference keys by name, a SecretStore reference by `namespace/name`, and an omitted `kind` follows the CRD default rather than being treated as cluster-scoped.

Verified against a live cluster with the External Secrets CRDs installed and stores covering every case: two AWS stores differing only by `service`, a Vault store, a ClusterSecretStore, an ExternalSecret in a *different* namespace referencing that cluster-scoped store, and one naming a store that does not exist.

All six resolved as intended. The two AWS stores render **AWS Secrets Manager** and **AWS Parameter Store** — the distinction #1658 made possible, and the one this column exists to show. The cross-namespace ClusterSecretStore reference resolves, which is what the keying is for. The missing store renders a dash rather than its own name.

The render also showed all three cloud provider names truncating at `w-40`: the longest needs 142px of text and the cell's padding pushed it past the 160px column, on a table with 460px of unused width. The column is `w-48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only enrichment in the resources table; store lists are gated to the ExternalSecrets view and degrade gracefully when stores are inaccessible.
> 
> **Overview**
> Restores a **Provider** column on ExternalSecret lists, but it now shows the **backend** (e.g. AWS Secrets Manager, Vault) resolved from the referenced SecretStore or ClusterSecretStore—not the store name already shown in **Store**.
> 
> The web app loads SecretStore and ClusterSecretStore lists once while viewing ExternalSecrets, builds a `storeProviders` lookup via `getSecretStoreProviderType`, and passes it through `ResourcesView` into `ExternalSecretCell`. Lookup keys use new **`getExternalSecretStoreKey`**: cluster stores by name only, namespace stores by `namespace/name`, with omitted `secretStoreRef.kind` treated as SecretStore.
> 
> The cell distinguishes **loading** (…), **resolved provider**, and **unreadable/missing store** (-) instead of guessing or duplicating the store column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e29a406de53a810c373c1957ff3a6a5251f644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
