### PR TITLE
Align investigation header status and action spacing

### DIFF
--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -443,37 +443,37 @@ function DiagnoseHeaderIdentity({
   onOpenSettings: (() => void) | null;
 }) {
   return (
-    <div className={`min-w-0 ${className}`}>
-      <div className="flex min-w-0 items-center gap-2">
-        <div className="min-w-0 flex-1 truncate text-sm font-medium text-theme-text-primary">
+    <div className={`flex min-w-0 items-center gap-3 ${className}`}>
+      <div className="min-w-0 flex-1">
+        <div className="min-w-0 truncate text-sm font-medium text-theme-text-primary">
           {title}
         </div>
-        {runMeta ? (
-          <div
-            className={`${MAXIMIZED_RUN_META_VISIBILITY_CLASS} shrink-0 items-center gap-1 text-[11px] tabular-nums text-theme-text-tertiary`}
-          >
-            <span className={`font-medium ${runMeta.labelClass}`}>
-              {runMeta.label}
-            </span>
-            <span aria-hidden>·</span>
-            <time dateTime={runMeta.dateTime}>{runMeta.time}</time>
-          </div>
-        ) : null}
+        <div className="flex items-center gap-1 text-xs text-theme-text-tertiary">
+          <span className="truncate">{configLine}</span>
+          {onOpenSettings && (
+            <Tooltip content="AI settings" position="bottom">
+              <button
+                onClick={onOpenSettings}
+                className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
+                aria-label="AI settings"
+              >
+                <Settings2 className="h-3 w-3" />
+              </button>
+            </Tooltip>
+          )}
+        </div>
       </div>
-      <div className="flex items-center gap-1 text-xs text-theme-text-tertiary">
-        <span className="truncate">{configLine}</span>
-        {onOpenSettings && (
-          <Tooltip content="AI settings" position="bottom">
-            <button
-              onClick={onOpenSettings}
-              className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
-              aria-label="AI settings"
-            >
-              <Settings2 className="h-3 w-3" />
-            </button>
-          </Tooltip>
-        )}
-      </div>
+      {runMeta ? (
+        <div
+          className={`${MAXIMIZED_RUN_META_VISIBILITY_CLASS} shrink-0 items-center gap-1 whitespace-nowrap text-[11px] tabular-nums text-theme-text-tertiary`}
+        >
+          <span className={`font-medium ${runMeta.labelClass}`}>
+            {runMeta.label}
+          </span>
+          <span aria-hidden>·</span>
+          <time dateTime={runMeta.dateTime}>{runMeta.time}</time>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -838,7 +838,7 @@ export function DiagnoseSurface({
       )}
 
       {/* Header */}
-      <div className="relative z-30 flex items-center justify-between border-b border-theme-border bg-theme-surface px-4 py-2.5">
+      <div className="relative z-30 flex items-center justify-between gap-3 border-b border-theme-border bg-theme-surface px-4 py-2.5">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {showHistory && (d.view !== "home" || !persistentHistory) ? (
             <Tooltip
@@ -893,7 +893,7 @@ export function DiagnoseSurface({
             )}
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div className="flex shrink-0 items-center gap-1">
           {activeRun &&
             canRerunInvestigation(d.view, activeRun, d.needsConsent) && (
               <Tooltip


### PR DESCRIPTION
## Summary

Align the investigation status and timestamp with the header action controls instead of the first line of the title. This gives the status, rerun, privacy, link, and close controls a shared vertical centerline.

## Changes

- Keep title and provider/settings subtitle in one column, with status/time centered alongside it.
- Add 12px between the identity/status area and actions, and use consistent 4px gaps between action controls.
- Preserve the existing responsive status visibility and all control behavior.

## Testing

- Frontend typecheck passed.
- Frontend tests passed: 86 files, 972 tests.
- Full `make build` passed.
- Visual-test skipped for this small layout-only change; no browser verification claimed.

This changes the shared Radar frontend; Cloud receives it through a future radar-app package release. No packages published by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks in the diagnose surface header; no logic or API changes.
> 
> **Overview**
> **Reworks the investigation panel header layout** so run status and timestamp sit beside the title/subtitle block (vertically centered with the identity column) instead of on the same row as the title only.
> 
> `DiagnoseHeaderIdentity` becomes a horizontal flex row: left column stacks title and config/settings line; optional `runMeta` is a right sibling with `whitespace-nowrap`, still gated by the existing `@min-[1750px]` visibility class. The main header adds **`gap-3`** between the identity block and action buttons, and action controls use **`gap-1`** instead of **`gap-0.5`** for consistent spacing with rerun, privacy, link, expand, and close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb3164b512ec0f546f6de42ab3e66e41ab67f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->