### PR TITLE
Chart the vitals diagnose captured as Findings evidence

### DIFF
--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -26,6 +26,7 @@ import type { Diagnosis } from "../../api/diagnose";
 import { AssessmentSources, ResultCard } from "./parts";
 import { investigationEvidenceCoverageLimited } from "./investigationState";
 import { groupEvidenceCoverage } from "./investigationEvidencePresentation";
+import { metricsChangeMarkers } from "./investigationMetrics";
 
 const onViewSource = vi.fn();
 const target = {
@@ -3089,6 +3090,188 @@ describe("InvestigationEvidencePane metrics cards", () => {
       "1 change recorded in this window is marked on the chart.",
     );
     expect(html).toContain("Open current Deployment shop/api in Radar");
+  });
+});
+
+describe("InvestigationEvidencePane diagnose vitals", () => {
+  const window = {
+    start: "2026-09-06T07:00:00Z",
+    end: "2026-09-06T08:00:00Z",
+    step: "1m2s",
+  };
+  const vitals = {
+    window,
+    pods: 1,
+    series: [
+      {
+        category: "cpu",
+        unit: "cores",
+        query:
+          "sum(rate(container_cpu_usage_seconds_total{container!='',namespace='shop',pod=~'^(api-abc)$'}[5m]))",
+        series: [
+          {
+            labels: {},
+            dataPoints: [
+              { timestamp: Date.parse(window.start) / 1000, value: 0.12 },
+              { timestamp: Date.parse(window.end) / 1000, value: 0.25 },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("keeps an uncited diagnose chart in the workload collection and marks the same-turn change on it", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        recentChanges: [
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "api",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "worker",
+            changeType: "update",
+            timestamp: "2026-09-06T07:40:00Z",
+          },
+        ],
+        metrics: vitals,
+      }),
+    );
+    const partition = partitionInvestigationEvidence(projection.groups);
+    expect(partition.main.map((group) => group.kind)).not.toContain("metrics");
+    expect(partition.workload.map((group) => group.kind)).toContain("metrics");
+    expect(partition.hiddenMetrics).toBe(0);
+    const onOpenResource = vi.fn();
+    const html = render(projection, false, undefined, undefined, onOpenResource);
+    expect(html).toContain("CPU usage · shop/api");
+    expect(html).toContain("1 pod · 60m window · 1m2s step");
+    expect(html).toContain("(cores)");
+    expect(html.match(/data-chart-annotation="change"/g)).toHaveLength(1);
+    expect(html).toContain("Deployment api");
+    expect(html).not.toContain("Deployment worker");
+    expect(html).toContain(
+      "1 change recorded in this window is marked on the chart.",
+    );
+    expect(html).toContain("Open current Deployment shop/api in Radar");
+  });
+
+  it("never marks the target's changes on a neighbour's chart", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        logsCurrent: [
+          {
+            pod: "api-abc",
+            container: "api",
+            logs: {
+              lines: ["ERROR boom"],
+              totalLines: 1,
+              matchedLines: 1,
+              fallback: false,
+            },
+          },
+        ],
+        recentChanges: [
+          {
+            kind: "Pod",
+            apiVersion: "v1",
+            namespace: "shop",
+            name: "api-abc",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+        ],
+      }),
+      tool(
+        "diag-worker",
+        "diagnose",
+        {
+          resource: {
+            apiVersion: "apps/v1",
+            kind: "Deployment",
+            metadata: { namespace: "shop", name: "worker" },
+          },
+          pods: 1,
+          metrics: vitals,
+        },
+        { summary: JSON.stringify({ namespace: "shop", name: "worker" }) },
+      ),
+    );
+    const chart = projection.groups.find(
+      (group) =>
+        group.kind === "metrics" && group.latest.relevance === "broader",
+    );
+    expect(chart).toBeDefined();
+    expect(metricsChangeMarkers(projection.groups, chart!.latest)).toEqual([]);
+    const targetChart = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        recentChanges: [
+          {
+            kind: "Deployment",
+            apiVersion: "apps/v1",
+            namespace: "shop",
+            name: "api",
+            changeType: "update",
+            timestamp: "2026-09-06T07:30:00Z",
+          },
+        ],
+        metrics: vitals,
+      }),
+    );
+    const target = targetChart.groups.find((group) => group.kind === "metrics");
+    expect(
+      metricsChangeMarkers(targetChart.groups, target!.latest),
+    ).toHaveLength(1);
+  });
+
+  it("shows a workload metrics limitation for a reported producer error", () => {
+    const projection = project(
+      tool("diag", "diagnose", {
+        resource: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { namespace: "shop", name: "api" },
+        },
+        pods: 1,
+        metrics: {
+          window,
+          pods: 1,
+          series: [],
+          error: "metrics omitted: 3s budget exceeded before all queries answered",
+        },
+      }),
+    );
+    const html = render(projection);
+    expect(html).toContain("Workload metrics");
+    expect(html).toContain(
+      "metrics omitted: 3s budget exceeded before all queries answered",
+    );
+    expect(html).not.toContain("CPU usage");
   });
 });
 

--- a/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.test.tsx
@@ -3155,8 +3155,29 @@ describe("InvestigationEvidencePane diagnose vitals", () => {
     expect(partition.main.map((group) => group.kind)).not.toContain("metrics");
     expect(partition.workload.map((group) => group.kind)).toContain("metrics");
     expect(partition.hiddenMetrics).toBe(0);
+    // The vitals lead the collection; the absence receipts follow in their
+    // own order, so a healthy workload does not open on four empty tiles.
+    const kinds = partition.workload.map((group) => group.kind);
+    const firstReceipt = kinds.indexOf("receipt");
+    expect(firstReceipt).toBeGreaterThan(0);
+    expect(kinds.slice(firstReceipt).every((kind) => kind === "receipt")).toBe(
+      true,
+    );
+    expect(kinds.indexOf("metrics")).toBeLessThan(firstReceipt);
+    expect(kinds.indexOf("resource")).toBeLessThan(kinds.indexOf("metrics"));
+    expect(
+      partition.workload
+        .filter((group) => group.kind === "receipt")
+        .map((group) => group.latest.title),
+    ).toEqual(["No classified workload issues", "No matching warning events"]);
     const onOpenResource = vi.fn();
-    const html = render(projection, false, undefined, undefined, onOpenResource);
+    const html = render(
+      projection,
+      false,
+      undefined,
+      undefined,
+      onOpenResource,
+    );
     expect(html).toContain("CPU usage · shop/api");
     expect(html).toContain("1 pod · 60m window · 1m2s step");
     expect(html).toContain("(cores)");
@@ -3262,7 +3283,8 @@ describe("InvestigationEvidencePane diagnose vitals", () => {
           window,
           pods: 1,
           series: [],
-          error: "metrics omitted: 3s budget exceeded before all queries answered",
+          error:
+            "metrics omitted: 3s budget exceeded before all queries answered",
         },
       }),
     );

--- a/web/src/components/diagnose/InvestigationEvidencePane.tsx
+++ b/web/src/components/diagnose/InvestigationEvidencePane.tsx
@@ -227,6 +227,13 @@ export function partitionInvestigationEvidence(
       Number(adverse(right)) - Number(adverse(left)) ||
       left.firstOrder - right.firstOrder,
   );
+  // A healthy workload's collection opens with several "nothing here"
+  // receipts; the cards that carry facts (its vitals above all) come first,
+  // and the receipts keep their order among themselves.
+  collections.workload.sort(
+    (left, right) =>
+      Number(left.kind === "receipt") - Number(right.kind === "receipt"),
+  );
   return { ...collections, collectionByGroup, hiddenBroader, hiddenMetrics };
 }
 

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -6045,6 +6045,60 @@ describe("diagnose metrics evidence", () => {
     }
   });
 
+  it("keeps same-named workloads in different API groups on separate charts", () => {
+    const rollout = {
+      ...deployment,
+      apiVersion: "argoproj.io/v1alpha1",
+      kind: "Rollout",
+    };
+    const projection = project([
+      tool(
+        "diag-deployment",
+        "diagnose",
+        { resource: deployment, pods: 2, metrics: vitals() },
+        { summary: JSON.stringify(args) },
+      ),
+      tool(
+        "diag-rollout",
+        "diagnose",
+        { resource: rollout, pods: 2, metrics: vitals() },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(6);
+    expect(groups.every((group) => group.observations.length === 1)).toBe(
+      true,
+    );
+    expect(new Set(groups.map((group) => group.identity)).size).toBe(6);
+  });
+
+  it("rejects inherited object keys posing as categories", () => {
+    for (const category of ["__proto__", "constructor", "toString"]) {
+      const projection = project([
+        tool(
+          "diag",
+          "diagnose",
+          {
+            resource: deployment,
+            pods: 2,
+            metrics: vitals({
+              series: [{ ...vitals().series[0], category }],
+            }),
+          },
+          { summary: JSON.stringify(args) },
+        ),
+      ]);
+      expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+      expect(
+        projection.limitations.some(
+          (item) =>
+            item.source === "Workload metrics" && item.kind === "unknown",
+        ),
+      ).toBe(true);
+    }
+  });
+
   it("rejects a category outside the contract or a series without a unit", () => {
     const projection = project([
       tool(

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5886,9 +5886,7 @@ describe("diagnose metrics evidence", () => {
     );
     const groups = groupsOf(projection.groups, "metrics");
     expect(groups).toHaveLength(3);
-    expect(groups.every((group) => group.observations.length === 2)).toBe(
-      true,
-    );
+    expect(groups.every((group) => group.observations.length === 2)).toBe(true);
     const data = groups[0].latest.data;
     if (data.type !== "metrics") throw new Error("expected metrics");
     expect(data.end).toBe("2026-09-06T08:30:00Z");
@@ -5904,7 +5902,8 @@ describe("diagnose metrics evidence", () => {
           pods: 2,
           metrics: vitals({
             series: [vitals().series[1]],
-            error: "cpu: prom: query error from prometheus: cpu exploded (execution)",
+            error:
+              "cpu: prom: query error from prometheus: cpu exploded (execution)",
           }),
         },
         { summary: JSON.stringify(args) },
@@ -5928,7 +5927,8 @@ describe("diagnose metrics evidence", () => {
           pods: 2,
           metrics: vitals({
             series: [],
-            error: "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
+            error:
+              "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
           }),
         },
         { summary: JSON.stringify(args) },
@@ -6067,9 +6067,7 @@ describe("diagnose metrics evidence", () => {
     ]);
     const groups = groupsOf(projection.groups, "metrics");
     expect(groups).toHaveLength(6);
-    expect(groups.every((group) => group.observations.length === 1)).toBe(
-      true,
-    );
+    expect(groups.every((group) => group.observations.length === 1)).toBe(true);
     expect(new Set(groups.map((group) => group.identity)).size).toBe(6);
   });
 
@@ -6124,8 +6122,7 @@ describe("diagnose metrics evidence", () => {
     ]);
     expect(
       projection.limitations.some(
-        (item) =>
-          item.source === "Workload metrics" && item.kind === "unknown",
+        (item) => item.source === "Workload metrics" && item.kind === "unknown",
       ),
     ).toBe(true);
   });

--- a/web/src/components/diagnose/investigationEvidence.test.ts
+++ b/web/src/components/diagnose/investigationEvidence.test.ts
@@ -5764,3 +5764,315 @@ describe("resource cards scaled by an HPA", () => {
     expect(card.summary).toBe("5/5 replicas ready");
   });
 });
+
+describe("diagnose metrics evidence", () => {
+  const window = {
+    start: "2026-09-06T07:00:00Z",
+    end: "2026-09-06T08:00:00Z",
+    step: "1m2s",
+  };
+  const samples = [
+    { timestamp: Date.parse(window.start) / 1000, value: 0.003457 },
+    { timestamp: Date.parse(window.end) / 1000, value: 0.004 },
+  ];
+  function vitals(patch: Record<string, unknown> = {}) {
+    return {
+      window,
+      pods: 2,
+      series: [
+        {
+          category: "cpu",
+          unit: "cores",
+          query:
+            "sum(rate(container_cpu_usage_seconds_total{container!='',namespace='shop',pod=~'^(api-a|api-b)$'}[5m]))",
+          series: [{ labels: {}, dataPoints: samples }],
+        },
+        {
+          category: "memory",
+          unit: "bytes",
+          query:
+            "sum(max by (pod,namespace,container) (container_memory_working_set_bytes{container!='',namespace='shop',pod=~'^(api-a|api-b)$'}))",
+          series: [{ labels: {}, dataPoints: samples }],
+        },
+        {
+          category: "restarts",
+          unit: "count",
+          query:
+            "sum(round(increase(kube_pod_container_status_restarts_total{namespace='shop',pod=~'^(api-a|api-b)$'}[1h])))",
+          series: [],
+        },
+      ],
+      ...patch,
+    };
+  }
+  const args = { kind: "Deployment", namespace: "shop", name: "api" };
+
+  it("charts each captured category as target evidence with the diagnosed resource as subject", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        { resource: deployment, pods: 2, metrics: vitals() },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups.map((group) => group.latest.title)).toEqual([
+      "CPU usage · Deployment shop/api",
+      "Memory working set · Deployment shop/api",
+      "Restarts · Deployment shop/api",
+    ]);
+    for (const group of groups) {
+      expect(group.latest.relevance).toBe("target");
+      expect(group.latest.tier).toBe("supporting");
+      expect(group.latest.tone).toBe("neutral");
+      const data = group.latest.data;
+      if (data.type !== "metrics") throw new Error("expected metrics");
+      expect(data.origin).toBe("diagnose");
+      expect(data.mode).toBe("range");
+      expect(data.start).toBe(window.start);
+      expect(data.end).toBe(window.end);
+      expect(data.step).toBe(window.step);
+      expect(data.pods).toBe(2);
+      expect(data.partial).toBe(false);
+      expect(data.truncated).toBe(false);
+      expect(data.subject).toEqual({
+        kind: "Deployment",
+        group: "apps",
+        namespace: "shop",
+        name: "api",
+      });
+      expect(investigationEvidenceSubjectRef(data)).toEqual(data.subject);
+    }
+    const [cpu, , restarts] = groups;
+    expect(cpu.latest.summary).toBe("2 pods · 60m window · 1m2s step");
+    const cpuData = cpu.latest.data;
+    if (cpuData.type !== "metrics") throw new Error("expected metrics");
+    expect(cpuData.unit).toBe("cores");
+    expect(cpuData.label).toBe("CPU usage");
+    expect(cpuData.query).toContain("pod=~'^(api-a|api-b)$'");
+    expect(cpuData.series).toEqual([{ labels: {}, dataPoints: samples }]);
+    expect(restarts.latest.summary).toBe(
+      "No samples in the window · 60m window · 1m2s step",
+    );
+    expect(
+      projection.limitations.filter(
+        (item) => item.source === "Workload metrics",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("merges a re-diagnose of the same workload into the same chart per category", () => {
+    const later = vitals({
+      window: { ...window, end: "2026-09-06T08:30:00Z" },
+    });
+    const projection = project(
+      [
+        tool(
+          "diag-1",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics: vitals() },
+          { summary: JSON.stringify(args) },
+        ),
+      ],
+      [
+        tool(
+          "diag-2",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics: later },
+          { summary: JSON.stringify(args) },
+        ),
+      ],
+    );
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(3);
+    expect(groups.every((group) => group.observations.length === 2)).toBe(
+      true,
+    );
+    const data = groups[0].latest.data;
+    if (data.type !== "metrics") throw new Error("expected metrics");
+    expect(data.end).toBe("2026-09-06T08:30:00Z");
+  });
+
+  it("reports a producer error as a limitation and still charts what answered", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [vitals().series[1]],
+            error: "cpu: prom: query error from prometheus: cpu exploded (execution)",
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(1);
+    const limitation = projection.limitations.find(
+      (item) => item.source === "Workload metrics",
+    );
+    expect(limitation?.kind).toBe("error");
+    expect(limitation?.message).toContain("cpu exploded");
+  });
+
+  it("reports an unreachable Prometheus without inventing a chart", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [],
+            error: "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    const limitation = projection.limitations.find(
+      (item) => item.source === "Workload metrics",
+    );
+    expect(limitation?.kind).toBe("error");
+    expect(limitation?.message).toBe(
+      "prometheus unreachable: dial tcp 10.0.0.9:9090: connection refused",
+    );
+  });
+
+  it("says nothing when diagnose carried no metrics field", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        { resource: deployment, pods: 2 },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+    expect(
+      projection.limitations.some((item) => item.source === "Workload metrics"),
+    ).toBe(false);
+  });
+
+  it("notes a partial pod set in the summary and keeps the cap on the card", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 55,
+          metrics: vitals({ pods: 50, partial: true, omittedPods: 5 }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const [cpu] = groupsOf(projection.groups, "metrics");
+    expect(cpu.latest.summary).toBe(
+      "first 50 of 55 pods · 60m window · 1m2s step · partial pod set",
+    );
+    const data = cpu.latest.data;
+    if (data.type !== "metrics") throw new Error("expected metrics");
+    expect(data.pods).toBe(50);
+    expect(data.partial).toBe(true);
+  });
+
+  it("keeps a neighbour's vitals broader with the neighbour as subject", () => {
+    const worker = {
+      ...deployment,
+      metadata: { namespace: "shop", name: "worker" },
+    };
+    const projection = project([
+      tool(
+        "diag-worker",
+        "diagnose",
+        { resource: worker, pods: 2, metrics: vitals() },
+        {
+          summary: JSON.stringify({
+            kind: "Deployment",
+            namespace: "shop",
+            name: "worker",
+          }),
+        },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups).toHaveLength(3);
+    for (const group of groups) {
+      expect(group.latest.relevance).toBe("broader");
+      expect(group.latest.tier).toBe("context");
+      const data = group.latest.data;
+      if (data.type !== "metrics") throw new Error("expected metrics");
+      expect(data.subject).toEqual({
+        kind: "Deployment",
+        group: "apps",
+        namespace: "shop",
+        name: "worker",
+      });
+    }
+  });
+
+  it("rejects a malformed metrics field instead of charting it", () => {
+    const malformed: Record<string, unknown>[] = [
+      { window: { start: window.start }, pods: "two", series: [] },
+      { window: { ...window, end: "not a date" }, pods: 2, series: [] },
+      { window: { ...window, end: window.start }, pods: 2, series: [] },
+      { window, pods: -1, series: [] },
+      { window, pods: 1.5, series: [] },
+      { window, pods: 2, omittedPods: -3, series: [] },
+    ];
+    for (const metrics of malformed) {
+      const projection = project([
+        tool(
+          "diag",
+          "diagnose",
+          { resource: deployment, pods: 2, metrics },
+          { summary: JSON.stringify(args) },
+        ),
+      ]);
+      expect(groupsOf(projection.groups, "metrics")).toHaveLength(0);
+      expect(
+        projection.limitations.some(
+          (item) =>
+            item.source === "Workload metrics" && item.kind === "unknown",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects a category outside the contract or a series without a unit", () => {
+    const projection = project([
+      tool(
+        "diag",
+        "diagnose",
+        {
+          resource: deployment,
+          pods: 2,
+          metrics: vitals({
+            series: [
+              { ...vitals().series[0], category: "latency" },
+              { ...vitals().series[1], unit: undefined },
+              vitals().series[2],
+            ],
+          }),
+        },
+        { summary: JSON.stringify(args) },
+      ),
+    ]);
+    const groups = groupsOf(projection.groups, "metrics");
+    expect(groups.map((group) => group.latest.title)).toEqual([
+      "Restarts · Deployment shop/api",
+    ]);
+    expect(
+      projection.limitations.some(
+        (item) =>
+          item.source === "Workload metrics" && item.kind === "unknown",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -4786,7 +4786,7 @@ function addDiagnoseMetrics(
     if (
       !entry ||
       !nonEmptyString(entry.category) ||
-      !(entry.category in DIAGNOSE_METRICS_LABELS) ||
+      !Object.hasOwn(DIAGNOSE_METRICS_LABELS, entry.category) ||
       !nonEmptyString(entry.query) ||
       !nonEmptyString(entry.unit) ||
       !Array.isArray(rawSeries) ||
@@ -4814,7 +4814,7 @@ function addDiagnoseMetrics(
       partial,
     };
     builder.observe(
-      `metrics:diagnose:${scope}:${entry.category}`,
+      `metrics:diagnose:${subject.group ?? ""}:${subject.kind}:${subject.namespace ?? ""}:${subject.name}:${entry.category}`,
       "metrics",
       source,
       {

--- a/web/src/components/diagnose/investigationEvidence.ts
+++ b/web/src/components/diagnose/investigationEvidence.ts
@@ -2852,6 +2852,21 @@ function adaptDiagnose(
   if (nonEmptyString(value.recentChangesError)) {
     builder.limit(source, "Recent changes", value.recentChangesError, "error");
   }
+
+  addDiagnoseMetrics(
+    builder,
+    source,
+    value.metrics,
+    {
+      kind: resource.kind,
+      ...(apiVersionToGroup(resource.apiVersion)
+        ? { group: apiVersionToGroup(resource.apiVersion) }
+        : {}),
+      namespace: resource.metadata.namespace,
+      name: resource.metadata.name,
+    },
+    bundleRelevance,
+  );
   if (value.recentChangesSaturated === true) {
     builder.limit(
       source,
@@ -4706,6 +4721,121 @@ function metricsWindowLabel(data: {
   return data.step
     ? `${window} window · ${data.step} step`
     : `${window} window`;
+}
+
+const DIAGNOSE_METRICS_LABELS: Record<string, string> = {
+  cpu: "CPU usage",
+  memory: "Memory working set",
+  restarts: "Restarts",
+};
+
+/**
+ * The vitals `diagnose` captured inside the same call: one chart per category
+ * over the exact pods the bundle covers. They take the bundle's relevance, so a
+ * neighbour's diagnose never charts as evidence for the target, and they carry
+ * the diagnosed resource as their subject so recorded changes can be marked
+ * on them. An absent field means Prometheus was not available or the read was
+ * not permitted, which is not a collection failure the producer reported.
+ */
+function addDiagnoseMetrics(
+  builder: ProjectionBuilder,
+  source: InvestigationEvidenceSource,
+  raw: unknown,
+  subject: DiagnosisResourceRef,
+  relevance: InvestigationEvidenceRelevance,
+): void {
+  if (raw === undefined) return;
+  const value = record(raw);
+  const window = record(value?.window);
+  if (
+    !value ||
+    !window ||
+    !nonEmptyString(window.start) ||
+    !nonEmptyString(window.end) ||
+    !nonEmptyString(window.step) ||
+    !(Date.parse(window.end) > Date.parse(window.start)) ||
+    !nonNegativeInteger(value.pods) ||
+    (value.partial !== undefined && typeof value.partial !== "boolean") ||
+    (value.omittedPods !== undefined &&
+      !nonNegativeInteger(value.omittedPods)) ||
+    (value.error !== undefined && typeof value.error !== "string") ||
+    !Array.isArray(value.series)
+  ) {
+    invalidPayload(builder, source, "Workload metrics");
+    return;
+  }
+  const scope = scopeFromArgs(source);
+  const partial = value.partial === true;
+  const podsLabel = partial
+    ? `first ${value.pods} of ${typeof value.omittedPods === "number" ? value.pods + value.omittedPods : "the"} pods`
+    : `${value.pods} pod${value.pods === 1 ? "" : "s"}`;
+  const windowLabel = metricsWindowLabel({
+    mode: "range",
+    start: window.start,
+    end: window.end,
+    step: window.step,
+  });
+  for (const rawEntry of value.series) {
+    const entry = record(rawEntry);
+    const rawSeries = entry?.series;
+    const series = Array.isArray(rawSeries)
+      ? rawSeries
+          .map(timeSeries)
+          .filter((item): item is TimeSeries => Boolean(item))
+      : undefined;
+    if (
+      !entry ||
+      !nonEmptyString(entry.category) ||
+      !(entry.category in DIAGNOSE_METRICS_LABELS) ||
+      !nonEmptyString(entry.query) ||
+      !nonEmptyString(entry.unit) ||
+      !Array.isArray(rawSeries) ||
+      !series ||
+      series.length !== rawSeries.length
+    ) {
+      invalidPayload(builder, source, "Workload metrics");
+      continue;
+    }
+    const label = DIAGNOSE_METRICS_LABELS[entry.category];
+    const data: InvestigationMetricsEvidence = {
+      type: "metrics",
+      origin: "diagnose",
+      query: entry.query,
+      mode: "range",
+      start: window.start,
+      end: window.end,
+      step: window.step,
+      unit: entry.unit,
+      label,
+      series,
+      truncated: false,
+      subject,
+      pods: value.pods,
+      partial,
+    };
+    builder.observe(
+      `metrics:diagnose:${scope}:${entry.category}`,
+      "metrics",
+      source,
+      {
+        tier: evidenceTierForRelevance("supporting", relevance),
+        relevance,
+        tone: "neutral",
+        title: `${label} · ${scope}`,
+        summary: [
+          series.length === 0 ? "No samples in the window" : podsLabel,
+          windowLabel,
+          partial ? "partial pod set" : undefined,
+        ]
+          .filter((part): part is string => Boolean(part))
+          .join(" · "),
+        data,
+      },
+    );
+  }
+  if (nonEmptyString(value.error)) {
+    builder.limit(source, "Workload metrics", value.error, "error");
+  }
 }
 
 function adaptQueryPrometheus(

--- a/web/src/components/diagnose/investigationMetrics.ts
+++ b/web/src/components/diagnose/investigationMetrics.ts
@@ -199,7 +199,16 @@ export function metricsChangeMarkers(
   observation: InvestigationEvidenceObservation,
 ): ChartAnnotation[] {
   const { data } = observation;
-  if (data.type !== "metrics" || !data.subject) return [];
+  // A broader chart's subject is a neighbour; the turn's non-broader relatives
+  // and changes all belong to the target, so marking them there would
+  // attribute the target's changes to the neighbour.
+  if (
+    data.type !== "metrics" ||
+    !data.subject ||
+    observation.relevance === "broader"
+  ) {
+    return [];
+  }
   const domain = metricsDomain(data);
   if (!domain) return [];
   const turnIndex = observation.source.turnIndex;


### PR DESCRIPTION
## Summary

`diagnose` returns a `metrics` field for workload targets — CPU, memory and restarts over the exact pods the bundle resolved (#1679, on `main`). Findings did not render it. This PR projects each category as a chart card in the shape the Prometheus chart cards already use (#1684), so the chart, the agent and the ledger hold the same numbers over the same window and the same pods, and the changes Radar recorded for that workload in the same turn are marked on it.

## What changed

**`addDiagnoseMetrics`** (`investigationEvidence.ts`) — one `metrics` observation per category with `origin: "diagnose"`, `mode: "range"`, the producer's own `query` and `unit`, a category label (`CPU usage`, `Memory working set`, `Restarts`), the diagnosed resource as `subject`, and `pods` / `partial` from the field.

- **Relevance follows the bundle** (`relevanceForResource`), never an unconditional target — a neighbour's vitals stay `broader` with the neighbour as subject.
- **Identity is `metrics:diagnose:<subject>:<category>`**, keyed by the diagnosed resource rather than its display scope, so a re-diagnose revises the same three cards instead of stacking new ones.
- **Summary line** reads `N pods · 60m window · 1m2s step`; `first 50 of 55 pods … · partial pod set` when the producer capped the set; `No samples in the window` for an empty series.
- **Failure is distinguished from absence.** `metrics.error` becomes a "Workload metrics" limitation while the categories that did answer still chart. An *absent* field emits nothing at all — Prometheus not configured, or the read not permitted, is not a collection failure and must not be reported as one.
- **Validation enforces the documented contract** before anything renders: a known category (own-property test, so inherited keys like `__proto__` cannot pass), a non-empty unit, non-negative integer counts, and a window whose end is after its start. Anything else is an invalid-payload limitation, never a card.

**`metricsChangeMarkers`** (`investigationMetrics.ts`) — no markers on a `broader` chart. The turn's non-broader relatives and change observations all belong to the target, so drawing them on a neighbour's chart would attribute the target's changes to it. That path is reachable only now that a diagnose chart can carry a neighbour as its subject.

**`partitionInvestigationEvidence`** (`InvestigationEvidencePane.tsx`) — inside "More evidence about this workload", cards that carry facts sort ahead of receipt-kind cards ("No classified workload issues", "No matching warning events"), which keep their order among themselves. A healthy workload no longer opens on four empty tiles before its vitals.

Placement: these observations sit in "More evidence about this workload" rather than the main collection.

## Testing

- `make tsc` ✓ · `web` 87 files / 1037 tests ✓ · `git diff --check` clean. No Go delta.
- Adapter tests: three series → three cards with subject, unit, label, window and pod count; a re-diagnose merging into the same cards; a producer error becoming a limitation while the surviving series still chart; an unreachable Prometheus as a limitation with no card; an absent field emitting nothing; a partial pod set noted in the summary; a neighbour's diagnose landing as `broader` with the neighbour as subject; six malformed envelopes plus an out-of-contract category and a missing unit rejected.
- Pane tests: a diagnose-origin chart in the workload collection with the same-turn Deployment change marked and the resource link present; the neighbour guard on the marker function; the limitation row for a producer error; and the receipt ordering — vitals first, receipts last and contiguous.
- Visual test (light, dark, narrow) against a saved investigation with the `metrics` field present: three cards titled per category showing `1 pod · 60m window · 1m2s step`, axis label and unit, three recorded changes marked with "3 changes recorded in this window are marked on the chart", the earlier diagnose folded under "Previous observations · 1", and the "Open current Deployment" link.

## Scope and tradeoffs

- Restarts render with unit `count`, which the shared formatter treats as unitless (values like `1.00`). A `count` case in `formatMetricValue` is a `k8s-ui` follow-up.
- Marker labels for several changes on the same resource within minutes overlap in the chart — that is the marker rendering shared with #1684.
- Recorded changes carrying no `apiVersion` (synthesized Helm rows, older stores) never match a chart subject and so are not marked. That rule is #1684's; it is restated here because a chart of a workload's own vitals is where its absence is most visible.

## Note on history

This is #1690 re-based onto `main`. It was approved and marked merged, but its base was the integration branch `feat/findings-next-layer`, so its content never reached `main`. The commits are the same three; the Prettier-only commit was dropped and the formatting applied directly. Rebase conflicts were confined to `InvestigationEvidencePane` and its test — the counters #1684 made disjoint (`hiddenBroader` / `hiddenMetrics`) are preserved alongside the new receipt-ordering sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125QDX24TNuod7FKLwTDhvW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evidence projection and chart annotation rules for diagnose output; validation is strict but malformed or partial metrics could affect what users see in investigations.
> 
> **Overview**
> Findings now surfaces the **`metrics` payload from `diagnose`** as workload chart cards (CPU, memory, restarts), aligned with existing Prometheus-style metrics evidence instead of ignoring that field.
> 
> **`addDiagnoseMetrics`** turns each valid category into a range chart with `origin: "diagnose"`, the producer query/unit, the diagnosed resource as **subject**, and relevance that follows the bundle (neighbour diagnoses stay **broader**). Re-diagnoses merge on stable identity; **`metrics.error`** becomes a "Workload metrics" limitation while partial series still render; a missing field stays silent; malformed payloads are rejected with limitations, not cards.
> 
> **`metricsChangeMarkers`** skips **broader** charts so same-turn target changes are not drawn on a neighbour’s vitals. **`partitionInvestigationEvidence`** sorts the workload section so fact cards (including vitals) appear before contiguous **receipt** tiles.
> 
> Coverage is mostly new adapter and pane tests for projection, merging, errors, ordering, change markers, and neighbour guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf9c12489b9e63c593ed676d4d46e5a983657b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->