### PR TITLE
Stop one saved investigation with no kind from killing the panel

### DIFF
--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -326,3 +326,13 @@ describe('lane identity helpers', () => {
     expect(parseLaneId('bogus')).toBeNull()
   })
 })
+
+describe('pluralToKind on absent input', () => {
+  // A saved investigation can carry an empty kind. This runs over every row of
+  // the run list, so throwing here took the whole investigations panel down and
+  // made every other run unopenable — one bad row, no panel.
+  test('returns the empty string instead of throwing', () => {
+    expect(() => pluralToKind('')).not.toThrow()
+    expect(pluralToKind('')).toBe('')
+  })
+})

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -147,6 +147,10 @@ export function kindToPluralWithGroup(kind: string, group: string): string {
  * singular PascalCase form for internal logic (health checks, badge colors, hierarchy matching).
  */
 export function pluralToKind(plural: string): string {
+  // A saved investigation can carry an empty kind, and this runs over every
+  // row of the run list — indexing [0] of "" threw and took the whole panel
+  // down with it, making every other run unopenable.
+  if (!plural) return plural
   const lower = plural.toLowerCase()
   const pluralToKindMap = getPluralToKind()
 


### PR DESCRIPTION
## Summary

A single saved investigation whose `kind` is empty takes down the entire AI investigations panel. Every other run becomes unopenable, and nothing on screen says why — the panel simply is not there.

`pluralToKind` indexes the first character of its argument to decide whether the value is already a singular PascalCase kind:

```ts
if (plural[0] === plural[0].toUpperCase() && plural[0] !== plural[0].toLowerCase())
```

On an empty string `plural[0]` is `undefined`, so `toUpperCase()` throws. The panel maps **every row of the run history** through this (`Home.tsx:139` and `:248`), so one bad row throws during render and unmounts everything.

Radar writes such a run when an investigation is started without a resolved target, and one already exists in the wild — which is how this was found.

## What changed

An empty kind returns unchanged, so the run renders without a kind, which is what is true about it. Three lines and a regression test.

## Testing

- `packages/k8s-ui` — 174 files, 3,583 pass. `web` — 85 files, 912 pass. `make tsc`, `make build` — pass.
- **Verified against the failure.** With the malformed run still present in the store, a build of this branch opens the investigation panel normally: five evidence cards render and the console is clean. The same store on `main` throws `TypeError: Cannot read properties of undefined (reading 'toUpperCase')` and shows an empty panel.

## Notes

The narrower bug is fixed here. The shape of the failure is worth noting separately: the run list has no error boundary, so any future render error in one row takes the whole panel with it. Containing that is a larger change and is tracked for the next round rather than folded in here.

I checked the same pattern elsewhere before patching. `investigationEvidence.ts:2880` indexes `kinds[0]` but is guarded by `kinds.length === 1`; `RightsizingStrip.tsx:344` indexes `row.confidence[0]`, which the server always sets. Neither is reachable with an empty value today, so neither is touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in navigation utilities with a regression test; no auth, data, or API behavior changes.
> 
> **Overview**
> **`pluralToKind`** now returns empty input unchanged instead of throwing when it reads `plural[0]` for PascalCase detection — a saved investigation with an empty `kind` used to crash render for the whole run list and blank the AI investigations panel.
> 
> A regression test asserts `pluralToKind('')` is `''` and does not throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcda8d93f8e16af9abc37df86182a90f6be93470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->