### PR TITLE
docs(helm): document that auth and cloud modes auto-enable rbac.secrets

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -287,7 +287,7 @@ Disabled by default for security:
 
 | Feature | Value | Description |
 |---------|-------|-------------|
-| Secrets | `rbac.secrets: true` | View secrets in resource list. Auto-enabled by `rbac.helm` (release storage is Secrets), under auth, and in cloud mode, so the Helm releases view can reach release Secrets a `view`-only identity cannot list. In those configurations `rbac.secrets: false` does not narrow the ClusterRole — the grant is cluster-wide `get/list/watch` on all Secrets. |
+| Secrets | `rbac.secrets: true` | View secrets in resource list. Auto-enabled by `rbac.helm` (Helm release storage is Secrets), by auth (`auth.mode` other than `none`), and in cloud mode. In those configurations `rbac.secrets: false` does not narrow the ClusterRole — the grant is cluster-wide `get/list/watch` on all Secrets. |
 | Terminal | `rbac.podExec: true` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods. Also the fallback for traffic sources (Hubble/Caretta) — Radar dials the relay/metrics Service directly first, so in-cluster installs only need this when a NetworkPolicy or routing blocks Radar's namespace from reaching the service |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -287,7 +287,7 @@ Disabled by default for security:
 
 | Feature | Value | Description |
 |---------|-------|-------------|
-| Secrets | `rbac.secrets: true` | View secrets in resource list |
+| Secrets | `rbac.secrets: true` | View secrets in resource list. Auto-enabled by `rbac.helm` (release storage is Secrets), under auth, and in cloud mode, so the Helm releases view can reach release Secrets a `view`-only identity cannot list. In those configurations `rbac.secrets: false` does not narrow the ClusterRole — the grant is cluster-wide `get/list/watch` on all Secrets. |
 | Terminal | `rbac.podExec: true` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods. Also the fallback for traffic sources (Hubble/Caretta) — Radar dials the relay/metrics Service directly first, so in-cluster installs only need this when a NetworkPolicy or routing blocks Radar's namespace from reaching the service |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -287,7 +287,7 @@ Disabled by default for security:
 
 | Feature | Value | Description |
 |---------|-------|-------------|
-| Secrets | `rbac.secrets: true` | View secrets in resource list. Auto-enabled by `rbac.helm` (Helm release storage is Secrets), by auth (`auth.mode` other than `none`), and in cloud mode. In those configurations `rbac.secrets: false` does not narrow the ClusterRole — the grant is cluster-wide `get/list/watch` on all Secrets. |
+| Secrets | `rbac.secrets: true` | View secrets in resource list. Also granted by `rbac.helm` (Helm stores releases in Secrets), by auth (`auth.mode` other than `none`), and in cloud mode, where every Secret read is re-checked against the requesting user's own RBAC. The grant is cluster-wide `get/list/watch` on all Secrets; `rbac.secrets: false` does not remove it in those modes. |
 | Terminal | `rbac.podExec: true` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods. Also the fallback for traffic sources (Hubble/Caretta) — Radar dials the relay/metrics Service directly first, so in-cluster installs only need this when a NetworkPolicy or routing blocks Radar's namespace from reaching the service |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -69,10 +69,10 @@ rules:
   {{- end }}
 
   {{- if or .Values.rbac.secrets .Values.rbac.helm (ne .Values.auth.mode "none") .Values.cloud.enabled }}
-  # Secrets access - required for Helm release storage (rbac.helm),
-  # showing secrets in the resource browser (rbac.secrets),
-  # or Helm visibility when auth is enabled / cloud-mode (Helm reads use the
-  # ServiceAccount since users with the K8s 'view' role cannot list secrets)
+  # Secrets access - required for Helm release storage (rbac.helm) and for
+  # showing secrets in the resource browser (rbac.secrets). Under auth / cloud
+  # mode the shared cache holds Secrets and every read is re-checked against
+  # the requesting user's own RBAC, so the grant is always on there.
   - apiGroups: [""]
     resources:
       - secrets

--- a/deploy/helm/radar/tests/secrets_rbac_test.yaml
+++ b/deploy/helm/radar/tests/secrets_rbac_test.yaml
@@ -26,6 +26,21 @@ tests:
             resourceNames: ["hubble-relay-client-certs"]
             verbs: ["get"]
 
+  - it: grants cluster-wide Secret read when rbac.secrets is set
+    set:
+      rbac:
+        secrets: true
+        helm: false
+      auth:
+        mode: none
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]
+
   - it: grants cluster-wide Secret read under auth even when rbac.secrets is false
     set:
       rbac:

--- a/deploy/helm/radar/tests/secrets_rbac_test.yaml
+++ b/deploy/helm/radar/tests/secrets_rbac_test.yaml
@@ -1,0 +1,77 @@
+suite: Secrets read RBAC
+templates:
+  - clusterrole.yaml
+tests:
+  - it: omits cluster-wide Secret read when no feature enables it
+    set:
+      rbac:
+        secrets: false
+        helm: false
+      auth:
+        mode: none
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]
+      # rbac.traffic defaults on, so a resourceNames-scoped Secret rule remains.
+      # Without it the assertion above would pass for the wrong reason.
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            resourceNames: ["hubble-relay-client-certs"]
+            verbs: ["get"]
+
+  - it: grants cluster-wide Secret read under auth even when rbac.secrets is false
+    set:
+      rbac:
+        secrets: false
+        helm: false
+      auth:
+        mode: oidc
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]
+
+  - it: grants cluster-wide Secret read in cloud mode even when rbac.secrets is false
+    set:
+      rbac:
+        secrets: false
+        helm: false
+      auth:
+        mode: none
+      cloud:
+        enabled: true
+        token: dummy
+        url: "wss://cloud.example"
+        clusterName: test-cluster
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]
+
+  - it: grants cluster-wide Secret read for Helm release storage even when rbac.secrets is false
+    set:
+      rbac:
+        secrets: false
+        helm: true
+      auth:
+        mode: none
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -46,7 +46,7 @@
         "create": { "type": "boolean" },
         "additionalRules": { "type": "array", "items": { "type": "object" } },
         "helm": { "type": "boolean", "description": "Allow Helm write operations. Grants broad permissions." },
-        "secrets": { "type": "boolean", "description": "Allow reading Secret contents. Auto-enabled regardless of this value by rbac.helm, by auth (auth.mode != none), and in cloud mode." },
+        "secrets": { "type": "boolean", "description": "Allow reading Secret contents. Also granted by rbac.helm, by auth (auth.mode != none), and in cloud mode, where reads are re-checked per user." },
         "podExec": { "type": "boolean", "description": "Allow pod exec (terminal feature)." },
         "podLogs": { "type": "boolean" },
         "portForward": { "type": "boolean" },

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -46,7 +46,7 @@
         "create": { "type": "boolean" },
         "additionalRules": { "type": "array", "items": { "type": "object" } },
         "helm": { "type": "boolean", "description": "Allow Helm write operations. Grants broad permissions." },
-        "secrets": { "type": "boolean", "description": "Allow reading Secret contents." },
+        "secrets": { "type": "boolean", "description": "Allow reading Secret contents. Auto-enabled regardless of this value by rbac.helm, by auth (auth.mode != none), and in cloud mode." },
         "podExec": { "type": "boolean", "description": "Allow pod exec (terminal feature)." },
         "podLogs": { "type": "boolean" },
         "portForward": { "type": "boolean" },

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -68,11 +68,10 @@ rbac:
 
   # Allow reading secrets (shows secrets in resource list).
   # Auto-enabled regardless of this flag by rbac.helm (Helm release storage is
-  # Secrets), when auth is on (auth.mode != none), or in cloud mode — there the
-  # Helm releases view reaches release Secrets that a user holding only the K8s
-  # 'view' role cannot list. Under any of those, setting this to false does NOT
-  # narrow the ClusterRole, and the grant is cluster-wide get/list/watch on all
-  # Secrets: check the rendered ClusterRole, not this value.
+  # Secrets), when auth is on (auth.mode != none), or in cloud mode. Under any
+  # of those, setting this to false does NOT narrow the ClusterRole, and the
+  # grant is cluster-wide get/list/watch on all Secrets: check the rendered
+  # ClusterRole, not this value.
   secrets: false
 
   # Allow reading RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -66,12 +66,16 @@ rbac:
   # Automatically enables secrets read access (needed for Helm release storage).
   helm: false
 
-  # Allow reading secrets (shows secrets in resource list).
-  # Auto-enabled regardless of this flag by rbac.helm (Helm release storage is
-  # Secrets), when auth is on (auth.mode != none), or in cloud mode. Under any
-  # of those, setting this to false does NOT narrow the ClusterRole, and the
-  # grant is cluster-wide get/list/watch on all Secrets: check the rendered
-  # ClusterRole, not this value.
+  # Allow reading secrets (shows secrets in the resource list, and backs the
+  # Helm releases view in no-auth installs since Helm stores releases in Secrets).
+  # Auto-enabled when rbac.helm is on, when auth is on (auth.mode != none), or in
+  # cloud mode. Under auth/cloud every Secret read is re-checked against the
+  # requesting user's own RBAC, so the ServiceAccount grant only lets the shared
+  # cache hold Secrets; it does not expose them to users who can't read them
+  # themselves. Like viewRBAC and viewWebhooks, this flag therefore only changes
+  # no-auth installs. The grant is cluster-wide get/list/watch on all Secrets, and
+  # setting this to false does not remove it in those modes: read the rendered
+  # ClusterRole.
   secrets: false
 
   # Allow reading RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -66,7 +66,13 @@ rbac:
   # Automatically enables secrets read access (needed for Helm release storage).
   helm: false
 
-  # Allow reading secrets (shows secrets in resource list)
+  # Allow reading secrets (shows secrets in resource list).
+  # Auto-enabled regardless of this flag by rbac.helm (Helm release storage is
+  # Secrets), when auth is on (auth.mode != none), or in cloud mode — there the
+  # Helm releases view reaches release Secrets that a user holding only the K8s
+  # 'view' role cannot list. Under any of those, setting this to false does NOT
+  # narrow the ClusterRole, and the grant is cluster-wide get/list/watch on all
+  # Secrets: check the rendered ClusterRole, not this value.
   secrets: false
 
   # Allow reading RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)


### PR DESCRIPTION
## Description

`rbac.secrets: false` does not keep Radar's ServiceAccount away from Secrets. The
ClusterRole grants cluster-wide `get/list/watch` on **all** Secrets whenever
`rbac.helm` is on, `auth.mode` is not `none`, or `cloud.enabled` is true:

```gotemplate
{{- if or .Values.rbac.secrets .Values.rbac.helm (ne .Values.auth.mode "none") .Values.cloud.enabled }}
```

Only the `rbac.helm` half of that was written down. `values.yaml` said just *"Allow
reading secrets (shows secrets in resource list)"*, and the README row and the values
schema said the same — so an `auth.mode` change silently widened RBAC while
`rbac.secrets: false` stayed in the values file reading as effective. The two flags
immediately below (`rbac.viewRBAC`, `rbac.viewWebhooks`) already document exactly this
auto-enable, which is what made the omission surprising rather than merely terse.

Reproduced on `main` with the reporter's check — unrestricted (no `resourceNames`)
cluster-wide Secret rules in the rendered ClusterRole:

| `--set rbac.secrets=false,rbac.helm=false,auth.mode=…` | rules |
|---|---|
| `none` | 0 |
| `oidc` | 1 |
| `proxy` | 1 |

## Type of change

- [x] Documentation update

This is issue option 1 (document the coupling). I deliberately did not touch the
template: the `auth.mode` term looks load-bearing for the Helm releases view, and
whether it should become an overridable opt-out (option 2) or a separate
`rbac.helmReleases` flag (option 3) is a behaviour decision for you rather than
something to infer from the outside. Happy to follow up with either if you'd like one.

## How has this been tested?

- [x] Added/updated unit tests

New `tests/secrets_rbac_test.yaml` pins every gate (off / `rbac.secrets` / auth / cloud / helm).
The negative case additionally asserts that the `resourceNames`-scoped `rbac.traffic`
rule still renders, so it can't pass by matching nothing.

```
helm unittest -f './tests/*_test.yaml' -v tests/ci/values.yaml deploy/helm/radar
Test Suites: 8 passed, 8 total
Tests:       35 passed, 35 total
```

`helm lint` clean. Dropping `(ne .Values.auth.mode "none")` from the template fails the
auth case and only that case; dropping `.Values.rbac.secrets` fails the direct case and
only that one — so each assertion is discriminating.

## Related issues

Fixes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test coverage only; rendered ClusterRole permissions are unchanged.
> 
> **Overview**
> Clarifies that **`rbac.secrets: false` does not suppress** cluster-wide `get/list/watch` on all Secrets when **`rbac.helm`**, **`auth.mode` ≠ `none`**, or **`cloud.enabled`** is set—the same `or` gate already in `clusterrole.yaml`. The README privileged-permissions table, **`values.yaml`** comments, **`values.schema.json`**, and inline ClusterRole comments now spell out that coupling, per-user re-checks under auth/cloud, and that the flag mainly affects **no-auth** installs.
> 
> Adds **`tests/secrets_rbac_test.yaml`** (helm unittest) to assert the Secret rule is omitted only when all gates are off (with a separate check that the scoped **`rbac.traffic`** Secret rule still renders), and present for **`rbac.secrets`**, auth, cloud, and Helm. **No template logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab2ebe7d8653eac4525cc096f5645619d59c994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

