### PR TITLE
Chart the vitals diagnose captured as Findings evidence

### DIFF
--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -25,6 +25,7 @@ import type { DiagnosisResourceRef } from "./diagnoseEvidenceTypes";
 import type { Diagnosis } from "../../api/diagnose";
 import { AssessmentSources, ResultCard } from "./parts";
 import { investigationEvidenceCoverageLimited } from "./investigationState";
+import { metricsChangeMarkers } from "./investigationMetrics";
 
 const onViewSource = vi.fn();
 const target = {
@@ -2400,6 +2401,188 @@ describe("InvestigationEvidencePane metrics cards", () => {
       "1 change recorded in this window is marked on the chart.",
     );
     expect(html).toContain("Open current Deployment shop/api in Radar");
+  });
+});
+
+describe("InvestigationEvidencePane diagnose vitals", () => {
+  const window = {
+    start: "2026-09-06T07:00:00Z",
+    end: "2026-09-06T08:00:00Z",
+    step: "1m2s",
+  };
+  const vitals = {
+    window,
+    pods: 1,
+    series: [
+      {
+        category: "cpu",
+        unit: "cores",
+        query:
+          "sum(rate(container_cpu_usage_seconds_total{container!='',namespace='shop',pod=~'^(api-abc)$'}[5m]))",
+        series: [
+          {
+            labels: {},
+            dataPoints: [
+              { timestamp: Date.parse(window.start) / 1000, value: 0.12 },
+              { timestamp: Date.parse(window.end) / 1000, value: 0.25 },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("keeps an uncited diagnose chart in the workload collection and marks the same-turn change on it", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        recentChanges: [
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "api",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "worker",
+            changeType: "update",
+            timestamp: "2026-09-06T07:40:00Z",
+          },
+        ],
+        metrics: vitals,
+      }),
+    );
+    const partition = partitionInvestigationEvidence(projection.groups);
+    expect(partition.main.map((group) => group.kind)).not.toContain("metrics");
+    expect(partition.workload.map((group) => group.kind)).toContain("metrics");
+    expect(partition.hiddenMetrics).toBe(0);
+    const onOpenResource = vi.fn();
+    const html = render(projection, false, undefined, undefined, onOpenResource);
+    expect(html).toContain("CPU usage · shop/api");
+    expect(html).toContain("1 pod · 60m window · 1m2s step");
+    expect(html).toContain("(cores)");
+    expect(html.match(/data-chart-annotation="change"/g)).toHaveLength(1);
+    expect(html).toContain("Deployment api");
+    expect(html).not.toContain("Deployment worker");
+    expect(html).toContain(
+      "1 change recorded in this window is marked on the chart.",
+    );
+    expect(html).toContain("Open current Deployment shop/api in Radar");
+  });
+
+  it("never marks the target's changes on a neighbour's chart", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        logsCurrent: [
+          {
+            pod: "api-abc",
+            container: "api",
+            logs: {
+              lines: ["ERROR boom"],
+              totalLines: 1,
+              matchedLines: 1,
+              fallback: false,
+            },
+          },
+        ],
+        recentChanges: [
+          {
+            kind: "Pod",
+            apiVersion: "v1",
+            namespace: "shop",
+            name: "api-abc",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+        ],
+      }),
+      tool(
+        "diag-worker",
+        "diagnose",
+        {
+          resource: {
+            apiVersion: "apps/v1",
+            kind: "Deployment",
+            metadata: { namespace: "shop", name: "worker" },
+          },
+          pods: 1,
+          metrics: vitals,
+        },
+        { summary: JSON.stringify({ namespace: "shop", name: "worker" }) },
+      ),
+    );
+    const chart = projection.groups.find(
+      (group) =>
+        group.kind === "metrics" && group.latest.relevance === "broader",
+    );
+    expect(chart).toBeDefined();
+    expect(metricsChangeMarkers(projection.groups, chart!.latest)).toEqual([]);
+    const targetChart = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        recentChanges: [
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "api",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+        ],
+        metrics: vitals,
+      }),
+    );
+    const target = targetChart.groups.find((group) => group.kind === "metrics");
+    expect(
+      metricsChangeMarkers(targetChart.groups, target!.latest),
+    ).toHaveLength(1);
+  });
+
+  it("shows a workload metrics limitation for a reported producer error", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        metrics: {
+          window,
+          pods: 1,
+          series: [],
+          error: "metrics omitted: 3s budget exceeded before all queries answered",
+        },
+      }),
+    );
+    const html = render(projection);
+    expect(html).toContain("Workload metrics");
+    expect(html).toContain(
+      "metrics omitted: 3s budget exceeded before all queries answered",
+    );
+    expect(html).not.toContain("CPU usage");
   });
 });
 

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5411,3 +5411,315 @@ describe("resource cards scaled by an HPA", () => {
     expect(card.summary).toBe("5/5 replicas ready");
   });
 });
+
+describe("diagnose metrics evidence", () => {
+  const window = {
+    start: "2026-09-06T07:00:00Z",
+    end: "2026-09-06T08:00:00Z",
+    step: "1m2s",
+  };
+  const samples = [
+    { timestamp: Date.parse(window.start) / 1000, value: 0.003457 },
+    { timestamp: Date.parse(window.end) / 1000, value: 0.004 },
+  ];
+  function vitals(patch: Record<string, unknown> = {}) {
+    return {
+      window,
+      pods: 2,
+      series: [
+        {
+          category: "cpu",
+          unit: "cores",
+          query:
+            "sum(rate(container_cpu_usage_seconds_total{container!='',namespace='shop',pod=~'^(api-a|api-b)$'}[5m]))",
+          series: [{ labels: {}, dataPoints: samples }],
+        },
+        {
+          category: "memory",
+          unit: "bytes",
+          query:
+            "sum(max by (pod,namespace,container) (container_memory_working_set_bytes{container!='',namespace='shop',pod=~'^(api-a|api-b)$'}))",
+          series: [{ labels: {}, dataPoints: samples }],
+        },
+        {
+          category: "restarts",
+          unit: "count",
+          query:
+            "sum(round(increase(kube_pod_container_status_restarts_total{namespace='shop',pod=~'^(api-a|api-b)$'}[1h])))",
+          series: [],
+        },
+      ],
+      ...patch,
+    };
+  }
+  const args = { kind: "Deployment", namespace: "shop", name: "api" };
+
+  it("charts each captured category as target evidence with the diagnosed resource as subject", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        { resource: deployment, pods: 2, metrics: vitals() },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups.map((group) => group.latest.title)).toEqual([
+      "CPU usage · Deployment shop/api",
+      "Memory working set · Deployment shop/api",
+      "Restarts · Deployment shop/api",
+    ]);
+    for (const group of groups) {
+      expect(group.latest.relevance).toBe("target");
+      expect(group.latest.tier).toBe("supporting");
+      expect(group.latest.tone).toBe("neutral");
+      const data = group.latest.data;
+      if (data.type !== "metrics") throw new Error("expected metrics");
+      expect(data.origin).toBe("diagnose");
+      expect(data.mode).toBe("range");
+      expect(data.start).toBe(window.start);
+      expect(data.end).toBe(window.end);
+      expect(data.step).toBe(window.step);
+      expect(data.pods).toBe(2);
+      expect(data.partial).toBe(false);
+      expect(data.truncated).toBe(false);
+      expect(data.subject).toEqual({
+        kind: "Deployment",
+        group: "apps",
+        namespace: "shop",
+        name: "api",
+      });
+      expect(investigationEvidenceSubjectRef(data)).toEqual(data.subject);
+    }
+    const [cpu, , restarts] = groups;
+    expect(cpu.latest.summary).toBe("2 pods · 60m window · 1m2s step");
+    const cpuData = cpu.latest.data;
+    if (cpuData.type !== "metrics") throw new Error("expected metrics");
+    expect(cpuData.unit).toBe("cores");
+    expect(cpuData.label).toBe("CPU usage");
+    expect(cpuData.query).toContain("pod=~'^(api-a|api-b)$'");
+    expect(cpuData.series).toEqual([{ labels: {}, dataPoints: samples }]);
+    expect(restarts.latest.summary).toBe(
+      "No samples in the window · 60m window · 1m2s step",
+    );
+    expect(
+      projection.limitations.filter(
+        (item) => item.source === "Workload metrics",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("merges a re-diagnose of the same workload into the same chart per category", () => {
+    const later = vitals({
+      window: { ...window, end: "2026-09-06T08:30:00Z" },
+    });
+    const projection = project(
+      [
+        tool(
+          "diag-1",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics: vitals() },
+          { summary: JSON.stringify(args) },
+        ),
+      ],
+      [
+        tool(
+          "diag-2",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics: later },
+          { summary: JSON.stringify(args) },
+        ),
+      ],
+    );
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(3);
+    expect(groups.every((group) => group.observations.length === 2)).toBe(
+      true,
+    );
+    const data = groups[0].latest.data;
+    if (data.type !== "metrics") throw new Error("expected metrics");
+    expect(data.end).toBe("2026-09-06T08:30:00Z");
+  });
+
+  it("reports a producer error as a limitation and still charts what answered", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [vitals().series[1]],
+            error: "cpu: prom: query error from prometheus: cpu exploded (execution)",
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(1);
+    const limitation = projection.limitations.find(
+      (item) => item.source === "Workload metrics",
+    );
+    expect(limitation?.kind).toBe("error");
+    expect(limitation?.message).toContain("cpu exploded");
+  });
+
+  it("reports an unreachable Prometheus without inventing a chart", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [],
+            error: "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    const limitation = projection.limitations.find(
+      (item) => item.source === "Workload metrics",
+    );
+    expect(limitation?.kind).toBe("error");
+    expect(limitation?.message).toBe(
+      "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
+    );
+  });
+
+  it("says nothing when diagnose carried no metrics field", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        { resource: deployment, pods: 2 },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    expect(
+      projection.limitations.some((item) => item.source === "Workload metrics"),
+    ).toBe(false);
+  });
+
+  it("notes a partial pod set in the summary and keeps the cap on the card", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 55,
+          metrics: vitals({ pods: 50, partial: true, omittedPods: 5 }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const [cpu] = groupsOf(projection.groups, "metrics");
+    expect(cpu.latest.summary).toBe(
+      "first 50 of 55 pods · 60m window · 1m2s step · partial pod set",
+    );
+    const data = cpu.latest.data;
+    if (data.type !== "metrics") throw new Error("expected metrics");
+    expect(data.pods).toBe(50);
+    expect(data.partial).toBe(true);
+  });
+
+  it("keeps a neighbour's vitals broader with the neighbour as subject", () => {
+    const worker = {
+      ...deployment,
+      metadata: { namespace: "shop", name: "worker" },
+    };
+    const projection = project([
+      tool(
+        "diag-worker",
+        "diagnose",
+        { resource: worker, pods: 2, metrics: vitals() },
+        {
+          summary: JSON.stringify({
+            kind: "Deployment",
+            namespace: "shop",
+            name: "worker",
+          }),
+        },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(3);
+    for (const group of groups) {
+      expect(group.latest.relevance).toBe("broader");
+      expect(group.latest.tier).toBe("context");
+      const data = group.latest.data;
+      if (data.type !== "metrics") throw new Error("expected metrics");
+      expect(data.subject).toEqual({
+        kind: "Deployment",
+        group: "apps",
+        namespace: "shop",
+        name: "worker",
+      });
+    }
+  });
+
+  it("rejects a malformed metrics field instead of charting it", () => {
+    const malformed: Record<string, unknown>[] = [
+      { window: { start: window.start }, pods: "two", series: [] },
+      { window: { ...window, end: "not a date" }, pods: 2, series: [] },
+      { window: { ...window, end: window.start }, pods: 2, series: [] },
+      { window, pods: -1, series: [] },
+      { window, pods: 1.5, series: [] },
+      { window, pods: 2, omittedPods: -3, series: [] },
+    ];
+    for (const metrics of malformed) {
+      const projection = project([
+        tool(
+          "diag",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics },
+          { summary: JSON.stringify(args) },
+        ),
+      ]);
+      expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+      expect(
+        projection.limitations.some(
+          (item) =>
+            item.source === "Workload metrics" && item.kind === "unknown",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects a category outside the contract or a series without a unit", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [
+              { ...vitals().series[0], category: "latency" },
+              { ...vitals().series[1], unit: undefined },
+              vitals().series[2],
+            ],
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups.map((group) => group.latest.title)).toEqual([
+      "Restarts · Deployment shop/api",
+    ]);
+    expect(
+      projection.limitations.some(
+        (item) =>
+          item.source === "Workload metrics" && item.kind === "unknown",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -2787,6 +2787,21 @@ function adaptDiagnose(
   if (nonEmptyString(value.recentChangesError)) {
     builder.limit(source, "Recent changes", value.recentChangesError, "error");
   }
+
+  addDiagnoseMetrics(
+    builder,
+    source,
+    value.metrics,
+    {
+      kind: resource.kind,
+      ...(apiVersionToGroup(resource.apiVersion)
+        ? { group: apiVersionToGroup(resource.apiVersion) }
+        : {}),
+      namespace: resource.metadata.namespace,
+      name: resource.metadata.name,
+    },
+    bundleRelevance,
+  );
   if (value.recentChangesSaturated === true) {
     builder.limit(
       source,
@@ -4582,6 +4597,121 @@ function metricsWindowLabel(data: {
         ? `${Math.round(minutes / 60)}h`
         : `${minutes}m`;
   return data.step ? `${window} window · ${data.step} step` : `${window} window`;
+}
+
+const DIAGNOSE_METRICS_LABELS: Record<string, string> = {
+  cpu: "CPU usage",
+  memory: "Memory working set",
+  restarts: "Restarts",
+};
+
+/**
+ * The vitals `diagnose` captured inside the same call: one chart per category
+ * over the exact pods the bundle covers. They take the bundle's relevance, so a
+ * neighbour's diagnose never charts as evidence for the target, and they carry
+ * the diagnosed resource as their subject so recorded changes can be marked
+ * on them. An absent field means Prometheus was not available or the read was
+ * not permitted, which is not a collection failure the producer reported.
+ */
+function addDiagnoseMetrics(
+  builder: ProjectionBuilder,
+  source: InvestigationEvidenceSource,
+  raw: unknown,
+  subject: DiagnosisResourceRef,
+  relevance: InvestigationEvidenceRelevance,
+): void {
+  if (raw === undefined) return;
+  const value = record(raw);
+  const window = record(value?.window);
+  if (
+    !value ||
+    !window ||
+    !nonEmptyString(window.start) ||
+    !nonEmptyString(window.end) ||
+    !nonEmptyString(window.step) ||
+    !(Date.parse(window.end) > Date.parse(window.start)) ||
+    !nonNegativeInteger(value.pods) ||
+    (value.partial !== undefined && typeof value.partial !== "boolean") ||
+    (value.omittedPods !== undefined &&
+      !nonNegativeInteger(value.omittedPods)) ||
+    (value.error !== undefined && typeof value.error !== "string") ||
+    !Array.isArray(value.series)
+  ) {
+    invalidPayload(builder, source, "Workload metrics");
+    return;
+  }
+  const scope = scopeFromArgs(source);
+  const partial = value.partial === true;
+  const podsLabel = partial
+    ? `first ${value.pods} of ${typeof value.omittedPods === "number" ? value.pods + value.omittedPods : "the"} pods`
+    : `${value.pods} pod${value.pods === 1 ? "" : "s"}`;
+  const windowLabel = metricsWindowLabel({
+    mode: "range",
+    start: window.start,
+    end: window.end,
+    step: window.step,
+  });
+  for (const rawEntry of value.series) {
+    const entry = record(rawEntry);
+    const rawSeries = entry?.series;
+    const series = Array.isArray(rawSeries)
+      ? rawSeries
+          .map(timeSeries)
+          .filter((item): item is TimeSeries => Boolean(item))
+      : undefined;
+    if (
+      !entry ||
+      !nonEmptyString(entry.category) ||
+      !(entry.category in DIAGNOSE_METRICS_LABELS) ||
+      !nonEmptyString(entry.query) ||
+      !nonEmptyString(entry.unit) ||
+      !Array.isArray(rawSeries) ||
+      !series ||
+      series.length !== rawSeries.length
+    ) {
+      invalidPayload(builder, source, "Workload metrics");
+      continue;
+    }
+    const label = DIAGNOSE_METRICS_LABELS[entry.category];
+    const data: InvestigationMetricsEvidence = {
+      type: "metrics",
+      origin: "diagnose",
+      query: entry.query,
+      mode: "range",
+      start: window.start,
+      end: window.end,
+      step: window.step,
+      unit: entry.unit,
+      label,
+      series,
+      truncated: false,
+      subject,
+      pods: value.pods,
+      partial,
+    };
+    builder.observe(
+      `metrics:diagnose:${scope}:${entry.category}`,
+      "metrics",
+      source,
+      {
+        tier: evidenceTierForRelevance("supporting", relevance),
+        relevance,
+        tone: "neutral",
+        title: `${label} · ${scope}`,
+        summary: [
+          series.length === 0 ? "No samples in the window" : podsLabel,
+          windowLabel,
+          partial ? "partial pod set" : undefined,
+        ]
+          .filter((part): part is string => Boolean(part))
+          .join(" · "),
+        data,
+      },
+    );
+  }
+  if (nonEmptyString(value.error)) {
+    builder.limit(source, "Workload metrics", value.error, "error");
+  }
 }
 
 function adaptQueryPrometheus(

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -145,7 +145,16 @@ export function metricsChangeMarkers(
   observation: InvestigationEvidenceObservation,
 ): ChartAnnotation[] {
   const { data } = observation;
-  if (data.type !== "metrics" || !data.subject) return [];
+  // A broader chart's subject is a neighbour; the turn's non-broader relatives
+  // and changes all belong to the target, so marking them there would
+  // attribute the target's changes to the neighbour.
+  if (
+    data.type !== "metrics" ||
+    !data.subject ||
+    observation.relevance === "broader"
+  ) {
+    return [];
+  }
   const domain = metricsDomain(data);
   if (!domain) return [];
   const turnIndex = observation.source.turnIndex;


### PR DESCRIPTION
## Summary

Track D1, second part: Findings now charts the vitals `diagnose` captures. The Go side (#1679, merged into the integration branch) returns a `metrics` field for workload targets with cpu, memory and restarts over the exact pods the bundle resolved. This PR projects each category as a chart card in the shape Track B (#1684) defined, so the chart, the agent and the ledger hold the same numbers, and the same-turn changes Radar recorded for the workload are marked on it.

## What changed

- `adaptDiagnose` → `addDiagnoseMetrics` (`web/src/components/diagnose/investigationEvidence.ts`): one `metrics` observation per category with `origin: "diagnose"`, `mode: "range"`, the producer's `query` and `unit`, a category label (`CPU usage`, `Memory working set`, `Restarts`), the diagnosed resource as `subject`, and `pods` / `partial` from the field. Relevance is the bundle's relevance from `relevanceForResource`, never an unconditional target, so a neighbour's vitals stay `broader` with the neighbour as subject. Identity is `metrics:diagnose:<args scope>:<category>`, so a re-diagnose revises the same three cards. Summary reads `N pods · 60m window · 1m2s step`, `first 50 of 55 pods … · partial pod set` when capped, and `No samples in the window` for an empty series. `metrics.error` becomes a "Workload metrics" limitation while the categories that answered still chart; an absent field emits nothing (Prometheus absent or read not permitted is not a collection failure). Validation enforces the documented contract: known category, non-empty unit, non-negative integer counts, a window whose end is after its start; anything else is an invalid-payload limitation, never a card.
- `metricsChangeMarkers` (`investigationMetrics.ts`): no markers on a `broader` chart. The turn's non-broader relatives and change observations all belong to the target, so marking them on a neighbour's chart would attribute the target's changes to it. Reachable only now that diagnose charts carry a neighbour subject.
- Placement per D-5: these observations sit in "More evidence about this workload" until Track C's subject-bearing placement promotes them.
- `partitionInvestigationEvidence`: inside "More evidence about this workload", cards that carry facts come before receipt-kind cards (the "No classified workload issues" / "No matching warning events" tiles), which keep their order among themselves. A healthy workload no longer opens on four empty tiles before its vitals.

## Testing

- `make tsc` — pass
- `cd web && npm test` — 85 of 86 files pass; the 5 failures are in `src/api/client.authRedirect.test.ts` (5 s timeouts) and reproduce on the untouched `main` checkout, unrelated to this change
- `cd packages/k8s-ui && npm test` — pass (174 files, 3560 tests)
- `make build` — pass
- `git diff --check` — clean

New tests: adapter — three series → three cards with subject, unit, label, window, pods; re-diagnose merges into the same cards; producer error → limitation with surviving series; unreachable Prometheus → limitation, no card; absent field → nothing; partial pod set noted in the summary; neighbour diagnose → broader with the neighbour as subject; six malformed envelopes and an out-of-contract category / missing unit rejected. Pane — a diagnose-origin chart in the workload collection with the same-turn Deployment change marked and the resource link; the neighbour guard on the marker function; the limitation row for a producer error.

Visual test (light, dark, narrow): `/Users/nadaverell/workspace/sky/ws2/worktrees/trackD1b/.playwright-mcp/visual-test/20260908-104530/`. A copy of the local investigation store under a scratch `HOME` had the `metrics` field injected into both diagnose results of saved run `run-1f386db525` (synthetic series, 59 points each; the run's own recorded Deployment changes given the `apiVersion` today's producer emits, which this older run predates); Radar restarted on it after the edit. Verified: three cards titled per category with `1 pod · 60m window · 1m2s step`, axis label and unit, the three recorded changes marked with "3 changes recorded in this window are marked on the chart", the earlier diagnose under "Previous observations · 1", and the "Open current Deployment" link.

Cross-model review: one Codex pass, 2 findings, both fixed (neighbour marker attribution; validation gaps). Bot round 1 (Qodo, head c01fb4ee): 2 bugs, both fixed in a13c1d47: card identity now derives from the subject (group, kind, namespace, name) plus category instead of the display scope, and the category check is an own-property test so inherited keys like `__proto__` cannot pass.

## Scope and tradeoffs

- Restarts render with unit `count`, which the shared formatter treats as unitless (values like `1.00`); a `count` case in `formatMetricValue` is a k8s-ui follow-up.
- Marker labels for several changes on the same resource within minutes overlap in the chart (Track B's marker rendering).
- Recorded changes without `apiVersion` (synthesized Helm rows, older stores) never match a chart subject and are not marked; that is Track B's key rule, noted here because the fixture hit it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI evidence projection and chart annotation logic with strict validation; no auth or data-persistence changes.
> 
> **Overview**
> Findings now turns the **`metrics`** payload from **`diagnose`** into workload chart cards (CPU, memory, restarts) with **`origin: "diagnose"`**, the producer query/unit/window, and the diagnosed resource as **`subject`**. Relevance follows the diagnose bundle (target vs neighbour **`broader`**), and re-diagnoses merge on **`metrics:diagnose:<scope>:<category>`**.
> 
> Producer **`metrics.error`** surfaces as a **Workload metrics** limitation while valid series still chart; missing **`metrics`** stays silent. Invalid envelopes are rejected with limitations instead of cards.
> 
> **`metricsChangeMarkers`** no longer annotates **`broader`** charts so the target’s same-turn changes are not drawn on a neighbour’s vitals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01fb4ee22635b89ddf36731662b8377afa107a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

