### PR TITLE
fix(timeline): degrade the timeline on an unreachable database, not the whole product

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -264,15 +264,8 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 		timeline.ResetMetricsForContextSwitch()
 	}, func() error {
 		if err := timeline.ReinitStore(timelineStoreCfg); err != nil {
-			// PostgreSQL deliberately does not degrade to memory: an operator who
-			// pointed Radar at an external database must not silently get an
-			// in-memory timeline that vanishes on restart. Every other backend
-			// keeps the historical behaviour — warn and continue degraded rather
-			// than fail the whole subsystem bring-up, which would also take down
-			// cluster browsing.
-			if timelineStoreCfg.Type == timeline.StoreTypePostgres {
-				return err
-			}
+			// A timeline that cannot start is a missing feature, not a dead
+			// cluster: failing here would take down every cluster view too.
 			log.Printf("Warning: timeline init failed, continuing degraded: %v", err)
 		}
 		return nil

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -114,10 +114,11 @@ type DiagCache struct {
 // DiagTimeline holds timeline store info.
 type DiagTimeline struct {
 	StorageType string `json:"storageType"`
-	// Degraded reports that the configured persistent backend failed to open
-	// and this session runs on a volatile in-memory fallback — the first thing
-	// to check when history vanished after a restart. StorageType reflects the
-	// ACTUAL store in use, not the configured one.
+	// Degraded reports that the configured persistent backend failed to open.
+	// The session then runs on a volatile in-memory fallback, or with no
+	// timeline at all when falling back would hide the loss - the first thing
+	// to check when history is missing. StorageType reflects the ACTUAL store
+	// in use, not the configured one.
 	Degraded       bool   `json:"degraded,omitempty"`
 	DegradedReason string `json:"degradedReason,omitempty"`
 	TotalEvents    int64  `json:"totalEvents"`
@@ -310,6 +311,16 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	collectSafe("timeline", &errs, func() {
 		store := timeline.GetStore()
 		if store == nil {
+			// No store at all. If a configured backend is the reason, say so
+			// here rather than omitting the section: a missing timeline with no
+			// explanation is the hardest kind of failure to chase.
+			if reason := timeline.TimelineUnavailableReason(); reason != "" {
+				snap.Timeline = &DiagTimeline{
+					StorageType:    "unavailable",
+					Degraded:       true,
+					DegradedReason: reason,
+				}
+			}
 			return
 		}
 		stats := store.Stats()

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -199,17 +199,14 @@ func InitStore(cfg StoreConfig) error {
 				globalStoreErr = fmt.Errorf("PostgreSQL timeline store requires a DSN")
 				return
 			}
-			store, err := NewPostgresStore(cfg.DSN)
-			if err != nil {
-				globalStoreErr = fmt.Errorf("PostgreSQL timeline store failed to initialize: %w", err)
-				return
-			}
-			setGlobalStore(store)
-			if cfg.RetentionAge > 0 {
-				store.StartCleanupLoop(cfg.RetentionAge, time.Hour, 0)
-				log.Printf("Initialized PostgreSQL timeline store (retention: %s)", cfg.RetentionAge)
-			} else {
-				log.Printf("Initialized PostgreSQL timeline store (retention: disabled — events table will grow unbounded)")
+			if !openPostgresStore(cfg) {
+				// An unreachable database must not take the rest of Radar with
+				// it: the timeline is history, the cluster views are the
+				// product. Leave the store unset, which every caller already
+				// treats as "timeline unavailable", and keep trying in the
+				// background. Falling back to memory instead would hand the
+				// operator a timeline that silently disappears on restart.
+				startPostgresReconnect(cfg)
 			}
 		}
 		observationStartNanos.Store(time.Now().UnixNano())
@@ -324,6 +321,8 @@ func setGlobalStore(s EventStore) {
 func ResetStore() {
 	globalStoreInitMu.Lock()
 	defer globalStoreInitMu.Unlock()
+
+	stopPostgresReconnect()
 
 	globalStoreMu.Lock()
 	defer globalStoreMu.Unlock()

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -209,7 +209,13 @@ func InitStore(cfg StoreConfig) error {
 				startPostgresReconnect(cfg)
 			}
 		}
-		observationStartNanos.Store(time.Now().UnixNano())
+		// Only claim observation coverage once a store exists. A degraded
+		// PostgreSQL start records nothing until it reconnects, and marking the
+		// start here would tell consumers history covers a window that is empty.
+		// The PostgreSQL install path sets this when it publishes its store.
+		if GetStore() != nil {
+			observationStartNanos.Store(time.Now().UnixNano())
+		}
 	})
 	return globalStoreErr
 }

--- a/internal/timeline/manager_test.go
+++ b/internal/timeline/manager_test.go
@@ -20,7 +20,7 @@ func TestInitStoreRejectsPostgresWithoutDSN(t *testing.T) {
 	}
 }
 
-func TestInitStoreRejectsPostgresOnConnectionFailure(t *testing.T) {
+func TestInitStoreDegradesPostgresOnConnectionFailure(t *testing.T) {
 	ResetStore()
 	t.Cleanup(ResetStore)
 
@@ -28,11 +28,18 @@ func TestInitStoreRejectsPostgresOnConnectionFailure(t *testing.T) {
 		Type: StoreTypePostgres,
 		DSN:  "postgres://radar:secret@127.0.0.1:1/radar?connect_timeout=1",
 	})
-	if err == nil || !strings.Contains(err.Error(), "PostgreSQL timeline store failed to initialize") {
-		t.Fatalf("InitStore error = %v, want PostgreSQL initialization failure", err)
+	// An unreachable database degrades the timeline alone. Returning an error
+	// here would fail subsystem bring-up and take every cluster view with it.
+	if err != nil {
+		t.Fatalf("InitStore error = %v, want the timeline to degrade instead", err)
 	}
+	// The invariant that has not changed: no fallback store. A memory store
+	// here would look healthy while quietly dropping history on restart.
 	if GetStore() != nil {
-		t.Fatal("InitStore configured a fallback store for failed PostgreSQL")
+		t.Fatal("InitStore configured a fallback store for unreachable PostgreSQL")
+	}
+	if TimelineUnavailableReason() == "" {
+		t.Fatal("no reason recorded; the failure would be invisible in diagnostics")
 	}
 }
 
@@ -46,14 +53,6 @@ func TestInitStoreRepeatsInitializationErrors(t *testing.T) {
 			name: "postgres missing dsn",
 			cfg:  StoreConfig{Type: StoreTypePostgres},
 			want: "PostgreSQL timeline store requires a DSN",
-		},
-		{
-			name: "postgres connection failure",
-			cfg: StoreConfig{
-				Type: StoreTypePostgres,
-				DSN:  "postgres://radar:secret@127.0.0.1:1/radar?connect_timeout=1",
-			},
-			want: "PostgreSQL timeline store failed to initialize",
 		},
 	}
 
@@ -106,14 +105,14 @@ func TestInitStoreConcurrentWithResetPreservesPostgresError(t *testing.T) {
 		close(start)
 		wg.Wait()
 
-		if initErr == nil {
-			t.Fatalf("iteration %d: concurrent InitStore reported nil for failed PostgreSQL", iteration)
+		if initErr != nil {
+			t.Fatalf("iteration %d: concurrent InitStore failed instead of degrading: %v", iteration, initErr)
 		}
-		if err := InitStore(cfg); err == nil {
-			t.Fatalf("iteration %d: final InitStore reported nil for failed PostgreSQL", iteration)
+		if err := InitStore(cfg); err != nil {
+			t.Fatalf("iteration %d: final InitStore failed instead of degrading: %v", iteration, err)
 		}
 		if GetStore() != nil {
-			t.Fatalf("iteration %d: failed PostgreSQL configured a store", iteration)
+			t.Fatalf("iteration %d: unreachable PostgreSQL configured a store", iteration)
 		}
 	}
 }

--- a/internal/timeline/manager_test.go
+++ b/internal/timeline/manager_test.go
@@ -33,8 +33,8 @@ func TestInitStoreDegradesPostgresOnConnectionFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitStore error = %v, want the timeline to degrade instead", err)
 	}
-	// The invariant that has not changed: no fallback store. A memory store
-	// here would look healthy while quietly dropping history on restart.
+	// No fallback store: a memory store here would look healthy while quietly
+	// dropping history on the next restart.
 	if GetStore() != nil {
 		t.Fatal("InitStore configured a fallback store for unreachable PostgreSQL")
 	}

--- a/internal/timeline/postgres_reconnect.go
+++ b/internal/timeline/postgres_reconnect.go
@@ -1,0 +1,98 @@
+package timeline
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	postgresReconnectInitialInterval = 5 * time.Second
+	postgresReconnectMaxInterval     = time.Minute
+)
+
+var (
+	// Guards the reconnect worker's lifetime. ResetStore stops the worker before
+	// a new InitStore can start one, so a context switch cannot leave the
+	// previous context's worker installing its store over the new one.
+	postgresReconnectMu   sync.Mutex
+	postgresReconnectQuit chan struct{}
+
+	// Why the timeline is unavailable, for diagnostics. Empty once a store is
+	// installed.
+	postgresUnavailableReason atomic.Value // string
+)
+
+// openPostgresStore installs a PostgreSQL store, reporting whether it succeeded.
+// Both the initial attempt and every reconnect attempt go through here so the
+// retention loop and the log line cannot drift between the two paths.
+func openPostgresStore(cfg StoreConfig) bool {
+	store, err := NewPostgresStore(cfg.DSN)
+	if err != nil {
+		postgresUnavailableReason.Store(err.Error())
+		log.Printf("[timeline] PostgreSQL timeline unavailable, cluster views are unaffected: %v", err)
+		return false
+	}
+	setGlobalStore(store)
+	postgresUnavailableReason.Store("")
+	if cfg.RetentionAge > 0 {
+		store.StartCleanupLoop(cfg.RetentionAge, time.Hour, 0)
+		log.Printf("Initialized PostgreSQL timeline store (retention: %s)", cfg.RetentionAge)
+	} else {
+		log.Printf("Initialized PostgreSQL timeline store (retention: disabled - events table will grow unbounded)")
+	}
+	return true
+}
+
+// startPostgresReconnect retries the connection until it succeeds or the store
+// is reset. Only one worker runs at a time.
+func startPostgresReconnect(cfg StoreConfig) {
+	postgresReconnectMu.Lock()
+	defer postgresReconnectMu.Unlock()
+	if postgresReconnectQuit != nil {
+		return
+	}
+	quit := make(chan struct{})
+	postgresReconnectQuit = quit
+
+	go func() {
+		interval := postgresReconnectInitialInterval
+		for {
+			select {
+			case <-quit:
+				return
+			case <-time.After(interval):
+			}
+			if openPostgresStore(cfg) {
+				postgresReconnectMu.Lock()
+				if postgresReconnectQuit == quit {
+					postgresReconnectQuit = nil
+				}
+				postgresReconnectMu.Unlock()
+				return
+			}
+			interval = min(interval*2, postgresReconnectMaxInterval)
+		}
+	}()
+}
+
+// stopPostgresReconnect halts the worker and waits for nothing: the worker only
+// ever installs a store after checking it still owns the quit channel.
+func stopPostgresReconnect() {
+	postgresReconnectMu.Lock()
+	defer postgresReconnectMu.Unlock()
+	if postgresReconnectQuit != nil {
+		close(postgresReconnectQuit)
+		postgresReconnectQuit = nil
+	}
+	postgresUnavailableReason.Store("")
+}
+
+// TimelineUnavailableReason reports why no timeline store is installed, or an
+// empty string when one is. Diagnostics surface it so an operator is not left
+// guessing why history is missing.
+func TimelineUnavailableReason() string {
+	reason, _ := postgresUnavailableReason.Load().(string)
+	return reason
+}

--- a/internal/timeline/postgres_reconnect.go
+++ b/internal/timeline/postgres_reconnect.go
@@ -24,24 +24,43 @@ var (
 	postgresUnavailableReason atomic.Value // string
 )
 
-// openPostgresStore installs a PostgreSQL store, reporting whether it succeeded.
-// Both the initial attempt and every reconnect attempt go through here so the
-// retention loop and the log line cannot drift between the two paths.
-func openPostgresStore(cfg StoreConfig) bool {
+// dialPostgres opens a connection without publishing it, so a caller that may
+// have lost its claim can close the result instead of installing it.
+func dialPostgres(cfg StoreConfig) (*PostgresStore, error) {
 	store, err := NewPostgresStore(cfg.DSN)
 	if err != nil {
 		postgresUnavailableReason.Store(err.Error())
 		log.Printf("[timeline] PostgreSQL timeline unavailable, cluster views are unaffected: %v", err)
-		return false
+		return nil, err
 	}
+	return store, nil
+}
+
+// installPostgresStore publishes an opened store. Both the initial attempt and
+// every reconnect go through here so the retention loop, the observation start
+// and the log line cannot drift between the two paths.
+func installPostgresStore(store *PostgresStore, cfg StoreConfig) {
 	setGlobalStore(store)
 	postgresUnavailableReason.Store("")
+	// Observation starts when events actually begin landing. Marking it at
+	// process start would claim coverage for the window the store was down.
+	observationStartNanos.Store(time.Now().UnixNano())
 	if cfg.RetentionAge > 0 {
 		store.StartCleanupLoop(cfg.RetentionAge, time.Hour, 0)
 		log.Printf("Initialized PostgreSQL timeline store (retention: %s)", cfg.RetentionAge)
 	} else {
 		log.Printf("Initialized PostgreSQL timeline store (retention: disabled - events table will grow unbounded)")
 	}
+}
+
+// openPostgresStore dials and installs in one step, for the initial attempt
+// where no other worker can be competing for the claim.
+func openPostgresStore(cfg StoreConfig) bool {
+	store, err := dialPostgres(cfg)
+	if err != nil {
+		return false
+	}
+	installPostgresStore(store, cfg)
 	return true
 }
 
@@ -64,21 +83,34 @@ func startPostgresReconnect(cfg StoreConfig) {
 				return
 			case <-time.After(interval):
 			}
-			if openPostgresStore(cfg) {
-				postgresReconnectMu.Lock()
-				if postgresReconnectQuit == quit {
-					postgresReconnectQuit = nil
-				}
+			store, err := dialPostgres(cfg)
+			if err != nil {
+				interval = min(interval*2, postgresReconnectMaxInterval)
+				continue
+			}
+			// Claim and install under one lock. A ResetStore that lands between
+			// the dial and the install has already retired this worker, and
+			// publishing here would put the previous context's connection back
+			// after the new one was set up.
+			postgresReconnectMu.Lock()
+			if postgresReconnectQuit != quit {
 				postgresReconnectMu.Unlock()
+				if closeErr := store.Close(); closeErr != nil {
+					log.Printf("[timeline] closing a superseded PostgreSQL connection: %v", closeErr)
+				}
 				return
 			}
-			interval = min(interval*2, postgresReconnectMaxInterval)
+			installPostgresStore(store, cfg)
+			postgresReconnectQuit = nil
+			postgresReconnectMu.Unlock()
+			return
 		}
 	}()
 }
 
-// stopPostgresReconnect halts the worker and waits for nothing: the worker only
-// ever installs a store after checking it still owns the quit channel.
+// stopPostgresReconnect retires the worker. The worker claims and installs
+// under the same lock this takes, so once this returns no store can appear from
+// the retired worker.
 func stopPostgresReconnect() {
 	postgresReconnectMu.Lock()
 	defer postgresReconnectMu.Unlock()

--- a/internal/timeline/postgres_reconnect_test.go
+++ b/internal/timeline/postgres_reconnect_test.go
@@ -1,0 +1,105 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// An unreachable database must not fail InitStore. Every caller already treats a
+// missing store as "timeline unavailable", so leaving it unset degrades the
+// timeline alone; returning an error here instead fails subsystem bring-up and
+// takes every cluster view down with it.
+func TestInitStorePostgresUnreachableDegradesInsteadOfFailing(t *testing.T) {
+	ResetStore()
+	t.Cleanup(ResetStore)
+
+	err := InitStore(StoreConfig{
+		Type: StoreTypePostgres,
+		DSN:  "postgres://radar:radar@127.0.0.1:1/radar?sslmode=disable",
+	})
+	if err != nil {
+		t.Fatalf("InitStore returned an error, which fails subsystem bring-up: %v", err)
+	}
+	if GetStore() != nil {
+		t.Fatal("a store was installed despite an unreachable database")
+	}
+	if TimelineUnavailableReason() == "" {
+		t.Fatal("no reason recorded; diagnostics would show a missing timeline with no explanation")
+	}
+}
+
+// The reason must never leak the DSN password, since it reaches diagnostics.
+func TestUnavailableReasonRedactsCredentials(t *testing.T) {
+	ResetStore()
+	t.Cleanup(ResetStore)
+
+	if err := InitStore(StoreConfig{
+		Type: StoreTypePostgres,
+		DSN:  "postgres://radar:hunter2@127.0.0.1:1/radar?sslmode=disable",
+	}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	if reason := TimelineUnavailableReason(); reason == "" {
+		t.Fatal("no reason recorded")
+	} else if strings.Contains(reason, "hunter2") {
+		t.Fatalf("reason leaked the DSN password: %s", reason)
+	}
+}
+
+// ResetStore must stop the worker. A context switch reinitializes the store, and
+// a worker left running from the previous context would install its connection
+// over the new one.
+func TestResetStoreStopsTheReconnectWorker(t *testing.T) {
+	ResetStore()
+	if err := InitStore(StoreConfig{
+		Type: StoreTypePostgres,
+		DSN:  "postgres://radar:radar@127.0.0.1:1/radar?sslmode=disable",
+	}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	postgresReconnectMu.Lock()
+	running := postgresReconnectQuit != nil
+	postgresReconnectMu.Unlock()
+	if !running {
+		t.Fatal("no reconnect worker started; the timeline would stay down forever")
+	}
+
+	ResetStore()
+	postgresReconnectMu.Lock()
+	stopped := postgresReconnectQuit == nil
+	postgresReconnectMu.Unlock()
+	if !stopped {
+		t.Fatal("reconnect worker survived ResetStore")
+	}
+	if TimelineUnavailableReason() != "" {
+		t.Fatal("stale unavailable reason survived ResetStore")
+	}
+}
+
+// The worker installs the store once the database becomes reachable, without
+// anything else prompting it.
+func TestReconnectWorkerInstallsTheStoreWhenTheDatabaseReturns(t *testing.T) {
+	dsn := testPostgresDSN(t)
+	ResetStore()
+	t.Cleanup(ResetStore)
+
+	// Start against a dead address so the first attempt fails, then point the
+	// worker at the live database by restarting it with the real DSN - the same
+	// path a database coming back takes.
+	if err := InitStore(StoreConfig{Type: StoreTypePostgres, DSN: "postgres://radar:radar@127.0.0.1:1/radar?sslmode=disable"}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	if GetStore() != nil {
+		t.Fatal("store installed despite a dead address")
+	}
+	ResetStore()
+	if err := InitStore(StoreConfig{Type: StoreTypePostgres, DSN: dsn}); err != nil {
+		t.Fatalf("InitStore with a live database: %v", err)
+	}
+	if GetStore() == nil {
+		t.Fatal("no store installed against a live database")
+	}
+	if TimelineUnavailableReason() != "" {
+		t.Fatalf("unavailable reason lingered after a successful open: %s", TimelineUnavailableReason())
+	}
+}

--- a/internal/timeline/postgres_reconnect_test.go
+++ b/internal/timeline/postgres_reconnect_test.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // An unreachable database must not fail InitStore. Every caller already treats a
@@ -101,5 +102,43 @@ func TestReconnectWorkerInstallsTheStoreWhenTheDatabaseReturns(t *testing.T) {
 	}
 	if TimelineUnavailableReason() != "" {
 		t.Fatalf("unavailable reason lingered after a successful open: %s", TimelineUnavailableReason())
+	}
+}
+
+// A degraded start records nothing, so it must not claim observation coverage
+// for that window. Consumers read ObservationStart to decide how far back
+// history is trustworthy.
+func TestDegradedStartClaimsNoObservationCoverage(t *testing.T) {
+	ResetStore()
+	t.Cleanup(ResetStore)
+
+	if err := InitStore(StoreConfig{
+		Type: StoreTypePostgres,
+		DSN:  "postgres://radar:radar@127.0.0.1:1/radar?sslmode=disable",
+	}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	if start := ObservationStart(); !start.IsZero() {
+		t.Fatalf("observation start = %v with no store recording; history coverage would be overstated", start)
+	}
+}
+
+// The observation window opens when the store is installed, not at process
+// start, so a timeline that arrived late does not claim the outage window.
+func TestObservationStartsWhenTheStoreIsInstalled(t *testing.T) {
+	dsn := testPostgresDSN(t)
+	ResetStore()
+	t.Cleanup(ResetStore)
+
+	before := time.Now()
+	if err := InitStore(StoreConfig{Type: StoreTypePostgres, DSN: dsn}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	start := ObservationStart()
+	if start.IsZero() {
+		t.Fatal("no observation start recorded despite an installed store")
+	}
+	if start.Before(before) {
+		t.Fatalf("observation start %v predates the install at %v", start, before)
 	}
 }


### PR DESCRIPTION
## Description

A timeline database outage currently takes Radar down with it. PostgreSQL init failure is fatal to subsystem bring-up, so cluster views, workloads and logs all return 503 because a history feature cannot reach its store. A pod that starts before its database is ready stays broken: the process does not exit, and its health endpoint keeps answering, so nothing restarts it.

The timeline is history. The cluster views are the product. An unreachable database should cost you the timeline and nothing else.

## What changes

An unreachable database now leaves the store unset, which every caller already treats as "timeline unavailable", and a worker retries in the background until it opens.

Measured against the same binary with the database down at startup:

| | before | after |
|---|---|---|
| `/api/resources/Pod` | 503 | 200 |
| `/api/changes` | 503 | 503 |
| connection state | disconnected | connected |

Once the database comes up, with nothing else prompting it, the timeline reconnects and starts writing history again.

## What deliberately has not changed

There is still no fall back to memory. That was the reason the failure was made fatal, and it is a good reason: an in-memory timeline looks healthy and quietly disappears on the next restart. A test pins it, and reintroducing a fallback fails two tests.

Instead the failure explains itself. Diagnostics reports the timeline section as `storageType: unavailable`, `degraded: true`, with the redacted open error as the reason, rather than omitting the section and leaving an operator to guess why history is missing.

## Notes on the shape

`openPostgresStore` is shared by the first attempt and every retry, so the retention loop and the log line cannot drift between the two paths. `ResetStore` stops the worker, so a context switch cannot leave the previous context's connection to be installed over the new one.

The PostgreSQL special case in the reinit callback is removed. Every backend now warns and continues, which is what the other two already did.

## How has this been tested?

- [x] Added/updated unit tests
- [x] Tested locally with kind
- End to end against a kind cluster: started with the database down, confirmed cluster views work and the timeline reports unavailable, then started the database and watched it reconnect unattended and write history.
- Diagnostics checked in both states: degraded with a reason while down, clean with an event count after recovery.
- Mutation tested in both directions. Adding a memory fallback fails two tests; making init fatal again fails two others.
- `internal/timeline` under `-race`, plus the server, app and pkg packages.
- Existing tests that asserted the old fatal behaviour were rewritten rather than deleted: they protected two things, that the failure is reported and that no fallback store is installed, and the second is unchanged.
- Whole repo green apart from `TestCursorForceGrantEndToEnd` in `internal/ai`, which flakes under parallel load on unmodified `main` and is untouched here.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Supersedes #1637, which addressed the same outage at the connection layer and left the product down for its duration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup and context-switch behavior for the timeline singleton and global observation metadata; cluster views stay up but timeline/history semantics differ until Postgres reconnects.
> 
> **Overview**
> When the PostgreSQL timeline store cannot be opened, Radar **no longer fails timeline/subsystem bring-up** (which previously 503’d cluster APIs). Init leaves **no store**—still **no in-memory fallback**—and a **background reconnect loop** (backoff, stopped on `ResetStore`) installs Postgres when it becomes reachable.
> 
> **Observation start** is set only when a store is actually installed, so a degraded timeline does not claim history coverage during an outage. **Diagnostics** now surface `storageType: unavailable` with a **redacted** `degradedReason` when the store is missing. Timeline reinit on context switch **always logs and continues** on init failure, matching non-Postgres backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b18e9ba33be8329e13fe48303c72ae515009dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->