### PR TITLE
Recognize cert-manager Secrets in the unused-resource audit

### DIFF
--- a/internal/audit/crd_config_refs.go
+++ b/internal/audit/crd_config_refs.go
@@ -144,6 +144,8 @@ func dynamicConfigRefHandlerFor(gvr schema.GroupVersionResource) dynamicConfigRe
 		}
 	case "cert-manager.io":
 		switch gvr.Resource {
+		case "certificates":
+			return certManagerCertificateConfigRefs
 		case "issuers":
 			return certManagerIssuerConfigRefs
 		case "clusterissuers":
@@ -313,6 +315,15 @@ func istioGatewayConfigRefs(u *unstructured.Unstructured) []bp.ConfigObjectRef {
 			addSecret(&refs, ns, name)
 		}
 	}
+	return refs
+}
+
+func certManagerCertificateConfigRefs(u *unstructured.Unstructured) []bp.ConfigObjectRef {
+	var refs []bp.ConfigObjectRef
+	ns := u.GetNamespace()
+	addSecret(&refs, ns, stringAt(u.Object, "spec", "secretName"))
+	addSecret(&refs, ns, stringAt(u.Object, "spec", "keystores", "pkcs12", "passwordSecretRef", "name"))
+	addSecret(&refs, ns, stringAt(u.Object, "spec", "keystores", "jks", "passwordSecretRef", "name"))
 	return refs
 }
 

--- a/internal/audit/crd_config_refs_test.go
+++ b/internal/audit/crd_config_refs_test.go
@@ -91,6 +91,19 @@ func TestDynamicConfigObjectRefs(t *testing.T) {
 			want: refs(secret("certs", "issuer-account-key"), secret("certs", "cloud-dns-key")),
 		},
 		{
+			name: "cert-manager certificate secret and keystore refs",
+			gvr:  gvr("cert-manager.io", "v1", "certificates"),
+			ns:   "app",
+			obj: map[string]any{"spec": map[string]any{
+				"secretName": "example-api-tls",
+				"keystores": map[string]any{
+					"pkcs12": map[string]any{"passwordSecretRef": map[string]any{"name": "pkcs12-password"}},
+					"jks":    map[string]any{"passwordSecretRef": map[string]any{"name": "jks-password"}},
+				},
+			}},
+			want: refs(secret("app", "example-api-tls"), secret("app", "pkcs12-password"), secret("app", "jks-password")),
+		},
+		{
 			name: "cert-manager clusterissuer acme refs",
 			gvr:  gvr("cert-manager.io", "v1", "clusterissuers"),
 			obj: map[string]any{"spec": map[string]any{"acme": map[string]any{

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -1050,8 +1050,12 @@ func checkOrphanConfigMapsSecrets(tr *evalTracker, input *CheckInput) []Finding 
 		if sec.Type == "helm.sh/release.v1" {
 			continue
 		}
-		// Skip TLS secrets used by cert-manager (they may be referenced by Ingress annotations, not spec)
-		if sec.Labels != nil && sec.Labels["cert-manager.io/certificate-name"] != "" {
+		// Skip cert-manager Certificate secrets. cert-manager stores
+		// cert-manager.io/certificate-name as an annotation (and some
+		// older/custom paths may copy it onto a label). Either form means
+		// the Secret is still managed for a Certificate even when no
+		// workload/Ingress in this namespace mounts it directly.
+		if isCertManagerCertificateSecret(sec) {
 			continue
 		}
 		if isKnownPlatformSecret(sec) {
@@ -1062,6 +1066,12 @@ func checkOrphanConfigMapsSecrets(tr *evalTracker, input *CheckInput) []Finding 
 		}
 		tr.record("orphanConfigMapSecret", sec.Namespace)
 		if referencedSecrets[sec.Namespace+"/"+sec.Name] {
+			continue
+		}
+		// Emberstack reflector: a source Secret mirrored into another
+		// namespace is "used" when that reflected copy is referenced
+		// (e.g. Istio Gateway credentialName in istio-system).
+		if isReflectorSourceWithReferencedCopy(sec, referencedSecrets) {
 			continue
 		}
 		findings = append(findings, Finding{
@@ -1161,6 +1171,66 @@ func isKnownPlatformConfigMap(cm *corev1.ConfigMap) bool {
 		return true
 	}
 
+	return false
+}
+
+const (
+	certManagerCertificateNameKey = "cert-manager.io/certificate-name"
+
+	reflectorReflectionAllowedAnno     = "reflector.v1.k8s.emberstack.com/reflection-allowed"
+	reflectorReflectionAutoEnabledAnno = "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"
+	reflectorReflectionAutoNamespaces  = "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"
+)
+
+// isCertManagerCertificateSecret reports whether sec is the Secret named by a
+// cert-manager Certificate. cert-manager writes certificate-name onto
+// annotations; accept a label too so secretTemplate / older copies still match.
+func isCertManagerCertificateSecret(sec *corev1.Secret) bool {
+	if sec == nil {
+		return false
+	}
+	return strings.TrimSpace(labelsValue(sec.Annotations, certManagerCertificateNameKey)) != "" ||
+		strings.TrimSpace(labelsValue(sec.Labels, certManagerCertificateNameKey)) != ""
+}
+
+// isReflectorSourceWithReferencedCopy is true when sec is configured for
+// Emberstack auto-reflection and a same-named Secret in a reflected target
+// namespace is already marked referenced (typically by an Istio Gateway).
+func isReflectorSourceWithReferencedCopy(sec *corev1.Secret, referencedSecrets map[string]bool) bool {
+	if sec == nil || len(referencedSecrets) == 0 {
+		return false
+	}
+	if !metadataValueEnabled(labelsValue(sec.Annotations, reflectorReflectionAllowedAnno)) {
+		return false
+	}
+	if !metadataValueEnabled(labelsValue(sec.Annotations, reflectorReflectionAutoEnabledAnno)) {
+		return false
+	}
+	autoNamespaces := labelsValue(sec.Annotations, reflectorReflectionAutoNamespaces)
+	for key := range referencedSecrets {
+		ns, name, ok := strings.Cut(key, "/")
+		if !ok || name != sec.Name || ns == "" || ns == sec.Namespace {
+			continue
+		}
+		if reflectorAutoNamespaceMatches(autoNamespaces, ns) {
+			return true
+		}
+	}
+	return false
+}
+
+// reflectorAutoNamespaceMatches follows Emberstack's list semantics: empty
+// means all namespaces; otherwise a comma-separated exact namespace list.
+func reflectorAutoNamespaceMatches(list, namespace string) bool {
+	list = strings.TrimSpace(list)
+	if list == "" {
+		return true
+	}
+	for _, part := range strings.Split(list, ",") {
+		if strings.TrimSpace(part) == namespace {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -1953,6 +1953,116 @@ func TestOrphanConfigMapSecretAdditionalRefs(t *testing.T) {
 	}
 }
 
+func TestOrphanConfigMapSecretCertManagerCertificateMetadata(t *testing.T) {
+	input := &CheckInput{
+		Secrets: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-tls-from-annotation",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"cert-manager.io/certificate-name": "api-tls",
+						"cert-manager.io/issuer-name":      "letsencrypt",
+					},
+					Labels: map[string]string{
+						"controller.cert-manager.io/fao": "true",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api-tls-from-label",
+					Namespace: "app",
+					Labels: map[string]string{
+						"cert-manager.io/certificate-name": "api-tls-label",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-tls",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"cert-manager.io/issuer-name": "letsencrypt",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+		},
+	}
+
+	orphans := findingResourceKeys(RunChecks(input).Findings, "orphanConfigMapSecret")
+	for _, key := range []string{
+		"Secret/app/api-tls-from-annotation",
+		"Secret/app/api-tls-from-label",
+	} {
+		if orphans[key] {
+			t.Errorf("%s should not be flagged as orphan", key)
+		}
+	}
+	if !orphans["Secret/app/unrelated-tls"] {
+		t.Errorf("Secret/app/unrelated-tls should still be flagged as orphan")
+	}
+}
+
+func TestOrphanConfigMapSecretReflectorSourceConsumedByIstioGateway(t *testing.T) {
+	input := &CheckInput{
+		ConfigObjectRefs: []ConfigObjectRef{
+			// Istio Gateway in istio-system consumes the reflected copy.
+			{Kind: "Secret", Namespace: "istio-system", Name: "example-api-tls"},
+		},
+		Secrets: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-api-tls",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"reflector.v1.k8s.emberstack.com/reflection-allowed":      "true",
+						"reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true",
+						"reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "istio-system",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-api-tls",
+					Namespace: "istio-system",
+					Annotations: map[string]string{
+						"reflector.v1.k8s.emberstack.com/reflected-version": "1",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-reflected-tls",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"reflector.v1.k8s.emberstack.com/reflection-allowed":         "true",
+						"reflector.v1.k8s.emberstack.com/reflection-auto-enabled":    "true",
+						"reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "istio-system",
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+			},
+		},
+	}
+
+	orphans := findingResourceKeys(RunChecks(input).Findings, "orphanConfigMapSecret")
+	if orphans["Secret/app/example-api-tls"] {
+		t.Errorf("reflector source Secret/app/example-api-tls should not be orphaned when its istio-system copy is referenced")
+	}
+	if orphans["Secret/istio-system/example-api-tls"] {
+		t.Errorf("referenced reflected Secret/istio-system/example-api-tls should not be orphaned")
+	}
+	if !orphans["Secret/app/other-reflected-tls"] {
+		t.Errorf("Secret/app/other-reflected-tls should still be orphaned when no copy is referenced")
+	}
+}
+
 func TestDeprecatedAPIVersion(t *testing.T) {
 	input := &CheckInput{
 		ClusterVersion: "1.30",


### PR DESCRIPTION
Fixes #1638.

The unused-resource audit checked `cert-manager.io/certificate-name` only as a label, but cert-manager records it as an annotation. Recognize both forms and register Certificate output Secrets and keystore password Secret references through the existing controller-reference collector. This prevents the reported TLS source Secret from being flagged when its reflected copy is consumed in another namespace, including when Radar cannot see that namespace.

The metadata exemption is conservative: a Secret retaining certificate-name metadata after its Certificate is deleted remains excluded from orphan findings. Generic Reflector detection is deferred; it needs explicit source relationships and a way to distinguish missing consumers from incomplete visibility.

Validation: both Go audit test packages and the full application build passed. A live cert-manager test on radar-test-management verified issued TLS Secrets, metadata exemptions, Certificate output and keystore references, unrelated orphan controls, and orphan detection after a Certificate reference was removed. A namespace-only reader denied Certificate access still excluded annotated cert-manager Secrets; annotation-free output and keystore password Secrets remained warnings under that restricted visibility. The Checks page loaded without console errors. Generic Reflector/Istio behavior was not tested.
