### PR TITLE
Let hosts own investigation collaboration actions

### DIFF
--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -42,6 +42,7 @@ import type { TimelineSourceConfig } from "./api/timelineSource";
 import { DiagnoseCustomizationProvider } from "./context/DiagnoseCustomization";
 import type {
   RenderDiagnoseAction,
+  RenderInvestigationRunActions,
   DiagnoseConsentCopy,
 } from "./context/DiagnoseCustomization";
 import { defaultDiagnoseAction } from "./components/diagnose/LocalDiagnoseAction";
@@ -113,6 +114,7 @@ export interface RadarAppProps {
    * agent-free. See ./context/DiagnoseCustomization for the render-prop shape.
    */
   renderDiagnoseAction?: RenderDiagnoseAction;
+  renderInvestigationRunActions?: RenderInvestigationRunActions;
   /**
    * Replaces the first-run consent card's trust copy. REQUIRED of any host whose
    * backend runs the agent somewhere other than the user's own machine — the
@@ -202,6 +204,7 @@ export function RadarApp({
   manageDocumentTitle = false,
   documentTitleSuffix,
   renderDiagnoseAction,
+  renderInvestigationRunActions,
   diagnoseConsent,
   initialPath,
   onClusterLoadStateChange,
@@ -234,6 +237,7 @@ export function RadarApp({
                 <DiagnoseCustomizationProvider
                   value={renderDiagnoseAction ?? defaultDiagnoseAction}
                   consentCopy={diagnoseConsent}
+                  renderRunActions={renderInvestigationRunActions}
                 >
                   <DiagnoseProvider
                     browserURLState={router !== "memory"}

--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -114,6 +114,7 @@ export interface RadarAppProps {
    * agent-free. See ./context/DiagnoseCustomization for the render-prop shape.
    */
   renderDiagnoseAction?: RenderDiagnoseAction;
+  /** Host-owned controls for the focused investigation; absent in standalone Radar. */
   renderInvestigationRunActions?: RenderInvestigationRunActions;
   /**
    * Replaces the first-run consent card's trust copy. REQUIRED of any host whose

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -255,20 +255,6 @@ export async function getRun(
   return res.json();
 }
 
-export async function updateRunVisibility(
-  id: string,
-  visibility: "private" | "organization",
-): Promise<RunSummary> {
-  const res = await fetch(`${RUNS()}/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    credentials: getCredentialsMode(),
-    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
-    body: JSON.stringify({ visibility }),
-  });
-  if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
-  return res.json();
-}
-
 // recordConsent acknowledges the current disclosure for an execution profile, server-side.
 export async function recordConsent(surface: string): Promise<void> {
   const res = await fetch(`${getApiBase()}/diagnose/consent`, {

--- a/web/src/components/diagnose/DiagnoseSurface.test.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.test.tsx
@@ -4,7 +4,6 @@ import {
   INVESTIGATION_HISTORY_MIN_WIDTH,
   MAXIMIZED_RUN_META_VISIBILITY_CLASS,
   canRerunInvestigation,
-  canCopyRunLink,
   investigationHistoryIsPersistent,
   investigationHeaderPresentation,
   openInvestigationEvidenceResource,
@@ -334,25 +333,6 @@ describe("canContinueInvestigation", () => {
         true,
       ),
     ).toBe(false);
-  });
-});
-
-describe("canCopyRunLink", () => {
-  it("does not expose collaboration UI for an OSS run", () => {
-    expect(canCopyRunLink(run("done"))).toBe(false);
-  });
-
-  it("exposes the copy action only for a canonical hosted URL", () => {
-    expect(
-      canCopyRunLink({
-        ...run("done"),
-        radarUrl: "/c/cluster-1?org=org-1&ai-run=r1",
-      }),
-    ).toBe(true);
-  });
-
-  it("treats an empty hosted URL as unavailable", () => {
-    expect(canCopyRunLink({ ...run("done"), radarUrl: "" })).toBe(false);
   });
 });
 

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -443,37 +443,37 @@ function DiagnoseHeaderIdentity({
   onOpenSettings: (() => void) | null;
 }) {
   return (
-    <div className={`min-w-0 ${className}`}>
-      <div className="flex min-w-0 items-center gap-2">
-        <div className="min-w-0 flex-1 truncate text-sm font-medium text-theme-text-primary">
+    <div className={`flex min-w-0 items-center gap-3 ${className}`}>
+      <div className="min-w-0 flex-1">
+        <div className="min-w-0 truncate text-sm font-medium text-theme-text-primary">
           {title}
         </div>
-        {runMeta ? (
-          <div
-            className={`${MAXIMIZED_RUN_META_VISIBILITY_CLASS} shrink-0 items-center gap-1 text-[11px] tabular-nums text-theme-text-tertiary`}
-          >
-            <span className={`font-medium ${runMeta.labelClass}`}>
-              {runMeta.label}
-            </span>
-            <span aria-hidden>·</span>
-            <time dateTime={runMeta.dateTime}>{runMeta.time}</time>
-          </div>
-        ) : null}
+        <div className="flex items-center gap-1 text-xs text-theme-text-tertiary">
+          <span className="truncate">{configLine}</span>
+          {onOpenSettings && (
+            <Tooltip content="AI settings" position="bottom">
+              <button
+                onClick={onOpenSettings}
+                className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
+                aria-label="AI settings"
+              >
+                <Settings2 className="h-3 w-3" />
+              </button>
+            </Tooltip>
+          )}
+        </div>
       </div>
-      <div className="flex items-center gap-1 text-xs text-theme-text-tertiary">
-        <span className="truncate">{configLine}</span>
-        {onOpenSettings && (
-          <Tooltip content="AI settings" position="bottom">
-            <button
-              onClick={onOpenSettings}
-              className="shrink-0 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
-              aria-label="AI settings"
-            >
-              <Settings2 className="h-3 w-3" />
-            </button>
-          </Tooltip>
-        )}
-      </div>
+      {runMeta ? (
+        <div
+          className={`${MAXIMIZED_RUN_META_VISIBILITY_CLASS} shrink-0 items-center gap-1 whitespace-nowrap text-[11px] tabular-nums text-theme-text-tertiary`}
+        >
+          <span className={`font-medium ${runMeta.labelClass}`}>
+            {runMeta.label}
+          </span>
+          <span aria-hidden>·</span>
+          <time dateTime={runMeta.dateTime}>{runMeta.time}</time>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -838,7 +838,7 @@ export function DiagnoseSurface({
       )}
 
       {/* Header */}
-      <div className="relative z-30 flex items-center justify-between border-b border-theme-border bg-theme-surface px-4 py-2.5">
+      <div className="relative z-30 flex items-center justify-between gap-3 border-b border-theme-border bg-theme-surface px-4 py-2.5">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {showHistory && (d.view !== "home" || !persistentHistory) ? (
             <Tooltip
@@ -893,7 +893,7 @@ export function DiagnoseSurface({
             )}
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div className="flex shrink-0 items-center gap-1">
           {activeRun &&
             canRerunInvestigation(d.view, activeRun, d.needsConsent) && (
               <Tooltip

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -22,13 +22,8 @@ import {
   Check,
   RotateCcw,
   PanelLeftOpen,
-  Link,
-  Lock,
-  Users,
 } from "lucide-react";
 import { Tooltip } from "../ui/Tooltip";
-import { ConfirmDialog } from "../ui/ConfirmDialog";
-import { Badge } from "@skyhook-io/k8s-ui/components/ui/Badge";
 import { useAnimatedUnmount } from "../../hooks/useAnimatedUnmount";
 import { TRANSITION_BACKDROP, TRANSITION_DRAWER } from "../../utils/animation";
 import {
@@ -52,7 +47,6 @@ import { AgentSetupNotice } from "./AgentSetupNotice";
 import { ConsentCard } from "./parts";
 import { buildLaunchCommand, launchAgentLabel, openInTerminal } from "./launch";
 import {
-  updateRunVisibility,
   type RunSummary,
   type ExecutionProfile,
 } from "../../api/diagnose";
@@ -187,153 +181,6 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
         </div>
       )}
     </div>
-  );
-}
-
-export function canCopyRunLink(
-  run: RunSummary | null | undefined,
-): run is RunSummary & { radarUrl: string } {
-  return typeof run?.radarUrl === "string" && run.radarUrl.length > 0;
-}
-
-function CopyRunLink({
-  radarUrl,
-  visibility,
-}: {
-  radarUrl: string;
-  visibility: RunSummary["visibility"];
-}) {
-  const label =
-    visibility === "private"
-      ? "Copy private link (only you can open it)"
-      : "Copy investigation link";
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
-    "idle",
-  );
-  const copy = async () => {
-    try {
-      if (!navigator.clipboard) throw new Error("clipboard unavailable");
-      await navigator.clipboard.writeText(
-        new URL(radarUrl, window.location.origin).href,
-      );
-      setCopyState("copied");
-    } catch {
-      setCopyState("error");
-    }
-    setTimeout(() => setCopyState("idle"), 1500);
-  };
-  return (
-    <Tooltip
-      content={
-        copyState === "copied"
-          ? "Link copied"
-          : copyState === "error"
-            ? "Couldn’t copy link"
-            : label
-      }
-      position="bottom"
-    >
-      <button
-        onClick={copy}
-        className="rounded-md p-1 text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary"
-        aria-label={label}
-      >
-        {copyState === "copied" ? (
-          <Check className="h-4 w-4 text-emerald-500" />
-        ) : (
-          <Link className="h-4 w-4" />
-        )}
-      </button>
-    </Tooltip>
-  );
-}
-
-function VisibilityControl({
-  run,
-  onChanged,
-}: {
-  run: RunSummary;
-  onChanged: (run: RunSummary) => void;
-}) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState(false);
-  const [confirmShare, setConfirmShare] = useState(false);
-  if (!run.canManageVisibility) {
-    return run.visibility === "organization" ? (
-      <Tooltip content="Shared with your organization" position="bottom">
-        <Badge severity="neutral" size="sm" className="shrink-0">
-          <Users className="h-3 w-3" />
-          Organization
-        </Badge>
-      </Tooltip>
-    ) : run.visibility === "private" ? (
-      <Tooltip
-        content="Only you can view this investigation. Other organization members don’t have access."
-        position="bottom"
-      >
-        <Badge severity="neutral" size="sm" className="shrink-0">
-          <Lock className="h-3 w-3" />
-          Private
-        </Badge>
-      </Tooltip>
-    ) : null;
-  }
-  const shared = run.visibility === "organization";
-  const update = () => {
-    if (busy) return;
-    setBusy(true);
-    setError(false);
-    updateRunVisibility(run.id, shared ? "private" : "organization")
-      .then((updated) => {
-        onChanged(updated);
-        setConfirmShare(false);
-      })
-      .catch(() => setError(true))
-      .finally(() => setBusy(false));
-  };
-  const label = shared ? "Organization" : "Private";
-  return (
-    <>
-      <Tooltip
-        content={
-          error
-            ? "Couldn't change sharing"
-            : shared
-              ? "Shared with your organization — make private"
-              : "Private — click to let organization members access this investigation"
-        }
-        position="bottom"
-      >
-        <button
-          onClick={() => (shared ? update() : setConfirmShare(true))}
-          disabled={busy}
-          className="flex items-center gap-1 rounded-md border border-theme-border/70 px-1.5 py-1 text-[11px] font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary disabled:opacity-50"
-          aria-label={
-            shared
-              ? "Shared with your organization — make private"
-              : "Private — click to let organization members access this investigation"
-          }
-        >
-          {shared ? (
-            <Users className="h-3.5 w-3.5" />
-          ) : (
-            <Lock className="h-3.5 w-3.5" />
-          )}
-          {label}
-        </button>
-      </Tooltip>
-      <ConfirmDialog
-        open={confirmShare}
-        onClose={() => !busy && setConfirmShare(false)}
-        onConfirm={update}
-        title="Share this investigation?"
-        message="Everyone in your organization can read this entire investigation—including your questions and the logs and manifests Radar read—and can continue or stop it."
-        confirmLabel="Share with organization"
-        showWarning={false}
-        variant="warning"
-        isLoading={busy}
-      />
-    </>
   );
 }
 
@@ -552,7 +399,7 @@ export function DiagnoseSurface({
   }, []);
   // Injected settings action: undefined = Radar's own Settings dialog;
   // null = hide the gear + links.
-  const { consentCopy, onOpenSettings: hostOpenSettings } =
+  const { consentCopy, onOpenSettings: hostOpenSettings, renderRunActions } =
     useDiagnoseCustomization();
   const { embedded } = useNavCustomization();
   const openSettings =
@@ -922,17 +769,7 @@ export function DiagnoseSurface({
             <div
               className={`items-center gap-1 ${headerPresentation.runActionsClass || "flex"}`}
             >
-              <VisibilityControl
-                key={visibleRunDetail.id}
-                run={visibleRunDetail}
-                onChanged={d.updateRunSummary}
-              />
-              {canCopyRunLink(visibleRunDetail) && (
-                <CopyRunLink
-                  radarUrl={visibleRunDetail.radarUrl}
-                  visibility={visibleRunDetail.visibility}
-                />
-              )}
+              {renderRunActions?.({ run: visibleRunDetail, onRunUpdated: d.updateRunSummary })}
               <InvestigationMenu run={visibleRunDetail} />
             </div>
           )}

--- a/web/src/context/DiagnoseCustomization.test.tsx
+++ b/web/src/context/DiagnoseCustomization.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DiagnoseCustomizationProvider, useDiagnoseCustomization } from './DiagnoseCustomization';
+import type { RunSummary } from '../api/diagnose';
+
+const run = { id: 'r1' } as RunSummary;
+const onRunUpdated = vi.fn();
+function Actions() {
+  const { renderRunActions } = useDiagnoseCustomization();
+  return <>{renderRunActions?.({ run, onRunUpdated })}</>;
+}
+
+describe('investigation action slot', () => {
+  it('has no default host actions in OSS', () => {
+    expect(renderToStaticMarkup(<Actions />)).toBe('');
+  });
+  it('passes the run and update callback to the host', () => {
+    const renderRunActions = vi.fn(() => <button>Host action</button>);
+    expect(renderToStaticMarkup(
+      <DiagnoseCustomizationProvider value={undefined} renderRunActions={renderRunActions}>
+        <Actions />
+      </DiagnoseCustomizationProvider>,
+    )).toContain('Host action');
+    expect(renderRunActions).toHaveBeenCalledWith({ run, onRunUpdated });
+  });
+});

--- a/web/src/context/DiagnoseCustomization.tsx
+++ b/web/src/context/DiagnoseCustomization.tsx
@@ -11,6 +11,12 @@
 // agent-free.
 import { createContext, useContext, useMemo } from "react";
 import type { ReactNode } from "react";
+import type { RunSummary } from "../api/diagnose";
+
+export type RenderInvestigationRunActions = (props: {
+  run: RunSummary;
+  onRunUpdated: (run: RunSummary) => void;
+}) => ReactNode;
 
 /** Render prop for the resource-level Investigate action. */
 export type RenderDiagnoseAction = (ctx: {
@@ -52,6 +58,7 @@ export type DiagnoseConsentCopy = {
 // set once at mount, so per-value re-render isolation buys nothing.
 export interface DiagnoseCustomization {
   renderAction: RenderDiagnoseAction | undefined;
+  renderRunActions?: RenderInvestigationRunActions;
   consentCopy: DiagnoseConsentCopy | undefined;
   // undefined = default (CustomEvent → Radar's own Settings dialog);
   // null = hide the settings affordances.
@@ -70,19 +77,21 @@ const DiagnoseCustomizationContext =
 export function DiagnoseCustomizationProvider({
   value,
   consentCopy,
+  renderRunActions,
   onOpenSettings,
   children,
 }: {
   value: RenderDiagnoseAction | undefined;
   consentCopy?: DiagnoseConsentCopy;
+  renderRunActions?: RenderInvestigationRunActions;
   /** Where "AI settings" affordances lead. Omit for Radar's own Settings
    *  dialog; pass `null` to hide them. */
   onOpenSettings?: (() => void) | null;
   children: ReactNode;
 }) {
   const ctx = useMemo(
-    () => ({ renderAction: value, consentCopy, onOpenSettings }),
-    [value, consentCopy, onOpenSettings],
+    () => ({ renderAction: value, consentCopy, onOpenSettings, renderRunActions }),
+    [value, consentCopy, onOpenSettings, renderRunActions],
   );
   return (
     <DiagnoseCustomizationContext.Provider value={ctx}>

--- a/web/src/context/DiagnoseCustomization.tsx
+++ b/web/src/context/DiagnoseCustomization.tsx
@@ -13,6 +13,9 @@ import { createContext, useContext, useMemo } from "react";
 import type { ReactNode } from "react";
 import type { RunSummary } from "../api/diagnose";
 
+/** Optional host controls beside shared run actions. Return a component element
+ * if hooks are needed: this callback is invoked conditionally. Call onRunUpdated
+ * after a mutation to refresh the shared run summary. */
 export type RenderInvestigationRunActions = (props: {
   run: RunSummary;
   onRunUpdated: (run: RunSummary) => void;

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './api/timelineSource';
 export type {
   RenderDiagnoseAction,
+  RenderInvestigationRunActions,
   DiagnoseConsentCopy,
 } from './context/DiagnoseCustomization';
 


### PR DESCRIPTION
## Summary

Keep Cloud investigation collaboration controls in the Cloud application instead of the shared Radar UI. Radar owns the investigation header, layout, status and local agent resume menu; the embedding host owns sharing policy and link actions.

## Design

- Add an optional `RenderInvestigationRunActions` callback to the existing investigation customization context and forward it through `RadarApp`.
- Pass the visible run and an update callback to the host. The update callback refreshes the shared run list after a host mutation.
- Remove visibility controls, sharing confirmation, link copying, and the Cloud-only visibility PATCH from Radar. Keep optional run metadata and read-only history labels unchanged.
- Standalone Radar supplies no slot and keeps its local resume menu. Hosts return a component element for hook-based controls.

Stacked on #1721 for the independent header alignment change.

Cloud counterpart: https://github.com/skyhook-dev/radar-hub-web/pull/297

## Verification

- Radar frontend typecheck and 971 tests passed, including default-empty and host-slot rendering tests.
- Full `make build` passed.
- Cloud counterpart: typecheck/build passed with the new slot API temporarily applied to the installed dependency; original dependency restored afterward.
- Cloud browser fixture verified sharing confirmation, failure, cancel/reopen, correct cluster URL, and updated header. API mocked; no customer data changed.
- Full-stack visual-test skipped: ownership refactor, no intended layout change beyond #1721.

## Release coordination

Publish a new radar-app package after merge, then update the Cloud lockfile and merge the Cloud counterpart. Updating Cloud to this package without supplying the slot removes the collaboration controls. No package publication is included in this PR.
