### PR TITLE
feat(k8score): drain classifier and read-only drain plan endpoint (#1584, part 1)

### DIFF
--- a/internal/k8s/node_ops.go
+++ b/internal/k8s/node_ops.go
@@ -15,6 +15,9 @@ type DrainOptions = k8score.DrainOptions
 // DrainResult is an alias for the reusable DrainResult type.
 type DrainResult = k8score.DrainResult
 
+// DrainPlan is an alias for the reusable DrainPlan type.
+type DrainPlan = k8score.DrainPlan
+
 // CordonNode marks a node as unschedulable.
 func CordonNode(ctx context.Context, nodeName string) error {
 	client := GetClient()
@@ -65,4 +68,13 @@ func DrainNodeWithClient(ctx context.Context, nodeName string, opts DrainOptions
 		return nil, fmt.Errorf("not connected to cluster")
 	}
 	return k8score.DrainNode(ctx, client, nodeName, opts)
+}
+
+// PlanNodeDrainWithClient computes a read-only drain plan with a caller-supplied client
+// (so the plan is evaluated under the caller's RBAC identity). It never mutates the cluster.
+func PlanNodeDrainWithClient(ctx context.Context, nodeName string, opts DrainOptions, client kubernetes.Interface) (*DrainPlan, error) {
+	if client == nil {
+		return nil, fmt.Errorf("not connected to cluster")
+	}
+	return k8score.PlanNodeDrain(ctx, client, nodeName, opts)
 }

--- a/internal/server/node_handlers.go
+++ b/internal/server/node_handlers.go
@@ -92,6 +92,75 @@ func (s *Server) handleUncordonNode(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, map[string]string{"status": "ok", "message": "Node uncordoned"})
 }
 
+// drainOptionsFromRequest turns the JSON body shared by the drain and drain-plan
+// endpoints into DrainOptions. The two endpoints differ only in what an omitted
+// deleteEmptyDirData means: the drain keeps its historical default (true, matching
+// kubectl drain --delete-emptydir-data), the plan defaults to false so a preview
+// never silently includes emptyDir data. The plan echoes the options it used.
+func drainOptionsFromRequest(req DrainRequest, deleteEmptyDirDefault bool) k8s.DrainOptions {
+	deleteLocal := deleteEmptyDirDefault
+	if req.DeleteEmptyDirData != nil {
+		deleteLocal = *req.DeleteEmptyDirData
+	}
+	opts := k8s.DrainOptions{
+		IgnoreDaemonSets:   true,
+		DeleteEmptyDirData: deleteLocal,
+		Force:              req.Force,
+		GracePeriodSeconds: req.GracePeriodSeconds,
+		Timeout:            60 * time.Second,
+	}
+	if req.Timeout > 0 {
+		opts.Timeout = time.Duration(req.Timeout) * time.Second
+	}
+	return opts
+}
+
+// handleDrainPlan returns a read-only estimate of what draining the node would do:
+// per-pod evict / skip / may-block outcomes with reasons, evaluated with the requesting
+// user's client. Nothing is cordoned or evicted. The result is a snapshot; the drain
+// endpoint re-lists and re-evaluates live state when it runs.
+func (s *Server) handleDrainPlan(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	nodeName := chi.URLParam(r, "name")
+	if nodeName == "" {
+		s.writeError(w, http.StatusBadRequest, "node name is required")
+		return
+	}
+
+	var req DrainRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	opts := drainOptionsFromRequest(req, false)
+
+	client := s.getClientForRequest(r)
+	if client == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "cluster client not available — check cluster connection")
+		return
+	}
+
+	plan, err := k8s.PlanNodeDrainWithClient(r.Context(), nodeName, opts, client)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if apierrors.IsForbidden(err) {
+			s.writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		log.Printf("[node-ops] Failed to plan drain for node %s: %v", nodeName, err)
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	s.writeJSON(w, plan)
+}
+
 func (s *Server) handleDrainNode(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -111,20 +180,7 @@ func (s *Server) handleDrainNode(w http.ResponseWriter, r *http.Request) {
 
 	// DeleteEmptyDirData defaults true (matching kubectl drain --delete-emptydir-data).
 	// Most pods use emptyDir for tmp/caches; without this, drain skips almost everything.
-	deleteLocal := true
-	if req.DeleteEmptyDirData != nil {
-		deleteLocal = *req.DeleteEmptyDirData
-	}
-	opts := k8s.DrainOptions{
-		IgnoreDaemonSets:   true,
-		DeleteEmptyDirData: deleteLocal,
-		Force:              req.Force,
-		GracePeriodSeconds: req.GracePeriodSeconds,
-		Timeout:            60 * time.Second,
-	}
-	if req.Timeout > 0 {
-		opts.Timeout = time.Duration(req.Timeout) * time.Second
-	}
+	opts := drainOptionsFromRequest(req, true)
 
 	auth.AuditLog(r, "", nodeName)
 	client := s.getClientForRequest(r)

--- a/internal/server/node_handlers_test.go
+++ b/internal/server/node_handlers_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDrainOptionsFromRequestDefaults(t *testing.T) {
+	no := false
+	yes := true
+	grace := int64(5)
+
+	tests := []struct {
+		name            string
+		req             DrainRequest
+		emptyDirDefault bool
+		wantEmptyDir    bool
+		wantForce       bool
+		wantTimeout     time.Duration
+	}{
+		{name: "drain keeps its historical emptyDir default", req: DrainRequest{}, emptyDirDefault: true, wantEmptyDir: true, wantTimeout: 60 * time.Second},
+		{name: "plan never includes emptyDir data unless asked", req: DrainRequest{}, emptyDirDefault: false, wantEmptyDir: false, wantTimeout: 60 * time.Second},
+		{name: "explicit false overrides the drain default", req: DrainRequest{DeleteEmptyDirData: &no}, emptyDirDefault: true, wantEmptyDir: false, wantTimeout: 60 * time.Second},
+		{name: "explicit true overrides the plan default", req: DrainRequest{DeleteEmptyDirData: &yes, Force: true, Timeout: 120}, emptyDirDefault: false, wantEmptyDir: true, wantForce: true, wantTimeout: 120 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := drainOptionsFromRequest(tt.req, tt.emptyDirDefault)
+			if !got.IgnoreDaemonSets {
+				t.Fatalf("DaemonSets must always be ignored")
+			}
+			if got.DeleteEmptyDirData != tt.wantEmptyDir || got.Force != tt.wantForce || got.Timeout != tt.wantTimeout {
+				t.Fatalf("got %+v", got)
+			}
+		})
+	}
+
+	got := drainOptionsFromRequest(DrainRequest{GracePeriodSeconds: &grace}, false)
+	if got.GracePeriodSeconds == nil || *got.GracePeriodSeconds != 5 {
+		t.Fatalf("grace period must pass through, got %+v", got.GracePeriodSeconds)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -659,9 +659,11 @@ func (s *Server) setupAppRoutes(r chi.Router) {
 			r.Post("/nodes/{name}/debug", s.handleNodeDebug)
 			r.Delete("/nodes/{name}/debug", s.handleNodeDebugCleanup)
 
-			// Node operations (cordon/uncordon)
+			// Node operations (cordon/uncordon) and the read-only drain plan.
+			// The drain itself lives outside this timeout group, see above.
 			r.Post("/nodes/{name}/cordon", s.handleCordonNode)
 			r.Post("/nodes/{name}/uncordon", s.handleUncordonNode)
+			r.Post("/nodes/{name}/drain-plan", s.handleDrainPlan)
 
 			// Pod file browser
 			r.Get("/pods/{namespace}/{name}/files", s.handlePodFileList)

--- a/pkg/k8score/drain_plan.go
+++ b/pkg/k8score/drain_plan.go
@@ -1,0 +1,207 @@
+package k8score
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DrainOutcome is what a drain is expected to do with one pod.
+type DrainOutcome string
+
+const (
+	// DrainOutcomeEvict: the pod would be evicted.
+	DrainOutcomeEvict DrainOutcome = "evict"
+	// DrainOutcomeSkip: the pod would be left alone (DaemonSet, mirror, unmanaged, emptyDir, terminal).
+	DrainOutcomeSkip DrainOutcome = "skip"
+	// DrainOutcomeMayBlock: the pod would be evicted, but a PodDisruptionBudget currently allows no
+	// disruptions, so the eviction may be refused until the budget recovers. Evidence, not a verdict:
+	// only the Eviction API and live state decide.
+	DrainOutcomeMayBlock DrainOutcome = "may-block"
+)
+
+// PodDrainDecision is the per-pod result of ClassifyPodForDrain.
+type PodDrainDecision struct {
+	Namespace    string       `json:"namespace"`
+	Name         string       `json:"name"`
+	Outcome      DrainOutcome `json:"outcome"`
+	Reason       string       `json:"reason"`
+	PDB          string       `json:"pdb,omitempty"` // namespace/name of the PDB behind a may-block outcome
+	PDBEvaluated bool         `json:"pdbEvaluated"`  // false when PDBs for this namespace could not be listed
+}
+
+// ClassifyPodForDrain decides, without touching the cluster, what DrainNode would do with pod
+// under opts. The rules mirror kubectl drain: terminal and mirror pods are always skipped,
+// DaemonSet pods are skipped when IgnoreDaemonSets is set, pods without a controller owner need
+// Force, pods using emptyDir need DeleteEmptyDirData. A pod that would be evicted but is covered
+// by a PDB with no disruptions allowed is reported as may-block.
+func ClassifyPodForDrain(pod corev1.Pod, opts DrainOptions, pdbs []policyv1.PodDisruptionBudget) PodDrainDecision {
+	d := PodDrainDecision{Namespace: pod.Namespace, Name: pod.Name, PDBEvaluated: pdbs != nil}
+	skip := func(reason string) PodDrainDecision {
+		d.Outcome, d.Reason = DrainOutcomeSkip, reason
+		return d
+	}
+
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return skip(fmt.Sprintf("pod is %s; nothing to evict", string(pod.Status.Phase)))
+	}
+	if _, isMirror := pod.Annotations[corev1.MirrorPodAnnotationKey]; isMirror {
+		return skip("static (mirror) pod managed by the kubelet; cannot be evicted")
+	}
+	controller := metav1.GetControllerOf(&pod)
+	if controller != nil && controller.Kind == "DaemonSet" && opts.IgnoreDaemonSets {
+		return skip("managed by a DaemonSet; the DaemonSet controller would recreate it on this node")
+	}
+	if controller == nil && !opts.Force {
+		return skip("not managed by a controller; would be lost, enable force to evict anyway")
+	}
+	if !opts.DeleteEmptyDirData && hasLocalStorage(pod) {
+		return skip("uses emptyDir volumes; their data is lost on eviction, enable deleteEmptyDirData to evict")
+	}
+
+	if name, blocked := pdbBlocking(pod, pdbs); blocked {
+		d.Outcome = DrainOutcomeMayBlock
+		d.PDB = name
+		d.Reason = fmt.Sprintf("PodDisruptionBudget %s currently allows no disruptions; the eviction may be refused until the budget recovers", name)
+		return d
+	}
+
+	d.Outcome = DrainOutcomeEvict
+	switch {
+	case controller == nil:
+		d.Reason = "not managed by a controller; evicted because force is set"
+	case !opts.IgnoreDaemonSets && controller.Kind == "DaemonSet":
+		d.Reason = "managed by a DaemonSet; evicted because DaemonSets are not ignored"
+	default:
+		d.Reason = fmt.Sprintf("managed by %s %s; the controller reschedules it", controller.Kind, controller.Name)
+	}
+	return d
+}
+
+// pdbBlocking returns the first PDB in the pod's namespace that selects the pod and has
+// no disruptions allowed. A nil selector matches nothing, an empty selector matches everything,
+// matching the policy/v1 semantics.
+func pdbBlocking(pod corev1.Pod, pdbs []policyv1.PodDisruptionBudget) (string, bool) {
+	podLabels := labels.Set(pod.Labels)
+	for i := range pdbs {
+		p := &pdbs[i]
+		if p.Namespace != pod.Namespace || p.Spec.Selector == nil || p.Status.DisruptionsAllowed > 0 {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(p.Spec.Selector)
+		if err != nil || !selector.Matches(podLabels) {
+			continue
+		}
+		return p.Namespace + "/" + p.Name, true
+	}
+	return "", false
+}
+
+// DrainPlanOptions echoes the options a plan was evaluated with, so the caller never has to
+// guess which defaults applied.
+type DrainPlanOptions struct {
+	IgnoreDaemonSets   bool   `json:"ignoreDaemonSets"`
+	DeleteEmptyDirData bool   `json:"deleteEmptyDirData"`
+	Force              bool   `json:"force"`
+	GracePeriodSeconds *int64 `json:"gracePeriodSeconds,omitempty"`
+}
+
+// DrainPlanSummary counts pods per outcome.
+type DrainPlanSummary struct {
+	Evict    int `json:"evict"`
+	Skip     int `json:"skip"`
+	MayBlock int `json:"mayBlock"`
+}
+
+// DrainPlan is a read-only estimate of what draining a node would do. It is computed from a
+// snapshot: pods, budgets and permissions can change before the drain runs, which re-lists and
+// re-evaluates live state.
+type DrainPlan struct {
+	Node          string             `json:"node"`
+	GeneratedAt   time.Time          `json:"generatedAt"`
+	Estimate      bool               `json:"estimate"` // always true; execution re-evaluates
+	Options       DrainPlanOptions   `json:"options"`
+	Summary       DrainPlanSummary   `json:"summary"`
+	Pods          []PodDrainDecision `json:"pods"`
+	PDBsEvaluated bool               `json:"pdbsEvaluated"`      // false when at least one namespace's PDBs could not be listed
+	PDBError      string             `json:"pdbError,omitempty"` // why, when PDBsEvaluated is false
+}
+
+// PlanNodeDrain lists the pods on nodeName and classifies each one with ClassifyPodForDrain.
+// It performs only reads with the given client, so it runs under the caller's RBAC identity and
+// never cordons or evicts. PDBs are listed per namespace; a namespace whose PDBs cannot be read
+// is classified without PDB knowledge and reported as such instead of pretending no PDB exists.
+func PlanNodeDrain(ctx context.Context, client kubernetes.Interface, nodeName string, opts DrainOptions) (*DrainPlan, error) {
+	if _, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{}); err != nil {
+		return nil, err
+	}
+	podList, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods on node: %w", err)
+	}
+
+	plan := &DrainPlan{
+		Node:        nodeName,
+		GeneratedAt: time.Now().UTC(),
+		Estimate:    true,
+		Options: DrainPlanOptions{
+			IgnoreDaemonSets:   opts.IgnoreDaemonSets,
+			DeleteEmptyDirData: opts.DeleteEmptyDirData,
+			Force:              opts.Force,
+			GracePeriodSeconds: opts.GracePeriodSeconds,
+		},
+		Pods:          make([]PodDrainDecision, 0, len(podList.Items)),
+		PDBsEvaluated: true,
+	}
+
+	// PDBs per namespace: nil marks "could not list", an empty slice marks "listed, none".
+	pdbsByNamespace := map[string][]policyv1.PodDisruptionBudget{}
+	for _, pod := range podList.Items {
+		if _, seen := pdbsByNamespace[pod.Namespace]; seen {
+			continue
+		}
+		list, err := client.PolicyV1().PodDisruptionBudgets(pod.Namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			pdbsByNamespace[pod.Namespace] = nil
+			plan.PDBsEvaluated = false
+			if plan.PDBError == "" {
+				plan.PDBError = fmt.Sprintf("list PodDisruptionBudgets in %s: %v", pod.Namespace, err)
+			}
+			continue
+		}
+		pdbs := list.Items
+		if pdbs == nil {
+			pdbs = []policyv1.PodDisruptionBudget{}
+		}
+		pdbsByNamespace[pod.Namespace] = pdbs
+	}
+
+	for _, pod := range podList.Items {
+		d := ClassifyPodForDrain(pod, opts, pdbsByNamespace[pod.Namespace])
+		plan.Pods = append(plan.Pods, d)
+		switch d.Outcome {
+		case DrainOutcomeEvict:
+			plan.Summary.Evict++
+		case DrainOutcomeSkip:
+			plan.Summary.Skip++
+		case DrainOutcomeMayBlock:
+			plan.Summary.MayBlock++
+		}
+	}
+	sort.Slice(plan.Pods, func(i, j int) bool {
+		if plan.Pods[i].Namespace != plan.Pods[j].Namespace {
+			return plan.Pods[i].Namespace < plan.Pods[j].Namespace
+		}
+		return plan.Pods[i].Name < plan.Pods[j].Name
+	})
+	return plan, nil
+}

--- a/pkg/k8score/drain_plan_test.go
+++ b/pkg/k8score/drain_plan_test.go
@@ -1,0 +1,189 @@
+package k8score
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func drainTestPod(name string, mutate ...func(*corev1.Pod)) corev1.Pod {
+	yes := true
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "shop",
+			Labels:    map[string]string{"app": "web"},
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "ReplicaSet", Name: "web-abc", Controller: &yes,
+			}},
+		},
+		Spec:   corev1.PodSpec{NodeName: "worker-1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	for _, m := range mutate {
+		m(&pod)
+	}
+	return pod
+}
+
+func withOwner(kind string, controller bool) func(*corev1.Pod) {
+	return func(p *corev1.Pod) {
+		c := controller
+		p.OwnerReferences = []metav1.OwnerReference{{Kind: kind, Name: "owner", Controller: &c}}
+	}
+}
+
+func withoutOwner(p *corev1.Pod) { p.OwnerReferences = nil }
+func withEmptyDir(p *corev1.Pod) {
+	p.Spec.Volumes = []corev1.Volume{{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}}
+}
+func withMirror(p *corev1.Pod) { p.Annotations = map[string]string{corev1.MirrorPodAnnotationKey: "x"} }
+func withPhase(ph corev1.PodPhase) func(*corev1.Pod) {
+	return func(p *corev1.Pod) { p.Status.Phase = ph }
+}
+
+func pdb(ns, name string, selector *metav1.LabelSelector, allowed int32) policyv1.PodDisruptionBudget {
+	return policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       policyv1.PodDisruptionBudgetSpec{Selector: selector},
+		Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: allowed},
+	}
+}
+
+func TestClassifyPodForDrain(t *testing.T) {
+	webSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+	defaults := DrainOptions{IgnoreDaemonSets: true}
+
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		opts DrainOptions
+		pdbs []policyv1.PodDisruptionBudget
+		want DrainOutcome
+	}{
+		{name: "managed running pod is evicted", pod: drainTestPod("a"), opts: defaults, want: DrainOutcomeEvict},
+		{name: "succeeded pod is skipped", pod: drainTestPod("a", withPhase(corev1.PodSucceeded)), opts: defaults, want: DrainOutcomeSkip},
+		{name: "failed pod is skipped", pod: drainTestPod("a", withPhase(corev1.PodFailed)), opts: defaults, want: DrainOutcomeSkip},
+		{name: "mirror pod is skipped even with force", pod: drainTestPod("a", withMirror), opts: DrainOptions{IgnoreDaemonSets: true, Force: true}, want: DrainOutcomeSkip},
+		{name: "DaemonSet pod is skipped when ignored", pod: drainTestPod("a", withOwner("DaemonSet", true)), opts: defaults, want: DrainOutcomeSkip},
+		{name: "DaemonSet pod is evicted when not ignored", pod: drainTestPod("a", withOwner("DaemonSet", true)), opts: DrainOptions{}, want: DrainOutcomeEvict},
+		{name: "non-controller DaemonSet reference does not make a DaemonSet pod", pod: drainTestPod("a", withOwner("DaemonSet", false)), opts: defaults, want: DrainOutcomeSkip}, // unmanaged, no force
+		{name: "unmanaged pod is skipped without force", pod: drainTestPod("a", withoutOwner), opts: defaults, want: DrainOutcomeSkip},
+		{name: "unmanaged pod is evicted with force", pod: drainTestPod("a", withoutOwner), opts: DrainOptions{IgnoreDaemonSets: true, Force: true}, want: DrainOutcomeEvict},
+		{name: "owner reference without controller flag counts as unmanaged", pod: drainTestPod("a", withOwner("ReplicaSet", false)), opts: defaults, want: DrainOutcomeSkip},
+		{name: "emptyDir pod is skipped unless allowed", pod: drainTestPod("a", withEmptyDir), opts: defaults, want: DrainOutcomeSkip},
+		{name: "emptyDir pod is evicted when allowed", pod: drainTestPod("a", withEmptyDir), opts: DrainOptions{IgnoreDaemonSets: true, DeleteEmptyDirData: true}, want: DrainOutcomeEvict},
+		{name: "exhausted PDB may block", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "web", webSelector, 0)}, want: DrainOutcomeMayBlock},
+		{name: "PDB with budget left does not block", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "web", webSelector, 1)}, want: DrainOutcomeEvict},
+		{name: "PDB in another namespace is ignored", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("other", "web", webSelector, 0)}, want: DrainOutcomeEvict},
+		{name: "PDB with non-matching selector is ignored", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "db", &metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}}, 0)}, want: DrainOutcomeEvict},
+		{name: "PDB with nil selector matches nothing", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "none", nil, 0)}, want: DrainOutcomeEvict},
+		{name: "PDB with empty selector matches every pod in the namespace", pod: drainTestPod("a"), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "all", &metav1.LabelSelector{}, 0)}, want: DrainOutcomeMayBlock},
+		{name: "skip decisions win over PDB", pod: drainTestPod("a", withEmptyDir), opts: defaults, pdbs: []policyv1.PodDisruptionBudget{pdb("shop", "web", webSelector, 0)}, want: DrainOutcomeSkip},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyPodForDrain(tt.pod, tt.opts, tt.pdbs)
+			if got.Outcome != tt.want {
+				t.Fatalf("outcome = %q (%s), want %q", got.Outcome, got.Reason, tt.want)
+			}
+			if got.Reason == "" {
+				t.Fatalf("every decision must carry an operator-facing reason")
+			}
+			if got.Namespace != tt.pod.Namespace || got.Name != tt.pod.Name {
+				t.Fatalf("decision must identify the pod: %+v", got)
+			}
+			if tt.want == DrainOutcomeMayBlock && got.PDB == "" {
+				t.Fatalf("may-block decision must name the PDB: %+v", got)
+			}
+		})
+	}
+}
+
+func TestPlanNodeDrainIsReadOnlyAndCountsOutcomes(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}},
+		func() *corev1.Pod { p := drainTestPod("web-1"); return &p }(),
+		func() *corev1.Pod { p := drainTestPod("web-2", withEmptyDir); return &p }(),
+		func() *corev1.Pod { p := drainTestPod("agent", withOwner("DaemonSet", true)); return &p }(),
+		func() *corev1.Pod { p := drainTestPod("elsewhere"); p.Spec.NodeName = "worker-2"; return &p }(),
+		&policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "shop"},
+			Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}},
+			Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+		},
+	)
+	// the fake clientset does not implement field selectors; filter like the API server would
+	client.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &corev1.PodList{}
+		all, _ := client.Tracker().List(schema.GroupVersionResource{Version: "v1", Resource: "pods"}, schema.GroupVersionKind{Version: "v1", Kind: "Pod"}, "")
+		for _, p := range all.(*corev1.PodList).Items {
+			if p.Spec.NodeName == "worker-1" {
+				list.Items = append(list.Items, p)
+			}
+		}
+		return true, list, nil
+	})
+
+	plan, err := PlanNodeDrain(context.Background(), client, "worker-1", DrainOptions{IgnoreDaemonSets: true})
+	if err != nil {
+		t.Fatalf("PlanNodeDrain: %v", err)
+	}
+	for _, a := range client.Actions() {
+		switch a.GetVerb() {
+		case "get", "list":
+		default:
+			t.Fatalf("plan must not mutate the cluster, saw %s %s", a.GetVerb(), a.GetResource().Resource)
+		}
+	}
+	if !plan.Estimate || plan.Node != "worker-1" || plan.GeneratedAt.IsZero() {
+		t.Fatalf("plan header is incomplete: %+v", plan)
+	}
+	if !plan.PDBsEvaluated {
+		t.Fatalf("PDBs were listable and must be reported as evaluated")
+	}
+	if got := plan.Summary; got.Evict != 0 || got.Skip != 2 || got.MayBlock != 1 {
+		t.Fatalf("summary = %+v, want evict=0 skip=2 mayBlock=1", got)
+	}
+	if len(plan.Pods) != 3 {
+		t.Fatalf("plan must list only pods on the node, got %d", len(plan.Pods))
+	}
+}
+
+func TestPlanNodeDrainReportsUnevaluatedPDBs(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}},
+		func() *corev1.Pod { p := drainTestPod("web-1"); return &p }(),
+	)
+	client.PrependReactor("list", "poddisruptionbudgets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "policy", Resource: "poddisruptionbudgets"}, "", nil)
+	})
+
+	plan, err := PlanNodeDrain(context.Background(), client, "worker-1", DrainOptions{IgnoreDaemonSets: true})
+	if err != nil {
+		t.Fatalf("a forbidden PDB list must not fail the plan: %v", err)
+	}
+	if plan.PDBsEvaluated || plan.PDBError == "" {
+		t.Fatalf("plan must say PDBs were not evaluated instead of reporting zero: %+v", plan)
+	}
+	if plan.Summary.MayBlock != 0 || plan.Pods[0].Outcome != DrainOutcomeEvict || plan.Pods[0].PDBEvaluated {
+		t.Fatalf("pod must be classified without PDB knowledge and flagged: %+v", plan.Pods[0])
+	}
+}
+
+func TestPlanNodeDrainUnknownNode(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	_, err := PlanNodeDrain(context.Background(), client, "ghost", DrainOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("want NotFound for an unknown node, got %v", err)
+	}
+}

--- a/pkg/k8score/node_ops.go
+++ b/pkg/k8score/node_ops.go
@@ -26,8 +26,9 @@ type DrainOptions struct {
 
 // DrainResult reports what happened during a drain operation.
 type DrainResult struct {
-	EvictedPods []string `json:"evictedPods"`
-	Errors      []string `json:"errors,omitempty"`
+	EvictedPods []string           `json:"evictedPods"`
+	SkippedPods []PodDrainDecision `json:"skippedPods,omitempty"` // pods left alone and why
+	Errors      []string           `json:"errors,omitempty"`
 }
 
 // CordonNode marks a node as unschedulable.
@@ -71,21 +72,22 @@ func DrainNode(ctx context.Context, client kubernetes.Interface, nodeName string
 		return nil, fmt.Errorf("list pods on node: %w", err)
 	}
 
-	// Filter pods to evict
+	// Decide per pod with the same classifier the drain plan uses. PDBs are not
+	// pre-checked here: the Eviction API is authoritative and evictPod retries on 429.
+	result := &DrainResult{}
 	var toEvict []corev1.Pod
-	var skipped []string
 	for _, pod := range podList.Items {
-		if shouldSkipPod(pod, opts, &skipped) {
+		decision := ClassifyPodForDrain(pod, opts, nil)
+		if decision.Outcome == DrainOutcomeSkip {
+			result.SkippedPods = append(result.SkippedPods, decision)
 			continue
 		}
 		toEvict = append(toEvict, pod)
 	}
 
-	if len(skipped) > 0 {
-		log.Printf("[node-ops] Drain %s: skipping %d pods: %v", nodeName, len(skipped), skipped)
+	if len(result.SkippedPods) > 0 {
+		log.Printf("[node-ops] Drain %s: skipping %d pods", nodeName, len(result.SkippedPods))
 	}
-
-	result := &DrainResult{}
 
 	if len(toEvict) == 0 {
 		return result, nil
@@ -121,53 +123,6 @@ func DrainNode(ctx context.Context, client kubernetes.Interface, nodeName string
 
 	wg.Wait()
 	return result, nil
-}
-
-// shouldSkipPod returns true if the pod should not be evicted during drain.
-func shouldSkipPod(pod corev1.Pod, opts DrainOptions, skipped *[]string) bool {
-	// Skip completed/failed pods
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
-		return true
-	}
-
-	// Skip mirror pods (static pods managed by kubelet)
-	if _, isMirror := pod.Annotations[corev1.MirrorPodAnnotationKey]; isMirror {
-		*skipped = append(*skipped, pod.Namespace+"/"+pod.Name+" (mirror)")
-		return true
-	}
-
-	// Skip DaemonSet pods
-	if opts.IgnoreDaemonSets && isDaemonSetPod(pod) {
-		*skipped = append(*skipped, pod.Namespace+"/"+pod.Name+" (daemonset)")
-		return true
-	}
-
-	// Skip unmanaged pods unless Force
-	if !opts.Force && !hasManagedOwner(pod) {
-		*skipped = append(*skipped, pod.Namespace+"/"+pod.Name+" (unmanaged)")
-		return true
-	}
-
-	// Skip pods with emptyDir unless DeleteEmptyDirData
-	if !opts.DeleteEmptyDirData && hasLocalStorage(pod) {
-		*skipped = append(*skipped, pod.Namespace+"/"+pod.Name+" (local-storage)")
-		return true
-	}
-
-	return false
-}
-
-func isDaemonSetPod(pod corev1.Pod) bool {
-	for _, ref := range pod.OwnerReferences {
-		if ref.Kind == "DaemonSet" {
-			return true
-		}
-	}
-	return false
-}
-
-func hasManagedOwner(pod corev1.Pod) bool {
-	return len(pod.OwnerReferences) > 0
 }
 
 func hasLocalStorage(pod corev1.Pod) bool {


### PR DESCRIPTION
## Description

First half of #1584, as proposed in the issue: the pure drain classifier and the read-only drain-plan endpoint. The plan dialog in `ResourceActionsBar` and the post-drain report are the second half and come as a follow-up PR once the API shape here is agreed.

- `pkg/k8score`: `ClassifyPodForDrain(pod, opts, pdbs)` returns `evict` / `skip` / `may-block` plus an operator-facing reason. Rules mirror `kubectl drain`: terminal and mirror pods skipped, DaemonSet pods skipped when ignored, no controller owner needs force, `emptyDir` needs `deleteEmptyDirData`. A pod counts as managed only with a controller owner reference (`metav1.GetControllerOf`), the way the rest of the codebase already does it; `hasManagedOwner` accepted any owner reference before.
- `PlanNodeDrain` lists the node's pods and per-namespace PDBs with the given client and classifies them. Reads only. A namespace whose PDBs cannot be listed is reported as not evaluated (`pdbsEvaluated`, `pdbError`, per-pod `pdbEvaluated`) rather than as "no PDB".
- `may-block` is evidence, not a verdict: a matching PDB with `disruptionsAllowed == 0`. The plan says `estimate: true`; the drain endpoint re-lists live state as before.
- `POST /api/nodes/{name}/drain-plan` in the regular timeout group next to cordon/uncordon, same JSON body as drain, evaluated with the requesting user's client. `deleteEmptyDirData` defaults to `false` here (the drain keeps its historical `true`) and the response echoes the options it used, so nothing is included silently.
- `DrainNode` now runs on the same classifier and returns `skippedPods` with reasons (additive field). The MCP `manage_node` tool builds its own response and is unchanged.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How has this been tested?

- [x] Added/updated unit tests: 19 table cases for the classifier (owner reference variants, DaemonSet controller vs non-controller reference, emptyDir, PDB matching incl. nil and empty selectors, skip winning over PDB), `PlanNodeDrain` on a fake clientset asserting only `get`/`list` actions, PDB list forbidden → not evaluated, unknown node → NotFound, and the shared request option parsing.
- [x] Tested against a remote cluster: k3s (Colima) with a 2-replica Deployment under a `minAvailable: 2` PDB, a Deployment with `emptyDir`, and a bare Pod.
  - `drain-plan` with `{}`: 2 evict, 3 skip (emptyDir ×2, unmanaged), 2 may-block (PDB); node stays schedulable, pods untouched.
  - `drain-plan` with `deleteEmptyDirData` + `force`: 5 evict, 2 may-block.
  - Unknown node → 404.
  - A real `drain` afterwards evicted 4 pods, timed out on exactly the two may-block pods (`timed out waiting for PDB to allow eviction`) and listed the bare pod under `skippedPods`, so the estimate and the execution agree.

`go vet ./internal/server/` reports pre-existing copylocks warnings in `exec_origin_test.go` and `localterm_disable_test.go` on `main`; untouched here.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Part of #1584
