### PR TITLE
Show startup progress before the agent's first message

### DIFF
--- a/internal/ai/agent_cursor.go
+++ b/internal/ai/agent_cursor.go
@@ -197,6 +197,7 @@ type cursorEvent struct {
 	Type      string          `json:"type"`    // system|user|assistant|thinking|tool_call|result
 	Subtype   string          `json:"subtype"` // init | delta | started | completed | success | ...
 	SessionID string          `json:"session_id"`
+	Model     string          `json:"model"`   // on system/init
 	Text      string          `json:"text"`    // on thinking/delta
 	Message   *cursorMessage  `json:"message"` // on assistant/user
 	ToolCall  *cursorToolCall `json:"tool_call"`
@@ -292,6 +293,11 @@ func (a *cursorAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagno
 			sessionID = e.SessionID
 		}
 		switch e.Type {
+		case "system":
+			// Cursor's init names the model but not its MCP servers or tools.
+			if e.Subtype == "init" {
+				onEvent(StreamEvent{Type: "phase", Phase: "ready", Model: e.Model})
+			}
 		case "thinking":
 			if e.Subtype == "delta" && e.Text != "" {
 				onEvent(StreamEvent{Type: "thinking", Token: e.Text})

--- a/internal/ai/agent_cursor_test.go
+++ b/internal/ai/agent_cursor_test.go
@@ -96,10 +96,14 @@ func TestCursorParseStream_FormatPin(t *testing.T) {
 
 	var running, done bool
 	var doneIsError *bool
-	var thinking, doneResult, doneEvidenceRef, runningSummary string
+	var thinking, doneResult, doneEvidenceRef, runningSummary, readyModel string
 	agent := &cursorAgent{bin: "cursor-agent"}
 	diag := agent.parseStream(strings.NewReader(stream), func(ev StreamEvent) {
 		switch ev.Type {
+		case "phase":
+			if ev.Phase == "ready" {
+				readyModel = ev.Model
+			}
 		case "thinking":
 			thinking += ev.Token
 		case "step":
@@ -145,6 +149,9 @@ func TestCursorParseStream_FormatPin(t *testing.T) {
 	}
 	if diag.SessionID != "sess-abc" {
 		t.Errorf("session id (system/init) not captured: %q", diag.SessionID)
+	}
+	if readyModel != "GPT-5.5" {
+		t.Errorf("ready phase model (system/init) = %q, want GPT-5.5", readyModel)
 	}
 }
 

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -249,8 +249,13 @@ type Diagnosis struct {
 // "turn" marks the start of a new turn (carries Question/Apply) so a connecting
 // or reconnecting client can reconstruct turn boundaries from the event log.
 type StreamEvent struct {
-	Type              string               `json:"type"` // "turn"|"phase"|"step"|"thinking"|"done"|"error"|"closed"
-	Phase             string               `json:"phase,omitempty"`
+	Type  string `json:"type"`            // "turn"|"phase"|"step"|"thinking"|"done"|"error"|"closed"
+	Phase string `json:"phase,omitempty"` // "investigating"|"connected"|"ready"
+	// Startup facts reported by the agent CLI on the "ready" phase: the model it
+	// resolved, how many Radar tools it registered, and each MCP server's status.
+	Model             string               `json:"model,omitempty"`
+	ToolCount         *int                 `json:"toolCount,omitempty"`
+	MCPServers        []MCPServerStatus    `json:"mcpServers,omitempty"`
 	Step              *StepInfo            `json:"step,omitempty"`
 	Token             string               `json:"token,omitempty"`
 	Diag              *Diagnosis           `json:"diagnosis,omitempty"`
@@ -276,6 +281,13 @@ const (
 	ApplyMutationFailed    ApplyMutationOutcome = "failed"
 	ApplyMutationUnknown   ApplyMutationOutcome = "unknown"
 )
+
+// MCPServerStatus is one MCP server's connection state as the agent CLI
+// reported it at startup. Only "connected" means the server's tools are usable.
+type MCPServerStatus struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
 
 // StepInfo describes one tool invocation (running → done).
 type StepInfo struct {
@@ -609,16 +621,49 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 		return Diagnosis{}, fmt.Errorf("ai: start %s: %w", agent.Name(), err)
 	}
 
-	onEvent(StreamEvent{Type: "phase", Phase: "investigating"})
+	// The handshake watcher and the stream parser both report to the caller;
+	// serialize them so callback consumers never see interleaved events.
+	var emitMu sync.Mutex
+	emit := func(event StreamEvent) {
+		emitMu.Lock()
+		defer emitMu.Unlock()
+		onEvent(event)
+	}
+	emit(StreamEvent{Type: "phase", Phase: "investigating"})
 	validator := investigationEvidenceValidator{
 		registry: d.evidenceRefs,
 		scope:    evidenceScope,
 		claimed:  make(map[string]struct{}),
 	}
 	streamEvent := func(event StreamEvent) {
-		onEvent(validator.validate(event))
+		emit(validator.validate(event))
+	}
+	streamDone := make(chan struct{})
+	var handshake sync.WaitGroup
+	if evidenceLease != nil {
+		// The private mount marks the scope connected on the agent's MCP
+		// handshake, which happens before its first message. Report it once.
+		handshake.Add(1)
+		go func() {
+			defer handshake.Done()
+			connected := evidenceLease.Connected()
+			select {
+			case <-connected:
+			case <-streamDone:
+				// Both may be ready when a short turn ends right after its
+				// handshake; select picks arbitrarily, so re-check before giving up.
+				select {
+				case <-connected:
+				default:
+					return
+				}
+			}
+			emit(StreamEvent{Type: "phase", Phase: "connected"})
+		}()
 	}
 	diag := agent.parseStream(stdout, streamEvent)
+	close(streamDone)
+	handshake.Wait()
 	diag.evidenceScope = evidenceScope
 
 	waitErr := cmd.Wait()
@@ -944,6 +989,26 @@ type cliEvent struct {
 	TotalCostUSD *float64 `json:"total_cost_usd"`
 	NumTurns     int      `json:"num_turns"`
 	SessionID    string   `json:"session_id"`
+	// system/init only.
+	Model      string            `json:"model"`
+	Tools      []string          `json:"tools"`
+	MCPServers []MCPServerStatus `json:"mcp_servers"`
+}
+
+// agentReadyEvent reports the CLI's init message as a startup phase. Radar
+// tools are counted by their MCP prefix so the count reflects what the model can
+// actually call, not what Radar offered.
+func agentReadyEvent(model string, tools []string, servers []MCPServerStatus) StreamEvent {
+	count := 0
+	for _, tool := range tools {
+		if strings.HasPrefix(tool, "mcp__radar__") {
+			count++
+		}
+	}
+	return StreamEvent{
+		Type: "phase", Phase: "ready",
+		Model: model, ToolCount: &count, MCPServers: servers,
+	}
 }
 
 func parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
@@ -982,6 +1047,10 @@ func parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
 			continue
 		}
 		switch ev.Type {
+		case "system":
+			if ev.Subtype == "init" {
+				onEvent(agentReadyEvent(ev.Model, ev.Tools, ev.MCPServers))
+			}
 		case "assistant":
 			if ev.Message == nil {
 				continue

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -662,11 +662,13 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 		}()
 	}
 	diag := agent.parseStream(stdout, streamEvent)
-	close(streamDone)
-	handshake.Wait()
 	diag.evidenceScope = evidenceScope
 
 	waitErr := cmd.Wait()
+	// The watcher outlives stdout so a handshake that lands between EOF and
+	// process exit is still reported, and always before this method returns.
+	close(streamDone)
+	handshake.Wait()
 	if evidenceLease != nil {
 		// Closing before the diagnosis leaves this method prevents any late private
 		// MCP call from minting evidence for a completed turn. The deferred close

--- a/internal/ai/diagnoser_test.go
+++ b/internal/ai/diagnoser_test.go
@@ -9,8 +9,11 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/skyhook-io/radar/internal/investigationrefs"
 )
@@ -920,5 +923,188 @@ func TestDiagnoseStream_ProcessAndStreamErrors(t *testing.T) {
 	}
 	if diag.RootCause != "bad tag" {
 		t.Errorf("structured conclusion not preserved: %q", diag.RootCause)
+	}
+}
+
+// TestParseStream_InitReportsAgentReady pins the Claude Code system/init line:
+// the resolved model, the Radar tool count by MCP prefix, and every MCP
+// server's status, including a failed one the UI must surface as a warning.
+func TestParseStream_InitReportsAgentReady(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"hook_started","hook_name":"SessionStart:startup","session_id":"s1"}`,
+		`{"type":"system","subtype":"init","session_id":"s1","tools":["Bash","mcp__radar__diagnose","mcp__radar__get_resource","mcp__other__ping"],"mcp_servers":[{"name":"radar","status":"connected"},{"name":"other","status":"failed"}],"model":"claude-opus-5[1m]"}`,
+		`{"type":"result","result":"done","num_turns":1}`,
+	}, "\n")
+	var ready []StreamEvent
+	parseStream(strings.NewReader(stream), func(ev StreamEvent) {
+		if ev.Type == "phase" {
+			ready = append(ready, ev)
+		}
+	})
+	if len(ready) != 1 || ready[0].Phase != "ready" {
+		t.Fatalf("phase events = %+v, want exactly one ready phase", ready)
+	}
+	got := ready[0]
+	if got.Model != "claude-opus-5[1m]" {
+		t.Errorf("model = %q", got.Model)
+	}
+	if got.ToolCount == nil || *got.ToolCount != 2 {
+		t.Errorf("radar tool count = %v, want 2", got.ToolCount)
+	}
+	want := []MCPServerStatus{{Name: "radar", Status: "connected"}, {Name: "other", Status: "failed"}}
+	if len(got.MCPServers) != len(want) {
+		t.Fatalf("mcp servers = %+v, want %+v", got.MCPServers, want)
+	}
+	for i := range want {
+		if got.MCPServers[i] != want[i] {
+			t.Errorf("mcp server %d = %+v, want %+v", i, got.MCPServers[i], want[i])
+		}
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{`"toolCount":2`, `"mcpServers":[`, `"model":"claude-opus-5[1m]"`} {
+		if !strings.Contains(string(raw), field) {
+			t.Errorf("serialized ready phase %s lacks %s", raw, field)
+		}
+	}
+	zero := agentReadyEvent("m", nil, nil)
+	if raw, _ := json.Marshal(zero); !strings.Contains(string(raw), `"toolCount":0`) {
+		t.Errorf("a zero Radar tool count must serialize, got %s", raw)
+	}
+}
+
+// TestDiagnoseStreamReportsHandshakeOnce pins the agent-agnostic "connected"
+// phase: the private mount's handshake produces exactly one event per turn, no
+// matter how many times the scope is marked, and it lands before the stream ends.
+func TestDiagnoseStreamReportsHandshakeOnce(t *testing.T) {
+	dir := t.TempDir()
+	flag := filepath.Join(dir, "handshake-observed")
+	bin := filepath.Join(dir, "claude")
+	resultLine := `{"type":"result","result":"` + "```json\\n{\\\"healthy\\\":true}\\n```" + `","num_turns":1}`
+	script := "#!/bin/sh\nwhile [ ! -f '" + flag + "' ]; do sleep 0.02; done\n" +
+		"printf '%s\\n' '" + resultLine + "'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	refs := investigationrefs.NewRegistry()
+	d, err := New(bin, refs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := strings.Repeat("d", 26)
+	started := make(chan struct{})
+	var mu sync.Mutex
+	var phases []string
+	type outcome struct {
+		diag Diagnosis
+		err  error
+	}
+	finished := make(chan outcome, 1)
+	go func() {
+		diag, err := d.DiagnoseStream(context.Background(), Request{
+			Kind: "Pod", Namespace: "ns", Name: "p", MCPPort: 1, EvidenceScope: scope,
+		}, func(ev StreamEvent) {
+			if ev.Type != "phase" {
+				return
+			}
+			mu.Lock()
+			phases = append(phases, ev.Phase)
+			mu.Unlock()
+			if ev.Phase == "investigating" {
+				close(started)
+			}
+		})
+		finished <- outcome{diag, err}
+	}()
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("agent never started")
+	}
+	if !refs.MarkConnected(scope) || !refs.MarkConnected(scope) {
+		t.Fatal("live turn scope rejected its handshake")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		seen := len(phases) >= 2
+		mu.Unlock()
+		if seen || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := os.WriteFile(flag, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var result outcome
+	select {
+	case result = <-finished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("DiagnoseStream did not finish")
+	}
+	if result.err != nil || !result.diag.Healthy {
+		t.Fatalf("diagnosis = %+v, err = %v", result.diag, result.err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(phases, ",") != "investigating,connected" {
+		t.Fatalf("phases = %v, want investigating then exactly one connected", phases)
+	}
+}
+
+// handshakeAgent completes the private-mount handshake from inside command()
+// and exits at once, so the stream can end in the same instant the scope is
+// marked connected.
+type handshakeAgent struct {
+	refs *investigationrefs.Registry
+}
+
+func (*handshakeAgent) Name() string      { return "claude" }
+func (*handshakeAgent) Path() string      { return "printf" }
+func (*handshakeAgent) SigninCmd() string { return "claude auth login" }
+func (a *handshakeAgent) parseStream(r io.Reader, onEvent func(StreamEvent)) Diagnosis {
+	return parseStream(r, onEvent)
+}
+func (a *handshakeAgent) command(ctx context.Context, spec turnSpec) (*exec.Cmd, func(), error) {
+	u, err := url.Parse(spec.mcpURL)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if !a.refs.MarkConnected(u.Query().Get("scope")) {
+		return nil, func() {}, fmt.Errorf("test agent could not mark the scope connected")
+	}
+	stream := `{"type":"result","result":"` + "```json\\n{\\\"healthy\\\":true}\\n```" + `","num_turns":1}`
+	return exec.CommandContext(ctx, "printf", "%s\n", stream), func() {}, nil
+}
+
+// TestDiagnoseStreamReportsHandshakeOnShortTurn pins that a handshake which
+// lands as the stream ends is still reported exactly once, before the turn
+// returns, rather than lost to a select that happens to observe the end first.
+func TestDiagnoseStreamReportsHandshakeOnShortTurn(t *testing.T) {
+	refs := investigationrefs.NewRegistry()
+	diagnoser := &Diagnoser{
+		agents:       map[string]Agent{"claude": &handshakeAgent{refs: refs}},
+		defName:      "claude",
+		evidenceRefs: refs,
+	}
+	for i := 0; i < 20; i++ {
+		var phases []string
+		diag, err := diagnoser.DiagnoseStream(context.Background(), Request{
+			Kind: "Pod", Namespace: "ns", Name: "p", MCPPort: 1,
+			EvidenceScope: strings.Repeat("e", 26),
+		}, func(ev StreamEvent) {
+			if ev.Type == "phase" {
+				phases = append(phases, ev.Phase)
+			}
+		})
+		if err != nil || !diag.Healthy {
+			t.Fatalf("diagnosis = %+v, err = %v", diag, err)
+		}
+		if strings.Join(phases, ",") != "investigating,connected" {
+			t.Fatalf("run %d phases = %v, want investigating then exactly one connected", i, phases)
+		}
 	}
 }

--- a/internal/investigationrefs/registry.go
+++ b/internal/investigationrefs/registry.go
@@ -24,6 +24,10 @@ type Records map[string]string
 
 type scopeState struct {
 	records Records
+	// connected closes once the agent has completed the MCP handshake on the
+	// private mount, so the runner can report progress before any tool call.
+	connected chan struct{}
+	connect   sync.Once
 }
 
 // Registry holds only currently active turn scopes. A private MCP request
@@ -41,10 +45,11 @@ func NewRegistry() *Registry {
 // Scope owns one active registry entry. Close is idempotent and returns the
 // same point-in-time records on every call.
 type Scope struct {
-	registry *Registry
-	id       string
-	once     sync.Once
-	records  Records
+	registry  *Registry
+	id        string
+	connected <-chan struct{}
+	once      sync.Once
+	records   Records
 }
 
 // Begin reserves a caller-generated turn scope. Reusing a live scope fails
@@ -58,8 +63,25 @@ func (r *Registry) Begin(scope string) (*Scope, error) {
 	if _, exists := r.scopes[scope]; exists {
 		return nil, ErrScopeActive
 	}
-	r.scopes[scope] = &scopeState{records: make(Records)}
-	return &Scope{registry: r, id: scope}, nil
+	state := &scopeState{records: make(Records), connected: make(chan struct{})}
+	r.scopes[scope] = state
+	return &Scope{registry: r, id: scope, connected: state.connected}, nil
+}
+
+// MarkConnected records that the agent completed the MCP handshake for a live
+// scope. It is idempotent and reports whether the scope was active.
+func (r *Registry) MarkConnected(scope string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state, active := r.scopes[scope]
+	if !active {
+		return false
+	}
+	state.connect.Do(func() { close(state.connected) })
+	return true
 }
 
 // Active reports whether the AI runner currently owns scope. It is used to
@@ -113,6 +135,12 @@ func (r *Registry) Matches(scope, ref, payload string) bool {
 	}
 	issuedPayload, issued := state.records[ref]
 	return issued && issuedPayload == payload
+}
+
+// Connected is closed the first time MarkConnected observes this scope's
+// handshake. It never closes for a scope that ends without one.
+func (s *Scope) Connected() <-chan struct{} {
+	return s.connected
 }
 
 func (s *Scope) Close() Records {

--- a/internal/investigationrefs/registry_test.go
+++ b/internal/investigationrefs/registry_test.go
@@ -91,3 +91,32 @@ func TestRegistryBoundsIssuedRecordsPerActiveScope(t *testing.T) {
 		t.Fatalf("closed records = %d, want %d", len(records), maxIssuedRefsPerScope)
 	}
 }
+
+func TestRegistryMarksHandshakeOncePerActiveScope(t *testing.T) {
+	registry := NewRegistry()
+	scope := strings.Repeat("c", 26)
+	if registry.MarkConnected(scope) {
+		t.Fatal("inactive scope reported a handshake")
+	}
+	lease, err := registry.Begin(scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-lease.Connected():
+		t.Fatal("scope reported connected before any handshake")
+	default:
+	}
+	if !registry.MarkConnected(scope) || !registry.MarkConnected(scope) {
+		t.Fatal("active scope rejected its handshake")
+	}
+	select {
+	case <-lease.Connected():
+	default:
+		t.Fatal("handshake did not close Connected")
+	}
+	lease.Close()
+	if registry.MarkConnected(scope) {
+		t.Fatal("closed scope reported a handshake")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -86,13 +86,16 @@ type investigationEvidenceScopeKey struct{}
 func investigationEvidenceReferenceMiddleware(refs *investigationrefs.Registry) mcpsdk.Middleware {
 	return func(next mcpsdk.MethodHandler) mcpsdk.MethodHandler {
 		return func(ctx context.Context, method string, req mcpsdk.Request) (mcpsdk.Result, error) {
+			result, err := next(ctx, method, req)
+			if err != nil {
+				return result, err
+			}
 			if method == "initialize" || method == "tools/list" {
 				if scope, _ := ctx.Value(investigationEvidenceScopeKey{}).(string); scope != "" {
 					refs.MarkConnected(scope)
 				}
 			}
-			result, err := next(ctx, method, req)
-			if err != nil || method != "tools/call" {
+			if method != "tools/call" {
 				return result, err
 			}
 			toolResult, ok := result.(*mcpsdk.CallToolResult)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -86,6 +86,11 @@ type investigationEvidenceScopeKey struct{}
 func investigationEvidenceReferenceMiddleware(refs *investigationrefs.Registry) mcpsdk.Middleware {
 	return func(next mcpsdk.MethodHandler) mcpsdk.MethodHandler {
 		return func(ctx context.Context, method string, req mcpsdk.Request) (mcpsdk.Result, error) {
+			if method == "initialize" || method == "tools/list" {
+				if scope, _ := ctx.Value(investigationEvidenceScopeKey{}).(string); scope != "" {
+					refs.MarkConnected(scope)
+				}
+			}
 			result, err := next(ctx, method, req)
 			if err != nil || method != "tools/call" {
 				return result, err

--- a/internal/mcp/server_investigation_test.go
+++ b/internal/mcp/server_investigation_test.go
@@ -276,16 +276,20 @@ func TestInvestigationHandlerAnnotatesRealToolCallWithoutChangingPublicContract(
 func TestInvestigationMiddlewareMarksScopeConnectedOnHandshake(t *testing.T) {
 	scope := strings.Repeat("a", 26)
 	validCtx := context.WithValue(context.Background(), investigationEvidenceScopeKey{}, scope)
+	handshakeErr := errors.New("handshake rejected")
 	for _, test := range []struct {
 		name      string
 		ctx       context.Context
 		method    string
+		err       error
 		connected bool
 	}{
 		{name: "initialize", ctx: validCtx, method: "initialize", connected: true},
 		{name: "tools/list", ctx: validCtx, method: "tools/list", connected: true},
 		{name: "tools/call is not a handshake", ctx: validCtx, method: "tools/call"},
 		{name: "missing scope", ctx: context.Background(), method: "initialize"},
+		{name: "rejected initialize", ctx: validCtx, method: "initialize", err: handshakeErr},
+		{name: "failed tools/list", ctx: validCtx, method: "tools/list", err: handshakeErr},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			refs := investigationrefs.NewRegistry()
@@ -296,11 +300,11 @@ func TestInvestigationMiddlewareMarksScopeConnectedOnHandshake(t *testing.T) {
 			defer lease.Close()
 			wrapped := investigationEvidenceReferenceMiddleware(refs)(
 				func(context.Context, string, mcpsdk.Request) (mcpsdk.Result, error) {
-					return &mcpsdk.CallToolResult{}, nil
+					return &mcpsdk.CallToolResult{}, test.err
 				},
 			)
-			if _, err := wrapped(test.ctx, test.method, nil); err != nil {
-				t.Fatal(err)
+			if _, err := wrapped(test.ctx, test.method, nil); !errors.Is(err, test.err) {
+				t.Fatalf("error = %v, want %v", err, test.err)
 			}
 			select {
 			case <-lease.Connected():

--- a/internal/mcp/server_investigation_test.go
+++ b/internal/mcp/server_investigation_test.go
@@ -241,7 +241,17 @@ func TestInvestigationHandlerAnnotatesRealToolCallWithoutChangingPublicContract(
 		t.Fatalf("public producer payload = %#v, want %q", publicResult.Content[0], payload)
 	}
 
+	select {
+	case <-lease.Connected():
+		t.Fatal("public mount handshake marked the private scope connected")
+	default:
+	}
 	privateResult := callFixture(httpServer.URL + "/mcp-investigation?scope=" + scope)
+	select {
+	case <-lease.Connected():
+	default:
+		t.Fatal("private mount handshake did not mark the scope connected")
+	}
 	if len(privateResult.Content) != 2 {
 		t.Fatalf("private content blocks = %d, want marker + producer payload", len(privateResult.Content))
 	}
@@ -260,5 +270,48 @@ func TestInvestigationHandlerAnnotatesRealToolCallWithoutChangingPublicContract(
 	}
 	if issuedPayload := lease.Close()[ref]; issuedPayload != payload {
 		t.Fatalf("issued payload = %q, want %q", issuedPayload, payload)
+	}
+}
+
+func TestInvestigationMiddlewareMarksScopeConnectedOnHandshake(t *testing.T) {
+	scope := strings.Repeat("a", 26)
+	validCtx := context.WithValue(context.Background(), investigationEvidenceScopeKey{}, scope)
+	for _, test := range []struct {
+		name      string
+		ctx       context.Context
+		method    string
+		connected bool
+	}{
+		{name: "initialize", ctx: validCtx, method: "initialize", connected: true},
+		{name: "tools/list", ctx: validCtx, method: "tools/list", connected: true},
+		{name: "tools/call is not a handshake", ctx: validCtx, method: "tools/call"},
+		{name: "missing scope", ctx: context.Background(), method: "initialize"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			refs := investigationrefs.NewRegistry()
+			lease, err := refs.Begin(scope)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer lease.Close()
+			wrapped := investigationEvidenceReferenceMiddleware(refs)(
+				func(context.Context, string, mcpsdk.Request) (mcpsdk.Result, error) {
+					return &mcpsdk.CallToolResult{}, nil
+				},
+			)
+			if _, err := wrapped(test.ctx, test.method, nil); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-lease.Connected():
+				if !test.connected {
+					t.Fatal("scope marked connected")
+				}
+			default:
+				if test.connected {
+					t.Fatal("scope not marked connected")
+				}
+			}
+		})
 	}
 }

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -87,6 +87,13 @@ export interface ResourceHealthSignal {
 
 export type ApplyMutationOutcome = "confirmed" | "failed" | "unknown";
 
+// One MCP server's connection state as the agent CLI reported it at startup.
+// Only "connected" means its tools are usable.
+export interface MCPServerStatus {
+  name: string;
+  status: string;
+}
+
 export interface DiagnoseStreamEvent {
   type:
     | "turn"
@@ -98,7 +105,11 @@ export interface DiagnoseStreamEvent {
     | "closed"
     | "history_unavailable"
     | "replay_complete";
-  phase?: string;
+  phase?: string; // "investigating" | "connected" | "ready"
+  // Startup facts the agent CLI reported on the "ready" phase.
+  model?: string;
+  toolCount?: number; // Radar tools the agent registered
+  mcpServers?: MCPServerStatus[];
   step?: DiagnoseStep;
   token?: string;
   diagnosis?: Diagnosis;

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -78,6 +78,7 @@ import {
   AssessmentSources,
   ApplyDialog,
   appendThinking,
+  mergeStartupSignal,
   upsertTool,
   type Turn,
 } from "./parts";
@@ -476,6 +477,14 @@ export function InvestigationView({
                 verify: ev.verify,
               },
             ]);
+            break;
+          case "phase":
+            // Startup phases only feed the pending status line; a replayed
+            // finished turn is not running, so nothing shows for it.
+            updateLast((t) => {
+              const startup = mergeStartupSignal(t.startup, ev);
+              return startup === t.startup ? t : { ...t, startup };
+            });
             break;
           case "thinking":
             if (ev.token) {
@@ -1680,6 +1689,7 @@ export function InvestigationView({
                       <Fragment key={index}>
                         <TurnView
                           turn={turn}
+                          agentLabel={agentLabel}
                           turnIndex={index}
                           evidenceStepIds={evidenceStepIdsByTurn.get(index)}
                           onViewEvidence={viewEvidenceSource}

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -9,6 +9,9 @@ import {
   TurnView,
   appendThinking,
   remediationCommands,
+  mergeStartupSignal,
+  toolDurationLabel,
+  toolErrorReason,
   upsertTool,
   type TimelineItem,
   type Turn,
@@ -17,6 +20,7 @@ import type {
   AgentInfo,
   Diagnosis,
   DiagnoseStep,
+  DiagnoseStreamEvent,
   ExecutionProfile,
 } from "../../api/diagnose";
 import { investigationEvidenceSourceId } from "./investigationEvidence";
@@ -374,6 +378,259 @@ describe("Timeline reasoning density", () => {
     );
 
     expect(html).toContain("height:47px");
+  });
+});
+
+describe("Timeline startup signals", () => {
+  const readyEvent: Pick<
+    DiagnoseStreamEvent,
+    "phase" | "model" | "toolCount" | "mcpServers"
+  > = {
+    phase: "ready",
+    model: "claude-opus-5",
+    toolCount: 24,
+    mcpServers: [{ name: "radar", status: "connected" }],
+  };
+
+  it("reports each startup phase in place of the generic pending label", () => {
+    const before = renderToStaticMarkup(
+      <Timeline items={[]} running agentLabel="Claude Code" />,
+    );
+    expect(before).toContain("Starting investigation…");
+
+    const starting = mergeStartupSignal(undefined, { phase: "investigating" });
+    expect(
+      renderToStaticMarkup(
+        <Timeline
+          items={[]}
+          running
+          agentLabel="Claude Code"
+          startup={starting}
+        />,
+      ),
+    ).toContain("Claude Code starting…");
+
+    const connected = mergeStartupSignal(starting, { phase: "connected" });
+    expect(
+      renderToStaticMarkup(
+        <Timeline
+          items={[]}
+          running
+          agentLabel="Claude Code"
+          startup={connected}
+        />,
+      ),
+    ).toContain("Connected to Radar&#x27;s tools");
+
+    const ready = mergeStartupSignal(connected, readyEvent);
+    const html = renderToStaticMarkup(
+      <Timeline items={[]} running agentLabel="Claude Code" startup={ready} />,
+    );
+    expect(html).toContain(
+      "Claude Code ready · claude-opus-5 · 24 Radar tools",
+    );
+    expect(html).not.toContain("Starting investigation…");
+    expect(html).not.toContain("MCP server");
+  });
+
+  it("keeps the furthest phase when the handshake lands after the init line", () => {
+    const ready = mergeStartupSignal(undefined, readyEvent);
+    const late = mergeStartupSignal(ready, { phase: "connected" });
+    expect(late).toEqual({
+      phase: "ready",
+      model: "claude-opus-5",
+      toolCount: 24,
+      mcpServers: [{ name: "radar", status: "connected" }],
+    });
+    expect(mergeStartupSignal(ready, { phase: "investigating" })).toBe(late);
+    expect(mergeStartupSignal(undefined, { phase: "unknown" })).toBeUndefined();
+  });
+
+  it("yields to the tool activity once the transcript has items", () => {
+    const html = renderToStaticMarkup(
+      <Timeline
+        items={[
+          {
+            kind: "tool",
+            id: "tool-1",
+            tool: "get_logs",
+            status: "running",
+            animate: false,
+          },
+        ]}
+        running
+        agentLabel="Claude Code"
+        startup={mergeStartupSignal(undefined, readyEvent)}
+      />,
+    );
+    expect(html).toContain("Reading logs…");
+    expect(html).not.toContain("Claude Code ready");
+  });
+
+  it("shows no startup label on a replayed finished turn", () => {
+    const html = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running={false}
+        agentLabel="Claude Code"
+        startup={mergeStartupSignal(undefined, readyEvent)}
+      />,
+    );
+    expect(html).not.toContain("Claude Code ready");
+    expect(html).not.toContain("Starting investigation…");
+    expect(html).not.toContain("Connected to Radar");
+  });
+
+  it("warns when the CLI reports an MCP server that is not connected", () => {
+    const startup = mergeStartupSignal(undefined, {
+      phase: "ready",
+      model: "claude-opus-5",
+      toolCount: 0,
+      mcpServers: [{ name: "radar", status: "failed" }],
+    });
+    const live = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running
+        agentLabel="Claude Code"
+        startup={startup}
+      />,
+    );
+    expect(live).toContain("Claude Code ready · claude-opus-5 · 0 Radar tools");
+    expect(live).toContain("failed to connect");
+    expect(live).toContain("had no Radar tools this turn");
+
+    // The warning is a fact of the run and survives replay; the label does not.
+    const replayed = renderToStaticMarkup(
+      <Timeline
+        items={[{ kind: "thinking", text: "done", animate: false }]}
+        running={false}
+        agentLabel="Claude Code"
+        startup={startup}
+      />,
+    );
+    expect(replayed).toContain("failed to connect");
+    expect(replayed).not.toContain("Claude Code ready");
+  });
+});
+
+describe("tool row duration and failure reason", () => {
+  const doneStep = (
+    overrides: Partial<Extract<TimelineItem, { kind: "tool" }>>,
+  ): TimelineItem => ({
+    kind: "tool",
+    id: "tool-1",
+    tool: "get_events",
+    status: "done",
+    summary: '{"namespace":"dev"}',
+    result: '{"events":[]}',
+    isError: false,
+    animate: false,
+    ...overrides,
+  });
+
+  it("hides sub-threshold durations and shows whole seconds above it", () => {
+    expect(toolDurationLabel(undefined)).toBeUndefined();
+    expect(toolDurationLabel(125)).toBeUndefined();
+    expect(toolDurationLabel(1999)).toBeUndefined();
+    expect(toolDurationLabel(2000)).toBe("2s");
+    expect(toolDurationLabel(3400)).toBe("3s");
+    expect(toolDurationLabel(12600)).toBe("13s");
+
+    const quick = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline items={[doneStep({ ms: 125 })]} running={false} />
+      </ThemeProvider>,
+    );
+    // The only millisecond figure is the expanded result header, not the row.
+    expect(quick.match(/125ms/g)).toHaveLength(1);
+    expect(quick.indexOf("125ms")).toBeGreaterThan(
+      quick.indexOf("Original result"),
+    );
+    expect(quick).not.toMatch(/>\d+s</);
+
+    const slow = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline items={[doneStep({ ms: 3400 })]} running={false} />
+      </ThemeProvider>,
+    );
+    expect(slow).toContain(">3s<");
+    expect(slow.indexOf(">3s<")).toBeLessThan(slow.indexOf("Original result"));
+    expect(slow.match(/3400ms/g)).toHaveLength(1);
+  });
+
+  it("keeps the exact milliseconds in the expanded result header", () => {
+    const sourceId = investigationEvidenceSourceId(0, "tool-1");
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline
+          items={[doneStep({ ms: 3400 })]}
+          running={false}
+          turnIndex={0}
+          sourceRevealRequest={{ sourceId, requestId: 1 }}
+        />
+      </ThemeProvider>,
+    );
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("Original result");
+    expect(html).toContain("3400ms");
+  });
+
+  it("extracts a one-line reason from the producer's error text", () => {
+    expect(
+      toolErrorReason('\ninvalid duration "30d": time: unknown unit "d"\nmore'),
+    ).toBe('invalid duration "30d": time: unknown unit "d"');
+    expect(
+      toolErrorReason(JSON.stringify({ error: 'resource not found: pod "x"' })),
+    ).toBe('resource not found: pod "x"');
+    expect(toolErrorReason("")).toBeUndefined();
+    expect(toolErrorReason("  \n ")).toBeUndefined();
+    expect(toolErrorReason('{"error":""}')).toBeUndefined();
+  });
+
+  it("shows the failure reason inline on a failed row only when the producer gave one", () => {
+    const failed = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline
+          items={[
+            doneStep({
+              isError: true,
+              result:
+                '\nfailed to get logs for dev/api: container "api" is waiting to start: CreateContainerConfigError',
+            }),
+          ]}
+          running={false}
+        />
+      </ThemeProvider>,
+    );
+    expect(failed).toContain("investigation-tool-reason");
+    expect(failed).toContain(
+      "failed to get logs for dev/api: container &quot;api&quot; is waiting to start",
+    );
+    expect(failed.indexOf("investigation-tool-reason")).toBeGreaterThan(
+      failed.indexOf("namespace=dev"),
+    );
+
+    const silent = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline
+          items={[doneStep({ isError: true, result: undefined })]}
+          running={false}
+        />
+      </ThemeProvider>,
+    );
+    expect(silent).toContain('aria-label="Tool failed"');
+    expect(silent).not.toContain("investigation-tool-reason");
+
+    const succeeded = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline
+          items={[doneStep({ isError: false, result: "plain text result" })]}
+          running={false}
+        />
+      </ThemeProvider>,
+    );
+    expect(succeeded).not.toContain("investigation-tool-reason");
   });
 });
 

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -481,6 +481,63 @@ describe("Timeline startup signals", () => {
     expect(html).not.toContain("Connected to Radar");
   });
 
+  it("renders a bare ready label when the init facts are absent", () => {
+    // Hosted transports may forward only the phase name; the label and the
+    // warning must degrade to exactly what was reported.
+    const startup = mergeStartupSignal(undefined, { phase: "ready" });
+    const html = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running
+        agentLabel="Claude Code"
+        startup={startup}
+      />,
+    );
+    expect(html).toContain("Claude Code ready</span>");
+    expect(html).not.toContain("Radar tools");
+    expect(html).not.toContain("MCP server");
+  });
+
+  it("uses conditional wording for servers whose startup state is not final", () => {
+    const startup = mergeStartupSignal(undefined, {
+      phase: "ready",
+      model: "claude-opus-5",
+      toolCount: 24,
+      mcpServers: [
+        { name: "radar", status: "connected" },
+        { name: "github", status: "pending" },
+      ],
+    });
+    const pending = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running
+        agentLabel="Claude Code"
+        startup={startup}
+      />,
+    );
+    expect(pending).toContain("is pending");
+    expect(pending).toContain("may not have been available");
+    expect(pending).not.toContain("ran this turn without");
+
+    const failed = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running
+        agentLabel="Claude Code"
+        startup={mergeStartupSignal(undefined, {
+          phase: "ready",
+          mcpServers: [
+            { name: "radar", status: "connected" },
+            { name: "github", status: "failed" },
+          ],
+        })}
+      />,
+    );
+    expect(failed).toContain("failed to connect");
+    expect(failed).toContain("ran this turn without those tools");
+  });
+
   it("warns when the CLI reports an MCP server that is not connected", () => {
     const startup = mergeStartupSignal(undefined, {
       phase: "ready",

--- a/web/src/components/diagnose/parts.test.tsx
+++ b/web/src/components/diagnose/parts.test.tsx
@@ -10,6 +10,8 @@ import {
   appendThinking,
   remediationCommands,
   mergeStartupSignal,
+  middleTruncate,
+  runningElapsedLabel,
   toolDurationLabel,
   toolErrorReason,
   upsertTool,
@@ -571,6 +573,27 @@ describe("Timeline startup signals", () => {
   });
 });
 
+describe("running status elapsed counter", () => {
+  it("is a row-level figure, never part of the phase label", () => {
+    expect(runningElapsedLabel(0)).toBeUndefined();
+    expect(runningElapsedLabel(2)).toBeUndefined();
+    expect(runningElapsedLabel(3)).toBe("3s elapsed");
+    expect(runningElapsedLabel(19)).toBe("19s elapsed");
+
+    const html = renderToStaticMarkup(
+      <Timeline
+        items={[]}
+        running
+        agentLabel="Claude Code"
+        startup={mergeStartupSignal(undefined, { phase: "connected" })}
+      />,
+    );
+    const label = html.match(/<span class="ai-shimmer[^"]*">([^<]*)</);
+    expect(label?.[1]).toBe("Connected to Radar&#x27;s tools");
+    expect(label?.[1]).not.toMatch(/\d+s/);
+  });
+});
+
 describe("tool row duration and failure reason", () => {
   const doneStep = (
     overrides: Partial<Extract<TimelineItem, { kind: "tool" }>>,
@@ -643,6 +666,54 @@ describe("tool row duration and failure reason", () => {
     expect(toolErrorReason("")).toBeUndefined();
     expect(toolErrorReason("  \n ")).toBeUndefined();
     expect(toolErrorReason('{"error":""}')).toBeUndefined();
+    // Radar's not-found hints are for the agent; the row keeps what failed.
+    expect(
+      toolErrorReason(
+        'resource not found: secret "project-infra" not found — found Deployment autopush/project-infra — retry with kind=deployment; or use search',
+      ),
+    ).toBe('resource not found: secret "project-infra" not found');
+  });
+
+  it("middle-truncates a long reason so its identifier tail survives", () => {
+    const short = 'resource not found: secret "dev/does-not-exist" not found';
+    expect(middleTruncate(short)).toBe(short);
+    const long =
+      "failed to get logs for autopush/project-infra-68c7b766dc-g2xlg: container is waiting to start: CreateContainerConfigError for pod project-infra-68c7b766dc-g2xlg";
+    const cut = middleTruncate(long);
+    expect(cut.length).toBeLessThanOrEqual(100);
+    expect(cut).toContain("…");
+    expect(cut.startsWith("failed to get logs for autopush")).toBe(true);
+    expect(cut.endsWith("project-infra-68c7b766dc-g2xlg")).toBe(true);
+    expect(middleTruncate("abcdefghij", 6, 2)).toBe("abc…ij");
+  });
+
+  it("lets the arguments give way before the reason on a collapsed failed row", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <Timeline
+          items={[
+            doneStep({
+              isError: true,
+              summary:
+                '{"kind":"Secret","namespace":"dev","name":"does-not-exist"}',
+              result:
+                'resource not found: secret "dev/does-not-exist" not found — found Deployment dev/api — retry with kind=deployment',
+            }),
+          ]}
+          running={false}
+        />
+      </ThemeProvider>,
+    );
+    const args = html.match(/<span class="([^"]*)">kind=Secret/);
+    expect(args?.[1]).toContain("flex-1");
+    expect(args?.[1]).toContain("truncate");
+    const reason = html.match(
+      /<span class="investigation-tool-reason ([^"]*)">([^<]*)</,
+    );
+    expect(reason?.[1]).toContain("shrink-0");
+    expect(reason?.[2]).toBe(
+      "resource not found: secret &quot;dev/does-not-exist&quot; not found",
+    );
   });
 
   it("shows the failure reason inline on a failed row only when the producer gave one", () => {

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -1185,6 +1185,9 @@ export function Timeline({
     (server) => server.status !== "connected",
   );
   const radarServer = failedServers.find((server) => server.name === "radar");
+  const allDefiniteFailures = failedServers.every((server) =>
+    mcpStatusIsFailure(server.status),
+  );
   return (
     <div className="space-y-1.5">
       {items.length > 0 && (
@@ -1195,9 +1198,9 @@ export function Timeline({
       {failedServers.length > 0 && (
         <div
           role="status"
-          className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary"
+          className="flex items-start gap-1.5 rounded border border-semantic-warning/40 bg-semantic-warning/10 p-2 text-[11px] leading-snug text-theme-text-secondary"
         >
-          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-semantic-warning" />
           <span>
             {failedServers.map((server, i) => (
               <span key={server.name}>
@@ -1213,7 +1216,9 @@ export function Timeline({
               ? mcpStatusIsFailure(radarServer.status)
                 ? ` at startup — ${agentLabel} had no Radar tools this turn, so it could not use Radar's cluster evidence.`
                 : ` at startup — Radar's tools may not have been available to ${agentLabel} this turn.`
-              : ` at startup — ${agentLabel} ran this turn without those tools.`}
+              : allDefiniteFailures
+                ? ` at startup — ${agentLabel} ran this turn without those tools.`
+                : ` at startup — those tools may not have been available to ${agentLabel} this turn.`}
           </span>
         </div>
       )}
@@ -1481,7 +1486,7 @@ function ToolRow({
         </span>
       )}
       {errorReason && !open && (
-        <span className="investigation-tool-reason min-w-0 flex-1 truncate text-[11px] text-red-400">
+        <span className="investigation-tool-reason min-w-0 flex-1 truncate text-[11px] text-semantic-error">
           {errorReason}
         </span>
       )}

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -37,6 +37,8 @@ import {
   type AgentInfo,
   type ApplyMutationOutcome,
   type ExecutionProfile,
+  type DiagnoseStreamEvent,
+  type MCPServerStatus,
 } from "../../api/diagnose";
 import { Collapse, CollapseChevron } from "@skyhook-io/k8s-ui";
 import { Markdown } from "../ui/Markdown";
@@ -448,7 +450,68 @@ export type Turn = {
   // Set from the replay/live boundary when the terminal event arrives. Historical
   // conclusions render immediately; conclusions observed live enter smoothly.
   animateResult?: boolean;
+  // The latest startup phase the server reported before the agent's first
+  // message. It drives the pending status line only; it is never a transcript item.
+  startup?: StartupSignal;
 };
+
+export type StartupSignal = {
+  phase: "investigating" | "connected" | "ready";
+  model?: string;
+  toolCount?: number;
+  mcpServers?: MCPServerStatus[];
+};
+
+const STARTUP_PHASE_RANK: Record<StartupSignal["phase"], number> = {
+  investigating: 0,
+  connected: 1,
+  ready: 2,
+};
+
+// Folds a phase event into the turn's startup signal. The handshake and the
+// CLI's init line are reported by different goroutines, so a later event can
+// name an earlier phase; the furthest phase wins and the init facts are kept.
+export function mergeStartupSignal(
+  prev: StartupSignal | undefined,
+  event: Pick<
+    DiagnoseStreamEvent,
+    "phase" | "model" | "toolCount" | "mcpServers"
+  >,
+): StartupSignal | undefined {
+  const phase = event.phase;
+  if (phase !== "investigating" && phase !== "connected" && phase !== "ready")
+    return prev;
+  const facts =
+    phase === "ready"
+      ? {
+          model: event.model,
+          toolCount: event.toolCount,
+          mcpServers: event.mcpServers,
+        }
+      : {};
+  if (prev && STARTUP_PHASE_RANK[prev.phase] >= STARTUP_PHASE_RANK[phase]) {
+    return phase === "ready" ? { ...prev, ...facts } : prev;
+  }
+  return { ...prev, ...facts, phase };
+}
+
+function startupLabel(startup: StartupSignal, agentLabel: string): string {
+  switch (startup.phase) {
+    case "investigating":
+      return `${agentLabel} starting…`;
+    case "connected":
+      return "Connected to Radar's tools";
+    case "ready": {
+      const parts = [`${agentLabel} ready`];
+      if (startup.model) parts.push(startup.model);
+      if (startup.toolCount !== undefined)
+        parts.push(
+          `${startup.toolCount} Radar ${startup.toolCount === 1 ? "tool" : "tools"}`,
+        );
+      return parts.join(" · ");
+    }
+  }
+}
 
 // TimelineItem is one ordered transcript entry: agent reasoning, or a tool call.
 export type TimelineItem =
@@ -542,6 +605,7 @@ export function upsertTool(
 
 export function TurnView({
   turn,
+  agentLabel,
   onApply,
   onViewExplanation,
   onCheckStatus,
@@ -553,6 +617,7 @@ export function TurnView({
   sourceRevealRequest,
 }: {
   turn: Turn;
+  agentLabel?: string;
   onApply?: (fix: string) => void;
   onViewExplanation?: () => void;
   onCheckStatus?: () => void;
@@ -637,6 +702,8 @@ export function TurnView({
         running={turn.status === "running"}
         applyMode={turn.apply}
         followup={followup}
+        startup={turn.startup}
+        agentLabel={agentLabel}
         turnIndex={turnIndex}
         evidenceStepIds={evidenceStepIds}
         onViewEvidence={onViewEvidence}
@@ -1069,6 +1136,8 @@ export function Timeline({
   running,
   applyMode,
   followup,
+  startup,
+  agentLabel = "Agent",
   turnIndex,
   evidenceStepIds,
   onViewEvidence,
@@ -1078,6 +1147,8 @@ export function Timeline({
   running: boolean;
   applyMode?: boolean;
   followup?: boolean;
+  startup?: StartupSignal;
+  agentLabel?: string;
   turnIndex?: number;
   evidenceStepIds?: ReadonlySet<string>;
   onViewEvidence?: (sourceId: string) => void;
@@ -1093,7 +1164,8 @@ export function Timeline({
       ? "Working"
       : "Investigation";
   // The live status verb tracks the running tool ("Reading logs…") so the wait is
-  // informative, not a generic spinner; falls back to a phase-appropriate label.
+  // informative, not a generic spinner; before the first item it reports the
+  // startup phases the server actually observed, never a timer-based guess.
   const activeTool = [...items]
     .reverse()
     .find((it) => it.kind === "tool" && it.status !== "done") as
@@ -1104,14 +1176,45 @@ export function Timeline({
       ? toolActivity(activeTool.tool)
       : items.length > 0
         ? "Working…"
-        : followup
-          ? "Thinking…"
-          : "Starting investigation…";
+        : startup
+          ? startupLabel(startup, agentLabel)
+          : followup
+            ? "Thinking…"
+            : "Starting investigation…";
+  const failedServers = (startup?.mcpServers ?? []).filter(
+    (server) => server.status !== "connected",
+  );
+  const radarServer = failedServers.find((server) => server.name === "radar");
   return (
     <div className="space-y-1.5">
       {items.length > 0 && (
         <div className="text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
           {heading}
+        </div>
+      )}
+      {failedServers.length > 0 && (
+        <div
+          role="status"
+          className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] leading-snug text-theme-text-secondary"
+        >
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
+          <span>
+            {failedServers.map((server, i) => (
+              <span key={server.name}>
+                {i > 0 ? "; " : ""}
+                MCP server{" "}
+                <span className="font-medium text-theme-text-primary">
+                  {server.name}
+                </span>{" "}
+                {mcpStatusPhrase(server.status)}
+              </span>
+            ))}
+            {radarServer
+              ? mcpStatusIsFailure(radarServer.status)
+                ? ` at startup — ${agentLabel} had no Radar tools this turn, so it could not use Radar's cluster evidence.`
+                : ` at startup — Radar's tools may not have been available to ${agentLabel} this turn.`
+              : ` at startup — ${agentLabel} ran this turn without those tools.`}
+          </span>
         </div>
       )}
       {items.map((it, i) => {
@@ -1270,6 +1373,19 @@ function RunningStatus({ label }: { label: string }) {
   );
 }
 
+// Claude Code reports each MCP server as connected, failed, needs-auth, or
+// pending. Only the first two are definite outcomes; anything else is left as
+// the CLI's own word so the warning never claims more than it knows.
+function mcpStatusIsFailure(status: string): boolean {
+  return status === "failed" || status === "needs-auth";
+}
+
+function mcpStatusPhrase(status: string): string {
+  if (status === "failed") return "failed to connect";
+  if (status === "needs-auth") return "needs authentication";
+  return `is ${status}`;
+}
+
 // Maps a running tool to a human verb so the status line reads as activity, not
 // machinery. Falls back to the prettified tool name for anything unmapped.
 function toolActivity(tool: string): string {
@@ -1321,6 +1437,9 @@ function ToolRow({
   const richResult =
     !!step.result && (isJsonPayload(step.result) || step.result.length > 200);
   const done = step.status === "done";
+  const durationLabel = toolDurationLabel(step.ms);
+  const errorReason =
+    step.isError === true ? toolErrorReason(step.result) : undefined;
   const outcomeLabel = !done
     ? "Running"
     : step.isError === true
@@ -1355,13 +1474,20 @@ function ToolRow({
         {prettyTool(step.tool)}
       </span>
       {step.summary && !open && (
-        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-theme-text-tertiary">
+        <span
+          className={`min-w-0 truncate font-mono text-[11px] text-theme-text-tertiary ${errorReason ? "max-w-[40%]" : "flex-1"}`}
+        >
           {argumentsPreview}
         </span>
       )}
-      {step.ms != null && (
+      {errorReason && !open && (
+        <span className="investigation-tool-reason min-w-0 flex-1 truncate text-[11px] text-red-400">
+          {errorReason}
+        </span>
+      )}
+      {durationLabel && (
         <span className="ml-auto shrink-0 text-[11px] text-theme-text-tertiary">
-          {step.ms}ms
+          {durationLabel}
         </span>
       )}
       {hasDetail && <CollapseChevron open={open} className="h-3.5 w-3.5" />}
@@ -1454,6 +1580,7 @@ function ToolRow({
               {step.result && (
                 <PayloadBlock
                   label="Original result"
+                  detail={step.ms != null ? `${step.ms}ms` : undefined}
                   text={step.result}
                   sourceExcerpt={sourceExcerpt}
                   revealRequestId={revealRequestId}
@@ -1488,6 +1615,40 @@ function ToolRow({
   );
 }
 
+// Only outliers carry information on the collapsed row: a slow log fetch or a
+// probe that hung. Sub-second calls stay silent; the exact figure lives in the
+// expanded result header.
+export function toolDurationLabel(ms: number | undefined): string | undefined {
+  if (ms == null || ms < 2000) return undefined;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+// The producer's own words for a failed call, reduced to one line. Radar's MCP
+// errors are plain text; a JSON envelope with an `error` field is unwrapped.
+export function toolErrorReason(
+  result: string | undefined,
+): string | undefined {
+  if (!result) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(result);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as { error?: unknown }).error === "string"
+    ) {
+      const reason = (parsed as { error: string }).error.trim();
+      return reason || undefined;
+    }
+  } catch {
+    // plain text
+  }
+  const line = result
+    .split("\n")
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+  return line || undefined;
+}
+
 // isJsonPayload / formatJson — a tool result is "structured" if it parses as JSON.
 function isJsonPayload(text: string): boolean {
   try {
@@ -1509,6 +1670,7 @@ function formatJson(text: string): string | null {
 // to keep indentation) or wrapped text (logs/prose), with copy + optional action.
 function PayloadBlock({
   label,
+  detail,
   text,
   truncated,
   action,
@@ -1516,6 +1678,7 @@ function PayloadBlock({
   revealRequestId,
 }: {
   label: string;
+  detail?: string;
   text: string;
   truncated?: boolean;
   action?: ReactNode;
@@ -1547,6 +1710,11 @@ function PayloadBlock({
       <div className="mb-0.5 flex items-center justify-between gap-2">
         <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">
           {label}
+          {detail && (
+            <span className="ml-1.5 normal-case tracking-normal">
+              · {detail}
+            </span>
+          )}
         </span>
         <div className="flex items-center gap-2">
           {action}

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -1362,20 +1362,30 @@ function RunningStatus({ label }: { label: string }) {
   }, []);
   const sinceChange = elapsed - lastChangeRef.current;
   const stalled = elapsed >= 30 && sinceChange >= 30;
+  const counter = runningElapsedLabel(elapsed);
   return (
     <div className="flex items-center gap-2 pt-1 text-xs">
       <Loader2 className="h-3 w-3 shrink-0 animate-spin text-accent" />
-      <span className="ai-shimmer">{label}</span>
-      {elapsed >= 3 && (
-        <span className="shrink-0 text-theme-text-tertiary">· {elapsed}s</span>
-      )}
+      <span className="ai-shimmer min-w-0 truncate">{label}</span>
       {stalled && (
         <span className="shrink-0 text-theme-text-tertiary">
           · still working — no update for {sinceChange}s
         </span>
       )}
+      {counter && (
+        <span className="ml-auto shrink-0 tabular-nums text-theme-text-tertiary">
+          {counter}
+        </span>
+      )}
     </div>
   );
+}
+
+// The wait the operator feels is the whole turn's, so the counter is a
+// row-level figure set apart from the label: "Connected to Radar's tools"
+// followed by "10s" read as if the handshake took that long.
+export function runningElapsedLabel(elapsed: number): string | undefined {
+  return elapsed >= 3 ? `${elapsed}s elapsed` : undefined;
 }
 
 // Claude Code reports each MCP server as connected, failed, needs-auth, or
@@ -1479,15 +1489,15 @@ function ToolRow({
         {prettyTool(step.tool)}
       </span>
       {step.summary && !open && (
-        <span
-          className={`min-w-0 truncate font-mono text-[11px] text-theme-text-tertiary ${errorReason ? "max-w-[40%]" : "flex-1"}`}
-        >
+        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-theme-text-tertiary">
           {argumentsPreview}
         </span>
       )}
       {errorReason && !open && (
-        <span className="investigation-tool-reason min-w-0 flex-1 truncate text-[11px] text-semantic-error">
-          {errorReason}
+        // The arguments give way first: they are still readable expanded,
+        // while the reason is the one thing this row exists to say.
+        <span className="investigation-tool-reason max-w-full shrink-0 truncate text-[11px] text-semantic-error">
+          {middleTruncate(errorReason)}
         </span>
       )}
       {durationLabel && (
@@ -1630,10 +1640,13 @@ export function toolDurationLabel(ms: number | undefined): string | undefined {
 
 // The producer's own words for a failed call, reduced to one line. Radar's MCP
 // errors are plain text; a JSON envelope with an `error` field is unwrapped.
+// Radar's not-found errors append retry hints for the agent after an em dash;
+// only the clause before it says what failed, so the hints are dropped.
 export function toolErrorReason(
   result: string | undefined,
 ): string | undefined {
   if (!result) return undefined;
+  let text = result;
   try {
     const parsed: unknown = JSON.parse(result);
     if (
@@ -1641,17 +1654,33 @@ export function toolErrorReason(
       typeof parsed === "object" &&
       typeof (parsed as { error?: unknown }).error === "string"
     ) {
-      const reason = (parsed as { error: string }).error.trim();
-      return reason || undefined;
+      text = (parsed as { error: string }).error;
     }
   } catch {
     // plain text
   }
-  const line = result
+  const line = text
     .split("\n")
     .map((part) => part.trim())
     .find((part) => part.length > 0);
-  return line || undefined;
+  if (!line) return undefined;
+  const clause = line.split(" — ")[0].trim();
+  return clause || line;
+}
+
+const COLLAPSED_REASON_MAX = 100;
+const COLLAPSED_REASON_TAIL = 36;
+
+// Keeps both ends of a long reason: the leading words say what failed and the
+// tail usually carries the identifier, which a plain end-truncation would lose.
+export function middleTruncate(
+  text: string,
+  max = COLLAPSED_REASON_MAX,
+  tail = COLLAPSED_REASON_TAIL,
+): string {
+  if (text.length <= max) return text;
+  const head = Math.max(1, max - tail - 1);
+  return `${text.slice(0, head).trimEnd()}…${text.slice(-tail).trimStart()}`;
 }
 
 // isJsonPayload / formatJson — a tool result is "structured" if it parses as JSON.


### PR DESCRIPTION
## Summary

After an investigation starts, the Activity pane showed only "Starting investigation…" and a timer for the 20+ seconds until the agent's first message. Three real signals exist before that message and none was shown. This PR reports the two Radar can observe honestly, with no timer-based labels:

- **Connected to Radar's tools** the moment the agent completes the MCP handshake on the private investigation mount (agent-agnostic).
- **Claude Code ready · \<model\> · \<n\> Radar tools** from Claude Code's stream-json `system`/`init` line. A non-connected MCP server becomes a visible warning in the Activity pane instead of a silent tool-less investigation. Cursor's init names the model only.

Also on the same Activity rows: sub-2s tool durations are hidden on the collapsed row (whole seconds above that), the exact milliseconds stay in the expanded result header, and a failed tool row shows the producer's own failure reason inline.

## What changed

- `internal/investigationrefs`: a scope now carries a `Connected()` channel; `Registry.MarkConnected(scope)` closes it once for a live scope. This is the seam between the MCP mount and the runner, so `internal/mcp` still does not import `internal/ai`.
- `internal/mcp/server.go`: the investigation middleware marks the scope connected after `initialize` or `tools/list` returns **without error** — a rejected handshake never reports as connected.
- `internal/ai/diagnoser.go`: `StreamEvent` gains optional `Model`, `ToolCount`, `MCPServers` (phase events were already persisted in the run log; no migration). The runner watches the scope and emits one `phase: connected` per turn, serialized with the parser's events and always before the turn returns — including when the handshake and the stream's end coincide. The watcher stays alive until process exit. `parseStream` handles `system`/`init` and emits `phase: ready` with the model, the `mcp__radar__` tool count and every MCP server status. Cursor emits the model.
- `web/src/api/diagnose.ts`, `parts.tsx`, `InvestigationView.tsx`: the `phase` event folds into `turn.startup` (furthest phase wins, since the handshake and init are reported by different goroutines). The pending status line shows the startup label only while the turn is running with no items, so it never renders on a replayed finished turn and never becomes a transcript item. The MCP warning is attributed to startup and survives replay, since it is a fact of the run; its copy is conditional on the server's state and reads in past tense on a replayed run.
- Tool rows: `toolDurationLabel` (hidden under 2s, whole seconds above), `toolErrorReason` (JSON `error` field or first non-empty line of the producer text, with Radar's retry hints after the em dash dropped), `middleTruncate` so a long reason keeps its identifier tail, arguments shrink before the reason on the collapsed row, `PayloadBlock` header detail for the exact ms.
- Running status: the elapsed counter is a row-level "Ns elapsed" figure set apart from the label, so "Connected to Radar's tools" no longer reads as if the handshake took that long.

## Testing

- `make tsc`, `make build`, `go test ./...` (both modules), `git diff --check` — pass. New Go tests: the Claude init parser, the handshake-emitted-once runner path including the short-turn race, the registry handshake, the middleware's success-only marking, and Cursor's init model.
- `packages/k8s-ui`: 3549 passed. `web`: 1023 passed across 87 files, including the startup-signal merge (furthest phase wins, init facts kept), the bare `ready` label with no init facts, replay suppression, and the tool-row duration/reason rendering.
- Visual test against a live GKE cluster (Deployment `dev/cloud-provisioner`, real Claude Code run). Observed from the click: 0.4s "Claude Code starting…", 0.9s "Connected to Radar's tools", 5.0s "Claude Code ready · claude-sonnet-5 · 23 Radar tools", 23.2s first tool row. Reloading a finished run shows no startup label. A follow-up turn on the same run repeated the progression without special-casing.
- Tool rows on the same cluster: a call for a nonexistent Secret rendered `resource not found: secret "…" not found` inline after the arguments. Every live call finished under 2s, so the slow row was verified against a saved run whose `search` took 3754ms — the collapsed row reads `4s`, the expanded header `ORIGINAL RESULT · 3754ms`.

## Scope and tradeoffs

- Codex (`codex exec --json`) only emits `thread.started`; it carries no model or MCP data, so it gets the agent-agnostic "connected" signal only.
- The startup warning is hand-rolled rather than `AlertBanner`. That component is the drawer-scale renderer surface (`mb-4 p-3`, 14px title plus message); the Activity pane is an 11px transcript and every warning in `parts.tsx` (consent, apply, truncation notes) is hand-rolled at that scale, so the banner would be out of register there.
- Radar Hub's hosted transport forwards only the phase name for `phase` events, so a hosted run shows the bare "\<agent\> ready" label with no model, tool count or warning. That is the same code path with fields absent — there is no version fallback.
- The "starting" label uses the agent's display name ("Claude Code starting…") rather than the literal "Agent starting…"; the label is right there and reads better.
- The 5s to 23s gap between "ready" and the first tool is the model's first thinking; removing it needs `--include-partial-messages`, which is the planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125QDX24TNuod7FKLwTDhvW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches investigation streaming, MCP handshake signaling, and live UI state; race handling is new but heavily tested—no auth or data-model changes.
> 
> **Overview**
> Investigation Activity now surfaces **real startup progress** before the first agent message, instead of a generic “Starting investigation…” line.
> 
> The backend emits new **`phase` stream events**: `investigating`, then **`connected`** when the agent completes MCP handshake on the private investigation mount (via `investigationrefs.MarkConnected` + middleware on successful `initialize`/`tools/list`), then **`ready`** from the CLI’s `system/init` line with **model**, **Radar tool count** (`mcp__radar__` prefix), and **MCP server statuses**. Events are **mutex-serialized** so handshake and parser callbacks don’t interleave; the handshake watcher still fires once on short turns. **Cursor** maps init to `ready` with **model only**.
> 
> The UI folds phases into **`turn.startup`** (`mergeStartupSignal` keeps the furthest phase), shows agent-specific pending labels while the turn is running and the transcript is empty, and **warns** when MCP servers aren’t `connected` (warning persists on replay). **Tool rows** hide sub-2s durations on the collapsed row (seconds + exact ms in expanded header), show **inline failure reasons**, and move the elapsed timer to a separate **“Ns elapsed”** figure beside the status label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d785134f72ced66d49cedfe46010c11ff6431d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->